### PR TITLE
fix(desktop): snap caret out of agent mention chips

### DIFF
--- a/desktop/src/features/messages/lib/mentionHighlightExtension.test.mjs
+++ b/desktop/src/features/messages/lib/mentionHighlightExtension.test.mjs
@@ -1,10 +1,30 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { getSchema } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+
 import {
   buildHighlightPatterns,
+  findAgentMentionRanges,
   findHighlightMatches,
+  snapCaretOutOfAgentMention,
 } from "./mentionHighlightExtension.ts";
+
+// Schema mirrors the composer for document-absolute position tests.
+const schema = getSchema([
+  StarterKit.configure({
+    hardBreak: { keepMarks: true },
+    heading: false,
+    trailingNode: false,
+    link: false,
+  }),
+]);
+const para = (...c) => schema.nodes.paragraph.create(null, c);
+const t = (s) => schema.text(s);
+function doc(...content) {
+  return schema.nodes.doc.create(null, content);
+}
 
 // ── buildHighlightPatterns ────────────────────────────────────────────
 
@@ -163,4 +183,62 @@ test("#general should NOT match inside #generally (trailing word boundary)", () 
   const patterns = buildHighlightPatterns([], ["general"]);
   const matches = findHighlightMatches("#generally", patterns);
   assert.equal(matches.length, 0);
+});
+
+// ── Agent-mention caret snap (#2707) ──────────────────────────────────
+// Persistent auto-tag keeps `@Agent ` at the head of the composer. Mentions
+// are decorations (not atoms) and the `@` is width:0, so a click that looks
+// like the start of the chip often lands *inside* the name. Typing there
+// mutates the display name and drops the decoration.
+
+test("findAgentMentionRanges locates agent mentions in document coords", () => {
+  // PM: doc=0, para opens at 0, text starts at 1: "@Ada " is positions 1..5
+  const d = doc(para(t("@Ada hello")));
+  const ranges = findAgentMentionRanges(d, ["Ada"]);
+  assert.equal(ranges.length, 1);
+  assert.equal(ranges[0].from, 1);
+  assert.equal(ranges[0].to, 5); // "@Ada"
+});
+
+test("snapCaretOutOfAgentMention leaves edge positions alone", () => {
+  const d = doc(para(t("@Ada ")));
+  // Positions: 1=before @, 5=after a, 6=after trailing space
+  assert.equal(snapCaretOutOfAgentMention(d, 1, ["Ada"]), 1);
+  assert.equal(snapCaretOutOfAgentMention(d, 5, ["Ada"]), 5);
+  assert.equal(snapCaretOutOfAgentMention(d, 6, ["Ada"]), 6);
+});
+
+test("snapCaretOutOfAgentMention snaps interior caret past trailing space", () => {
+  // "@Ada " — interior positions 2..4 (after @, mid-name) must jump to 6
+  // (after the trailing space hydration always inserts).
+  const d = doc(para(t("@Ada ")));
+  for (const pos of [2, 3, 4]) {
+    assert.equal(
+      snapCaretOutOfAgentMention(d, pos, ["Ada"]),
+      6,
+      `interior pos ${pos} should snap after trailing space`,
+    );
+  }
+});
+
+test("snapCaretOutOfAgentMention snaps to name end when no trailing space", () => {
+  const d = doc(para(t("@Ada")));
+  assert.equal(snapCaretOutOfAgentMention(d, 3, ["Ada"]), 5);
+});
+
+test("snapCaretOutOfAgentMention ignores non-agent mention names", () => {
+  // Human-only name list: no snap (agents are the ones with hidden @ + auto-tag).
+  const d = doc(para(t("@Alice hello")));
+  assert.equal(snapCaretOutOfAgentMention(d, 3, []), 3);
+});
+
+test("snapCaretOutOfAgentMention handles multiple agent chips", () => {
+  // "@Ada @Bob " — caret inside Bob should land after Bob's trailing space.
+  const d = doc(para(t("@Ada @Bob more")));
+  const ranges = findAgentMentionRanges(d, ["Ada", "Bob"]);
+  assert.equal(ranges.length, 2);
+  const bob = ranges[1];
+  const interior = bob.from + 2;
+  const snapped = snapCaretOutOfAgentMention(d, interior, ["Ada", "Bob"]);
+  assert.equal(snapped, bob.to + 1); // consume trailing space after @Bob
 });

--- a/desktop/src/features/messages/lib/mentionHighlightExtension.test.mjs
+++ b/desktop/src/features/messages/lib/mentionHighlightExtension.test.mjs
@@ -5,10 +5,12 @@ import { getSchema } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 
 import {
+  agentMentionChipDeleteRange,
   buildHighlightPatterns,
   findAgentMentionRanges,
   findHighlightMatches,
   snapCaretOutOfAgentMention,
+  withTrailingSpace,
 } from "./mentionHighlightExtension.ts";
 
 // Schema mirrors the composer for document-absolute position tests.
@@ -241,4 +243,83 @@ test("snapCaretOutOfAgentMention handles multiple agent chips", () => {
   const interior = bob.from + 2;
   const snapped = snapCaretOutOfAgentMention(d, interior, ["Ada", "Bob"]);
   assert.equal(snapped, bob.to + 1); // consume trailing space after @Bob
+});
+
+// ── Atomic Backspace/Delete on agent chips (#2707) ────────────────────
+
+test("withTrailingSpace consumes a single trailing space", () => {
+  const d = doc(para(t("@Ada more")));
+  // "@Ada" is 1..5; trailing space at 5 → 6
+  assert.equal(withTrailingSpace(d, 5), 6);
+  assert.equal(withTrailingSpace(d, 6), 6); // already past space
+});
+
+test("agentMentionChipDeleteRange: interior Backspace/Delete remove whole chip", () => {
+  const d = doc(para(t("@Ada hello")));
+  // "@Ada" 1..5, chip with space 1..6
+  for (const key of /** @type {const} */ (["Backspace", "Delete"])) {
+    for (const pos of [2, 3, 4]) {
+      assert.deepEqual(
+        agentMentionChipDeleteRange(d, pos, ["Ada"], key),
+        { from: 1, to: 6 },
+        `${key} at interior ${pos}`,
+      );
+    }
+  }
+});
+
+test("agentMentionChipDeleteRange: Backspace at end of name or after space", () => {
+  const d = doc(para(t("@Ada hello")));
+  // end of name (5) and after trailing space (6)
+  assert.deepEqual(agentMentionChipDeleteRange(d, 5, ["Ada"], "Backspace"), {
+    from: 1,
+    to: 6,
+  });
+  assert.deepEqual(agentMentionChipDeleteRange(d, 6, ["Ada"], "Backspace"), {
+    from: 1,
+    to: 6,
+  });
+  // Deep in following text: default editing
+  assert.equal(agentMentionChipDeleteRange(d, 10, ["Ada"], "Backspace"), null);
+});
+
+test("agentMentionChipDeleteRange: Delete at start of chip only", () => {
+  const d = doc(para(t("@Ada hello")));
+  assert.deepEqual(agentMentionChipDeleteRange(d, 1, ["Ada"], "Delete"), {
+    from: 1,
+    to: 6,
+  });
+  // Delete from after the chip leaves following text alone
+  assert.equal(agentMentionChipDeleteRange(d, 6, ["Ada"], "Delete"), null);
+});
+
+test("agentMentionChipDeleteRange: Backspace between two agent chips removes the left one", () => {
+  // "@Ada @Bob" — caret after Ada's trailing space is Bob's `@`
+  const d = doc(para(t("@Ada @Bob")));
+  const ranges = findAgentMentionRanges(d, ["Ada", "Bob"]);
+  const ada = ranges[0];
+  const bob = ranges[1];
+  const afterAdaSpace = withTrailingSpace(d, ada.to);
+  assert.equal(afterAdaSpace, bob.from);
+  assert.deepEqual(
+    agentMentionChipDeleteRange(d, afterAdaSpace, ["Ada", "Bob"], "Backspace"),
+    { from: ada.from, to: afterAdaSpace },
+  );
+  // Delete at that same spot removes Bob (start of next chip)
+  assert.deepEqual(
+    agentMentionChipDeleteRange(d, afterAdaSpace, ["Ada", "Bob"], "Delete"),
+    { from: bob.from, to: withTrailingSpace(d, bob.to) },
+  );
+});
+
+test("agentMentionChipDeleteRange: chip without trailing space", () => {
+  const d = doc(para(t("@Ada")));
+  assert.deepEqual(agentMentionChipDeleteRange(d, 3, ["Ada"], "Backspace"), {
+    from: 1,
+    to: 5,
+  });
+  assert.deepEqual(agentMentionChipDeleteRange(d, 5, ["Ada"], "Backspace"), {
+    from: 1,
+    to: 5,
+  });
 });

--- a/desktop/src/features/messages/lib/mentionHighlightExtension.ts
+++ b/desktop/src/features/messages/lib/mentionHighlightExtension.ts
@@ -1,5 +1,11 @@
 import { Extension } from "@tiptap/core";
-import { Plugin, PluginKey, type Transaction } from "@tiptap/pm/state";
+import type { Node as PMNode } from "@tiptap/pm/model";
+import {
+  Plugin,
+  PluginKey,
+  TextSelection,
+  type Transaction,
+} from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
 export const mentionHighlightKey = new PluginKey("mentionHighlight");
@@ -10,6 +16,13 @@ export const mentionHighlightKey = new PluginKey("mentionHighlight");
  *
  * Accepts `names` (display names) and `channelNames` storage options.
  * On every doc update the plugin scans text nodes and decorates matches.
+ *
+ * Agent mentions are still plain text (decorations, not atom nodes), but the
+ * composer hides the leading `@` (width:0). Clicks that look like "start of
+ * the chip" often land *inside* the name; typing then mutates the display
+ * name and drops the decoration — the persistent auto-tag regression (#2707).
+ * This extension snaps an empty caret out of the interior of agent mentions
+ * and rewrites text input so it lands after the chip instead.
  */
 export const MentionHighlightExtension = Extension.create({
   name: "mentionHighlight",
@@ -80,15 +93,106 @@ export const MentionHighlightExtension = Extension.create({
             return oldDecorations.map(tr.mapping, tr.doc);
           },
         },
+        appendTransaction(_transactions, _oldState, newState) {
+          if (!newState.selection.empty) return null;
+          const agentNames = extension.storage.agentNames as string[];
+          if (agentNames.length === 0) return null;
+          const pos = newState.selection.from;
+          const snapped = snapCaretOutOfAgentMention(
+            newState.doc,
+            pos,
+            agentNames,
+          );
+          if (snapped === pos) return null;
+          return newState.tr.setSelection(
+            TextSelection.create(newState.doc, snapped),
+          );
+        },
         props: {
           decorations(state) {
             return this.getState(state) ?? DecorationSet.empty;
+          },
+          // Typing must not land inside an agent chip: once the name mutates
+          // the decoration dies and persistent auto-tag appears "broken".
+          handleTextInput(view, from, to, text) {
+            const agentNames = extension.storage.agentNames as string[];
+            if (agentNames.length === 0) return false;
+            const snappedFrom = snapCaretOutOfAgentMention(
+              view.state.doc,
+              from,
+              agentNames,
+            );
+            const snappedTo =
+              from === to
+                ? snappedFrom
+                : snapCaretOutOfAgentMention(view.state.doc, to, agentNames);
+            if (snappedFrom === from && snappedTo === to) return false;
+            // Empty caret (or a selection wholly interior to the chip): insert
+            // after the chip instead of corrupting the display name.
+            const insertAt = Math.max(snappedFrom, snappedTo);
+            const tr = view.state.tr.insertText(text, insertAt);
+            tr.setSelection(
+              TextSelection.create(tr.doc, insertAt + text.length),
+            );
+            view.dispatch(tr);
+            return true;
           },
         },
       }),
     ];
   },
 });
+
+/**
+ * Document-absolute ranges of agent `@Name` mentions.
+ * Exported for testing.
+ */
+export function findAgentMentionRanges(
+  doc: PMNode,
+  agentNames: string[],
+): { from: number; to: number }[] {
+  if (agentNames.length === 0) return [];
+  const patterns = buildHighlightPatterns(agentNames, []);
+  if (patterns.length === 0) return [];
+  const ranges: { from: number; to: number }[] = [];
+  doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return;
+    for (const match of findHighlightMatches(node.text, patterns)) {
+      ranges.push({ from: pos + match.from, to: pos + match.to });
+    }
+  });
+  return ranges;
+}
+
+/**
+ * If `pos` lies strictly inside an agent mention, snap it just after the
+ * mention, consuming a single trailing space when present (the space
+ * autocomplete / persistent hydration always inserts after `@Name`).
+ *
+ * Edge positions stay put:
+ * - `from` (before `@`) so Backspace still works as expected
+ * - `to` (right after the name) so the user can type after a chip without a
+ *   trailing space yet
+ */
+export function snapCaretOutOfAgentMention(
+  doc: PMNode,
+  pos: number,
+  agentNames: string[],
+): number {
+  if (agentNames.length === 0) return pos;
+  for (const { from, to } of findAgentMentionRanges(doc, agentNames)) {
+    if (pos > from && pos < to) {
+      let snapped = to;
+      // Prefer the trailing space that insertResolvedMention always adds.
+      if (snapped < doc.content.size) {
+        const next = doc.textBetween(snapped, snapped + 1, "\n", "\0");
+        if (next === " ") snapped += 1;
+      }
+      return snapped;
+    }
+  }
+  return pos;
+}
 
 /**
  * Build highlight patterns for @Name and #channel-name matching.

--- a/desktop/src/features/messages/lib/mentionHighlightExtension.ts
+++ b/desktop/src/features/messages/lib/mentionHighlightExtension.ts
@@ -21,8 +21,9 @@ export const mentionHighlightKey = new PluginKey("mentionHighlight");
  * composer hides the leading `@` (width:0). Clicks that look like "start of
  * the chip" often land *inside* the name; typing then mutates the display
  * name and drops the decoration — the persistent auto-tag regression (#2707).
- * This extension snaps an empty caret out of the interior of agent mentions
- * and rewrites text input so it lands after the chip instead.
+ * This extension snaps an empty caret out of the interior of agent mentions,
+ * rewrites text input so it lands after the chip, and treats Backspace/Delete
+ * on the chip as an atomic remove (whole `@Name` + trailing space).
  */
 export const MentionHighlightExtension = Extension.create({
   name: "mentionHighlight",
@@ -137,6 +138,27 @@ export const MentionHighlightExtension = Extension.create({
             view.dispatch(tr);
             return true;
           },
+          // Backspace/Delete must not nibble the display name char-by-char
+          // (that also kills the decoration). Treat the chip as atomic.
+          handleKeyDown(view, event) {
+            if (event.key !== "Backspace" && event.key !== "Delete") {
+              return false;
+            }
+            const agentNames = extension.storage.agentNames as string[];
+            if (agentNames.length === 0) return false;
+            const { empty, from } = view.state.selection;
+            if (!empty) return false;
+            const range = agentMentionChipDeleteRange(
+              view.state.doc,
+              from,
+              agentNames,
+              event.key,
+            );
+            if (!range) return false;
+            const tr = view.state.tr.delete(range.from, range.to);
+            view.dispatch(tr);
+            return true;
+          },
         },
       }),
     ];
@@ -165,9 +187,20 @@ export function findAgentMentionRanges(
 }
 
 /**
+ * Expand a mention end position by one trailing space when present (the
+ * space autocomplete / persistent hydration always inserts after `@Name`).
+ */
+export function withTrailingSpace(doc: PMNode, mentionTo: number): number {
+  if (mentionTo < doc.content.size) {
+    const next = doc.textBetween(mentionTo, mentionTo + 1, "\n", "\0");
+    if (next === " ") return mentionTo + 1;
+  }
+  return mentionTo;
+}
+
+/**
  * If `pos` lies strictly inside an agent mention, snap it just after the
- * mention, consuming a single trailing space when present (the space
- * autocomplete / persistent hydration always inserts after `@Name`).
+ * mention, consuming a single trailing space when present.
  *
  * Edge positions stay put:
  * - `from` (before `@`) so Backspace still works as expected
@@ -182,16 +215,48 @@ export function snapCaretOutOfAgentMention(
   if (agentNames.length === 0) return pos;
   for (const { from, to } of findAgentMentionRanges(doc, agentNames)) {
     if (pos > from && pos < to) {
-      let snapped = to;
-      // Prefer the trailing space that insertResolvedMention always adds.
-      if (snapped < doc.content.size) {
-        const next = doc.textBetween(snapped, snapped + 1, "\n", "\0");
-        if (next === " ") snapped += 1;
-      }
-      return snapped;
+      return withTrailingSpace(doc, to);
     }
   }
   return pos;
+}
+
+/**
+ * Range to delete when Backspace/Delete should treat an agent chip as atomic
+ * (`@Name` + optional trailing space). Returns null when the key should use
+ * default text editing.
+ *
+ * - Interior of the name → either key removes the whole chip
+ * - Backspace at the end of the name or just after its trailing space → chip
+ * - Delete at the start of the chip (before `@`) → chip
+ */
+export function agentMentionChipDeleteRange(
+  doc: PMNode,
+  pos: number,
+  agentNames: string[],
+  key: "Backspace" | "Delete",
+): { from: number; to: number } | null {
+  if (agentNames.length === 0) return null;
+  for (const { from, to } of findAgentMentionRanges(doc, agentNames)) {
+    const chipTo = withTrailingSpace(doc, to);
+
+    // Strictly inside the `@Name` span — never nibble individual letters.
+    if (pos > from && pos < to) {
+      return { from, to: chipTo };
+    }
+
+    if (key === "Backspace") {
+      // Caret at end of name, or right after the trailing space.
+      if (pos === to || pos === chipTo) {
+        return { from, to: chipTo };
+      }
+    }
+
+    if (key === "Delete" && pos === from) {
+      return { from, to: chipTo };
+    }
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #2707.

With **Keep addressed agents active** (persistent auto-tag), the composer re-inserts `@AgentName ` after each send. Agent mentions are **decorations on plain text**, not atom nodes, and the leading `@` is rendered at `width: 0`. A click that looks like the start of the chip often lands *inside* the display name; the next keystrokes (or Backspace/Delete) mutate that name, the decoration dies, and the agent is no longer tagged.

This PR treats agent chips as non-editable caret space and atomic units:

1. **`snapCaretOutOfAgentMention`** — if the empty caret is strictly inside `@Name`, move it just after the mention (consuming the trailing space hydration always inserts).
2. **`appendTransaction`** — apply that snap after selection changes (clicks, arrows).
3. **`handleTextInput`** — if input would land inside a chip, insert after the chip instead of corrupting the name.
4. **`handleKeyDown` (Backspace/Delete)** — remove the whole chip (`@Name` + trailing space) instead of nibbling letters:
   - interior caret → either key deletes the chip
   - Backspace at end of name or just after trailing space → chip
   - Delete at start of chip (before `@`) → chip

Edge positions for typing stay put (`before @` for normal Backspace into prior text when not using atomic delete rules above; after-name typing still works). Human-only mentions are unchanged.

## How it was implemented

- Pure helpers in `mentionHighlightExtension.ts` (`findAgentMentionRanges`, `snapCaretOutOfAgentMention`, `withTrailingSpace`, `agentMentionChipDeleteRange`) so the policy is unit-testable without the full editor.
- Wired into the existing TipTap plugin that already owns agent decoration ranges — single source of truth for “what is an agent chip”.

## Test plan

- [x] Unit tests for range finding + caret snap (interior → after trailing space; edges untouched; multi-agent; empty agent list)
- [x] Unit tests for atomic Backspace/Delete (interior, end/after-space, Delete-at-start, two chips, no trailing space)
- [x] `node --test src/features/messages/lib/mentionHighlightExtension.test.mjs` — 35/35 pass
- [ ] Manual (desktop): enable keep-addressed-agents, @ an agent in a thread, send a few messages, click the chip / place caret mid-name, type — text should land *after* the chip; Backspace/Delete on the chip should remove it whole; the tag should remain intact when typing after it

## Notes

Out of scope: turning mentions into real atom nodes (larger rewrite). This is the minimal fix for the auto-tag breakage path reported in #2707.