### PR TITLE
fix(dev): fall back to PATH tools when Hermit shims are unusable

### DIFF
--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -24,6 +24,18 @@ success() { echo -e "${GREEN}[dev-setup]${NC} $*"; }
 warn()    { echo -e "${YELLOW}[dev-setup]${NC} $*"; }
 error()   { echo -e "${RED}[dev-setup]${NC} $*" >&2; }
 
+# Hermit's bin/ entries are git symlinks. Windows checks them out as plain text
+# files when core.symlinks is false, and Hermit has no Windows build, so fall
+# back to whichever copy of the tool is already on PATH.
+hermit_tool() {
+  local tool="$1"
+  if [[ -x "${REPO_ROOT}/bin/${tool}" ]]; then
+    printf '%s' "${REPO_ROOT}/bin/${tool}"
+  else
+    printf '%s' "${tool}"
+  fi
+}
+
 # ---- Preflight checks -------------------------------------------------------
 
 if ! command -v docker &>/dev/null; then
@@ -111,7 +123,7 @@ fail_if_local_redis_blocks_compose
 # ---- Start services ---------------------------------------------------------
 
 log "Starting services and waiting for health..."
-"${REPO_ROOT}/bin/just" _ensure-services
+"$(hermit_tool just)" _ensure-services
 
 # ---- Run migrations ---------------------------------------------------------
 
@@ -128,7 +140,7 @@ until postgres_accepting_connections; do
   sleep 2
 done
 
-"${REPO_ROOT}/bin/cargo" run -p buzz-admin -- migrate
+"$(hermit_tool cargo)" run -p buzz-admin -- migrate
 "${REPO_ROOT}/scripts/seed-local-community.sh"
 success "Database migrations complete"
 
@@ -175,8 +187,13 @@ log "Installing git hooks..."
 # linked-worktree dispatch (same failure mode as the old worktree-relative .hooks).
 HOOKS_DIR="$(git -C "${REPO_ROOT}" rev-parse --path-format=absolute --git-common-dir)/hooks"
 git -C "${REPO_ROOT}" config --local core.hooksPath "$HOOKS_DIR"
-lefthook install --force
-success "Git hooks installed"
+if command -v lefthook &>/dev/null || [[ -x "${REPO_ROOT}/bin/lefthook" ]]; then
+  "$(hermit_tool lefthook)" install --force
+  success "Git hooks installed"
+else
+  warn "lefthook not found — skipping git hook install."
+  warn "Install it from https://lefthook.dev, then rerun 'just hooks'."
+fi
 
 # ---- Print connection info --------------------------------------------------
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -28,6 +28,18 @@ warn()   { echo -e "${YELLOW}[run-tests]${NC} $*"; }
 error()  { echo -e "${RED}[run-tests]${NC} $*" >&2; }
 section(){ echo -e "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"; echo -e "${CYAN}  $*${NC}"; echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"; }
 
+# Hermit's bin/ entries are git symlinks. Windows checks them out as plain text
+# files when core.symlinks is false, and Hermit has no Windows build, so fall
+# back to whichever copy of the tool is already on PATH.
+hermit_tool() {
+  local tool="$1"
+  if [[ -x "${REPO_ROOT}/bin/${tool}" ]]; then
+    printf '%s' "${REPO_ROOT}/bin/${tool}"
+  else
+    printf '%s' "${tool}"
+  fi
+}
+
 cd "${REPO_ROOT}"
 
 # ---- Load .env if present ---------------------------------------------------
@@ -70,7 +82,7 @@ run_test_step() {
 # ---- Check / start infra (for integration tests) ----------------------------
 
 ensure_infra() {
-  "${REPO_ROOT}/bin/just" _ensure-migrations
+  "$(hermit_tool just)" _ensure-migrations
 }
 
 # ---- Unit tests (no infra needed) -------------------------------------------


### PR DESCRIPTION
## Summary

Falls back to a PATH-resolved tool when a Hermit shim in `bin/` is not executable.

Hermit's `bin/` entries are git symlinks. On Windows they are checked out as plain text files whenever `core.symlinks` is false — which is the default without Developer Mode or an elevated shell — so `"${REPO_ROOT}/bin/just"` fails with exit 127. Hermit has no Windows build, so there is nothing to repair locally; the tools are simply installed on PATH instead.

`scripts/dev-setup.sh` and `scripts/run-tests.sh` now route their Hermit invocations through a small helper:

```bash
hermit_tool() {
  local tool="$1"
  if [[ -x "${REPO_ROOT}/bin/${tool}" ]]; then
    printf '%s' "${REPO_ROOT}/bin/${tool}"
  else
    printf '%s' "${tool}"
  fi
}
```

The `-x` test means every Hermit-enabled host keeps using the pinned shim exactly as before. Only a host where the shim is not executable takes the PATH path.

`lefthook install` is also guarded rather than assumed, with a warning pointing at the install docs, since it is not a hard requirement to run the suite.

### Related issue

Part of #2388 (Windows Support).

No duplicate found: 11 open PRs touch `scripts/run-tests.sh` or `scripts/dev-setup.sh`, but none add hermit or PATH-fallback handling. Checked by intersecting changed-file paths across all open PRs.

### Testing

Verified on Windows 11 (`x86_64-pc-windows-msvc`, Git Bash):

- Before: `scripts/dev-setup.sh` exits 127 at `"${REPO_ROOT}/bin/just"` — `bin/just` is a 19-byte text file containing the symlink target, not an executable.
- After: it resolves `just` from PATH and completes.
- `scripts/run-tests.sh` likewise reaches the test run instead of failing at tool resolution.
- `bash -n` clean on both scripts.

Not verified on macOS or Linux — I have no such hardware. On any host where Hermit's shims are real symlinks the `-x` test succeeds and the resolved path is byte-identical to today's, so the change is inert there by construction.

Worth flagging: this makes the scripts *run* on Windows, but it means those runs use whatever tool versions are on PATH rather than Hermit's pinned ones. That seemed better than not running at all, though I would understand a maintainer preferring an explicit warning when the fallback fires.
