### PR TITLE
fix(desktop): create skill links on Windows

### DIFF
--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -20,6 +20,7 @@ use tauri::{AppHandle, Manager};
 use crate::managed_agents::discovery::known_skill_dirs;
 #[cfg(unix)]
 use crate::util::create_symlink;
+use crate::util::{create_dir_link, remove_dir_link};
 
 /// Subdirectories created inside the nest.
 /// `REPOS` is intentionally absent: it is provisioned by
@@ -282,10 +283,29 @@ pub fn ensure_nest_at(root: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// Link target for `<skill_dir>/buzz-cli`, given the nest `root`.
+///
+/// Unix uses a target relative to the link so the nest stays movable. Windows
+/// cannot: when symlink creation is denied, [`create_dir_link`] falls back to a
+/// junction, and junctions store only absolute targets. Pinning to `root` is
+/// the cost of not requiring Developer Mode or elevation.
+fn skill_link_target(root: &Path, skill_dir: &str) -> PathBuf {
+    #[cfg(unix)]
+    {
+        let _ = root;
+        let depth = Path::new(skill_dir).components().count();
+        PathBuf::from(format!("{}{CANONICAL_SKILL_DIR}", "../".repeat(depth)))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = skill_dir;
+        root.join(CANONICAL_SKILL_DIR)
+    }
+}
+
 /// Create harness-specific skill symlinks for each known provider.
 /// Idempotent: skips any path where `symlink_metadata` succeeds — real
 /// directories, valid symlinks, and dangling symlinks are all left alone.
-#[cfg(unix)]
 fn ensure_skill_symlinks(root: &Path) -> Result<(), String> {
     for skill_dir in known_skill_dirs() {
         let parent = root.join(skill_dir);
@@ -294,17 +314,10 @@ fn ensure_skill_symlinks(root: &Path) -> Result<(), String> {
         if link.symlink_metadata().is_ok() {
             continue; // symlink or real path exists — skip
         }
-        let depth = std::path::Path::new(skill_dir).components().count();
-        let prefix = "../".repeat(depth);
-        let target = format!("{prefix}{CANONICAL_SKILL_DIR}");
-        create_symlink(std::path::Path::new(&target), &link)
-            .map_err(|e| format!("symlink {} → {}: {e}", link.display(), target))?;
+        let target = skill_link_target(root, skill_dir);
+        create_dir_link(&target, &link)
+            .map_err(|e| format!("skill link {} → {}: {e}", link.display(), target.display()))?;
     }
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn ensure_skill_symlinks(_root: &Path) -> Result<(), String> {
     Ok(())
 }
 
@@ -490,27 +503,26 @@ fn refresh_skill_md_if_stale(root: &Path) -> Result<(), String> {
             .map_err(|e| format!("remove {}: {e}", old_skill_dir.display()))?;
     }
 
-    // Create/replace the .claude/skills/buzz-cli symlink.
-    #[cfg(unix)]
+    // Create/replace the .claude/skills/buzz-cli symlink. The old real
+    // directory is removed above on every platform, so this must run on every
+    // platform too or Windows is left with no link at all until the next boot.
     {
         let claude_skills_dir = root.join(".claude/skills");
         fs::create_dir_all(&claude_skills_dir)
             .map_err(|e| format!("create {}: {e}", claude_skills_dir.display()))?;
-        let symlink_path = root.join(".claude/skills/buzz-cli");
+        let symlink_path = claude_skills_dir.join("buzz-cli");
         // Remove any stale symlink before (re)creating.
         let symlink_exists = symlink_path
             .symlink_metadata()
             .map(|m| m.file_type().is_symlink())
             .unwrap_or(false);
         if symlink_exists {
-            fs::remove_file(&symlink_path)
+            remove_dir_link(&symlink_path)
                 .map_err(|e| format!("remove symlink {}: {e}", symlink_path.display()))?;
         }
-        create_symlink(
-            std::path::Path::new("../../.agents/skills/buzz-cli"),
-            &symlink_path,
-        )
-        .map_err(|e| format!("symlink {}: {e}", symlink_path.display()))?;
+        let target = skill_link_target(root, ".claude/skills");
+        create_dir_link(&target, &symlink_path)
+            .map_err(|e| format!("symlink {}: {e}", symlink_path.display()))?;
     }
 
     fs::write(&version_path, format!("{NEST_SKILL_VERSION}\n"))

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -256,7 +256,6 @@ fn ensure_nest_migrates_old_skill_dir() {
     );
 }
 
-#[cfg(unix)]
 #[test]
 fn ensure_skill_symlinks_are_idempotent() {
     let tmp = tempfile::tempdir().unwrap();
@@ -264,15 +263,24 @@ fn ensure_skill_symlinks_are_idempotent() {
     ensure_nest_at(&root).unwrap();
     // Second call should succeed without errors.
     ensure_nest_at(&root).unwrap();
-    // All symlinks still valid and point to relative targets.
     for dir in [".goose/skills", ".claude/skills", ".codex/skills"] {
         let link = root.join(dir).join("buzz-cli");
         assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
         assert!(
             link.join("SKILL.md").exists(),
-            "symlink at {dir}/buzz-cli should resolve to dir with SKILL.md"
+            "link at {dir}/buzz-cli should resolve to dir with SKILL.md"
         );
-        let target = fs::read_link(&link).unwrap();
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_skill_symlinks_use_relative_targets_on_unix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+    for dir in [".goose/skills", ".claude/skills", ".codex/skills"] {
+        let target = fs::read_link(root.join(dir).join("buzz-cli")).unwrap();
         assert_eq!(
             target.to_str().unwrap(),
             format!("../../{CANONICAL_SKILL_DIR}"),
@@ -281,7 +289,27 @@ fn ensure_skill_symlinks_are_idempotent() {
     }
 }
 
-#[cfg(unix)]
+/// Windows junctions — the fallback when symlink creation is denied — store
+/// only absolute targets, so the nest is not relocatable there.
+#[cfg(windows)]
+#[test]
+fn ensure_skill_symlinks_use_absolute_targets_on_windows() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+    // Windows stores link targets in verbatim (`\\?\C:\…`) form, which never
+    // compares equal to the path passed in — canonicalize both sides.
+    let canonical = root.join(CANONICAL_SKILL_DIR).canonicalize().unwrap();
+    for dir in [".goose/skills", ".claude/skills", ".codex/skills"] {
+        let link = root.join(dir).join("buzz-cli");
+        let stored = fs::read_link(&link).unwrap().canonicalize().unwrap();
+        assert_eq!(
+            stored, canonical,
+            "link at {dir}/buzz-cli should resolve to the canonical skill dir"
+        );
+    }
+}
+
 #[test]
 fn ensure_skill_symlinks_skips_existing_path_during_initial_pass() {
     // ensure_skill_symlinks skips any path where symlink_metadata succeeds.
@@ -316,28 +344,32 @@ fn ensure_skill_symlinks_skips_existing_path_during_initial_pass() {
     );
 }
 
-#[cfg(unix)]
 #[test]
 fn ensure_skill_symlinks_skip_dangling_symlink() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join(".buzz");
-    // Pre-create a dangling symlink where the .codex link would go.
+    // Pre-create a dangling link where the .codex link would go.
     let codex_skills = root.join(".codex/skills");
     fs::create_dir_all(&codex_skills).unwrap();
     let dangling = codex_skills.join("buzz-cli");
-    std::os::unix::fs::symlink("/nonexistent/target", &dangling).unwrap();
+    let missing = tmp.path().join("nonexistent-target");
+    // A junction cannot be created against a missing target, so make the
+    // target vanish after linking rather than before.
+    fs::create_dir_all(&missing).unwrap();
+    crate::util::create_dir_link(&missing, &dangling).unwrap();
+    fs::remove_dir(&missing).unwrap();
 
     ensure_nest_at(&root).unwrap();
 
-    // Dangling symlink should be left alone (not clobbered).
+    // Dangling link should be left alone (not clobbered).
     assert!(dangling
         .symlink_metadata()
         .unwrap()
         .file_type()
         .is_symlink());
-    assert_eq!(
-        fs::read_link(&dangling).unwrap().to_str().unwrap(),
-        "/nonexistent/target"
+    assert!(
+        !dangling.join("SKILL.md").exists(),
+        "dangling link should not have been repointed at the canonical skill dir"
     );
 }
 

--- a/desktop/src-tauri/src/util.rs
+++ b/desktop/src-tauri/src/util.rs
@@ -77,6 +77,69 @@ pub(crate) fn symlink_points_to(link: &std::path::Path, target: &std::path::Path
             .unwrap_or(false)
 }
 
+/// Link a directory at `link` so it resolves to `target`.
+///
+/// Unix uses a plain symlink. Windows prefers a directory symlink and falls
+/// back to a junction, which needs neither Developer Mode nor elevation —
+/// without the fallback this fails for most users. Junctions only address
+/// local volumes, so the symlink attempt comes first to keep UNC targets
+/// working.
+#[cfg(unix)]
+pub(crate) fn create_dir_link(
+    target: &std::path::Path,
+    link: &std::path::Path,
+) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+pub(crate) fn create_dir_link(
+    target: &std::path::Path,
+    link: &std::path::Path,
+) -> std::io::Result<()> {
+    use std::os::windows::process::CommandExt;
+
+    let symlink_error = match std::os::windows::fs::symlink_dir(target, link) {
+        Ok(()) => return Ok(()),
+        Err(error) => error,
+    };
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    // `raw_arg` because cmd.exe re-parses its command line with rules the
+    // standard argument escaping does not match; paths cannot contain `"`,
+    // so quoting them here is sufficient.
+    let output = std::process::Command::new("cmd")
+        .arg("/C")
+        .raw_arg(format!(
+            "mklink /J \"{}\" \"{}\"",
+            link.display(),
+            target.display()
+        ))
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(std::io::Error::other(format!(
+        "symlink failed ({symlink_error}) and junction fallback failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    )))
+}
+
+/// Remove a directory link created by [`create_dir_link`].
+///
+/// Windows directory symlinks and junctions are directory entries, so
+/// `remove_file` refuses them; `remove_dir` unlinks without following.
+#[cfg(unix)]
+pub(crate) fn remove_dir_link(link: &std::path::Path) -> std::io::Result<()> {
+    std::fs::remove_file(link)
+}
+
+#[cfg(windows)]
+pub(crate) fn remove_dir_link(link: &std::path::Path) -> std::io::Result<()> {
+    std::fs::remove_dir(link)
+}
+
 /// Compute a collision-safe backup path for `dst`.
 ///
 /// The candidate is `<parent>/<full-filename>.bak.<ms-timestamp>`. If that


### PR DESCRIPTION
## Problem

`ensure_skill_symlinks` is a no-op on non-Unix. The canonical skill is written to
`.agents/skills/buzz-cli/SKILL.md`, but nothing links to it, so on Windows the
harness skill directories are never created:

```
$ ls ~/.buzz-dev/.agents/skills/buzz-cli/SKILL.md
SKILL.md                                  <- written
$ ls ~/.buzz-dev/.claude/skills
No such file or directory                 <- never created
$ ls ~/.buzz-dev/.goose/skills
No such file or directory
```

`nest_skill.md` is the document that teaches an agent the CLI it uses to publish
every reply. On Windows no agent has ever loaded it.

## Fix

`ensure_skill_symlinks` becomes platform-neutral and uses `create_dir_link`,
which tries `symlink_dir` and falls back to a junction — neither Developer Mode
nor elevation required. A new `skill_link_target` picks the target form:
relative on Unix, absolute on Windows, because junctions store only absolute
targets.

Unix behaviour is unchanged by construction — `create_dir_link` on Unix is the
same `std::os::unix::fs::symlink` the previous code called, and the relative
target string is pinned by a test.

### A second hole in the same area

`refresh_skill_md_if_stale` removes the old real `.claude/skills/buzz-cli`
directory on *every* platform but re-created the link only under `#[cfg(unix)]`.
On Windows a `NEST_SKILL_VERSION` bump would have deleted the directory and left
nothing behind. Made platform-neutral in the same commit.

## Tests

The three skill-link tests were `#[cfg(unix)]`, so the platform that was broken
had no coverage. They now run everywhere:

- relative-target assertion stays Unix-only; a new test asserts the absolute
  target on Windows
- the dangling-link test creates its link and *then* deletes the target — a
  junction cannot be created against a target that does not exist

Also removes three dead-code warnings that only appeared on Windows
(`known_skill_dirs` import and function, `runtime_metadata::skill_dir`).

## Notes for review

**Overlap with #3547.** `create_dir_link` and `remove_dir_link` are identical to
the versions in that PR, which has not merged. They are carried here so this
branch compiles standalone. Happy to rebase onto whichever lands first.

**Reproducing on Windows needs the dev-tooling PRs.** `just dev` cannot run off
`main` on Windows — the Tauri `beforeDevCommand` is `exec ./node_modules/.bin/vite`
and cmd.exe has no `exec` (#3534). Verification here ran on `main` plus #3534,
#3546, #3545 and #3540, with this commit's diff confirmed untouched by that
merge. The fix itself depends on none of them.

## Verification

On Windows 11, Developer Mode off, non-elevated process:

- deleted all three existing links, booted, all three came back as
  `LinkType=Junction` resolving to `.agents/skills/buzz-cli/SKILL.md`
- an agent asked to list its skills named `buzz-cli`; `~/.claude/skills` is empty
  on that box, so the nest link is the only possible source
- desktop lib suite: 1946 passed, 1 pre-existing unrelated failure
