### PR TITLE
feat(buzz-agent): allow forcing the account chooser on interactive login

### DIFF
--- a/crates/buzz-agent/src/auth.rs
+++ b/crates/buzz-agent/src/auth.rs
@@ -232,9 +232,18 @@ impl PkceOAuthTokenSource {
 
     /// Run the full browser-mediated Authorization Code + PKCE flow.
     /// Caller must hold a TTY/browser: this opens a window and blocks.
-    pub async fn interactive_login(&self) -> Result<(), AgentError> {
+    ///
+    /// `force_account_selection` adds `prompt=select_account` to the
+    /// authorization request. Without it the provider silently reuses whatever
+    /// session the default browser already holds, so a user signed into the
+    /// wrong account has no way to reach a different one. Pass `true` for
+    /// explicitly user-initiated logins ("use a different account"); leave it
+    /// `false` on implicit first-run auth, where an unnecessary account chooser
+    /// is friction and some providers reject the parameter.
+    pub async fn interactive_login(&self, force_account_selection: bool) -> Result<(), AgentError> {
         let endpoints = self.endpoints().await?;
-        let token = browser_pkce_flow(&self.http, &self.cfg, &endpoints).await?;
+        let token =
+            browser_pkce_flow(&self.http, &self.cfg, &endpoints, force_account_selection).await?;
         let mut state = self.state.lock().await;
         self.save(&mut state, token)?;
         Ok(())
@@ -289,8 +298,10 @@ impl TokenSource for PkceOAuthTokenSource {
             }
         }
 
-        // 5. No usable cache: full browser dance.
-        let fresh = browser_pkce_flow(&self.http, &self.cfg, &endpoints).await?;
+        // 5. No usable cache: full browser dance. No forced account chooser —
+        //    this path is reached implicitly mid-request, not by a user who
+        //    asked to switch accounts (see `interactive_login`).
+        let fresh = browser_pkce_flow(&self.http, &self.cfg, &endpoints, false).await?;
         let bearer = fresh.access_token.clone();
         self.save(&mut state, fresh)?;
         Ok(bearer)
@@ -521,6 +532,34 @@ fn random_state() -> Result<String, AgentError> {
     Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
 }
 
+/// Build the authorization-endpoint URL for one PKCE attempt.
+///
+/// When `force_account_selection` is set the request carries
+/// `prompt=select_account`, which tells the provider to show its account
+/// chooser instead of silently reusing the browser's current session.
+fn authorize_url(
+    endpoints: &OidcEndpoints,
+    cfg: &PkceOAuthConfig,
+    redirect_uri: &str,
+    state: &str,
+    challenge: &str,
+    force_account_selection: bool,
+) -> String {
+    let mut url = format!(
+        "{}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}&code_challenge={}&code_challenge_method=S256",
+        endpoints.authorization_endpoint,
+        urlencoding::encode(&cfg.client_id),
+        urlencoding::encode(redirect_uri),
+        urlencoding::encode(&cfg.scopes.join(" ")),
+        urlencoding::encode(state),
+        urlencoding::encode(challenge),
+    );
+    if force_account_selection {
+        url.push_str("&prompt=select_account");
+    }
+    url
+}
+
 /// Spin up a localhost callback server, open the authorize URL in a
 /// browser, wait up to [`BROWSER_AUTH_TIMEOUT`] for the redirect, then
 /// exchange the code for a token.
@@ -528,6 +567,7 @@ async fn browser_pkce_flow(
     http: &Client,
     cfg: &PkceOAuthConfig,
     endpoints: &OidcEndpoints,
+    force_account_selection: bool,
 ) -> Result<CachedToken, AgentError> {
     use axum::{extract::Query, response::Html, routing::get, Router};
     use std::collections::HashMap;
@@ -585,14 +625,13 @@ async fn browser_pkce_flow(
         let _ = axum::serve(listener, app).await;
     }));
 
-    let auth_url = format!(
-        "{}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}&code_challenge={}&code_challenge_method=S256",
-        endpoints.authorization_endpoint,
-        urlencoding::encode(&cfg.client_id),
-        urlencoding::encode(&redirect_uri),
-        urlencoding::encode(&cfg.scopes.join(" ")),
-        urlencoding::encode(&state),
-        urlencoding::encode(&challenge),
+    let auth_url = authorize_url(
+        endpoints,
+        cfg,
+        &redirect_uri,
+        &state,
+        &challenge,
+        force_account_selection,
     );
 
     eprintln!("Opening browser for authentication. If it doesn't open, visit:\n  {auth_url}");
@@ -640,6 +679,52 @@ mod tests {
         let expected = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(sha2::Sha256::digest(verifier.as_bytes()));
         assert_eq!(expected, challenge);
+    }
+
+    fn test_authorize_url(force_account_selection: bool) -> String {
+        let endpoints = OidcEndpoints {
+            authorization_endpoint: "https://accounts.example.com/authorize".into(),
+            token_endpoint: "https://accounts.example.com/token".into(),
+        };
+        let cfg = PkceOAuthConfig {
+            discovery_url: "https://accounts.example.com/.well-known/openid-configuration".into(),
+            client_id: "client-123".into(),
+            scopes: vec!["openid".into(), "email".into()],
+            cache_namespace: "example".into(),
+            cache_dir_override: None,
+        };
+        authorize_url(
+            &endpoints,
+            &cfg,
+            "http://localhost:1234",
+            "state-abc",
+            "challenge-xyz",
+            force_account_selection,
+        )
+    }
+
+    #[test]
+    fn authorize_url_omits_prompt_by_default() {
+        let url = test_authorize_url(false);
+        assert!(url.starts_with("https://accounts.example.com/authorize?"));
+        assert!(url.contains("client_id=client-123"));
+        assert!(url.contains("scope=openid%20email"));
+        assert!(
+            !url.contains("prompt="),
+            "implicit auth must not force an account chooser: {url}"
+        );
+    }
+
+    #[test]
+    fn authorize_url_requests_account_chooser_when_forced() {
+        let url = test_authorize_url(true);
+        assert!(
+            url.contains("&prompt=select_account"),
+            "explicit re-auth must let the user pick an account: {url}"
+        );
+        // The rest of the request is unchanged by the added parameter.
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("state=state-abc"));
     }
 
     #[test]

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -125,9 +125,14 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// `buzz-agent auth <provider>` — run the interactive auth flow for a
 /// provider and persist the result, then exit. Today this supports Databricks
 /// OAuth 2.0 PKCE. Reads `DATABRICKS_HOST` from env; needs a browser on the
-/// machine.
+/// machine. Pass `--select-account` to force the provider's account chooser
+/// rather than reusing whatever session the browser already holds.
 async fn auth_subcommand(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let provider = args.first().map(String::as_str);
+    // `--select-account` forces the provider's account chooser instead of
+    // silently reusing the browser's current session — the only way to
+    // authenticate as an account other than the one already signed in.
+    let force_account_selection = args.iter().any(|arg| arg == "--select-account");
     match provider {
         Some("databricks" | "databricks_v2" | "databricks-v2") => {
             let host = std::env::var("DATABRICKS_HOST")
@@ -143,12 +148,14 @@ async fn auth_subcommand(args: &[String]) -> Result<(), Box<dyn std::error::Erro
                 cache_dir_override: None,
             };
             let src = auth::PkceOAuthTokenSource::new(pkce)?;
-            src.interactive_login().await?;
+            src.interactive_login(force_account_selection).await?;
             eprintln!("Authenticated. Token cached under ~/.config/buzz-agent/oauth/databricks/.");
             Ok(())
         }
         Some(other) => Err(format!("auth: unknown provider {other:?}").into()),
-        None => Err("auth: provider required (try: buzz-agent auth databricks)".into()),
+        None => Err(
+            "auth: provider required (try: buzz-agent auth databricks [--select-account])".into(),
+        ),
     }
 }
 


### PR DESCRIPTION
Part of #2802.

> **Scope note:** this PR originally also changed the Builderlab sign-in path in Desktop. I removed that half after verifying it could never work — see [this comment](https://github.com/block/buzz/pull/2821#issuecomment-5081019602) for the evidence. What remains is the `buzz-agent` change, which talks to the provider's authorization endpoint directly.

## What problem this solves

`PkceOAuthTokenSource`'s browser flow builds its authorization URL with no `prompt` parameter:

```rust
// crates/buzz-agent/src/auth.rs, before this change
"{}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}&code_challenge={}&code_challenge_method=S256"
```

Per OIDC, omitting `prompt` lets the provider reuse an existing authenticated session. So when the flow opens a browser, whatever account that browser is already signed into is the account you get — silently, with no chooser. If it's the wrong one, there is no way to reach a different account: there's no re-auth path that forces the picker, and the on-disk token cache is keyed on `sha256(discovery_url|client_id|scopes)` (`cache_path_for`), so the cached token from the wrong account keeps satisfying requests.

## How it was implemented

- Extracted the URL construction out of `browser_pkce_flow` into a pure `authorize_url()` — this is what made it unit-testable.
- Threaded a `force_account_selection` flag through. When set, the request carries `prompt=select_account`.
- `interactive_login()` takes the flag, surfaced as `buzz-agent auth <provider> --select-account`.

### Key decision: implicit auth is unchanged

`bearer()`'s fall-through to the browser flow (step 5) passes `false`. That path is reached mid-request, not by a user who asked to switch accounts — forcing a chooser there is friction, and a provider that rejects `prompt=select_account` would start failing requests that work today. The parameter is only ever sent when someone explicitly asks for it on the command line.

Net effect on existing behavior: none. Every current call site produces a byte-identical authorization URL.

## Tests

`authorize_url_omits_prompt_by_default` and `authorize_url_requests_account_chooser_when_forced` in `crates/buzz-agent/src/auth.rs`. The first pins the default-off behavior, so a future change that starts forcing a chooser on implicit auth trips a test.

## How to test it manually

```
buzz-agent auth databricks --select-account
```
The authorization URL printed to stderr (and opened in the browser) carries `&prompt=select_account`; without the flag it doesn't.

## Follow-up deferred

The OAuth cache key doesn't include the authenticated account, so one machine still can't hold tokens for two accounts of the same provider. That's a cache-key migration and wants a maintainer opinion first — it's noted in #2802 and not addressed here.

## PR Checklist

- [x] `cargo fmt --all --check`, `cargo clippy -p buzz-agent --all-targets -- -D warnings` clean
- [x] `cargo test -p buzz-agent` (268 passing), `just test-unit` (full workspace); rebased onto current `main`
- [x] New public API documented (`authorize_url`, `interactive_login`)
- [x] No new `unwrap()` in production code paths
- [x] No new `unsafe` blocks
- [ ] Integration tests (`just test`) — not run; needs Postgres + Redis, and this touches none of the `buzz-relay`, `buzz-db`, or `buzz-auth` crates
