### PR TITLE
fix(tls): trust the OS certificate store on relay WebSocket connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9998,6 +9998,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ moka    = { version = "0.12", features = ["sync"] }
 futures-util = "0.3"
 
 # WebSocket client (test client)
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 url = "2"
 
 # Property-based testing (dev-only)

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -11200,6 +11200,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -83,7 +83,7 @@ infer = "0.19"
 hex = "0.4"
 ed25519-dalek = "=3.0.0-rc.0"
 tokio = { version = "1", features = ["fs", "sync", "rt", "macros", "time", "net", "io-util"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 bytes = "1"
 futures-util = "0.3"


### PR DESCRIPTION
## Problem

The desktop app's relay WebSocket trusts only a compiled-in Mozilla root list and ignores the OS trust store, so Buzz cannot connect to a relay from a machine behind a TLS-inspecting proxy (Netskope, Zscaler, Palo Alto, …). The connection fails with:

```
invalid peer certificate: UnknownIssuer
```

There is no user- or admin-side workaround: installing the corporate CA into the system keychain has no effect, and neither `SSL_CERT_FILE` nor `NODE_EXTRA_CA_CERTS` is consulted on this path.

This is easy to misdiagnose, because everything *else* in the app works. HTTPS requests go through `reqwest`, which uses `rustls-platform-verifier` and **does** read the OS trust store. Only the WebSocket path is affected, so the app looks healthy right up until the relay never connects.

## Root cause

1. `desktop/src-tauri/Cargo.toml` and the root `Cargo.toml` build `tokio-tungstenite` with only the `rustls-tls-webpki-roots` feature. `rustls-tls-native-roots` is not enabled anywhere in the workspace, so feature unification does not compensate.
2. `desktop/src-tauri/src/native_websocket.rs` calls bare `connect_async(url)` with no custom `Connector`, so tokio-tungstenite builds its default root store — which under that feature set is the bundled Mozilla roots only.
3. `desktop/src/shared/api/relayClientSession.ts` and `readOnlyRelayClient.ts` reach the relay via `invoke("plugin:websocket|connect")`, so relay traffic goes through the Rust path above rather than the webview. (The webview would have used the OS trust store and would not have this problem.)

The same applies to the workspace dependency, so `buzz`, `buzz-acp` and `buzz-dev-mcp` are affected too. `buzz-agent` uses `reqwest` only and is unaffected.

Confirmed against a v0.5.0 release build: the binary contains the Mozilla root names (`ISRG Root X1`, `DigiCert Global Root G2`, …) and contains `SecTrustEvaluateWithError` (rustls-platform-verifier, via reqwest) but no `rustls_native_certs` / `load_native_certs` symbols.

## Fix

Enable `rustls-tls-native-roots` alongside the existing feature, in both manifests.

The two root-store features are **additive** — tokio-tungstenite's `src/tls.rs` pushes both sets into the same `RootCertStore`, and the webpki branch is not gated on `not(rustls-tls-native-roots)`. So this preserves today's behaviour for everyone (the bundled Mozilla roots are still there) and additionally honours the platform trust store.

## Verification

Reproduced with a standalone tokio-tungstenite 0.29 probe against a real proxied relay, connecting with each root store in turn:

```
(a) webpki-roots only      => FAILED: invalid peer certificate: UnknownIssuer
    native cert load: added=148 ignored=0 errors=[]
(b) native + webpki roots  => SUCCESS (TLS + WS handshake completed)
```

I then built the full app from this branch and confirmed the relay connects normally on the affected machine, and that the rebuilt `buzz` / `buzz-acp` / `buzz-dev-mcp` sidecars pick up the change through the workspace dependency.

## Alternative worth considering

Since the app already depends on `rustls-platform-verifier` through reqwest, an arguably tidier fix is to build a `Connector::Rustls` from the platform verifier and pass it to `connect_async_tls_with_config`. That would make WebSocket trust behaviour match HTTP trust behaviour instead of having the two paths use different trust stores. Happy to rework this PR that way if you'd prefer it.
