### PR TITLE
security: track quick-xml DoS advisories (RUSTSEC-2026-0194/0195)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,5 +167,23 @@ strip = true
 # aws-creds to a fork that adopts the aws-creds portion of durch/rust-s3#449
 # (FULL_URI + token-file + Authorization header, refresh-safe, with a loopback
 # allowlist for the auth token). Revert to crates.io once #449 lands upstream.
+#
+# SECURITY TRACKING (quick-xml DoS): rust-s3 0.37.2 and the aws-creds fork above
+# both pull in quick-xml 0.38.4, which is affected by RUSTSEC-2026-0194 (O(N²) CPU
+# amplification on malformed attribute values) and RUSTSEC-2026-0195 (unbounded
+# memory growth from deeply-nested XML). The fix requires quick-xml ≥ 0.40.0, but
+# that is a semver-incompatible bump from rust-s3's current ^0.38 pin — a Cargo
+# workspace patch cannot bridge incompatible minor versions without recompile errors.
+#
+# Exploitability in buzz: quick-xml is reached only via S3 API response parsing
+# (ListBucket/GetObject XML). In production the S3 endpoint is operator-controlled
+# and trusted; risk materialises only if the S3 layer is compromised or MITM'd.
+#
+# Remediation path:
+#   1. Upstream: https://github.com/durch/rust-s3 — bump quick-xml to ^0.40 and
+#      release ≥0.38.0 (or 0.37.3). Track: durch/rust-s3#[upstream issue].
+#   2. Fork: mirror the same bump in tlongwell-block/rust-s3 and advance the
+#      rev pin in aws-creds below to pick up the fix.
+# Remove this comment block once the pin above is updated to a fixed revision.
 [patch.crates-io]
 aws-creds = { git = "https://github.com/tlongwell-block/rust-s3", rev = "c9fce3620dd434c1f810101d672cf384268dbb0f" }


### PR DESCRIPTION
## Summary

Automated dependency audit flagged two publicly disclosed advisories affecting `quick-xml 0.38.4`, which enters the workspace transitively via `rust-s3 0.37.2` and the `aws-creds` fork pinned in `[patch.crates-io]`.

| Advisory | Severity | Description |
|---|---|---|
| RUSTSEC-2026-0194 | HIGH (CVSS 7.5) | O(N²) CPU amplification — malformed XML attribute values trigger quadratic work in the attribute-value parser |
| RUSTSEC-2026-0195 | HIGH (CVSS 7.5) | Unbounded memory growth — deeply-nested XML elements cause unbounded stack/heap growth without a depth cap |

Both are fixed in `quick-xml ≥ 0.40.0`.

## Exploitability in buzz

`quick-xml` is reached only via S3 API response parsing (`ListBucket`, `GetObject`, multipart XML). In production, the S3 endpoint is operator-controlled (the `S3_ENDPOINT` env var) and trusted. The risk window is narrow: an attacker would need to MITM the S3 connection or compromise the storage backend to deliver malicious XML to the parser. Severity is **HIGH** in isolation but **LOW** in the current threat model.

## Why this PR cannot include the fix

`quick-xml 0.40.0` is a semver-incompatible bump from the `^0.38` pin in `rust-s3`. A `[patch.crates-io]` override pointing to `quick-xml 0.40.x` will not compile because `rust-s3`'s XML parsing code uses the 0.38 API surface. The fix must come from `rust-s3` itself:

1. **Upstream (`durch/rust-s3`)**: bump `quick-xml` to `^0.40` and release a new crate version.
2. **Fork (`tlongwell-block/rust-s3`)**: mirror that bump and advance the `rev` pin in `[patch.crates-io]` here.

## This PR

Adds a `# SECURITY TRACKING` comment in `Cargo.toml` adjacent to the existing fork pin, explaining the vulnerability, exploitability assessment, and exact remediation path. This prevents the comment from being lost if the patch block is touched for unrelated reasons.

## References

- https://rustsec.org/advisories/RUSTSEC-2026-0194
- https://rustsec.org/advisories/RUSTSEC-2026-0195
- https://github.com/tafia/quick-xml/blob/master/CHANGELOG.md