### PR TITLE
feat(desktop): add a clear action to the harness log toolbar

### DIFF
--- a/desktop/src-tauri/src/commands/agent_logs.rs
+++ b/desktop/src-tauri/src/commands/agent_logs.rs
@@ -3,8 +3,8 @@ use tauri::{AppHandle, Manager};
 use crate::{
     app_state::AppState,
     managed_agents::{
-        latest_managed_agent_log_path, load_managed_agents, read_log_tail, BackendKind,
-        ManagedAgentLogResponse,
+        latest_managed_agent_log_path, load_managed_agents, read_log_tail, truncate_log_file,
+        BackendKind, ManagedAgentLogResponse,
     },
 };
 
@@ -34,6 +34,31 @@ pub async fn get_managed_agent_log(
             content: read_log_tail(&log_path, line_count.unwrap_or(120) as usize)?,
             log_path: log_path.display().to_string(),
         })
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {e}"))?
+}
+
+/// Truncate the log `get_managed_agent_log` reads, so a running harness keeps
+/// appending to the same file rather than the viewer and the writer diverging.
+#[tauri::command]
+pub async fn clear_managed_agent_log(pubkey: String, app: AppHandle) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let records = load_managed_agents(&app)?;
+        let record = records
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .ok_or_else(|| format!("agent {pubkey} not found"))?;
+        if record.backend != BackendKind::Local {
+            return Err("logs are not available for remote agents".to_string());
+        }
+
+        truncate_log_file(&latest_managed_agent_log_path(&app, &pubkey)?)
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))?

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -772,6 +772,7 @@ pub fn run() {
             set_managed_agent_auto_restart,
             delete_managed_agent,
             get_managed_agent_log,
+            clear_managed_agent_log,
             get_agent_models,
             discover_agent_models,
             agent_access_owner_only,

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -721,6 +721,25 @@ pub(crate) fn append_log_marker(path: &Path, message: &str) -> Result<(), String
     writeln!(file, "{message}").map_err(|error| format!("failed to write log marker: {error}"))
 }
 
+/// Truncate `path` to zero length, leaving the file in place.
+///
+/// Safe while the harness is running: [`open_log_file`] hands the child an
+/// append-mode handle, so its next write seeks to the new end rather than
+/// leaving a NUL-filled hole at the old offset. A missing file is already
+/// clear, so it succeeds rather than reporting an error the user can't act on.
+pub(crate) fn truncate_log_file(path: &Path) -> Result<(), String> {
+    match OpenOptions::new().write(true).open(path) {
+        Ok(file) => file
+            .set_len(0)
+            .map_err(|error| format!("failed to clear log file {}: {error}", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "failed to open log file {}: {error}",
+            path.display()
+        )),
+    }
+}
+
 fn agent_pids_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = managed_agents_base_dir(app)?.join("agent-pids");
     fs::create_dir_all(&dir)

--- a/desktop/src-tauri/src/managed_agents/storage_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/storage_tests.rs
@@ -830,3 +830,40 @@ fn install_log_filename_accepts_ordinary_runtime_ids() {
         );
     }
 }
+#[test]
+fn truncate_log_file_empties_an_existing_log() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("agent.log");
+    std::fs::write(&path, b"noisy previous run\n").expect("seed log");
+
+    super::truncate_log_file(&path).expect("truncate");
+
+    assert!(path.exists(), "the file itself must survive the clear");
+    assert_eq!(std::fs::read(&path).expect("read back"), Vec::<u8>::new());
+}
+
+#[test]
+fn truncate_log_file_tolerates_a_missing_log() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    // An agent that has never run has no log; that state is already clear.
+    assert!(super::truncate_log_file(&dir.path().join("absent.log")).is_ok());
+}
+
+#[test]
+fn appends_after_truncate_land_at_the_start() {
+    // Guards the reason clearing is safe mid-run: the harness holds an
+    // append-mode handle, so its next write must not leave a NUL hole at the
+    // pre-truncate offset.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("agent.log");
+    let mut held = super::open_log_file(&path).expect("open like the harness does");
+    writeln!(held, "before clear").expect("write");
+
+    super::truncate_log_file(&path).expect("truncate");
+    writeln!(held, "after clear").expect("write through the pre-existing handle");
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read back"),
+        "after clear\n"
+    );
+}

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -41,6 +41,7 @@ import {
 } from "@/shared/api/tauri";
 import type { HarnessDefinitionInput } from "@/shared/api/tauri";
 import {
+  clearManagedAgentLog,
   setManagedAgentAutoRestart,
   setManagedAgentStartOnAppLaunch,
   startManagedAgent,
@@ -902,6 +903,17 @@ export function useManagedAgentLogQuery(
     retry: false,
     staleTime: 3_000,
     refetchInterval: pubkey ? 30_000 : false,
+  });
+}
+
+export function useClearManagedAgentLogMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (pubkey: string) => clearManagedAgentLog(pubkey),
+    onSuccess: (_result, pubkey) =>
+      queryClient.invalidateQueries({
+        queryKey: ["managed-agent-log", pubkey],
+      }),
   });
 }
 

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -11,6 +11,7 @@ import {
   useAcpRuntimesQuery,
   useAvailableAcpRuntimes,
   useCreateManagedAgentMutation,
+  useClearManagedAgentLogMutation,
   useCreatePersonaMutation,
   useDeleteManagedAgentMutation,
   useDeletePersonaMutation,
@@ -758,6 +759,18 @@ export function UserProfilePanel({
       relayAgent,
     });
   const isDiagnosticsLikeView = view === "diagnostics" || view === "logs";
+  const clearLogMutation = useClearManagedAgentLogMutation();
+  const handleClearLog = React.useCallback(() => {
+    if (!managedAgent) return;
+    clearLogMutation.mutate(managedAgent.pubkey, {
+      onError: (error) =>
+        toast.error(
+          error instanceof Error
+            ? `Failed to clear log: ${error.message}`
+            : "Failed to clear log.",
+        ),
+    });
+  }, [clearLogMutation, managedAgent]);
   const managedAgentLogContent = managedAgentLogQuery.data?.content ?? null;
   const logHeaderSubtitle =
     isDiagnosticsLikeView && managedAgent
@@ -767,9 +780,11 @@ export function UserProfilePanel({
     {
       agentSettingsMenu,
       effectivePubkey,
+      isLogClearPending: clearLogMutation.isPending,
       logCopyValue: isDiagnosticsLikeView ? managedAgentLogContent : null,
       logSubtitle: logHeaderSubtitle,
       onBack: () => setView("summary"),
+      onClearLog: managedAgent ? handleClearLog : undefined,
       view,
       viewerIsOwner,
     },

--- a/desktop/src/features/profile/ui/UserProfilePanelHeaderContent.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelHeaderContent.tsx
@@ -1,6 +1,8 @@
+import { Eraser } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { CopyButton } from "@/features/agents/ui/CopyButton";
+import { Button } from "@/shared/ui/button";
 import { MemoryRefreshButton } from "@/features/agent-memory/ui/MemorySection";
 import {
   PROFILE_PANEL_VIEW_TITLES,
@@ -15,17 +17,21 @@ import {
 export function getUserProfilePanelHeaderContent({
   agentSettingsMenu,
   effectivePubkey,
+  isLogClearPending,
   logCopyValue,
   logSubtitle,
   onBack,
+  onClearLog,
   view,
   viewerIsOwner,
 }: {
   agentSettingsMenu: ReactNode;
   effectivePubkey: string | null;
+  isLogClearPending?: boolean;
   logCopyValue?: string | null;
   logSubtitle?: string | null;
   onBack: () => void;
+  onClearLog?: () => void;
   view: ProfilePanelView;
   viewerIsOwner: boolean;
 }) {
@@ -56,6 +62,20 @@ export function getUserProfilePanelHeaderContent({
         />
       ) : null}
       {view === "summary" ? agentSettingsMenu : null}
+      {shouldShowLogDetails && onClearLog ? (
+        <Button
+          className="text-muted-foreground hover:text-foreground"
+          data-testid="user-profile-clear-log"
+          disabled={isLogClearPending}
+          onClick={onClearLog}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <Eraser className="h-4 w-4" />
+          <span className="sr-only">Clear log</span>
+        </Button>
+      ) : null}
       {shouldShowLogDetails ? (
         <CopyButton
           className="text-muted-foreground hover:text-foreground"

--- a/desktop/src/shared/api/tauriManagedAgents.ts
+++ b/desktop/src/shared/api/tauriManagedAgents.ts
@@ -94,3 +94,7 @@ export async function reconcileManagedAgentRuntimes(
 ): Promise<ManagedAgentRuntimeStatus[]> {
   return invokeTauri("reconcile_managed_agent_runtimes", { communities });
 }
+
+export async function clearManagedAgentLog(pubkey: string): Promise<void> {
+  return invokeTauri("clear_managed_agent_log", { pubkey });
+}


### PR DESCRIPTION
## Summary

Adds a clear action to the harness log toolbar, next to the existing copy button.

Restarting an agent to test a change means re-reading a log that still holds the previous run's output. Today the only way to get a clean view is to find the file on disk and empty it by hand.

The command truncates in place rather than deleting:

```rust
OpenOptions::new().write(true).open(path)?.set_len(0)
```

A running harness holds the file open in append mode, so unlinking it would leave the writer appending to an inode the viewer can no longer see — the log would look permanently frozen. `set_len(0)` keeps writer and reader on the same file, and the next append lands at offset 0.

`clear_managed_agent_log` mirrors the guards already on `get_managed_agent_log`: same store lock, same "not found" error, and the same refusal for non-`Local` backends, since there is no local file to truncate for a remote agent. A missing log is treated as success — clearing something already absent is not an error.

The button is gated on the same `shouldShowLogDetails` condition as the copy button, so it only appears on the diagnostics and logs views.

### Related issue

None found. Checked by intersecting changed-file paths across all 567 open PRs: no open work adds a clear, truncate, or reset action for agent logs. The only PR touching `UserProfilePanelHeaderContent.tsx` is #2544, which restores thread context and does not touch the toolbar actions.

Note `desktop/src-tauri/src/lib.rs` here is a one-line command registration; 51 open PRs touch that file, so expect a trivial conflict there if this sits for a while.

### Testing

Three unit tests in `managed_agents::storage`:

- `truncate_log_file_empties_an_existing_log`
- `truncate_log_file_tolerates_a_missing_log`
- `appends_after_truncate_land_at_the_start` — the one that matters, pinning that a writer holding the file open keeps writing to the same inode

`cargo test --lib truncate` passes (11 tests in scope). Manually verified on Windows 11: with an agent running, clearing the log empties the panel and subsequent harness output continues to stream into the same view.

UI change, so a before/after of the toolbar:

- before: `[copy]`
- after: `[clear] [copy]`

Happy to attach a screenshot if useful — the change is a single icon button, so I did not want to pad the PR with one unprompted.
