### PR TITLE
feat(cli): expose verified reaction events

### DIFF
--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -33,6 +33,7 @@ buzz messages send --channel <uuid> --content "Hello"
 buzz messages send --channel <uuid> --content "Reply" --reply-to <event-id> --broadcast
 buzz messages send --channel <uuid> --content - < message.md   # read body from stdin
 buzz messages get --channel <uuid> --limit 20
+buzz --format raw messages get --channel <uuid> --limit 20  # complete signed Nostr events
 buzz messages thread --channel <uuid> --event <event-id>
 buzz messages search --query "architecture"
 buzz messages search --author <pubkey|npub|name> --since <unix-ts>
@@ -94,6 +95,11 @@ buzz repos protect remove --id my-repo --ref refs/heads/main
 # Pipe to jq
 buzz channels list | jq '.[].name'
 ```
+
+`--format raw` preserves complete relay event objects, including signatures, for
+`messages get`, `messages thread`, and `messages search`. Raw message results are
+ordered deterministically by timestamp and event ID when the command applies a
+chronological sort.
 
 `protect set` replaces every existing rule for the exact ref pattern. Any
 constraint omitted from the command is removed. `protect list` reports malformed

--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -51,6 +51,7 @@ buzz channels topic --channel <uuid> --topic "New topic"
 # Reactions
 buzz reactions add --event <event-id> --emoji "👍"
 buzz reactions get --event <event-id>
+buzz reactions get --event <event-id> --events  # verified signed kind-7 events, oldest first
 
 # Users & Presence
 buzz users get                          # your own profile

--- a/crates/buzz-cli/TESTING.md
+++ b/crates/buzz-cli/TESTING.md
@@ -280,6 +280,11 @@ buzz reactions add --event "$REACT_ID" --emoji "👍" | jq .
 buzz reactions get --event "$REACT_ID" | jq .
 # Expected: {"reactions":[{"emoji":"...","count":N,"pubkeys":["..."]}]}
 
+# complete, cryptographically-verified kind-7 reaction events from every query page,
+# ordered by created_at ascending and then exact event ID for deterministic first-wins consumers
+buzz reactions get --event "$REACT_ID" --events | jq .
+# Expected: {"events":[{"id":"...","pubkey":"...","kind":7,"content":"...","created_at":N,"tags":[...],"sig":"..."}]}
+
 # reactions remove
 buzz reactions remove --event "$REACT_ID" --emoji "👍" | jq .
 ```

--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -106,6 +106,11 @@ pub async fn cmd_list_channels(
             serde_json::to_string(&compact).unwrap_or_default()
         }
         crate::OutputFormat::Json => serde_json::to_string(&channels).unwrap_or_default(),
+        crate::OutputFormat::Raw => {
+            return Err(CliError::Usage(
+                "--format raw is not supported by channels list".into(),
+            ));
+        }
     };
     println!("{output}");
     Ok(())

--- a/crates/buzz-cli/src/commands/feed.rs
+++ b/crates/buzz-cli/src/commands/feed.rs
@@ -59,6 +59,11 @@ pub async fn cmd_get_feed(
             serde_json::to_string(&compact).unwrap_or_default()
         }
         crate::OutputFormat::Json => normalized,
+        crate::OutputFormat::Raw => {
+            return Err(CliError::Usage(
+                "--format raw is not supported by feed get".into(),
+            ));
+        }
     };
     println!("{output}");
     Ok(())

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -1,5 +1,5 @@
 use buzz_sdk::{DeleteMessageOptions, DiffMeta, ThreadRef, VoteDirection};
-use nostr::PublicKey;
+use nostr::{Event, PublicKey};
 use uuid::Uuid;
 
 use crate::client::{normalize_events, normalize_write_response, BuzzClient};
@@ -329,11 +329,69 @@ fn parse_member_pubkeys(event: &serde_json::Value) -> Vec<String> {
         .collect()
 }
 
-fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
+fn parse_query_events(raw: &str) -> Result<Vec<serde_json::Value>, CliError> {
+    serde_json::from_str(raw)
+        .map_err(|e| CliError::Other(format!("failed to parse messages query response: {e}")))
+}
+
+fn event_created_at(event: &serde_json::Value) -> u64 {
+    event
+        .get("created_at")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0)
+}
+
+fn event_id(event: &serde_json::Value) -> &str {
+    event
+        .get("id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+}
+
+fn sort_events_oldest_first(events: &mut [serde_json::Value]) {
+    events.sort_by(|left, right| {
+        event_created_at(left)
+            .cmp(&event_created_at(right))
+            .then_with(|| event_id(left).cmp(event_id(right)))
+    });
+}
+
+fn sort_events_newest_first(events: &mut [serde_json::Value]) {
+    events.sort_by(|left, right| {
+        event_created_at(right)
+            .cmp(&event_created_at(left))
+            .then_with(|| event_id(left).cmp(event_id(right)))
+    });
+}
+
+fn verify_raw_events(events: &[serde_json::Value]) -> Result<(), CliError> {
+    for (index, raw_event) in events.iter().enumerate() {
+        let event: Event = serde_json::from_value(raw_event.clone()).map_err(|e| {
+            CliError::Other(format!(
+                "malformed messages query response: event {index} is not a complete Nostr event: {e}"
+            ))
+        })?;
+        event.verify().map_err(|e| {
+            CliError::Other(format!(
+                "malformed messages query response: event {index} failed cryptographic verification: {e}"
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
+fn format_events(
+    events: &[serde_json::Value],
+    format: &crate::OutputFormat,
+) -> Result<String, CliError> {
     match format {
         crate::OutputFormat::Compact => {
+            let normalized = normalize_events(events);
             let events: Vec<serde_json::Value> =
-                serde_json::from_str(normalized).unwrap_or_default();
+                serde_json::from_str(&normalized).map_err(|e| {
+                    CliError::Other(format!("failed to format normalized message events: {e}"))
+                })?;
             let compact: Vec<serde_json::Value> = events
                 .iter()
                 .map(|e| {
@@ -344,9 +402,16 @@ fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
                     })
                 })
                 .collect();
-            serde_json::to_string(&compact).unwrap_or_default()
+            serde_json::to_string(&compact)
+                .map_err(|e| CliError::Other(format!("failed to serialize message events: {e}")))
         }
-        crate::OutputFormat::Json => normalized.to_string(),
+        crate::OutputFormat::Json => Ok(normalize_events(events)),
+        crate::OutputFormat::Raw => {
+            verify_raw_events(events)?;
+            serde_json::to_string(events).map_err(|e| {
+                CliError::Other(format!("failed to serialize raw message events: {e}"))
+            })
+        }
     }
 }
 
@@ -384,10 +449,9 @@ pub async fn cmd_get_messages(
     }
 
     let resp = client.query(&filter).await?;
-    let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
-    events.sort_by_key(|e| e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0));
-    let normalized = normalize_events(&events);
-    println!("{}", format_events(&normalized, format));
+    let mut events = parse_query_events(&resp)?;
+    sort_events_oldest_first(&mut events);
+    println!("{}", format_events(&events, format)?);
     Ok(())
 }
 
@@ -420,10 +484,9 @@ pub async fn cmd_get_thread(
         "limit": 1
     });
     let resp = client.query_multi(&[reply_filter, root_filter]).await?;
-    let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
-    events.sort_by_key(|e| e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0));
-    let normalized = normalize_events(&events);
-    println!("{}", format_events(&normalized, format));
+    let mut events = parse_query_events(&resp)?;
+    sort_events_oldest_first(&mut events);
+    println!("{}", format_events(&events, format)?);
     Ok(())
 }
 
@@ -461,16 +524,13 @@ pub async fn cmd_search(
         filter["since"] = serde_json::json!(s);
     }
     let resp = client.query(&filter).await?;
-    let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
+    let mut events = parse_query_events(&resp)?;
     // The full-text path returns relevance order; a pure author/time query has
     // no relevance, so present newest-first like `messages get`.
     if query.is_none() {
-        events.sort_by_key(|e| {
-            std::cmp::Reverse(e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0))
-        });
+        sort_events_newest_first(&mut events);
     }
-    let normalized = normalize_events(&events);
-    println!("{}", format_events(&normalized, format));
+    println!("{}", format_events(&events, format)?);
     Ok(())
 }
 
@@ -993,13 +1053,14 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
-        resolve_names_to_pubkeys,
+        event_mention_pubkeys, find_root_from_tags, format_events, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        parse_query_events, resolve_names_to_pubkeys, sort_events_oldest_first,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
+    use nostr::{Event, EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
 
     const ID_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -1011,6 +1072,105 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    fn signed_message(keys: &Keys, created_at: u64, content: &str) -> Event {
+        EventBuilder::new(Kind::Custom(9), content)
+            .tags([Tag::parse(["h", "11111111-1111-4111-8111-111111111111"]).unwrap()])
+            .custom_created_at(Timestamp::from(created_at))
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    #[test]
+    fn raw_format_round_trips_complete_signed_events_deterministically() {
+        let keys = Keys::generate();
+        let mut signed = [
+            signed_message(&keys, 123, "first"),
+            signed_message(&keys, 123, "second"),
+        ];
+        signed.sort_by_key(|event| event.id);
+        let mut second = serde_json::to_value(&signed[1]).unwrap();
+        second["relay_extension"] = json!({ "preserved": true });
+        let mut events = vec![second, serde_json::to_value(&signed[0]).unwrap()];
+
+        sort_events_oldest_first(&mut events);
+        let raw = format_events(&events, &crate::OutputFormat::Raw).unwrap();
+        let round_trip: Vec<serde_json::Value> = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(round_trip, events);
+        assert_eq!(round_trip[0]["id"], signed[0].id.to_hex());
+        assert_eq!(round_trip[0]["sig"], signed[0].sig.to_string());
+        assert_eq!(round_trip[1]["id"], signed[1].id.to_hex());
+        assert_eq!(round_trip[1]["sig"], signed[1].sig.to_string());
+        assert_eq!(round_trip[1]["relay_extension"]["preserved"], true);
+    }
+
+    #[test]
+    fn raw_format_rejects_empty_object() {
+        assert!(format_events(&[json!({})], &crate::OutputFormat::Raw).is_err());
+    }
+
+    #[test]
+    fn raw_format_rejects_missing_signature() {
+        let mut raw =
+            serde_json::to_value(signed_message(&Keys::generate(), 123, "message")).unwrap();
+        raw.as_object_mut().unwrap().remove("sig");
+
+        assert!(format_events(&[raw], &crate::OutputFormat::Raw).is_err());
+    }
+
+    #[test]
+    fn raw_format_rejects_bad_event_schema() {
+        let mut raw =
+            serde_json::to_value(signed_message(&Keys::generate(), 123, "message")).unwrap();
+        raw["tags"] = json!("not-an-array");
+
+        assert!(format_events(&[raw], &crate::OutputFormat::Raw).is_err());
+    }
+
+    #[test]
+    fn raw_format_rejects_mismatched_event_id() {
+        let mut raw =
+            serde_json::to_value(signed_message(&Keys::generate(), 123, "message")).unwrap();
+        raw["id"] = json!("0".repeat(64));
+
+        assert!(format_events(&[raw], &crate::OutputFormat::Raw).is_err());
+    }
+
+    #[test]
+    fn raw_format_rejects_invalid_signature() {
+        let mut raw =
+            serde_json::to_value(signed_message(&Keys::generate(), 123, "message")).unwrap();
+        raw["sig"] = json!("0".repeat(128));
+
+        assert!(format_events(&[raw], &crate::OutputFormat::Raw).is_err());
+    }
+
+    #[test]
+    fn normalized_json_still_omits_signatures() {
+        let event = json!({
+            "id": ID_A,
+            "pubkey": PK_VALID_A,
+            "created_at": 123,
+            "kind": 9,
+            "tags": [["h", "11111111-1111-4111-8111-111111111111"]],
+            "content": "message",
+            "sig": "1".repeat(128),
+        });
+
+        let output = format_events(&[event], &crate::OutputFormat::Json).unwrap();
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+
+        assert!(rows[0].get("sig").is_none());
+    }
+
+    #[test]
+    fn malformed_query_json_is_an_error() {
+        let error = parse_query_events("{not-json").unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("failed to parse messages query response"));
+    }
 
     #[test]
     fn root_marker_wins_over_reply_marker() {

--- a/crates/buzz-cli/src/commands/reactions.rs
+++ b/crates/buzz-cli/src/commands/reactions.rs
@@ -1,10 +1,108 @@
 use std::collections::HashMap;
 
-use nostr::EventId;
+use nostr::{Event, EventId, Kind};
 
 use crate::client::{normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::validate_hex64;
+
+fn verify_reaction_events(
+    raw_events: Vec<serde_json::Value>,
+    target_event_id: &str,
+) -> Result<Vec<Event>, CliError> {
+    let mut events = Vec::with_capacity(raw_events.len());
+    for (index, raw_event) in raw_events.into_iter().enumerate() {
+        let event: Event = serde_json::from_value(raw_event).map_err(|e| {
+            CliError::Other(format!(
+                "malformed reactions query response: event {index} is not a complete Nostr event: {e}"
+            ))
+        })?;
+        event.verify().map_err(|e| {
+            CliError::Other(format!(
+                "malformed reactions query response: event {index} failed cryptographic verification: {e}"
+            ))
+        })?;
+        if event.kind != Kind::Reaction {
+            return Err(CliError::Other(format!(
+                "malformed reactions query response: event {index} has kind {}, expected 7",
+                event.kind.as_u16()
+            )));
+        }
+        let targets_requested_event = event.tags.iter().any(|tag| {
+            let tag = tag.as_slice();
+            tag.first().map(String::as_str) == Some("e")
+                && tag.get(1).map(String::as_str) == Some(target_event_id)
+        });
+        if !targets_requested_event {
+            return Err(CliError::Other(format!(
+                "malformed reactions query response: event {index} does not target {target_event_id}"
+            )));
+        }
+        events.push(event);
+    }
+
+    Ok(events)
+}
+
+fn render_reactions(mut events: Vec<Event>, include_events: bool) -> Result<String, CliError> {
+    if include_events {
+        events.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        return serde_json::to_string(&serde_json::json!({ "events": events }))
+            .map_err(|e| CliError::Other(format!("failed to serialize reaction events: {e}")));
+    }
+
+    let mut groups: HashMap<String, Vec<String>> = HashMap::new();
+    for event in &events {
+        let emoji = if event.content.is_empty() {
+            "+"
+        } else {
+            &event.content
+        };
+        groups
+            .entry(emoji.to_string())
+            .or_default()
+            .push(event.pubkey.to_hex());
+    }
+
+    let mut reactions: Vec<serde_json::Value> = groups
+        .into_iter()
+        .map(|(emoji, pubkeys)| {
+            serde_json::json!({
+                "emoji": emoji,
+                "count": pubkeys.len(),
+                "pubkeys": pubkeys,
+            })
+        })
+        .collect();
+    reactions.sort_by(|a, b| {
+        a.get("emoji")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .cmp(b.get("emoji").and_then(|v| v.as_str()).unwrap_or(""))
+    });
+
+    serde_json::to_string(&serde_json::json!({ "reactions": reactions }))
+        .map_err(|e| CliError::Other(format!("failed to serialize reactions: {e}")))
+}
+
+async fn fetch_reaction_events(
+    client: &BuzzClient,
+    target_event_id: &str,
+) -> Result<Vec<Event>, CliError> {
+    let filter = serde_json::json!({
+        "kinds": [7],
+        "#e": [target_event_id]
+    });
+    let raw_events = client.query_all(filter).await?;
+    let target_event_id = target_event_id.to_string();
+    tokio::task::spawn_blocking(move || verify_reaction_events(raw_events, &target_event_id))
+        .await
+        .map_err(|e| CliError::Other(format!("reaction verification task failed: {e}")))?
+}
 
 pub async fn cmd_add_reaction(
     client: &BuzzClient,
@@ -77,50 +175,17 @@ pub async fn cmd_remove_reaction(
     Ok(())
 }
 
-pub async fn cmd_get_reactions(client: &BuzzClient, event_id: &str) -> Result<(), CliError> {
+pub async fn cmd_get_reactions(
+    client: &BuzzClient,
+    event_id: &str,
+    include_events: bool,
+) -> Result<(), CliError> {
     validate_hex64(event_id)?;
-    let filter = serde_json::json!({
-        "kinds": [7],
-        "#e": [event_id]
-    });
-    let resp = client.query(&filter).await?;
-    let events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
-
-    let mut groups: HashMap<String, Vec<String>> = HashMap::new();
-    for e in &events {
-        let emoji = e
-            .get("content")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("+")
-            .to_string();
-        let pubkey = e
-            .get("pubkey")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        groups.entry(emoji).or_default().push(pubkey);
-    }
-
-    let mut reactions: Vec<serde_json::Value> = groups
-        .into_iter()
-        .map(|(emoji, pubkeys)| {
-            serde_json::json!({
-                "emoji": emoji,
-                "count": pubkeys.len(),
-                "pubkeys": pubkeys,
-            })
-        })
-        .collect();
-    reactions.sort_by(|a, b| {
-        a.get("emoji")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .cmp(b.get("emoji").and_then(|v| v.as_str()).unwrap_or(""))
-    });
-
-    let output = serde_json::json!({ "reactions": reactions });
-    println!("{}", serde_json::to_string(&output).unwrap_or_default());
+    let target_event_id = EventId::parse(event_id)
+        .map_err(|e| CliError::Usage(format!("invalid event ID: {e}")))?
+        .to_hex();
+    let events = fetch_reaction_events(client, &target_event_id).await?;
+    println!("{}", render_reactions(events, include_events)?);
     Ok(())
 }
 
@@ -133,6 +198,296 @@ pub async fn dispatch(cmd: crate::ReactionsCmd, client: &BuzzClient) -> Result<(
             emoji_url,
         } => cmd_add_reaction(client, &event, &emoji, emoji_url.as_deref()).await,
         ReactionsCmd::Remove { event, emoji } => cmd_remove_reaction(client, &event, &emoji).await,
-        ReactionsCmd::Get { event } => cmd_get_reactions(client, &event).await,
+        ReactionsCmd::Get { event, events } => cmd_get_reactions(client, &event, events).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use axum::{
+        body::Bytes,
+        extract::State,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        routing::post,
+        Json, Router,
+    };
+    use nostr::{Event, EventBuilder, EventId, Keys, Kind, Tag, Timestamp};
+    use tokio::net::TcpListener;
+
+    use super::{fetch_reaction_events, render_reactions, verify_reaction_events};
+    use crate::client::BuzzClient;
+
+    const TARGET_ID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn target_id() -> EventId {
+        EventId::from_hex(TARGET_ID).unwrap()
+    }
+
+    fn signed_reaction(keys: &Keys, created_at: u64, content: &str) -> Event {
+        buzz_sdk::build_reaction(target_id(), content)
+            .unwrap()
+            .custom_created_at(Timestamp::from(created_at))
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    fn signed_custom_reaction(keys: &Keys, created_at: u64) -> Event {
+        buzz_sdk::build_custom_emoji_reaction(target_id(), "fire", "https://example.com/fire.png")
+            .unwrap()
+            .custom_created_at(Timestamp::from(created_at))
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    fn verify(events: &[Event]) -> Result<Vec<Event>, crate::error::CliError> {
+        verify_reaction_events(
+            events
+                .iter()
+                .map(|event| serde_json::to_value(event).unwrap())
+                .collect(),
+            TARGET_ID,
+        )
+    }
+
+    #[test]
+    fn events_output_preserves_exact_full_event_fields_and_orders_oldest_first() {
+        let first_keys = Keys::generate();
+        let second_keys = Keys::generate();
+        let first = signed_reaction(&first_keys, 1_750_000_000, "+");
+        let second = signed_custom_reaction(&second_keys, 1_750_000_001);
+        let verified = verify(&[second.clone(), first.clone()]).unwrap();
+
+        let output: serde_json::Value =
+            serde_json::from_str(&render_reactions(verified, true).unwrap()).unwrap();
+
+        assert_eq!(
+            output,
+            serde_json::json!({
+                "events": [
+                    serde_json::to_value(&first).unwrap(),
+                    serde_json::to_value(&second).unwrap()
+                ]
+            })
+        );
+        assert_eq!(output["events"][0]["id"], first.id.to_hex());
+        assert_eq!(output["events"][0]["created_at"], 1_750_000_000u64);
+        assert_eq!(output["events"][0]["sig"], first.sig.to_string());
+        assert_eq!(
+            output["events"][1]["tags"][1],
+            serde_json::json!(["emoji", "fire", "https://example.com/fire.png"])
+        );
+    }
+
+    #[test]
+    fn events_output_breaks_timestamp_ties_by_exact_event_id() {
+        let keys = Keys::generate();
+        let mut events = vec![
+            signed_reaction(&keys, 1_750_000_000, "👎"),
+            signed_reaction(&keys, 1_750_000_000, "👍"),
+        ];
+        events.sort_by_key(|event| event.id);
+        let first_id = events[0].id.to_hex();
+        let second_id = events[1].id.to_hex();
+
+        let output: serde_json::Value =
+            serde_json::from_str(&render_reactions(verify(&events).unwrap(), true).unwrap())
+                .unwrap();
+
+        assert_eq!(output["events"][0]["id"], first_id);
+        assert_eq!(output["events"][1]["id"], second_id);
+    }
+
+    #[test]
+    fn aggregate_output_remains_compatible_by_default() {
+        let first_keys = Keys::generate();
+        let second_keys = Keys::generate();
+        let events = verify(&[
+            signed_reaction(&first_keys, 1, "👍"),
+            signed_reaction(&second_keys, 2, "👍"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            render_reactions(events, false).unwrap(),
+            format!(
+                r#"{{"reactions":[{{"count":2,"emoji":"👍","pubkeys":["{}","{}"]}}]}}"#,
+                first_keys.public_key().to_hex(),
+                second_keys.public_key().to_hex()
+            )
+        );
+    }
+
+    #[test]
+    fn forged_event_id_is_rejected_before_output() {
+        let event = signed_reaction(&Keys::generate(), 1, "+");
+        let mut forged = serde_json::to_value(event).unwrap();
+        forged["id"] = serde_json::json!("0".repeat(64));
+
+        assert!(verify_reaction_events(vec![forged], TARGET_ID).is_err());
+    }
+
+    #[test]
+    fn tampered_content_is_rejected_before_output() {
+        let event = signed_reaction(&Keys::generate(), 1, "+");
+        let mut tampered = serde_json::to_value(event).unwrap();
+        tampered["content"] = serde_json::json!("approve");
+
+        assert!(verify_reaction_events(vec![tampered], TARGET_ID).is_err());
+    }
+
+    #[test]
+    fn bad_schnorr_signature_is_rejected_before_output() {
+        let event = signed_reaction(&Keys::generate(), 1, "+");
+        let mut tampered = serde_json::to_value(event).unwrap();
+        tampered["sig"] = serde_json::json!("0".repeat(128));
+
+        assert!(verify_reaction_events(vec![tampered], TARGET_ID).is_err());
+    }
+
+    #[test]
+    fn incomplete_wrong_kind_and_wrong_target_rows_are_rejected() {
+        let keys = Keys::generate();
+        let valid = signed_reaction(&keys, 1, "+");
+        let mut incomplete = serde_json::to_value(&valid).unwrap();
+        incomplete.as_object_mut().unwrap().remove("sig");
+        let wrong_kind = EventBuilder::new(Kind::TextNote, "+")
+            .tags([Tag::event(target_id())])
+            .custom_created_at(Timestamp::from(1))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let wrong_target =
+            buzz_sdk::build_reaction(EventId::from_hex(&"b".repeat(64)).unwrap(), "+")
+                .unwrap()
+                .custom_created_at(Timestamp::from(1))
+                .sign_with_keys(&keys)
+                .unwrap();
+
+        for raw in [
+            incomplete,
+            serde_json::to_value(wrong_kind).unwrap(),
+            serde_json::to_value(wrong_target).unwrap(),
+        ] {
+            assert!(verify_reaction_events(vec![raw], TARGET_ID).is_err());
+        }
+    }
+
+    #[derive(Clone)]
+    struct PagingState {
+        first_page_event: serde_json::Value,
+        second_page_event: serde_json::Value,
+        expected_until: u64,
+        expected_before_id: String,
+        calls: Arc<AtomicUsize>,
+        requested_limit: Arc<AtomicUsize>,
+    }
+
+    async fn paging_handler(State(state): State<PagingState>, body: Bytes) -> Response {
+        let filters: Vec<serde_json::Value> = match serde_json::from_slice(&body) {
+            Ok(filters) => filters,
+            Err(error) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": error.to_string()})),
+                )
+                    .into_response();
+            }
+        };
+        let filter = &filters[0];
+        let limit = filter["limit"].as_u64().unwrap() as usize;
+        state.requested_limit.store(limit, Ordering::SeqCst);
+        let call = state.calls.fetch_add(1, Ordering::SeqCst);
+
+        if call == 0 {
+            return Json(serde_json::Value::Array(vec![
+                state.first_page_event.clone();
+                limit
+            ]))
+            .into_response();
+        }
+
+        if filter["until"].as_u64() != Some(state.expected_until)
+            || filter["before_id"].as_str() != Some(&state.expected_before_id)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "incorrect composite cursor"})),
+            )
+                .into_response();
+        }
+
+        Json(serde_json::Value::Array(vec![state.second_page_event])).into_response()
+    }
+
+    async fn paged_client(
+        first_page_event: &Event,
+        second_page_event: &Event,
+    ) -> (BuzzClient, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let requested_limit = Arc::new(AtomicUsize::new(0));
+        let state = PagingState {
+            first_page_event: serde_json::to_value(first_page_event).unwrap(),
+            second_page_event: serde_json::to_value(second_page_event).unwrap(),
+            expected_until: first_page_event.created_at.as_secs(),
+            expected_before_id: first_page_event.id.to_hex(),
+            calls: calls.clone(),
+            requested_limit: requested_limit.clone(),
+        };
+        let app = Router::new()
+            .route("/query", post(paging_handler))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client =
+            BuzzClient::new(format!("http://{addr}"), Keys::generate(), None, None).unwrap();
+        (client, calls, requested_limit)
+    }
+
+    #[tokio::test]
+    async fn pagination_finds_first_winner_beyond_more_than_one_hundred_reactions() {
+        let keys = Keys::generate();
+        let first_page = signed_reaction(&keys, 200, "reject");
+        let globally_oldest = signed_reaction(&keys, 100, "approve");
+        let (client, calls, requested_limit) = paged_client(&first_page, &globally_oldest).await;
+
+        let events = fetch_reaction_events(&client, TARGET_ID).await.unwrap();
+        let page_size = requested_limit.load(Ordering::SeqCst);
+        assert!(page_size > 100);
+        assert_eq!(events.len(), page_size + 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        let output: serde_json::Value =
+            serde_json::from_str(&render_reactions(events, true).unwrap()).unwrap();
+        assert_eq!(output["events"][0]["id"], globally_oldest.id.to_hex());
+        assert_eq!(output["events"][0]["content"], "approve");
+    }
+
+    #[tokio::test]
+    async fn pagination_retains_timestamp_ties_across_the_page_boundary() {
+        let keys = Keys::generate();
+        let mut tied = vec![
+            signed_reaction(&keys, 300, "first"),
+            signed_reaction(&keys, 300, "second"),
+        ];
+        tied.sort_by_key(|event| event.id);
+        let first_page = tied.remove(0);
+        let second_page = tied.remove(0);
+        let (client, calls, requested_limit) = paged_client(&first_page, &second_page).await;
+
+        let events = fetch_reaction_events(&client, TARGET_ID).await.unwrap();
+        let page_size = requested_limit.load(Ordering::SeqCst);
+        assert_eq!(events.len(), page_size + 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        let output: serde_json::Value =
+            serde_json::from_str(&render_reactions(events, true).unwrap()).unwrap();
+        assert_eq!(output["events"][0]["id"], first_page.id.to_hex());
+        assert_eq!(output["events"][page_size]["id"], second_page.id.to_hex());
     }
 }

--- a/crates/buzz-cli/src/commands/users.rs
+++ b/crates/buzz-cli/src/commands/users.rs
@@ -79,6 +79,11 @@ pub async fn cmd_get_users(
             serde_json::to_string(&compact).unwrap_or_default()
         }
         crate::OutputFormat::Json => serde_json::to_string(&profiles).unwrap_or_default(),
+        crate::OutputFormat::Raw => {
+            return Err(CliError::Usage(
+                "--format raw is not supported by users get".into(),
+            ));
+        }
     };
     println!("{output}");
     Ok(())
@@ -351,6 +356,11 @@ async fn search_by_name(
             serde_json::to_string(&compact).unwrap_or_default()
         }
         crate::OutputFormat::Json => serde_json::to_string(&profiles).unwrap_or_default(),
+        crate::OutputFormat::Raw => {
+            return Err(CliError::Usage(
+                "--format raw is not supported by users search".into(),
+            ));
+        }
     };
     println!("{output}");
     Ok(())

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -725,6 +725,9 @@ pub enum ReactionsCmd {
         /// Event ID (64-char hex)
         #[arg(long)]
         event: String,
+        /// Return full kind-7 events, oldest first, instead of aggregate counts
+        #[arg(long)]
+        events: bool,
     },
 }
 
@@ -1863,6 +1866,19 @@ mod tests {
             "--emoji alone must not imply a status"
         );
         assert!(Cli::try_parse_from(["buzz", "users", "set-status", "--clear"]).is_ok());
+    }
+
+    #[test]
+    fn reactions_get_accepts_full_events_flag() {
+        assert!(Cli::try_parse_from([
+            "buzz",
+            "reactions",
+            "get",
+            "--event",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--events",
+        ])
+        .is_ok());
     }
 
     #[test]

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -89,7 +89,7 @@ struct Cli {
     #[arg(long, env = "BUZZ_AUTH_TAG", hide_env_values = true)]
     auth_tag: Option<String>,
 
-    /// Output format: 'json' (default, full fields) or 'compact' (reduced fields).
+    /// Output format: 'json' (default), 'compact' (reduced fields), or 'raw' (complete signed events where supported).
     #[arg(long, value_enum, default_value = "json")]
     format: OutputFormat,
 
@@ -169,6 +169,9 @@ pub enum OutputFormat {
     /// Reduced fields for agent scanning
     #[value(name = "compact")]
     Compact,
+    /// Complete signed Nostr events for supported event read commands
+    #[value(name = "raw")]
+    Raw,
 }
 
 #[derive(Subcommand)]
@@ -1877,6 +1880,20 @@ mod tests {
             "--event",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "--events",
+        ])
+        .is_ok());
+    }
+
+    #[test]
+    fn messages_get_accepts_raw_format() {
+        assert!(Cli::try_parse_from([
+            "buzz",
+            "--format",
+            "raw",
+            "messages",
+            "get",
+            "--channel",
+            "11111111-1111-4111-8111-111111111111",
         ])
         .is_ok());
     }


### PR DESCRIPTION
## Summary
- add `buzz reactions get --event <id> --events` while preserving the aggregate response by default
- add global `--format raw` support for `messages get`, returning original complete signed relay event objects
- preserve normalized JSON behavior for existing consumers
- fail closed on malformed HTTP-200 bodies and incomplete, forged, mismatched-ID, or invalid-signature events
- preserve deterministic ordering, including timestamp ties

## Security invariants
- deserialize cloned raw rows as canonical `nostr::Event` values
- verify NIP-01 event IDs and BIP-340 signatures with `Event::verify()` before output
- serialize the original relay JSON values after verification so extension fields survive
- retain the existing authenticated `BuzzClient` query path with no credential handling changes
- reject raw format on unsupported commands with usage exit code 1

## Downstream contracts

### Inbox reactions
`buzz reactions get --event "$EVENT_ID" --events` emits complete signed kind-7 events in deterministic `(created_at ASC, id ASC)` order. Inbox can apply first-wins deterministically and use the reaction event ID as its idempotency receipt.

### Watcher / Launchwatch / Watchlist message recovery
`buzz --format raw messages get --channel "$CHANNEL_ID" ...` emits the original complete signed message event objects, including `id`, `pubkey`, `created_at`, `kind`, `tags`, `content`, and `sig`. Consumers can require verified publisher, channel, and thread markers without trusting normalized caller-controlled fields.

## Compatibility
- reaction aggregate output remains unchanged without `--events`
- normalized message JSON remains unchanged and still omits signatures
- raw output is limited to the message read path

## Tests
- `cargo test -p buzz-cli`: 290 passed
- `cargo clippy -p buzz-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- regressions cover empty objects, missing signatures, malformed schema, mismatched IDs, invalid signatures, malformed success JSON, raw-format command scoping, normalized compatibility, relay extension preservation, and deterministic equal-timestamp ordering

## Review note
The raw-message verification change was independently reviewed after remediation. The final signed-off head is `921188ab5399f8fc17ffff39f95d533a078925ab`. DCO, Semgrep OSS, and zizmor are green.
