### PR TITLE
fix(acp): map Codex full-access permission mode

### DIFF
--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -859,13 +859,13 @@ async fn create_session_and_apply_model(
     );
 
     // Apply permission mode if not the agent's built-in default AND the agent
-    // advertises the requested mode in session/new. Agents that don't support
+    // advertises a compatible mode in session/new. Agents that don't support
     // the mode (e.g., goose crashes on unrecognized set_config_option values)
-    // are safely skipped — the harness auto-approves via handle_permission_request.
-    if !ctx.permission_mode.is_default()
-        && agent_supports_mode(&resp.raw, ctx.permission_mode.as_wire_str())
-    {
-        apply_permission_mode(&mut agent.acp, &resp.session_id, &ctx.permission_mode).await?;
+    // are safely skipped; the harness auto-approves via handle_permission_request.
+    if !ctx.permission_mode.is_default() {
+        if let Some(mode_id) = resolve_permission_mode_id(&resp.raw, &ctx.permission_mode) {
+            apply_permission_mode(&mut agent.acp, &resp.session_id, mode_id).await?;
+        }
     }
 
     Ok(resp.session_id)
@@ -946,26 +946,43 @@ async fn apply_model_switch(
     Ok(())
 }
 
+/// Resolve the ACP mode ID that matches the requested permission semantics.
+///
+/// Most adapters use Buzz's wire IDs directly. Codex ACP names its equivalent
+/// bypass preset `agent-full-access`, so accept that as a compatibility alias
+/// only when `bypassPermissions` itself is not advertised.
+fn resolve_permission_mode_id(
+    session_new_result: &serde_json::Value,
+    permission_mode: &PermissionMode,
+) -> Option<&'static str> {
+    let available_modes = session_new_result
+        .get("modes")
+        .and_then(|m| m.get("availableModes"))
+        .and_then(|a| a.as_array())?;
+
+    let requested = permission_mode.as_wire_str();
+    if available_modes
+        .iter()
+        .any(|mode| mode.get("id").and_then(|value| value.as_str()) == Some(requested))
+    {
+        return Some(requested);
+    }
+
+    if matches!(permission_mode, PermissionMode::BypassPermissions)
+        && available_modes.iter().any(|mode| {
+            mode.get("id").and_then(|value| value.as_str()) == Some("agent-full-access")
+        })
+    {
+        return Some("agent-full-access");
+    }
+
+    None
+}
+
 /// Set the session permission mode via `session/set_config_option`.
 ///
 /// Non-fatal for most errors: logs and proceeds. The agent falls back
 /// to its default permission mode (`"default"`), which still works via
-/// Check if the agent's `session/new` response advertises a given mode ID
-/// in `result.modes.availableModes[].id`. Returns `false` if the modes
-/// field is absent or the mode isn't listed.
-fn agent_supports_mode(session_new_result: &serde_json::Value, mode_wire: &str) -> bool {
-    session_new_result
-        .get("modes")
-        .and_then(|m| m.get("availableModes"))
-        .and_then(|a| a.as_array())
-        .map(|modes| {
-            modes
-                .iter()
-                .any(|m| m.get("id").and_then(|v| v.as_str()) == Some(mode_wire))
-        })
-        .unwrap_or(false)
-}
-
 /// per-tool auto-approval in `handle_permission_request`.
 ///
 /// **Fatal exception:** if the agent process exits (e.g., goose crashes on
@@ -973,11 +990,10 @@ fn agent_supports_mode(session_new_result: &serde_json::Value, mode_wire: &str) 
 async fn apply_permission_mode(
     acp: &mut AcpClient,
     session_id: &str,
-    mode: &PermissionMode,
+    mode_wire: &str,
 ) -> Result<(), AcpError> {
-    let wire = mode.as_wire_str();
     let result = tokio::time::timeout(PERMISSION_MODE_TIMEOUT, async {
-        acp.session_set_config_option(session_id, "mode", wire)
+        acp.session_set_config_option(session_id, "mode", mode_wire)
             .await
     })
     .await;
@@ -986,7 +1002,7 @@ async fn apply_permission_mode(
         Ok(Ok(_)) => {
             tracing::info!(
                 target: "pool::permission",
-                "applied permission mode {wire:?} on session {session_id}"
+                "applied permission mode {mode_wire:?} on session {session_id}"
             );
         }
         // Transport-class errors may have corrupted the stdio stream — propagate
@@ -998,7 +1014,7 @@ async fn apply_permission_mode(
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
                 target: "pool::permission",
-                "fatal error setting permission mode {wire:?}: {e}"
+                "fatal error setting permission mode {mode_wire:?}: {e}"
             );
             return Err(e);
         }
@@ -1006,7 +1022,7 @@ async fn apply_permission_mode(
         Ok(Err(e)) => {
             tracing::warn!(
                 target: "pool::permission",
-                "failed to set permission mode {wire:?}: {e} — falling back to per-tool auto-approval"
+                "failed to set permission mode {mode_wire:?}: {e} — falling back to per-tool auto-approval"
             );
         }
         Err(_) => {
@@ -3608,6 +3624,59 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
+
+    #[test]
+    fn permission_mode_prefers_the_requested_wire_id() {
+        let session = json!({
+            "modes": {
+                "availableModes": [
+                    {"id": "bypassPermissions"},
+                    {"id": "agent-full-access"}
+                ]
+            }
+        });
+
+        assert_eq!(
+            resolve_permission_mode_id(&session, &PermissionMode::BypassPermissions),
+            Some("bypassPermissions")
+        );
+    }
+
+    #[test]
+    fn bypass_permissions_maps_to_codex_full_access_mode() {
+        let session = json!({
+            "modes": {
+                "availableModes": [
+                    {"id": "read-only"},
+                    {"id": "agent"},
+                    {"id": "agent-full-access"}
+                ]
+            }
+        });
+
+        assert_eq!(
+            resolve_permission_mode_id(&session, &PermissionMode::BypassPermissions),
+            Some("agent-full-access")
+        );
+    }
+
+    #[test]
+    fn permission_mode_does_not_map_to_a_weaker_semantic_alias() {
+        let session = json!({
+            "modes": {
+                "availableModes": [
+                    {"id": "read-only"},
+                    {"id": "agent"},
+                    {"id": "agent-full-access"}
+                ]
+            }
+        });
+
+        assert_eq!(
+            resolve_permission_mode_id(&session, &PermissionMode::AcceptEdits),
+            None
+        );
+    }
 
     // These pin the initial_message dispatch path (run_prompt_task, ~line 855):
     // a legacy agent WITH a base_prompt must get [Base] prepended to the user


### PR DESCRIPTION
### Summary

- Map Buzz's `bypassPermissions` setting to Codex ACP's advertised `agent-full-access` mode when the exact Buzz mode ID is unavailable.
- Keep exact mode IDs preferred for adapters that already use Buzz's wire values.
- Avoid mapping other permission settings to weaker or semantically different Codex presets.

### Problem

Buzz defaults managed agents to `bypassPermissions`, but the current Codex ACP adapter advertises `read-only`, `agent`, and `agent-full-access`.

Buzz previously applied a session mode only when the adapter advertised the exact requested ID. That meant `bypassPermissions` was skipped for Codex ACP, leaving the adapter in its default `agent` mode. Codex ACP then supplied `on-request` approval and `workspace-write` sandbox policies on each turn, even when the local Codex config showed `never` and `danger-full-access`.

Upstream Codex ACP source:

- [`agent-full-access` is the `never` plus `danger-full-access` preset](https://github.com/agentclientprotocol/codex-acp/blob/2524dfb8568eeac659353ca9705e73501bb403c8/src/AgentMode.ts#L48-L57)
- [The selected mode's approval and sandbox policies are passed into every turn](https://github.com/agentclientprotocol/codex-acp/blob/2524dfb8568eeac659353ca9705e73501bb403c8/src/CodexAcpClient.ts#L686-L712)

### Fix

Resolve the requested permission setting against the modes returned by `session/new`:

1. Prefer the exact Buzz wire ID.
2. If `bypassPermissions` is requested and the exact ID is absent, use `agent-full-access` when the adapter advertises it.
3. Otherwise keep the existing safe fallback and do not send an unsupported mode.

### Tests

- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp` - 573 passed
- `cargo clippy -p buzz-acp --all-targets --all-features` with warnings denied
- `just desktop-tauri-test` - 1,527 passed, 13 ignored
- `just web-build mobile-test` - passed, including 525 mobile tests with 1 skipped

I also ran `just ci`. Every component gate passed independently, but the aggregate run exposed an existing test-isolation race in `relay_admission`: one paused-time test first observed 300 seconds instead of 5 seconds, and a later aggregate run left the same shared-gate test group waiting. The complete desktop test stage passed on its standalone rerun. This change does not touch desktop relay admission code.

### Scope

One Rust source file. No schema, UI, public API, or documentation changes.
