### PR TITLE
feat(desktop): autocomplete ACP slash commands

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -1571,16 +1571,25 @@ impl AcpClient {
             }
             "available_commands_update" => {
                 // Advertised slash commands (ACP slash-commands extension).
-                // Logged for observability; UI surfacing is a follow-up.
-                let names: Vec<&str> = update["availableCommands"]
+                // Forward the complete latest list through the encrypted observer
+                // stream so Desktop can offer commands for the originating agent.
+                let commands = update["availableCommands"]
                     .as_array()
-                    .map(|cmds| cmds.iter().filter_map(|c| c["name"].as_str()).collect())
+                    .cloned()
                     .unwrap_or_default();
+                let names: Vec<&str> = commands
+                    .iter()
+                    .filter_map(|command| command["name"].as_str())
+                    .collect();
                 tracing::info!(
                     target: "acp::update",
                     "available_commands_update: {} commands [{}]",
                     names.len(),
                     names.join(", ")
+                );
+                self.observe(
+                    "available_commands_captured",
+                    serde_json::json!({ "commands": commands }),
                 );
                 false
             }
@@ -3088,6 +3097,43 @@ mod tests {
                 },
             }
         })
+    }
+
+    #[tokio::test]
+    async fn available_commands_update_emits_complete_semantic_snapshot() {
+        let mut client = spawn_inert_client().await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 3);
+
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "test-session",
+                "update": {
+                    "sessionUpdate": "available_commands_update",
+                    "availableCommands": [
+                        { "name": "review", "description": "Review changes" },
+                        { "name": "deploy", "description": "Ship it" }
+                    ]
+                }
+            }
+        });
+        let _ = client.handle_session_update(&msg);
+
+        let events = observer.snapshot();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "available_commands_captured");
+        assert_eq!(events[0].agent_index, Some(3));
+        assert_eq!(
+            events[0].payload,
+            serde_json::json!({
+                "commands": [
+                    { "name": "review", "description": "Review changes" },
+                    { "name": "deploy", "description": "Ship it" }
+                ]
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -1792,16 +1792,25 @@ impl AcpClient {
             }
             "available_commands_update" => {
                 // Advertised slash commands (ACP slash-commands extension).
-                // Logged for observability; UI surfacing is a follow-up.
-                let names: Vec<&str> = update["availableCommands"]
+                // Forward the complete latest list through the encrypted observer
+                // stream so Desktop can offer commands for the originating agent.
+                let commands = update["availableCommands"]
                     .as_array()
-                    .map(|cmds| cmds.iter().filter_map(|c| c["name"].as_str()).collect())
+                    .cloned()
                     .unwrap_or_default();
+                let names: Vec<&str> = commands
+                    .iter()
+                    .filter_map(|command| command["name"].as_str())
+                    .collect();
                 tracing::info!(
                     target: "acp::update",
                     "available_commands_update: {} commands [{}]",
                     names.len(),
                     names.join(", ")
+                );
+                self.observe(
+                    "available_commands_captured",
+                    serde_json::json!({ "commands": commands }),
                 );
                 false
             }
@@ -3747,6 +3756,43 @@ mod tests {
                 },
             }
         })
+    }
+
+    #[tokio::test]
+    async fn available_commands_update_emits_complete_semantic_snapshot() {
+        let mut client = spawn_inert_client().await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 3);
+
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "test-session",
+                "update": {
+                    "sessionUpdate": "available_commands_update",
+                    "availableCommands": [
+                        { "name": "review", "description": "Review changes" },
+                        { "name": "deploy", "description": "Ship it" }
+                    ]
+                }
+            }
+        });
+        let _ = client.handle_session_update(&msg);
+
+        let events = observer.snapshot();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "available_commands_captured");
+        assert_eq!(events[0].agent_index, Some(3));
+        assert_eq!(
+            events[0].payload,
+            serde_json::json!({
+                "commands": [
+                    { "name": "review", "description": "Review changes" },
+                    { "name": "deploy", "description": "Ship it" }
+                ]
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -1794,10 +1794,9 @@ impl AcpClient {
                 // Advertised slash commands (ACP slash-commands extension).
                 // Forward the complete latest list through the encrypted observer
                 // stream so Desktop can offer commands for the originating agent.
-                let commands = update["availableCommands"]
-                    .as_array()
-                    .cloned()
-                    .unwrap_or_default();
+                let Some(commands) = update["availableCommands"].as_array() else {
+                    return false;
+                };
                 let names: Vec<&str> = commands
                     .iter()
                     .filter_map(|command| command["name"].as_str())
@@ -3793,6 +3792,16 @@ mod tests {
                 ]
             })
         );
+        let mut empty = msg.clone();
+        empty["params"]["update"]["availableCommands"] = serde_json::json!([]);
+        let _ = client.handle_session_update(&empty);
+        let events = observer.snapshot();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].payload, serde_json::json!({ "commands": [] }));
+
+        empty["params"]["update"]["availableCommands"] = serde_json::Value::Null;
+        let _ = client.handle_session_update(&empty);
+        assert_eq!(observer.snapshot().len(), 2);
     }
 
     #[tokio::test]

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
         "**/composer-selection-formatting.spec.ts",
         "**/composer-tooltip-dismiss.spec.ts",
         "**/mentions.spec.ts",
+        "**/slash-command-autocomplete.spec.ts",
         "**/mention-spacing.spec.ts",
         "**/mention-clipboard.spec.ts",
         "**/cloud-provenance.spec.ts",

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -517,7 +517,10 @@ const overrides = new Map([
   // ownerPubkey) feeding the newly-added-mentions diff. Diff logic itself
   // lives in threading.ts (diffAddedMentionPubkeys); this is the minimal
   // composer-side wiring. Queued to split with the rest of this list.
-  ["src/features/messages/ui/MessageComposer.tsx", 1114],
+  // +46: ACP slash-command autocomplete hook, editor update/key routing, and
+  // grouped popup handoff. Catalog logic, filtering, and rendering live in
+  // dedicated modules; these are the load-bearing composer integration seams.
+  ["src/features/messages/ui/MessageComposer.tsx", 1160],
   // global-agent-config: model-tuning section (BuzzAgentModelTuningFields via
   // EditAgentAdvancedFields) + providerValid gate + effectiveProvider derivation
   // + globalProvider threading into getPersonaProviderOptions. All load-bearing

--- a/desktop/src/features/agents/agentCommandCatalog.test.mjs
+++ b/desktop/src/features/agents/agentCommandCatalog.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+
+import {
+  getAgentCommandCatalog,
+  parseAvailableCommandsPayload,
+  recordAvailableCommandsUpdate,
+  resetAgentCommandCatalogForTests,
+} from "./agentCommandCatalog.ts";
+
+const OWNER = "aa".repeat(32);
+const OTHER_OWNER = "bb".repeat(32);
+const AGENT = "cc".repeat(32);
+
+function installLocalStorage() {
+  const values = new Map();
+  globalThis.window = {
+    localStorage: {
+      get length() {
+        return values.size;
+      },
+      getItem: (key) => values.get(key) ?? null,
+      key: (index) => [...values.keys()][index] ?? null,
+      removeItem: (key) => values.delete(key),
+      setItem: (key, value) => values.set(key, String(value)),
+    },
+  };
+}
+
+describe("agent command catalog", () => {
+  beforeEach(() => {
+    installLocalStorage();
+    resetAgentCommandCatalogForTests();
+  });
+
+  it("sanitizes, bounds, and deduplicates advertised commands", () => {
+    const commands = parseAvailableCommandsPayload({
+      commands: [
+        { name: "/review", description: " Review changes " },
+        { name: "REVIEW", description: "duplicate" },
+        { name: "bad name" },
+        { name: "deploy", description: 42 },
+      ],
+    });
+
+    assert.deepEqual(commands, [
+      { name: "review", description: "Review changes" },
+      { name: "deploy", description: null },
+    ]);
+  });
+
+  it("keeps the latest complete command list per owner and agent", () => {
+    assert.equal(
+      recordAvailableCommandsUpdate(OWNER, AGENT, {
+        seq: 8,
+        timestamp: "2026-07-23T08:00:00Z",
+        payload: { commands: [{ name: "review", description: "Review" }] },
+      }),
+      true,
+    );
+    assert.equal(
+      recordAvailableCommandsUpdate(OWNER, AGENT, {
+        seq: 7,
+        timestamp: "2026-07-23T07:00:00Z",
+        payload: { commands: [{ name: "stale" }] },
+      }),
+      false,
+    );
+
+    assert.deepEqual(getAgentCommandCatalog(OWNER).get(AGENT)?.commands, [
+      { name: "review", description: "Review" },
+    ]);
+    assert.equal(getAgentCommandCatalog(OTHER_OWNER).has(AGENT), false);
+  });
+
+  it("treats an empty update as authoritative removal of prior commands", () => {
+    recordAvailableCommandsUpdate(OWNER, AGENT, {
+      seq: 1,
+      timestamp: "2026-07-23T08:00:00Z",
+      payload: { commands: [{ name: "review" }] },
+    });
+    recordAvailableCommandsUpdate(OWNER, AGENT, {
+      seq: 2,
+      timestamp: "2026-07-23T08:01:00Z",
+      payload: { commands: [] },
+    });
+
+    assert.deepEqual(getAgentCommandCatalog(OWNER).get(AGENT)?.commands, []);
+  });
+
+  it("hydrates a persisted owner-scoped catalog after restart", () => {
+    recordAvailableCommandsUpdate(OWNER, AGENT, {
+      seq: 3,
+      timestamp: "2026-07-23T08:00:00Z",
+      payload: { commands: [{ name: "review" }] },
+    });
+    resetAgentCommandCatalogForTests();
+
+    assert.deepEqual(getAgentCommandCatalog(OWNER).get(AGENT)?.commands, [
+      { name: "review", description: null },
+    ]);
+  });
+});

--- a/desktop/src/features/agents/agentCommandCatalog.test.mjs
+++ b/desktop/src/features/agents/agentCommandCatalog.test.mjs
@@ -3,6 +3,8 @@ import { beforeEach, describe, it } from "node:test";
 
 import {
   getAgentCommandCatalog,
+  initAgentCommandCatalog,
+  resetAgentCommandCatalog,
   parseAvailableCommandsPayload,
   recordAvailableCommandsUpdate,
   resetAgentCommandCatalogForTests,
@@ -31,6 +33,7 @@ describe("agent command catalog", () => {
   beforeEach(() => {
     installLocalStorage();
     resetAgentCommandCatalogForTests();
+    initAgentCommandCatalog("test-community");
   });
 
   it("sanitizes, bounds, and deduplicates advertised commands", () => {
@@ -73,6 +76,82 @@ describe("agent command catalog", () => {
     assert.equal(getAgentCommandCatalog(OTHER_OWNER).has(AGENT), false);
   });
 
+  it("rejects hidden controls in command names and removes them from descriptions", () => {
+    assert.deepEqual(
+      parseAvailableCommandsPayload({
+        commands: [
+          { name: "rev\u0000iew" },
+          { name: "rev\u202eiew" },
+          { name: "rev\u200biew" },
+          { name: "review", description: "a\u001bb\u202ec" },
+        ],
+      }),
+      [{ name: "review", description: "a b c" }],
+    );
+  });
+
+  it("enforces count, name, and description bounds", () => {
+    assert.equal(
+      parseAvailableCommandsPayload({
+        commands: Array.from({ length: 300 }, (_, i) => ({ name: `cmd-${i}` })),
+      }).length,
+      256,
+    );
+    assert.deepEqual(
+      parseAvailableCommandsPayload({ commands: [{ name: "a".repeat(129) }] }),
+      [],
+    );
+    assert.equal(
+      parseAvailableCommandsPayload({
+        commands: [{ name: "review", description: "a".repeat(600) }],
+      })[0].description.length,
+      512,
+    );
+  });
+
+  it("ignores malformed snapshots and uses sequence to break timestamp ties", () => {
+    const timestamp = "2026-07-23T08:00:00Z";
+    recordAvailableCommandsUpdate(OWNER, AGENT, {
+      seq: 2,
+      timestamp,
+      payload: { commands: [{ name: "review" }] },
+    });
+    for (const event of [
+      { seq: 3, timestamp, payload: {} },
+      { seq: 3, timestamp: "invalid", payload: { commands: [] } },
+      { seq: 1, timestamp, payload: { commands: [] } },
+    ])
+      assert.equal(recordAvailableCommandsUpdate(OWNER, AGENT, event), false);
+    assert.deepEqual(getAgentCommandCatalog(OWNER).get(AGENT).commands, [
+      { name: "review", description: null },
+    ]);
+  });
+
+  it("re-sanitizes persisted commands and tolerates unavailable storage", () => {
+    window.localStorage.setItem(
+      `buzz-agent-command-catalog.v1:test-community:${OWNER}`,
+      JSON.stringify({
+        version: 1,
+        agents: {
+          [AGENT]: {
+            commands: [{ name: "bad\u202e" }, { name: "review" }],
+            seq: 1,
+            timestamp: "2026-07-23T08:00:00Z",
+          },
+        },
+      }),
+    );
+    assert.deepEqual(getAgentCommandCatalog(OWNER).get(AGENT).commands, [
+      { name: "review", description: null },
+    ]);
+    resetAgentCommandCatalogForTests();
+    initAgentCommandCatalog("test-community");
+    window.localStorage.getItem = () => {
+      throw new Error("storage disabled");
+    };
+    assert.equal(getAgentCommandCatalog(OWNER).size, 0);
+  });
+
   it("treats an empty update as authoritative removal of prior commands", () => {
     recordAvailableCommandsUpdate(OWNER, AGENT, {
       seq: 1,
@@ -95,8 +174,31 @@ describe("agent command catalog", () => {
       payload: { commands: [{ name: "review" }] },
     });
     resetAgentCommandCatalogForTests();
+    initAgentCommandCatalog("test-community");
 
     assert.deepEqual(getAgentCommandCatalog(OWNER).get(AGENT)?.commands, [
+      { name: "review", description: null },
+    ]);
+  });
+
+  it("isolates the same owner and agent across community switches and restores on return", () => {
+    const event = {
+      seq: 1,
+      timestamp: "2026-07-23T08:00:00Z",
+      payload: { commands: [{ name: "review" }] },
+    };
+    recordAvailableCommandsUpdate(OWNER, AGENT, event);
+    resetAgentCommandCatalog();
+    assert.equal(getAgentCommandCatalog(OWNER).size, 0);
+    assert.equal(recordAvailableCommandsUpdate(OWNER, AGENT, event), false);
+    initAgentCommandCatalog("other-community");
+    assert.equal(getAgentCommandCatalog(OWNER).size, 0);
+    recordAvailableCommandsUpdate(OWNER, AGENT, {
+      ...event,
+      payload: { commands: [{ name: "deploy" }] },
+    });
+    initAgentCommandCatalog("test-community");
+    assert.deepEqual(getAgentCommandCatalog(OWNER).get(AGENT).commands, [
       { name: "review", description: null },
     ]);
   });

--- a/desktop/src/features/agents/agentCommandCatalog.ts
+++ b/desktop/src/features/agents/agentCommandCatalog.ts
@@ -1,0 +1,207 @@
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { setLocalStorageItemWithRecovery } from "@/shared/lib/localStorageQuota";
+
+const STORAGE_PREFIX = "buzz-agent-command-catalog.v1";
+const MAX_COMMANDS_PER_AGENT = 256;
+const MAX_COMMAND_NAME_LENGTH = 128;
+const MAX_COMMAND_DESCRIPTION_LENGTH = 512;
+
+export type AgentCommand = {
+  name: string;
+  description: string | null;
+};
+
+export type AgentCommandCatalogEntry = {
+  commands: readonly AgentCommand[];
+  seq: number;
+  timestamp: string;
+};
+
+export type AgentCommandCatalog = ReadonlyMap<string, AgentCommandCatalogEntry>;
+
+type PersistedCatalog = {
+  version: 1;
+  agents: Record<string, AgentCommandCatalogEntry>;
+};
+
+type AvailableCommandsEvent = {
+  payload: unknown;
+  seq: number;
+  timestamp: string;
+};
+
+const EMPTY_CATALOG: AgentCommandCatalog = new Map();
+// Managed-agent observer ingestion is owner-global; command capabilities belong
+// to the agent pubkey rather than whichever community currently renders it.
+const catalogByOwner = new Map<string, AgentCommandCatalog>();
+const hydratedOwners = new Set<string>();
+const listeners = new Set<() => void>();
+
+function storageKey(ownerPubkey: string): string {
+  return `${STORAGE_PREFIX}:${normalizePubkey(ownerPubkey)}`;
+}
+
+function sanitizeCommand(value: unknown): AgentCommand | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.name !== "string") return null;
+
+  const name = record.name.trim().replace(/^\/+/, "");
+  if (
+    name.length === 0 ||
+    name.length > MAX_COMMAND_NAME_LENGTH ||
+    /\s|\//u.test(name)
+  ) {
+    return null;
+  }
+
+  const description =
+    typeof record.description === "string"
+      ? record.description.trim().slice(0, MAX_COMMAND_DESCRIPTION_LENGTH) ||
+        null
+      : null;
+  return { name, description };
+}
+
+export function parseAvailableCommandsPayload(
+  payload: unknown,
+): readonly AgentCommand[] | null {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    return null;
+  }
+  const commands = (payload as Record<string, unknown>).commands;
+  if (!Array.isArray(commands)) return null;
+
+  const parsed: AgentCommand[] = [];
+  const seen = new Set<string>();
+  for (const value of commands.slice(0, MAX_COMMANDS_PER_AGENT)) {
+    const command = sanitizeCommand(value);
+    if (!command) continue;
+    const key = command.name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    parsed.push(command);
+  }
+  return parsed;
+}
+
+function parseStoredCatalog(raw: string | null): AgentCommandCatalog {
+  if (!raw) return EMPTY_CATALOG;
+  try {
+    const parsed = JSON.parse(raw) as Partial<PersistedCatalog>;
+    if (
+      parsed.version !== 1 ||
+      !parsed.agents ||
+      typeof parsed.agents !== "object"
+    ) {
+      return EMPTY_CATALOG;
+    }
+    const next = new Map<string, AgentCommandCatalogEntry>();
+    for (const [pubkey, entry] of Object.entries(parsed.agents)) {
+      if (!entry || typeof entry !== "object") continue;
+      const candidate = entry as Partial<AgentCommandCatalogEntry>;
+      const commands = parseAvailableCommandsPayload({
+        commands: candidate.commands,
+      });
+      if (
+        commands === null ||
+        typeof candidate.seq !== "number" ||
+        !Number.isSafeInteger(candidate.seq) ||
+        typeof candidate.timestamp !== "string"
+      ) {
+        continue;
+      }
+      next.set(normalizePubkey(pubkey), {
+        commands,
+        seq: candidate.seq,
+        timestamp: candidate.timestamp,
+      });
+    }
+    return next;
+  } catch {
+    return EMPTY_CATALOG;
+  }
+}
+
+function hydrate(ownerPubkey: string): AgentCommandCatalog {
+  const owner = normalizePubkey(ownerPubkey);
+  if (!hydratedOwners.has(owner)) {
+    const raw =
+      typeof window === "undefined"
+        ? null
+        : window.localStorage.getItem(storageKey(owner));
+    catalogByOwner.set(owner, parseStoredCatalog(raw));
+    hydratedOwners.add(owner);
+  }
+  return catalogByOwner.get(owner) ?? EMPTY_CATALOG;
+}
+
+function persist(ownerPubkey: string, catalog: AgentCommandCatalog): void {
+  if (typeof window === "undefined") return;
+  const agents = Object.fromEntries(catalog.entries());
+  setLocalStorageItemWithRecovery(
+    storageKey(ownerPubkey),
+    JSON.stringify({ version: 1, agents } satisfies PersistedCatalog),
+  );
+}
+
+function isNewer(
+  incoming: Pick<AgentCommandCatalogEntry, "seq" | "timestamp">,
+  current: AgentCommandCatalogEntry | undefined,
+): boolean {
+  if (!current) return true;
+  const incomingTime = Date.parse(incoming.timestamp);
+  const currentTime = Date.parse(current.timestamp);
+  if (Number.isFinite(incomingTime) && Number.isFinite(currentTime)) {
+    if (incomingTime !== currentTime) return incomingTime > currentTime;
+  }
+  return incoming.seq > current.seq;
+}
+
+export function recordAvailableCommandsUpdate(
+  ownerPubkey: string,
+  agentPubkey: string,
+  event: AvailableCommandsEvent,
+): boolean {
+  const commands = parseAvailableCommandsPayload(event.payload);
+  if (commands === null || !Number.isSafeInteger(event.seq)) return false;
+
+  const owner = normalizePubkey(ownerPubkey);
+  const agent = normalizePubkey(agentPubkey);
+  const current = hydrate(owner);
+  if (!isNewer(event, current.get(agent))) return false;
+
+  const next = new Map(current);
+  next.set(agent, {
+    commands,
+    seq: event.seq,
+    timestamp: event.timestamp,
+  });
+  catalogByOwner.set(owner, next);
+  persist(owner, next);
+  for (const listener of listeners) listener();
+  return true;
+}
+
+export function getAgentCommandCatalog(
+  ownerPubkey: string | null,
+): AgentCommandCatalog {
+  return ownerPubkey ? hydrate(ownerPubkey) : EMPTY_CATALOG;
+}
+
+export function subscribeAgentCommandCatalog(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function resetAgentCommandCatalogForTests(): void {
+  catalogByOwner.clear();
+  hydratedOwners.clear();
+  listeners.clear();
+}

--- a/desktop/src/features/agents/agentCommandCatalog.ts
+++ b/desktop/src/features/agents/agentCommandCatalog.ts
@@ -1,0 +1,209 @@
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { setLocalStorageItemWithRecovery } from "@/shared/lib/localStorageQuota";
+
+const STORAGE_PREFIX = "buzz-agent-command-catalog.v1";
+const MAX_COMMANDS_PER_AGENT = 256;
+const MAX_COMMAND_NAME_LENGTH = 128;
+const MAX_COMMAND_DESCRIPTION_LENGTH = 512;
+
+export type AgentCommand = {
+  name: string;
+  description: string | null;
+};
+
+export type AgentCommandCatalogEntry = {
+  commands: readonly AgentCommand[];
+  seq: number;
+  timestamp: string;
+};
+
+export type AgentCommandCatalog = ReadonlyMap<string, AgentCommandCatalogEntry>;
+
+type PersistedCatalog = {
+  version: 1;
+  agents: Record<string, AgentCommandCatalogEntry>;
+};
+
+type AvailableCommandsEvent = {
+  payload: unknown;
+  seq: number;
+  timestamp: string;
+};
+
+const EMPTY_CATALOG: AgentCommandCatalog = new Map();
+// Managed-agent observer ingestion is owner-global; command capabilities belong
+// to the agent pubkey rather than whichever community currently renders it.
+const catalogByOwner = new Map<string, AgentCommandCatalog>();
+const listeners = new Set<() => void>();
+
+function storageKey(ownerPubkey: string): string {
+  return `${STORAGE_PREFIX}:${normalizePubkey(ownerPubkey)}`;
+}
+
+function sanitizeCommand(value: unknown): AgentCommand | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.name !== "string") return null;
+
+  const name = record.name.trim().replace(/^\/+/, "");
+  if (
+    name.length === 0 ||
+    name.length > MAX_COMMAND_NAME_LENGTH ||
+    /[\s/\p{Cc}\p{Cf}]/u.test(name)
+  ) {
+    return null;
+  }
+
+  const description =
+    typeof record.description === "string"
+      ? record.description
+          .replace(/[\p{Cc}\p{Bidi_Control}]/gu, " ")
+          .trim()
+          .slice(0, MAX_COMMAND_DESCRIPTION_LENGTH) || null
+      : null;
+  return { name, description };
+}
+
+export function parseAvailableCommandsPayload(
+  payload: unknown,
+): readonly AgentCommand[] | null {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    return null;
+  }
+  const commands = (payload as Record<string, unknown>).commands;
+  if (!Array.isArray(commands)) return null;
+
+  const parsed: AgentCommand[] = [];
+  const seen = new Set<string>();
+  for (const value of commands.slice(0, MAX_COMMANDS_PER_AGENT)) {
+    const command = sanitizeCommand(value);
+    if (!command) continue;
+    const key = command.name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    parsed.push(command);
+  }
+  return parsed;
+}
+
+function parseStoredCatalog(raw: string | null): AgentCommandCatalog {
+  if (!raw) return EMPTY_CATALOG;
+  try {
+    const parsed = JSON.parse(raw) as Partial<PersistedCatalog>;
+    if (
+      parsed.version !== 1 ||
+      !parsed.agents ||
+      typeof parsed.agents !== "object"
+    ) {
+      return EMPTY_CATALOG;
+    }
+    const next = new Map<string, AgentCommandCatalogEntry>();
+    for (const [pubkey, entry] of Object.entries(parsed.agents)) {
+      if (!entry || typeof entry !== "object") continue;
+      const candidate = entry as Partial<AgentCommandCatalogEntry>;
+      const commands = parseAvailableCommandsPayload({
+        commands: candidate.commands,
+      });
+      if (
+        commands === null ||
+        typeof candidate.seq !== "number" ||
+        !Number.isSafeInteger(candidate.seq) ||
+        typeof candidate.timestamp !== "string"
+      ) {
+        continue;
+      }
+      next.set(normalizePubkey(pubkey), {
+        commands,
+        seq: candidate.seq,
+        timestamp: candidate.timestamp,
+      });
+    }
+    return next;
+  } catch {
+    return EMPTY_CATALOG;
+  }
+}
+
+function hydrate(ownerPubkey: string): AgentCommandCatalog {
+  const owner = normalizePubkey(ownerPubkey);
+  if (!catalogByOwner.has(owner)) {
+    let raw: string | null = null;
+    try {
+      if (typeof window !== "undefined")
+        raw = window.localStorage.getItem(storageKey(owner));
+    } catch {
+      // Storage can be unavailable; live updates still maintain the memory cache.
+    }
+    catalogByOwner.set(owner, parseStoredCatalog(raw));
+  }
+  return catalogByOwner.get(owner) ?? EMPTY_CATALOG;
+}
+
+function persist(ownerPubkey: string, catalog: AgentCommandCatalog): void {
+  if (typeof window === "undefined") return;
+  const agents = Object.fromEntries(catalog.entries());
+  setLocalStorageItemWithRecovery(
+    storageKey(ownerPubkey),
+    JSON.stringify({ version: 1, agents } satisfies PersistedCatalog),
+  );
+}
+
+function isNewer(
+  incoming: Pick<AgentCommandCatalogEntry, "seq" | "timestamp">,
+  current: AgentCommandCatalogEntry | undefined,
+): boolean {
+  if (!current) return true;
+  const incomingTime = Date.parse(incoming.timestamp);
+  const currentTime = Date.parse(current.timestamp);
+  if (Number.isFinite(incomingTime) && Number.isFinite(currentTime)) {
+    if (incomingTime !== currentTime) return incomingTime > currentTime;
+  }
+  return incoming.seq > current.seq;
+}
+
+export function recordAvailableCommandsUpdate(
+  ownerPubkey: string,
+  agentPubkey: string,
+  event: AvailableCommandsEvent,
+): boolean {
+  const commands = parseAvailableCommandsPayload(event.payload);
+  if (commands === null || !Number.isSafeInteger(event.seq)) return false;
+
+  const owner = normalizePubkey(ownerPubkey);
+  const agent = normalizePubkey(agentPubkey);
+  const current = hydrate(owner);
+  if (!isNewer(event, current.get(agent))) return false;
+
+  const next = new Map(current);
+  next.set(agent, {
+    commands,
+    seq: event.seq,
+    timestamp: event.timestamp,
+  });
+  catalogByOwner.set(owner, next);
+  persist(owner, next);
+  for (const listener of listeners) listener();
+  return true;
+}
+
+export function getAgentCommandCatalog(
+  ownerPubkey: string | null,
+): AgentCommandCatalog {
+  return ownerPubkey ? hydrate(ownerPubkey) : EMPTY_CATALOG;
+}
+
+export function subscribeAgentCommandCatalog(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function resetAgentCommandCatalogForTests(): void {
+  catalogByOwner.clear();
+  listeners.clear();
+}

--- a/desktop/src/features/agents/agentCommandCatalog.ts
+++ b/desktop/src/features/agents/agentCommandCatalog.ts
@@ -6,17 +6,20 @@ const MAX_COMMANDS_PER_AGENT = 256;
 const MAX_COMMAND_NAME_LENGTH = 128;
 const MAX_COMMAND_DESCRIPTION_LENGTH = 512;
 
+/** A sanitized command advertised by an ACP connector. */
 export type AgentCommand = {
   name: string;
   description: string | null;
 };
 
+/** The latest complete command snapshot and its observer ordering key. */
 export type AgentCommandCatalogEntry = {
   commands: readonly AgentCommand[];
   seq: number;
   timestamp: string;
 };
 
+/** Commands indexed by normalized agent pubkey within an owner and community. */
 export type AgentCommandCatalog = ReadonlyMap<string, AgentCommandCatalogEntry>;
 
 type PersistedCatalog = {
@@ -31,13 +34,25 @@ type AvailableCommandsEvent = {
 };
 
 const EMPTY_CATALOG: AgentCommandCatalog = new Map();
-// Managed-agent observer ingestion is owner-global; command capabilities belong
-// to the agent pubkey rather than whichever community currently renders it.
+let communityScope: string | null = null;
 const catalogByOwner = new Map<string, AgentCommandCatalog>();
 const listeners = new Set<() => void>();
 
 function storageKey(ownerPubkey: string): string {
-  return `${STORAGE_PREFIX}:${normalizePubkey(ownerPubkey)}`;
+  return `${STORAGE_PREFIX}:${encodeURIComponent(communityScope ?? "")}:${normalizePubkey(ownerPubkey)}`;
+}
+
+/** Scope both memory and persisted command catalogs to the active community. */
+export function initAgentCommandCatalog(communityId: string | null): void {
+  if (communityScope === communityId) return;
+  communityScope = communityId;
+  catalogByOwner.clear();
+  for (const listener of listeners) listener();
+}
+
+/** Retire the current community's memory cache before another community mounts. */
+export function resetAgentCommandCatalog(): void {
+  initAgentCommandCatalog(null);
 }
 
 function sanitizeCommand(value: unknown): AgentCommand | null {
@@ -66,6 +81,7 @@ function sanitizeCommand(value: unknown): AgentCommand | null {
   return { name, description };
 }
 
+/** Bound and sanitize an untrusted snapshot; null denotes a malformed payload. */
 export function parseAvailableCommandsPayload(
   payload: unknown,
 ): readonly AgentCommand[] | null {
@@ -114,7 +130,8 @@ function parseStoredCatalog(raw: string | null): AgentCommandCatalog {
         commands === null ||
         typeof candidate.seq !== "number" ||
         !Number.isSafeInteger(candidate.seq) ||
-        typeof candidate.timestamp !== "string"
+        typeof candidate.timestamp !== "string" ||
+        !Number.isFinite(Date.parse(candidate.timestamp))
       ) {
         continue;
       }
@@ -167,13 +184,20 @@ function isNewer(
   return incoming.seq > current.seq;
 }
 
+/** Record a newer complete snapshot, including an authoritative empty list. */
 export function recordAvailableCommandsUpdate(
   ownerPubkey: string,
   agentPubkey: string,
   event: AvailableCommandsEvent,
 ): boolean {
+  if (communityScope === null) return false;
   const commands = parseAvailableCommandsPayload(event.payload);
-  if (commands === null || !Number.isSafeInteger(event.seq)) return false;
+  if (
+    commands === null ||
+    !Number.isSafeInteger(event.seq) ||
+    !Number.isFinite(Date.parse(event.timestamp))
+  )
+    return false;
 
   const owner = normalizePubkey(ownerPubkey);
   const agent = normalizePubkey(agentPubkey);
@@ -192,18 +216,24 @@ export function recordAvailableCommandsUpdate(
   return true;
 }
 
+/** Read the active community's last known commands for an owner. */
 export function getAgentCommandCatalog(
   ownerPubkey: string | null,
 ): AgentCommandCatalog {
-  return ownerPubkey ? hydrate(ownerPubkey) : EMPTY_CATALOG;
+  return ownerPubkey && communityScope !== null
+    ? hydrate(ownerPubkey)
+    : EMPTY_CATALOG;
 }
 
+/** Subscribe to command snapshot or community changes. */
 export function subscribeAgentCommandCatalog(listener: () => void): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
 }
 
+/** Clear module state and subscriptions between tests. */
 export function resetAgentCommandCatalogForTests(): void {
+  communityScope = null;
   catalogByOwner.clear();
   listeners.clear();
 }

--- a/desktop/src/features/agents/ingestArchivedObserverEvents.test.mjs
+++ b/desktop/src/features/agents/ingestArchivedObserverEvents.test.mjs
@@ -12,6 +12,10 @@ import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 
 import {
+  getAgentCommandCatalog,
+  resetAgentCommandCatalogForTests,
+} from "@/features/agents/agentCommandCatalog.ts";
+import {
   ingestArchivedObserverEvents,
   injectObserverEventsForE2E,
   getAgentObserverSnapshot,
@@ -74,6 +78,7 @@ function makeDecryptFail() {
 describe("ingestArchivedObserverEvents", () => {
   beforeEach(() => {
     resetAgentObserverStore();
+    resetAgentCommandCatalogForTests();
   });
 
   it("test_unknown_agent_drops_event_before_decrypt", async () => {
@@ -92,6 +97,28 @@ describe("ingestArchivedObserverEvents", () => {
     );
     const snap = getAgentObserverSnapshot(AGENT_PUBKEY, true);
     assert.equal(snap.events.length, 0);
+  });
+
+  it("hydrates command catalogs from trusted archived semantic frames", async () => {
+    _testRegisterKnownAgents(SUB_ID, [AGENT_PUBKEY]);
+    const ownerPubkey = "c".repeat(64);
+    const commandEvent = makeObserverEvent({
+      kind: "available_commands_captured",
+      payload: {
+        commands: [{ name: "review", description: "Review changes" }],
+      },
+    });
+
+    await ingestArchivedObserverEvents(
+      [makeRawEvent()],
+      makeDecrypt(commandEvent),
+      async () => ownerPubkey,
+    );
+
+    assert.deepEqual(
+      getAgentCommandCatalog(ownerPubkey).get(AGENT_PUBKEY)?.commands,
+      [{ name: "review", description: "Review changes" }],
+    );
   });
 
   it("test_mismatched_sender_drops_event_before_decrypt", async () => {
@@ -687,6 +714,7 @@ describe("eager initial hydration loop control flow (production runHydrationLoop
 describe("archive window holds more than MAX_OBSERVER_EVENTS (3000) frames", () => {
   beforeEach(() => {
     resetAgentObserverStore();
+    resetAgentCommandCatalogForTests();
   });
 
   it("test_archive_window_retains_all_events_beyond_3000_cap", async () => {
@@ -804,6 +832,7 @@ import { mergeObserverEventWindows } from "@/features/agents/ui/agentSessionPane
 describe("archive page subscription notification", () => {
   beforeEach(() => {
     resetAgentObserverStore();
+    resetAgentCommandCatalogForTests();
   });
 
   it("test_full_archive_page_notifies_subscribers", async () => {
@@ -882,6 +911,7 @@ describe("archive page subscription notification", () => {
 describe("raw-event-level merge: stateful aggregates across live/archive boundary", () => {
   beforeEach(() => {
     resetAgentObserverStore();
+    resetAgentCommandCatalogForTests();
   });
 
   it("test_tool_start_in_archive_plus_update_in_live_yields_complete_row", () => {

--- a/desktop/src/features/agents/ingestArchivedObserverEvents.test.mjs
+++ b/desktop/src/features/agents/ingestArchivedObserverEvents.test.mjs
@@ -13,6 +13,7 @@ import { beforeEach, describe, it } from "node:test";
 
 import {
   getAgentCommandCatalog,
+  initAgentCommandCatalog,
   resetAgentCommandCatalogForTests,
 } from "@/features/agents/agentCommandCatalog.ts";
 import {
@@ -79,6 +80,7 @@ describe("ingestArchivedObserverEvents", () => {
   beforeEach(() => {
     resetAgentObserverStore();
     resetAgentCommandCatalogForTests();
+    initAgentCommandCatalog("test-community");
   });
 
   it("test_unknown_agent_drops_event_before_decrypt", async () => {
@@ -119,6 +121,56 @@ describe("ingestArchivedObserverEvents", () => {
       getAgentCommandCatalog(ownerPubkey).get(AGENT_PUBKEY)?.commands,
       [{ name: "review", description: "Review changes" }],
     );
+  });
+
+  it("hydrates the latest catalog from batched archive frames", async () => {
+    _testRegisterKnownAgents(SUB_ID, [AGENT_PUBKEY]);
+    const owner = "c".repeat(64);
+    await ingestArchivedObserverEvents(
+      [makeRawEvent()],
+      makeDecrypt(
+        makeObserverEvent({
+          kind: "batch",
+          payload: {
+            events: [
+              makeObserverEvent({
+                kind: "available_commands_captured",
+                payload: { commands: [{ name: "review" }] },
+              }),
+              makeObserverEvent({
+                seq: 2,
+                kind: "available_commands_captured",
+                payload: { commands: [] },
+              }),
+            ],
+          },
+        }),
+      ),
+      async () => owner,
+    );
+    assert.deepEqual(
+      getAgentCommandCatalog(owner).get(AGENT_PUBKEY)?.commands,
+      [],
+    );
+  });
+
+  it("does not restore command catalogs after reset during owner lookup", async () => {
+    _testRegisterKnownAgents(SUB_ID, [AGENT_PUBKEY]);
+    const owner = "c".repeat(64);
+    await ingestArchivedObserverEvents(
+      [makeRawEvent()],
+      makeDecrypt(
+        makeObserverEvent({
+          kind: "available_commands_captured",
+          payload: { commands: [{ name: "review" }] },
+        }),
+      ),
+      async () => {
+        resetAgentObserverStore();
+        return owner;
+      },
+    );
+    assert.equal(getAgentCommandCatalog(owner).size, 0);
   });
 
   it("test_mismatched_sender_drops_event_before_decrypt", async () => {

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -14,6 +14,7 @@ import {
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { useQueryClient } from "@tanstack/react-query";
 import { agentConfigSurfaceQueryKey } from "@/features/agents/hooks";
+import { recordAvailableCommandsUpdate } from "./agentCommandCatalog";
 import type {
   ConnectionState,
   ObserverEvent,
@@ -168,6 +169,7 @@ let unsubscribeRelay: (() => Promise<void>) | null = null;
 let startPromise: Promise<void> | null = null;
 let eventProcessingQueue: Promise<void> = Promise.resolve();
 let generation = 0;
+let observerOwnerPubkey: string | null = null;
 
 function notifyListeners() {
   for (const listener of listeners) {
@@ -401,6 +403,11 @@ async function handleRelayObserverEvent(
     if (parsed.kind === "session_config_captured") {
       void putAgentSessionConfig(agentPubkey, parsed.payload);
       onSessionConfigCaptured?.(agentPubkey);
+    } else if (
+      parsed.kind === "available_commands_captured" &&
+      observerOwnerPubkey
+    ) {
+      recordAvailableCommandsUpdate(observerOwnerPubkey, agentPubkey, parsed);
     } else if (parsed.kind === "control_result") {
       dispatchControlResult(agentPubkey, parsed.payload);
     } else if (parsed.kind === "managed_agent_runtime_lifecycle") {
@@ -435,6 +442,10 @@ export function ensureRelayObserverSubscription() {
   setConnectionState("connecting", null);
   startPromise = (async () => {
     const identity = await getIdentity();
+    if (activeGeneration !== generation) {
+      return;
+    }
+    observerOwnerPubkey = normalizePubkey(identity.pubkey);
     const unsubscribe = await subscribeToAgentObserverFrames(
       identity.pubkey,
       (event) => {
@@ -654,14 +665,18 @@ export function useManagedAgentObserverBridge(
  * (e.g. an agent that is stopped but has archived history) are dropped.
  * The caller should ensure the agent is registered before calling.
  *
- * `_decryptFn` is only used by tests to inject a mock decryption function.
- * Production callers must always omit it.
+ * `_decryptFn` and `_ownerPubkeyFn` are only used by tests to inject mock
+ * functions. Production callers must always omit them.
  */
 export async function ingestArchivedObserverEvents(
   rawEvents: RelayEvent[],
   _decryptFn: (event: RelayEvent) => Promise<unknown> = decryptObserverEvent,
+  _ownerPubkeyFn: () => Promise<string> = async () =>
+    normalizePubkey((await getIdentity()).pubkey),
 ): Promise<void> {
+  const activeGeneration = generation;
   let archiveChanged = false;
+  let archiveOwnerPubkey = observerOwnerPubkey;
   for (const event of rawEvents) {
     const agentPubkey = observerTag(event, "agent");
     const frame = observerTag(event, "frame");
@@ -676,6 +691,12 @@ export async function ingestArchivedObserverEvents(
     }
     try {
       const parsed = (await _decryptFn(event)) as ObserverEvent;
+      if (activeGeneration !== generation) return;
+      if (parsed.kind === "available_commands_captured") {
+        archiveOwnerPubkey ??= normalizePubkey(await _ownerPubkeyFn());
+        if (activeGeneration !== generation) return;
+        recordAvailableCommandsUpdate(archiveOwnerPubkey, agentPubkey, parsed);
+      }
       // Route archived events to the channel-scoped archive window (no cap)
       // rather than the per-agent live-relay store (MAX_OBSERVER_EVENTS cap).
       // Events without a channelId fall through to the live store so they
@@ -741,6 +762,7 @@ export function resetAgentObserverStore() {
   unsubscribeRelay = null;
   startPromise = null;
   eventProcessingQueue = Promise.resolve();
+  observerOwnerPubkey = null;
   eventsByAgent.clear();
   transcriptByAgent.clear();
   snapshotByAgent.clear();

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -7,6 +7,7 @@ import { putAgentSessionConfig } from "@/shared/api/tauri";
 import { putManagedAgentRuntimeLifecycle } from "@/shared/api/tauriManagedAgents";
 import { getIdentity } from "@/shared/api/tauriIdentity";
 import { decryptObserverEvent } from "@/shared/api/tauriObserver";
+import { recordAvailableCommandsUpdate } from "./agentCommandCatalog";
 import {
   parseAgentManagementRequest,
   type AgentManagementRequest,
@@ -65,6 +66,7 @@ export type AgentObserverStoreUpdate = {
 type AgentObserverStoreListener = (update?: AgentObserverStoreUpdate) => void;
 
 const listeners = new Set<AgentObserverStoreListener>();
+let observerOwnerPubkey: string | null = null;
 const eventsByAgent = new Map<string, ObserverEvent[]>();
 const transcriptByAgent = new Map<string, TranscriptState>();
 const snapshotByAgent = new Map<string, ObserverSnapshot>();
@@ -488,6 +490,9 @@ function processLiveObserverEvents(
   const accepted = appendAgentEvents(agentPubkey, events);
 
   for (const parsed of accepted ?? []) {
+    if (parsed.kind === "available_commands_captured" && observerOwnerPubkey) {
+      recordAvailableCommandsUpdate(observerOwnerPubkey, agentPubkey, parsed);
+    }
     // Track the latest-live-session-id per (agent, channel) on the live path.
     // Only set when the parsed event carries both a sessionId and channelId,
     // so we never attribute a session to the wrong channel.
@@ -602,6 +607,8 @@ export function ensureRelayObserverSubscription() {
   setConnectionState("connecting", null);
   startPromise = (async () => {
     const identity = await getIdentity();
+    if (activeGeneration !== generation) return;
+    observerOwnerPubkey = normalizePubkey(identity.pubkey);
     const unsubscribe = await subscribeToAgentObserverFrames(
       identity.pubkey,
       (event) => {
@@ -847,7 +854,11 @@ export function useManagedAgentObserverBridge(
 export async function ingestArchivedObserverEvents(
   rawEvents: RelayEvent[],
   _decryptFn: (event: RelayEvent) => Promise<unknown> = decryptObserverEvent,
+  _ownerPubkeyFn: () => Promise<string> = async () =>
+    (await getIdentity()).pubkey,
 ): Promise<void> {
+  const activeGeneration = generation;
+  let archiveOwnerPubkey: string | null = null;
   let archiveChanged = false;
   for (const event of rawEvents) {
     const agentPubkey = observerTag(event, "agent");
@@ -863,7 +874,13 @@ export async function ingestArchivedObserverEvents(
     }
     try {
       const parsed = (await _decryptFn(event)) as ObserverEvent;
+      if (activeGeneration !== generation) return;
       for (const inner of unwrapObserverBatch(parsed)) {
+        if (inner.kind === "available_commands_captured") {
+          archiveOwnerPubkey ??= normalizePubkey(await _ownerPubkeyFn());
+          if (activeGeneration !== generation) return;
+          recordAvailableCommandsUpdate(archiveOwnerPubkey, agentPubkey, inner);
+        }
         // Route archived events to the channel-scoped archive window (no cap)
         // rather than the per-agent live-relay store (MAX_OBSERVER_EVENTS cap).
         // Events without a channelId fall through to the live store so they
@@ -927,6 +944,7 @@ export function syncAgentObserverEvents(
 
 export function resetAgentObserverStore() {
   generation += 1;
+  observerOwnerPubkey = null;
   const unsubscribe = unsubscribeRelay;
   unsubscribeRelay = null;
   startPromise = null;

--- a/desktop/src/features/agents/useAgentCommandCatalog.ts
+++ b/desktop/src/features/agents/useAgentCommandCatalog.ts
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+import {
+  getAgentCommandCatalog,
+  subscribeAgentCommandCatalog,
+} from "./agentCommandCatalog";
+
+export function useAgentCommandCatalog(ownerPubkey: string | null) {
+  return React.useSyncExternalStore(
+    subscribeAgentCommandCatalog,
+    () => getAgentCommandCatalog(ownerPubkey),
+    () => getAgentCommandCatalog(null),
+  );
+}

--- a/desktop/src/features/agents/useAgentCommandCatalog.ts
+++ b/desktop/src/features/agents/useAgentCommandCatalog.ts
@@ -5,6 +5,7 @@ import {
   subscribeAgentCommandCatalog,
 } from "./agentCommandCatalog";
 
+/** Subscribe to the current owner's command catalog without copying snapshots. */
 export function useAgentCommandCatalog(ownerPubkey: string | null) {
   return React.useSyncExternalStore(
     subscribeAgentCommandCatalog,

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -36,6 +36,10 @@ import {
 } from "@/features/agents/activeAgentTurnsStore";
 import { resetAgentWorkingSignal } from "@/features/agents/agentWorkingSignal";
 import { resetAgentObserverStore } from "@/features/agents/observerRelayStore";
+import {
+  initAgentCommandCatalog,
+  resetAgentCommandCatalog,
+} from "@/features/agents/agentCommandCatalog";
 import { resetAvatarPresentations } from "@/features/profile/avatarPresentationStore";
 import { resetAvatarProfileSync } from "@/features/profile/avatarProfileSync";
 import { resetSidebarRelayConnectionCardState } from "@/features/sidebar/ui/useSidebarRelayConnectionCard";
@@ -66,6 +70,7 @@ async function resetCommunityState({
   resetRateLimitGate();
   clearAllDrafts();
   resetAgentObserverStore();
+  resetAgentCommandCatalog();
   resetActiveAgentTurnsStore();
   resetAgentWorkingSignal();
   if (isTauri() && isMacPlatform()) {
@@ -353,6 +358,7 @@ export function useCommunityInit(
         if (identityPubkey !== null) {
           initDraftStore(identityPubkey, activeCommunity.relayUrl);
         }
+        initAgentCommandCatalog(activeCommunity.id);
         // Restore any turn state saved for this community (a prior A→B round-
         // trip). This runs after applyCommunity succeeds and before the app
         // renders so components see the restored timers on first render.

--- a/desktop/src/features/messages/lib/slashCommandAutocomplete.test.mjs
+++ b/desktop/src/features/messages/lib/slashCommandAutocomplete.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildSlashCommandGroups,
+  buildSlashCommandInsertText,
+  detectSlashCommandQuery,
+  resolveLeadingAgentMentionPubkeys,
+} from "./slashCommandAutocomplete.ts";
+
+const ALPHA = "aa".repeat(32);
+const BETA = "bb".repeat(32);
+const catalog = new Map([
+  [
+    ALPHA,
+    {
+      seq: 1,
+      timestamp: "2026-07-23T08:00:00Z",
+      commands: [
+        { name: "review", description: "Review the current changes" },
+        { name: "deploy", description: "Ship to production" },
+      ],
+    },
+  ],
+  [
+    BETA,
+    {
+      seq: 1,
+      timestamp: "2026-07-23T08:00:00Z",
+      commands: [{ name: "review", description: "Independent review" }],
+    },
+  ],
+]);
+const providers = [
+  { pubkey: ALPHA, displayName: "Alpha" },
+  { pubkey: BETA, displayName: "Beta" },
+];
+
+describe("slash command autocomplete", () => {
+  it("detects a slash at message start and after leading agent mentions", () => {
+    assert.deepEqual(detectSlashCommandQuery("/rev", 4), {
+      leadingText: "",
+      query: "rev",
+      replaceFromOffset: 0,
+    });
+    assert.deepEqual(detectSlashCommandQuery("@Alpha /dep", 11), {
+      leadingText: "@Alpha ",
+      query: "dep",
+      replaceFromOffset: 7,
+    });
+  });
+
+  it("resolves selected or manually typed leading member-agent mentions", () => {
+    assert.deepEqual(
+      resolveLeadingAgentMentionPubkeys("@Alpha ", [
+        { displayName: "Alpha", pubkey: ALPHA },
+      ]),
+      [ALPHA],
+    );
+    assert.deepEqual(
+      resolveLeadingAgentMentionPubkeys("@Alpha @Beta ", [
+        { displayName: "Alpha", pubkey: ALPHA },
+        { displayName: "Beta", pubkey: BETA },
+      ]),
+      [ALPHA, BETA],
+    );
+    assert.deepEqual(
+      resolveLeadingAgentMentionPubkeys("@Alpha hello ", [
+        { displayName: "Alpha", pubkey: ALPHA },
+      ]),
+      [],
+    );
+  });
+
+  it("does not trigger for inline paths, arguments, or multi-line text", () => {
+    assert.equal(detectSlashCommandQuery("please /review", 14), null);
+    assert.equal(detectSlashCommandQuery("/review now", 11), null);
+    assert.equal(detectSlashCommandQuery("hello\n/review", 13), null);
+  });
+
+  it("routes commands chosen at message start through the provider mention", () => {
+    const [group] = buildSlashCommandGroups({
+      catalog,
+      providers: [providers[0]],
+      query: "rev",
+      selectedAgentPubkeys: null,
+    });
+    const [suggestion] = group.commands;
+
+    assert.equal(
+      buildSlashCommandInsertText(suggestion, false),
+      "@Alpha /review ",
+    );
+    assert.equal(buildSlashCommandInsertText(suggestion, true), "/review ");
+  });
+
+  it("groups duplicate command names by provider and narrows to mentions", () => {
+    const all = buildSlashCommandGroups({
+      catalog,
+      providers,
+      query: "rev",
+      selectedAgentPubkeys: null,
+    });
+    assert.deepEqual(
+      all.map((group) => [group.agentDisplayName, group.commands[0].name]),
+      [
+        ["Alpha", "review"],
+        ["Beta", "review"],
+      ],
+    );
+
+    const mentioned = buildSlashCommandGroups({
+      catalog,
+      providers,
+      query: "",
+      selectedAgentPubkeys: [BETA],
+    });
+    assert.deepEqual(
+      mentioned.map((group) => group.agentPubkey),
+      [BETA],
+    );
+  });
+
+  it("ranks name prefixes before infix and description matches", () => {
+    const rankedCatalog = new Map([
+      [
+        ALPHA,
+        {
+          seq: 1,
+          timestamp: "2026-07-23T08:00:00Z",
+          commands: [
+            { name: "preview", description: null },
+            { name: "review", description: null },
+            { name: "inspect", description: "review changes" },
+          ],
+        },
+      ],
+    ]);
+    const [group] = buildSlashCommandGroups({
+      catalog: rankedCatalog,
+      providers: [providers[0]],
+      query: "rev",
+      selectedAgentPubkeys: null,
+    });
+    assert.deepEqual(
+      group.commands.map((command) => command.name),
+      ["review", "preview", "inspect"],
+    );
+  });
+});

--- a/desktop/src/features/messages/lib/slashCommandAutocomplete.ts
+++ b/desktop/src/features/messages/lib/slashCommandAutocomplete.ts
@@ -1,0 +1,170 @@
+import type { AgentCommandCatalog } from "@/features/agents/agentCommandCatalog";
+
+export type SlashCommandProvider = {
+  pubkey: string;
+  displayName: string;
+};
+
+export type AgentMentionCandidate = {
+  displayName: string;
+  pubkey: string;
+};
+
+export type SlashCommandSuggestion = {
+  agentDisplayName: string;
+  agentPubkey: string;
+  description: string | null;
+  name: string;
+};
+
+export type SlashCommandGroup = {
+  agentDisplayName: string;
+  agentPubkey: string;
+  commands: readonly SlashCommandSuggestion[];
+};
+
+export type SlashCommandQuery = {
+  leadingText: string;
+  query: string;
+  replaceFromOffset: number;
+};
+
+export function detectSlashCommandQuery(
+  value: string,
+  cursorPosition: number,
+): SlashCommandQuery | null {
+  const beforeCursor = value.slice(0, cursorPosition);
+  if (beforeCursor.includes("\n")) return null;
+
+  const slashIndex = beforeCursor.lastIndexOf("/");
+  if (slashIndex < 0) return null;
+  const leadingText = beforeCursor.slice(0, slashIndex);
+  const query = beforeCursor.slice(slashIndex + 1);
+  if (/\s|\//u.test(query)) return null;
+  if (
+    leadingText.length > 0 &&
+    (!leadingText.startsWith("@") || !/\s$/u.test(leadingText))
+  ) {
+    return null;
+  }
+
+  return { leadingText, query, replaceFromOffset: slashIndex };
+}
+
+export function resolveLeadingAgentMentionPubkeys(
+  leadingText: string,
+  candidates: readonly AgentMentionCandidate[],
+): string[] {
+  let remaining = leadingText;
+  const pubkeys: string[] = [];
+  const seen = new Set<string>();
+  const names = [
+    ...new Set(candidates.map((candidate) => candidate.displayName)),
+  ]
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length);
+
+  while (remaining.startsWith("@")) {
+    const lowerRemaining = remaining.toLowerCase();
+    const name = names.find((candidate) => {
+      const token = `@${candidate.toLowerCase()}`;
+      return (
+        lowerRemaining.startsWith(token) &&
+        (remaining.length === token.length ||
+          /\s/u.test(remaining.charAt(token.length)))
+      );
+    });
+    if (!name) return [];
+
+    for (const candidate of candidates) {
+      if (candidate.displayName.toLowerCase() !== name.toLowerCase()) continue;
+      const normalized = candidate.pubkey.toLowerCase();
+      if (!seen.has(normalized)) {
+        seen.add(normalized);
+        pubkeys.push(normalized);
+      }
+    }
+
+    remaining = remaining.slice(name.length + 1);
+    const whitespace = remaining.match(/^\s+/u)?.[0] ?? "";
+    if (!whitespace) return [];
+    remaining = remaining.slice(whitespace.length);
+  }
+
+  return remaining.length === 0 ? pubkeys : [];
+}
+
+export function buildSlashCommandInsertText(
+  suggestion: SlashCommandSuggestion,
+  hasLeadingAgentMention: boolean,
+): string {
+  const command = `/${suggestion.name} `;
+  return hasLeadingAgentMention
+    ? command
+    : `@${suggestion.agentDisplayName} ${command}`;
+}
+
+function commandRank(
+  name: string,
+  description: string | null,
+  query: string,
+): number | null {
+  if (!query) return 0;
+  const lowerName = name.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  if (lowerName.startsWith(lowerQuery)) return 0;
+  if (lowerName.includes(lowerQuery)) return 1;
+  if (description?.toLowerCase().includes(lowerQuery)) return 2;
+  return null;
+}
+
+export function buildSlashCommandGroups({
+  catalog,
+  providers,
+  query,
+  selectedAgentPubkeys,
+}: {
+  catalog: AgentCommandCatalog;
+  providers: readonly SlashCommandProvider[];
+  query: string;
+  selectedAgentPubkeys: readonly string[] | null;
+}): SlashCommandGroup[] {
+  const selected = selectedAgentPubkeys
+    ? new Set(selectedAgentPubkeys.map((pubkey) => pubkey.toLowerCase()))
+    : null;
+
+  return providers
+    .filter(
+      (provider) => !selected || selected.has(provider.pubkey.toLowerCase()),
+    )
+    .map((provider) => {
+      const commands = (
+        catalog.get(provider.pubkey.toLowerCase())?.commands ?? []
+      )
+        .map((command) => ({
+          command,
+          rank: commandRank(command.name, command.description, query),
+        }))
+        .filter(
+          (entry): entry is typeof entry & { rank: number } =>
+            entry.rank !== null,
+        )
+        .sort(
+          (left, right) =>
+            left.rank - right.rank ||
+            left.command.name.localeCompare(right.command.name),
+        )
+        .map(({ command }) => ({
+          agentDisplayName: provider.displayName,
+          agentPubkey: provider.pubkey,
+          description: command.description,
+          name: command.name,
+        }));
+      return {
+        agentDisplayName: provider.displayName,
+        agentPubkey: provider.pubkey,
+        commands,
+      };
+    })
+    .filter((group) => group.commands.length > 0);
+}

--- a/desktop/src/features/messages/lib/slashCommandAutocomplete.ts
+++ b/desktop/src/features/messages/lib/slashCommandAutocomplete.ts
@@ -1,11 +1,13 @@
 import type { AgentCommandCatalog } from "@/features/agents/agentCommandCatalog";
 import { mentionOccurrences } from "@/shared/lib/mentionOccurrences";
 
+/** A channel agent eligible to supply slash-command suggestions. */
 export type SlashCommandProvider = {
   pubkey: string;
   displayName: string;
 };
 
+/** A command bound to the specific agent that advertised it. */
 export type SlashCommandSuggestion = {
   agentDisplayName: string;
   agentPubkey: string;
@@ -13,18 +15,21 @@ export type SlashCommandSuggestion = {
   name: string;
 };
 
+/** Suggestions grouped by their originating agent. */
 export type SlashCommandGroup = {
   agentDisplayName: string;
   agentPubkey: string;
   commands: readonly SlashCommandSuggestion[];
 };
 
+/** A command query at message start or after leading mentions. */
 export type SlashCommandQuery = {
   leadingText: string;
   query: string;
   replaceFromOffset: number;
 };
 
+/** Detect a first-line command prefix without matching paths or arguments. */
 export function detectSlashCommandQuery(
   value: string,
   cursorPosition: number,
@@ -47,6 +52,7 @@ export function detectSlashCommandQuery(
   return { leadingText, query, replaceFromOffset: slashIndex };
 }
 
+/** Require a prefix made entirely of complete mention labels and separators. */
 export function resolveLeadingAgentMentionPubkeys(
   leadingText: string,
   candidates: readonly SlashCommandProvider[],
@@ -64,6 +70,7 @@ export function resolveLeadingAgentMentionPubkeys(
   return offset === leadingText.length ? [...pubkeys] : [];
 }
 
+/** Add the provider mention only when the message has no leading mentions. */
 export function buildSlashCommandInsertText(
   suggestion: SlashCommandSuggestion,
   hasLeadingAgentMention: boolean,
@@ -87,6 +94,7 @@ function commandRank(
   return null;
 }
 
+/** Filter by recipient and rank name matches before description matches. */
 export function buildSlashCommandGroups({
   catalog,
   providers,

--- a/desktop/src/features/messages/lib/slashCommandAutocomplete.ts
+++ b/desktop/src/features/messages/lib/slashCommandAutocomplete.ts
@@ -1,0 +1,140 @@
+import type { AgentCommandCatalog } from "@/features/agents/agentCommandCatalog";
+import { mentionOccurrences } from "@/shared/lib/mentionOccurrences";
+
+export type SlashCommandProvider = {
+  pubkey: string;
+  displayName: string;
+};
+
+export type SlashCommandSuggestion = {
+  agentDisplayName: string;
+  agentPubkey: string;
+  description: string | null;
+  name: string;
+};
+
+export type SlashCommandGroup = {
+  agentDisplayName: string;
+  agentPubkey: string;
+  commands: readonly SlashCommandSuggestion[];
+};
+
+export type SlashCommandQuery = {
+  leadingText: string;
+  query: string;
+  replaceFromOffset: number;
+};
+
+export function detectSlashCommandQuery(
+  value: string,
+  cursorPosition: number,
+): SlashCommandQuery | null {
+  const beforeCursor = value.slice(0, cursorPosition);
+  if (beforeCursor.includes("\n")) return null;
+
+  const slashIndex = beforeCursor.lastIndexOf("/");
+  if (slashIndex < 0) return null;
+  const leadingText = beforeCursor.slice(0, slashIndex);
+  const query = beforeCursor.slice(slashIndex + 1);
+  if (/\s|\//u.test(query)) return null;
+  if (
+    leadingText.length > 0 &&
+    (!leadingText.startsWith("@") || !/\s$/u.test(leadingText))
+  ) {
+    return null;
+  }
+
+  return { leadingText, query, replaceFromOffset: slashIndex };
+}
+
+export function resolveLeadingAgentMentionPubkeys(
+  leadingText: string,
+  candidates: readonly SlashCommandProvider[],
+): string[] {
+  const pubkeys = new Set<string>();
+  let offset = 0;
+  for (const match of mentionOccurrences(leadingText, candidates)) {
+    if (match.start !== offset) return [];
+    for (const candidate of match.candidates)
+      pubkeys.add(candidate.pubkey.toLowerCase());
+    const whitespace = leadingText.slice(match.end).match(/^\s+/u)?.[0];
+    if (!whitespace) return [];
+    offset = match.end + whitespace.length;
+  }
+  return offset === leadingText.length ? [...pubkeys] : [];
+}
+
+export function buildSlashCommandInsertText(
+  suggestion: SlashCommandSuggestion,
+  hasLeadingAgentMention: boolean,
+): string {
+  const command = `/${suggestion.name} `;
+  return hasLeadingAgentMention
+    ? command
+    : `@${suggestion.agentDisplayName} ${command}`;
+}
+
+function commandRank(
+  name: string,
+  description: string | null,
+  query: string,
+): number | null {
+  if (!query) return 0;
+  const lowerName = name.toLowerCase();
+  if (lowerName.startsWith(query)) return 0;
+  if (lowerName.includes(query)) return 1;
+  if (description?.toLowerCase().includes(query)) return 2;
+  return null;
+}
+
+export function buildSlashCommandGroups({
+  catalog,
+  providers,
+  query,
+  selectedAgentPubkeys,
+}: {
+  catalog: AgentCommandCatalog;
+  providers: readonly SlashCommandProvider[];
+  query: string;
+  selectedAgentPubkeys: readonly string[] | null;
+}): SlashCommandGroup[] {
+  const lowerQuery = query.toLowerCase();
+  const selected = selectedAgentPubkeys
+    ? new Set(selectedAgentPubkeys.map((pubkey) => pubkey.toLowerCase()))
+    : null;
+
+  return providers
+    .filter(
+      (provider) => !selected || selected.has(provider.pubkey.toLowerCase()),
+    )
+    .map((provider) => {
+      const commands = (
+        catalog.get(provider.pubkey.toLowerCase())?.commands ?? []
+      )
+        .map((command) => ({
+          command,
+          rank: commandRank(command.name, command.description, lowerQuery),
+        }))
+        .filter(
+          (entry): entry is typeof entry & { rank: number } =>
+            entry.rank !== null,
+        )
+        .sort(
+          (left, right) =>
+            left.rank - right.rank ||
+            left.command.name.localeCompare(right.command.name),
+        )
+        .map(({ command }) => ({
+          agentDisplayName: provider.displayName,
+          agentPubkey: provider.pubkey,
+          description: command.description,
+          name: command.name,
+        }));
+      return {
+        agentDisplayName: provider.displayName,
+        agentPubkey: provider.pubkey,
+        commands,
+      };
+    })
+    .filter((group) => group.commands.length > 0);
+}

--- a/desktop/src/features/messages/lib/useSlashCommandAutocomplete.test.mjs
+++ b/desktop/src/features/messages/lib/useSlashCommandAutocomplete.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+import * as React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { JSDOM } from "jsdom";
+import {
+  initAgentCommandCatalog,
+  recordAvailableCommandsUpdate,
+  resetAgentCommandCatalogForTests,
+} from "@/features/agents/agentCommandCatalog.ts";
+import {
+  extractMentionPubkeys,
+  selectedMentionLabel,
+} from "./extractMentionPubkeys.ts";
+import { useSlashCommandAutocomplete } from "./useSlashCommandAutocomplete.ts";
+
+const OWNER = "a".repeat(64);
+const ALPHA = "b".repeat(64);
+const BETA = "c".repeat(64);
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+const clients = [];
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+  for (const client of clients.splice(0)) client.clear();
+  resetAgentCommandCatalogForTests();
+  window.localStorage.clear();
+});
+after(() => dom.window.close());
+
+async function setup({ sameName = false } = {}) {
+  initAgentCommandCatalog("test-community");
+  const { renderHook } = await import("@testing-library/react");
+  const members = [
+    { pubkey: ALPHA, displayName: "Alpha", isAgent: true, isMember: true },
+    {
+      pubkey: BETA,
+      displayName: sameName ? "Alpha" : "Beta",
+      isAgent: true,
+      isMember: true,
+    },
+  ];
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  clients.push(client);
+  client.setQueryData(["channels", "channel", "members"], members);
+  client.setQueryData(["channels", "other-channel", "members"], members);
+  for (const member of members) {
+    recordAvailableCommandsUpdate(OWNER, member.pubkey, {
+      seq: 1,
+      timestamp: "2026-07-23T08:00:00Z",
+      payload: { commands: [{ name: "review" }, { name: "deploy" }] },
+    });
+  }
+  const bindings = new Map();
+  const mentions = {
+    registerMentionPubkey(name, pubkey) {
+      const label = selectedMentionLabel(name, pubkey, bindings);
+      bindings.set(label, pubkey);
+      return label;
+    },
+    getMentionIdentities: () => [
+      ...[...bindings].map(([label, pubkey]) => ({
+        label,
+        pubkey,
+        isAgent: true,
+      })),
+      ...members
+        .filter((member) => !bindings.has(member.displayName))
+        .map((member) => ({
+          label: member.displayName,
+          pubkey: member.pubkey,
+          isAgent: true,
+        })),
+    ],
+    extractMentionPubkeys: (text) =>
+      extractMentionPubkeys({
+        text,
+        selectedMentions: bindings,
+        memberCandidates: members,
+      }),
+  };
+  const hook = renderHook(
+    ({ channelId }) =>
+      useSlashCommandAutocomplete({
+        channelId,
+        ownerPubkey: OWNER,
+        mentions,
+      }),
+    {
+      initialProps: { channelId: "channel" },
+      wrapper: ({ children }) =>
+        React.createElement(QueryClientProvider, { client }, children),
+    },
+  );
+  return { ...hook, bindings, mentions };
+}
+
+function keyEvent(key, modifiers = {}) {
+  return {
+    key,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    ...modifiers,
+  };
+}
+
+test("keyboard selection inserts and binds the exact registered same-name agent label", async () => {
+  const { act } = await import("@testing-library/react");
+  const { result, mentions } = await setup({ sameName: true });
+  mentions.registerMentionPubkey("Alpha", ALPHA);
+  act(() => result.current.updateQuery("/rev", 4));
+  act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+  let edit;
+  act(() => {
+    const selection = result.current.handleKeyDown(keyEvent("Enter"));
+    edit = result.current.insertCommand(selection.suggestion, 4);
+  });
+  assert.equal(edit.insertText, `@Alpha (${BETA}) /review `);
+  assert.deepEqual(mentions.extractMentionPubkeys(edit.insertText), [BETA]);
+  assert.equal(result.current.isOpen, false);
+  const text = `@Alpha (${BETA}) /rev`;
+  act(() => result.current.updateQuery(text, text.length));
+  assert.deepEqual(
+    result.current.groups.map((group) => group.agentPubkey),
+    [BETA],
+  );
+});
+
+test("ambiguous manually typed names do not offer a command to an arbitrary agent", async () => {
+  const { act } = await import("@testing-library/react");
+  const { result } = await setup({ sameName: true });
+  act(() => result.current.updateQuery("@Alpha /rev", 11));
+  assert.equal(result.current.isOpen, false);
+});
+
+test("escape keeps the literal query dismissed until it changes and tab selects", async () => {
+  const { act } = await import("@testing-library/react");
+  const { result } = await setup();
+  act(() => result.current.updateQuery("/", 1));
+  act(() => result.current.handleKeyDown(keyEvent("Escape")));
+  act(() => result.current.updateQuery("/", 1));
+  assert.equal(result.current.isOpen, false);
+  act(() => result.current.updateQuery("/rev", 4));
+  assert.equal(result.current.isOpen, true);
+  assert.equal(
+    result.current.handleKeyDown(keyEvent("Enter", { shiftKey: true })).handled,
+    false,
+  );
+  assert.equal(
+    result.current.handleKeyDown(keyEvent("Tab")).suggestion.name,
+    "review",
+  );
+});
+
+test("live catalog removal closes the picker without clearing a leading mention", async () => {
+  const { act } = await import("@testing-library/react");
+  const { result } = await setup();
+  act(() => result.current.updateQuery("@Alpha /rev", 11));
+  assert.equal(result.current.isOpen, true);
+  act(() =>
+    recordAvailableCommandsUpdate(OWNER, ALPHA, {
+      seq: 2,
+      timestamp: "2026-07-23T08:01:00Z",
+      payload: { commands: [] },
+    }),
+  );
+  assert.equal(result.current.isOpen, false);
+});
+
+test("code context and composing keys leave the literal command alone", async () => {
+  const { act } = await import("@testing-library/react");
+  const { result } = await setup();
+  act(() => result.current.updateQuery("/rev", 4, true));
+  assert.equal(result.current.isOpen, false);
+  act(() => result.current.updateQuery("/rev", 4));
+  assert.equal(
+    result.current.handleKeyDown(
+      keyEvent("Enter", { nativeEvent: { isComposing: true } }),
+    ).handled,
+    false,
+  );
+  assert.equal(
+    result.current.handleKeyDown(keyEvent("Tab", { shiftKey: true })).handled,
+    false,
+  );
+});
+
+test("reusing the composer in another channel clears its command query", async () => {
+  const { act } = await import("@testing-library/react");
+  const { result, rerender } = await setup();
+  act(() => result.current.updateQuery("/rev", 4));
+  assert.equal(result.current.isOpen, true);
+  rerender({ channelId: "other-channel" });
+  assert.equal(result.current.isOpen, false);
+});

--- a/desktop/src/features/messages/lib/useSlashCommandAutocomplete.ts
+++ b/desktop/src/features/messages/lib/useSlashCommandAutocomplete.ts
@@ -1,0 +1,180 @@
+import * as React from "react";
+
+import { useAgentCommandCatalog } from "@/features/agents/useAgentCommandCatalog";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+import type { AutocompleteEdit } from "./useRichTextEditor";
+import {
+  buildSlashCommandInsertText,
+  buildSlashCommandGroups,
+  detectSlashCommandQuery,
+  resolveLeadingAgentMentionPubkeys,
+  type SlashCommandQuery,
+  type SlashCommandSuggestion,
+} from "./slashCommandAutocomplete";
+
+type ActiveQuery = {
+  detected: SlashCommandQuery;
+  selectedAgentPubkeys: readonly string[] | null;
+  signature: string;
+};
+
+export function useSlashCommandAutocomplete({
+  channelId,
+  ownerPubkey,
+}: {
+  channelId: string | null;
+  ownerPubkey: string | null;
+}) {
+  const membersQuery = useChannelMembersQuery(channelId, Boolean(channelId));
+  const catalog = useAgentCommandCatalog(ownerPubkey);
+  const [activeQuery, setActiveQuery] = React.useState<ActiveQuery | null>(
+    null,
+  );
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const dismissedSignatureRef = React.useRef<string | null>(null);
+
+  const providers = React.useMemo(
+    () =>
+      (membersQuery.data ?? [])
+        .filter((member) => member.isAgent || member.role === "bot")
+        .map((member) => ({
+          pubkey: normalizePubkey(member.pubkey),
+          displayName:
+            member.displayName?.trim() || truncatePubkey(member.pubkey),
+        })),
+    [membersQuery.data],
+  );
+
+  const groups = React.useMemo(
+    () =>
+      activeQuery
+        ? buildSlashCommandGroups({
+            catalog,
+            providers,
+            query: activeQuery.detected.query,
+            selectedAgentPubkeys: activeQuery.selectedAgentPubkeys,
+          })
+        : [],
+    [activeQuery, catalog, providers],
+  );
+  const suggestions = React.useMemo(
+    () => groups.flatMap((group) => group.commands),
+    [groups],
+  );
+  const isOpen = activeQuery !== null && suggestions.length > 0;
+
+  React.useEffect(() => {
+    setSelectedIndex((current) =>
+      suggestions.length === 0 ? 0 : Math.min(current, suggestions.length - 1),
+    );
+  }, [suggestions.length]);
+
+  const updateQuery = React.useCallback(
+    (value: string, cursorPosition: number) => {
+      const detected = detectSlashCommandQuery(value, cursorPosition);
+      if (!detected) {
+        dismissedSignatureRef.current = null;
+        setActiveQuery(null);
+        setSelectedIndex(0);
+        return;
+      }
+
+      let selectedAgentPubkeys: readonly string[] | null = null;
+      if (detected.leadingText) {
+        selectedAgentPubkeys = resolveLeadingAgentMentionPubkeys(
+          detected.leadingText,
+          providers,
+        );
+        if (selectedAgentPubkeys.length === 0) {
+          setActiveQuery(null);
+          setSelectedIndex(0);
+          return;
+        }
+      }
+
+      const signature = `${detected.replaceFromOffset}:${detected.leadingText}:${detected.query}`;
+      if (dismissedSignatureRef.current === signature) {
+        setActiveQuery(null);
+        return;
+      }
+      dismissedSignatureRef.current = null;
+      setActiveQuery({ detected, selectedAgentPubkeys, signature });
+      setSelectedIndex(0);
+    },
+    [providers],
+  );
+
+  const insertCommand = React.useCallback(
+    (
+      suggestion: SlashCommandSuggestion,
+      selectionEnd: number,
+    ): AutocompleteEdit | null => {
+      if (!activeQuery) return null;
+      const edit = {
+        replaceFromOffset: activeQuery.detected.replaceFromOffset,
+        replaceToOffset: selectionEnd,
+        insertText: buildSlashCommandInsertText(
+          suggestion,
+          activeQuery.selectedAgentPubkeys !== null,
+        ),
+      };
+      setActiveQuery(null);
+      setSelectedIndex(0);
+      return edit;
+    },
+    [activeQuery],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (
+      event: React.KeyboardEvent,
+    ): { handled: boolean; suggestion?: SlashCommandSuggestion } => {
+      if (!isOpen || !activeQuery) return { handled: false };
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSelectedIndex((current) =>
+          current < suggestions.length - 1 ? current + 1 : 0,
+        );
+        return { handled: true };
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSelectedIndex((current) =>
+          current > 0 ? current - 1 : suggestions.length - 1,
+        );
+        return { handled: true };
+      }
+      if (
+        event.key === "Tab" ||
+        (event.key === "Enter" &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey)
+      ) {
+        event.preventDefault();
+        return { handled: true, suggestion: suggestions[selectedIndex] };
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismissedSignatureRef.current = activeQuery.signature;
+        setActiveQuery(null);
+        setSelectedIndex(0);
+        return { handled: true };
+      }
+      return { handled: false };
+    },
+    [activeQuery, isOpen, selectedIndex, suggestions],
+  );
+
+  return {
+    groups,
+    handleKeyDown,
+    insertCommand,
+    isOpen,
+    selectedIndex,
+    suggestions,
+    updateQuery,
+  };
+}

--- a/desktop/src/features/messages/lib/useSlashCommandAutocomplete.ts
+++ b/desktop/src/features/messages/lib/useSlashCommandAutocomplete.ts
@@ -1,0 +1,216 @@
+import * as React from "react";
+
+import { useAgentCommandCatalog } from "@/features/agents/useAgentCommandCatalog";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+import type { AutocompleteEdit } from "./useRichTextEditor";
+import type { UseMentionsResult } from "./useMentions";
+import {
+  buildSlashCommandInsertText,
+  buildSlashCommandGroups,
+  detectSlashCommandQuery,
+  resolveLeadingAgentMentionPubkeys,
+  type SlashCommandQuery,
+  type SlashCommandSuggestion,
+} from "./slashCommandAutocomplete";
+
+type ActiveQuery = {
+  detected: SlashCommandQuery;
+  selectedAgentPubkeys: readonly string[] | null;
+  signature: string;
+};
+
+export function useSlashCommandAutocomplete({
+  channelId,
+  ownerPubkey,
+  mentions,
+}: {
+  channelId: string | null;
+  ownerPubkey: string | null;
+  mentions: Pick<
+    UseMentionsResult,
+    "getMentionIdentities" | "extractMentionPubkeys" | "registerMentionPubkey"
+  >;
+}) {
+  const membersQuery = useChannelMembersQuery(channelId, Boolean(channelId));
+  const catalog = useAgentCommandCatalog(ownerPubkey);
+  const [activeQuery, setActiveQuery] = React.useState<ActiveQuery | null>(
+    null,
+  );
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const dismissedSignatureRef = React.useRef<string | null>(null);
+
+  const providers = React.useMemo(
+    () =>
+      (membersQuery.data ?? [])
+        .filter((member) => member.isAgent || member.role === "bot")
+        .map((member) => ({
+          pubkey: normalizePubkey(member.pubkey),
+          displayName:
+            member.displayName?.trim() || truncatePubkey(member.pubkey),
+        })),
+    [membersQuery.data],
+  );
+
+  const groups = React.useMemo(
+    () =>
+      activeQuery
+        ? buildSlashCommandGroups({
+            catalog,
+            providers,
+            query: activeQuery.detected.query,
+            selectedAgentPubkeys: activeQuery.selectedAgentPubkeys,
+          })
+        : [],
+    [activeQuery, catalog, providers],
+  );
+  const suggestions = React.useMemo(
+    () => groups.flatMap((group) => group.commands),
+    [groups],
+  );
+  const isOpen = activeQuery !== null && suggestions.length > 0;
+
+  React.useEffect(() => {
+    setSelectedIndex((current) =>
+      suggestions.length === 0 ? 0 : Math.min(current, suggestions.length - 1),
+    );
+  }, [suggestions.length]);
+
+  const updateQuery = React.useCallback(
+    (value: string, cursorPosition: number) => {
+      const detected = detectSlashCommandQuery(value, cursorPosition);
+      if (!detected) {
+        dismissedSignatureRef.current = null;
+        setActiveQuery(null);
+        setSelectedIndex(0);
+        return;
+      }
+
+      let selectedAgentPubkeys: readonly string[] | null = null;
+      if (detected.leadingText) {
+        const candidates = mentions.getMentionIdentities().map((identity) => ({
+          displayName: identity.label,
+          pubkey: identity.pubkey,
+        }));
+        const leadingPubkeys = resolveLeadingAgentMentionPubkeys(
+          detected.leadingText,
+          candidates,
+        );
+        try {
+          selectedAgentPubkeys = leadingPubkeys.length
+            ? mentions.extractMentionPubkeys(detected.leadingText)
+            : [];
+        } catch {
+          // Ambiguous mentions remain literal; the send flow explains how to resolve them.
+          selectedAgentPubkeys = [];
+        }
+        if (
+          selectedAgentPubkeys.length === 0 ||
+          selectedAgentPubkeys.some(
+            (pubkey) =>
+              !providers.some(
+                (provider) => provider.pubkey === normalizePubkey(pubkey),
+              ),
+          )
+        ) {
+          setActiveQuery(null);
+          setSelectedIndex(0);
+          return;
+        }
+      }
+
+      const signature = `${detected.replaceFromOffset}:${detected.leadingText}:${detected.query}`;
+      if (dismissedSignatureRef.current === signature) {
+        setActiveQuery(null);
+        return;
+      }
+      dismissedSignatureRef.current = null;
+      setActiveQuery({ detected, selectedAgentPubkeys, signature });
+      setSelectedIndex(0);
+    },
+    [providers, mentions.getMentionIdentities, mentions.extractMentionPubkeys],
+  );
+
+  const insertCommand = React.useCallback(
+    (
+      suggestion: SlashCommandSuggestion,
+      selectionEnd: number,
+    ): AutocompleteEdit | null => {
+      if (!activeQuery) return null;
+      let agentDisplayName = suggestion.agentDisplayName;
+      if (activeQuery.selectedAgentPubkeys === null) {
+        const label = mentions.registerMentionPubkey(
+          agentDisplayName,
+          suggestion.agentPubkey,
+          { isAgent: true },
+        );
+        if (!label) return null;
+        agentDisplayName = label;
+      }
+      const edit = {
+        replaceFromOffset: activeQuery.detected.replaceFromOffset,
+        replaceToOffset: selectionEnd,
+        insertText: buildSlashCommandInsertText(
+          { ...suggestion, agentDisplayName },
+          activeQuery.selectedAgentPubkeys !== null,
+        ),
+      };
+      setActiveQuery(null);
+      setSelectedIndex(0);
+      return edit;
+    },
+    [activeQuery, mentions.registerMentionPubkey],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (
+      event: React.KeyboardEvent,
+    ): { handled: boolean; suggestion?: SlashCommandSuggestion } => {
+      if (!isOpen || !activeQuery) return { handled: false };
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSelectedIndex((current) =>
+          current < suggestions.length - 1 ? current + 1 : 0,
+        );
+        return { handled: true };
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSelectedIndex((current) =>
+          current > 0 ? current - 1 : suggestions.length - 1,
+        );
+        return { handled: true };
+      }
+      if (
+        event.key === "Tab" ||
+        (event.key === "Enter" &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey)
+      ) {
+        event.preventDefault();
+        return { handled: true, suggestion: suggestions[selectedIndex] };
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismissedSignatureRef.current = activeQuery.signature;
+        setActiveQuery(null);
+        setSelectedIndex(0);
+        return { handled: true };
+      }
+      return { handled: false };
+    },
+    [activeQuery, isOpen, selectedIndex, suggestions],
+  );
+
+  return {
+    groups,
+    handleKeyDown,
+    insertCommand,
+    isOpen,
+    selectedIndex,
+    suggestions,
+    updateQuery,
+  };
+}

--- a/desktop/src/features/messages/lib/useSlashCommandAutocomplete.ts
+++ b/desktop/src/features/messages/lib/useSlashCommandAutocomplete.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { useAgentCommandCatalog } from "@/features/agents/useAgentCommandCatalog";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
-import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+import { normalizePubkey, truncateNpub } from "@/shared/lib/pubkey";
 import type { AutocompleteEdit } from "./useRichTextEditor";
 import type { UseMentionsResult } from "./useMentions";
 import {
@@ -20,6 +20,7 @@ type ActiveQuery = {
   signature: string;
 };
 
+/** Complete advertised agent commands without changing command execution semantics. */
 export function useSlashCommandAutocomplete({
   channelId,
   ownerPubkey,
@@ -40,6 +41,13 @@ export function useSlashCommandAutocomplete({
   const [selectedIndex, setSelectedIndex] = React.useState(0);
   const dismissedSignatureRef = React.useRef<string | null>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: a composer can be reused for a different channel or identity without unmounting
+  React.useEffect(() => {
+    setActiveQuery(null);
+    setSelectedIndex(0);
+    dismissedSignatureRef.current = null;
+  }, [channelId, ownerPubkey]);
+
   const providers = React.useMemo(
     () =>
       (membersQuery.data ?? [])
@@ -47,7 +55,7 @@ export function useSlashCommandAutocomplete({
         .map((member) => ({
           pubkey: normalizePubkey(member.pubkey),
           displayName:
-            member.displayName?.trim() || truncatePubkey(member.pubkey),
+            member.displayName?.trim() || truncateNpub(member.pubkey),
         })),
     [membersQuery.data],
   );
@@ -77,8 +85,10 @@ export function useSlashCommandAutocomplete({
   }, [suggestions.length]);
 
   const updateQuery = React.useCallback(
-    (value: string, cursorPosition: number) => {
-      const detected = detectSlashCommandQuery(value, cursorPosition);
+    (value: string, cursorPosition: number, isCodeContext = false) => {
+      const detected = isCodeContext
+        ? null
+        : detectSlashCommandQuery(value, cursorPosition);
       if (!detected) {
         dismissedSignatureRef.current = null;
         setActiveQuery(null);
@@ -166,7 +176,8 @@ export function useSlashCommandAutocomplete({
     (
       event: React.KeyboardEvent,
     ): { handled: boolean; suggestion?: SlashCommandSuggestion } => {
-      if (!isOpen || !activeQuery) return { handled: false };
+      if (!isOpen || !activeQuery || event.nativeEvent?.isComposing)
+        return { handled: false };
       if (event.key === "ArrowDown") {
         event.preventDefault();
         setSelectedIndex((current) =>
@@ -182,12 +193,11 @@ export function useSlashCommandAutocomplete({
         return { handled: true };
       }
       if (
-        event.key === "Tab" ||
-        (event.key === "Enter" &&
-          !event.ctrlKey &&
-          !event.metaKey &&
-          !event.altKey &&
-          !event.shiftKey)
+        (event.key === "Tab" || event.key === "Enter") &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.shiftKey
       ) {
         event.preventDefault();
         return { handled: true, suggestion: suggestions[selectedIndex] };

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -26,6 +26,8 @@ import {
   useMediaUpload,
 } from "@/features/messages/lib/useMediaUpload";
 import { useMentions } from "@/features/messages/lib/useMentions";
+import { useSlashCommandAutocomplete } from "@/features/messages/lib/useSlashCommandAutocomplete";
+import type { SlashCommandSuggestion } from "@/features/messages/lib/slashCommandAutocomplete";
 import { diffAddedMentionPubkeys } from "@/features/messages/lib/threading";
 import { getPersistentAgentAudienceScope } from "@/features/messages/lib/persistentAgentAudience";
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -55,6 +57,7 @@ import {
   type MentionSuggestion,
 } from "./MentionAutocomplete";
 import { MessageComposerToolbar } from "./MessageComposerToolbar";
+import { SlashCommandAutocomplete } from "./SlashCommandAutocomplete";
 import { NonMemberMentionDialog } from "./NonMemberMentionDialog";
 import { useMentionSendFlow } from "./useMentionSendFlow";
 import { usePersistentAgentMentionHydration } from "./usePersistentAgentMentionHydration";
@@ -224,6 +227,10 @@ function MessageComposerImpl({
   const mentions = useMentions(channelId, undefined, profiles, {
     channelType,
   });
+  const slashCommands = useSlashCommandAutocomplete({
+    channelId,
+    ownerPubkey,
+  });
   const channelLinks = useChannelLinks();
   const customEmoji = useCustomEmoji();
   const emojiAutocomplete = useEmojiAutocomplete(customEmoji);
@@ -269,6 +276,7 @@ function MessageComposerImpl({
     setIsEmojiPickerOpen(false);
     channelLinks.clearChannels();
     emojiAutocomplete.clearEmojis();
+    slashCommands.updateQuery("", 0);
   }, [effectiveDraftKey]);
 
   const disabledRef = React.useRef(disabled);
@@ -294,7 +302,8 @@ function MessageComposerImpl({
   isAutocompleteOpenRef.current =
     mentions.isMentionOpen ||
     channelLinks.isChannelOpen ||
-    emojiAutocomplete.isEmojiAutocompleteOpen;
+    emojiAutocomplete.isEmojiAutocompleteOpen ||
+    slashCommands.isOpen;
 
   const submitMessageRef = React.useRef<() => void>(() => {});
   const composerScrollRef = React.useRef<HTMLDivElement>(null);
@@ -350,6 +359,7 @@ function MessageComposerImpl({
       mentions.updateMentionQuery(text, cursor);
       channelLinks.updateChannelQuery(text, cursor);
       emojiAutocomplete.updateEmojiQuery(text, cursor);
+      slashCommands.updateQuery(text, cursor);
 
       persistentMentionHydrationRef.current?.reconcile(text);
 
@@ -525,6 +535,27 @@ function MessageComposerImpl({
       applyAutocompleteEdit,
       emojiAutocomplete.insertEmoji,
       richText.getPlainTextAndCursor,
+    ],
+  );
+
+  const applySlashCommandInsert = React.useCallback(
+    (suggestion: SlashCommandSuggestion) => {
+      const { cursor } = richText.getPlainTextAndCursor();
+      const edit = slashCommands.insertCommand(suggestion, cursor);
+      if (edit) {
+        mentions.registerMentionPubkey(
+          suggestion.agentDisplayName,
+          suggestion.agentPubkey,
+          { isAgent: true },
+        );
+        applyAutocompleteEdit(edit);
+      }
+    },
+    [
+      applyAutocompleteEdit,
+      mentions.registerMentionPubkey,
+      richText.getPlainTextAndCursor,
+      slashCommands.insertCommand,
     ],
   );
 
@@ -786,6 +817,14 @@ function MessageComposerImpl({
   const handleEditorKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       // Let autocomplete handle keys first
+      const slashCommandResult = slashCommands.handleKeyDown(event);
+      if (slashCommandResult.handled) {
+        if (slashCommandResult.suggestion) {
+          applySlashCommandInsert(slashCommandResult.suggestion);
+        }
+        return;
+      }
+
       const emojiResult = emojiAutocomplete.handleEmojiKeyDown(event);
       if (emojiResult.handled) {
         if (emojiResult.suggestion) {
@@ -826,6 +865,8 @@ function MessageComposerImpl({
       }
     },
     [
+      slashCommands.handleKeyDown,
+      applySlashCommandInsert,
       emojiAutocomplete.handleEmojiKeyDown,
       applyEmojiInsert,
       channelLinks.handleChannelKeyDown,
@@ -1007,6 +1048,11 @@ function MessageComposerImpl({
             }}
           >
             {ownsDropZone && media.isDragOver && <DropZoneOverlay />}
+            <SlashCommandAutocomplete
+              groups={slashCommands.isOpen ? slashCommands.groups : []}
+              onSelect={applySlashCommandInsert}
+              selectedIndex={slashCommands.selectedIndex}
+            />
             <EmojiAutocomplete
               onSelect={applyEmojiInsert}
               selectedIndex={emojiAutocomplete.emojiSelectedIndex}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -28,6 +28,8 @@ import {
 import { useComposerFocusOwnership } from "@/features/messages/lib/useComposerFocusOwnership";
 import { isMentionCodeContext } from "@/features/messages/lib/mentionCodeContext";
 import { useMentions } from "@/features/messages/lib/useMentions";
+import { useSlashCommandAutocomplete } from "@/features/messages/lib/useSlashCommandAutocomplete";
+import type { SlashCommandSuggestion } from "@/features/messages/lib/slashCommandAutocomplete";
 import { getPersistentAgentAudienceScope } from "@/features/messages/lib/persistentAgentAudience";
 import { setKeepMentionedAgentsPinned } from "@/features/messages/lib/autoPinMentionedAgentsPreference";
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -148,6 +150,11 @@ function MessageComposerImpl({
     recentMentionPubkeys,
   });
   const channelLinks = useChannelLinks();
+  const slashCommands = useSlashCommandAutocomplete({
+    channelId,
+    ownerPubkey,
+    mentions,
+  });
   const customEmoji = useCustomEmoji();
   const emojiAutocomplete = useEmojiAutocomplete(customEmoji);
   const notifyTyping = useTypingBroadcast(
@@ -253,7 +260,8 @@ function MessageComposerImpl({
   isAutocompleteOpenRef.current =
     mentions.isMentionOpen ||
     channelLinks.isChannelOpen ||
-    emojiAutocomplete.isEmojiAutocompleteOpen;
+    emojiAutocomplete.isEmojiAutocompleteOpen ||
+    slashCommands.isOpen;
   const submitMessageRef = React.useRef<() => void>(() => {});
   const composerScrollRef = React.useRef<HTMLDivElement>(null);
   const formRef = React.useRef<HTMLFormElement>(null);
@@ -308,6 +316,7 @@ function MessageComposerImpl({
       mentions.updateMentionQuery(text, cursor);
       channelLinks.updateChannelQuery(text, cursor);
       emojiAutocomplete.updateEmojiQuery(text, cursor);
+      slashCommands.updateQuery(text, cursor);
       if (text.trim().length > 0) {
         notifyTyping();
       }
@@ -504,6 +513,19 @@ function MessageComposerImpl({
       applyAutocompleteEdit,
       emojiAutocomplete.insertEmoji,
       richText.getPlainTextAndCursor,
+    ],
+  );
+  const applySlashCommandInsert = React.useCallback(
+    (suggestion: SlashCommandSuggestion) => {
+      const { cursor } = richText.getPlainTextAndCursor();
+      const edit = slashCommands.insertCommand(suggestion, cursor);
+      if (!edit) return;
+      applyAutocompleteEdit(edit);
+    },
+    [
+      applyAutocompleteEdit,
+      richText.getPlainTextAndCursor,
+      slashCommands.insertCommand,
     ],
   );
   // ── Emoji insertion ─────────────────────────────────────────────────
@@ -726,6 +748,12 @@ function MessageComposerImpl({
   const handleEditorKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (handleAlwaysAddressShortcut(event)) return;
+      const commandResult = slashCommands.handleKeyDown(event);
+      if (commandResult.handled) {
+        if (commandResult.suggestion)
+          applySlashCommandInsert(commandResult.suggestion);
+        return;
+      }
       // Let autocomplete handle keys first
       const emojiResult = emojiAutocomplete.handleEmojiKeyDown(event);
       if (emojiResult.handled) {
@@ -784,6 +812,8 @@ function MessageComposerImpl({
     },
     [
       handleAlwaysAddressShortcut,
+      slashCommands.handleKeyDown,
+      applySlashCommandInsert,
       emojiAutocomplete.handleEmojiKeyDown,
       applyEmojiInsert,
       channelLinks.handleChannelKeyDown,
@@ -881,6 +911,8 @@ function MessageComposerImpl({
                 audienceScope && editTarget == null,
               )}
               channelLinks={channelLinks}
+              slashCommands={slashCommands}
+              onSlashCommandSelect={applySlashCommandInsert}
               composerOwnsFocus={composerOwnsFocus}
               emojiAutocomplete={emojiAutocomplete}
               keepMentionedAgentsPinned={keepMentionedAgentsPinned}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -316,7 +316,11 @@ function MessageComposerImpl({
       mentions.updateMentionQuery(text, cursor);
       channelLinks.updateChannelQuery(text, cursor);
       emojiAutocomplete.updateEmojiQuery(text, cursor);
-      slashCommands.updateQuery(text, cursor);
+      slashCommands.updateQuery(
+        text,
+        cursor,
+        isMentionCodeContext(richText.editor),
+      );
       if (text.trim().length > 0) {
         notifyTyping();
       }

--- a/desktop/src/features/messages/ui/MessageComposerAutocompletes.tsx
+++ b/desktop/src/features/messages/ui/MessageComposerAutocompletes.tsx
@@ -8,6 +8,9 @@ import type {
   UseEmojiAutocompleteResult,
 } from "@/features/messages/lib/useEmojiAutocomplete";
 import type { UseMentionsResult } from "@/features/messages/lib/useMentions";
+import type { useSlashCommandAutocomplete } from "@/features/messages/lib/useSlashCommandAutocomplete";
+import type { SlashCommandSuggestion } from "@/features/messages/lib/slashCommandAutocomplete";
+import { SlashCommandAutocomplete } from "./SlashCommandAutocomplete";
 import { ChannelAutocomplete } from "./ChannelAutocomplete";
 import { EmojiAutocomplete } from "./EmojiAutocomplete";
 import {
@@ -22,6 +25,8 @@ type MessageComposerAutocompletesProps = {
    */
   audienceControlsEnabled: boolean;
   channelLinks: UseChannelLinksResult;
+  slashCommands: ReturnType<typeof useSlashCommandAutocomplete>;
+  onSlashCommandSelect: (suggestion: SlashCommandSuggestion) => void;
   composerOwnsFocus: boolean;
   emojiAutocomplete: UseEmojiAutocompleteResult;
   keepMentionedAgentsPinned: boolean;
@@ -40,7 +45,7 @@ type MessageComposerAutocompletesProps = {
 };
 
 /**
- * The message composer's three suggestion overlays. Each one gates its own
+ * The message composer's suggestion overlays. Each one gates its own
  * rendering on `composerOwnsFocus`, so a background composer replaying a
  * stale update cannot resurrect a suggestion menu over the focused composer,
  * while keyboard focus moving into an overlay's own controls keeps that
@@ -49,6 +54,8 @@ type MessageComposerAutocompletesProps = {
 export function MessageComposerAutocompletes({
   audienceControlsEnabled,
   channelLinks,
+  slashCommands,
+  onSlashCommandSelect,
   composerOwnsFocus,
   emojiAutocomplete,
   keepMentionedAgentsPinned,
@@ -63,6 +70,13 @@ export function MessageComposerAutocompletes({
 }: MessageComposerAutocompletesProps) {
   return (
     <>
+      <SlashCommandAutocomplete
+        groups={
+          composerOwnsFocus && slashCommands.isOpen ? slashCommands.groups : []
+        }
+        onSelect={onSlashCommandSelect}
+        selectedIndex={slashCommands.selectedIndex}
+      />
       <EmojiAutocomplete
         composerOwnsFocus={composerOwnsFocus}
         onSelect={onEmojiSelect}

--- a/desktop/src/features/messages/ui/SlashCommandAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/SlashCommandAutocomplete.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+import { Bot, Terminal } from "lucide-react";
+
+import type {
+  SlashCommandGroup,
+  SlashCommandSuggestion,
+} from "@/features/messages/lib/slashCommandAutocomplete";
+import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
+
+type SlashCommandAutocompleteProps = {
+  groups: readonly SlashCommandGroup[];
+  onSelect: (suggestion: SlashCommandSuggestion) => void;
+  selectedIndex: number;
+};
+
+export const SlashCommandAutocomplete = React.memo(
+  function SlashCommandAutocomplete({
+    groups,
+    onSelect,
+    selectedIndex,
+  }: SlashCommandAutocompleteProps) {
+    const listRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+      listRef.current
+        ?.querySelector<HTMLElement>(`[data-command-index="${selectedIndex}"]`)
+        ?.scrollIntoView({ block: "nearest" });
+    }, [selectedIndex]);
+
+    if (groups.length === 0) return null;
+
+    let commandIndex = -1;
+    return (
+      <div className="absolute bottom-full left-0 right-0 z-50 mb-1 px-3 sm:px-4">
+        <div
+          className={cn(
+            "max-h-64 overflow-y-auto rounded-xl p-1",
+            POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+            "origin-bottom slide-in-from-bottom-1",
+            POPOVER_SURFACE_CLASS,
+          )}
+          data-testid="slash-command-autocomplete"
+          ref={listRef}
+          style={POPOVER_SHADOW_STYLE}
+        >
+          {groups.map((group) => (
+            <div key={group.agentPubkey}>
+              <div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-2xs font-medium text-muted-foreground first:pt-1">
+                <Bot aria-hidden="true" className="h-3 w-3" />
+                <span className="truncate">{group.agentDisplayName}</span>
+              </div>
+              {group.commands.map((command) => {
+                commandIndex += 1;
+                const index = commandIndex;
+                return (
+                  <button
+                    className={cn(
+                      "flex w-full cursor-pointer items-start gap-2 rounded-lg px-3 py-1.5 text-left text-sm",
+                      index === selectedIndex
+                        ? "bg-accent text-accent-foreground"
+                        : "text-popover-foreground hover:bg-accent/50",
+                    )}
+                    data-command-index={index}
+                    data-testid={`slash-command-suggestion-${group.agentPubkey}-${command.name}`}
+                    key={`${group.agentPubkey}:${command.name}`}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      onSelect(command);
+                    }}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    <Terminal
+                      aria-hidden="true"
+                      className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-medium">/{command.name}</span>
+                      {command.description ? (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {command.description}
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+);

--- a/desktop/src/features/messages/ui/SlashCommandAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/SlashCommandAutocomplete.tsx
@@ -18,6 +18,7 @@ type SlashCommandAutocompleteProps = {
   selectedIndex: number;
 };
 
+/** Group agent command suggestions while the owning composer keeps focus. */
 export const SlashCommandAutocomplete = React.memo(
   function SlashCommandAutocomplete({
     groups,
@@ -35,8 +36,15 @@ export const SlashCommandAutocomplete = React.memo(
     if (groups.length === 0) return null;
 
     let commandIndex = -1;
+    const selected = groups.flatMap((group) => group.commands)[selectedIndex];
     return (
       <div className="absolute bottom-full left-0 right-0 z-50 mb-1 px-3 sm:px-4">
+        <div className="sr-only" role="status">
+          {selected
+            ? `${selected.agentDisplayName}: /${selected.name}. Enter or Tab to insert, Escape to dismiss.`
+            : ""}
+        </div>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: keep the editor focused when pressing the scrollbar or a group label */}
         <div
           className={cn(
             "max-h-64 overflow-y-auto rounded-xl p-1",
@@ -45,11 +53,16 @@ export const SlashCommandAutocomplete = React.memo(
             POPOVER_SURFACE_CLASS,
           )}
           data-testid="slash-command-autocomplete"
+          onMouseDown={(event) => event.preventDefault()}
           ref={listRef}
           style={POPOVER_SHADOW_STYLE}
         >
           {groups.map((group) => (
-            <div key={group.agentPubkey}>
+            <fieldset
+              aria-label={`${group.agentDisplayName} commands`}
+              className="min-w-0"
+              key={group.agentPubkey}
+            >
               <div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-2xs font-medium text-muted-foreground first:pt-1">
                 <Bot aria-hidden="true" className="h-3 w-3" />
                 <span className="truncate">{group.agentDisplayName}</span>
@@ -68,10 +81,7 @@ export const SlashCommandAutocomplete = React.memo(
                     data-command-index={index}
                     data-testid={`slash-command-suggestion-${group.agentPubkey}-${command.name}`}
                     key={`${group.agentPubkey}:${command.name}`}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      onSelect(command);
-                    }}
+                    onClick={() => onSelect(command)}
                     tabIndex={-1}
                     type="button"
                   >
@@ -90,7 +100,7 @@ export const SlashCommandAutocomplete = React.memo(
                   </button>
                 );
               })}
-            </div>
+            </fieldset>
           ))}
         </div>
       </div>

--- a/desktop/src/shared/lib/localStorageQuota.ts
+++ b/desktop/src/shared/lib/localStorageQuota.ts
@@ -10,6 +10,7 @@
 const PURE_CACHE_KEY_PREFIXES = [
   "buzz-channel-messages.v1",
   "buzz-channels.v1",
+  "buzz-agent-command-catalog.v1",
   "buzz-timeline-skeleton-shape.v1",
 ];
 

--- a/desktop/src/shared/lib/localStorageQuota.ts
+++ b/desktop/src/shared/lib/localStorageQuota.ts
@@ -8,6 +8,7 @@
  */
 
 const PURE_CACHE_KEY_PREFIXES = [
+  "buzz-agent-command-catalog.v1:",
   "buzz-channel-messages.v1:",
   "buzz-channels.v1:",
   "buzz-observed-unread.v1:",

--- a/desktop/tests/e2e/slash-command-autocomplete.spec.ts
+++ b/desktop/tests/e2e/slash-command-autocomplete.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+import { installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+
+const OWNER = "deadbeef".repeat(8);
+const ALPHA = "a".repeat(64);
+const BETA = "b".repeat(64);
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(
+    ({ owner, alpha, beta }) => {
+      localStorage.setItem(
+        `buzz-agent-command-catalog.v1:e2e-default-community:${owner}`,
+        JSON.stringify({
+          version: 1,
+          agents: Object.fromEntries(
+            [alpha, beta].map((pubkey) => [
+              pubkey,
+              {
+                seq: 1,
+                timestamp: "2026-07-23T08:00:00Z",
+                commands: [
+                  { name: "review", description: "Review the current changes" },
+                ],
+              },
+            ]),
+          ),
+        }),
+      );
+    },
+    { owner: OWNER, alpha: ALPHA, beta: BETA },
+  );
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: ALPHA,
+        name: "Alpha",
+        channelNames: ["general"],
+        status: "running",
+      },
+      {
+        pubkey: BETA,
+        name: "Beta",
+        channelNames: ["general"],
+        status: "running",
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+});
+
+test("persisted commands group by provider and keyboard selection binds the sent recipient", async ({
+  page,
+}, testInfo) => {
+  const input = page.getByTestId("message-input");
+  const menu = page.getByTestId("slash-command-autocomplete");
+  await input.fill("/rev");
+  await expect(
+    menu.getByRole("group", { name: "Alpha commands" }),
+  ).toBeVisible();
+  await expect(
+    menu.getByRole("group", { name: "Beta commands" }),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await menu.screenshot({ path: testInfo.outputPath("slash-commands.png") });
+  await input.press("ArrowDown");
+  await input.press("Tab");
+  await expect(input).toHaveText("@Beta /review ");
+  await expect(menu).not.toBeVisible();
+  await input.press("Enter");
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_SIGNED_EVENTS__
+          ?.filter((event) => event.content.includes("/review"))
+          .map((event) =>
+            event.tags.filter((tag) => tag[0] === "p").map((tag) => tag[1]),
+          ),
+      ),
+    )
+    .toContainEqual([BETA]);
+});
+
+test("leading mentions filter commands and escape preserves the literal text", async ({
+  page,
+}) => {
+  const input = page.getByTestId("message-input");
+  const menu = page.getByTestId("slash-command-autocomplete");
+  await input.fill("@Alpha /rev");
+  await expect(
+    menu.getByRole("group", { name: "Alpha commands" }),
+  ).toBeVisible();
+  await expect(menu.getByRole("group", { name: "Beta commands" })).toHaveCount(
+    0,
+  );
+  await input.press("Escape");
+  await expect(menu).not.toBeVisible();
+  await expect(input).toHaveText("@Alpha /rev");
+  await input.fill("/review");
+  await menu
+    .getByRole("group", { name: "Beta commands" })
+    .getByRole("button")
+    .click();
+  await expect(input).toHaveText("@Beta /review ");
+});


### PR DESCRIPTION
## summary

adds slash-command autocomplete for commands advertised by acp agents. typing `/` at the start of a message groups suggestions by agent; selecting one inserts its exact mention and command. typing after leading agent mentions filters to those agents and preserves the existing mentions.

rebased onto current `main` and adapted to the current observer batching, composer focus handling, and autocomplete overlays. the follow-up pass reuses the shared mention parser, isolates catalogs by community and owner, rejects control/bidi characters, and respects code blocks and ime input. no file-size override is needed.

## behavior and scope

- catalogs survive restarts, accept newer snapshots, and honor empty updates as removals.
- only agents owned by the current user populate catalogs, since observer frames are encrypted to their owner.
- acp supplies command names and descriptions without a built-in/skill category. command execution and send-time freshness remain the connector's responsibility.
- multiple leading mentions stay addressed when inserting a command.

## testing

- desktop unit suite: 6,512 passed; final focused regression suite: 55 passed.
- browser tests: 2 passed, including persistence, keyboard and mouse selection, filtering, escape, and the exact recipient on the signed message.
- full acp suite passed: 931 unit tests and 9 lifecycle tests, including snapshot coverage for empty and malformed updates.
- native desktop unit suite: 3,173 passed (19 ignored); mobile suite: 2,098 passed.
- full local `CHECK_FILE_SIZES_BASE=upstream/main just ci`: passed. the explicit base avoids comparing against the fork's older `origin/main`. desktop typecheck also passed.
- github ci and the security review need maintainer authorization for this head.

fixes #2528
