### PR TITLE
feat(web): add Browse releases link next to invite download

### DIFF
--- a/web/src/features/invite/ui/InvitePage.tsx
+++ b/web/src/features/invite/ui/InvitePage.tsx
@@ -274,6 +274,17 @@ export function InvitePage({ code }: { code: string }) {
           >
             Download it now
           </a>
+          <span aria-hidden="true" className="mx-1.5 text-black/30">
+            ·
+          </span>
+          <a
+            className="font-medium text-black underline-offset-4 hover:text-black/70 hover:underline focus-visible:underline"
+            href={BUZZ_RELEASES_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Browse releases
+          </a>
         </p>
       </div>
 

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -74,6 +74,9 @@ test("invite requires age and legal consent before opening Buzz", async ({
     "href",
     "https://github.com/block/buzz/releases/download/v0.4.9/Buzz_0.4.9_x64-setup_alpha-unsigned.exe",
   );
+  await expect(
+    page.getByRole("link", { name: "Browse releases" }),
+  ).toHaveAttribute("href", "https://github.com/block/buzz/releases");
 
   const ageConfirmation = page.getByLabel("I am 18 years of age or older.");
   const agreementConfirmation = page.getByLabel(
@@ -342,6 +345,10 @@ test("invite download falls back for mobile and non-desktop devices", async ({
     await page.goto("/invite/demo-code");
     await expect(
       page.getByRole("link", { name: "Download it now" }),
+      device.name,
+    ).toHaveAttribute("href", "https://github.com/block/buzz/releases");
+    await expect(
+      page.getByRole("link", { name: "Browse releases" }),
       device.name,
     ).toHaveAttribute("href", "https://github.com/block/buzz/releases");
     await context.close();


### PR DESCRIPTION
Related to https://github.com/block/buzz/issues/2093

Invite pages offered a platform-resolved binary download with no path to the GitHub releases listing for users who wanted information first.

### Changes
- Keep the smart **Download it now** CTA
- Add an always-visible **Browse releases** link pointing at `https://github.com/block/buzz/releases`
- Extend invite smoke coverage for the new link

Note: the marketing-site “Get the App” button on buzz.xyz appears to live outside this repository; this improves the in-repo web invite flow.