### PR TITLE
fix(relay): join invite claimers to open channels

### DIFF
--- a/crates/buzz-relay/src/api/invites.rs
+++ b/crates/buzz-relay/src/api/invites.rs
@@ -24,7 +24,9 @@ use axum::{
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::handlers::side_effects::{publish_nip43_member_added, publish_nip43_membership_list};
+use crate::handlers::side_effects::{
+    emit_group_discovery_events, publish_nip43_member_added, publish_nip43_membership_list,
+};
 use buzz_core::invite::{
     hash_v2_code, validate_v2_code, DEFAULT_INVITE_TTL_SECS, MAX_INVITE_TTL_SECS, MAX_INVITE_USES,
     MIN_INVITE_TTL_SECS, V2_PREFIX,
@@ -406,6 +408,7 @@ pub async fn claim_invite(
                     member = %claimer_hex,
                     "relay member added via v2 invite"
                 );
+                join_active_open_channels(&tenant, &state, &claimer_hex).await;
                 // NIP-43 side effects only on Joined, never on other outcomes.
                 if let Err(e) = publish_nip43_member_added(&tenant, &state, &claimer_hex).await {
                     tracing::warn!(
@@ -484,6 +487,7 @@ pub async fn claim_invite(
             member = %claimer_hex,
             "relay member added via invite"
         );
+        join_active_open_channels(&tenant, &state, &claimer_hex).await;
         if let Err(e) = publish_nip43_member_added(&tenant, &state, &claimer_hex).await {
             tracing::warn!("failed to publish NIP-43 member-added delta after claim: {e}");
         }
@@ -524,6 +528,93 @@ fn claim_key_rate_limited(
 ) -> bool {
     let counter = cache.get_with(key, || Arc::new(std::sync::atomic::AtomicU32::new(0)));
     counter.fetch_add(1, Ordering::Relaxed) >= CLAIM_RATE_LIMIT
+}
+
+/// Add a newly joined relay member to every active open channel and republish
+/// each channel's NIP-29 discovery state. Relay membership has already been
+/// committed when this runs, so failures are logged rather than changing the
+/// successful claim response.
+async fn join_active_open_channels(
+    tenant: &buzz_core::tenant::TenantContext,
+    state: &Arc<AppState>,
+    claimer_hex: &str,
+) {
+    let claimer_bytes = match hex::decode(claimer_hex) {
+        Ok(bytes) if bytes.len() == 32 => bytes,
+        Ok(bytes) => {
+            tracing::warn!(
+                community = %tenant.community(),
+                member = %claimer_hex,
+                decoded_len = bytes.len(),
+                "cannot auto-join invite claimer to open channels: decoded pubkey is not 32 bytes"
+            );
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(
+                community = %tenant.community(),
+                member = %claimer_hex,
+                error = %error,
+                "cannot auto-join invite claimer to open channels: invalid hex pubkey"
+            );
+            return;
+        }
+    };
+
+    let channels = match state
+        .db
+        .list_channels(tenant.community(), Some("open"))
+        .await
+    {
+        Ok(channels) => channels,
+        Err(error) => {
+            tracing::warn!(
+                community = %tenant.community(),
+                member = %claimer_hex,
+                error = %error,
+                "failed to list open channels after invite claim"
+            );
+            return;
+        }
+    };
+
+    for channel in channels {
+        if channel.archived_at.is_some() || channel.channel_type == "dm" {
+            continue;
+        }
+
+        if let Err(error) = state
+            .db
+            .add_member(
+                tenant.community(),
+                channel.id,
+                &claimer_bytes,
+                buzz_db::channel::MemberRole::Member,
+                None,
+            )
+            .await
+        {
+            tracing::warn!(
+                community = %tenant.community(),
+                channel = %channel.id,
+                member = %claimer_hex,
+                error = %error,
+                "failed to auto-join invite claimer to open channel"
+            );
+            continue;
+        }
+
+        state.invalidate_membership(tenant, channel.id, &claimer_bytes);
+        if let Err(error) = emit_group_discovery_events(tenant, state, channel.id).await {
+            tracing::warn!(
+                community = %tenant.community(),
+                channel = %channel.id,
+                member = %claimer_hex,
+                error = %error,
+                "failed to publish open-channel discovery after invite claim"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -655,7 +746,8 @@ mod tests {
             .or_else(|_| std::env::var("DATABASE_URL"))
             .unwrap_or_else(|_| TEST_DB_URL.to_string());
         config.database_url = database_url.clone();
-        config.redis_url = "redis://127.0.0.1:1".to_string();
+        config.redis_url = std::env::var("BUZZ_TEST_REDIS_URL")
+            .unwrap_or_else(|_| "redis://127.0.0.1:1".to_string());
         config.relay_url = format!("wss://{host}");
         // The claim route must work on relays where membership is enforced —
         // that is the entire point of an invite.
@@ -749,6 +841,44 @@ mod tests {
             })
             .await
             .expect("count side-effect events")
+    }
+
+    async fn has_channel_member(
+        state: &AppState,
+        community: buzz_core::CommunityId,
+        channel: Uuid,
+        member: &Keys,
+    ) -> bool {
+        state
+            .db
+            .is_member(community, channel, &member.public_key().to_bytes())
+            .await
+            .expect("channel membership lookup")
+    }
+
+    async fn group_members_event_mentions(
+        state: &AppState,
+        community: buzz_core::CommunityId,
+        channel: Uuid,
+        member: &Keys,
+    ) -> bool {
+        let events = state
+            .db
+            .query_events(&buzz_db::EventQuery {
+                channel_id: Some(channel),
+                kinds: Some(vec![buzz_core::kind::KIND_NIP29_GROUP_MEMBERS as i32]),
+                limit: Some(1),
+                ..buzz_db::EventQuery::for_community(community)
+            })
+            .await
+            .expect("query group members event");
+        let member_hex = member.public_key().to_hex();
+        events.first().is_some_and(|stored| {
+            stored.event.tags.iter().any(|tag| {
+                let parts = tag.as_slice();
+                parts.len() >= 2 && parts[0] == "p" && parts[1] == member_hex
+            })
+        })
     }
 
     #[test]
@@ -954,6 +1084,51 @@ mod tests {
             .add_relay_member(community.id, &owner.public_key().to_hex(), "owner", None)
             .await
             .expect("seed owner");
+        let owner_bytes = owner.public_key().to_bytes();
+        let open_channel = state
+            .db
+            .create_channel(
+                community.id,
+                "open-invites",
+                buzz_db::channel::ChannelType::Stream,
+                buzz_db::channel::ChannelVisibility::Open,
+                None,
+                &owner_bytes,
+                None,
+            )
+            .await
+            .expect("create open channel");
+        let private_channel = state
+            .db
+            .create_channel(
+                community.id,
+                "private-invites",
+                buzz_db::channel::ChannelType::Stream,
+                buzz_db::channel::ChannelVisibility::Private,
+                None,
+                &owner_bytes,
+                None,
+            )
+            .await
+            .expect("create private channel");
+        let archived_channel = state
+            .db
+            .create_channel(
+                community.id,
+                "archived-invites",
+                buzz_db::channel::ChannelType::Stream,
+                buzz_db::channel::ChannelVisibility::Open,
+                None,
+                &owner_bytes,
+                None,
+            )
+            .await
+            .expect("create archived channel");
+        state
+            .db
+            .archive_channel(community.id, archived_channel.id)
+            .await
+            .expect("archive channel");
         let before_delta_count = event_count(
             &state,
             community.id,
@@ -1005,6 +1180,35 @@ mod tests {
         .await;
         assert_eq!(delta_count, before_delta_count + 1);
         assert_eq!(list_count, before_list_count + 1);
+        assert!(
+            has_channel_member(&state, community.id, open_channel.id, &first).await,
+            "new claimer must join active open channels"
+        );
+        assert!(
+            group_members_event_mentions(&state, community.id, open_channel.id, &first).await,
+            "kind:39002 must advertise the new open-channel membership"
+        );
+        assert!(
+            !has_channel_member(&state, community.id, private_channel.id, &first).await,
+            "new claimer must not join private channels"
+        );
+        assert!(
+            !has_channel_member(&state, community.id, archived_channel.id, &first).await,
+            "new claimer must not join archived open channels"
+        );
+        let late_open_channel = state
+            .db
+            .create_channel(
+                community.id,
+                "late-open-invites",
+                buzz_db::channel::ChannelType::Stream,
+                buzz_db::channel::ChannelVisibility::Open,
+                None,
+                &owner_bytes,
+                None,
+            )
+            .await
+            .expect("create open channel after the genuine claim");
 
         let response = post_json(
             state.clone(),
@@ -1039,6 +1243,10 @@ mod tests {
             )
             .await,
             list_count
+        );
+        assert!(
+            !has_channel_member(&state, community.id, late_open_channel.id, &first).await,
+            "AlreadyMember re-claim must not add channel memberships"
         );
 
         let response = post_json(


### PR DESCRIPTION
### What changed?

Accepting a community invite previously granted relay-level membership only. The claimer joined the community but was not a member of any channel, so clients that derive their channel list from per-channel membership showed an empty community. This adds channel membership to the claim path: on a genuine new join, the claimer is added to the community's active open, non-DM channels, and NIP-29 discovery is republished for each so kind 39002 advertises the new membership. Kind 39002 is the event mobile's channel list is built from, so the discovery republish is the load-bearing half, not the database write alone.

Idempotent reclaims (`AlreadyMember`) run no channel-join side effects, and neither do exhausted, expired, invalid, policy-rejected, or rate-limited outcomes.

This covers future claimers. Users who already claimed before this change are in `relay_members` and get `already_member` with no membership write, so they are not healed by this PR. #4199 covers that population with client-side open-channel discovery. The two together cover both.

### Why?

Reported on Buzz mobile: accepting a community invite added the community to the list, but no channels or messages ever loaded. The claim endpoint wrote `relay_members` and emitted relay-level NIP-43 events, and never called `add_member` for any channel.

Relay membership is already durable before these side effects run. A channel membership or discovery failure is therefore logged at `warn` and does not turn a successful claim into an error, matching the existing NIP-43 partial-failure handling in this flow. That is a deliberate availability tradeoff with a known cost: a partial failure returns 200 `joined` with an incomplete channel list, and because a retry becomes `already_member` it does not self-heal. No test covers that path.

### How is it tested?

The new assertions are `#[ignore = "requires Postgres"]`, so a plain `cargo test -p buzz-relay` does not execute them. They run in CI under `Backend Integration (relay e2e)`, step `Invite security tests`, which selects the invite module with `--run-ignored ignored-only` (18 of 18 passing at this head).

Added tests, in [`api::invites::tests`](https://github.com/block/buzz/tree/main/crates/buzz-relay/src/api/invites.rs):

- A new v2 claimer becomes a member of an active open channel, and kind 39002 advertises that membership.
- Private and archived channels are excluded, and an `AlreadyMember` reclaim adds nothing.

Mutation results, per call site rather than in aggregate:

- Removing the v2 claim-path call fails the open-channel membership assertion. Removing `emit_group_discovery_events` fails the kind 39002 assertion. Forcing side effects on `AlreadyMember`, and removing the archived guard, each fail their assertions.
- Removing only the v1 call site leaves the suite green: the v1 auto-join has no committed coverage. It was verified working out of band with a throwaway probe driving the v1 HMAC path, whose control (same probe, v1 call site removed) fails as expected.

Claims that hold by code reading but have no test behind them at this head, so a future regression would not be caught by CI:

- The loop joins every active open non-DM channel, but the fixture has exactly one such channel, so a `break` after the first join also passes. "Every" is not test-enforced.
- Each membership write calls `invalidate_membership`; removing that call leaves the suite green.
- DM channels are excluded by an explicit `channel_type == "dm"` guard; removing it leaves the suite green. It is not dead code: `create_dm` hardcodes `visibility='private'`, but the kind 9002 metadata-edit path changes visibility with no channel-type guard, so an open DM is reachable.
- Private exclusion is observed in the integration test, but it is enforced by `add_member` rejecting private admission when `invited_by` is `None`. Removing the `Some("open")` visibility filter still passes, so the list-level filter is not proven load-bearing.

Full package suite at this head: 835 passed, 37 ignored, with `api::mesh_demo::tests::demo_join_forwarded_arm_round_trips_echo` failing (504 instead of 200). That failure reproduces identically at the base commit and is additionally flaky, so it is pre-existing and not from this branch. `cargo clippy -p buzz-relay --all-targets -- -D warnings` passes.

The uncovered-claim list and the per-call-site mutation split come from two independent blind reviews of this exact head, which converged on the `Some("open")` finding separately.
