### PR TITLE
fix(desktop): honor the configured repos directory on Windows

### DIFF
--- a/desktop/src-tauri/src/managed_agents/repos.rs
+++ b/desktop/src-tauri/src/managed_agents/repos.rs
@@ -9,8 +9,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-#[cfg(unix)]
-use crate::util::{create_symlink, symlink_points_to};
+use crate::util::{create_dir_link, dir_link_points_to, remove_dir_link};
 
 /// Validate a user-supplied `repos_dir`, returning the canonical target path.
 ///
@@ -72,7 +71,6 @@ pub fn validate_repos_dir(nest_root: &Path, repos_dir: &str) -> Result<PathBuf, 
 ///
 /// Validation (`validate_repos_dir`) runs before any filesystem mutation, so
 /// an invalid path returns `Err` with `REPOS` left exactly as it was.
-#[cfg(unix)]
 pub fn ensure_repos_symlink(nest_root: &Path, repos_dir: Option<&str>) -> Result<(), String> {
     let repos_path = nest_root.join("REPOS");
 
@@ -88,7 +86,7 @@ pub fn ensure_repos_symlink(nest_root: &Path, repos_dir: Option<&str>) -> Result
         // place. remove_file never touches the link's target.
         if let Ok(meta) = repos_path.symlink_metadata() {
             if meta.file_type().is_symlink() {
-                fs::remove_file(&repos_path)
+                remove_dir_link(&repos_path)
                     .map_err(|e| format!("remove symlink {}: {e}", repos_path.display()))?;
             }
         }
@@ -101,10 +99,10 @@ pub fn ensure_repos_symlink(nest_root: &Path, repos_dir: Option<&str>) -> Result
         // Existing symlink → replace it if it points elsewhere. Re-pointing a
         // symlink is data-safe; remove_file never follows the link.
         Ok(meta) if meta.file_type().is_symlink() => {
-            if symlink_points_to(&repos_path, &target) {
+            if dir_link_points_to(&repos_path, &target) {
                 return Ok(()); // already correct
             }
-            fs::remove_file(&repos_path)
+            remove_dir_link(&repos_path)
                 .map_err(|e| format!("remove symlink {}: {e}", repos_path.display()))?;
             symlink_repos(&target, &repos_path)
         }
@@ -135,16 +133,9 @@ pub fn ensure_repos_symlink(nest_root: &Path, repos_dir: Option<&str>) -> Result
     }
 }
 
-#[cfg(unix)]
 fn symlink_repos(target: &Path, link: &Path) -> Result<(), String> {
-    create_symlink(target, link)
+    create_dir_link(target, link)
         .map_err(|e| format!("symlink {} → {}: {e}", link.display(), target.display()))
-}
-
-#[cfg(not(unix))]
-pub fn ensure_repos_symlink(nest_root: &Path, _repos_dir: Option<&str>) -> Result<(), String> {
-    let repos_path = nest_root.join("REPOS");
-    fs::create_dir_all(&repos_path).map_err(|e| format!("create {}: {e}", repos_path.display()))
 }
 
 /// Provision `REPOS` at nest setup, before any configured `repos_dir` is known.
@@ -284,7 +275,6 @@ mod tests {
 
     // ── ensure_repos_symlink ──────────────────────────────────────────────
 
-    #[cfg(unix)]
     #[test]
     fn ensure_repos_symlink_none_creates_real_dir() {
         let tmp = tempfile::tempdir().unwrap();
@@ -301,7 +291,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn ensure_repos_symlink_none_reverts_existing_symlink_to_real_dir() {
         let tmp = tempfile::tempdir().unwrap();
@@ -331,7 +320,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn ensure_repos_symlink_absent_creates_symlink() {
         let tmp = tempfile::tempdir().unwrap();
@@ -344,10 +332,9 @@ mod tests {
 
         let repos = root.join("REPOS");
         assert!(repos.symlink_metadata().unwrap().file_type().is_symlink());
-        assert_eq!(repos.read_link().unwrap(), external.canonicalize().unwrap());
+        assert!(dir_link_points_to(&repos, &external));
     }
 
-    #[cfg(unix)]
     #[test]
     fn ensure_repos_symlink_repoints_existing_wrong_symlink() {
         let tmp = tempfile::tempdir().unwrap();
@@ -364,14 +351,13 @@ mod tests {
         ensure_repos_symlink(&root, Some(new.to_str().unwrap())).unwrap();
 
         let repos = root.join("REPOS");
-        assert_eq!(repos.read_link().unwrap(), new.canonicalize().unwrap());
+        assert!(dir_link_points_to(&repos, &new));
         assert!(
             payload.exists(),
             "re-pointing a symlink must not touch the old target's contents"
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn ensure_repos_symlink_correct_symlink_is_noop() {
         let tmp = tempfile::tempdir().unwrap();
@@ -383,10 +369,9 @@ mod tests {
         ensure_repos_symlink(&root, Some(external.to_str().unwrap())).unwrap();
 
         let repos = root.join("REPOS");
-        assert_eq!(repos.read_link().unwrap(), external);
+        assert!(dir_link_points_to(&repos, &external));
     }
 
-    #[cfg(unix)]
     #[test]
     fn ensure_repos_symlink_empty_real_dir_converts() {
         let tmp = tempfile::tempdir().unwrap();
@@ -404,7 +389,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn ensure_repos_symlink_nonempty_real_dir_refuses_and_preserves() {
         let tmp = tempfile::tempdir().unwrap();
@@ -435,7 +419,6 @@ mod tests {
     // call used to remove a configured symlink and mint an empty real REPOS,
     // which async-restored agents could write into — the FE re-point then
     // refused the now-non-empty dir, silently breaking a configured repos_dir.
-    #[cfg(unix)]
     #[test]
     fn ensure_nest_startup_preserves_existing_repos_symlink() {
         let tmp = tempfile::tempdir().unwrap();
@@ -450,7 +433,7 @@ mod tests {
         fs::create_dir(&external).unwrap();
         fs::write(external.join("KEEP.md"), "data").unwrap();
         fs::remove_dir(root.join("REPOS")).unwrap();
-        std::os::unix::fs::symlink(&external, root.join("REPOS")).unwrap();
+        create_dir_link(&external, &root.join("REPOS")).unwrap();
 
         // Next launch must leave the configured symlink intact.
         crate::managed_agents::ensure_nest_at(&root).unwrap();
@@ -460,14 +443,13 @@ mod tests {
             repos.symlink_metadata().unwrap().file_type().is_symlink(),
             "an existing REPOS symlink must survive startup"
         );
-        assert_eq!(repos.read_link().unwrap(), external);
+        assert!(dir_link_points_to(&repos, &external));
         assert!(
             external.join("KEEP.md").exists(),
             "the symlink's target contents must be untouched"
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn validate_repos_dir_rejects_tilde_relative_and_missing() {
         let tmp = tempfile::tempdir().unwrap();
@@ -483,7 +465,6 @@ mod tests {
         assert!(validate_repos_dir(&root, file.to_str().unwrap()).is_err());
     }
 
-    #[cfg(unix)]
     #[test]
     fn validate_repos_dir_rejects_nest_ancestor() {
         let tmp = tempfile::tempdir().unwrap();
@@ -546,7 +527,6 @@ mod tests {
         write_persisted_repos_dir(&root, None).expect("clearing an absent dotfile is not an error");
     }
 
-    #[cfg(unix)]
     #[test]
     fn boot_resolves_symlink_from_persisted_value_into_empty_repos() {
         // Mirrors the boot sequence: ensure_nest leaves REPOS an empty real
@@ -566,10 +546,9 @@ mod tests {
             repos.symlink_metadata().unwrap().file_type().is_symlink(),
             "boot must convert the empty real REPOS into a symlink"
         );
-        assert_eq!(repos.read_link().unwrap(), external.canonicalize().unwrap());
+        assert!(dir_link_points_to(&repos, &external));
     }
 
-    #[cfg(unix)]
     #[test]
     fn boot_leaves_already_correct_symlink_untouched() {
         let tmp = tempfile::tempdir().unwrap();
@@ -586,10 +565,9 @@ mod tests {
 
         let repos = root.join("REPOS");
         assert!(repos.symlink_metadata().unwrap().file_type().is_symlink());
-        assert_eq!(repos.read_link().unwrap(), external.canonicalize().unwrap());
+        assert!(dir_link_points_to(&repos, &external));
     }
 
-    #[cfg(unix)]
     #[test]
     fn boot_with_cleared_value_reverts_symlink_to_real_dir() {
         let tmp = tempfile::tempdir().unwrap();
@@ -618,7 +596,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn effective_repos_dir_drives_persisted_dotfile_for_all_three_cases() {
         // Pins the CRITICAL persist decision on `.repos-dir` CONTENTS, not just
@@ -681,7 +658,6 @@ mod tests {
 
     // ── resolve_repos_at_boot (boot sequence + fail-closed gate) ──────────
 
-    #[cfg(unix)]
     #[test]
     fn resolve_repos_at_boot_converts_empty_real_repos_and_allows_restore() {
         // Drives the real boot sequence: ensure_repos_setup_default (called by
@@ -709,10 +685,9 @@ mod tests {
             repos.symlink_metadata().unwrap().file_type().is_symlink(),
             "boot resolve converts the empty real REPOS into the configured symlink"
         );
-        assert_eq!(repos.read_link().unwrap(), external.canonicalize().unwrap());
+        assert!(dir_link_points_to(&repos, &external));
     }
 
-    #[cfg(unix)]
     #[test]
     fn resolve_repos_at_boot_fails_closed_when_target_unresolvable() {
         // Persisted repos_dir whose target does not exist at boot (transiently
@@ -739,7 +714,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn resolve_repos_at_boot_allows_restore_with_no_repos_dir() {
         // No configured repos_dir → the real in-nest REPOS default is correct,
@@ -776,11 +750,9 @@ mod tests {
     }
 
     /// Test helper: canonicalize a path, creating it as a directory first.
-    #[cfg(unix)]
     trait CanonicalizeOrMake {
         fn canonicalize_or_make(&self) -> PathBuf;
     }
-    #[cfg(unix)]
     impl CanonicalizeOrMake for PathBuf {
         fn canonicalize_or_make(&self) -> PathBuf {
             fs::create_dir_all(self).unwrap();

--- a/desktop/src-tauri/src/util.rs
+++ b/desktop/src-tauri/src/util.rs
@@ -77,6 +77,93 @@ pub(crate) fn symlink_points_to(link: &std::path::Path, target: &std::path::Path
             .unwrap_or(false)
 }
 
+/// Link a directory at `link` so it resolves to `target`.
+///
+/// Unix uses a plain symlink. Windows prefers a directory symlink and falls
+/// back to a junction, which needs neither Developer Mode nor elevation —
+/// without the fallback this fails for most users. Junctions only address
+/// local volumes, so the symlink attempt comes first to keep UNC targets
+/// working.
+#[cfg(unix)]
+pub(crate) fn create_dir_link(
+    target: &std::path::Path,
+    link: &std::path::Path,
+) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+pub(crate) fn create_dir_link(
+    target: &std::path::Path,
+    link: &std::path::Path,
+) -> std::io::Result<()> {
+    use std::os::windows::process::CommandExt;
+
+    let symlink_error = match std::os::windows::fs::symlink_dir(target, link) {
+        Ok(()) => return Ok(()),
+        Err(error) => error,
+    };
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    // `raw_arg` because cmd.exe re-parses its command line with rules the
+    // standard argument escaping does not match; paths cannot contain `"`,
+    // so quoting them here is sufficient.
+    let output = std::process::Command::new("cmd")
+        .arg("/C")
+        .raw_arg(format!(
+            "mklink /J \"{}\" \"{}\"",
+            link.display(),
+            target.display()
+        ))
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(std::io::Error::other(format!(
+        "symlink failed ({symlink_error}) and junction fallback failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    )))
+}
+
+/// Remove a directory link created by [`create_dir_link`].
+///
+/// Windows directory symlinks and junctions are directory entries, so
+/// `remove_file` refuses them; `remove_dir` unlinks without following.
+#[cfg(unix)]
+pub(crate) fn remove_dir_link(link: &std::path::Path) -> std::io::Result<()> {
+    std::fs::remove_file(link)
+}
+
+#[cfg(windows)]
+pub(crate) fn remove_dir_link(link: &std::path::Path) -> std::io::Result<()> {
+    std::fs::remove_dir(link)
+}
+
+/// Returns `true` when `link` is a directory link already resolving to `target`.
+///
+/// Unlike [`symlink_points_to`] this canonicalizes both sides: Windows stores
+/// junction and symlink targets in verbatim (`\\?\C:\…`) form, which never
+/// compares equal to the path the caller passed in.
+pub(crate) fn dir_link_points_to(link: &std::path::Path, target: &std::path::Path) -> bool {
+    let Ok(metadata) = link.symlink_metadata() else {
+        return false;
+    };
+    if !metadata.file_type().is_symlink() {
+        return false;
+    }
+    let Ok(stored) = std::fs::read_link(link) else {
+        return false;
+    };
+    if stored == target {
+        return true;
+    }
+    match (stored.canonicalize(), target.canonicalize()) {
+        (Ok(stored), Ok(target)) => stored == target,
+        _ => false,
+    }
+}
+
 /// Compute a collision-safe backup path for `dst`.
 ///
 /// The candidate is `<parent>/<full-filename>.bak.<ms-timestamp>`. If that

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   clearCommunityStorage,
   initFirstCommunity,
+  joinHomePath,
   loadCommunities,
   loadCommunityDiscoveryAfterLeave,
   markCommunityDiscoveryAfterLeave,
@@ -131,4 +132,32 @@ test("clearCommunityStorage preserves completed final-leave discovery", () => {
 
   assert.equal(storage.length, 1);
   assert.equal(loadCommunityDiscoveryAfterLeave(storage), true);
+});
+
+const WINDOWS_HOME = "C:\\Users\\you\\";
+
+test("joinHomePath strips a trailing separator of either style", () => {
+  assert.equal(
+    joinHomePath("/Users/you/", "Development"),
+    "/Users/you/Development",
+  );
+  assert.equal(
+    joinHomePath("/Users/you", "Development"),
+    "/Users/you/Development",
+  );
+  assert.equal(
+    joinHomePath(WINDOWS_HOME, "Documents"),
+    "C:\\Users\\you\\Documents",
+  );
+});
+
+test("joinHomePath rewrites forward slashes for a Windows home", () => {
+  assert.equal(
+    joinHomePath(WINDOWS_HOME, "Documents/docker"),
+    "C:\\Users\\you\\Documents\\docker",
+  );
+});
+
+test("joinHomePath keeps backslashes intact for a Unix home", () => {
+  assert.equal(joinHomePath("/Users/you", "odd\\name"), "/Users/you/odd\\name");
 });

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -10,10 +10,26 @@ const COMMUNITY_DISCOVERY_AFTER_LEAVE_KEY =
   "buzz-community-discovery-after-leave";
 
 /**
+ * Join `rest` onto `home`, matching the separator style `home` already uses.
+ *
+ * Windows `homeDir()` returns a trailing backslash, so stripping only `/`
+ * yields a doubled separator. A backslash in `home` also means a Windows path,
+ * where `\` is not a legal filename character — rewriting `/` in `rest` is
+ * lossless there, but would corrupt a real filename on Unix.
+ */
+export function joinHomePath(home: string, rest: string): string {
+  const base = home.replace(/[/\\]+$/, "");
+  return base.includes("\\")
+    ? `${base}\\${rest.replace(/\//g, "\\")}`
+    : `${base}/${rest}`;
+}
+
+/**
  * Expand a leading `~` to the user's home directory. The backend rejects
  * `~`-prefixed paths (`std::fs` does not expand the shell tilde), so the UI
- * resolves it before save. Returns non-`~` input unchanged. Empty/whitespace
- * input returns `undefined` so callers can clear the override.
+ * resolves it before save. Accepts `~/` and the Windows-native `~\`. Returns
+ * non-`~` input unchanged. Empty/whitespace input returns `undefined` so
+ * callers can clear the override.
  */
 export async function expandTilde(input: string): Promise<string | undefined> {
   const trimmed = input.trim();
@@ -23,10 +39,8 @@ export async function expandTilde(input: string): Promise<string | undefined> {
   if (trimmed === "~") {
     return homeDir();
   }
-  if (trimmed.startsWith("~/")) {
-    const home = await homeDir();
-    const base = home.endsWith("/") ? home.slice(0, -1) : home;
-    return `${base}/${trimmed.slice(2)}`;
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return joinHomePath(await homeDir(), trimmed.slice(2));
   }
   return trimmed;
 }


### PR DESCRIPTION
## Summary

Honours the configured repos directory on Windows.

`ensure_repos_symlink` was `#[cfg(unix)]`, and the `cfg(not(unix))` fallback dropped its argument entirely:

```rust
#[cfg(not(unix))]
pub fn ensure_repos_symlink(nest_root: &Path, _repos_dir: Option<&str>) -> Result<(), String> {
    let repos_path = nest_root.join("REPOS");
    fs::create_dir_all(&repos_path).map_err(...)
}
```

So on Windows the community's *Repos Directory* setting silently did nothing: agents worked in `%USERPROFILE%\.buzz\REPOS` while `canonical_repos_roots` — which is cross-platform — pointed the desktop's own git commands at the configured path. Two halves of the app looking in different places, with no error.

The `cfg(unix)` gate is gone; one decision tree now runs everywhere, with three small platform helpers in `util.rs`:

- **`create_dir_link`** — `symlink` on Unix. On Windows it tries `symlink_dir` first, then falls back to a **junction** via `mklink /J`. The fallback is what actually carries this: `symlink_dir` needs Developer Mode or elevation, and failed on every attempt on my machine. Junctions need neither. `symlink_dir` is still tried first because junctions cannot address UNC targets.
- **`remove_dir_link`** — `remove_file` on Unix, `remove_dir` on Windows, which is what Windows requires to unlink a directory link. The previous code called `remove_file` unconditionally.
- **`dir_link_points_to`** — canonicalizes both sides, because Windows stores link targets in verbatim `\\?\C:\…` form which never compares equal to the caller's path.

Every existing safety property is preserved: a non-empty real `REPOS` is still refused rather than deleted, an empty one still converts, and re-pointing never touches either target's contents.

Second commit: `expandTilde` only matched a `~/` prefix, so the Windows-native `~\Documents\repos` fell through to the backend, which rejects any `~` path with a message suggesting `/Users/you/Development`. Its trailing-separator strip also only handled `/`, doubling the separator on a Windows home. Both fixed, with the join logic extracted so it is testable without mocking `homeDir()`.

The forward-slash rewrite is deliberately gated on the home path containing a backslash — `\` is not a legal filename character on Windows so rewriting is lossless there, but it *is* legal on Unix and would corrupt a real filename. There is a test pinning that.

### Windows link creation: privilege, and an existing `REPOS`

#### Symlink privilege

`create_dir_link` tries `std::os::windows::fs::symlink_dir` first, and on failure
falls back to `mklink /J` (a junction), which needs neither Developer Mode nor
elevation. Without that fallback this would fail for most users, since creating a
directory symlink on Windows requires `SeCreateSymbolicLinkPrivilege`.

The symlink attempt comes first on purpose: junctions only address local
volumes, so trying the junction first would silently break UNC targets.

If **both** fail, the error carries both causes:

```rust
Err(std::io::Error::other(format!(
    "symlink failed ({symlink_error}) and junction fallback failed: {}",
    String::from_utf8_lossy(&output.stderr).trim()
)))
```

`symlink_repos` wraps that with the link and target paths, and it propagates out
of `ensure_repos_symlink` as `Err(String)`. `apply_workspace` emits it on the
`repos-dir-error` channel, which `useNestNotifications` renders as a
`Repos directory not applied` toast with the message as its description — so the
failure is visible in the UI, not just on stderr.

**The silent fall-through the old code had is now gone.** The deleted
`#[cfg(not(unix))]` stub ignored `repos_dir` entirely and just `create_dir_all`'d
the in-nest `REPOS`, which is exactly the "silent fall-through to
`%USERPROFILE%\.buzz\REPOS`" worth avoiding. There is now one implementation for
all platforms and no path that discards the configured value without saying so.

#### When `REPOS` already exists

Handled as an explicit match rather than a blind create. Validation
(`validate_repos_dir`) runs before any filesystem mutation, so an invalid
`repos_dir` returns `Err` with `REPOS` untouched.

| existing `REPOS` | behaviour |
|---|---|
| absent | create the link |
| a link already resolving to the target | no-op |
| a link pointing elsewhere | unlink and recreate — never follows the link, so the old target's contents survive |
| an **empty** real directory | remove and replace with the link |
| a **non-empty** real directory | **refuse** with `holds repositories; move or delete them before pointing repos dir elsewhere`. Never `remove_dir_all` — that would destroy repos the agent cloned in-nest |
| exists but is not a directory | refuse |

Two Windows-specific details that the unix code got away with ignoring:

- **Unlinking.** `remove_dir_link` uses `remove_dir` on Windows, not
  `remove_file`. Windows treats both directory symlinks and junctions as
  directory entries, so `remove_file` refuses them outright; `remove_dir`
  unlinks without following. The pre-existing `fs::remove_file` call would have
  failed on every re-point.
- **Comparison.** `dir_link_points_to` canonicalizes both sides before
  comparing. Windows stores junction and symlink targets in verbatim
  (`\\?\C:\…`) form, which never compares equal to the path the caller passed
  in, so the old `read_link() == target` assertion would have reported "points
  somewhere else" for a link that was in fact correct — and re-created it on
  every single apply. `is_symlink()` is true for junctions as well as symlinks
  on Windows, so both link kinds take the same path.

### Related issue

Part of #2388 (Windows Support).

No duplicate found: nothing open touches `managed_agents/repos.rs` or `src-tauri/src/util.rs`, and the one PR touching `communityStorage.ts` (#2580) does not touch `expandTilde`. Checked by intersecting changed-file paths across all open PRs.

### Testing

Verified on Windows 11 (`x86_64-pc-windows-msvc`):

- The 21 tests in `managed_agents::repos` were all `#[cfg(unix)]` and had **never run on Windows**. Un-gated, they pass there. That required swapping raw `read_link()` equality assertions for `dir_link_points_to` and one direct `std::os::unix::fs::symlink` call.
- End to end: setting the repos directory produces `REPOS [\\?\C:\Users\...\repos]` under `dir /AL`, and a file created through `REPOS/` appears at the target.
- `communityStorage` suite passes, including three new `joinHomePath` cases covering both separator styles and the Unix-backslash-filename edge.
- `cargo clippy --lib` and `cargo fmt --check` clean.

Not verified on macOS or Linux. The Unix arms of the new helpers are the original calls unchanged, and the previously-Unix-only tests still pass here, but I have no such hardware to confirm.

Left alone deliberately: `util::create_symlink` is still a silent no-op on non-Unix (`util.rs:60`), used by `nest.rs` for skill and binary links and by `migration.rs`. Those are file links with a different failure mode and deserve their own change.

