### PR TITLE
fix(dev): add .exe to Windows sidecar stub paths

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -156,11 +156,15 @@ _ensure-sidecar-stubs:
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     mkdir -p desktop/src-tauri/binaries
     SIDECARS=(buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz)
-    if [[ "$TARGET" != *windows* ]]; then
+    EXT=""
+    if [[ "$TARGET" == *windows* ]]; then
+        # Tauri's externalBin validation expects binaries/<bin>-<triple>.exe.
+        EXT=".exe"
+    else
         SIDECARS+=(buzz-backend-kubernetes)
     fi
     for bin in "${SIDECARS[@]}"; do
-        touch "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        touch "desktop/src-tauri/binaries/${bin}-${TARGET}${EXT}"
     done
 
 # Ensure Docker dev services (Postgres, Redis, etc.) are running and healthy


### PR DESCRIPTION
## Summary

Appends `.exe` to the sidecar stub filenames on Windows so `_ensure-sidecar-stubs` produces the names Tauri's `externalBin` validation expects.

On Windows the host triple is `x86_64-pc-windows-msvc` and Tauri looks for `binaries/<bin>-x86_64-pc-windows-msvc.exe`. The recipe creates the stubs without the suffix, so Tauri rejects them and every recipe depending on `_ensure-sidecar-stubs` — `dev`, `desktop`, `desktop-standalone`, `desktop-staging` — fails before the app starts.

Three lines, and a no-op on every other platform: `EXT` stays empty unless the triple contains `windows`.

### Related issue

Fixes #2492.

Two open PRs touch the same recipe, and I have not seen a maintainer signal which should land first:

- **#2496** contains this same `.exe` fix, bundled with a managed-Node install and an onboarding scroll fix. It is currently `CONFLICTING` and has been unreviewed since 2026-07-27. This PR isolates just the `.exe` change so it can be reviewed on its own; if #2496 is preferred, close this one.
- **#2597** rewrites the same loop to stage real binaries over the stubs (a different bug — `os error 13`). It keeps the extensionless name, so it does not fix Windows and would conflict textually with this change. Whichever merges first, the other is a small rebase — happy to do that on this branch.

### Testing

Verified on Windows 11 (`x86_64-pc-windows-msvc`, Git Bash):

```
$ rm -rf desktop/src-tauri/binaries && just _ensure-sidecar-stubs
$ ls desktop/src-tauri/binaries/
buzz-acp-x86_64-pc-windows-msvc.exe
buzz-agent-x86_64-pc-windows-msvc.exe
buzz-dev-mcp-x86_64-pc-windows-msvc.exe
buzz-x86_64-pc-windows-msvc.exe
git-credential-nostr-x86_64-pc-windows-msvc.exe
```

Before this change the same command produced extensionless files and `just dev` aborted with `binaries\buzz-acp-x86_64-pc-windows-msvc.exe doesn't exist`.

Not verified on macOS or Linux — I have no such hardware. The guard is `[[ "$TARGET" == *windows* ]]`, so `EXT` is empty and the emitted paths are byte-identical to today's on any non-Windows triple.
