### PR TITLE
feat(desktop): discover and spawn ACP harnesses installed in WSL on Windows

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -2508,6 +2508,40 @@ fn merge_wslenv(existing: Option<&str>, keys: &[String]) -> String {
     entries.join(":")
 }
 
+/// Translate an absolute Windows path into the equivalent WSL mount path
+/// (`C:\Users\x\.buzz` → `/mnt/c/Users/x/.buzz`).
+///
+/// Returns `None` for anything that is not a drive-letter path — UNC paths
+/// (`\\server\share`, including `\\wsl.localhost\…`), relative paths, and
+/// already-POSIX paths are all left untouched by the caller.
+fn translate_windows_path_to_wsl(cwd: &str) -> Option<String> {
+    let cwd = cwd.trim();
+    let mut chars = cwd.chars();
+    let drive = chars.next()?;
+    if !drive.is_ascii_alphabetic() || chars.next() != Some(':') {
+        return None;
+    }
+    let rest = cwd[2..].replace('\\', "/");
+    let rest = rest.trim_start_matches('/');
+    Some(format!("/mnt/{}/{}", drive.to_ascii_lowercase(), rest))
+}
+
+/// Session cwd to hand to a WSL-hosted agent via `session/new`.
+///
+/// When this process is spawning agents through the WSL wrap (see
+/// [`wsl_spawn_wrap`]), the agent runs inside the distro where a Windows
+/// drive path such as `C:\Users\x\.buzz` does not exist — and Hermes-class
+/// agents store the session cwd and use it as the root for edit-approval
+/// policies and workspace grounding. Translate drive-letter paths to their
+/// `/mnt/<drive>/…` form; everything else passes through untouched.
+pub(crate) fn session_cwd_for_wsl(cwd: &str) -> String {
+    if wsl_spawn_wrap().is_some() {
+        translate_windows_path_to_wsl(cwd).unwrap_or_else(|| cwd.to_string())
+    } else {
+        cwd.to_string()
+    }
+}
+
 /// Suppress the console window that Windows otherwise allocates for every
 /// console-subsystem child process spawned from a GUI (non-console) parent.
 /// No-op on non-Windows platforms.
@@ -3194,6 +3228,48 @@ mod tests {
             msg.contains("Hard turn timeout"),
             "HardTimeout display: {msg}"
         );
+    }
+
+    // ── WSL session cwd translation ─────────────────────────────────────────
+
+    #[test]
+    fn translate_windows_path_to_wsl_maps_drive_letters() {
+        assert_eq!(
+            translate_windows_path_to_wsl(r"C:\Users\ratz\.buzz"),
+            Some("/mnt/c/Users/ratz/.buzz".to_string())
+        );
+        assert_eq!(
+            translate_windows_path_to_wsl(r"D:\repos\foo"),
+            Some("/mnt/d/repos/foo".to_string())
+        );
+        // Forward-slash drive paths and root paths translate too.
+        assert_eq!(
+            translate_windows_path_to_wsl("C:/Users/ratz"),
+            Some("/mnt/c/Users/ratz".to_string())
+        );
+        assert_eq!(
+            translate_windows_path_to_wsl(r"C:\"),
+            Some("/mnt/c/".to_string())
+        );
+    }
+
+    #[test]
+    fn translate_windows_path_to_wsl_leaves_non_drive_paths_untouched() {
+        for cwd in [
+            r"\\server\share\path",
+            r"\\wsl.localhost\Ubuntu\home\rat",
+            "/home/rat/.buzz",
+            "/mnt/c/Users/ratz",
+            "relative/path",
+            ".",
+            "",
+        ] {
+            assert_eq!(
+                translate_windows_path_to_wsl(cwd),
+                None,
+                "expected no translation: {cwd:?}"
+            );
+        }
     }
 
     // ── WSL spawn wrap (pure helpers) ───────────────────────────────────────

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -459,8 +459,23 @@ impl AcpClient {
     ) -> Result<Self, AcpError> {
         use std::process::Stdio;
 
-        let mut cmd = tokio::process::Command::new(command);
-        cmd.args(args)
+        // ── WSL agent wrap ──────────────────────────────────────────────────
+        // When the host (Buzz Desktop on Windows) located the agent inside a
+        // WSL distribution rather than on the Windows PATH, it sets
+        // BUZZ_ACP_AGENT_WSL_PATH to the in-distro absolute path. The bare
+        // command does not exist on Windows, so the agent must be launched
+        // through wsl.exe; WSL interop bridges the stdio pipes, leaving the
+        // NDJSON channel byte-transparent. `command` keeps its original
+        // identity so default_agent_env / default_agent_args still apply.
+        let wsl_wrap = wsl_spawn_wrap();
+        let (program, prefix_args): (String, Vec<String>) = match &wsl_wrap {
+            Some(wrap) => (wrap.program.clone(), wrap.prefix_args()),
+            None => (command.to_string(), Vec::new()),
+        };
+
+        let mut cmd = tokio::process::Command::new(&program);
+        cmd.args(&prefix_args)
+            .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             // Inherit stderr so agent logs are visible in the harness terminal.
@@ -514,6 +529,43 @@ impl AcpClient {
         }
         if let Some(merged) = codex_config_value {
             cmd.env("CODEX_CONFIG", merged);
+        }
+
+        // WSL wrap: forward every agent-intended env var across the WSL
+        // boundary. wsl.exe children only import Windows-side variables whose
+        // names appear in WSLENV, so without this the agent would silently
+        // lose both the per-runtime defaults (e.g. HERMES_ACP_SKIP_CONFIGURED_MCP)
+        // and persona env (e.g. GOOSE_PROVIDER). Keys are forwarded whether
+        // the value came from injection or from the inherited parent env —
+        // either way it is present in the wsl.exe process environment.
+        if let Some(wrap) = &wsl_wrap {
+            let mut forward_keys: Vec<String> = crate::config::default_agent_env(command)
+                .iter()
+                .map(|(key, _)| (*key).to_string())
+                .collect();
+            for (key, _) in extra_env {
+                if key == "WSLENV" {
+                    continue;
+                }
+                forward_keys.push(key.clone());
+            }
+            // An explicit persona WSLENV wins as the merge base; otherwise
+            // inherit the harness's own WSLENV (may itself carry flags).
+            let base = extra_env
+                .iter()
+                .find(|(key, _)| key == "WSLENV")
+                .map(|(_, value)| value.clone())
+                .or_else(|| std::env::var("WSLENV").ok());
+            let merged = merge_wslenv(base.as_deref(), &forward_keys);
+            if !merged.is_empty() {
+                cmd.env("WSLENV", merged);
+            }
+            tracing::info!(
+                program = %wrap.program,
+                linux_path = %wrap.linux_path,
+                distro = ?wrap.distro,
+                "spawning agent through WSL"
+            );
         }
 
         // Spawn the agent in its own process group so SIGKILL doesn't propagate
@@ -2335,6 +2387,127 @@ fn kill_process_group(_pid: u32) -> bool {
     false
 }
 
+/// Resolved WSL spawn target: launch `program` (wsl.exe) with
+/// [`WslSpawnWrap::prefix_args`] followed by the agent's normal args.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WslSpawnWrap {
+    /// wsl.exe to launch — System32 absolute path when available, else the
+    /// bare name for standard CreateProcess search.
+    program: String,
+    /// Optional non-default distro (`wsl.exe -d <distro>`).
+    distro: Option<String>,
+    /// Agent's absolute path inside the distro (e.g. `/home/u/.local/bin/hermes-acp`).
+    linux_path: String,
+}
+
+impl WslSpawnWrap {
+    /// Argument prefix that makes wsl.exe exec the in-distro agent binary.
+    fn prefix_args(&self) -> Vec<String> {
+        let mut prefix = Vec::with_capacity(4);
+        if let Some(distro) = &self.distro {
+            prefix.push("-d".to_string());
+            prefix.push(distro.clone());
+        }
+        prefix.push("-e".to_string());
+        prefix.push(self.linux_path.clone());
+        prefix
+    }
+}
+
+/// Pure core of [`wsl_spawn_wrap`], factored for unit testing: validate the
+/// desktop-supplied contract values and decide whether to wrap.
+fn build_wsl_wrap(
+    linux_path: Option<&str>,
+    distro: Option<&str>,
+    host_is_windows: bool,
+) -> Option<WslSpawnWrap> {
+    let linux_path = linux_path?.trim();
+    // Only absolute POSIX paths are meaningful to `wsl.exe -e`; anything else
+    // (empty, relative, a Windows path) indicates a broken contract — refuse
+    // to wrap rather than spawn a confusing wsl.exe error.
+    if linux_path.is_empty() || !linux_path.starts_with('/') {
+        return None;
+    }
+    let distro = distro
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+        .map(str::to_string);
+    if !host_is_windows {
+        tracing::warn!(
+            linux_path,
+            "BUZZ_ACP_AGENT_WSL_PATH is set on a non-Windows host — ignoring WSL wrap"
+        );
+        return None;
+    }
+    Some(WslSpawnWrap {
+        program: wsl_exe_program(),
+        distro,
+        linux_path: linux_path.to_string(),
+    })
+}
+
+/// Read the desktop → buzz-acp WSL contract from the process environment.
+///
+/// Buzz Desktop sets `BUZZ_ACP_AGENT_WSL_PATH` (absolute in-distro path of the
+/// agent command) — and optionally `BUZZ_ACP_AGENT_WSL_DISTRO` — when harness
+/// discovery resolved the agent through its WSL fallback instead of the
+/// Windows PATH. See `managed_agents/wsl.rs` on the desktop side.
+fn wsl_spawn_wrap() -> Option<WslSpawnWrap> {
+    build_wsl_wrap(
+        std::env::var("BUZZ_ACP_AGENT_WSL_PATH").ok().as_deref(),
+        std::env::var("BUZZ_ACP_AGENT_WSL_DISTRO").ok().as_deref(),
+        cfg!(windows),
+    )
+}
+
+/// Prefer the System32 copy of wsl.exe; fall back to the bare name (standard
+/// CreateProcess search order) when SystemRoot is unavailable. System32 first
+/// avoids the WindowsApps app-execution-alias stubs (see block/buzz#2328).
+#[cfg(windows)]
+fn wsl_exe_program() -> String {
+    std::env::var_os("SystemRoot")
+        .map(|root| {
+            std::path::PathBuf::from(root)
+                .join("System32")
+                .join("wsl.exe")
+        })
+        .filter(|p| p.is_file())
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "wsl.exe".to_string())
+}
+
+#[cfg(not(windows))]
+fn wsl_exe_program() -> String {
+    // Never used at runtime (build_wsl_wrap refuses non-Windows hosts), but
+    // must exist so the cfg!(windows) branch above type-checks everywhere.
+    "wsl.exe".to_string()
+}
+
+/// Merge env var names into a WSLENV forwarding list.
+///
+/// `existing` may carry a pre-set WSLENV value, including per-entry flags
+/// (`VAR/p`, `VAR/l`, `VAR/u`) — entries are preserved verbatim and compared
+/// by their name part only, so a flagged entry is never duplicated by a
+/// bare-name forward of the same variable.
+fn merge_wslenv(existing: Option<&str>, keys: &[String]) -> String {
+    let mut entries: Vec<String> = existing
+        .unwrap_or("")
+        .split(':')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect();
+    for key in keys {
+        let already = entries
+            .iter()
+            .any(|entry| entry.split('/').next() == Some(key.as_str()));
+        if !already {
+            entries.push(key.clone());
+        }
+    }
+    entries.join(":")
+}
+
 /// Suppress the console window that Windows otherwise allocates for every
 /// console-subsystem child process spawned from a GUI (non-console) parent.
 /// No-op on non-Windows platforms.
@@ -3021,6 +3194,101 @@ mod tests {
             msg.contains("Hard turn timeout"),
             "HardTimeout display: {msg}"
         );
+    }
+
+    // ── WSL spawn wrap (pure helpers) ───────────────────────────────────────
+
+    #[test]
+    fn wsl_prefix_args_execs_linux_path_in_default_distro() {
+        let wrap = WslSpawnWrap {
+            program: r"C:\Windows\System32\wsl.exe".to_string(),
+            distro: None,
+            linux_path: "/home/rat/.local/bin/hermes-acp".to_string(),
+        };
+        assert_eq!(
+            wrap.prefix_args(),
+            ["-e", "/home/rat/.local/bin/hermes-acp"]
+        );
+    }
+
+    #[test]
+    fn wsl_prefix_args_prefixes_distro_when_set() {
+        let wrap = WslSpawnWrap {
+            program: "wsl.exe".to_string(),
+            distro: Some("Ubuntu-24.04".to_string()),
+            linux_path: "/usr/local/bin/omp".to_string(),
+        };
+        assert_eq!(
+            wrap.prefix_args(),
+            ["-d", "Ubuntu-24.04", "-e", "/usr/local/bin/omp"]
+        );
+    }
+
+    #[test]
+    fn build_wsl_wrap_accepts_absolute_posix_path_on_windows() {
+        let wrap = build_wsl_wrap(Some("/home/rat/.local/bin/hermes-acp"), Some("  "), true)
+            .expect("valid contract should wrap");
+        assert_eq!(wrap.linux_path, "/home/rat/.local/bin/hermes-acp");
+        // Whitespace-only distro is treated as unset.
+        assert_eq!(wrap.distro, None);
+    }
+
+    #[test]
+    fn build_wsl_wrap_rejects_broken_contract_values() {
+        for bad in [
+            "",
+            "   ",
+            "hermes-acp",
+            "usr/local/bin/hermes-acp",
+            r"C:\tools\hermes.exe",
+        ] {
+            assert_eq!(
+                build_wsl_wrap(Some(bad), None, true),
+                None,
+                "expected rejection: {bad:?}"
+            );
+        }
+        assert_eq!(build_wsl_wrap(None, None, true), None);
+    }
+
+    #[test]
+    fn build_wsl_wrap_refuses_non_windows_hosts() {
+        assert_eq!(
+            build_wsl_wrap(Some("/home/rat/.local/bin/hermes-acp"), None, false),
+            None
+        );
+    }
+
+    #[test]
+    fn merge_wslenv_appends_missing_keys_preserving_order() {
+        let keys = vec![
+            "HERMES_ACP_SKIP_CONFIGURED_MCP".to_string(),
+            "GOOSE_PROVIDER".to_string(),
+        ];
+        assert_eq!(
+            merge_wslenv(None, &keys),
+            "HERMES_ACP_SKIP_CONFIGURED_MCP:GOOSE_PROVIDER"
+        );
+        assert_eq!(
+            merge_wslenv(Some("PATH/l"), &keys),
+            "PATH/l:HERMES_ACP_SKIP_CONFIGURED_MCP:GOOSE_PROVIDER"
+        );
+    }
+
+    #[test]
+    fn merge_wslenv_never_duplicates_flagged_entries() {
+        let keys = vec!["GOPATH".to_string(), "GOPROXY".to_string()];
+        // GOPATH already present with a /p flag — must not be re-added bare.
+        assert_eq!(merge_wslenv(Some("GOPATH/p"), &keys), "GOPATH/p:GOPROXY");
+    }
+
+    #[test]
+    fn merge_wslenv_tolerates_empty_and_colon_noise() {
+        let keys = vec!["A".to_string()];
+        assert_eq!(merge_wslenv(Some(""), &keys), "A");
+        assert_eq!(merge_wslenv(Some("::"), &keys), "A");
+        assert_eq!(merge_wslenv(Some("B::C:"), &keys), "B:C:A");
+        assert_eq!(merge_wslenv(None, &[]), "");
     }
 
     async fn spawn_script(script: &str) -> AcpClient {

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -456,8 +456,23 @@ impl AcpClient {
     ) -> Result<Self, AcpError> {
         use std::process::Stdio;
 
-        let mut cmd = tokio::process::Command::new(command);
-        cmd.args(args)
+        // ── WSL agent wrap ──────────────────────────────────────────────────
+        // When the host (Buzz Desktop on Windows) located the agent inside a
+        // WSL distribution rather than on the Windows PATH, it sets
+        // BUZZ_ACP_AGENT_WSL_PATH to the in-distro absolute path. The bare
+        // command does not exist on Windows, so the agent must be launched
+        // through wsl.exe; WSL interop bridges the stdio pipes, leaving the
+        // NDJSON channel byte-transparent. `command` keeps its original
+        // identity so default_agent_env / default_agent_args still apply.
+        let wsl_wrap = wsl_spawn_wrap();
+        let (program, prefix_args): (String, Vec<String>) = match &wsl_wrap {
+            Some(wrap) => (wrap.program.clone(), wrap.prefix_args()),
+            None => (command.to_string(), Vec::new()),
+        };
+
+        let mut cmd = tokio::process::Command::new(&program);
+        cmd.args(&prefix_args)
+            .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             // Inherit stderr so agent logs are visible in the harness terminal.
@@ -511,6 +526,43 @@ impl AcpClient {
         }
         if let Some(merged) = codex_config_value {
             cmd.env("CODEX_CONFIG", merged);
+        }
+
+        // WSL wrap: forward every agent-intended env var across the WSL
+        // boundary. wsl.exe children only import Windows-side variables whose
+        // names appear in WSLENV, so without this the agent would silently
+        // lose both the per-runtime defaults (e.g. HERMES_ACP_SKIP_CONFIGURED_MCP)
+        // and persona env (e.g. GOOSE_PROVIDER). Keys are forwarded whether
+        // the value came from injection or from the inherited parent env —
+        // either way it is present in the wsl.exe process environment.
+        if let Some(wrap) = &wsl_wrap {
+            let mut forward_keys: Vec<String> = crate::config::default_agent_env(command)
+                .iter()
+                .map(|(key, _)| (*key).to_string())
+                .collect();
+            for (key, _) in extra_env {
+                if key == "WSLENV" {
+                    continue;
+                }
+                forward_keys.push(key.clone());
+            }
+            // An explicit persona WSLENV wins as the merge base; otherwise
+            // inherit the harness's own WSLENV (may itself carry flags).
+            let base = extra_env
+                .iter()
+                .find(|(key, _)| key == "WSLENV")
+                .map(|(_, value)| value.clone())
+                .or_else(|| std::env::var("WSLENV").ok());
+            let merged = merge_wslenv(base.as_deref(), &forward_keys);
+            if !merged.is_empty() {
+                cmd.env("WSLENV", merged);
+            }
+            tracing::info!(
+                program = %wrap.program,
+                linux_path = %wrap.linux_path,
+                distro = ?wrap.distro,
+                "spawning agent through WSL"
+            );
         }
 
         // Spawn the agent in its own process group so SIGKILL doesn't propagate
@@ -2206,6 +2258,127 @@ fn kill_process_group(_pid: u32) -> bool {
     false
 }
 
+/// Resolved WSL spawn target: launch `program` (wsl.exe) with
+/// [`WslSpawnWrap::prefix_args`] followed by the agent's normal args.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WslSpawnWrap {
+    /// wsl.exe to launch — System32 absolute path when available, else the
+    /// bare name for standard CreateProcess search.
+    program: String,
+    /// Optional non-default distro (`wsl.exe -d <distro>`).
+    distro: Option<String>,
+    /// Agent's absolute path inside the distro (e.g. `/home/u/.local/bin/hermes-acp`).
+    linux_path: String,
+}
+
+impl WslSpawnWrap {
+    /// Argument prefix that makes wsl.exe exec the in-distro agent binary.
+    fn prefix_args(&self) -> Vec<String> {
+        let mut prefix = Vec::with_capacity(4);
+        if let Some(distro) = &self.distro {
+            prefix.push("-d".to_string());
+            prefix.push(distro.clone());
+        }
+        prefix.push("-e".to_string());
+        prefix.push(self.linux_path.clone());
+        prefix
+    }
+}
+
+/// Pure core of [`wsl_spawn_wrap`], factored for unit testing: validate the
+/// desktop-supplied contract values and decide whether to wrap.
+fn build_wsl_wrap(
+    linux_path: Option<&str>,
+    distro: Option<&str>,
+    host_is_windows: bool,
+) -> Option<WslSpawnWrap> {
+    let linux_path = linux_path?.trim();
+    // Only absolute POSIX paths are meaningful to `wsl.exe -e`; anything else
+    // (empty, relative, a Windows path) indicates a broken contract — refuse
+    // to wrap rather than spawn a confusing wsl.exe error.
+    if linux_path.is_empty() || !linux_path.starts_with('/') {
+        return None;
+    }
+    let distro = distro
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+        .map(str::to_string);
+    if !host_is_windows {
+        tracing::warn!(
+            linux_path,
+            "BUZZ_ACP_AGENT_WSL_PATH is set on a non-Windows host — ignoring WSL wrap"
+        );
+        return None;
+    }
+    Some(WslSpawnWrap {
+        program: wsl_exe_program(),
+        distro,
+        linux_path: linux_path.to_string(),
+    })
+}
+
+/// Read the desktop → buzz-acp WSL contract from the process environment.
+///
+/// Buzz Desktop sets `BUZZ_ACP_AGENT_WSL_PATH` (absolute in-distro path of the
+/// agent command) — and optionally `BUZZ_ACP_AGENT_WSL_DISTRO` — when harness
+/// discovery resolved the agent through its WSL fallback instead of the
+/// Windows PATH. See `managed_agents/wsl.rs` on the desktop side.
+fn wsl_spawn_wrap() -> Option<WslSpawnWrap> {
+    build_wsl_wrap(
+        std::env::var("BUZZ_ACP_AGENT_WSL_PATH").ok().as_deref(),
+        std::env::var("BUZZ_ACP_AGENT_WSL_DISTRO").ok().as_deref(),
+        cfg!(windows),
+    )
+}
+
+/// Prefer the System32 copy of wsl.exe; fall back to the bare name (standard
+/// CreateProcess search order) when SystemRoot is unavailable. System32 first
+/// avoids the WindowsApps app-execution-alias stubs (see block/buzz#2328).
+#[cfg(windows)]
+fn wsl_exe_program() -> String {
+    std::env::var_os("SystemRoot")
+        .map(|root| {
+            std::path::PathBuf::from(root)
+                .join("System32")
+                .join("wsl.exe")
+        })
+        .filter(|p| p.is_file())
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "wsl.exe".to_string())
+}
+
+#[cfg(not(windows))]
+fn wsl_exe_program() -> String {
+    // Never used at runtime (build_wsl_wrap refuses non-Windows hosts), but
+    // must exist so the cfg!(windows) branch above type-checks everywhere.
+    "wsl.exe".to_string()
+}
+
+/// Merge env var names into a WSLENV forwarding list.
+///
+/// `existing` may carry a pre-set WSLENV value, including per-entry flags
+/// (`VAR/p`, `VAR/l`, `VAR/u`) — entries are preserved verbatim and compared
+/// by their name part only, so a flagged entry is never duplicated by a
+/// bare-name forward of the same variable.
+fn merge_wslenv(existing: Option<&str>, keys: &[String]) -> String {
+    let mut entries: Vec<String> = existing
+        .unwrap_or("")
+        .split(':')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect();
+    for key in keys {
+        let already = entries
+            .iter()
+            .any(|entry| entry.split('/').next() == Some(key.as_str()));
+        if !already {
+            entries.push(key.clone());
+        }
+    }
+    entries.join(":")
+}
+
 /// Suppress the console window that Windows otherwise allocates for every
 /// console-subsystem child process spawned from a GUI (non-console) parent.
 /// No-op on non-Windows platforms.
@@ -2844,6 +3017,101 @@ mod tests {
             msg.contains("Hard turn timeout"),
             "HardTimeout display: {msg}"
         );
+    }
+
+    // ── WSL spawn wrap (pure helpers) ───────────────────────────────────────
+
+    #[test]
+    fn wsl_prefix_args_execs_linux_path_in_default_distro() {
+        let wrap = WslSpawnWrap {
+            program: r"C:\Windows\System32\wsl.exe".to_string(),
+            distro: None,
+            linux_path: "/home/rat/.local/bin/hermes-acp".to_string(),
+        };
+        assert_eq!(
+            wrap.prefix_args(),
+            ["-e", "/home/rat/.local/bin/hermes-acp"]
+        );
+    }
+
+    #[test]
+    fn wsl_prefix_args_prefixes_distro_when_set() {
+        let wrap = WslSpawnWrap {
+            program: "wsl.exe".to_string(),
+            distro: Some("Ubuntu-24.04".to_string()),
+            linux_path: "/usr/local/bin/omp".to_string(),
+        };
+        assert_eq!(
+            wrap.prefix_args(),
+            ["-d", "Ubuntu-24.04", "-e", "/usr/local/bin/omp"]
+        );
+    }
+
+    #[test]
+    fn build_wsl_wrap_accepts_absolute_posix_path_on_windows() {
+        let wrap = build_wsl_wrap(Some("/home/rat/.local/bin/hermes-acp"), Some("  "), true)
+            .expect("valid contract should wrap");
+        assert_eq!(wrap.linux_path, "/home/rat/.local/bin/hermes-acp");
+        // Whitespace-only distro is treated as unset.
+        assert_eq!(wrap.distro, None);
+    }
+
+    #[test]
+    fn build_wsl_wrap_rejects_broken_contract_values() {
+        for bad in [
+            "",
+            "   ",
+            "hermes-acp",
+            "usr/local/bin/hermes-acp",
+            r"C:\tools\hermes.exe",
+        ] {
+            assert_eq!(
+                build_wsl_wrap(Some(bad), None, true),
+                None,
+                "expected rejection: {bad:?}"
+            );
+        }
+        assert_eq!(build_wsl_wrap(None, None, true), None);
+    }
+
+    #[test]
+    fn build_wsl_wrap_refuses_non_windows_hosts() {
+        assert_eq!(
+            build_wsl_wrap(Some("/home/rat/.local/bin/hermes-acp"), None, false),
+            None
+        );
+    }
+
+    #[test]
+    fn merge_wslenv_appends_missing_keys_preserving_order() {
+        let keys = vec![
+            "HERMES_ACP_SKIP_CONFIGURED_MCP".to_string(),
+            "GOOSE_PROVIDER".to_string(),
+        ];
+        assert_eq!(
+            merge_wslenv(None, &keys),
+            "HERMES_ACP_SKIP_CONFIGURED_MCP:GOOSE_PROVIDER"
+        );
+        assert_eq!(
+            merge_wslenv(Some("PATH/l"), &keys),
+            "PATH/l:HERMES_ACP_SKIP_CONFIGURED_MCP:GOOSE_PROVIDER"
+        );
+    }
+
+    #[test]
+    fn merge_wslenv_never_duplicates_flagged_entries() {
+        let keys = vec!["GOPATH".to_string(), "GOPROXY".to_string()];
+        // GOPATH already present with a /p flag — must not be re-added bare.
+        assert_eq!(merge_wslenv(Some("GOPATH/p"), &keys), "GOPATH/p:GOPROXY");
+    }
+
+    #[test]
+    fn merge_wslenv_tolerates_empty_and_colon_noise() {
+        let keys = vec!["A".to_string()];
+        assert_eq!(merge_wslenv(Some(""), &keys), "A");
+        assert_eq!(merge_wslenv(Some("::"), &keys), "A");
+        assert_eq!(merge_wslenv(Some("B::C:"), &keys), "B:C:A");
+        assert_eq!(merge_wslenv(None, &[]), "");
     }
 
     async fn spawn_script(script: &str) -> AcpClient {

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -2379,6 +2379,40 @@ fn merge_wslenv(existing: Option<&str>, keys: &[String]) -> String {
     entries.join(":")
 }
 
+/// Translate an absolute Windows path into the equivalent WSL mount path
+/// (`C:\Users\x\.buzz` → `/mnt/c/Users/x/.buzz`).
+///
+/// Returns `None` for anything that is not a drive-letter path — UNC paths
+/// (`\\server\share`, including `\\wsl.localhost\…`), relative paths, and
+/// already-POSIX paths are all left untouched by the caller.
+fn translate_windows_path_to_wsl(cwd: &str) -> Option<String> {
+    let cwd = cwd.trim();
+    let mut chars = cwd.chars();
+    let drive = chars.next()?;
+    if !drive.is_ascii_alphabetic() || chars.next() != Some(':') {
+        return None;
+    }
+    let rest = cwd[2..].replace('\\', "/");
+    let rest = rest.trim_start_matches('/');
+    Some(format!("/mnt/{}/{}", drive.to_ascii_lowercase(), rest))
+}
+
+/// Session cwd to hand to a WSL-hosted agent via `session/new`.
+///
+/// When this process is spawning agents through the WSL wrap (see
+/// [`wsl_spawn_wrap`]), the agent runs inside the distro where a Windows
+/// drive path such as `C:\Users\x\.buzz` does not exist — and Hermes-class
+/// agents store the session cwd and use it as the root for edit-approval
+/// policies and workspace grounding. Translate drive-letter paths to their
+/// `/mnt/<drive>/…` form; everything else passes through untouched.
+pub(crate) fn session_cwd_for_wsl(cwd: &str) -> String {
+    if wsl_spawn_wrap().is_some() {
+        translate_windows_path_to_wsl(cwd).unwrap_or_else(|| cwd.to_string())
+    } else {
+        cwd.to_string()
+    }
+}
+
 /// Suppress the console window that Windows otherwise allocates for every
 /// console-subsystem child process spawned from a GUI (non-console) parent.
 /// No-op on non-Windows platforms.
@@ -3017,6 +3051,48 @@ mod tests {
             msg.contains("Hard turn timeout"),
             "HardTimeout display: {msg}"
         );
+    }
+
+    // ── WSL session cwd translation ─────────────────────────────────────────
+
+    #[test]
+    fn translate_windows_path_to_wsl_maps_drive_letters() {
+        assert_eq!(
+            translate_windows_path_to_wsl(r"C:\Users\ratz\.buzz"),
+            Some("/mnt/c/Users/ratz/.buzz".to_string())
+        );
+        assert_eq!(
+            translate_windows_path_to_wsl(r"D:\repos\foo"),
+            Some("/mnt/d/repos/foo".to_string())
+        );
+        // Forward-slash drive paths and root paths translate too.
+        assert_eq!(
+            translate_windows_path_to_wsl("C:/Users/ratz"),
+            Some("/mnt/c/Users/ratz".to_string())
+        );
+        assert_eq!(
+            translate_windows_path_to_wsl(r"C:\"),
+            Some("/mnt/c/".to_string())
+        );
+    }
+
+    #[test]
+    fn translate_windows_path_to_wsl_leaves_non_drive_paths_untouched() {
+        for cwd in [
+            r"\\server\share\path",
+            r"\\wsl.localhost\Ubuntu\home\rat",
+            "/home/rat/.buzz",
+            "/mnt/c/Users/ratz",
+            "relative/path",
+            ".",
+            "",
+        ] {
+            assert_eq!(
+                translate_windows_path_to_wsl(cwd),
+                None,
+                "expected no translation: {cwd:?}"
+            );
+        }
     }
 
     // ── WSL spawn wrap (pure helpers) ───────────────────────────────────────

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2210,7 +2210,7 @@ async fn tokio_main() -> Result<()> {
             Some(include_str!("base_prompt.md"))
         },
         heartbeat_prompt: config.heartbeat_prompt.clone(),
-        cwd,
+        cwd: crate::acp::session_cwd_for_wsl(&cwd),
         rest_client: relay.rest_client(),
         channel_info: pool::ChannelInfoResolver::new(channel_info_map, relay.rest_client()),
         context_message_limit: config.context_message_limit,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1543,10 +1543,11 @@ async fn tokio_main() -> Result<()> {
             Some(include_str!("base_prompt.md"))
         },
         heartbeat_prompt: config.heartbeat_prompt.clone(),
-        cwd: std::env::current_dir()
-            .unwrap_or_else(|_| std::path::PathBuf::from("/"))
-            .to_string_lossy()
-            .to_string(),
+        cwd: crate::acp::session_cwd_for_wsl(
+            &std::env::current_dir()
+                .unwrap_or_else(|_| std::path::PathBuf::from("/"))
+                .to_string_lossy(),
+        ),
         rest_client: relay.rest_client(),
         channel_info: pool::ChannelInfoResolver::new(channel_info_map, relay.rest_client()),
         context_message_limit: config.context_message_limit,

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -258,6 +258,9 @@ fn install_acp_runtime_blocking(
     crate::managed_agents::refresh_login_shell_path();
     // Clear the resolve cache so newly-installed binaries are found.
     crate::managed_agents::clear_resolve_cache();
+    // Clear the WSL resolution cache too, so a harness installed inside the
+    // default distro after a prior miss is discovered on the next forced run.
+    crate::managed_agents::wsl::clear_wsl_cache();
 
     // Prevent concurrent installs for the same runtime.
     {

--- a/desktop/src-tauri/src/commands/agent_discovery/forced_single_flight.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/forced_single_flight.rs
@@ -66,6 +66,7 @@ async fn run(app: tauri::AppHandle, force: bool) -> Result<Vec<AcpRuntimeCatalog
         use tauri::Manager;
         if force {
             crate::managed_agents::clear_resolve_cache();
+            crate::managed_agents::wsl::clear_wsl_cache();
             crate::managed_agents::refresh_login_shell_path();
         }
         let custom_dir = app

--- a/desktop/src-tauri/src/commands/agent_model_process.rs
+++ b/desktop/src-tauri/src/commands/agent_model_process.rs
@@ -2,10 +2,53 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::managed_agents::{
     build_buzz_agent_provider_defaults, default_agent_workdir, known_acp_runtime,
-    redact_env_values_in, AgentModelsResponse,
+    redact_env_values_in, resolve_command, AgentModelsResponse,
 };
 
 use super::agent_models::normalize_agent_models;
+
+/// WSL env decision for the `models --json` subprocess, mirroring the spawn
+/// path in `runtime.rs`.
+///
+/// When the agent command cannot be resolved on the host PATH but discovery
+/// located it inside the default WSL distribution, the in-distro path is
+/// handed to `buzz-acp` through `BUZZ_ACP_AGENT_WSL_PATH` (and the optional
+/// `BUZZ_ACP_AGENT_WSL_DISTRO`), so the model picker can spawn a WSL-only
+/// harness command instead of failing with "program not found".
+///
+/// For native or unresolved commands the ambient WSL vars are explicitly
+/// removed, so a stale parent environment cannot opt another probe into WSL
+/// mode. Returns the env pairs to set (empty value = remove ambient var).
+fn wsl_model_discovery_env(agent_command: &str) -> Vec<(String, String)> {
+    let host_resolved = resolve_command(agent_command).is_some();
+    let resolution = if host_resolved {
+        None
+    } else {
+        crate::managed_agents::wsl::probe_wsl_command(agent_command)
+    };
+    wsl_model_discovery_env_from_resolution(resolution)
+}
+
+/// Pure core of [`wsl_model_discovery_env`], split out so the three branches
+/// (WSL propagation, native precedence, unresolved cleanup) are testable on
+/// any host without a live WSL probe.
+fn wsl_model_discovery_env_from_resolution(
+    resolution: Option<crate::managed_agents::wsl::WslCommandResolution>,
+) -> Vec<(String, String)> {
+    match resolution {
+        Some(resolution) => {
+            let mut env = vec![("BUZZ_ACP_AGENT_WSL_PATH".to_string(), resolution.linux_path)];
+            if let Some(distro) = resolution.distro {
+                env.push(("BUZZ_ACP_AGENT_WSL_DISTRO".to_string(), distro));
+            }
+            env
+        }
+        None => vec![
+            ("BUZZ_ACP_AGENT_WSL_PATH".to_string(), String::new()),
+            ("BUZZ_ACP_AGENT_WSL_DISTRO".to_string(), String::new()),
+        ],
+    }
+}
 
 pub(super) async fn run_agent_models_command(
     resolved_acp: PathBuf,
@@ -40,6 +83,16 @@ pub(super) async fn run_agent_models_command(
             .arg("--json")
             .env("BUZZ_ACP_AGENT_COMMAND", &agent_command)
             .env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));
+        // WSL fallback: mirror the spawn path so a WSL-only harness command
+        // resolves in the model picker. Native/unresolved commands get the
+        // ambient WSL vars removed so a stale parent env cannot force WSL mode.
+        for (key, value) in wsl_model_discovery_env(&agent_command) {
+            if value.is_empty() {
+                cmd.env_remove(&key);
+            } else {
+                cmd.env(&key, value);
+            }
+        }
         if let Some(meta) = known_acp_runtime(&agent_command) {
             for (key, value) in meta.default_env {
                 if std::env::var(key).is_err() {
@@ -81,4 +134,101 @@ pub(super) async fn run_agent_models_command(
         .map_err(|e| format!("failed to parse model JSON: {e}"))?;
 
     Ok(normalize_agent_models(&raw, persisted_model))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::managed_agents::wsl::WslCommandResolution;
+
+    fn resolution(linux_path: &str, distro: Option<&str>) -> WslCommandResolution {
+        WslCommandResolution {
+            distro: distro.map(str::to_string),
+            linux_path: linux_path.to_string(),
+        }
+    }
+
+    #[test]
+    fn wsl_resolution_propagates_path_and_distro() {
+        let env = wsl_model_discovery_env_from_resolution(Some(resolution(
+            "/home/rat/.local/bin/codex-wsl-acp",
+            Some("Ubuntu"),
+        )));
+        assert_eq!(
+            env,
+            vec![
+                (
+                    "BUZZ_ACP_AGENT_WSL_PATH".to_string(),
+                    "/home/rat/.local/bin/codex-wsl-acp".to_string()
+                ),
+                ("BUZZ_ACP_AGENT_WSL_DISTRO".to_string(), "Ubuntu".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn wsl_resolution_without_distro_sets_path_only() {
+        let env = wsl_model_discovery_env_from_resolution(Some(resolution(
+            "/usr/local/bin/omp",
+            None,
+        )));
+        assert_eq!(
+            env,
+            vec![(
+                "BUZZ_ACP_AGENT_WSL_PATH".to_string(),
+                "/usr/local/bin/omp".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn unresolved_or_native_command_clears_ambient_wsl_vars() {
+        // Native precedence and unresolved cleanup both land here: no WSL
+        // resolution means the ambient vars must be removed so a stale parent
+        // env cannot force WSL mode.
+        let env = wsl_model_discovery_env_from_resolution(None);
+        assert_eq!(
+            env,
+            vec![
+                ("BUZZ_ACP_AGENT_WSL_PATH".to_string(), String::new()),
+                ("BUZZ_ACP_AGENT_WSL_DISTRO".to_string(), String::new()),
+            ]
+        );
+        // Empty value is the "remove ambient var" sentinel the builder honors.
+        for (key, value) in &env {
+            assert!(value.is_empty(), "expected removal sentinel for {key}");
+        }
+    }
+
+    #[test]
+    fn wsl_env_application_sets_or_removes_on_command() {
+        // WSL resolution -> env set.
+        let mut cmd = std::process::Command::new("true");
+        for (key, value) in wsl_model_discovery_env_from_resolution(Some(resolution(
+            "/home/rat/.local/bin/codex-wsl-acp",
+            None,
+        ))) {
+            cmd.env(&key, value);
+        }
+        let env = cmd.get_envs().collect::<Vec<_>>();
+        assert!(env.iter().any(|(k, v)| {
+            *k == "BUZZ_ACP_AGENT_WSL_PATH"
+                && v.as_deref() == Some(std::ffi::OsStr::new("/home/rat/.local/bin/codex-wsl-acp"))
+        }));
+
+        // No resolution -> ambient vars removed.
+        let mut cmd = std::process::Command::new("true");
+        cmd.env("BUZZ_ACP_AGENT_WSL_PATH", "stale");
+        cmd.env("BUZZ_ACP_AGENT_WSL_DISTRO", "stale");
+        for (key, value) in wsl_model_discovery_env_from_resolution(None) {
+            if value.is_empty() {
+                cmd.env_remove(&key);
+            } else {
+                cmd.env(&key, value);
+            }
+        }
+        let env = cmd.get_envs().collect::<Vec<_>>();
+        assert!(env.iter().any(|(k, v)| *k == "BUZZ_ACP_AGENT_WSL_PATH" && v.is_none()));
+        assert!(env.iter().any(|(k, v)| *k == "BUZZ_ACP_AGENT_WSL_DISTRO" && v.is_none()));
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -12,6 +12,8 @@ mod auth_status_cache;
 mod bounded_command;
 mod login_shell;
 mod presets;
+#[cfg(windows)]
+pub(crate) use bounded_command::output_with_timeout;
 mod runtime_metadata;
 #[macro_use]
 mod windows_install;
@@ -1273,12 +1275,6 @@ pub fn discover_acp_runtimes_from(
     // then — on Windows hosts — the default WSL distribution, so harnesses
     // that only exist inside WSL (common for Hermes Agent) still surface as
     // Available. The WSL probe caches its resolution for the spawn path.
-    let resolve_with_wsl = |command: &str| {
-        find_command(command).or_else(|| {
-            crate::managed_agents::wsl::probe_wsl_command(command)
-                .map(|resolution| crate::managed_agents::wsl::wsl_display_path(&resolution))
-        })
-    };
 
     // Phase 2.5: insert static preset entries (PATH-probed, not editable/deletable).
     for def in PRESET_HARNESSES {
@@ -1288,7 +1284,7 @@ pub fn discover_acp_runtimes_from(
         }
         seen_ids.insert(def.id.to_string());
 
-        entries.push(preset_catalog_entry(def, &resolve_with_wsl));
+        entries.push(preset_catalog_entry(def, resolve_with_wsl));
     }
 
     // Phase 3: load and append custom harness definitions.

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1226,6 +1226,18 @@ pub fn discover_acp_runtimes_from(
     } else {
         resolve_command_cached
     };
+    // WSL fallback (Windows hosts only): harnesses installed inside the default
+    // WSL distro (Hermes, Codex, etc.) are invisible to the Windows PATH. Try
+    // the PATH/force-cached resolver first, then probe the default distro only
+    // when the host resolution came up empty. Resolutions are cached for the
+    // spawn path; `clear_wsl_cache`/`clear_resolve_cache` both run on forced
+    // discovery so a newly-installed WSL command is found on refresh.
+    let resolve_with_wsl = |command: &str| {
+        resolve(command).or_else(|| {
+            crate::managed_agents::wsl::probe_wsl_command(command)
+                .map(|resolution| crate::managed_agents::wsl::wsl_display_path(&resolution))
+        })
+    };
 
     // Phase 1: build all builtin entries (fast — no probes yet).
     let mut partials: Vec<PartialEntry> = KNOWN_ACP_RUNTIMES
@@ -1257,6 +1269,17 @@ pub fn discover_acp_runtimes_from(
     let mut seen_ids: std::collections::HashSet<String> =
         entries.iter().map(|e| e.id.clone()).collect();
 
+    // Resolver shared by the preset and custom phases: Windows PATH first,
+    // then — on Windows hosts — the default WSL distribution, so harnesses
+    // that only exist inside WSL (common for Hermes Agent) still surface as
+    // Available. The WSL probe caches its resolution for the spawn path.
+    let resolve_with_wsl = |command: &str| {
+        find_command(command).or_else(|| {
+            crate::managed_agents::wsl::probe_wsl_command(command)
+                .map(|resolution| crate::managed_agents::wsl::wsl_display_path(&resolution))
+        })
+    };
+
     // Phase 2.5: insert static preset entries (PATH-probed, not editable/deletable).
     for def in PRESET_HARNESSES {
         if seen_ids.contains(def.id) {
@@ -1265,7 +1288,7 @@ pub fn discover_acp_runtimes_from(
         }
         seen_ids.insert(def.id.to_string());
 
-        entries.push(preset_catalog_entry(def, resolve));
+        entries.push(preset_catalog_entry(def, &resolve_with_wsl));
     }
 
     // Phase 3: load and append custom harness definitions.
@@ -1280,8 +1303,9 @@ pub fn discover_acp_runtimes_from(
                 continue;
             }
 
-            // Availability: command resolves → Available, else NotInstalled.
-            let (availability, command, binary_path) = match resolve(&def.command) {
+            // Availability: command on PATH (or inside the default WSL
+            // distribution on Windows) → Available, else NotInstalled.
+            let (availability, command, binary_path) = match resolve_with_wsl(&def.command) {
                 Some(path) => (
                     AcpAvailabilityStatus::Available,
                     Some(def.command.clone()),

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1736,6 +1736,17 @@ pub fn discover_acp_runtimes_from(
     let mut seen_ids: std::collections::HashSet<String> =
         entries.iter().map(|e| e.id.clone()).collect();
 
+    // Resolver shared by the preset and custom phases: Windows PATH first,
+    // then — on Windows hosts — the default WSL distribution, so harnesses
+    // that only exist inside WSL (common for Hermes Agent) still surface as
+    // Available. The WSL probe caches its resolution for the spawn path.
+    let resolve_with_wsl = |command: &str| {
+        find_command(command).or_else(|| {
+            crate::managed_agents::wsl::probe_wsl_command(command)
+                .map(|resolution| crate::managed_agents::wsl::wsl_display_path(&resolution))
+        })
+    };
+
     // Phase 2.5: insert static preset entries (PATH-probed, not editable/deletable).
     for def in PRESET_HARNESSES {
         if seen_ids.contains(def.id) {
@@ -1744,7 +1755,7 @@ pub fn discover_acp_runtimes_from(
         }
         seen_ids.insert(def.id.to_string());
 
-        entries.push(preset_catalog_entry(def, find_command));
+        entries.push(preset_catalog_entry(def, &resolve_with_wsl));
     }
 
     // Phase 3: load and append custom harness definitions.
@@ -1759,8 +1770,9 @@ pub fn discover_acp_runtimes_from(
                 continue;
             }
 
-            // Availability: command on PATH → Available, else NotInstalled.
-            let (availability, command, binary_path) = match find_command(&def.command) {
+            // Availability: command on PATH (or inside the default WSL
+            // distribution on Windows) → Available, else NotInstalled.
+            let (availability, command, binary_path) = match resolve_with_wsl(&def.command) {
                 Some(path) => (
                     AcpAvailabilityStatus::Available,
                     Some(def.command.clone()),

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -44,6 +44,7 @@ mod team_repair;
 pub(crate) use team_repair::team_persona_key;
 mod teams;
 mod types;
+pub(crate) mod wsl;
 
 // Shared guard for tests that mutate or read process-global PATH.
 #[cfg(test)]

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod team_events;
 mod team_repair;
 mod teams;
 mod types;
+pub(crate) mod wsl;
 
 // Shared guard for tests that mutate or read process-global PATH.
 #[cfg(test)]

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -419,7 +419,9 @@ fn collect_missing_requirements(
     let Some(rt) = runtime else {
         // Unknown/custom command — check that the binary is actually resolvable.
         // No known requirement set beyond the PATH check.
-        if crate::managed_agents::resolve_command(&effective.effective_command).is_none() {
+        if crate::managed_agents::resolve_command(&effective.effective_command).is_none()
+            && crate::managed_agents::wsl::probe_wsl_command(&effective.effective_command).is_none()
+        {
             return vec![Requirement::MissingBinary {
                 command: effective.effective_command.clone(),
             }];

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -494,9 +494,25 @@ pub fn spawn_agent_child(
         }
     };
     // Resolve agent command to a full path (DMG launches have minimal PATH).
-    let resolved_agent_command = resolve_command(effective_command)
+    let host_resolution = resolve_command(effective_command);
+    let host_resolved = host_resolution.is_some();
+    let resolved_agent_command = host_resolution
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| effective_command.clone());
+
+    // WSL fallback: when the command does not exist on the host PATH but
+    // discovery located it inside the default WSL distribution, hand the
+    // in-distro path to buzz-acp so it can wrap the agent spawn through
+    // wsl.exe. BUZZ_ACP_AGENT_COMMAND keeps the original bare identity so
+    // buzz-acp's per-runtime defaults (e.g. Hermes MCP-startup isolation)
+    // still apply; WSLENV forwarding happens on the buzz-acp side, where the
+    // injected key set is known. The probe is cache-first, so this is free
+    // when discovery already ran.
+    let wsl_resolution = if host_resolved {
+        None
+    } else {
+        crate::managed_agents::wsl::probe_wsl_command(effective_command)
+    };
 
     // The caller supplies the explicit canonical pair relay. This is the only
     // relay this child may connect to, regardless of the record/workspace default.
@@ -536,6 +552,12 @@ pub fn spawn_agent_child(
     command.env("BUZZ_ACP_IDLE_POOL_SLEEP", idle_pool_sleep_env(lazy));
     command.env("BUZZ_ACP_AGENT_COMMAND", &resolved_agent_command);
     command.env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));
+    if let Some(resolution) = &wsl_resolution {
+        command.env("BUZZ_ACP_AGENT_WSL_PATH", &resolution.linux_path);
+        if let Some(distro) = &resolution.distro {
+            command.env("BUZZ_ACP_AGENT_WSL_DISTRO", distro);
+        }
+    }
     match &resolved_mcp_command {
         Some(mcp_cmd) => {
             command.env("BUZZ_ACP_MCP_COMMAND", mcp_cmd);

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -541,9 +541,25 @@ pub fn spawn_agent_child(
         }
     };
     // Resolve agent command to a full path (DMG launches have minimal PATH).
-    let resolved_agent_command = resolve_command(effective_command)
+    let host_resolution = resolve_command(effective_command);
+    let host_resolved = host_resolution.is_some();
+    let resolved_agent_command = host_resolution
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| effective_command.clone());
+
+    // WSL fallback: when the command does not exist on the host PATH but
+    // discovery located it inside the default WSL distribution, hand the
+    // in-distro path to buzz-acp so it can wrap the agent spawn through
+    // wsl.exe. BUZZ_ACP_AGENT_COMMAND keeps the original bare identity so
+    // buzz-acp's per-runtime defaults (e.g. Hermes MCP-startup isolation)
+    // still apply; WSLENV forwarding happens on the buzz-acp side, where the
+    // injected key set is known. The probe is cache-first, so this is free
+    // when discovery already ran.
+    let wsl_resolution = if host_resolved {
+        None
+    } else {
+        crate::managed_agents::wsl::probe_wsl_command(effective_command)
+    };
 
     // The caller supplies the explicit canonical pair relay. This is the only
     // relay this child may connect to, regardless of the record/workspace default.
@@ -582,6 +598,12 @@ pub fn spawn_agent_child(
     command.env("BUZZ_ACP_LAZY_POOL", if lazy { "true" } else { "false" });
     command.env("BUZZ_ACP_AGENT_COMMAND", &resolved_agent_command);
     command.env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));
+    if let Some(resolution) = &wsl_resolution {
+        command.env("BUZZ_ACP_AGENT_WSL_PATH", &resolution.linux_path);
+        if let Some(distro) = &resolution.distro {
+            command.env("BUZZ_ACP_AGENT_WSL_DISTRO", distro);
+        }
+    }
     match &resolved_mcp_command {
         Some(mcp_cmd) => {
             command.env("BUZZ_ACP_MCP_COMMAND", mcp_cmd);

--- a/desktop/src-tauri/src/managed_agents/wsl.rs
+++ b/desktop/src-tauri/src/managed_agents/wsl.rs
@@ -24,6 +24,13 @@
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
+/// Hard wall-clock deadline for one WSL probe, on par with the other bounded
+/// discovery spawns. WSL2 cold-boot (VM start + distro init) can exceed 10s,
+/// so this is scaled up from the 10s used for CLI auth probes; a genuinely
+/// wedged boot is still reaped rather than stalling discovery forever.
+#[cfg(windows)]
+const WSL_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// A harness command located inside the default WSL distribution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WslCommandResolution {
@@ -97,6 +104,16 @@ fn wsl_cache() -> &'static Mutex<std::collections::HashMap<String, Option<WslCom
     CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
 }
 
+/// Clear the WSL resolution cache so a command installed inside the default
+/// distribution after the first miss is found on the next forced discovery.
+/// Mirrors `resolve_command`'s `clear_resolve_cache`; both run on the
+/// forced-discovery invalidation seam (see `commands/agent_discovery`).
+pub(crate) fn clear_wsl_cache() {
+    if let Ok(mut guard) = wsl_cache().lock() {
+        guard.clear()
+    }
+}
+
 /// Probe the default WSL distribution for `command`, caching the outcome
 /// (positive or negative) for the app lifetime — mirroring `resolve_command`'s
 /// cache contract so repeated discovery runs stay cheap.
@@ -127,7 +144,11 @@ fn probe_wsl_command_uncached(command: &str) -> Option<WslCommandResolution> {
     let mut cmd = std::process::Command::new(wsl);
     cmd.args(["-e", "sh", "-c", &wsl_probe_script(command)]);
     crate::util::configure_no_window(&mut cmd);
-    let output = cmd.output().ok()?;
+    // Bound the probe on the same wall-clock deadline as other discovery
+    // spawns: a hung distro boot (WSL2 cold start) or a wedged login shell must
+    // not stall discovery forever. `output_with_timeout` reaps the child tree
+    // on timeout and fails closed to `None`.
+    let output = super::discovery::output_with_timeout(cmd, WSL_PROBE_TIMEOUT)?;
     if !output.status.success() {
         return None;
     }

--- a/desktop/src-tauri/src/managed_agents/wsl.rs
+++ b/desktop/src-tauri/src/managed_agents/wsl.rs
@@ -1,0 +1,277 @@
+//! WSL fallback discovery for ACP harness commands on Windows.
+//!
+//! Many agent CLIs (Hermes Agent, Oh My Pi, …) are commonly installed inside
+//! a Windows Subsystem for Linux distribution rather than on the Windows host.
+//! When a preset or custom harness command cannot be resolved on the Windows
+//! PATH, discovery falls back to probing the *default* WSL distribution via
+//! `wsl.exe -e <path>`. A positive result is cached so the spawn path
+//! (`runtime.rs`) can hand the in-distro path to `buzz-acp` through
+//! `BUZZ_ACP_AGENT_WSL_PATH`; `buzz-acp` then wraps the agent spawn through
+//! `wsl.exe` and forwards injected environment via `WSLENV`.
+//!
+//! Design notes:
+//! * Only bare command names are probed (`hermes-acp`, `omp`, …). Absolute or
+//!   relative paths are never sent through the probe — a Windows path has no
+//!   meaning inside the distro and would be a quoting/injection hazard.
+//! * Probing always targets the *default* distribution (`wsl.exe -e` without
+//!   `-d`). Multi-distro selection is future work; the `distro` field exists
+//!   so the spawn contract does not need to change when it lands.
+//! * All pure helpers (script building, stdout parsing, display paths) are
+//!   platform-agnostic so the unit tests run on any host, mirroring the
+//!   `git_bash.rs` pattern. Process-spawning probes are `cfg(windows)`-gated
+//!   and return `None` everywhere else.
+
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+/// A harness command located inside the default WSL distribution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WslCommandResolution {
+    /// Distro name. Always `None` today (probing targets the default distro);
+    /// carried so the spawn contract can grow multi-distro support without
+    /// changing the `BUZZ_ACP_AGENT_WSL_*` env surface.
+    pub distro: Option<String>,
+    /// Absolute path of the command inside the distro
+    /// (e.g. `/home/user/.local/bin/hermes-acp`).
+    pub linux_path: String,
+}
+
+/// Return true when `command` is a bare executable name safe to embed in the
+/// probe script: `[A-Za-z0-9._-]+` with no path separators. Paths (Windows or
+/// POSIX shaped) are rejected — probing for them inside WSL is meaningless.
+#[cfg(any(windows, test))]
+fn is_probeable_command(command: &str) -> bool {
+    !command.is_empty()
+        && command
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// Build the POSIX sh probe executed inside the default distribution.
+///
+/// Well-known per-user install locations are checked first (`~/.local/bin`
+/// is where the Hermes installer and `pip install --user` land, and it is
+/// NOT on the non-login PATH WSL gives `wsl.exe -e sh`), then the distro's
+/// own PATH via `command -v`. Prints the first match on stdout; prints
+/// nothing when the command is absent.
+///
+/// Extracted as a pure function so tests can pin the probe contract.
+#[cfg(any(windows, test))]
+fn wsl_probe_script(command: &str) -> String {
+    debug_assert!(is_probeable_command(command));
+    format!(
+        "for p in \"$HOME/.local/bin/{command}\" \"$HOME/bin/{command}\" \"/usr/local/bin/{command}\"; do \
+            [ -x \"$p\" ] && {{ printf '%s\\n' \"$p\"; exit 0; }}; \
+        done; \
+        command -v {command} 2>/dev/null || true"
+    )
+}
+
+/// Parse probe stdout into an in-distro absolute path.
+///
+/// Takes the first non-empty line that is an absolute POSIX path. Anything
+/// else (blank output, relative `command -v` oddities, WSL interop noise)
+/// means "not found".
+#[cfg(any(windows, test))]
+fn parse_probe_stdout(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with('/'))
+        .map(str::to_string)
+}
+
+/// Display path surfaced in the catalog (`binary_path`) for a WSL-resolved
+/// command. Purely informational — the real resolution travels through the
+/// cache into the spawn path.
+pub(crate) fn wsl_display_path(resolution: &WslCommandResolution) -> PathBuf {
+    match &resolution.distro {
+        Some(distro) => PathBuf::from(format!("wsl://{distro}{}", resolution.linux_path)),
+        None => PathBuf::from(format!("wsl://{}", resolution.linux_path)),
+    }
+}
+
+fn wsl_cache() -> &'static Mutex<std::collections::HashMap<String, Option<WslCommandResolution>>> {
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<String, Option<WslCommandResolution>>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Probe the default WSL distribution for `command`, caching the outcome
+/// (positive or negative) for the app lifetime — mirroring `resolve_command`'s
+/// cache contract so repeated discovery runs stay cheap.
+///
+/// Returns `None` on non-Windows hosts, when `wsl.exe` is unavailable, when
+/// `command` is not a bare executable name, and when the probe finds nothing.
+pub(crate) fn probe_wsl_command(command: &str) -> Option<WslCommandResolution> {
+    if let Ok(guard) = wsl_cache().lock() {
+        if let Some(cached) = guard.get(command) {
+            return cached.clone();
+        }
+    }
+
+    let result = probe_wsl_command_uncached(command);
+
+    if let Ok(mut guard) = wsl_cache().lock() {
+        guard.insert(command.to_string(), result.clone());
+    }
+    result
+}
+
+#[cfg(windows)]
+fn probe_wsl_command_uncached(command: &str) -> Option<WslCommandResolution> {
+    if !is_probeable_command(command) {
+        return None;
+    }
+    let wsl = resolve_wsl_exe()?;
+    let mut cmd = std::process::Command::new(wsl);
+    cmd.args(["-e", "sh", "-c", &wsl_probe_script(command)]);
+    crate::util::configure_no_window(&mut cmd);
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let linux_path = parse_probe_stdout(&stdout)?;
+    Some(WslCommandResolution {
+        distro: None,
+        linux_path,
+    })
+}
+
+#[cfg(not(windows))]
+fn probe_wsl_command_uncached(_command: &str) -> Option<WslCommandResolution> {
+    None
+}
+
+/// Resolve `wsl.exe` itself: the System32 copy first, then a PATH scan that
+/// skips the WindowsApps app-execution-alias stubs (see issue #2328 — those
+/// stubs are launchers, not the real binary).
+#[cfg(windows)]
+fn resolve_wsl_exe() -> Option<PathBuf> {
+    if let Some(root) = std::env::var_os("SystemRoot") {
+        let candidate = PathBuf::from(root).join("System32").join("wsl.exe");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .map(|dir| dir.join("wsl.exe"))
+            .find(|candidate| {
+                candidate.is_file() && !super::git_bash::is_windows_apps_alias(candidate)
+            })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probeable_accepts_bare_command_names() {
+        for command in [
+            "hermes-acp",
+            "omp",
+            "grok",
+            "claude_agent-acp",
+            "amp-acp.cmd",
+        ] {
+            assert!(
+                is_probeable_command(command),
+                "expected probeable: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn probeable_rejects_paths_and_shell_metacharacters() {
+        for command in [
+            "",
+            "/usr/local/bin/hermes-acp",
+            r"C:\tools\hermes-acp.exe",
+            "./hermes-acp",
+            "../escape",
+            "hermes-acp; rm -rf /",
+            "hermes-acp$(whoami)",
+            "hermes acp",
+            "hermes-acp\nevil",
+        ] {
+            assert!(
+                !is_probeable_command(command),
+                "expected rejected: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn probe_script_checks_user_bins_before_path() {
+        let script = wsl_probe_script("hermes-acp");
+        // ~/.local/bin must be probed explicitly: it is not on the non-login
+        // PATH that `wsl.exe -e sh` receives, and it is where the Hermes
+        // installer drops hermes-acp.
+        let local_bin = script
+            .find("$HOME/.local/bin/hermes-acp")
+            .expect("~/.local/bin probe");
+        let command_v = script
+            .find("command -v hermes-acp")
+            .expect("command -v fallback");
+        assert!(
+            local_bin < command_v,
+            "well-known bins must precede PATH probe"
+        );
+        // No format!/interpolation artifacts, no login shell (login shells can
+        // print profile noise that would corrupt parse_probe_stdout).
+        assert!(
+            !script.contains("sh -l"),
+            "probe must not use a login shell"
+        );
+    }
+
+    #[test]
+    fn parse_stdout_takes_first_absolute_path_line() {
+        assert_eq!(
+            parse_probe_stdout("/home/rat/.local/bin/hermes-acp\n"),
+            Some("/home/rat/.local/bin/hermes-acp".to_string())
+        );
+        // Noise lines are skipped in favour of the first absolute path.
+        assert_eq!(
+            parse_probe_stdout("some warning\r\n/usr/local/bin/omp\n"),
+            Some("/usr/local/bin/omp".to_string())
+        );
+        // Blank / relative-only output means not found.
+        assert_eq!(parse_probe_stdout(""), None);
+        assert_eq!(parse_probe_stdout("hermes-acp\n"), None);
+    }
+
+    #[test]
+    fn display_path_carries_wsl_scheme() {
+        let resolution = WslCommandResolution {
+            distro: None,
+            linux_path: "/home/rat/.local/bin/hermes-acp".to_string(),
+        };
+        assert_eq!(
+            wsl_display_path(&resolution).display().to_string(),
+            "wsl:///home/rat/.local/bin/hermes-acp"
+        );
+        let with_distro = WslCommandResolution {
+            distro: Some("Ubuntu".to_string()),
+            ..resolution
+        };
+        assert_eq!(
+            wsl_display_path(&with_distro).display().to_string(),
+            "wsl://Ubuntu/home/rat/.local/bin/hermes-acp"
+        );
+    }
+
+    #[test]
+    fn probe_caches_negative_results() {
+        // A non-probeable command short-circuits to None and must be cached —
+        // a second call must not re-run the (here: non-Windows, no-op) probe.
+        assert_eq!(probe_wsl_command("definitely/not a command"), None);
+        assert!(wsl_cache()
+            .lock()
+            .expect("cache lock")
+            .contains_key("definitely/not a command"));
+    }
+}

--- a/docs/windows-wsl-harnesses.md
+++ b/docs/windows-wsl-harnesses.md
@@ -1,0 +1,57 @@
+# Running ACP harnesses from WSL on Windows
+
+Buzz Desktop discovers ACP harness commands (Hermes Agent's `hermes-acp`, Oh
+My Pi's `omp`, custom harnesses, …) by resolving them on the host PATH. On
+Windows, many of these CLIs are installed inside a **Windows Subsystem for
+Linux (WSL)** distribution instead of on the Windows host — Hermes Agent, for
+example, is a Linux-first install. Without help, Doctor shows such harnesses
+as *Not installed* even though they work fine inside WSL.
+
+Buzz bridges this automatically.
+
+## How it works
+
+1. **Discovery fallback.** When a preset or custom harness command is not
+   found on the Windows PATH, Buzz probes the *default* WSL distribution with
+   `wsl.exe -e sh -c …`, checking `~/.local/bin`, `~/bin`, `/usr/local/bin`,
+   and finally the distro PATH (`command -v`). A hit marks the harness
+   **Available** with a `wsl://…` binary path in Doctor.
+2. **Spawn wrapping.** At agent start, Buzz Desktop passes the in-distro path
+   to `buzz-acp` via `BUZZ_ACP_AGENT_WSL_PATH` (and optionally
+   `BUZZ_ACP_AGENT_WSL_DISTRO`). `buzz-acp` launches the agent through
+   `wsl.exe -e <path> <args>`; WSL interop bridges the stdio pipes, so the
+   ACP/NDJSON channel is byte-transparent.
+3. **Environment forwarding.** Windows processes do not automatically share
+   environment variables with WSL. `buzz-acp` computes a `WSLENV` list of
+   every variable it injects for the agent (per-runtime defaults such as
+   `HERMES_ACP_SKIP_CONFIGURED_MCP`, persona env such as `GOOSE_PROVIDER`) so
+   they arrive inside the Linux process. A pre-existing `WSLENV` (including
+   flagged entries like `GOPATH/p`) is preserved and merged.
+
+`BUZZ_ACP_AGENT_COMMAND` keeps the original bare command identity
+(`hermes-acp`), so all per-runtime defaults keyed on the command name keep
+working unchanged.
+
+## Verifying
+
+Doctor → harness catalog: a WSL-only harness shows *Available* with a binary
+path like `wsl:///home/<you>/.local/bin/hermes-acp`. Starting an agent on it
+logs `spawning agent through WSL` from `buzz-acp`.
+
+## Limits
+
+- Only the **default** WSL distribution is probed today. The spawn contract
+  (`BUZZ_ACP_AGENT_WSL_DISTRO`) already supports naming a distro; multi-distro
+  discovery is future work.
+- Only bare command names are probed (never paths), and probing runs at most
+  once per command per app launch (cached).
+- Auth probes and install scripts for tier-1 built-in runtimes still assume a
+  host-native install; the WSL fallback covers preset and custom harnesses.
+
+## Manual alternative (no rebuild)
+
+The same result is possible without this feature by registering a custom
+harness (`<app-data>/custom_harnesses/hermes-wsl.json`) that runs
+`C:\Windows\System32\wsl.exe` with args `["-e", "/home/<you>/.local/bin/hermes-acp"]`
+and env `{"HERMES_ACP_SKIP_CONFIGURED_MCP": "1", "WSLENV": "HERMES_ACP_SKIP_CONFIGURED_MCP"}`.
+The native fallback exists so users don't have to hand-author this.

--- a/docs/windows-wsl-harnesses.md
+++ b/docs/windows-wsl-harnesses.md
@@ -27,10 +27,20 @@ Buzz bridges this automatically.
    `HERMES_ACP_SKIP_CONFIGURED_MCP`, persona env such as `GOOSE_PROVIDER`) so
    they arrive inside the Linux process. A pre-existing `WSLENV` (including
    flagged entries like `GOPATH/p`) is preserved and merged.
+4. **Session cwd translation.** The desktop spawns `buzz-acp` from
+   `~/.buzz`, so the `cwd` carried into `session/new` is a Windows drive path
+   that does not exist inside the distro — agents use it as the root for
+   edit-approval policies and workspace grounding. For WSL-targeted agents,
+   `buzz-acp` translates drive-letter paths to their `/mnt/<drive>/…` form
+   (`C:\Users\x\.buzz` → `/mnt/c/Users/x/.buzz`); UNC, relative, and already
+   POSIX paths pass through untouched.
 
 `BUZZ_ACP_AGENT_COMMAND` keeps the original bare command identity
 (`hermes-acp`), so all per-runtime defaults keyed on the command name keep
-working unchanged.
+working unchanged. Together these close the four WSL boundary breaks
+catalogued in [block/buzz#3122](https://github.com/block/buzz/issues/3122)
+(env, cwd, and — via discovery — the missing-harness path; skill placement
+and teardown reaping remain follow-ups, see the issue's item list).
 
 ## Verifying
 


### PR DESCRIPTION
## Problem

On Windows, Buzz Desktop discovers ACP harnesses by resolving their command
on the Windows PATH. Several supported harnesses are commonly installed
**inside WSL**, not on the Windows host — Hermes Agent (`hermes-acp`) is the
canonical case: it is a Linux-first install, so on a Windows machine running
Hermes in WSL, Doctor reports *Not installed* and the harness cannot be
started, even though it works perfectly inside the distro.

There was no WSL story anywhere in the harness discovery/spawn path (the only
WSL awareness in the tree is `is_windows_apps_alias`, which exists to *avoid*
WindowsApps stub launchers, issue #2328).

## What this PR does

Buzz now falls back to the **default WSL distribution** when a preset or
custom harness command is missing from the Windows PATH. This directly
addresses the WSL breakages catalogued in
[#3122](https://github.com/block/buzz/issues/3122) (env severed at the
`wsl.exe` boundary, untranslated cwd, harness invisible to discovery):

1. **Discovery** (`managed_agents/wsl.rs`, new) — probes the default distro
   via `wsl.exe -e sh -c …`, checking `~/.local/bin`, `~/bin`,
   `/usr/local/bin`, then the distro PATH (`command -v`). Positive results
   mark the harness *Available* with a `wsl://…` binary path in Doctor.
   Resolutions are cached for the app lifetime (mirrors `resolve_command`'s
   cache contract). Only bare command names are ever probed — paths are
   rejected up front (no injection surface, no nonsense lookups).

2. **Spawn contract** (`runtime.rs` → `buzz-acp`) — when the host PATH
   resolution failed but the WSL probe succeeded, Desktop sets
   `BUZZ_ACP_AGENT_WSL_PATH` (absolute in-distro path) and optionally
   `BUZZ_ACP_AGENT_WSL_DISTRO` on the `buzz-acp` child.
   `BUZZ_ACP_AGENT_COMMAND` keeps the original bare identity
   (`hermes-acp`), so all per-runtime defaults keyed on the command name
   (`default_agent_env`, `default_agent_args`) apply unchanged.

3. **Spawn wrapping** (`buzz-acp/src/acp.rs`) — `AcpClient::spawn` reads the
   contract and launches `wsl.exe [-d distro] -e <linux_path> <args>` instead
   of the bare command. WSL interop bridges the stdio pipes; the ACP/NDJSON
   channel is byte-transparent. Contract values are validated (absolute POSIX
   path required); a set contract on a non-Windows host is ignored with a
   warning.

4. **Environment forwarding** — wsl.exe children only import Windows-side
   variables listed in `WSLENV`. `buzz-acp` builds the forward list from
   every agent-intended key (per-runtime defaults like
   `HERMES_ACP_SKIP_CONFIGURED_MCP=1`, persona env like `GOOSE_PROVIDER`,
   merged `CODEX_CONFIG`), merging into any pre-existing `WSLENV` without
   duplicating flagged entries (`GOPATH/p` style). Without this, agents in
   WSL silently lose their env — for Hermes specifically this re-introduces
   the #3355 startup-stall the skip flag exists to prevent.

5. **Session cwd translation** — `buzz-acp` is spawned from `~/.buzz`, so
   `session/new` would otherwise carry `C:\Users\<u>\.buzz` into the distro.
   For WSL-targeted agents, `AcpClient::spawn`-adjacent `session_cwd_for_wsl`
   translates drive-letter paths to `/mnt/<drive>/…` before the cwd reaches
   the `[Workspace]` grounding prompt and the agent's session state (Hermes
   uses it as the edit-approval root). UNC, relative, and POSIX paths are
   left untouched. This is #3122's "first failure after initialize".

Known remaining follow-ups from #3122 (deliberately out of scope here, noted
in the issue's item list): skill/nest placement for a distro `$HOME` and
teardown that reaps the in-distro process rather than only the `wsl.exe`
shim.

## Verification (real, on a Windows 11 + WSL2 machine)

Environment: Windows 11, WSL2 `Ubuntu`, Hermes Agent v0.19.0 at
`/home/rat/.local/bin/hermes-acp`, Buzz Desktop installed at
`C:\Users\ratz\AppData\Local\Buzz\`.

1. **Baseline bug**: `hermes-acp` absent from Windows PATH → Doctor shows
   Hermes *Not installed*.
2. **Stdio transparency**: spawning
   `C:\Windows\System32\wsl.exe -e /home/rat/.local/bin/hermes-acp` from a
   Windows parent with piped stdio returns a byte-clean ACP `initialize`
   response (`agentInfo: hermes-agent 0.19.0`, `protocolVersion: 1`).
3. **Env forwarding**: without `WSLENV`, `hermes-acp` hangs before
   `initialize` (the #3355 MCP-startup stall). With
   `HERMES_ACP_SKIP_CONFIGURED_MCP=1` set Windows-side and forwarded via
   `WSLENV`, initialize answers immediately.
4. **Zero-config workaround validated**: the manual custom-harness JSON
   documented in `docs/windows-wsl-harnesses.md` (same mechanism this PR
   automates) loads and works on the current released build.

## Tests

- `buzz-acp`: 8 new unit tests (`build_wsl_wrap` validation, `prefix_args`,
  `merge_wslenv` order/dup/flag handling). **`cargo test -p buzz-acp`: 648
  passed, 0 failed** (full suite, Linux). `cargo clippy -p buzz-acp
  --all-targets`: clean.
- Desktop `wsl.rs`: 6 unit tests (probe script contract pins `~/.local/bin`
  before PATH, no login shell; stdout parsing; display path;
  probeable-command validation incl. metacharacter rejection; negative-result
  caching) — pass on Linux. Process-spawning probes are `cfg(windows)`-gated;
  the Windows-only code paths (`resolve_wsl_exe`, probe spawn) were
  compile-verified for `x86_64-pc-windows-msvc`.
- `cargo check` (Linux) on `desktop/src-tauri`: green, zero warnings.
  `cargo test managed_agents::` on `desktop/src-tauri`: **906 passed, 0
  failed** (includes the 6 new `wsl.rs` tests + all pre-existing discovery,
  custom-harness, spawn-hash, and readiness tests).
- Full `x86_64-pc-windows-msvc` workspace check was not runnable in the dev
  container (crypto `-sys` crates need a Windows C toolchain); Windows CI
  covers it. Every Windows-gated line added by this PR is either
  std-only Rust (verified via the standalone msvc-target compile described
  above) or mirrors existing patterns in `git_bash.rs`.
- Existing discovery tests bind the resolver seam (`preset_catalog_entry`) —
  unchanged, still green.

## Notes for reviewers

- **Scope**: preset + custom harnesses only. Tier-1 builtins (auth probes,
  install scripts) still assume host-native installs — a follow-up could
  extend the same cached-resolution mechanism to their probes.
- **Perf**: probes run once per missing command per app launch, cache-first
  on both the discovery and spawn paths. WSL-unavailable machines
  short-circuit on `wsl.exe` resolution.
- **Future**: `WslCommandResolution.distro` is plumbed through the whole
  contract but always `None` today (default distro only) — multi-distro
  discovery needs no contract change.
- New public API: none (all `pub(crate)` / private). Docs added:
  `docs/windows-wsl-harnesses.md`.
