### PR TITLE
Guard remaining unguarded Tauri calls for web deployments

### DIFF
--- a/desktop/src/features/agents/lib/useAgentsDataRefresh.ts
+++ b/desktop/src/features/agents/lib/useAgentsDataRefresh.ts
@@ -1,3 +1,4 @@
+import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
@@ -28,6 +29,11 @@ export function useAgentsDataRefresh(): void {
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    // Both events come from the local Rust agents backend — no on-disk agents
+    // data exists in a browser (web) runtime, and `listen()` throws without
+    // Tauri internals.
+    if (!isTauri()) return;
+
     let timer: ReturnType<typeof setTimeout> | undefined;
 
     const unlistenRuntime = listen("managed-agent-runtime-status", () => {

--- a/desktop/src/features/agents/usePreventSleep.ts
+++ b/desktop/src/features/agents/usePreventSleep.ts
@@ -7,6 +7,7 @@ import {
 import { createPreventSleepActivityTracker } from "@/features/agents/preventSleepActivity";
 import { setPreventSleepActive } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
 // Intentionally not scoped per-pubkey — multi-user desktop is rare and the
@@ -82,9 +83,17 @@ function usePreventSleepInternal() {
   }, []);
 
   React.useEffect(() => {
+    // Fire-and-forget with no .catch, so an unguarded call is a genuine
+    // unhandled rejection in a browser (web) runtime, not just console noise.
+    if (!isTauri()) return;
+
     void setPreventSleepActive(active);
   }, [active]);
   React.useEffect(() => {
+    // Sleep prevention is a native OS concept — no such event exists in a
+    // browser (web) runtime, and `listen()` throws without Tauri internals.
+    if (!isTauri()) return;
+
     const unlisten = listen("prevent-sleep-expired", () => {
       setExpired(true);
     });

--- a/desktop/src/features/communities/legacyCommunityStorage.ts
+++ b/desktop/src/features/communities/legacyCommunityStorage.ts
@@ -1,3 +1,5 @@
+import { isTauri } from "@tauri-apps/api/core";
+
 import { invokeTauri } from "@/shared/api/tauri";
 import { getStorageItem } from "@/shared/lib/safeStorage";
 import { migrateLegacyCommunityStorage } from "./communityStorage";
@@ -113,6 +115,12 @@ export function applyLegacyCommunityStorage(
  */
 export async function migrateLegacyCommunityStorageBeforeRender(): Promise<void> {
   if (typeof window === "undefined") {
+    return;
+  }
+
+  // The legacy Sprout WebKit SQLite database only exists in the native shell
+  // — there is nothing to migrate from in a browser (web) runtime.
+  if (!isTauri()) {
     return;
   }
 

--- a/desktop/src/features/communities/useNestNotifications.ts
+++ b/desktop/src/features/communities/useNestNotifications.ts
@@ -1,3 +1,4 @@
+import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect } from "react";
 import { toast } from "sonner";
@@ -22,6 +23,10 @@ const MIGRATION_TOAST_KEY = "buzz-legacy-nest-migrated-notified";
  */
 export function useNestNotifications(): void {
   useEffect(() => {
+    // Both events come from the Rust nest backend — no local nest exists in a
+    // browser (web) runtime, and `listen()` throws without Tauri internals.
+    if (!isTauri()) return;
+
     const unlistenReposError = listen<string>("repos-dir-error", (event) => {
       toast.error("Repos directory not applied", {
         description: event.payload,

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import * as React from "react";
 
@@ -820,6 +820,9 @@ export function HuddleProvider({
   // in-flight guard collapses duplicate disconnect events from failed dials.
   const audioReconnectInFlightRef = React.useRef(false);
   React.useEffect(() => {
+    // Huddle audio is a native Tauri pipeline — no such event exists in a
+    // browser (web) runtime, and `listen()` throws without Tauri internals.
+    if (!isTauri()) return;
     if (!ownsAudioSession) return;
 
     let cancelled = false;

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -217,6 +217,11 @@ export function HuddleBar({
   }, []);
   // Huddle state: event-driven + slow fallback poll.
   React.useEffect(() => {
+    // The huddle backend (state + audio pipeline) is native Tauri-only — none
+    // of this works in a browser (web) runtime, and `listen()` throws without
+    // Tauri internals.
+    if (!isTauri()) return;
+
     let cancelled = false;
     let unlisten: (() => void) | null = null;
 

--- a/desktop/src/features/huddle/components/HuddleIndicator.tsx
+++ b/desktop/src/features/huddle/components/HuddleIndicator.tsx
@@ -1,3 +1,4 @@
+import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Headphones } from "lucide-react";
 import * as React from "react";
@@ -198,6 +199,11 @@ export function HuddleIndicator({
   // waiting for the relay's 48103 event (which may arrive late or not at all
   // if the relay connection tears down first).
   React.useEffect(() => {
+    // Huddle state is emitted by the native Tauri audio pipeline — no such
+    // event exists in a browser (web) runtime, and `listen()` throws without
+    // Tauri internals.
+    if (!isTauri()) return;
+
     let unlisten: (() => void) | null = null;
     let cancelled = false;
 

--- a/desktop/src/features/settings/ui/MobilePairingCard.tsx
+++ b/desktop/src/features/settings/ui/MobilePairingCard.tsx
@@ -6,6 +6,7 @@ import {
   RefreshCw,
   TriangleAlert,
 } from "lucide-react";
+import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { toast } from "sonner";
@@ -296,6 +297,13 @@ export function MobilePairingCard({
     setError(null);
 
     if (!currentPubkey) {
+      return;
+    }
+
+    // Mobile pairing is a native Tauri feature (QR/SAS handshake with a
+    // phone) — none of these events exist in a browser (web) runtime, and
+    // `listen()` throws without Tauri internals.
+    if (!isTauri()) {
       return;
     }
 

--- a/desktop/src/shared/deep-link.test.mjs
+++ b/desktop/src/shared/deep-link.test.mjs
@@ -22,6 +22,10 @@ globalThis.window = {
   __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: () => {} },
 };
 globalThis.__TAURI_INTERNALS__ = tauriInternals;
+// `isTauri()` reads `globalThis.isTauri`, which the native shell injects
+// alongside the IPC internals. The listeners under test are guarded on it,
+// so the fake runtime has to set it too.
+globalThis.isTauri = true;
 
 const { listenForNavigationDeepLinks, resetNavigationDeepLinkDrain } =
   await import("@/shared/deep-link.ts");

--- a/desktop/src/shared/deep-link.ts
+++ b/desktop/src/shared/deep-link.ts
@@ -1,5 +1,5 @@
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import type { StartCommunityOnboardingInput } from "@/features/onboarding/communityOnboarding";
 
 export type AddCommunityDeepLinkPayload = {
@@ -99,6 +99,11 @@ function acceptPendingCommunityDeepLink(
 }
 
 async function drainPendingCommunityDeepLinks(deps: DeepLinkDeps) {
+  // The pending-deep-link queue is populated by the Rust backend and only
+  // exists in the native Tauri shell — invoke() throws without Tauri
+  // internals in a browser (web) runtime.
+  if (!isTauri()) return;
+
   while (true) {
     const pending = await invoke<PendingCommunityDeepLink | null>(
       "take_pending_community_deep_link",
@@ -148,6 +153,13 @@ export async function listenForDeepLinks(
       }
     })();
   };
+  // OS-level deep links (`buzz://…`) only exist in the native Tauri shell —
+  // `listen()` throws without Tauri internals in a browser (web) runtime. The
+  // pending-link queue that `drain` reads is native-only too, so there is
+  // nothing for an availability subscription to wake here: guard before
+  // subscribing rather than registering a callback that can never do work.
+  if (!isTauri()) return () => {};
+
   const stopAvailabilityListener = deps.onAddCommunityAvailable(drain);
   const connectPromise = listen<string>("deep-link-connect", drain);
   const joinPromise = listen<JoinDeepLinkPayload>("deep-link-join", drain);
@@ -172,6 +184,11 @@ let navigationDrainGeneration = 0;
 let navigationDrainEnabled = true;
 
 export async function resetNavigationDeepLinkDrain(): Promise<void> {
+  // No native queue exists outside the Tauri shell, so there is nothing to
+  // clear and nothing that could have been queued — invoke() would just throw
+  // and reject this await in the caller's community-init path.
+  if (!isTauri()) return;
+
   const generation = ++navigationDrainGeneration;
   // Fail closed while the outgoing community's native queue is being cleared.
   // A rejected clear leaves that queue's identity unknown, so no later listener
@@ -243,6 +260,9 @@ export async function listenForNavigationDeepLinks(
     payload: MessageDeepLinkPayload,
   ) => boolean | Promise<boolean>,
 ): Promise<UnlistenFn> {
+  // OS-level deep link — no-op outside the native Tauri shell.
+  if (!isTauri()) return () => {};
+
   let drainRunning = false;
   let drainRequested = false;
   const drain = () => {
@@ -284,6 +304,9 @@ export async function listenForNavigationDeepLinks(
 export function listenForEntityDeepLinks(
   onOpen: (href: string) => boolean,
 ): Promise<UnlistenFn> {
+  // OS-level deep link — no-op outside the native Tauri shell.
+  if (!isTauri()) return Promise.resolve(() => {});
+
   let drainRunning = false;
   let drainRequested = false;
   const drain = () => {
@@ -332,6 +355,8 @@ export function listenForEntityDeepLinks(
 export function listenForNostrBindDeepLinks(
   onOpen: (payload: NostrBindDeepLinkPayload) => void,
 ): Promise<UnlistenFn> {
+  // OS-level deep link — no-op outside the native Tauri shell.
+  if (!isTauri()) return Promise.resolve(() => {});
   return listen<NostrBindDeepLinkPayload>("deep-link-nostr-bind", (event) => {
     onOpen(event.payload);
   });

--- a/desktop/src/shared/deep-link.web.test.mjs
+++ b/desktop/src/shared/deep-link.web.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+// Standalone-web coverage for the isTauri() guards in deep-link.ts.
+//
+// This file deliberately sets no Tauri globals at all. `isTauri()` reads
+// `globalThis.isTauri` (it ignores `__TAURI_INTERNALS__`), so leaving the
+// global unset is exactly the browser runtime these guards exist for — no
+// mocking required, and the real `@tauri-apps/api` modules are under test
+// rather than a stand-in for them.
+//
+// This matters because deep-link.test.mjs sets `globalThis.isTauri = true`,
+// so every test in that file exercises the native branch only. Without this
+// file the guards themselves have no coverage.
+//
+// If a guard ever leaks, the real `invoke()`/`listen()` reject without Tauri
+// internals, so the awaits below fail rather than quietly passing.
+//
+// It lives in its own file because node's per-process ESM module cache would
+// otherwise hand a second import of deep-link.ts the instance evaluated under
+// the other file's globals. `node --test` runs each matched file in its own
+// process, which sidesteps that.
+
+const {
+  listenForDeepLinks,
+  resetNavigationDeepLinkDrain,
+  listenForNavigationDeepLinks,
+  listenForEntityDeepLinks,
+  listenForNostrBindDeepLinks,
+} = await import("@/shared/deep-link.ts");
+
+function makeDeps() {
+  const state = {
+    onboarding: 0,
+    addCommunity: 0,
+    availabilitySubscriptions: 0,
+  };
+  return {
+    state,
+    deps: {
+      startCommunityOnboarding: () => {
+        state.onboarding += 1;
+        return true;
+      },
+      openAddCommunity: () => {
+        state.addCommunity += 1;
+        return true;
+      },
+      onAddCommunityAvailable: () => {
+        state.availabilitySubscriptions += 1;
+        return () => {
+          state.availabilitySubscriptions -= 1;
+        };
+      },
+    },
+  };
+}
+
+test("listenForDeepLinks resolves to a callable cleanup without reaching the native bridge", async () => {
+  const harness = makeDeps();
+
+  const unlisten = await listenForDeepLinks(harness.deps);
+
+  assert.equal(typeof unlisten, "function");
+  assert.doesNotThrow(() => unlisten());
+  assert.equal(harness.state.onboarding, 0);
+  assert.equal(harness.state.addCommunity, 0);
+});
+
+test("listenForDeepLinks does not subscribe to add-community availability in web mode", async () => {
+  const harness = makeDeps();
+
+  const unlisten = await listenForDeepLinks(harness.deps);
+
+  // The pending-link queue the drain reads is native-only, so a subscription
+  // here could never do work. Guarding before subscribing keeps that explicit.
+  assert.equal(harness.state.availabilitySubscriptions, 0);
+  unlisten();
+  assert.equal(harness.state.availabilitySubscriptions, 0);
+});
+
+test("resetNavigationDeepLinkDrain resolves without clearing a native queue", async () => {
+  await assert.doesNotReject(() => resetNavigationDeepLinkDrain());
+});
+
+test("listenForNavigationDeepLinks resolves to a callable cleanup and never routes", async () => {
+  let routed = 0;
+  const route = () => {
+    routed += 1;
+    return true;
+  };
+
+  const unlisten = await listenForNavigationDeepLinks(route, route);
+
+  assert.equal(typeof unlisten, "function");
+  assert.doesNotThrow(() => unlisten());
+  assert.equal(routed, 0);
+});
+
+test("listenForEntityDeepLinks resolves to a callable cleanup and never routes", async () => {
+  let routed = 0;
+
+  const unlisten = await listenForEntityDeepLinks(() => {
+    routed += 1;
+    return true;
+  });
+
+  assert.equal(typeof unlisten, "function");
+  assert.doesNotThrow(() => unlisten());
+  assert.equal(routed, 0);
+});
+
+test("listenForNostrBindDeepLinks resolves to a callable cleanup and never routes", async () => {
+  let routed = 0;
+
+  const unlisten = await listenForNostrBindDeepLinks(() => {
+    routed += 1;
+  });
+
+  assert.equal(typeof unlisten, "function");
+  assert.doesNotThrow(() => unlisten());
+  assert.equal(routed, 0);
+});


### PR DESCRIPTION
## Summary
- Several call sites into `@tauri-apps/api` still assume a native Tauri runtime and throw when the desktop chat UI is served as a plain web page instead (no `window.__TAURI_INTERNALS__`): `"Cannot read properties of undefined (reading 'transformCallback'/'invoke')"`. Most of the codebase already guards this correctly with `isTauri()` before calling `listen()`/`invoke()` (e.g. `audioWorklet.ts`); this closes the boot-reachable gaps found by exercising a web-served build end-to-end.
- `useAgentsDataRefresh`, `useNestNotifications`, `HuddleContext`, `HuddleBar`, `HuddleIndicator`, `MobilePairingCard`: guard `listen()` registration with `isTauri()`.
- `usePreventSleep`: guard both effects. The `listen()` registration throws without Tauri internals, and `setPreventSleepActive` is fired fire-and-forget (`void`, no `.catch`), so an unguarded call there is a genuine unhandled rejection rather than a logged warning.
- `deep-link.ts`: the pending-deep-link queue is populated by the Rust backend and only exists in the native shell, so both the `invoke()` drain and the `listen()`-based registrations are guarded. In `listenForDeepLinks` the guard precedes `deps.onAddCommunityAvailable` — that subscription only wakes the native queue, so in a browser it would register a callback that can never do work.
- `legacyCommunityStorage.ts`: the legacy Sprout WebKit SQLite database read only exists in the native shell — skip it in a web runtime.

Guards stay at the consumer rather than inside `shared/api/tauri.ts`: that module is an API wrapper, not a policy layer, and its callers already handle failure (`useCommunityInit` wraps its calls in try/catch and falls back to `needsSetup`, `App.tsx` catches `is_shared_identity` and falls back to `false`). Guarding inside the wrapper would only suppress those console warnings, which are the signal that a packaged native build is misconfigured. It would also grow a file the repo's own size ratchet already holds at its limit.

Apart from the prevent-sleep unhandled rejection, these failures were already caught and logged as console warnings, so this doesn't change behavior for native Tauri users.

Scope note: this covers the boot-reachable native calls surfaced by a standalone-web smoke test, not an exhaustive audit of every `invoke()`/`listen()` in the desktop client.

Independent of #3189, but both were found while exercising the same web-served build, and neither on its own makes the bundle usable as a plain web page.

## Test plan
- [x] `pnpm build` (tsc + vite build) — passes
- [x] `pnpm test` — 5799/5799 passing
- [x] `just file-size-check` — passes
- [x] `pnpm check` (biome + px-text + pubkey-truncation) — clean
- [x] New `deep-link.web.test.mjs` sets no Tauri globals, so it runs against the real `@tauri-apps/api` in the browser runtime the guards exist for. Verified by mutation, not just a green run: removing any one of the five guards fails that file (`listenForDeepLinks` fails two of six cases, the rest one each).
- [x] Manually verified in a browser: served the built bundle as a plain web page outside Tauri. Note this was verified against an earlier revision that also guarded `shared/api/tauri.ts`; those guards were dropped deliberately (see above), so a browser load still logs the `is_shared_identity command failed` warning from `App.tsx`'s existing `.catch`. That warning is intended — it is the signal that the native bridge is absent, and suppressing it was the only thing those guards bought.

## Related
Checked open PRs/issues for duplicates before submitting — no duplicate found. #3027 is open in an adjacent but different subsystem (relay-side SPA routing config, vs. this PR's desktop-client Tauri guards) for a similarly-motivated self-hosted deployment; not overlapping, noted for context.

