### PR TITLE
test(buzz-acp): quote the steer capture path for bash

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -3906,14 +3906,25 @@ mod tests {
     ///
     /// The steer request is the first thing this read loop writes, so the
     /// captured line IS the steer request bytes.
+    /// Render a path for interpolation into a `bash -c` script.
+    ///
+    /// A Windows path must not reach bash with its backslashes intact: unquoted,
+    /// bash consumes them as escapes, so `C:\Users\x\Temp\cap.json` collapses to
+    /// the relative `C:UsersxTempcap.json` and the redirect lands a junk file in
+    /// the working directory instead. Forward slashes are accepted by the MSYS
+    /// bash used on Windows, and the quotes the caller adds cover spaces.
+    fn bash_path(path: &std::path::Path) -> String {
+        path.display().to_string().replace('\\', "/")
+    }
+
     async fn spawn_steer_capture_script(
         capture_path: &std::path::Path,
         response: &str,
     ) -> AcpClient {
         let script = format!(
-            "read -r line; printf '%s' \"$line\" > {capture}; \
+            "read -r line; printf '%s' \"$line\" > \"{capture}\"; \
              printf '%s\\n' '{response}'; sleep 10",
-            capture = capture_path.display(),
+            capture = bash_path(capture_path),
             response = response,
         );
         spawn_script(&script).await


### PR DESCRIPTION
## Problem

`spawn_steer_capture_script` interpolates the capture path unquoted into a `bash -c` script:

```
read -r line; printf '%s' "$line" > C:\Users\me\AppData\Local\Temp\buzz-acp-steer-capture\acp_shape.json
```

Unquoted, bash consumes the backslashes as escapes, so the redirect target collapses to the relative `C:UsersmeAppDataLocalTempbuzz-acp-steer-captureacp_shape.json`. Two consequences on Windows:

- `acp_steer_request_omits_expected_run_id_and_carries_session_and_prompt` and `goose_transport_wins_when_both_run_id_and_capability_present` fail, because `run_one_steer` reads the intended path and finds nothing.
- Each run litters `crates/buzz-acp/` with junk files named `C:UsersmeAppData…json`.

## Change

New `bash_path` test helper renders the path with forward slashes — accepted by the MSYS bash used on Windows — and the redirect target is quoted so spaces are covered too. Test-only; no production code touched.

## Result

On Windows, `cargo test -p buzz-acp` goes from 3 failures to 1, and no stray files are left behind. The remaining failure is `keepalive_resets_idle_past_deadline`, an unrelated timing flake that passes in isolation and is not addressed here.
