### PR TITLE
Fix identity query hanging indefinitely outside a Tauri runtime

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,7 +14,7 @@
     "lint": "biome lint .",
     "check": "biome check . && pnpm check:px-text && pnpm check:pubkey-truncation",
     "format": "biome format --write .",
-    "test": "node --import ./test-loader.mjs --experimental-strip-types --test \"src/**/*.test.mjs\"",
+    "test": "node --import ./test-loader.mjs --experimental-strip-types --experimental-test-module-mocks --test \"src/**/*.test.mjs\"",
     "preview": "vite preview",
     "tauri": "tauri",
     "test:e2e": "pnpm build:e2e && playwright test",

--- a/desktop/src/shared/api/hooks.ts
+++ b/desktop/src/shared/api/hooks.ts
@@ -7,5 +7,14 @@ export function useIdentityQuery() {
     queryKey: ["identity"],
     queryFn: getIdentity,
     staleTime: Number.POSITIVE_INFINITY,
+    // A failure here means "no native identity backend" (e.g. web deployment
+    // outside Tauri) — retrying can't change that. This also sidesteps a
+    // query-core gotcha: the default queryClient's networkMode: "always" only
+    // bypasses the *online* check in the retryer, not focusManager.isFocused().
+    // If the window isn't OS-focused at the moment the single default retry
+    // fires, canContinue() returns false and the retryer calls pause() —
+    // which then waits indefinitely for a focus/visibility event, leaving
+    // this query stuck on fetchStatus "paused" forever instead of "error".
+    retry: false,
   });
 }

--- a/desktop/src/shared/api/tauriIdentity.available.test.mjs
+++ b/desktop/src/shared/api/tauriIdentity.available.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Split into its own file (not merged with tauriIdentity.test.mjs) because
+// node's per-process ESM module cache means mixing an "isTauri: () => true"
+// mock with an "isTauri: () => false" mock in the same test file causes
+// later imports of tauriIdentity.ts to return the first test's cached module
+// instance rather than re-evaluating against the new mock. node --test runs
+// each matched file in its own process, which sidesteps that entirely.
+
+test("getIdentity calls the native bridge when Tauri is available", async (t) => {
+  t.mock.module("@tauri-apps/api/core", {
+    exports: { isTauri: () => true },
+  });
+  const invokeTauriFn = t.mock.fn(async () => ({
+    pubkey: "abc",
+    display_name: "Test",
+  }));
+  t.mock.module("@/shared/api/tauri", {
+    exports: { invokeTauri: invokeTauriFn },
+  });
+
+  const { getIdentity } = await import("@/shared/api/tauriIdentity");
+
+  const identity = await getIdentity();
+  assert.equal(identity.pubkey, "abc");
+  assert.equal(invokeTauriFn.mock.calls.length, 1);
+  assert.equal(invokeTauriFn.mock.calls[0].arguments[0], "get_identity");
+});

--- a/desktop/src/shared/api/tauriIdentity.test.mjs
+++ b/desktop/src/shared/api/tauriIdentity.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Regression coverage for the standalone-web splash-screen hang: get_identity
+// (and its siblings) must never reach invokeTauri when there is no Tauri
+// runtime — reaching it produced a raw TypeError deep inside
+// @tauri-apps/api/core's invoke(), and combined with the identity query's
+// retry policy, left the query stuck on fetchStatus "paused" forever instead
+// of settling to "error". These tests assert the guard short-circuits before
+// any native call is attempted.
+//
+// Each test mocks fresh via its own TestContext (`t.mock.module`), which
+// auto-restores at test end — a shared/global `mock.module` call here hits
+// "module is already mocked" on the second test, since the mock registry is
+// process-global and outlives a manual `.restore()` call made mid-run.
+//
+// The "Tauri is available" happy-path case lives in
+// tauriIdentity.available.test.mjs, a separate file — see that file's
+// comment for why it can't share a process with these "unavailable" tests.
+
+test("getIdentity rejects without invoking the native bridge when Tauri is unavailable", async (t) => {
+  t.mock.module("@tauri-apps/api/core", {
+    exports: { isTauri: () => false },
+  });
+  const invokeTauriFn = t.mock.fn();
+  t.mock.module("@/shared/api/tauri", {
+    exports: { invokeTauri: invokeTauriFn },
+  });
+
+  const { getIdentity } = await import("@/shared/api/tauriIdentity");
+
+  await assert.rejects(() => getIdentity(), /no native identity backend/);
+  assert.equal(
+    invokeTauriFn.mock.calls.length,
+    0,
+    "invokeTauri must not be called when Tauri is unavailable",
+  );
+});
+
+for (const [name, fn] of [
+  ["getNsec", (m) => m.getNsec()],
+  ["importIdentity", (m) => m.importIdentity("nsec1test")],
+  ["persistCurrentIdentity", (m) => m.persistCurrentIdentity()],
+  ["signOut", (m) => m.signOut()],
+]) {
+  test(`${name} rejects without invoking the native bridge when Tauri is unavailable`, async (t) => {
+    t.mock.module("@tauri-apps/api/core", {
+      exports: { isTauri: () => false },
+    });
+    const invokeTauriFn = t.mock.fn();
+    t.mock.module("@/shared/api/tauri", {
+      exports: { invokeTauri: invokeTauriFn },
+    });
+
+    const module = await import("@/shared/api/tauriIdentity");
+
+    await assert.rejects(() => fn(module));
+    assert.equal(
+      invokeTauriFn.mock.calls.length,
+      0,
+      `invokeTauri must not be called by ${name} when Tauri is unavailable`,
+    );
+  });
+}

--- a/desktop/src/shared/api/tauriIdentity.ts
+++ b/desktop/src/shared/api/tauriIdentity.ts
@@ -1,3 +1,5 @@
+import { isTauri } from "@tauri-apps/api/core";
+
 import { invokeTauri } from "@/shared/api/tauri";
 import type { Identity, IdentityStorage } from "@/shared/api/types";
 
@@ -21,11 +23,27 @@ function fromRawIdentity(raw: RawIdentity): Identity {
   };
 }
 
+// Web deployments serve this same bundle outside the Tauri shell, where
+// there is no native keychain-backed identity at all. Without this guard,
+// get_identity fell through to invokeTauri, which throws deep inside
+// @tauri-apps/api/core's invoke() — the identity query never settled to a
+// clean "error" (it hung on "pending"/"paused" indefinitely), which kept
+// useMachineOnboardingState() stuck on the "blocking" stage forever. Failing
+// fast here lets identityQuery.status reach "error" immediately, which
+// machineOnboarding.ts already treats as a signal to proceed to "ready".
+function requireTauri(command: string): void {
+  if (!isTauri()) {
+    throw new Error(`${command}: no native identity backend in web mode`);
+  }
+}
+
 export async function getIdentity(): Promise<Identity> {
+  requireTauri("get_identity");
   return fromRawIdentity(await invokeTauri<RawIdentity>("get_identity"));
 }
 
 export async function getNsec(): Promise<string> {
+  requireTauri("get_nsec");
   return invokeTauri<string>("get_nsec");
 }
 
@@ -33,12 +51,14 @@ export async function importIdentity(
   nsec: string,
   password?: string,
 ): Promise<Identity> {
+  requireTauri("import_identity");
   return fromRawIdentity(
     await invokeTauri<RawIdentity>("import_identity", { nsec, password }),
   );
 }
 
 export async function persistCurrentIdentity(): Promise<Identity> {
+  requireTauri("persist_current_identity");
   return fromRawIdentity(
     await invokeTauri<RawIdentity>("persist_current_identity"),
   );
@@ -52,6 +72,7 @@ export async function persistCurrentIdentity(): Promise<Identity> {
  * state until the process exits and only handle errors (e.g. display a toast).
  */
 export async function signOut(): Promise<void> {
+  requireTauri("sign_out");
   await invokeTauri("sign_out");
 }
 


### PR DESCRIPTION
## Summary
- The desktop chat UI can be served as a plain web page (no `window.__TAURI_INTERNALS__`), where `get_identity()` can never succeed. `useIdentityQuery`'s `queryFn` always rejects in that environment, and with the default retry config the single configured retry can hit query-core's `pause()` path if the window isn't focused at that exact moment — `canContinue()` requires `focusManager.isFocused()` regardless of `networkMode`. The query then gets stuck on `fetchStatus: "paused"` forever instead of ever settling to `"error"`, so anything gating UI on the query's settled status hangs indefinitely.
- `retry: false` on `useIdentityQuery` — a missing native identity backend can't be fixed by retrying, so there's no reason to ever enter that retry/pause branch.
- Guard `get_identity`/`get_nsec`/`import_identity`/`persist_current_identity`/`sign_out` with `isTauri()`, matching the guard convention already used elsewhere in this codebase (e.g. `audioWorklet.ts`), so a missing runtime produces a clean, identifiable `Error` instead of a raw `TypeError` surfaced from deep inside `invoke()`.

## Test plan
- [x] `pnpm build` (tsc + vite build) passes
- [x] `pnpm test` — 3662/3662 passing
- [x] `pnpm exec biome check` on both touched files — clean
- [x] Manually verified in a browser: served the built bundle as a plain web page outside Tauri and confirmed the identity query now settles to `"error"` immediately instead of hanging on `pending`/`paused`

## Related
Checked open PRs/issues for duplicates before submitting — no duplicate found. #3027 is open in an adjacent but different subsystem (relay-side SPA routing config, vs. this PR's desktop-client Tauri guards) for a similarly-motivated self-hosted deployment; not overlapping, noted for context.
