### PR TITLE
fix(desktop): dedupe welcome intro per channel

### DIFF
--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -360,19 +360,26 @@ fn event_has_client_marker(event: &Event, marker: &str) -> bool {
 
 async fn find_managed_agent_channel_message_by_marker(
     state: &AppState,
-    agent_pubkey: &str,
+    agent_pubkey: Option<&str>,
     channel_id: &str,
     marker: &str,
 ) -> Result<Option<Event>, String> {
+    let author = agent_pubkey
+        .map(str::trim)
+        .filter(|pubkey| !pubkey.is_empty())
+        .map(str::to_ascii_lowercase);
+
     let mut until: Option<u64> = None;
 
     for _ in 0..10 {
         let mut filter = serde_json::json!({
-            "authors": [agent_pubkey],
             "kinds": [buzz_core_pkg::kind::KIND_STREAM_MESSAGE],
             "#h": [channel_id],
             "limit": 500,
         });
+        if let Some(author) = author.as_deref() {
+            filter["authors"] = serde_json::json!([author]);
+        }
         if let Some(until) = until {
             filter["until"] = serde_json::json!(until);
         }
@@ -399,6 +406,16 @@ async fn find_managed_agent_channel_message_by_marker(
     }
 
     Ok(None)
+}
+
+fn marker_author_for_scope<'a>(
+    marker_scope: Option<&str>,
+    agent_pubkey: &'a str,
+) -> Option<&'a str> {
+    match marker_scope {
+        Some("channel") => None,
+        _ => Some(agent_pubkey),
+    }
 }
 
 fn stored_managed_agent_auth_tag(auth_tag: Option<&str>) -> Option<String> {
@@ -440,6 +457,7 @@ pub async fn send_managed_agent_channel_message(
     channel_id: String,
     content: String,
     marker: Option<String>,
+    marker_scope: Option<String>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<SendChannelMessageResponse, String> {
@@ -480,7 +498,7 @@ pub async fn send_managed_agent_channel_message(
     if let Some(marker) = marker.as_deref() {
         if let Some(existing) = find_managed_agent_channel_message_by_marker(
             &state,
-            &record.pubkey,
+            marker_author_for_scope(marker_scope.as_deref(), &record.pubkey),
             &channel_id,
             marker,
         )
@@ -525,6 +543,30 @@ pub async fn send_managed_agent_channel_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn marker_author_scope_defaults_to_agent() {
+        assert_eq!(
+            marker_author_for_scope(None, "agent-pubkey"),
+            Some("agent-pubkey")
+        );
+        assert_eq!(
+            marker_author_for_scope(Some("agent"), "agent-pubkey"),
+            Some("agent-pubkey")
+        );
+        assert_eq!(
+            marker_author_for_scope(Some("unknown"), "agent-pubkey"),
+            Some("agent-pubkey")
+        );
+    }
+
+    #[test]
+    fn marker_author_scope_can_dedupe_across_channel() {
+        assert_eq!(
+            marker_author_for_scope(Some("channel"), "agent-pubkey"),
+            None
+        );
+    }
 
     #[test]
     fn stored_managed_agent_auth_tag_trims_blank_values() {

--- a/desktop/src/features/onboarding/welcomeGuide.ts
+++ b/desktop/src/features/onboarding/welcomeGuide.ts
@@ -160,6 +160,7 @@ export async function ensureWelcomeGuideIntro(
     channelId,
     content: WELCOME_GUIDE_INTRO_MESSAGE,
     marker: WELCOME_GUIDE_INTRO_MARKER,
+    markerScope: "channel",
   });
   return agent;
 }

--- a/desktop/src/shared/api/tauriManagedAgentMessages.ts
+++ b/desktop/src/shared/api/tauriManagedAgentMessages.ts
@@ -14,6 +14,7 @@ export async function sendManagedAgentChannelMessage(input: {
   channelId: string;
   content: string;
   marker?: string;
+  markerScope?: "agent" | "channel";
 }): Promise<SendChannelMessageResult> {
   const response = await invokeTauri<RawSendChannelMessageResult>(
     "send_managed_agent_channel_message",
@@ -22,6 +23,7 @@ export async function sendManagedAgentChannelMessage(input: {
       channelId: input.channelId,
       content: input.content,
       marker: input.marker ?? null,
+      markerScope: input.markerScope ?? null,
     },
   );
 


### PR DESCRIPTION
## Summary
- Add an optional managed-agent message marker scope so marker dedupe can be either per-agent or per-channel.
- Use channel-scoped marker dedupe for the Fizz welcome intro to prevent duplicate welcome messages when another dev copy shares the user identity but has a different local Fizz agent.
- Keep existing default marker behavior unchanged for other managed-agent sends.

## Validation
- `pnpm --dir desktop test -- --runInBand`
- `pnpm --dir desktop typecheck`
- `(cd desktop && ../bin/pnpm exec biome check src/features/onboarding/welcomeGuide.ts src/shared/api/tauriManagedAgentMessages.ts)`
- `bin/cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- Pre-commit hooks passed during commit (`rust-fmt`, `desktop-tauri-fmt`, `desktop-fix`, `web-fix`, `mobile-fix`).
- Pre-push hooks passed during push (`desktop-test`, `rust-tests`, `mobile-test`, `desktop-tauri-test`).
