### PR TITLE
fix(desktop): prefer packaged sidecars in release builds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -149,7 +149,7 @@ fmt-all: fmt desktop-tauri-fmt mobile-fmt
 fix-all: fmt desktop-tauri-fmt desktop-fix web-fix mobile-fix
 
 # Ensure sidecar placeholder binaries exist (Tauri validates externalBin at compile time)
-# Sidecar binary list must stay in sync with desktop-release-build below.
+# Sidecar binary list must stay in sync with scripts/bundle-sidecars.sh.
 _ensure-sidecar-stubs:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -227,18 +227,19 @@ desktop-tauri-test-compiled-flags: _ensure-sidecar-stubs
     echo "Both compiled states verified."
 
 # Build the full desktop Tauri app locally (unsigned, for testing)
-# Sidecar binary list must stay in sync with _ensure-sidecar-stubs above.
+# Uses the same sidecar build/bundle sequence as the official release workflows.
 # pnpm install is unconditional here: release builds must start from a clean dep tree.
 desktop-release-build target="aarch64-apple-darwin":
     #!/usr/bin/env bash
     set -euo pipefail
     TARGET={{target}}
-    mkdir -p desktop/src-tauri/binaries
-    touch "desktop/src-tauri/binaries/buzz-acp-$TARGET"
-    touch "desktop/src-tauri/binaries/buzz-agent-$TARGET"
-    touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET"
-    touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
-    touch "desktop/src-tauri/binaries/buzz-$TARGET"
+    cargo build --release --target "$TARGET" \
+        -p buzz-acp \
+        -p buzz-agent \
+        -p buzz-dev-mcp \
+        -p git-credential-nostr \
+        -p buzz-cli
+    ./scripts/bundle-sidecars.sh "$TARGET"
     pnpm install
     cd {{desktop_dir}} && pnpm tauri build --features mesh-llm --target {{target}}
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -372,8 +372,8 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
     normalized
 }
 
-fn profile_target_dirs(root: &Path) -> [PathBuf; 2] {
-    if cfg!(debug_assertions) {
+fn profile_target_dirs(root: &Path, debug_profile: bool) -> [PathBuf; 2] {
+    if debug_profile {
         // `just dev` builds fresh debug sidecars; never prefer stale release output.
         [root.join("target/debug"), root.join("target/release")]
     } else {
@@ -381,23 +381,52 @@ fn profile_target_dirs(root: &Path) -> [PathBuf; 2] {
     }
 }
 
-fn command_search_dirs() -> Vec<PathBuf> {
-    let mut dirs = profile_target_dirs(&workspace_root_dir()).to_vec();
-    if let Ok(current_dir) = std::env::current_dir() {
-        dirs.extend(profile_target_dirs(&current_dir));
+fn command_search_dirs_for_profile(
+    workspace_root: &Path,
+    current_dir: Option<&Path>,
+    current_exe_parent: Option<&Path>,
+    debug_profile: bool,
+) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    // Release builds must use the sidecars shipped beside the app executable.
+    // Workspace paths can still exist on developer machines and may contain
+    // stale artifacts that do not match the packaged application.
+    if !debug_profile {
+        dirs.extend(current_exe_parent.map(Path::to_path_buf));
     }
 
-    dirs.extend(
-        std::env::current_exe()
-            .ok()
-            .and_then(|path| path.parent().map(Path::to_path_buf)),
-    );
+    dirs.extend(profile_target_dirs(workspace_root, debug_profile));
+    if let Some(current_dir) = current_dir {
+        dirs.extend(profile_target_dirs(current_dir, debug_profile));
+    }
+
+    // Debug builds prefer fresh workspace artifacts while retaining bundled
+    // sidecars as a fallback.
+    if debug_profile {
+        dirs.extend(current_exe_parent.map(Path::to_path_buf));
+    }
+
     dirs.into_iter().fold(Vec::new(), |mut unique, dir| {
         if !unique.contains(&dir) {
             unique.push(dir);
         }
         unique
     })
+}
+
+fn command_search_dirs() -> Vec<PathBuf> {
+    let current_dir = std::env::current_dir().ok();
+    let current_exe_parent = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf));
+
+    command_search_dirs_for_profile(
+        &workspace_root_dir(),
+        current_dir.as_deref(),
+        current_exe_parent.as_deref(),
+        cfg!(debug_assertions),
+    )
 }
 
 fn is_executable_file(path: &Path) -> bool {

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -142,6 +142,52 @@ fn explicit_path_resolution_ignores_non_executable_files() {
 }
 
 #[test]
+fn release_command_search_prefers_bundled_sidecars() {
+    let dirs = super::command_search_dirs_for_profile(
+        std::path::Path::new("/workspace"),
+        Some(std::path::Path::new("/working-copy")),
+        Some(std::path::Path::new(
+            "/Applications/Buzz.app/Contents/MacOS",
+        )),
+        false,
+    );
+
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/Applications/Buzz.app/Contents/MacOS"),
+            PathBuf::from("/workspace/target/release"),
+            PathBuf::from("/workspace/target/debug"),
+            PathBuf::from("/working-copy/target/release"),
+            PathBuf::from("/working-copy/target/debug"),
+        ]
+    );
+}
+
+#[test]
+fn debug_command_search_prefers_fresh_workspace_artifacts() {
+    let dirs = super::command_search_dirs_for_profile(
+        std::path::Path::new("/workspace"),
+        Some(std::path::Path::new("/working-copy")),
+        Some(std::path::Path::new(
+            "/Applications/Buzz.app/Contents/MacOS",
+        )),
+        true,
+    );
+
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/workspace/target/debug"),
+            PathBuf::from("/workspace/target/release"),
+            PathBuf::from("/working-copy/target/debug"),
+            PathBuf::from("/working-copy/target/release"),
+            PathBuf::from("/Applications/Buzz.app/Contents/MacOS"),
+        ]
+    );
+}
+
+#[test]
 fn classifies_available_when_adapter_found() {
     let (status, cmd, path) = classify_runtime(
         Some(("goose", PathBuf::from("/usr/local/bin/goose"))),

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -164,6 +164,85 @@ fn release_command_search_prefers_bundled_sidecars() {
     );
 }
 
+/// Resolve a command against an explicit, ordered dir list using the same
+/// first-executable-wins rule as `resolve_workspace_command`. Keeps the
+/// assertion on real files instead of only on directory ordering.
+#[cfg(unix)]
+fn first_executable_in(dirs: &[PathBuf], file_name: &str) -> Option<PathBuf> {
+    dirs.iter()
+        .map(|dir| dir.join(file_name))
+        .find(|candidate| super::is_executable_file(candidate))
+}
+
+/// Release profile must pick the packaged sidecar even when a workspace
+/// artifact with the same name also exists. The ordering tests alone cannot
+/// catch a regression here, because they never place real files on disk.
+#[cfg(unix)]
+#[test]
+fn release_resolution_picks_bundled_sidecar_over_workspace_artifact() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = std::env::temp_dir().join(format!("buzz-sidecar-{}", uuid::Uuid::new_v4()));
+    let bundled = root.join("Buzz.app/Contents/MacOS");
+    let workspace = root.join("workspace");
+    let workspace_release = workspace.join("target/release");
+    std::fs::create_dir_all(&bundled).expect("create bundled dir");
+    std::fs::create_dir_all(&workspace_release).expect("create workspace target dir");
+
+    // Both locations hold an executable named buzz-acp.
+    for dir in [&bundled, &workspace_release] {
+        let bin = dir.join("buzz-acp");
+        std::fs::write(&bin, "").expect("write sidecar");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod sidecar");
+    }
+
+    let dirs = super::command_search_dirs_for_profile(&workspace, None, Some(&bundled), false);
+    assert_eq!(
+        first_executable_in(&dirs, "buzz-acp"),
+        Some(bundled.join("buzz-acp")),
+        "release profile must resolve the packaged sidecar, not the workspace artifact"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Documents the fallback contract explicitly: when the packaged sidecar is
+/// present but NOT executable, release resolution falls through to the
+/// workspace artifact rather than failing. Locking this down makes the
+/// behavior intentional and visible instead of incidental.
+#[cfg(unix)]
+#[test]
+fn release_resolution_falls_back_when_bundled_sidecar_is_not_executable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = std::env::temp_dir().join(format!("buzz-sidecar-{}", uuid::Uuid::new_v4()));
+    let bundled = root.join("Buzz.app/Contents/MacOS");
+    let workspace = root.join("workspace");
+    let workspace_release = workspace.join("target/release");
+    std::fs::create_dir_all(&bundled).expect("create bundled dir");
+    std::fs::create_dir_all(&workspace_release).expect("create workspace target dir");
+
+    let broken = bundled.join("buzz-acp");
+    std::fs::write(&broken, "").expect("write bundled sidecar");
+    std::fs::set_permissions(&broken, std::fs::Permissions::from_mode(0o644))
+        .expect("chmod bundled sidecar non-executable");
+
+    let usable = workspace_release.join("buzz-acp");
+    std::fs::write(&usable, "").expect("write workspace sidecar");
+    std::fs::set_permissions(&usable, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod workspace sidecar");
+
+    let dirs = super::command_search_dirs_for_profile(&workspace, None, Some(&bundled), false);
+    assert_eq!(
+        first_executable_in(&dirs, "buzz-acp"),
+        Some(usable),
+        "a non-executable packaged sidecar must fall through to the workspace artifact"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 #[test]
 fn debug_command_search_prefers_fresh_workspace_artifacts() {
     let dirs = super::command_search_dirs_for_profile(


### PR DESCRIPTION
## Problem

In release builds, the desktop app's sidecar discovery (`command_search_dirs`) can find stale debug workspace artifacts instead of the bundled target-suffixed sidecars shipped beside the executable. This causes runtime failures when debug and release binaries are incompatible.

## What This Changes

Refactors `command_search_dirs` into `command_search_dirs_for_profile` with explicit profile awareness:

- **Release builds** prefer bundled sidecars beside the app executable first, then fall back to workspace artifacts
- **Debug builds** continue preferring fresh workspace debug artifacts (unchanged behavior)
- The `Justfile` release recipe now calls `scripts/bundle-sidecars.sh` before Tauri packaging

## Scope

- `desktop/src-tauri/src/managed_agents/discovery.rs` — `command_search_dirs` refactored
- `desktop/src-tauri/src/managed_agents/discovery/tests.rs` — release/debug precedence tests
- `Justfile` — release recipe uses canonical sidecar bundling

## Verification

```
cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::discovery  →  77 passed (1 pre-existing)
cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --lib -- -D warnings  →  clean
```
