### PR TITLE
fix(desktop): honour CLAUDE_CONFIG_DIR in agent MCP config panel

### DIFF
--- a/desktop/src-tauri/src/managed_agents/config_bridge/claude.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/claude.rs
@@ -1,10 +1,31 @@
+use std::path::{Path, PathBuf};
+
 use super::types::{ExtensionEntry, RuntimeFileConfig};
 
-/// Read Claude Code config from `~/.claude/settings.json` and `~/.claude.json`.
-pub(super) fn read_config_file() -> Option<RuntimeFileConfig> {
+/// Resolve Claude settings + MCP config paths for an optional `CLAUDE_CONFIG_DIR`.
+///
+/// Default layout (no override):
+/// - settings: `~/.claude/settings.json`
+/// - MCP: `~/.claude.json`
+///
+/// Isolated layout (`CLAUDE_CONFIG_DIR=<dir>`):
+/// - settings: `<dir>/settings.json`
+/// - MCP: `<dir>/.claude.json`
+pub(super) fn claude_config_paths(config_dir: Option<&Path>) -> Option<(PathBuf, PathBuf)> {
+    if let Some(dir) = config_dir {
+        return Some((dir.join("settings.json"), dir.join(".claude.json")));
+    }
     let home = dirs::home_dir()?;
-    let settings_path = home.join(".claude").join("settings.json");
-    let mcp_path = home.join(".claude.json");
+    Some((
+        home.join(".claude").join("settings.json"),
+        home.join(".claude.json"),
+    ))
+}
+
+/// Read Claude Code config from the default home paths, or from an isolated
+/// `CLAUDE_CONFIG_DIR` when the agent sets that env var.
+pub(super) fn read_config_file(config_dir: Option<&Path>) -> Option<RuntimeFileConfig> {
+    let (settings_path, mcp_path) = claude_config_paths(config_dir)?;
 
     let settings = read_json_file(&settings_path);
     let mcp_config = read_json_file(&mcp_path);
@@ -200,5 +221,21 @@ mod tests {
             Some("value"),
             "unknown future fields should appear in extra"
         );
+    }
+
+    #[test]
+    fn isolated_config_dir_paths_prefer_dir_over_home() {
+        let dir = PathBuf::from("/tmp/nest-claude-config");
+        let (settings, mcp) = claude_config_paths(Some(&dir)).expect("paths");
+        assert_eq!(settings, dir.join("settings.json"));
+        assert_eq!(mcp, dir.join(".claude.json"));
+    }
+
+    #[test]
+    fn default_config_paths_use_home_layout() {
+        let (settings, mcp) = claude_config_paths(None).expect("paths");
+        assert!(settings.ends_with(".claude/settings.json"));
+        assert!(mcp.ends_with(".claude.json"));
+        assert!(!mcp.ends_with(".claude/.claude.json"));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -16,11 +16,17 @@ pub(crate) fn read_config_surface(
     let is_pre_spawn = session_cache.is_none();
 
     // Tier 2b: config file values.
+    let claude_config_dir = record
+        .env_vars
+        .get("CLAUDE_CONFIG_DIR")
+        .map(std::path::PathBuf::from);
     let (file_config, file_was_read) = runtime_meta
         .map(|m| m.id)
         .and_then(|id| match id {
             "goose" => super::goose::read_config_file().map(|c| (c, true)),
-            "claude" => super::claude::read_config_file().map(|c| (c, true)),
+            "claude" => {
+                super::claude::read_config_file(claude_config_dir.as_deref()).map(|c| (c, true))
+            }
             "codex" => super::codex::read_config_file().map(|c| (c, true)),
             "buzz-agent" => super::buzz_agent::read_config_file().map(|c| (c, true)),
             _ => None,
@@ -167,7 +173,8 @@ pub(crate) fn read_config_surface(
     let config_file_path = runtime_meta
         .and_then(|m| m.config_file_path)
         .map(resolve_tilde);
-    let mcp_config_file_path = runtime_meta.and_then(mcp_config_file_path_for_runtime);
+    let mcp_config_file_path =
+        mcp_config_file_path_for_runtime(runtime_meta, claude_config_dir.as_deref());
     let extensions = file_config.extensions.clone();
 
     let sources = ConfigSourceReport {
@@ -213,12 +220,19 @@ pub(crate) fn read_config_surface(
     }
 }
 
-fn mcp_config_file_path_for_runtime(runtime: &KnownAcpRuntime) -> Option<String> {
+fn mcp_config_file_path_for_runtime(
+    runtime: Option<&KnownAcpRuntime>,
+    claude_config_dir: Option<&std::path::Path>,
+) -> Option<String> {
+    let runtime = runtime?;
     match runtime.id {
         "goose" => {
             super::goose::goose_config_path().map(|path| path.to_string_lossy().into_owned())
         }
-        "claude" => Some(resolve_tilde("~/.claude.json")),
+        "claude" => {
+            let (_settings, mcp) = super::claude::claude_config_paths(claude_config_dir)?;
+            Some(mcp.to_string_lossy().into_owned())
+        }
         "codex" => {
             super::codex::codex_config_path().map(|path| path.to_string_lossy().into_owned())
         }


### PR DESCRIPTION
## Summary
- Resolve Claude settings + MCP config from the agent’s `CLAUDE_CONFIG_DIR` when set
- Default remains `~/.claude/settings.json` + `~/.claude.json`
- Panel “From config file (…)” attribution points at the isolated `.claude.json`

## Why
Isolated Claude agents correctly load an empty MCP set at runtime, but the config panel always listed the operator’s `~/.claude.json` servers and labeled them enabled (#3493).

## Test plan
- [ ] Agent with `CLAUDE_CONFIG_DIR=<nest>/claude-config` and empty `.claude.json` — panel MCP list is empty and path shows the nest dir
- [ ] Agent without the env var — panel still shows `~/.claude.json`
- [x] Unit tests for isolated vs default path resolution

Fixes #3493

Made with [Cursor](https://cursor.com)