### PR TITLE
fix(dev): reset desktop state on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
           scripts/test-mobile-release-candidate-publisher.sh
       - name: Mobile worktree identity contract
         run: scripts/test-mobile-worktree-overrides.sh
+      - name: Desktop dev-state reset contract
+        run: |
+          scripts/test-reset-desktop-dev-state.sh
+          scripts/test-reset-desktop-standalone-state.sh
       - name: File size ratchet unit tests
         run: node --test scripts/check-file-sizes-core.test.mjs
 

--- a/scripts/reset-desktop-dev-state.sh
+++ b/scripts/reset-desktop-dev-state.sh
@@ -32,7 +32,20 @@ remove_bundle_state() {
   shopt -u nullglob
 }
 
-case "$(uname -s)" in
+# Windows Credential Manager names each keyring entry `secrets.<service>`.
+# The trailing pattern keeps per-worktree `buzz-desktop-dev.<slug>` variants in
+# scope while the required `-dev` segment keeps production `buzz-desktop` out.
+remove_dev_credentials() {
+  command -v cmdkey >/dev/null 2>&1 || return 0
+  local target
+  while IFS= read -r target; do
+    log "Removing credential $target"
+    cmdkey "/delete:${target}" >/dev/null 2>&1 || true
+  done < <(cmdkey /list | tr -d '\r' |
+    grep -oE 'secrets\.(buzz|sprout)-desktop-dev(\.[A-Za-z0-9-]+)?$' | sort -u)
+}
+
+case "${BUZZ_TEST_PLATFORM:-$(uname -s)}" in
   Darwin)
     remove_bundle_state "$HOME/Library/Application Support"
     remove_bundle_state "$HOME/Library/Caches"
@@ -52,6 +65,11 @@ case "$(uname -s)" in
     remove_bundle_state "${XDG_DATA_HOME:-$HOME/.local/share}"
     remove_bundle_state "${XDG_CONFIG_HOME:-$HOME/.config}"
     remove_bundle_state "${XDG_CACHE_HOME:-$HOME/.cache}"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    remove_bundle_state "${APPDATA:-$HOME/AppData/Roaming}"
+    remove_bundle_state "${LOCALAPPDATA:-$HOME/AppData/Local}"
+    remove_dev_credentials
     ;;
   *)
     log "Desktop bundle cleanup is not implemented for $(uname -s); continuing"

--- a/scripts/reset-desktop-standalone-state.sh
+++ b/scripts/reset-desktop-standalone-state.sh
@@ -39,6 +39,13 @@ case "${BUZZ_TEST_PLATFORM:-$(uname -s)}" in
         remove_path "${XDG_CONFIG_HOME:-$HOME/.config}/$instance_id"
         remove_path "${XDG_CACHE_HOME:-$HOME/.cache}/$instance_id"
         ;;
+    MINGW*|MSYS*|CYGWIN*)
+        remove_path "${APPDATA:-$HOME/AppData/Roaming}/$instance_id"
+        remove_path "${LOCALAPPDATA:-$HOME/AppData/Local}/$instance_id"
+        if command -v cmdkey >/dev/null 2>&1; then
+            cmdkey "/delete:secrets.${keyring_service}" >/dev/null 2>&1 || true
+        fi
+        ;;
     *)
         echo "reset-desktop-standalone-state: unsupported platform" >&2
         exit 1

--- a/scripts/test-reset-desktop-dev-state.sh
+++ b/scripts/test-reset-desktop-dev-state.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+export HOME="$tmp/home"
+export APPDATA="$HOME/AppData/Roaming"
+export LOCALAPPDATA="$HOME/AppData/Local"
+export BUZZ_TEST_PLATFORM=MINGW64_NT-10.0-26100
+
+for base in "$APPDATA" "$LOCALAPPDATA"; do
+    mkdir -p "$base/xyz.block.buzz.app.dev"
+    mkdir -p "$base/xyz.block.buzz.app.dev.wt1"
+    mkdir -p "$base/xyz.block.sprout.app.dev"
+    mkdir -p "$base/xyz.block.buzz.app"
+done
+mkdir -p "$HOME/.buzz"
+touch "$HOME/.buzz/production-identity"
+
+mkdir -p "$tmp/bin"
+# \r mirrors cmdkey's real CRLF output so the parser's newline handling is covered.
+cat > "$tmp/bin/cmdkey" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "/list" ]]; then
+    printf '    Target: LegacyGeneric:target=secrets.buzz-desktop-dev\r\n'
+    printf '    Target: LegacyGeneric:target=secrets.buzz-desktop-dev.wt1\r\n'
+    printf '    Target: LegacyGeneric:target=secrets.sprout-desktop-dev\r\n'
+    printf '    Target: LegacyGeneric:target=secrets.buzz-desktop\r\n'
+    printf '    Target: LegacyGeneric:target=secrets.buzz-desktop-development\r\n'
+    exit 0
+fi
+printf '%s\n' "$*" >> "$HOME/cmdkey-calls"
+MOCK
+chmod +x "$tmp/bin/cmdkey"
+export PATH="$tmp/bin:$PATH"
+
+"$repo_root/scripts/reset-desktop-dev-state.sh" >/dev/null
+
+for base in "$APPDATA" "$LOCALAPPDATA"; do
+    [[ ! -e "$base/xyz.block.buzz.app.dev" ]]
+    [[ ! -e "$base/xyz.block.buzz.app.dev.wt1" ]]
+    [[ ! -e "$base/xyz.block.sprout.app.dev" ]]
+    [[ -d "$base/xyz.block.buzz.app" ]]
+done
+
+[[ -f "$HOME/.buzz/production-identity" ]]
+[[ -f "$HOME/.buzz-dev/.dev-nest-migrated" ]]
+
+grep -Fx -- "/delete:secrets.buzz-desktop-dev" "$HOME/cmdkey-calls" >/dev/null
+grep -Fx -- "/delete:secrets.buzz-desktop-dev.wt1" "$HOME/cmdkey-calls" >/dev/null
+grep -Fx -- "/delete:secrets.sprout-desktop-dev" "$HOME/cmdkey-calls" >/dev/null
+
+if grep -Fx -- "/delete:secrets.buzz-desktop" "$HOME/cmdkey-calls" >/dev/null; then
+    echo "expected production credential to be left untouched" >&2
+    exit 1
+fi
+if grep -F -- "development" "$HOME/cmdkey-calls" >/dev/null; then
+    echo "expected non-dev credential prefix match to be rejected" >&2
+    exit 1
+fi
+
+echo "desktop dev-state reset scope test passed"

--- a/scripts/test-reset-desktop-standalone-state.sh
+++ b/scripts/test-reset-desktop-standalone-state.sh
@@ -35,4 +35,33 @@ if "$repo_root/scripts/reset-desktop-standalone-state.sh" \
     exit 1
 fi
 
+win=$(mktemp -d)
+trap 'rm -rf "$tmp" "$win"' EXIT
+export HOME="$win/home"
+export APPDATA="$HOME/AppData/Roaming"
+export LOCALAPPDATA="$HOME/AppData/Local"
+export BUZZ_TEST_PLATFORM=MINGW64_NT-10.0-26100
+mkdir -p "$APPDATA/xyz.block.buzz.app.dev.example"
+mkdir -p "$APPDATA/xyz.block.buzz.app.dev.other"
+mkdir -p "$APPDATA/xyz.block.buzz.app"
+mkdir -p "$LOCALAPPDATA/xyz.block.buzz.app.dev.example"
+mkdir -p "$LOCALAPPDATA/xyz.block.buzz.app"
+mkdir -p "$win/bin"
+cat > "$win/bin/cmdkey" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$HOME/cmdkey-calls"
+MOCK
+chmod +x "$win/bin/cmdkey"
+export PATH="$win/bin:$PATH"
+
+"$repo_root/scripts/reset-desktop-standalone-state.sh" \
+    xyz.block.buzz.app.dev.example buzz-desktop-dev.example
+
+[[ ! -e "$APPDATA/xyz.block.buzz.app.dev.example" ]]
+[[ ! -e "$LOCALAPPDATA/xyz.block.buzz.app.dev.example" ]]
+[[ -d "$APPDATA/xyz.block.buzz.app.dev.other" ]]
+[[ -d "$APPDATA/xyz.block.buzz.app" ]]
+[[ -d "$LOCALAPPDATA/xyz.block.buzz.app" ]]
+grep -Fx -- "/delete:secrets.buzz-desktop-dev.example" "$HOME/cmdkey-calls" >/dev/null
+
 echo "standalone desktop reset scope test passed"


### PR DESCRIPTION
## Summary

Adds Windows support to the two desktop state-reset scripts.

`scripts/reset-desktop-dev-state.sh` had no Windows arm, so it left the app data behind. `scripts/reset-desktop-standalone-state.sh` was worse — it hit an explicit `exit 1`, so resetting standalone state was impossible there.

Both now handle `MINGW*|MSYS*|CYGWIN*`:

- **App data** — removes the bundle directory under both `%APPDATA%` and `%LOCALAPPDATA%`, falling back to `$HOME/AppData/...` when the variables are unset.
- **Credentials** — Windows Credential Manager is the keyring backend, and it names each entry `secrets.<service>`. `cmdkey /list` is filtered to `secrets.(buzz|sprout)-desktop-dev`, with an optional trailing `.<slug>` so per-worktree entries are cleaned up too. The required `-dev` segment keeps production `buzz-desktop` credentials out of scope.

Also adds contract tests for both scripts and wires them into CI, since neither had any coverage.

The existing `BUZZ_TEST_PLATFORM` override is honoured, so the platform branches can be exercised from any host — that is how the tests reach the Windows arm on a Linux runner.

### Related issue

Part of #2388 (Windows Support).

No duplicate found: no open PR touches `scripts/reset-desktop-*.sh`. Checked by intersecting changed-file paths across all open PRs, not just titles.

### Testing

Verified on Windows 11 (`x86_64-pc-windows-msvc`, Git Bash):

- `scripts/reset-desktop-dev-state.sh` removes `%APPDATA%\xyz.block.buzz.app.dev` and the matching `secrets.buzz-desktop-dev` credential; the app returns to first-run onboarding afterwards.
- Production `secrets.buzz-desktop` is left untouched — confirmed via `cmdkey /list` before and after.
- `scripts/reset-desktop-standalone-state.sh` completes instead of exiting 1.
- Both new contract tests pass locally.

The `cmdkey` path is a no-op where the binary is absent (`command -v` guard), so non-Windows behaviour is unchanged.
