### PR TITLE
fix(acp): treat an empty --respond-to-allowlist as absent

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -993,16 +993,28 @@ impl Config {
             )));
         }
 
+        // An empty `BUZZ_ACP_RESPOND_TO_ALLOWLIST` is how launchers spell "no
+        // allowlist" — the env var is exported unconditionally and clap turns
+        // `""` into `Some([""])`, which is *set* but carries no entries. Treat
+        // blank entries as absent so an empty export neither trips the
+        // ignored-flag warning below nor reaches hex validation as a bogus
+        // pubkey.
+        let allowlist_entries: Vec<String> = args
+            .respond_to_allowlist
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|entry| !entry.trim().is_empty())
+            .collect();
+
         let respond_to_allowlist = if args.respond_to == RespondTo::Allowlist {
-            let raw = args.respond_to_allowlist.unwrap_or_default();
-            if raw.is_empty() {
+            if allowlist_entries.is_empty() {
                 return Err(ConfigError::ConfigFile(
                     "--respond-to=allowlist requires --respond-to-allowlist with at least one pubkey".into(),
                 ));
             }
-            validate_allowlist(&raw)?
+            validate_allowlist(&allowlist_entries)?
         } else {
-            if args.respond_to_allowlist.is_some() {
+            if !allowlist_entries.is_empty() {
                 tracing::warn!(
                     "--respond-to-allowlist is ignored when --respond-to is not 'allowlist'"
                 );
@@ -2716,6 +2728,55 @@ channels = "ALL"
     // A minimal valid private key for test use (secp256k1 scalar = 1).
     const TEST_PRIVATE_KEY: &str =
         "0000000000000000000000000000000000000000000000000000000000000001";
+
+    #[test]
+    fn empty_allowlist_is_treated_as_absent() {
+        // Launchers export BUZZ_ACP_RESPOND_TO_ALLOWLIST unconditionally, so an
+        // agent with no allowlist gets `""`. clap parses that into Some([""]),
+        // which must not read as "an allowlist was supplied".
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--respond-to",
+            "anyone",
+            "--respond-to-allowlist",
+            "",
+        ])
+        .expect("clap should parse args");
+        let config = Config::from_args(args).expect("empty allowlist should not fail config");
+
+        assert!(
+            config.respond_to_allowlist.is_empty(),
+            "blank entries must not land in the resolved allowlist"
+        );
+    }
+
+    #[test]
+    fn empty_allowlist_in_allowlist_mode_reports_the_missing_pubkey_error() {
+        // Same empty export, but in allowlist mode: the blank entry must surface
+        // the "requires at least one pubkey" error rather than failing hex
+        // validation on an empty string.
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--respond-to",
+            "allowlist",
+            "--respond-to-allowlist",
+            "",
+        ])
+        .expect("clap should parse args");
+        let result = Config::from_args(args);
+
+        let msg = result
+            .expect_err("allowlist mode with a blank allowlist must fail")
+            .to_string();
+        assert!(
+            msg.contains("at least one pubkey"),
+            "error should name the missing pubkey requirement: {msg}"
+        );
+    }
 
     #[test]
     fn allowed_respond_to_full_path_rejects_disallowed_mode() {


### PR DESCRIPTION
## Problem

Launchers export `BUZZ_ACP_RESPOND_TO_ALLOWLIST` unconditionally, so an agent with no allowlist gets `""`. With `value_delimiter = ','`, clap parses that into `Some([""])` — *set*, but carrying no entries. Two paths treated that as "an allowlist was supplied":

1. **Non-allowlist modes logged a misleading warning on every startup:**
   ```
   WARN buzz_acp::config: --respond-to-allowlist is ignored when --respond-to is not 'allowlist'
   ```
   The check was `args.respond_to_allowlist.is_some()`. Every agent on an unconfigured allowlist logged this at each launch, implying an allowlist had been set when none had. Found while debugging a fleet of eight agents, all of which had `respond_to: anyone` and an empty allowlist.

2. **Allowlist mode reported the wrong error.** The blank entry skipped the `is_empty()` guard and reached `validate_allowlist`, so a misconfigured launcher got a hex-validation failure instead of the intended `--respond-to=allowlist requires --respond-to-allowlist with at least one pubkey`.

## Fix

Filter blank entries once, before both checks, so an empty export reads as absent.

Desktop's spawn path already removes the variable in non-allowlist modes (`build_respond_to_env`, `managed_agents/runtime.rs`); this covers every other launcher.

## Tests

Two added:
- `empty_allowlist_is_treated_as_absent` — `--respond-to=anyone --respond-to-allowlist=""` resolves to an empty allowlist without error.
- `empty_allowlist_in_allowlist_mode_reports_the_missing_pubkey_error` — the same empty value in allowlist mode surfaces the missing-pubkey error, not a hex failure.

`cargo fmt --check`, `cargo clippy -p buzz-acp --all-targets -- -D warnings`, and all 114 `config::` tests pass.

*Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXtzskvxVRMTnAGwwC7Dxz