### PR TITLE
fix(dev): let PGPORT choose the postgres host port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ DATABASE_URL=postgres://buzz:buzz_dev@localhost:5432/buzz
 # Optional read-replica URL; unset/blank keeps all reads on the writer.
 # READ_DATABASE_URL=postgres://buzz:buzz_dev@localhost:5433/buzz
 PGHOST=localhost
+# PGPORT is also the host port docker-compose.yml publishes for postgres.
+# Change it if something else already owns 5432 on your machine, and keep
+# DATABASE_URL above pointing at the same port.
 PGPORT=5432
 PGUSER=buzz
 PGPASSWORD=buzz_dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_DB: buzz
       PGDATA: /var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${PGPORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:

--- a/scripts/start-relay-for-tests.sh
+++ b/scripts/start-relay-for-tests.sh
@@ -89,16 +89,16 @@ wait_healthy "MinIO" "buzz-minio"
 # ── Apply database schema ────────────────────────────────────────────────────
 
 log "Applying database schema..."
-export PGHOST=localhost
-export PGPORT=5432
+export PGHOST="${PGHOST:-localhost}"
+export PGPORT="${PGPORT:-5432}"
 export PGUSER=buzz
 export PGPASSWORD=buzz_dev
 export PGDATABASE=buzz
 
 # Use the already-running docker postgres for desired-state planning instead of
 # downloading an embedded Postgres from Maven Central (transient-fetch flake source).
-export PGSCHEMA_PLAN_HOST=localhost
-export PGSCHEMA_PLAN_PORT=5432
+export PGSCHEMA_PLAN_HOST="${PGHOST}"
+export PGSCHEMA_PLAN_PORT="${PGPORT}"
 export PGSCHEMA_PLAN_DB=buzz
 export PGSCHEMA_PLAN_USER=buzz
 export PGSCHEMA_PLAN_PASSWORD=buzz_dev
@@ -152,7 +152,7 @@ fi
 
 log "Starting relay..."
 nohup env \
-  DATABASE_URL=postgres://buzz:buzz_dev@localhost:5432/buzz \
+  DATABASE_URL="postgres://buzz:buzz_dev@${PGHOST}:${PGPORT}/buzz" \
   REDIS_URL=redis://localhost:6379 \
   RELAY_URL=ws://localhost:3000 \
   BUZZ_BIND_ADDR=0.0.0.0:3000 \


### PR DESCRIPTION
## Summary

`docker-compose.yml` published Postgres on a hardcoded `5432:5432`, so local setup breaks whenever something already owns that host port.

The failure mode is nastier than a plain bind conflict. A more specific `127.0.0.1:5432` listener takes precedence over the Docker forward's `*:5432`, so connections silently reach the *other* Postgres, which then rejects the dev credentials. `just relay` dies in `_ensure-migrations` with:

```
error: database error: error returned from database: password authentication failed for user "buzz"
```

Nothing points at a port conflict — a real Postgres answered, it just wasn't ours. In my case the squatter was a `cloudflared access tcp` tunnel; the linked issue hit the same wall with Homebrew `postgresql@15`.

This publishes the port as `${PGPORT:-5432}`, reusing the variable `.env` already defines rather than adding a second one, which is the direction proposed in #2479. Compose interpolates it from `.env` automatically, so the conflict is resolved without editing tracked files.

**The committed default is unchanged**, so CI and existing checkouts keep using 5432.

`scripts/start-relay-for-tests.sh` hardcoded the same port in three places and does not source `.env`, so it would have overridden any override. `PGHOST`/`PGPORT` now fall back to the standard defaults instead of being pinned, `DATABASE_URL` is derived from them instead of being spelled out a second time, and the `pgschema` desired-state planner reuses them too.

### Related issue

Addresses the Postgres half of #2479. That issue also asks for `BUZZ_REDIS_HOST_PORT` and a matching `dev-setup.sh` collision check for Redis — deliberately left out here to keep this to one service, so #2479 should stay open. I searched open PRs for `POSTGRES_PORT` / postgres port conflicts and found no duplicates.

### Testing

Verified on macOS with Colima, reproducing the original conflict (`cloudflared` holding `127.0.0.1:5432`):

- With `PGPORT=5442` in `.env`, `docker compose config` resolves `postgres.ports[0].published` to `5442`; with it unset, `5432`.
- `just relay` starts clean — migrations apply, `/health` returns `ok`, NIP-11 serves, relay listening on `ws://localhost:3000`.
- `just test` — all 9 steps pass, 954 passed / 0 failed. `run-tests.sh` sources `.env`, so this exercises the remapped port end to end, including the `_ensure-migrations` step that previously failed.
- `just check` — clean (fmt, clippy, desktop, tauri, web, mobile lint).
- `bash -n scripts/start-relay-for-tests.sh` — clean.

Not covered: `scripts/start-relay-for-tests.sh` is CI-only and I did not execute it, so its three edits are verified by inspection and a syntax check rather than a run. Redis, MinIO, and the other services are untouched.

One unrelated pre-existing failure showed up in `just ci` at `mobile-test` — `channel_detail_page_test.dart:1053` (*"keeps follow mode off while a tall newest message stays visible"*). It reproduces on a clean checkout of `main` at `10d5a2641`, so it is not from this change, and this diff touches nothing reachable from Flutter.
