### PR TITLE
feat(desktop): add Cline as a tier-2 preset harness

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -188,6 +188,15 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "cline",
+        label: "Cline",
+        command: "cline",
+        args: &["--acp"],
+        install_instructions_url: "https://docs.cline.bot/cli/overview",
+        install_hint: "Buzz talks to Cline through its CLI's ACP mode (cline --acp).",
+        underlying_cli: None,
+    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -174,6 +174,15 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "cline",
+        label: "Cline",
+        command: "cline",
+        args: &["--acp"],
+        install_instructions_url: "https://docs.cline.bot/cli/overview",
+        install_hint: "Buzz talks to Cline through its CLI's ACP mode (cline --acp).",
+        underlying_cli: None,
+    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.


### PR DESCRIPTION
## Summary
- Adds Cline (`cline --acp`) as a tier-2 `PresetHarness` entry. Cline ships native ACP support upstream (`npm i -g cline`), so this is a plain flag-preset like `opencode`/`kimi` — no adapter, no PATH resolution gap.
- No open or closed Buzz PR previously touched Cline; confirmed via `gh pr list --repo block/buzz` search across gemini/openclaw/claude/cline/aider/continue/windsurf/copilot/codex.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `node desktop/scripts/check-file-sizes.mjs` exit 0 (desktop file-size ratchet)
- [ ] Live handshake spike against installed `cline` binary