### PR TITLE
fix(desktop): drop orphaned separators from sidebar section menus

### DIFF
--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -161,8 +161,24 @@ export function SectionActionsMenu({
   onSortModeChange?: (mode: ChannelSortMode) => void;
 }) {
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const showSectionManagement = Boolean(onRenameSection || onDeleteSection);
+  // Gate on the items this block actually renders. Including `onDeleteSection`
+  // here would open the wrapper for a delete-only section and emit nothing.
+  const showSectionManagement = Boolean(
+    onRenameSection || onMoveSectionUp || onMoveSectionDown,
+  );
   const showSort = Boolean(sortMode && onSortModeChange);
+  // Separators are only meaningful with an item above them. The built-in
+  // Channels header supplies just `onMarkAllRead` (itself gated on unread) and
+  // a sort preference, so with everything read the menu would otherwise open
+  // on a divider with nothing before it.
+  const hasItemsBeforeSort = Boolean(
+    (hasUnread && onMarkAllRead) ||
+      onNewMessage ||
+      onBrowse ||
+      onCreate ||
+      showSectionManagement,
+  );
+  const hasItemsBeforeDelete = hasItemsBeforeSort || showSort;
 
   return (
     <DropdownMenu onOpenChange={onOpenChange}>
@@ -245,7 +261,7 @@ export function SectionActionsMenu({
         ) : null}
         {showSort ? (
           <>
-            <DropdownMenuSeparator />
+            {hasItemsBeforeSort ? <DropdownMenuSeparator /> : null}
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <ArrowUpDown className="h-4 w-4" />
@@ -273,7 +289,7 @@ export function SectionActionsMenu({
         ) : null}
         {onDeleteSection ? (
           <>
-            <DropdownMenuSeparator />
+            {hasItemsBeforeDelete ? <DropdownMenuSeparator /> : null}
             <DropdownMenuItem
               className="text-destructive focus:text-destructive"
               onSelect={() => deferMenuAction(onDeleteSection)}


### PR DESCRIPTION
## What problem this solves

The sidebar section "more actions" menu (`SectionActionsMenu`) renders every item
conditionally, but two of its dividers are unconditional. When the items above a
divider all happen to be absent, the menu opens **on a divider with nothing
before it**.

The built-in **Channels** header hits this in normal use. `AppSidebar` supplies
it only two things that can produce items:

- `onMarkAllRead`, itself gated on `hasUnread`
- a sort preference (`sortMode` / `onSortModeChange`)

"Browse channels" is wired to the adjacent quick-create `+` button, not into this
menu, and rename/move/delete apply only to user-created sections. So the menu has
two states, and one of them is broken:

| state | menu |
|---|---|
| a channel is unread | `Mark all as read` · divider · `Sort` — correct |
| everything read | divider · `Sort` — **orphaned divider** |

That intermittency is why it reads as "sometimes broken": the divider is correct
right up until you read your last unread channel.

## Fix

Compute whether anything actually precedes each divider and render it only then.

Two further points, same bug class, same component:

- The `Delete section` divider has the identical flaw. Reachable when a section
  supplies `onDeleteSection` but no rename/move handlers and no sort preference.
- `showSectionManagement` was gated on `onRenameSection || onDeleteSection`, but
  the block it guards renders rename/move-up/move-down. A delete-only section
  therefore opened the wrapper and emitted nothing — which would in turn make the
  new "is anything above me" check wrong. Now gated on the items it renders.

## Verification

Confirmed by state transition in a running dev app rather than by inspection —
opened the Channels menu with unread present, clicked `Mark all as read`, then
reopened:

```
unread present  → items: [Mark all as read, separator, Sort]   separators: 1
all read        → items: [Sort]                                separators: 0
```

`tsc --noEmit` clean, biome clean, 3781 frontend unit tests pass.

## Notes for reviewers

Not platform-specific — nothing here depends on the host, and it reproduces
anywhere the Channels section has no unread items.

**Conflict likely with [#2947](https://github.com/block/buzz/pull/2947)**
(sidebar categories and manual channel ordering), which also touches
`CustomChannelSection.tsx` and `AppSidebar.tsx`. That PR adds section
reordering, so it may introduce more conditional items above these dividers —
if it lands first, the `hasItemsBeforeSort` expression here needs its new
handlers added to the list. Happy to rebase behind it.
