### PR TITLE
feat(desktop): add People/Agents tabs to channel members dialog

### DIFF
--- a/desktop/src/features/channels/lib/memberTypeTab.test.mjs
+++ b/desktop/src/features/channels/lib/memberTypeTab.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  filterAddSearchResultsForTypeTab,
+  filterMembersForTypeTab,
+} from "./memberTypeTab.ts";
+
+function member(pubkey, role, isAgent) {
+  return {
+    pubkey,
+    role,
+    isAgent,
+    joinedAt: "2026-07-01T00:00:00.000Z",
+    displayName: null,
+  };
+}
+
+const owner = member("owner-pk", "owner", false);
+const human = member("human-pk", "member", false);
+const roleBot = member("role-bot-pk", "bot", true);
+// Backend-flagged agent added by someone else with a plain "member" role —
+// classification must not depend on role alone.
+const flaggedAgent = member("flagged-agent-pk", "member", true);
+
+const members = [owner, human, roleBot, flaggedAgent];
+const isBot = (candidate) => candidate.role === "bot" || candidate.isAgent;
+
+test("filterMembersForTypeTab returns every member for the all tab", () => {
+  assert.deepEqual(filterMembersForTypeTab(members, "all", isBot), members);
+});
+
+test("filterMembersForTypeTab keeps only non-agents on the people tab", () => {
+  assert.deepEqual(filterMembersForTypeTab(members, "people", isBot), [
+    owner,
+    human,
+  ]);
+});
+
+test("filterMembersForTypeTab keeps only agents on the agents tab", () => {
+  assert.deepEqual(filterMembersForTypeTab(members, "agents", isBot), [
+    roleBot,
+    flaggedAgent,
+  ]);
+});
+
+test("filterMembersForTypeTab preserves input order", () => {
+  const reversed = [...members].reverse();
+  assert.deepEqual(filterMembersForTypeTab(reversed, "agents", isBot), [
+    flaggedAgent,
+    roleBot,
+  ]);
+});
+
+function searchResult(pubkey, isAgent) {
+  return {
+    pubkey,
+    displayName: pubkey,
+    avatarUrl: null,
+    nip05Handle: null,
+    ownerPubkey: null,
+    isAgent,
+  };
+}
+
+const humanResult = searchResult("human-result-pk", false);
+const agentResult = searchResult("agent-result-pk", true);
+const results = [humanResult, agentResult];
+
+test("filterAddSearchResultsForTypeTab returns everything for the all tab", () => {
+  assert.deepEqual(filterAddSearchResultsForTypeTab(results, "all"), results);
+});
+
+test("filterAddSearchResultsForTypeTab scopes the people tab to non-agents", () => {
+  assert.deepEqual(filterAddSearchResultsForTypeTab(results, "people"), [
+    humanResult,
+  ]);
+});
+
+test("filterAddSearchResultsForTypeTab scopes the agents tab to agents", () => {
+  assert.deepEqual(filterAddSearchResultsForTypeTab(results, "agents"), [
+    agentResult,
+  ]);
+});

--- a/desktop/src/features/channels/lib/memberTypeTab.ts
+++ b/desktop/src/features/channels/lib/memberTypeTab.ts
@@ -1,0 +1,30 @@
+import type { ChannelMember, UserSearchResult } from "@/shared/api/types";
+
+export type MemberTypeTab = "all" | "people" | "agents";
+
+export function filterMembersForTypeTab<T extends ChannelMember>(
+  members: readonly T[],
+  tab: MemberTypeTab,
+  isBot: (member: T) => boolean,
+): T[] {
+  if (tab === "people") {
+    return members.filter((member) => !isBot(member));
+  }
+  if (tab === "agents") {
+    return members.filter((member) => isBot(member));
+  }
+  return [...members];
+}
+
+export function filterAddSearchResultsForTypeTab<T extends UserSearchResult>(
+  results: readonly T[],
+  tab: MemberTypeTab,
+): T[] {
+  if (tab === "people") {
+    return results.filter((result) => !result.isAgent);
+  }
+  if (tab === "agents") {
+    return results.filter((result) => result.isAgent);
+  }
+  return [...results];
+}

--- a/desktop/src/features/channels/lib/useClassifiedMembers.ts
+++ b/desktop/src/features/channels/lib/useClassifiedMembers.ts
@@ -33,8 +33,12 @@ export function useClassifiedMembers(
   const isBot = React.useCallback(
     (member: ChannelMember) => {
       const normalized = normalizePubkey(member.pubkey);
+      // member.isAgent carries the backend's NIP-OA owner check — without it,
+      // an agent added by another user under a plain "member" role (and absent
+      // from this viewer's managed/relay agent lists) classifies as a person.
       return (
         member.role === "bot" ||
+        member.isAgent ||
         managedAgentPubkeys.has(normalized) ||
         relayAgentPubkeys.has(normalized)
       );

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Bot, UserRoundPlus, X } from "lucide-react";
+import { UserRoundPlus, X } from "lucide-react";
 import {
   invalidateChannelState,
   useAddChannelMembersMutation,
@@ -13,6 +13,11 @@ import {
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
+import {
+  filterAddSearchResultsForTypeTab,
+  filterMembersForTypeTab,
+  type MemberTypeTab,
+} from "@/features/channels/lib/memberTypeTab";
 import { formatMemberName } from "@/features/channels/lib/memberUtils";
 import {
   useFlattenedUserSearchResults,
@@ -32,7 +37,6 @@ import type {
   ManagedAgent,
   UserSearchResult,
 } from "@/shared/api/types";
-import { Button } from "@/shared/ui/button";
 import {
   Dialog,
   DialogClose,
@@ -42,14 +46,17 @@ import {
 } from "@/shared/ui/dialog";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
-import { cn } from "@/shared/lib/cn";
 import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
-import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
   MODAL_SEARCH_INPUT_CLASS,
   MODAL_SEARCH_SHELL_CLASS,
 } from "@/shared/ui/modalSearchStyles";
+import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 import { MembersSidebarMemberCard } from "./MembersSidebarMemberCard";
+import {
+  formatAddCandidateName,
+  MembersSidebarAddResultRow,
+} from "./MembersSidebarAddResultRow";
 import { useManagedAgentRuntimesQuery } from "@/features/agents/managedAgentRuntimeHooks";
 import {
   findManagedAgentRuntime,
@@ -60,16 +67,9 @@ import { useMembersSidebarActions } from "./useMembersSidebarActions";
 import { useMembersSidebarModeration } from "./useMembersSidebarModeration";
 const MEMBER_ADD_RESULT_LIMIT = 50;
 const MEMBER_SEARCH_MIN_QUERY_LENGTH = 2;
-const MEMBER_ROW_INSET_DIVIDER_CLASS =
-  "after:pointer-events-none after:absolute after:bottom-0 after:left-[3.75rem] after:right-0 after:h-px after:bg-border/60 after:content-[''] last:after:hidden";
+const MEMBER_TYPE_TAB_TRIGGER_CLASS =
+  "rounded-none border-b-2 border-transparent bg-transparent px-0 py-2 text-sm font-medium shadow-none transition-colors duration-150 ease-out data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none";
 
-function formatAddCandidateName(user: UserSearchResult) {
-  return (
-    user.displayName?.trim() ||
-    user.nip05Handle?.trim() ||
-    truncatePubkey(user.pubkey)
-  );
-}
 type AddMemberSearchCandidate = UserSearchResult & {
   isManagedAgent?: boolean;
   isMember?: boolean;
@@ -147,6 +147,8 @@ export function MembersSidebar({
   const queryClient = useQueryClient();
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = React.useState("");
+  const [memberTypeTab, setMemberTypeTab] =
+    React.useState<MemberTypeTab>("all");
   const [inviteSubmissionErrors, setInviteSubmissionErrors] = React.useState<
     AddChannelMembersResult["errors"]
   >([]);
@@ -179,6 +181,8 @@ export function MembersSidebar({
     people,
     bots,
     archived,
+    peopleCount,
+    botCount,
     isBot,
     isMyBot,
     managedAgentsQuery,
@@ -236,6 +240,10 @@ export function MembersSidebar({
     memberProfilesQuery.data?.profiles,
     normalizedSearchQuery,
   ]);
+  const tabVisibleMembers = React.useMemo(
+    () => filterMembersForTypeTab(filteredActiveMembers, memberTypeTab, isBot),
+    [filteredActiveMembers, isBot, memberTypeTab],
+  );
   const memberPubkeys = React.useMemo(
     () => new Set(rawMembers.map((member) => normalizePubkey(member.pubkey))),
     [rawMembers],
@@ -370,6 +378,10 @@ export function MembersSidebar({
     userSearchResults,
     rawMembers,
   ]);
+  const visibleAddSearchResults = React.useMemo(
+    () => filterAddSearchResultsForTypeTab(addSearchResults, memberTypeTab),
+    [addSearchResults, memberTypeTab],
+  );
   const isAddSearchLoading =
     userSearchQuery.isLoading ||
     managedAgentsQuery.isLoading ||
@@ -524,6 +536,7 @@ export function MembersSidebar({
   React.useEffect(() => {
     if (!open) {
       setSearchQuery("");
+      setMemberTypeTab("all");
       setInviteSubmissionErrors([]);
       setAddingMemberPubkeys(new Set());
       return;
@@ -705,12 +718,15 @@ export function MembersSidebar({
                   setSearchQuery(event.target.value);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key !== "Enter" || addSearchResults.length === 0) {
+                  if (
+                    event.key !== "Enter" ||
+                    visibleAddSearchResults.length === 0
+                  ) {
                     return;
                   }
 
                   event.preventDefault();
-                  void handleAddSearchResult(addSearchResults[0]);
+                  void handleAddSearchResult(visibleAddSearchResults[0]);
                 }}
                 placeholder={
                   canAddMembers
@@ -725,6 +741,38 @@ export function MembersSidebar({
             </label>
           </DialogHeader>
 
+          <Tabs
+            className="shrink-0 pb-3"
+            onValueChange={(value) => {
+              setMemberTypeTab(value as MemberTypeTab);
+            }}
+            value={memberTypeTab}
+          >
+            <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b border-border/70 bg-transparent p-0 text-muted-foreground">
+              <TabsTrigger
+                className={MEMBER_TYPE_TAB_TRIGGER_CLASS}
+                data-testid="members-type-tab-all"
+                value="all"
+              >
+                All · {activeMembers.length}
+              </TabsTrigger>
+              <TabsTrigger
+                className={MEMBER_TYPE_TAB_TRIGGER_CLASS}
+                data-testid="members-type-tab-people"
+                value="people"
+              >
+                People · {peopleCount}
+              </TabsTrigger>
+              <TabsTrigger
+                className={MEMBER_TYPE_TAB_TRIGGER_CLASS}
+                data-testid="members-type-tab-agents"
+                value="agents"
+              >
+                Agents · {botCount}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
           <div className="max-h-[calc(100vh-12rem)] overflow-y-auto pb-6">
             <section>
               <div
@@ -735,22 +783,27 @@ export function MembersSidebar({
                 <SearchResultSectionTitle>
                   {normalizedSearchQuery
                     ? "Members"
-                    : `Members · ${activeMembers.length}`}
+                    : memberTypeTab === "people"
+                      ? `People · ${peopleCount}`
+                      : memberTypeTab === "agents"
+                        ? `Agents · ${botCount}`
+                        : `Members · ${activeMembers.length}`}
                 </SearchResultSectionTitle>
                 {normalizedSearchQuery ? (
                   <div>
-                    {filteredActiveMembers.map((member) =>
+                    {tabVisibleMembers.map((member) =>
                       renderMemberCard(member, isBot(member)),
                     )}
                     {canAddMembers ? (
                       <>
-                        {addSearchResults.length > 0 || isAddSearchLoading ? (
+                        {visibleAddSearchResults.length > 0 ||
+                        isAddSearchLoading ? (
                           <SearchResultSectionTitle>
                             Not in this channel
                           </SearchResultSectionTitle>
                         ) : null}
-                        {addSearchResults.map((user) => (
-                          <AddMemberSearchResultRow
+                        {visibleAddSearchResults.map((user) => (
+                          <MembersSidebarAddResultRow
                             disabled={
                               addingMemberPubkeys.has(user.pubkey) || isArchived
                             }
@@ -773,17 +826,17 @@ export function MembersSidebar({
                         ) : null}
                       </>
                     ) : null}
-                    {filteredActiveMembers.length === 0 &&
-                    addSearchResults.length === 0 &&
+                    {tabVisibleMembers.length === 0 &&
+                    visibleAddSearchResults.length === 0 &&
                     !isAddSearchLoading ? (
                       <p className="px-4 py-3 text-sm text-muted-foreground">
                         No matching people or agents.
                       </p>
                     ) : null}
                   </div>
-                ) : filteredActiveMembers.length > 0 ? (
+                ) : tabVisibleMembers.length > 0 ? (
                   <div>
-                    {filteredActiveMembers.map((member) =>
+                    {tabVisibleMembers.map((member) =>
                       renderMemberCard(member, isBot(member)),
                     )}
                   </div>
@@ -791,15 +844,17 @@ export function MembersSidebar({
                   <p className="px-4 py-3 text-sm text-muted-foreground">
                     {membersQuery.isLoading
                       ? "Loading members..."
-                      : normalizedSearchQuery
-                        ? "No members match your search."
-                        : "No members found."}
+                      : memberTypeTab === "people"
+                        ? "No people in this channel."
+                        : memberTypeTab === "agents"
+                          ? "No agents in this channel."
+                          : "No members found."}
                   </p>
                 )}
               </div>
             </section>
 
-            {archived.length > 0 ? (
+            {archived.length > 0 && memberTypeTab === "all" ? (
               <section className="mt-4">
                 <details
                   className="group/archived"
@@ -886,78 +941,6 @@ function SearchResultSectionTitle({
     <div className="sticky top-0 z-10 mr-3 flex min-h-9 items-center gap-2 bg-background/95 px-4 pb-1.5 pt-3 text-xs font-medium text-muted-foreground/75 backdrop-blur supports-[backdrop-filter]:bg-background/80">
       <span>{children}</span>
       {action ? <span>{action}</span> : null}
-    </div>
-  );
-}
-
-function AddMemberSearchResultRow({
-  disabled,
-  onSelect,
-  ownerLabel,
-  user,
-}: {
-  disabled: boolean;
-  onSelect: (user: UserSearchResult) => void;
-  ownerLabel?: string | null;
-  user: UserSearchResult;
-}) {
-  return (
-    <div
-      className={cn(
-        "group/add-result relative isolate flex min-h-14 w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40",
-        MEMBER_ROW_INSET_DIVIDER_CLASS,
-      )}
-      data-testid={`channel-user-search-result-${user.pubkey}`}
-    >
-      <button
-        aria-label={`Select ${formatAddCandidateName(user)}`}
-        className="absolute inset-0 z-0 cursor-pointer focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-        disabled={disabled}
-        onClick={() => onSelect(user)}
-        type="button"
-      />
-      <UserAvatar
-        avatarUrl={user.avatarUrl}
-        className="pointer-events-none relative z-10 h-8 w-8 text-xs shadow-none"
-        displayName={formatAddCandidateName(user)}
-        size="sm"
-      />
-      <div className="pointer-events-none relative z-10 min-w-0 flex-1">
-        {user.isAgent ? (
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-center gap-2">
-              <span className="truncate text-sm font-medium tracking-tight">
-                {formatAddCandidateName(user)}
-              </span>
-              <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-                <Bot aria-hidden="true" className="h-4 w-4" />
-                agent
-              </span>
-            </div>
-            {ownerLabel ? (
-              <span className="block truncate text-xs text-muted-foreground">
-                managed by {ownerLabel}
-              </span>
-            ) : null}
-          </div>
-        ) : (
-          <span className="block truncate text-sm font-medium tracking-tight">
-            {formatAddCandidateName(user)}
-          </span>
-        )}
-      </div>
-      <Button
-        className="relative z-20 shrink-0"
-        disabled={disabled}
-        onClick={(event) => {
-          event.stopPropagation();
-          onSelect(user);
-        }}
-        size="sm"
-        type="button"
-      >
-        Add
-      </Button>
     </div>
   );
 }

--- a/desktop/src/features/channels/ui/MembersSidebarAddResultRow.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarAddResultRow.tsx
@@ -1,0 +1,90 @@
+import { Bot } from "lucide-react";
+
+import type { UserSearchResult } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/cn";
+import { truncatePubkey } from "@/shared/lib/pubkey";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+export const MEMBER_ROW_INSET_DIVIDER_CLASS =
+  "after:pointer-events-none after:absolute after:bottom-0 after:left-[3.75rem] after:right-0 after:h-px after:bg-border/60 after:content-[''] last:after:hidden";
+
+export function formatAddCandidateName(user: UserSearchResult) {
+  return (
+    user.displayName?.trim() ||
+    user.nip05Handle?.trim() ||
+    truncatePubkey(user.pubkey)
+  );
+}
+
+export function MembersSidebarAddResultRow({
+  disabled,
+  onSelect,
+  ownerLabel,
+  user,
+}: {
+  disabled: boolean;
+  onSelect: (user: UserSearchResult) => void;
+  ownerLabel?: string | null;
+  user: UserSearchResult;
+}) {
+  return (
+    <div
+      className={cn(
+        "group/add-result relative isolate flex min-h-14 w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40",
+        MEMBER_ROW_INSET_DIVIDER_CLASS,
+      )}
+      data-testid={`channel-user-search-result-${user.pubkey}`}
+    >
+      <button
+        aria-label={`Select ${formatAddCandidateName(user)}`}
+        className="absolute inset-0 z-0 cursor-pointer focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+        disabled={disabled}
+        onClick={() => onSelect(user)}
+        type="button"
+      />
+      <UserAvatar
+        avatarUrl={user.avatarUrl}
+        className="pointer-events-none relative z-10 h-8 w-8 text-xs shadow-none"
+        displayName={formatAddCandidateName(user)}
+        size="sm"
+      />
+      <div className="pointer-events-none relative z-10 min-w-0 flex-1">
+        {user.isAgent ? (
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-sm font-medium tracking-tight">
+                {formatAddCandidateName(user)}
+              </span>
+              <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+                <Bot aria-hidden="true" className="h-4 w-4" />
+                agent
+              </span>
+            </div>
+            {ownerLabel ? (
+              <span className="block truncate text-xs text-muted-foreground">
+                managed by {ownerLabel}
+              </span>
+            ) : null}
+          </div>
+        ) : (
+          <span className="block truncate text-sm font-medium tracking-tight">
+            {formatAddCandidateName(user)}
+          </span>
+        )}
+      </div>
+      <Button
+        className="relative z-20 shrink-0"
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelect(user);
+        }}
+        size="sm"
+        type="button"
+      >
+        Add
+      </Button>
+    </div>
+  );
+}

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2817,6 +2817,67 @@ test("new DM picker pages people search beyond the first 50 results", async ({
   );
 });
 
+test("members sidebar filters members with People and Agents tabs", async ({
+  page,
+}) => {
+  // Profile-only agent "mira" (see e2eBridge PROFILE_ONLY_AGENT_PUBKEY): a
+  // general member whose role is plain "member" but whose backend is_agent
+  // flag is true — classification must come from the flag, not the role.
+  const profileOnlyAgentPubkey =
+    "8f83d6b7f3d74f7d933ae3a54dd8c6cc85c7f98e531c16e5a827b953441a8d67";
+  const alicePubkey = TEST_IDENTITIES.alice.pubkey;
+  const bobPubkey = TEST_IDENTITIES.bob.pubkey;
+
+  await installMockBridge(page);
+  await page.goto("/");
+  await openMembersSidebar(page, "general");
+
+  // Default All tab: everyone is visible, tab labels carry the split counts.
+  await expect(page.getByTestId("members-type-tab-all")).toHaveText("All · 4");
+  await expect(page.getByTestId("members-type-tab-people")).toHaveText(
+    "People · 2",
+  );
+  await expect(page.getByTestId("members-type-tab-agents")).toHaveText(
+    "Agents · 2",
+  );
+  await expect(
+    page.getByTestId(`sidebar-member-${MOCK_IDENTITY_PUBKEY}`),
+  ).toBeVisible();
+  await expect(page.getByTestId(`sidebar-member-${alicePubkey}`)).toBeVisible();
+
+  await page.getByTestId("members-type-tab-agents").click();
+  await expect(page.getByText("Agents · 2")).toHaveCount(2);
+  await expect(page.getByTestId(`sidebar-member-${alicePubkey}`)).toBeVisible();
+  await expect(
+    page.getByTestId(`sidebar-member-${profileOnlyAgentPubkey}`),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId(`sidebar-member-${MOCK_IDENTITY_PUBKEY}`),
+  ).not.toBeVisible();
+  await expect(
+    page.getByTestId(`sidebar-member-${bobPubkey}`),
+  ).not.toBeVisible();
+
+  await page.getByTestId("members-type-tab-people").click();
+  await expect(
+    page.getByTestId(`sidebar-member-${MOCK_IDENTITY_PUBKEY}`),
+  ).toBeVisible();
+  await expect(page.getByTestId(`sidebar-member-${bobPubkey}`)).toBeVisible();
+  await expect(
+    page.getByTestId(`sidebar-member-${alicePubkey}`),
+  ).not.toBeVisible();
+  await expect(
+    page.getByTestId(`sidebar-member-${profileOnlyAgentPubkey}`),
+  ).not.toBeVisible();
+
+  // Reopening the dialog resets the filter to All.
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("members-sidebar")).not.toBeVisible();
+  await openMembersSidebar(page, "general");
+  await expect(page.getByTestId(`sidebar-member-${bobPubkey}`)).toBeVisible();
+  await expect(page.getByTestId(`sidebar-member-${alicePubkey}`)).toBeVisible();
+});
+
 test("member people search starts at two characters", async ({ page }) => {
   const jmPubkey =
     "abababababababababababababababababababababababababababababababab";


### PR DESCRIPTION
## Summary

**TLDR: Adds All / People / Agents tabs (with live counts) to the channel members dialog, so large mixed rosters can be filtered by member type — and fixes a classification gap where backend-flagged agents showed up as people.**

Channels routinely mix humans and agents in one flat list (hundreds of members in larger channels), with no way to see just one or the other. This restores a member-type view as a *lens* rather than a hierarchy — **All** stays the default and preserves today's flat list, in keeping with the flattening in #1054.

- Tab row `All · N | People · N | Agents · N` between the dialog header and the list; state resets to All when the dialog closes.
- Section title follows the tab (`People · N` / `Agents · N` / `Members · N`).
- Add-member search results follow the active tab (on **Agents**, you only see agent candidates).
- Tab-aware empty states ("No people in this channel." / "No agents in this channel.").
- Classification fix: `useClassifiedMembers.isBot()` now ORs in `member.isAgent` (the backend's NIP-OA owner check). Previously an agent added by another user under a plain `member` role — and absent from the viewer's managed/relay agent lists — classified as a person.
- `MembersSidebarAddResultRow` extracted to its own file to stay under the 1000-line guard (markup unchanged).

Deliberate calls (happy to change any of these in review):
- **"People", not "Humans"** — matches existing product language (`peopleCount`, "Add people").
- **All is the default tab** — preserves current behavior; matches the ChannelBrowserDialog all-first precedent.
- **Archived section renders on the All tab only** — archived-wins-over-bot classification (NIP-IA) makes archived agents fold into "Archived", so splitting that section across tabs would be misleading.
- Mobile already splits People/Bots in `members_sheet.dart`; this brings desktop to parity.

### Related issue

Closes #2992

### Testing

- 7 new unit tests for the pure tab-filter helpers (`memberTypeTab.test.mjs`); full desktop unit suite passes (3522 tests).
- New Playwright e2e smoke test (`members sidebar filters members with People and Agents tabs`): asserts tab counts, per-tab row visibility, section title, and close/reopen reset — including a backend-flagged agent (`is_agent: true`, role `member`) that proves the classification fix. All 11 member-related e2e tests in `channels.spec.ts` pass.
- `pnpm check` (biome + file-size + px-text + pubkey-truncation guards) and `tsc --noEmit` clean.
- Screenshots to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
