### PR TITLE
feat(desktop): add Gemini CLI as a tier-2 preset harness

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -188,6 +188,15 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "gemini",
+        label: "Gemini CLI",
+        command: "gemini",
+        args: &["--acp"],
+        install_instructions_url: "https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/acp-mode.md",
+        install_hint: "Buzz talks to Gemini CLI through its native ACP mode (gemini --acp).",
+        underlying_cli: None,
+    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -174,6 +174,15 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "gemini",
+        label: "Gemini CLI",
+        command: "gemini",
+        args: &["--acp"],
+        install_instructions_url: "https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/acp-mode.md",
+        install_hint: "Buzz talks to Gemini CLI through its native ACP mode (gemini --acp).",
+        underlying_cli: None,
+    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.


### PR DESCRIPTION
## Summary
- Adds Gemini CLI (`gemini --acp`, native ACP support, no adapter) as a tier-2 `PresetHarness` entry — matches the shape of `opencode`/`kimi`/`cursor`.
- Splits the tier-2 preset block (struct, `PRESET_HARNESSES`, and its two accessor fns) out of `discovery.rs` into a new sibling module `discovery/presets.rs`. `discovery.rs` was already past the desktop file-size ratchet, so a bare addition would have failed `just desktop-check`. No behavior change from the split itself.
- Adds an inline SVG mark (simple-icons, CC0) and settings catalog copy for Gemini CLI.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `node desktop/scripts/check-file-sizes.mjs` passes (discovery.rs down to 1648 lines, new presets.rs at 234)
- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml discovery` — 172 passed
- [x] `pnpm exec biome check` clean on modified frontend files
- [x] `node desktop/scripts/check-px-text.mjs` clean
- [x] Live ACP handshake spike against `gemini --acp` — spawned the real CLI (`gemini-cli@0.53.0`) locally, sent a JSON-RPC `initialize` request over stdio matching the exact params `buzz-acp` sends, got back a well-formed response: agent negotiated down to `protocolVersion: 1`, returned `agentInfo` (`gemini-cli` v0.53.0), `agentCapabilities` (`loadSession`, image/audio/embeddedContext prompts, MCP http/sse), and `authMethods` including `gemini-api-key`. Confirms `command: "gemini", args: ["--acp"]` is correct and the harness starts and speaks ACP as configured. (Auth/prompt flow beyond `initialize` not exercised — out of scope for this spike.)
