### PR TITLE
feat(cli): scope message search to one channel

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -427,9 +427,42 @@ pub async fn cmd_get_thread(
     Ok(())
 }
 
+/// Build the NIP-50 search filter sent to the relay.
+///
+/// `channel` becomes an `#h` tag. The relay intersects it with the caller's
+/// accessible channels, so an unreadable id returns nothing rather than
+/// widening access — scoping here narrows results, it is never the access
+/// boundary.
+fn build_search_filter(
+    query: Option<&str>,
+    channel: Option<&str>,
+    author_hex: Option<&str>,
+    since: Option<i64>,
+    limit: u32,
+) -> serde_json::Value {
+    let mut filter = serde_json::json!({
+        "kinds": [9, 40002, 45001, 45003],
+        "limit": limit
+    });
+    if let Some(q) = query {
+        filter["search"] = serde_json::json!(q);
+    }
+    if let Some(channel_id) = channel {
+        filter["#h"] = serde_json::json!([channel_id]);
+    }
+    if let Some(pk) = author_hex {
+        filter["authors"] = serde_json::json!([pk]);
+    }
+    if let Some(s) = since {
+        filter["since"] = serde_json::json!(s);
+    }
+    filter
+}
+
 pub async fn cmd_search(
     client: &BuzzClient,
     query: Option<&str>,
+    channel: Option<&str>,
     author: Option<&str>,
     since: Option<i64>,
     limit: Option<u32>,
@@ -440,6 +473,9 @@ pub async fn cmd_search(
             "at least one of --query or --author is required".into(),
         ));
     }
+    if let Some(channel_id) = channel {
+        validate_uuid(channel_id)?;
+    }
     let limit = limit.unwrap_or(20).min(100);
 
     let author_hex = match author {
@@ -447,19 +483,7 @@ pub async fn cmd_search(
         None => None,
     };
 
-    let mut filter = serde_json::json!({
-        "kinds": [9, 40002, 45001, 45003],
-        "limit": limit
-    });
-    if let Some(q) = query {
-        filter["search"] = serde_json::json!(q);
-    }
-    if let Some(ref pk) = author_hex {
-        filter["authors"] = serde_json::json!([pk]);
-    }
-    if let Some(s) = since {
-        filter["since"] = serde_json::json!(s);
-    }
+    let filter = build_search_filter(query, channel, author_hex.as_deref(), since, limit);
     let resp = client.query(&filter).await?;
     let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
     // The full-text path returns relevance order; a pure author/time query has
@@ -970,6 +994,7 @@ pub async fn dispatch(
         } => cmd_get_thread(client, &channel, &event, limit, depth_limit, format).await,
         MessagesCmd::Search {
             query,
+            channel,
             author,
             since,
             limit,
@@ -977,6 +1002,7 @@ pub async fn dispatch(
             cmd_search(
                 client,
                 query.as_deref(),
+                channel.as_deref(),
                 author.as_deref(),
                 since,
                 limit,
@@ -993,8 +1019,8 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        build_search_filter, event_mention_pubkeys, find_root_from_tags, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys,
     };
     use buzz_sdk::mentions::{
@@ -1011,6 +1037,34 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    const CHANNEL_ID: &str = "0b3a4bd2-4d4a-4a0e-9c3f-1f2d3e4a5b6c";
+
+    #[test]
+    fn search_filter_scopes_to_one_channel() {
+        let filter = build_search_filter(Some("checkout"), Some(CHANNEL_ID), None, None, 20);
+        assert_eq!(filter["#h"], json!([CHANNEL_ID]));
+        assert_eq!(filter["search"], json!("checkout"));
+    }
+
+    #[test]
+    fn search_filter_omits_channel_tag_when_unscoped() {
+        let filter = build_search_filter(Some("checkout"), None, None, None, 20);
+        assert!(
+            filter.get("#h").is_none(),
+            "an unscoped search must not send an #h tag"
+        );
+    }
+
+    #[test]
+    fn search_filter_combines_channel_with_author_and_since() {
+        let filter = build_search_filter(None, Some(CHANNEL_ID), Some(PUBKEY), Some(1783497600), 5);
+        assert_eq!(filter["#h"], json!([CHANNEL_ID]));
+        assert_eq!(filter["authors"], json!([PUBKEY]));
+        assert_eq!(filter["since"], json!(1783497600));
+        assert_eq!(filter["limit"], json!(5));
+        assert!(filter.get("search").is_none());
+    }
 
     #[test]
     fn root_marker_wins_over_reply_marker() {

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -478,12 +478,16 @@ pub enum MessagesCmd {
     },
     /// Full-text search across messages
     #[command(
-        after_help = "Examples:\n  buzz messages search --query checkout\n  buzz messages search --author npub1... --since 1783497600\n  buzz messages search --author Aaron --query checkout --limit 20"
+        after_help = "Examples:\n  buzz messages search --query checkout\n  buzz messages search --author npub1... --since 1783497600\n  buzz messages search --author Aaron --query checkout --limit 20\n  buzz messages search --channel <UUID> --query checkout"
     )]
     Search {
         /// Search query string (optional when --author is given)
         #[arg(long)]
         query: Option<String>,
+        /// Restrict results to one channel (UUID, from 'buzz channels list').
+        /// Omit to search every channel you can read.
+        #[arg(long)]
+        channel: Option<String>,
         /// Filter by author: 64-char hex pubkey, npub, or display name
         #[arg(long)]
         author: Option<String>,


### PR DESCRIPTION
## Problem

`buzz messages search` is community-wide only. There is no way to search within
a single channel, so the common case — "what was said about X *here*" — has to be
done by fetching pages of `messages get` and grepping, or by searching everything
and filtering by hand.

This matters most for agents. An agent whose context window has been truncated
knows its channel id and nothing else; without channel scoping it cannot look up
its own recent history.

## Change

Adds `--channel <UUID>` to `buzz messages search`. It becomes an `#h` tag on the
NIP-50 filter.

```
buzz messages search --channel <UUID> --query checkout
```

**No relay work.** `api/bridge.rs` already reads `#h` off a search filter,
intersects the values with the caller's accessible channels, and skips the filter
entirely when none survive. The flag narrows results; it is never the access
boundary. An id the caller cannot read returns an empty list, exactly as if the
channel were empty.

`--channel` is validated with `validate_uuid` before any network call, so a
malformed id exits 1 with `{"error":"user_error","message":"invalid UUID: …"}`
rather than producing a confusing empty result.

## Tests

`cmd_search` needs a live client, so the filter construction is extracted into a
pure `build_search_filter` and unit-tested — scoped, unscoped, and combined with
`--author`/`--since`. That matches the existing convention in this module
(pure helper + unit test).

## Verification

End-to-end against a local relay with three generated identities:

| Check | Result |
|---|---|
| Unscoped search | finds messages in both test channels |
| `--channel A` | finds only channel A's message |
| Identity 1 → identity 2's **private** channel | `[]` |
| Scoped to a **DM** channel id | only the DM message |
| Non-participant → that DM | `[]` |

The private-channel case was checked both ways: the scoped search returned `[]`,
and the same identity's *unscoped* search did not contain the message either —
so the ACL is doing the work, not the flag. The non-participant's unscoped search
still returned the two open channels, confirming correct visibility rather than
blanket denial.

DMs needed no special handling: they are ordinary messages tagged
`h=<channel-id>`, so channel scoping and the ACL apply unchanged.
