### PR TITLE
fix(desktop): render goose's system prompt in the activity log

### DIFF
--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -2077,3 +2077,59 @@ test("buildTranscript session/new bare systemPrompt field takes precedence over 
     "_meta.systemPrompt.append must not appear when bare field is present",
   );
 });
+
+test("goose's custom system-prompt request renders the same System prompt card", () => {
+  // Goose takes its standing context through a separate request after
+  // session/new (`_goose/unstable/session/system-prompt/set`, acp.rs), not a
+  // field on it. Before this was read, goose agents showed no System prompt
+  // card at all while every other runtime did.
+  const events = [
+    {
+      seq: 1,
+      timestamp: "2026-08-01T10:00:00.000Z",
+      kind: "acp_write",
+      agentIndex: 0,
+      channelId: "ch-1",
+      sessionId: null,
+      turnId: "turn-1",
+      payload: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "session/new",
+        params: { _meta: { sessionTitle: "Goosey #general" } },
+      },
+    },
+    {
+      seq: 2,
+      timestamp: "2026-08-01T10:00:00.100Z",
+      kind: "acp_write",
+      agentIndex: 0,
+      channelId: "ch-1",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      payload: {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "_goose/unstable/session/system-prompt/set",
+        params: {
+          sessionId: "sess-1",
+          mode: "append",
+          key: "buzz",
+          text: "[Base]\nYou are helpful.\n\n[System]\nObserver.",
+        },
+      },
+    },
+  ];
+
+  const items = flattenDisplayBlocks(
+    buildTranscriptDisplayBlocks(buildTranscript(events)),
+  );
+  const cards = items.filter((i) => i.title === "System prompt");
+  assert.equal(cards.length, 1, "expected exactly one System prompt card");
+  assert.deepEqual(
+    cards[0].sections.map((s) => s.title),
+    ["Base", "System"],
+  );
+  // Placed like the other two routes: standalone, out of any turn bucket.
+  assert.equal(cards[0].turnId ?? null, null);
+});

--- a/desktop/src/features/agents/ui/agentSessionTranscript.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.ts
@@ -896,6 +896,32 @@ export function processTranscriptEvent(
       }
     } else if (
       event.kind === "acp_write" &&
+      method === "_goose/unstable/session/system-prompt/set"
+    ) {
+      // Goose takes its system prompt through a separate request sent just
+      // after session/new (`session_set_goose_system_prompt`, buzz-acp
+      // acp.rs), not a field on it — so without this branch a goose agent
+      // showed no System prompt card at all, while every other runtime did.
+      // The request lands before the session's first turn, so reusing acpSource
+      // "session/new" puts the card in the same standalone slot as theirs.
+      const params = asRecord(payload.params);
+      const systemPrompt = asString(params.text);
+      if (systemPrompt) {
+        const sections = parseSystemPromptSections(systemPrompt);
+        if (sections.length > 0) {
+          upsertMetadata(
+            d,
+            `system-prompt:${ch}:${event.seq}:${event.timestamp}`,
+            "System prompt",
+            sections,
+            event.timestamp,
+            { ...ctx, turnId: null },
+            "session/new",
+          );
+        }
+      }
+    } else if (
+      event.kind === "acp_write" &&
       method === "_goose/unstable/session/steer"
     ) {
       const promptText = extractPromptText(payload);


### PR DESCRIPTION
## Problem

Goose agents never show a **System prompt** card in the agent activity log. Every other runtime does.

The transcript builder turns a `session/new` request into that card by reading `params.systemPrompt`. Goose does not receive its system prompt that way — `buzz-acp` sends it as a **separate request** immediately after `session/new`:

```rust
// crates/buzz-acp/src/acp.rs — session_set_goose_system_prompt
self.send_request(
    "_goose/unstable/session/system-prompt/set",
    json!({ "sessionId": session_id, "mode": "append", "key": "buzz", "text": text }),
)
```

`agentSessionTranscript.ts` has no branch for that method, so the request is observed but never rendered. The result is that a goose agent's base prompt, persona, team instructions, core memory and canvas are invisible in the UI — there is no way to see what the agent was actually told.

## Fix

Read `params.text` from that request and upsert the same `"System prompt"` metadata item the `session/new` path already produces.

The request lands before the session's first turn, so reusing the existing `acpSource: "session/new"` places the card in the same standalone slot at the head of the session run — no changes to grouping or presentation.

## Notes

- Purely additive: one new `else if` branch. No existing path changes, and nothing renders differently for runtimes that already worked.
- Goose falls back to user-message framing when the custom method is unsupported (`goose_system_prompt_supported == Some(false)`). That path is untouched — `[Base]` continues to appear in Prompt context as before.
- The Rust side already pins the request shape (`goose_system_prompt_request_uses_append_contract` asserts `method`, `mode`, `key` and `text` on the bytes written), and `write_ndjson` observes every outbound message, so the frame this branch consumes is guaranteed to be emitted.

## Test

One new test asserting a goose system-prompt request produces exactly one card, with the same `["Base", "System"]` sections, outside any turn bucket.

`pnpm test` 3886 passing, `pnpm typecheck` clean, `biome check` clean.

Not verified against a live goose agent — I have no goose model configured. The chain is covered by tests on both sides of the wire.
