### PR TITLE
fix(desktop): prevent process text truncation

### DIFF
--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -163,7 +163,7 @@ export function BotActivityComposerAction({
           className={cn(
             "inline-flex items-center justify-center rounded-full border border-border/60 bg-background font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary",
             isInline
-              ? "h-7 min-w-0 gap-2 overflow-visible border-transparent bg-transparent px-0 text-xs font-semibold leading-none shadow-none hover:border-transparent hover:bg-transparent data-[state=open]:border-transparent data-[state=open]:bg-transparent"
+              ? "h-7 min-w-0 max-w-full gap-2 overflow-hidden border-transparent bg-transparent px-0 text-left text-xs font-semibold leading-none shadow-none hover:border-transparent hover:bg-transparent data-[state=open]:border-transparent data-[state=open]:bg-transparent"
               : "h-9 min-w-9 gap-1.5 px-2 text-xs",
           )}
           data-testid="bot-activity-composer-trigger"
@@ -177,7 +177,7 @@ export function BotActivityComposerAction({
           onMouseLeave={closeWithDelay}
           type="button"
         >
-          <span className="flex items-center overflow-visible py-px -space-x-1">
+          <span className="flex shrink-0 items-center overflow-visible py-px -space-x-1">
             {typingAgents.slice(0, 2).map((agent) => (
               <UserAvatar
                 avatarUrl={agentAvatarUrl(agent)}
@@ -193,12 +193,20 @@ export function BotActivityComposerAction({
             ))}
           </span>
           {typingAgents.length > 2 ? (
-            <span className="text-2xs leading-none">
+            <span className="shrink-0 text-2xs leading-none">
               +{typingAgents.length - 2}
             </span>
           ) : null}
-          <span className={cn(isInline ? "max-w-40 truncate" : "sr-only")}>
-            {isInline ? <Shimmer>{visibleStatusLabel}</Shimmer> : "working"}
+          <span
+            className={cn(isInline ? "min-w-0 flex-1 truncate" : "sr-only")}
+          >
+            {isInline ? (
+              <Shimmer className="max-w-full truncate">
+                {visibleStatusLabel}
+              </Shimmer>
+            ) : (
+              "working"
+            )}
           </span>
           {isInline ? null : (
             <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" />

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -785,7 +785,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                 <div className="h-7 overflow-visible bg-background px-5 pb-1 pt-0">
                   <div className="flex h-full w-full items-center gap-2 overflow-visible">
                     {hasComposerBotActivity ? (
-                      <div className="shrink-0 overflow-visible">
+                      <div className="min-w-0 flex-1 overflow-hidden">
                         <BotActivityComposerAction
                           agents={activityAgents}
                           channelId={activeChannel?.id ?? null}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -98,6 +98,7 @@ const EMPTY_THREAD_REPLIES: MainTimelineEntry[] = [];
 const THREAD_PANEL_MESSAGE_GUTTER_CLASS = "px-2";
 const THREAD_PANEL_COMPOSER_GUTTER_CLASS = "px-5";
 const THREAD_PANEL_SUMMARY_INDENT_OFFSET_REM = -0.125;
+
 type MessageThreadPanelSkeletonProps = {
   isSinglePanelView?: boolean;
   layout?: "standalone" | "split";
@@ -902,7 +903,9 @@ export function MessageThreadPanel({
           >
             <div className="mx-auto flex h-full w-full max-w-4xl items-center gap-2">
               {toolbarExtraActions ? (
-                <div className="shrink-0">{toolbarExtraActions}</div>
+                <div className="min-w-0 flex-1 overflow-hidden">
+                  {toolbarExtraActions}
+                </div>
               ) : null}
               {threadTypingPubkeys.length > 0 ? (
                 <TypingIndicatorRow


### PR DESCRIPTION
## Summary
- Let inline bot/process activity use available composer toolbar width instead of a fixed `max-w-40` cap
- Add flex/truncation containment for both the main composer activity row and thread panel toolbar
- Add Playwright screenshot coverage for main + thread process text ellipsizing

## Validation
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check`
- `pnpm --dir desktop exec playwright test process-text-screenshots.spec.ts --project=smoke`

## Screenshots
Posted in Buzz thread.