### PR TITLE
fix(dev): launch Vite through its Node entry point on Windows

### DIFF
--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -25,7 +25,16 @@ if [[ "${BUZZ_RESET_WEBVIEW_STATE:-0}" == "1" ]]; then
     DEV_URL="${DEV_URL}?resetDevState=1"
 fi
 
-BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev\",\"productName\":\"Buzz Dev\"}"
+# Tauri runs this through `cmd /C` on Windows, which has no `exec` and cannot
+# execute the extensionless `.bin/vite` shim. Vite's Node entry point is
+# portable; `exec` still hands the shell's process slot to Vite elsewhere so
+# Tauri's Ctrl+C reaches it directly.
+case "${BUZZ_TEST_PLATFORM:-$(uname -s)}" in
+    MINGW*|MSYS*|CYGWIN*) VITE_LAUNCH="node ./node_modules/vite/bin/vite.js" ;;
+    *) VITE_LAUNCH="exec node ./node_modules/vite/bin/vite.js" ;;
+esac
+
+BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"${VITE_LAUNCH} --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev\",\"productName\":\"Buzz Dev\"}"
 unset VITE_DEV_BRANCH
 
 # In worktrees, extract a label from the branch name and derive a unique app
@@ -89,7 +98,7 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         if swift "$GENERATE_DEV_ICON" "$BASE_ICON" "$DEV_ICON" "$BUZZ_WORKTREE_LABEL"; then
             echo "🌳 Worktree: ${BUZZ_WORKTREE_LABEL}"
             export VITE_DEV_BRANCH="$BUZZ_WORKTREE_LABEL"
-            BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev.${BUZZ_INSTANCE_SLUG}\",\"productName\":\"Buzz Dev (${BUZZ_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
+            BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"${VITE_LAUNCH} --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev.${BUZZ_INSTANCE_SLUG}\",\"productName\":\"Buzz Dev (${BUZZ_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

Launches Vite through its Node entry point in `scripts/instance-env.sh`, so `just dev` starts on Windows.

Tauri runs `beforeDevCommand` through `cmd /C` on Windows, which has no `exec` builtin and cannot execute the extensionless `./node_modules/.bin/vite` shim (only `vite.CMD` / `vite.ps1` are executable there). `just dev` therefore fails before the app window ever appears.

`node ./node_modules/vite/bin/vite.js` is portable, and `exec` is kept on every other platform so Tauri's Ctrl+C still reaches Vite directly rather than leaving it parented to the shell.

Both `BUZZ_TAURI_CONFIG` assignments are covered — the plain one and the worktree variant.

### Related issue

Part of #2388 (Windows Support).

**Complements #3515**, which applies the same Node entry point to `desktop/src-tauri/tauri.conf.json`. The two do not overlap, and either can merge first.

Worth flagging for reviewers of both PRs: the four recipes that start Tauri (`Justfile` lines 472, 501, 528, 555) all pass `--config "$BUZZ_TAURI_CONFIG"`, and that merged override carries its own `beforeDevCommand` built here in `instance-env.sh`. It therefore wins over the value in `tauri.conf.json`, so #3515 alone does not unblock those recipes on Windows — this change is what does. #3515 covers a bare `pnpm tauri dev` invocation, which reads `tauri.conf.json` directly.

(#3515's description mentions `just desktop-dev`; that recipe runs `pnpm exec vite` directly without invoking Tauri, so it never reads `beforeDevCommand` and is unaffected on either side.)

### Testing

Verified on Windows 11 (Git Bash, `MINGW64_NT-10.0`):

- `node ./node_modules/vite/bin/vite.js --version` from `desktop/` → `vite/8.0.16 win32-x64 node-v24.15.0`
- Sourcing the script emits valid JSON with the expected command:
  ```
  beforeDevCommand: node ./node_modules/vite/bin/vite.js --port 43252 --strictPort
  identifier: xyz.block.buzz.app.dev
  ```
- `just dev` reaches the running desktop app; before this change it exited during startup.
- Platform branch exercised both ways via the existing `BUZZ_TEST_PLATFORM` override — `Darwin` yields the `exec` form, `MINGW64_NT-10.0` yields the bare form.
- `bash -n scripts/instance-env.sh` clean.

Not verified: signal delivery on macOS/Linux is unchanged by inspection (`exec` retained), but I have no Apple or Linux hardware to confirm Ctrl+C behaviour end to end.
