### PR TITLE
fix(acp): re-root custom log targets under `buzz_acp`

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -541,7 +541,7 @@ impl AcpClient {
         // on ACP v2 ahead of the upstream ACP RFD. Revisit when that RFD merges.
         let params = build_initialize_params();
         let result = self.send_request("initialize", params).await?;
-        tracing::debug!(target: "acp::init", "initialize response: {result}");
+        tracing::debug!(target: "buzz_acp::acp::init", "initialize response: {result}");
         Ok(result)
     }
 
@@ -585,7 +585,7 @@ impl AcpClient {
             .as_str()
             .ok_or_else(|| AcpError::Protocol("session/new response missing sessionId".into()))?
             .to_owned();
-        tracing::info!(target: "acp::session", "session created: {session_id}");
+        tracing::info!(target: "buzz_acp::acp::session", "session created: {session_id}");
         Ok(SessionNewResponse {
             session_id,
             raw: result,
@@ -708,7 +708,7 @@ impl AcpClient {
             "params": params,
         });
 
-        tracing::debug!(target: "acp::wire", "→ {}", &serde_json::to_string(&msg).unwrap_or_default());
+        tracing::debug!(target: "buzz_acp::acp::wire", "→ {}", &serde_json::to_string(&msg).unwrap_or_default());
         if let Err(e) = self.write_ndjson(&msg).await {
             self.last_prompt_id = None;
             self.current_hard_deadline = None;
@@ -921,7 +921,7 @@ impl AcpClient {
                 let response = permission_response_cancelled(&perm_id);
                 self.write_ndjson(&response).await?;
                 tracing::debug!(
-                    target: "acp::cancel",
+                    target: "buzz_acp::acp::cancel",
                     "responded cancelled to pending permission id={perm_id}"
                 );
             }
@@ -931,7 +931,7 @@ impl AcpClient {
 
         // Step 2: send session/cancel notification (no id)
         self.session_cancel(session_id).await?;
-        tracing::info!(target: "acp::cancel", "sent session/cancel for {session_id}");
+        tracing::info!(target: "buzz_acp::acp::cancel", "sent session/cancel for {session_id}");
         // Use a fixed 30s idle timeout during cleanup — the cancel notification
         // needs time to propagate and the agent may go silent while winding down.
         // The separate hard_deadline bounds agents that keep producing output
@@ -999,7 +999,7 @@ impl AcpClient {
             "params": params,
         });
 
-        tracing::debug!(target: "acp::wire", "→ {}", &serde_json::to_string(&msg).unwrap_or_default());
+        tracing::debug!(target: "buzz_acp::acp::wire", "→ {}", &serde_json::to_string(&msg).unwrap_or_default());
 
         // Wrap write + read in a single timeout so a hung agent can't block forever.
         // We cannot use an async block that borrows `self` mutably across two awaits
@@ -1041,7 +1041,7 @@ impl AcpClient {
                 Err(_) | Ok(None) => break,
                 Ok(Some(Ok(_))) => {
                     // Consumed one buffered line; loop to drain more.
-                    tracing::debug!(target: "acp::wire", "drained stale buffered line");
+                    tracing::debug!(target: "buzz_acp::acp::wire", "drained stale buffered line");
                 }
                 Ok(Some(Err(_))) => break,
             }
@@ -1064,7 +1064,7 @@ impl AcpClient {
             "params": params,
         });
 
-        tracing::debug!(target: "acp::wire", "→ (notification) {}", &serde_json::to_string(&msg).unwrap_or_default());
+        tracing::debug!(target: "buzz_acp::acp::wire", "→ (notification) {}", &serde_json::to_string(&msg).unwrap_or_default());
         self.write_ndjson(&msg).await?;
         Ok(())
     }
@@ -1106,7 +1106,7 @@ impl AcpClient {
             }
 
             // Only log and reset idle after we have a valid non-empty line.
-            tracing::debug!(target: "acp::wire", "← {trimmed}");
+            tracing::debug!(target: "buzz_acp::acp::wire", "← {trimmed}");
 
             let msg: serde_json::Value = match serde_json::from_str(trimmed) {
                 Ok(v) => v,
@@ -1119,7 +1119,7 @@ impl AcpClient {
                         }),
                     );
                     tracing::warn!(
-                        target: "acp::wire",
+                        target: "buzz_acp::acp::wire",
                         "failed to parse line as JSON: {e} — skipping"
                     );
                     continue;
@@ -1165,7 +1165,7 @@ impl AcpClient {
                             // agent process is dead and continuing would hang.
                             self.write_ndjson(&err_resp).await?;
                         }
-                        tracing::debug!(target: "acp::wire", "ignoring unknown method: {other}");
+                        tracing::debug!(target: "buzz_acp::acp::wire", "ignoring unknown method: {other}");
                     }
                 }
             }
@@ -1322,7 +1322,7 @@ impl AcpClient {
                                 "params": params,
                             });
                             tracing::debug!(
-                                target: "acp::wire",
+                                target: "buzz_acp::acp::wire",
                                 "→ {}",
                                 serde_json::to_string(&msg).unwrap_or_default()
                             );
@@ -1400,7 +1400,7 @@ impl AcpClient {
                         continue;
                     }
 
-                    tracing::debug!(target: "acp::wire", "← {trimmed}");
+                    tracing::debug!(target: "buzz_acp::acp::wire", "← {trimmed}");
 
                     let msg: serde_json::Value = match serde_json::from_str(trimmed) {
                         Ok(v) => v,
@@ -1413,7 +1413,7 @@ impl AcpClient {
                                 }),
                             );
                             tracing::warn!(
-                                target: "acp::wire",
+                                target: "buzz_acp::acp::wire",
                                 "failed to parse line as JSON: {e} — skipping"
                             );
                             continue;
@@ -1512,7 +1512,7 @@ impl AcpClient {
                                     // agent process is dead and continuing would hang.
                                     self.write_ndjson(&err_resp).await?;
                                 }
-                                tracing::debug!(target: "acp::wire", "ignoring unknown method: {other}");
+                                tracing::debug!(target: "buzz_acp::acp::wire", "ignoring unknown method: {other}");
                             }
                         }
                     }
@@ -1542,7 +1542,7 @@ impl AcpClient {
         match update_type {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
-                    tracing::info!(target: "acp::stream", "{text}");
+                    tracing::info!(target: "buzz_acp::acp::stream", "{text}");
                 }
                 false
             }
@@ -1555,7 +1555,7 @@ impl AcpClient {
                     .get("kind")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
-                tracing::info!(target: "acp::tool", "tool_call: {title} ({kind})");
+                tracing::info!(target: "buzz_acp::acp::tool", "tool_call: {title} ({kind})");
                 true
             }
             "tool_call_update" => {
@@ -1564,16 +1564,16 @@ impl AcpClient {
                     .and_then(|v| v.as_str())
                     .unwrap_or("?");
                 let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("?");
-                tracing::info!(target: "acp::tool", "tool_call_update: {tool_id} → {status}");
+                tracing::info!(target: "buzz_acp::acp::tool", "tool_call_update: {tool_id} → {status}");
                 false
             }
             "plan" => {
-                tracing::info!(target: "acp::plan", "plan update received");
+                tracing::info!(target: "buzz_acp::acp::plan", "plan update received");
                 false
             }
             "agent_thought_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
-                    tracing::debug!(target: "acp::thought", "{text}");
+                    tracing::debug!(target: "buzz_acp::acp::thought", "{text}");
                 }
                 false
             }
@@ -1585,7 +1585,7 @@ impl AcpClient {
                     .map(|cmds| cmds.iter().filter_map(|c| c["name"].as_str()).collect())
                     .unwrap_or_default();
                 tracing::info!(
-                    target: "acp::update",
+                    target: "buzz_acp::acp::update",
                     "available_commands_update: {} commands [{}]",
                     names.len(),
                     names.join(", ")
@@ -1610,14 +1610,14 @@ impl AcpClient {
                     match goose_meta.get("activeRunId") {
                         Some(serde_json::Value::String(run_id)) => {
                             tracing::debug!(
-                                target: "acp::update",
+                                target: "buzz_acp::acp::update",
                                 "session_info_update: activeRunId={run_id}"
                             );
                             self.active_run_id = Some(run_id.clone());
                         }
                         Some(serde_json::Value::Null) => {
                             tracing::debug!(
-                                target: "acp::update",
+                                target: "buzz_acp::acp::update",
                                 "session_info_update: activeRunId cleared"
                             );
                             self.active_run_id = None;
@@ -1630,7 +1630,7 @@ impl AcpClient {
             }
             "keepalive" => false,
             other => {
-                tracing::debug!(target: "acp::update", "session/update: {other}");
+                tracing::debug!(target: "buzz_acp::acp::update", "session/update: {other}");
                 false
             }
         }
@@ -1648,7 +1648,7 @@ impl AcpClient {
             Some(p) => p,
             None => {
                 tracing::debug!(
-                    target: "acp::usage",
+                    target: "buzz_acp::acp::usage",
                     "_goose/unstable/session/update: missing params"
                 );
                 return;
@@ -1658,7 +1658,7 @@ impl AcpClient {
             Ok(notif) => {
                 if let GooseSessionUpdateVariant::UsageUpdate(payload) = &notif.update {
                     tracing::debug!(
-                        target: "acp::usage",
+                        target: "buzz_acp::acp::usage",
                         session_id = %notif.session_id,
                         input = payload.accumulated_input_tokens,
                         output = payload.accumulated_output_tokens,
@@ -1669,7 +1669,7 @@ impl AcpClient {
             }
             Err(e) => {
                 tracing::debug!(
-                    target: "acp::usage",
+                    target: "buzz_acp::acp::usage",
                     "_goose/unstable/session/update: deserialization error: {e}"
                 );
             }
@@ -1702,7 +1702,7 @@ impl AcpClient {
             .ok_or_else(|| AcpError::Protocol("permission request missing options".into()))?;
 
         tracing::debug!(
-            target: "acp::permission",
+            target: "buzz_acp::acp::permission",
             "session/request_permission id={id}, {} options",
             options.len()
         );
@@ -1717,14 +1717,14 @@ impl AcpClient {
                 .as_str()
                 .ok_or_else(|| AcpError::Protocol("allow_once option missing optionId".into()))?;
             tracing::info!(
-                target: "acp::permission",
+                target: "buzz_acp::acp::permission",
                 "auto-approving permission id={id} with allow_once optionId={option_id:?}"
             );
             permission_response_selected(&id, option_id)
         } else {
             // No allow_once — fall back to reject_once.
             tracing::warn!(
-                target: "acp::permission",
+                target: "buzz_acp::acp::permission",
                 "no allow_once option found in permission request id={id}, falling back to reject_once"
             );
             let reject = options

--- a/crates/buzz-acp/src/engram_fetch.rs
+++ b/crates/buzz-acp/src/engram_fetch.rs
@@ -46,7 +46,7 @@ pub async fn build_core_section(
         Ok(None) => Some(format!("[{SECTION_LABEL}]\n{ONBOARDING_NUDGE}")),
         Err(reason) => {
             tracing::warn!(
-                target: "engram::core",
+                target: "buzz_acp::engram::core",
                 "core fetch failed: {reason} — emitting no section to avoid \
                  confusing a relay outage with an absent core"
             );

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1565,7 +1565,7 @@ async fn tokio_main() -> Result<()> {
 
     if !config.memory_enabled {
         tracing::info!(
-            target: "engram::core",
+            target: "buzz_acp::engram::core",
             "NIP-AE core memory injection disabled (re-enable by removing --no-memory / BUZZ_ACP_NO_MEMORY)"
         );
     }

--- a/crates/buzz-acp/src/observer.rs
+++ b/crates/buzz-acp/src/observer.rs
@@ -94,7 +94,7 @@ impl ObserverHandle {
         match self.inner.buffer.lock() {
             Ok(buffer) => buffer.iter().cloned().collect(),
             Err(error) => {
-                tracing::warn!(target: "observer", "observer replay buffer lock poisoned: {error}");
+                tracing::warn!(target: "buzz_acp::observer", "observer replay buffer lock poisoned: {error}");
                 Vec::new()
             }
         }
@@ -128,7 +128,7 @@ impl ObserverHandle {
                 buffer.push_back(event.clone());
             }
             Err(error) => {
-                tracing::warn!(target: "observer", "observer replay buffer lock poisoned: {error}");
+                tracing::warn!(target: "buzz_acp::observer", "observer replay buffer lock poisoned: {error}");
             }
         }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -902,7 +902,7 @@ async fn create_session_and_apply_model(
                 Err(AcpError::AgentError { code: -32601, .. }) => {
                     agent.goose_system_prompt_supported = Some(false);
                     tracing::warn!(
-                        target: "pool::session",
+                        target: "buzz_acp::pool::session",
                         "Goose does not support its system-prompt extension; using user-message framing"
                     );
                 }
@@ -930,7 +930,7 @@ async fn create_session_and_apply_model(
             }
             None => {
                 tracing::warn!(
-                    target: "pool::model",
+                    target: "buzz_acp::pool::model",
                     "desired model {desired} not found in agent's available models — proceeding with agent default"
                 );
                 // Surface the miss so the desktop ModelPicker can reject a live
@@ -1021,7 +1021,7 @@ async fn apply_model_switch(
     match result {
         Ok(Ok(_)) => {
             tracing::info!(
-                target: "pool::model",
+                target: "buzz_acp::pool::model",
                 "applied model {desired} via {method_label} on session {session_id}"
             );
         }
@@ -1033,7 +1033,7 @@ async fn apply_model_switch(
         | Ok(Err(e @ AcpError::Protocol(_)))
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
-                target: "pool::model",
+                target: "buzz_acp::pool::model",
                 "fatal error setting model {desired} via {method_label}: {e}"
             );
             return Err(e);
@@ -1041,7 +1041,7 @@ async fn apply_model_switch(
         // Application-level errors (Json, etc.) — agent is fine, just uses default model.
         Ok(Err(e)) => {
             tracing::warn!(
-                target: "pool::model",
+                target: "buzz_acp::pool::model",
                 "failed to set model {desired} via {method_label}: {e} — proceeding with agent default"
             );
         }
@@ -1049,7 +1049,7 @@ async fn apply_model_switch(
             // Outer timeout fired — the inner send_request may have left the
             // stream in an unknown state. Treat as transport error.
             tracing::error!(
-                target: "pool::model",
+                target: "buzz_acp::pool::model",
                 "model set via {method_label} timed out ({MODEL_SWITCH_TIMEOUT:?}) — treating as fatal"
             );
             return Err(AcpError::Timeout(MODEL_SWITCH_TIMEOUT));
@@ -1097,7 +1097,7 @@ async fn apply_permission_mode(
     match result {
         Ok(Ok(_)) => {
             tracing::info!(
-                target: "pool::permission",
+                target: "buzz_acp::pool::permission",
                 "applied permission mode {wire:?} on session {session_id}"
             );
         }
@@ -1109,7 +1109,7 @@ async fn apply_permission_mode(
         | Ok(Err(e @ AcpError::Protocol(_)))
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
-                target: "pool::permission",
+                target: "buzz_acp::pool::permission",
                 "fatal error setting permission mode {wire:?}: {e}"
             );
             return Err(e);
@@ -1117,14 +1117,14 @@ async fn apply_permission_mode(
         // Application-level errors — agent is fine, just uses default permission mode.
         Ok(Err(e)) => {
             tracing::warn!(
-                target: "pool::permission",
+                target: "buzz_acp::pool::permission",
                 "failed to set permission mode {wire:?}: {e} — falling back to per-tool auto-approval"
             );
         }
         Err(_) => {
             // Outer timeout fired — stream may be in unknown state.
             tracing::error!(
-                target: "pool::permission",
+                target: "buzz_acp::pool::permission",
                 "permission mode set timed out ({PERMISSION_MODE_TIMEOUT:?}) — treating as fatal"
             );
             return Err(AcpError::Timeout(PERMISSION_MODE_TIMEOUT));
@@ -1446,7 +1446,7 @@ pub async fn run_prompt_task(
                     Ok(s) => s,
                     Err(_) => {
                         tracing::warn!(
-                            target: "engram::core",
+                            target: "buzz_acp::engram::core",
                             channel = %cid,
                             timeout_ms = CORE_FETCH_TIMEOUT.as_millis() as u64,
                             "core fetch timed out — emitting no section"
@@ -1456,7 +1456,7 @@ pub async fn run_prompt_task(
                 };
                 if let Some(rendered) = section {
                     tracing::info!(
-                        target: "engram::core",
+                        target: "buzz_acp::engram::core",
                         channel = %cid,
                         section_len = rendered.len(),
                         "injected NIP-AE core section into system prompt"
@@ -1540,7 +1540,7 @@ pub async fn run_prompt_task(
                 {
                     Ok(sid) => {
                         tracing::info!(
-                            target: "pool::session",
+                            target: "buzz_acp::pool::session",
                             "created session {sid} for channel {cid}"
                         );
                         agent.state.sessions.insert(*cid, sid.clone());
@@ -1585,7 +1585,7 @@ pub async fn run_prompt_task(
                 match create_session_and_apply_model(&mut agent, &ctx, None, None, None).await {
                     Ok(sid) => {
                         tracing::info!(
-                            target: "pool::session",
+                            target: "buzz_acp::pool::session",
                             "created heartbeat session {sid} for agent {}",
                             agent.index
                         );
@@ -1640,7 +1640,7 @@ pub async fn run_prompt_task(
         if let (PromptSource::Channel(cid), Some(ref initial_msg)) = (&source, &ctx.initial_message)
         {
             tracing::info!(
-                target: "pool::session",
+                target: "buzz_acp::pool::session",
                 "sending initial_message to session {session_id} for channel {cid}"
             );
             // For agents with systemPrompt support (protocol_version >= 2),
@@ -1680,7 +1680,7 @@ pub async fn run_prompt_task(
             match init_result {
                 Ok(stop_reason) => {
                     tracing::info!(
-                        target: "pool::session",
+                        target: "buzz_acp::pool::session",
                         "initial_message complete for channel {cid}: {stop_reason:?}"
                     );
                 }
@@ -1698,7 +1698,7 @@ pub async fn run_prompt_task(
                 }
                 Err(AcpError::IdleTimeout(_)) => {
                     tracing::warn!(
-                        target: "pool::session",
+                        target: "buzz_acp::pool::session",
                         "initial_message idle timeout ({}s) for channel {cid} — cancelling",
                         ctx.idle_timeout.as_secs()
                     );
@@ -1724,7 +1724,7 @@ pub async fn run_prompt_task(
                         }
                         Err(e) => {
                             tracing::error!(
-                                target: "pool::session",
+                                target: "buzz_acp::pool::session",
                                 "cancel_with_cleanup failed during initial_message timeout: {e}"
                             );
                             agent.state.invalidate(&source);
@@ -1743,7 +1743,7 @@ pub async fn run_prompt_task(
                 Err(AcpError::HardTimeout { silence }) => {
                     let recently_active = silence < RECENT_ACTIVITY_WINDOW;
                     tracing::error!(
-                        target: "pool::session",
+                        target: "buzz_acp::pool::session",
                         "hard timeout ({}s cap, silence {silence:?}, recently_active={recently_active}) during initial_message for channel {cid} — agent process is unrecoverable",
                         ctx.max_turn_duration.as_secs()
                     );
@@ -1760,7 +1760,7 @@ pub async fn run_prompt_task(
                 }
                 Err(e) => {
                     tracing::error!(
-                        target: "pool::session",
+                        target: "buzz_acp::pool::session",
                         "initial_message failed for channel {cid}: {e} — invalidating session"
                     );
                     agent.state.invalidate(&source);
@@ -1820,7 +1820,7 @@ pub async fn run_prompt_task(
         slash_command = crate::queue::slash_command_for_batch(b, &known_names);
         if let Some(ref cmd) = slash_command {
             tracing::info!(
-                target: "pool::prompt",
+                target: "buzz_acp::pool::prompt",
                 channel = %b.channel_id,
                 command = %cmd,
                 "slash-command pass-through"
@@ -2007,12 +2007,12 @@ pub async fn run_prompt_task(
                             ControlSignal::Rotate | ControlSignal::SwitchModel(_)
                         ) {
                             tracing::debug!(
-                                target: "pool::prompt",
+                                target: "buzz_acp::pool::prompt",
                                 "rotate/switch signal arrived but turn already completed — invalidating session"
                             );
                         } else {
                             tracing::debug!(
-                                target: "pool::prompt",
+                                target: "buzz_acp::pool::prompt",
                                 "control signal arrived but turn already completed — treating as success"
                             );
                         }
@@ -2076,7 +2076,7 @@ pub async fn run_prompt_task(
 
             if should_rotate {
                 tracing::info!(
-                    target: "pool::session",
+                    target: "buzz_acp::pool::session",
                     "rotating session for {source:?} after {stop_reason:?}",
                 );
                 agent.state.invalidate(&source);
@@ -2104,7 +2104,7 @@ pub async fn run_prompt_task(
             );
         }
         Err(AcpError::AgentExited) => {
-            tracing::error!(target: "pool::prompt", "agent {} exited during prompt", agent.index);
+            tracing::error!(target: "buzz_acp::pool::prompt", "agent {} exited during prompt", agent.index);
             agent.state.invalidate_all();
             let usage = agent.acp.take_turn_usage();
             publish_agent_turn_metric(
@@ -2127,7 +2127,7 @@ pub async fn run_prompt_task(
         }
         Err(AcpError::IdleTimeout(_)) => {
             tracing::warn!(
-                target: "pool::prompt",
+                target: "buzz_acp::pool::prompt",
                 "idle timeout ({}s) — cancelling session {session_id}",
                 ctx.idle_timeout.as_secs()
             );
@@ -2161,7 +2161,7 @@ pub async fn run_prompt_task(
                 }
                 Err(AcpError::AgentExited) => {
                     tracing::error!(
-                        target: "pool::prompt",
+                        target: "buzz_acp::pool::prompt",
                         "agent {} exited during cancel_with_cleanup",
                         agent.index
                     );
@@ -2187,7 +2187,7 @@ pub async fn run_prompt_task(
                 }
                 Err(e) => {
                     tracing::error!(
-                        target: "pool::prompt",
+                        target: "buzz_acp::pool::prompt",
                         "cancel_with_cleanup error: {e} — invalidating session"
                     );
                     agent.state.invalidate(&source);
@@ -2215,7 +2215,7 @@ pub async fn run_prompt_task(
         Err(AcpError::HardTimeout { silence }) => {
             let recently_active = silence < RECENT_ACTIVITY_WINDOW;
             tracing::error!(
-                target: "pool::prompt",
+                target: "buzz_acp::pool::prompt",
                 "hard timeout ({}s cap, silence {silence:?}, recently_active={recently_active}) — agent process is unrecoverable, invalidating all sessions",
                 ctx.max_turn_duration.as_secs()
             );
@@ -2240,7 +2240,7 @@ pub async fn run_prompt_task(
             );
         }
         Err(e) => {
-            tracing::error!(target: "pool::prompt", "session_prompt error: {e}");
+            tracing::error!(target: "buzz_acp::pool::prompt", "session_prompt error: {e}");
             // AgentError means the agent caught a problem before mutating
             // session state (e.g. bad LLM response). The session is healthy —
             // don't invalidate it. Other errors may have corrupted state.
@@ -2382,7 +2382,7 @@ async fn fetch_canvas_section(channel_id: Uuid, rest: &RestClient) -> Option<Str
         Ok(Ok(v)) => v,
         Ok(Err(e)) => {
             tracing::warn!(
-                target: "canvas::fetch",
+                target: "buzz_acp::canvas::fetch",
                 channel = %channel_id,
                 "canvas query failed: {e} — emitting no section"
             );
@@ -2390,7 +2390,7 @@ async fn fetch_canvas_section(channel_id: Uuid, rest: &RestClient) -> Option<Str
         }
         Err(_) => {
             tracing::warn!(
-                target: "canvas::fetch",
+                target: "buzz_acp::canvas::fetch",
                 channel = %channel_id,
                 timeout_ms = CANVAS_FETCH_TIMEOUT.as_millis() as u64,
                 "canvas fetch timed out — emitting no section"
@@ -2403,7 +2403,7 @@ async fn fetch_canvas_section(channel_id: Uuid, rest: &RestClient) -> Option<Str
         Some(arr) => arr,
         None => {
             tracing::warn!(
-                target: "canvas::fetch",
+                target: "buzz_acp::canvas::fetch",
                 channel = %channel_id,
                 "canvas query response is not a JSON array — emitting no section"
             );
@@ -2434,7 +2434,7 @@ pub(crate) fn canvas_section_from_query_response(
         Ok(ev) => ev,
         Err(err) => {
             tracing::warn!(
-                target: "canvas::fetch",
+                target: "buzz_acp::canvas::fetch",
                 channel = %channel_uuid,
                 %err,
                 "canvas query returned a malformed event — emitting no section",
@@ -2447,7 +2447,7 @@ pub(crate) fn canvas_section_from_query_response(
     // A structurally complete but tampered event must not supply trusted metadata.
     if let Err(err) = event.verify() {
         tracing::warn!(
-            target: "canvas::fetch",
+            target: "buzz_acp::canvas::fetch",
             channel = %channel_uuid,
             %err,
             "canvas event failed signature verification — emitting no section",
@@ -2458,7 +2458,7 @@ pub(crate) fn canvas_section_from_query_response(
     // Validate kind: must be KIND_CANVAS (40100).
     if event.kind != nostr::Kind::Custom(buzz_core::kind::KIND_CANVAS as u16) {
         tracing::warn!(
-            target: "canvas::fetch",
+            target: "buzz_acp::canvas::fetch",
             channel = %channel_uuid,
             kind = %event.kind.as_u16(),
             "canvas event has unexpected kind — emitting no section",
@@ -2475,7 +2475,7 @@ pub(crate) fn canvas_section_from_query_response(
     });
     if !h_tag_matches {
         tracing::warn!(
-            target: "canvas::fetch",
+            target: "buzz_acp::canvas::fetch",
             channel = %channel_uuid,
             "canvas event is missing expected h-tag — emitting no section",
         );
@@ -2485,7 +2485,7 @@ pub(crate) fn canvas_section_from_query_response(
     // Blank content means the canvas was cleared; do not fall back to older events.
     if event.content.trim().is_empty() {
         tracing::debug!(
-            target: "canvas::fetch",
+            target: "buzz_acp::canvas::fetch",
             channel = %channel_uuid,
             "latest canvas event has blank content — emitting no section"
         );
@@ -2502,7 +2502,7 @@ pub(crate) fn canvas_section_from_query_response(
         Ok(s) => s,
         Err(_) => {
             tracing::warn!(
-                target: "canvas::fetch",
+                target: "buzz_acp::canvas::fetch",
                 channel = %channel_uuid,
                 "canvas event created_at overflows i64 — emitting no section",
             );
@@ -2513,7 +2513,7 @@ pub(crate) fn canvas_section_from_query_response(
         Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         None => {
             tracing::warn!(
-                target: "canvas::fetch",
+                target: "buzz_acp::canvas::fetch",
                 channel = %channel_uuid,
                 ts_secs,
                 "canvas event has out-of-range created_at — emitting no section",
@@ -2523,7 +2523,7 @@ pub(crate) fn canvas_section_from_query_response(
     };
 
     tracing::info!(
-        target: "canvas::fetch",
+        target: "buzz_acp::canvas::fetch",
         channel = %channel_uuid,
         event_id = %id,
         "injected channel canvas metadata section into system prompt"
@@ -3121,19 +3121,19 @@ fn log_stop_reason(source: &PromptSource, stop_reason: &StopReason) {
     };
     match stop_reason {
         StopReason::EndTurn => {
-            tracing::info!(target: "pool::prompt", "turn complete for {label}: end_turn");
+            tracing::info!(target: "buzz_acp::pool::prompt", "turn complete for {label}: end_turn");
         }
         StopReason::Cancelled => {
-            tracing::warn!(target: "pool::prompt", "turn cancelled for {label}");
+            tracing::warn!(target: "buzz_acp::pool::prompt", "turn cancelled for {label}");
         }
         StopReason::MaxTokens => {
-            tracing::warn!(target: "pool::prompt", "turn hit max_tokens for {label} — session will be rotated");
+            tracing::warn!(target: "buzz_acp::pool::prompt", "turn hit max_tokens for {label} — session will be rotated");
         }
         StopReason::MaxTurnRequests => {
-            tracing::warn!(target: "pool::prompt", "turn hit max_turn_requests for {label} — session will be rotated");
+            tracing::warn!(target: "buzz_acp::pool::prompt", "turn hit max_turn_requests for {label} — session will be rotated");
         }
         StopReason::Refusal => {
-            tracing::warn!(target: "pool::prompt", "turn refused for {label}");
+            tracing::warn!(target: "buzz_acp::pool::prompt", "turn refused for {label}");
         }
     }
 }
@@ -3440,7 +3440,7 @@ async fn publish_agent_turn_metric(
         Ok(c) => c,
         Err(e) => {
             tracing::warn!(
-                target: "pool::metrics",
+                target: "buzz_acp::pool::metrics",
                 session_id,
                 turn_id,
                 "NIP-AM: encrypt failed: {e}"
@@ -3463,7 +3463,7 @@ async fn publish_agent_turn_metric(
         Ok(e) => e,
         Err(e) => {
             tracing::warn!(
-                target: "pool::metrics",
+                target: "buzz_acp::pool::metrics",
                 session_id,
                 turn_id,
                 "NIP-AM: sign failed: {e}"
@@ -3475,13 +3475,13 @@ async fn publish_agent_turn_metric(
     match tokio::time::timeout(METRIC_TIMEOUT, ctx.rest_client.submit_event(&event)).await {
         Ok(Ok(_)) => {}
         Ok(Err(e)) => tracing::warn!(
-            target: "pool::metrics",
+            target: "buzz_acp::pool::metrics",
             session_id,
             turn_id,
             "NIP-AM: publish failed: {e}"
         ),
         Err(_) => tracing::warn!(
-            target: "pool::metrics",
+            target: "buzz_acp::pool::metrics",
             session_id,
             turn_id,
             "NIP-AM: publish timed out"


### PR DESCRIPTION
The default filter is `buzz_acp=info` — set in `run()` and matched by the desktop's child-process filter in `managed_agents/runtime.rs` — but 84 log sites across the message-handling path declare their own target: `pool::session`, `pool::prompt`, `acp::wire`, `canvas::fetch`, and a dozen more.

`EnvFilter` matches a target by prefix from its root, and none of those roots is `buzz_acp`, so every one of them is filtered out. Turn dispatch, wire traffic, and session lifecycle never appear in a production journal, and `RUST_LOG=buzz_acp=debug` — the line `TESTING.md` hands operators when the default log is too quiet — turns none of them on.

This is the mechanism behind an observation in #2795: that fix's only trace was "a `pool::model` WARN that never reaches the per-agent log files."

Each target is now prefixed with `buzz_acp::`, so the crate filter reaches them while the existing suffixes keep working as narrower selectors (`RUST_LOG=buzz_acp::acp::wire=trace`). Names are otherwise unchanged, and nothing outside these call sites referenced them.

Pure rename — 84 insertions, 84 deletions, every changed line a `target:` string. No behavior change beyond the logs becoming reachable.

## Testing

`cargo test -p buzz-acp --lib`: `616 passed; 0 failed`. `cargo fmt --check` and `cargo clippy -p buzz-acp --all-targets` clean.