### PR TITLE
fix(desktop): queue agent draft requests

### DIFF
--- a/desktop/src/features/agents/agentManagementBuffer.test.mjs
+++ b/desktop/src/features/agents/agentManagementBuffer.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { classifyAgentManagementOrigin } from "./agentManagementBuffer.ts";
+import {
+  advanceAgentManagementRequest,
+  classifyAgentManagementOrigin,
+  enqueueAgentManagementRequest,
+} from "./agentManagementBuffer.ts";
+import { AGENT_MANAGEMENT_REQUEST } from "./agentManagement.ts";
 
 const AGENT = "a".repeat(64);
 const CHANNEL = "channel-1";
@@ -9,6 +14,58 @@ const OWNED_AGENT = [{ pubkey: AGENT }];
 const SHARED_CHANNEL = [
   { id: CHANNEL, isMember: true, memberPubkeys: [AGENT] },
 ];
+
+function queuedRequest(requestId) {
+  return {
+    agentPubkey: AGENT,
+    request: {
+      type: AGENT_MANAGEMENT_REQUEST,
+      action: "update",
+      requestId,
+      request: {
+        channelId: CHANNEL,
+        agentName: "Agent",
+        displayName: requestId,
+      },
+    },
+  };
+}
+
+test("queues agent management requests while another draft is active", () => {
+  const first = queuedRequest("first");
+  const second = queuedRequest("second");
+  const third = queuedRequest("third");
+
+  let state = { active: null, queued: [] };
+  state = enqueueAgentManagementRequest(state, first);
+  state = enqueueAgentManagementRequest(state, second);
+  state = enqueueAgentManagementRequest(state, third);
+
+  assert.equal(state.active, first);
+  assert.deepEqual(state.queued, [second, third]);
+});
+
+test("advances queued agent management requests in arrival order", () => {
+  const first = queuedRequest("first");
+  const second = queuedRequest("second");
+  const third = queuedRequest("third");
+  let state = {
+    active: first,
+    queued: [second, third],
+  };
+
+  state = advanceAgentManagementRequest(state);
+  assert.equal(state.active, second);
+  assert.deepEqual(state.queued, [third]);
+
+  state = advanceAgentManagementRequest(state);
+  assert.equal(state.active, third);
+  assert.deepEqual(state.queued, []);
+
+  state = advanceAgentManagementRequest(state);
+  assert.equal(state.active, null);
+  assert.deepEqual(state.queued, []);
+});
 
 test("buffers a draft until ownership and channel data resolve", () => {
   assert.equal(

--- a/desktop/src/features/agents/agentManagementBuffer.ts
+++ b/desktop/src/features/agents/agentManagementBuffer.ts
@@ -1,4 +1,32 @@
 import type { Channel, ManagedAgent } from "@/shared/api/types";
+import type { AgentManagementRequest } from "./agentManagement";
+
+export type QueuedAgentManagementRequest = {
+  agentPubkey: string;
+  request: AgentManagementRequest;
+};
+
+export type AgentManagementRequestQueue = {
+  active: QueuedAgentManagementRequest | null;
+  queued: QueuedAgentManagementRequest[];
+};
+
+export function enqueueAgentManagementRequest(
+  state: AgentManagementRequestQueue,
+  incoming: QueuedAgentManagementRequest,
+): AgentManagementRequestQueue {
+  if (state.active === null) {
+    return { active: incoming, queued: state.queued };
+  }
+  return { active: state.active, queued: [...state.queued, incoming] };
+}
+
+export function advanceAgentManagementRequest(
+  state: AgentManagementRequestQueue,
+): AgentManagementRequestQueue {
+  const [active, ...queued] = state.queued;
+  return { active: active ?? null, queued };
+}
 
 /**
  * Defers the trust decision until both ownership and channel membership have

--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -23,7 +23,12 @@ import {
   type BackendIntent,
 } from "./lib/instanceInputForDefinition";
 import { useCreatedAgentChannelAttachment } from "./useCreatedAgentChannelAttachment";
-import { classifyAgentManagementOrigin } from "./agentManagementBuffer";
+import {
+  advanceAgentManagementRequest,
+  classifyAgentManagementOrigin,
+  enqueueAgentManagementRequest,
+  type AgentManagementRequestQueue,
+} from "./agentManagementBuffer";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { resolveManagedAgentAvatarUrl } from "./ui/managedAgentAvatar";
 import type { AgentCreateIntent } from "./ui/agentCreateIntent";
@@ -72,8 +77,11 @@ export function useAgentManagement() {
   const [error, setError] = React.useState<string | null>(null);
   const createdAgentAttachment = useCreatedAgentChannelAttachment();
   const seenRequestIds = React.useRef(new Set<string>());
-  const pendingRequestId = React.useRef<string | null>(null);
   const sourceAgentPubkey = React.useRef<string | null>(null);
+  const requestQueueRef = React.useRef<AgentManagementRequestQueue>({
+    active: null,
+    queued: [],
+  });
   const managedAgentsRef = React.useRef(managedAgentsQuery.data);
   const channelsRef = React.useRef(channelsQuery.data);
   const bufferedRequestsRef = React.useRef<
@@ -94,9 +102,14 @@ export function useAgentManagement() {
         return;
       }
       seenRequestIds.current.add(next.requestId);
-      setError(null);
-      if (pendingRequestId.current === null) {
-        pendingRequestId.current = next.requestId;
+      const previousQueue = requestQueueRef.current;
+      const nextQueue = enqueueAgentManagementRequest(previousQueue, {
+        agentPubkey,
+        request: next,
+      });
+      requestQueueRef.current = nextQueue;
+      if (previousQueue.active === null && nextQueue.active !== null) {
+        setError(null);
         sourceAgentPubkey.current = agentPubkey;
         setRequest(next);
       }
@@ -260,9 +273,11 @@ export function useAgentManagement() {
   }
 
   function dismiss() {
-    pendingRequestId.current = null;
-    sourceAgentPubkey.current = null;
-    setRequest(null);
+    const nextQueue = advanceAgentManagementRequest(requestQueueRef.current);
+    requestQueueRef.current = nextQueue;
+    setError(null);
+    sourceAgentPubkey.current = nextQueue.active?.agentPubkey ?? null;
+    setRequest(nextQueue.active?.request ?? null);
   }
 
   const createInitialValues = React.useMemo(


### PR DESCRIPTION
## Summary

`useAgentManagement` marked every accepted agent-management request as seen before checking whether another draft was open. Later requests were therefore lost for the rest of the Desktop session.

This change keeps accepted requests in an in-memory FIFO and advances after the current draft is saved or dismissed. Each item retains the requesting agent pubkey, and request errors are cleared when the next draft opens. The queue is deliberately uncapped: these events are authenticated and owner-scoped, and a cap would recreate silent loss.

### Related issue

Fixes #3559.

#2454 is an earlier draft with a broader persistence and sidebar design. This PR is limited to the in-session FIFO needed for #3559.

### Testing

- `pnpm --dir desktop exec node --experimental-strip-types --test src/features/agents/agentManagementBuffer.test.mjs`
- `pnpm --dir desktop typecheck`
- `just ci`
- Screenshots: N/A (no visual change)
