### PR TITLE
fix(relay): reject events containing NUL characters at validation time

### DIFF
--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1754,6 +1754,21 @@ fn validate_not_before(tag_value: &str) -> Result<u64, &'static str> {
     Ok(value)
 }
 
+/// Postgres cannot store NUL in `text`/`jsonb` columns, so an event carrying
+/// `\u0000` in its content or tag values would otherwise pass validation and
+/// then fail at insert time as an internal database error.
+fn validate_no_nul_bytes(event: &Event) -> Result<(), &'static str> {
+    if event.content.contains('\0') {
+        return Err("content contains a NUL character");
+    }
+    for tag in event.tags.iter() {
+        if tag.as_slice().iter().any(|value| value.contains('\0')) {
+            return Err("tag value contains a NUL character");
+        }
+    }
+    Ok(())
+}
+
 /// Validate the public tag envelope of a NIP-ER `kind:30300` event before it
 /// reaches NIP-33 parameterized replacement.
 ///
@@ -2018,6 +2033,10 @@ async fn ingest_event_inner(
             MAX_EVENT_CONTENT_BYTES,
             event.content.len()
         )));
+    }
+
+    if let Err(e) = validate_no_nul_bytes(&event) {
+        return Err(IngestError::Rejected(format!("invalid: {e}")));
     }
 
     let is_gift_wrap = kind_u32 == KIND_GIFT_WRAP;
@@ -3955,6 +3974,43 @@ mod tests {
             let event = make_link_preview_event(title, site, description);
             assert!(validate_link_preview_tags(&event, "https://media.example.com").is_err());
         }
+    }
+
+    #[test]
+    fn nul_validation_rejects_content_with_nul() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "hello\0world", &[]);
+        assert_eq!(
+            validate_no_nul_bytes(&event),
+            Err("content contains a NUL character")
+        );
+    }
+
+    #[test]
+    fn nul_validation_rejects_tag_value_with_nul() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "hello", &[&["title", "a\0b"]]);
+        assert_eq!(
+            validate_no_nul_bytes(&event),
+            Err("tag value contains a NUL character")
+        );
+    }
+
+    #[test]
+    fn nul_validation_rejects_tag_name_with_nul() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "hello", &[&["ti\0tle", "a"]]);
+        assert_eq!(
+            validate_no_nul_bytes(&event),
+            Err("tag value contains a NUL character")
+        );
+    }
+
+    #[test]
+    fn nul_validation_accepts_clean_event() {
+        let event = make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            "hello world",
+            &[&["title", "greeting"]],
+        );
+        assert!(validate_no_nul_bytes(&event).is_ok());
     }
 
     fn make_dummy_event() -> Event {

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1973,6 +1973,21 @@ fn validate_not_before(tag_value: &str) -> Result<u64, &'static str> {
     Ok(value)
 }
 
+/// Postgres cannot store NUL in `text`/`jsonb` columns, so an event carrying
+/// `\u0000` in its content or tag values would otherwise pass validation and
+/// then fail at insert time as an internal database error.
+fn validate_no_nul_bytes(event: &Event) -> Result<(), &'static str> {
+    if event.content.contains('\0') {
+        return Err("content contains a NUL character");
+    }
+    for tag in event.tags.iter() {
+        if tag.as_slice().iter().any(|value| value.contains('\0')) {
+            return Err("tag value contains a NUL character");
+        }
+    }
+    Ok(())
+}
+
 /// Validate the public tag envelope of a NIP-ER `kind:30300` event before it
 /// reaches NIP-33 parameterized replacement.
 ///
@@ -2237,6 +2252,10 @@ async fn ingest_event_inner(
             MAX_EVENT_CONTENT_BYTES,
             event.content.len()
         )));
+    }
+
+    if let Err(e) = validate_no_nul_bytes(&event) {
+        return Err(IngestError::Rejected(format!("invalid: {e}")));
     }
 
     let is_gift_wrap = kind_u32 == KIND_GIFT_WRAP;
@@ -4231,6 +4250,43 @@ mod tests {
             let event = make_link_preview_event(title, site, description);
             assert!(validate_link_preview_tags(&event, "https://media.example.com").is_err());
         }
+    }
+
+    #[test]
+    fn nul_validation_rejects_content_with_nul() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "hello\0world", &[]);
+        assert_eq!(
+            validate_no_nul_bytes(&event),
+            Err("content contains a NUL character")
+        );
+    }
+
+    #[test]
+    fn nul_validation_rejects_tag_value_with_nul() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "hello", &[&["title", "a\0b"]]);
+        assert_eq!(
+            validate_no_nul_bytes(&event),
+            Err("tag value contains a NUL character")
+        );
+    }
+
+    #[test]
+    fn nul_validation_rejects_tag_name_with_nul() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "hello", &[&["ti\0tle", "a"]]);
+        assert_eq!(
+            validate_no_nul_bytes(&event),
+            Err("tag value contains a NUL character")
+        );
+    }
+
+    #[test]
+    fn nul_validation_accepts_clean_event() {
+        let event = make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            "hello world",
+            &[&["title", "greeting"]],
+        );
+        assert!(validate_no_nul_bytes(&event).is_ok());
     }
 
     fn make_dummy_event() -> Event {


### PR DESCRIPTION
Events with `\u0000` in content or a tag value pass signature verification, then
fail at Postgres insert with `invalid byte sequence for encoding "UTF8": 0x00`,
surfacing as a 500. Postgres text and jsonb cannot contain the NUL character.
Fixes #3116.

`ingest_event_inner` now rejects NUL in content or any tag element, next to the
content size check. Both transports route through it. `id`, `pubkey`, and `sig`
are hex and cannot carry NUL; profiles (kind 0) and workflow definitions
(kind 30620) are ordinary events, so the paths named in the issue are covered.

Verified live: 500 before, 400 `invalid: content contains a NUL character` or
`invalid: tag value contains a NUL character` after, no row written, clean
events unaffected. Four unit tests added; fmt and clippy pass. The 9 failing
`buzz-relay --lib` tests also fail at the merge base (noted as preexisting
in #3128).
