### PR TITLE
fix(desktop): Claude model picks + agent avatars after restart

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -122,7 +122,10 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         adapter_install_hint: "Buzz talks to the Claude Code CLI through an ACP adapter. Install it with: npm install -g @agentclientprotocol/claude-agent-acp.",
         skill_dir: Some(".claude/skills"),
         supports_acp_model_switching: false,
-        model_env_var: None,
+        // Claude Code reads ANTHROPIC_MODEL at process start (same key readiness
+        // already maps for anthropic). Without this, Edit Agent model picks never
+        // reach the spawned process (#2692).
+        model_env_var: Some("ANTHROPIC_MODEL"),
         provider_env_var: None,
         provider_locked: true,
         default_env: &[],

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -122,10 +122,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         adapter_install_hint: "Buzz talks to the Claude Code CLI through an ACP adapter. Install it with: npm install -g @agentclientprotocol/claude-agent-acp.",
         skill_dir: Some(".claude/skills"),
         supports_acp_model_switching: false,
-        // Claude Code reads ANTHROPIC_MODEL at process start (same key readiness
-        // already maps for anthropic). Without this, Edit Agent model picks never
-        // reach the spawned process (#2692).
-        model_env_var: Some(crate::managed_agents::ANTHROPIC_MODEL_ENV_KEY),
+        model_env_var: Some(crate::managed_agents::ANTHROPIC_MODEL_ENV_KEY), // #2692
         provider_env_var: None,
         provider_locked: true,
         default_env: &[],

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -125,7 +125,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         // Claude Code reads ANTHROPIC_MODEL at process start (same key readiness
         // already maps for anthropic). Without this, Edit Agent model picks never
         // reach the spawned process (#2692).
-        model_env_var: Some("ANTHROPIC_MODEL"),
+        model_env_var: Some(crate::managed_agents::ANTHROPIC_MODEL_ENV_KEY),
         provider_env_var: None,
         provider_locked: true,
         default_env: &[],

--- a/desktop/src-tauri/src/managed_agents/discovery/catalog.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/catalog.rs
@@ -65,7 +65,10 @@ pub(crate) const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         adapter_install_hint: "Buzz talks to the Claude Code CLI through an ACP adapter. Install it with: npm install -g @agentclientprotocol/claude-agent-acp.",
         skill_dir: Some(".claude/skills"),
         supports_acp_model_switching: false,
-        model_env_var: None,
+        // Claude Code reads ANTHROPIC_MODEL at process start (same key readiness
+        // already maps for anthropic). Without this, Edit Agent model picks never
+        // reach the spawned process (#2692).
+        model_env_var: Some("ANTHROPIC_MODEL"),
         provider_env_var: None,
         provider_locked: true,
         default_env: &[],

--- a/desktop/src-tauri/src/managed_agents/discovery/catalog.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/catalog.rs
@@ -68,7 +68,7 @@ pub(crate) const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         // Claude Code reads ANTHROPIC_MODEL at process start (same key readiness
         // already maps for anthropic). Without this, Edit Agent model picks never
         // reach the spawned process (#2692).
-        model_env_var: Some("ANTHROPIC_MODEL"),
+        model_env_var: Some(crate::managed_agents::ANTHROPIC_MODEL_ENV_KEY),
         provider_env_var: None,
         provider_locked: true,
         default_env: &[],

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1921,3 +1921,12 @@ fn discovery_publish_path_drops_mid_flight_delete() {
         "discovery's publish must not resurrect a harness deleted mid-discovery"
     );
 }
+
+/// The claude runtime must declare a model env channel — without one, the
+/// model picked in the UI is persisted but never applied at spawn (#2692).
+#[test]
+fn claude_runtime_declares_anthropic_model_env_var() {
+    let claude = super::known_acp_runtime_exact("claude").expect("claude runtime registered");
+    assert_eq!(claude.model_env_var, Some("ANTHROPIC_MODEL"));
+    assert!(claude.provider_locked);
+    assert_eq!(claude.provider_env_var, None);

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -780,7 +780,7 @@ fn probe_codex_acp_version_parses_full_semver_output() {
         "adapter output must parse to its full semantic version"
     );
 }
-
+mod claude_model_env;
 mod codex_version;
 
 #[cfg(unix)]
@@ -1921,12 +1921,3 @@ fn discovery_publish_path_drops_mid_flight_delete() {
         "discovery's publish must not resurrect a harness deleted mid-discovery"
     );
 }
-
-/// The claude runtime must declare a model env channel — without one, the
-/// model picked in the UI is persisted but never applied at spawn (#2692).
-#[test]
-fn claude_runtime_declares_anthropic_model_env_var() {
-    let claude = super::known_acp_runtime_exact("claude").expect("claude runtime registered");
-    assert_eq!(claude.model_env_var, Some("ANTHROPIC_MODEL"));
-    assert!(claude.provider_locked);
-    assert_eq!(claude.provider_env_var, None);

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -637,7 +637,7 @@ fn probe_codex_acp_version_parses_full_semver_output() {
         "adapter output must parse to its full semantic version"
     );
 }
-
+mod claude_model_env;
 mod codex_version;
 
 #[cfg(unix)]
@@ -1755,12 +1755,3 @@ fn discovery_publish_path_drops_mid_flight_delete() {
         "discovery's publish must not resurrect a harness deleted mid-discovery"
     );
 }
-
-/// The claude runtime must declare a model env channel — without one, the
-/// model picked in the UI is persisted but never applied at spawn (#2692).
-#[test]
-fn claude_runtime_declares_anthropic_model_env_var() {
-    let claude = super::known_acp_runtime_exact("claude").expect("claude runtime registered");
-    assert_eq!(claude.model_env_var, Some("ANTHROPIC_MODEL"));
-    assert!(claude.provider_locked);
-    assert_eq!(claude.provider_env_var, None);

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1755,3 +1755,12 @@ fn discovery_publish_path_drops_mid_flight_delete() {
         "discovery's publish must not resurrect a harness deleted mid-discovery"
     );
 }
+
+/// The claude runtime must declare a model env channel — without one, the
+/// model picked in the UI is persisted but never applied at spawn (#2692).
+#[test]
+fn claude_runtime_declares_anthropic_model_env_var() {
+    let claude = super::known_acp_runtime_exact("claude").expect("claude runtime registered");
+    assert_eq!(claude.model_env_var, Some("ANTHROPIC_MODEL"));
+    assert!(claude.provider_locked);
+    assert_eq!(claude.provider_env_var, None);

--- a/desktop/src-tauri/src/managed_agents/discovery/tests/claude_model_env.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests/claude_model_env.rs
@@ -1,0 +1,9 @@
+/// The claude runtime must declare a model env channel — without one, the
+/// model picked in the UI is persisted but never applied at spawn (#2692).
+#[test]
+fn claude_runtime_declares_anthropic_model_env_var() {
+    let claude = super::super::known_acp_runtime_exact("claude").expect("claude runtime registered");
+    assert_eq!(claude.model_env_var, Some("ANTHROPIC_MODEL"));
+    assert!(claude.provider_locked);
+    assert_eq!(claude.provider_env_var, None);
+}

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -25,6 +25,7 @@ use std::collections::BTreeMap;
 /// Non-structured knobs (`GOOSE_TEMPERATURE`, `GOOSE_CONTEXT_LIMIT`) are NOT
 /// in this list — they have no structured counterpart and must be preserved.
 pub(crate) const DERIVED_PROVIDER_MODEL_ENV_KEYS: &[&str] = &[
+    "ANTHROPIC_MODEL",
     "GOOSE_MODEL",
     "GOOSE_PROVIDER",
     "BUZZ_AGENT_MODEL",

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -24,8 +24,14 @@ use std::collections::BTreeMap;
 ///
 /// Non-structured knobs (`GOOSE_TEMPERATURE`, `GOOSE_CONTEXT_LIMIT`) are NOT
 /// in this list — they have no structured counterpart and must be preserved.
+/// Env var the Claude CLI honors as a session model override. Single source
+/// of truth for the key — referenced by the claude runtime entry
+/// (`discovery.rs`), the derived-key list below, and the readiness
+/// provider-model mapping, so the three cannot drift apart.
+pub(crate) const ANTHROPIC_MODEL_ENV_KEY: &str = "ANTHROPIC_MODEL";
+
 pub(crate) const DERIVED_PROVIDER_MODEL_ENV_KEYS: &[&str] = &[
-    "ANTHROPIC_MODEL",
+    ANTHROPIC_MODEL_ENV_KEY,
     "GOOSE_MODEL",
     "GOOSE_PROVIDER",
     "BUZZ_AGENT_MODEL",

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -26,8 +26,14 @@ use std::collections::BTreeMap;
 ///
 /// Non-structured knobs (`GOOSE_TEMPERATURE`, `GOOSE_CONTEXT_LIMIT`) are NOT
 /// in this list — they have no structured counterpart and must be preserved.
+/// Env var the Claude CLI honors as a session model override. Single source
+/// of truth for the key — referenced by the claude runtime entry
+/// (`discovery.rs`), the derived-key list below, and the readiness
+/// provider-model mapping, so the three cannot drift apart.
+pub(crate) const ANTHROPIC_MODEL_ENV_KEY: &str = "ANTHROPIC_MODEL";
+
 pub(crate) const DERIVED_PROVIDER_MODEL_ENV_KEYS: &[&str] = &[
-    "ANTHROPIC_MODEL",
+    ANTHROPIC_MODEL_ENV_KEY,
     "GOOSE_MODEL",
     "GOOSE_PROVIDER",
     "BUZZ_AGENT_MODEL",

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -27,6 +27,7 @@ use std::collections::BTreeMap;
 /// Non-structured knobs (`GOOSE_TEMPERATURE`, `GOOSE_CONTEXT_LIMIT`) are NOT
 /// in this list — they have no structured counterpart and must be preserved.
 pub(crate) const DERIVED_PROVIDER_MODEL_ENV_KEYS: &[&str] = &[
+    "ANTHROPIC_MODEL",
     "GOOSE_MODEL",
     "GOOSE_PROVIDER",
     "BUZZ_AGENT_MODEL",

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -418,9 +418,9 @@ fn merged_env_drops_oversize_value() {
 
 // ── derived provider/model key filter ──────────────────────────────
 //
-// Pack import must strip derived env keys (GOOSE_MODEL, GOOSE_PROVIDER,
-// BUZZ_AGENT_MODEL, BUZZ_AGENT_PROVIDER) so they don't shadow the
-// structured AgentDefinition.model / AgentDefinition.provider fields after
+// Pack import must strip derived env keys (ANTHROPIC_MODEL, GOOSE_MODEL,
+// GOOSE_PROVIDER, BUZZ_AGENT_MODEL, BUZZ_AGENT_PROVIDER) so they don't shadow
+// the structured AgentDefinition.model / AgentDefinition.provider fields after
 // the user edits them in the UI.
 
 #[test]
@@ -439,6 +439,7 @@ fn is_derived_key_is_case_insensitive() {
     assert!(is_derived_provider_model_key("Goose_Provider"));
     assert!(is_derived_provider_model_key("buzz_agent_model"));
     assert!(is_derived_provider_model_key("BUZZ_AGENT_PROVIDER"));
+    assert!(is_derived_provider_model_key("anthropic_model"));
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -442,9 +442,9 @@ fn merged_env_drops_oversize_value() {
 
 // ── derived provider/model key filter ──────────────────────────────
 //
-// Pack import must strip derived env keys (GOOSE_MODEL, GOOSE_PROVIDER,
-// BUZZ_AGENT_MODEL, BUZZ_AGENT_PROVIDER) so they don't shadow the
-// structured AgentDefinition.model / AgentDefinition.provider fields after
+// Pack import must strip derived env keys (ANTHROPIC_MODEL, GOOSE_MODEL,
+// GOOSE_PROVIDER, BUZZ_AGENT_MODEL, BUZZ_AGENT_PROVIDER) so they don't shadow
+// the structured AgentDefinition.model / AgentDefinition.provider fields after
 // the user edits them in the UI.
 
 #[test]
@@ -463,6 +463,7 @@ fn is_derived_key_is_case_insensitive() {
     assert!(is_derived_provider_model_key("Goose_Provider"));
     assert!(is_derived_provider_model_key("buzz_agent_model"));
     assert!(is_derived_provider_model_key("BUZZ_AGENT_PROVIDER"));
+    assert!(is_derived_provider_model_key("anthropic_model"));
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -479,7 +479,7 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
         Some("databricks") | Some("databricks_v2") | Some("databricks-v2") => {
             Some("DATABRICKS_MODEL")
         }
-        Some("anthropic") => Some("ANTHROPIC_MODEL"),
+        Some("anthropic") => Some(super::ANTHROPIC_MODEL_ENV_KEY),
         Some("openai") | Some("openai-compat") => Some("OPENAI_COMPAT_MODEL"),
         _ => None,
     };

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -493,7 +493,7 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
         Some("databricks") | Some("databricks_v2") | Some("databricks-v2") => {
             Some("DATABRICKS_MODEL")
         }
-        Some("anthropic") => Some("ANTHROPIC_MODEL"),
+        Some("anthropic") => Some(super::ANTHROPIC_MODEL_ENV_KEY),
         Some("openai") | Some("openai-compat") => Some("OPENAI_COMPAT_MODEL"),
         Some("openrouter") => Some("OPENROUTER_MODEL"),
         _ => None,

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -534,7 +534,6 @@ fn runtime_metadata_env_vars_injects_model_and_provider() {
 
 #[test]
 fn runtime_metadata_env_vars_skips_provider_when_locked() {
-    // Claude: model via ANTHROPIC_MODEL; provider stays locked (no provider env).
     let vars = runtime_metadata_env_vars(
         Some("ANTHROPIC_MODEL"),
         None,

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -534,14 +534,15 @@ fn runtime_metadata_env_vars_injects_model_and_provider() {
 
 #[test]
 fn runtime_metadata_env_vars_skips_provider_when_locked() {
+    // Claude: model via ANTHROPIC_MODEL; provider stays locked (no provider env).
     let vars = runtime_metadata_env_vars(
-        None, // claude has no model_env_var
-        None, // claude has no provider_env_var
+        Some("ANTHROPIC_MODEL"),
+        None,
         true, // provider_locked = true
         Some("claude-opus-4-7"),
         Some("anthropic"),
     );
-    assert!(vars.is_empty());
+    assert_eq!(vars, vec![("ANTHROPIC_MODEL", "claude-opus-4-7")]);
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -523,7 +523,6 @@ fn runtime_metadata_env_vars_injects_model_and_provider() {
 
 #[test]
 fn runtime_metadata_env_vars_skips_provider_when_locked() {
-    // Claude: model via ANTHROPIC_MODEL; provider stays locked (no provider env).
     let vars = runtime_metadata_env_vars(
         Some("ANTHROPIC_MODEL"),
         None,

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -523,14 +523,15 @@ fn runtime_metadata_env_vars_injects_model_and_provider() {
 
 #[test]
 fn runtime_metadata_env_vars_skips_provider_when_locked() {
+    // Claude: model via ANTHROPIC_MODEL; provider stays locked (no provider env).
     let vars = runtime_metadata_env_vars(
-        None, // claude has no model_env_var
-        None, // claude has no provider_env_var
+        Some("ANTHROPIC_MODEL"),
+        None,
         true, // provider_locked = true
         Some("claude-opus-4-7"),
         Some("anthropic"),
     );
-    assert!(vars.is_empty());
+    assert_eq!(vars, vec![("ANTHROPIC_MODEL", "claude-opus-4-7")]);
 }
 
 #[test]

--- a/desktop/src/features/agents/lib/agentCardAvatar.test.mjs
+++ b/desktop/src/features/agents/lib/agentCardAvatar.test.mjs
@@ -23,6 +23,17 @@ test("running agent card falls back to the definition avatar", () => {
   );
 });
 
+test("running agent card falls back to the managed agent avatar", () => {
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      null,
+      null,
+      " https://relay.example/managed.png ",
+    ),
+    "https://relay.example/managed.png",
+  );
+});
+
 test("running agent card ignores blank avatar values", () => {
   assert.equal(resolveAgentCardAvatarUrl("  ", ""), null);
 });

--- a/desktop/src/features/agents/lib/agentCardAvatar.ts
+++ b/desktop/src/features/agents/lib/agentCardAvatar.ts
@@ -8,8 +8,13 @@
 export function resolveAgentCardAvatarUrl(
   profileAvatarUrl: string | null | undefined,
   personaAvatarUrl: string | null | undefined,
+  managedAgentAvatarUrl?: string | null | undefined,
 ): string | null {
-  for (const candidate of [profileAvatarUrl, personaAvatarUrl]) {
+  for (const candidate of [
+    profileAvatarUrl,
+    managedAgentAvatarUrl,
+    personaAvatarUrl,
+  ]) {
     const trimmed = candidate?.trim();
     if (trimmed) return trimmed;
   }

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -272,8 +272,14 @@ function AgentPersonaCard({
   });
   const isActive = agent ? isManagedAgentActive(agent) : false;
   const profileQuery = useUserProfileQuery(agent?.pubkey);
+  // Prefer the managed agent record — it survives restart even when the
+  // profile query cache is still empty (#2576).
   const avatarUrl = agent
-    ? firstAvatarUrl(persona.avatarUrl, profileQuery.data?.avatarUrl)
+    ? firstAvatarUrl(
+        agent.avatarUrl,
+        persona.avatarUrl,
+        profileQuery.data?.avatarUrl,
+      )
     : persona.avatarUrl;
   const friendlyError = agent
     ? friendlyAgentLastError(agent.lastError, agent.lastErrorCode)?.copy
@@ -361,6 +367,12 @@ function StandaloneAgentCard({
 }) {
   const title = agent.name;
   const profileQuery = useUserProfileQuery(agent.pubkey);
+  // Prefer the managed agent record — it survives restart even when the
+  // profile query cache is still empty (#2576).
+  const avatarUrl = firstAvatarUrl(
+    agent.avatarUrl,
+    profileQuery.data?.avatarUrl,
+  );
   const friendlyError = friendlyAgentLastError(
     agent.lastError,
     agent.lastErrorCode,
@@ -374,7 +386,7 @@ function StandaloneAgentCard({
       avatar={
         <AgentRuntimeAvatarControl
           activeTestId={`agent-runtime-active-${agent.pubkey}`}
-          avatarUrl={profileQuery.data?.avatarUrl}
+          avatarUrl={avatarUrl}
           errorLabel={friendlyError}
           errorTestId={`agent-runtime-error-${agent.pubkey}`}
           isActive={isActive}
@@ -387,7 +399,7 @@ function StandaloneAgentCard({
           onStart={() => onStartAgent(agent.pubkey)}
         />
       }
-      avatarUrl={profileQuery.data?.avatarUrl}
+      avatarUrl={avatarUrl}
       dataTestId={`managed-agent-${agent.pubkey}`}
       label={title}
       modelLabel={resolveAgentCardModelLabel({

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -285,8 +285,14 @@ function AgentPersonaCard({
     });
   const isActive = agent ? isManagedAgentActive(agent) : false;
   const profileQuery = useUserProfileQuery(agent?.pubkey);
+  // Prefer the managed agent record — it survives restart even when the
+  // profile query cache is still empty (#2576).
   const avatarUrl = agent
-    ? resolveAgentCardAvatarUrl(profileQuery.data?.avatarUrl, persona.avatarUrl)
+    ? resolveAgentCardAvatarUrl(
+        profileQuery.data?.avatarUrl,
+        persona.avatarUrl,
+        agent.avatarUrl,
+      )
     : persona.avatarUrl;
   const friendlyError = agent
     ? friendlyAgentLastError(agent.lastError, agent.lastErrorCode)?.copy
@@ -394,6 +400,13 @@ function StandaloneAgentCard({
   const availability = getAvailability(agent.pubkey);
   const title = agent.name;
   const profileQuery = useUserProfileQuery(agent.pubkey);
+  // Prefer the managed agent record — it survives restart even when the
+  // profile query cache is still empty (#2576).
+  const avatarUrl = resolveAgentCardAvatarUrl(
+    profileQuery.data?.avatarUrl,
+    undefined,
+    agent.avatarUrl,
+  );
   const friendlyError = friendlyAgentLastError(
     agent.lastError,
     agent.lastErrorCode,
@@ -407,7 +420,7 @@ function StandaloneAgentCard({
       avatar={
         <AgentRuntimeAvatarControl
           activeTestId={`agent-runtime-active-${agent.pubkey}`}
-          avatarUrl={profileQuery.data?.avatarUrl}
+          avatarUrl={avatarUrl}
           errorLabel={friendlyError}
           errorTestId={`agent-runtime-error-${agent.pubkey}`}
           isActive={isActive}
@@ -427,7 +440,7 @@ function StandaloneAgentCard({
           }
         />
       }
-      avatarUrl={profileQuery.data?.avatarUrl}
+      avatarUrl={avatarUrl}
       dataTestId={`managed-agent-${agent.pubkey}`}
       footerAccessory={
         <ProtectedBestieCardBadge agent={agent} isBestie={isBestie} />


### PR DESCRIPTION
## Summary
- Claude Code agents honor the Edit Agent model picker via `ANTHROPIC_MODEL` at spawn
- Agents screen keeps custom avatars after restart by preferring the managed agent URL

## Test plan
- [x] `just ci`
- [ ] Set a Claude Code agent model ≠ global default → restart → ask which model it is
- [ ] Set a custom agent avatar → quit/relaunch Buzz → Agents screen still shows it

Closes #2692
Closes #2576

Made with [Cursor](https://cursor.com)