### PR TITLE
fix(mobile): route plain DM messages to participants

### DIFF
--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -5,12 +5,15 @@ import '../channels/channel_management_provider.dart';
 import '../profile/user_cache_provider.dart';
 import '../profile/user_profile.dart';
 import 'channel_messages_provider.dart';
+import 'channels_provider.dart';
 
 /// Sends messages by signing an event with the user's nsec and publishing it
 /// over the relay's NIP-42-authenticated WebSocket session.
 class SendMessage {
   final SignedEventRelay _signedEventRelay;
   final Future<List<ChannelMember>> Function(String channelId) _fetchMembers;
+  final Future<List<String>> Function(String channelId)
+  _fetchImplicitRecipients;
   final Map<String, UserProfile> Function() _readUserCache;
   final void Function(String channelId, NostrEvent event) _addLocalMessage;
   final void Function(String channelId, String eventId) _completeLocalMessage;
@@ -20,6 +23,8 @@ class SendMessage {
     required SignedEventRelay signedEventRelay,
     required Future<List<ChannelMember>> Function(String channelId)
     fetchMembers,
+    required Future<List<String>> Function(String channelId)
+    fetchImplicitRecipients,
     required Map<String, UserProfile> Function() readUserCache,
     required void Function(String channelId, NostrEvent event) addLocalMessage,
     required void Function(String channelId, String eventId)
@@ -27,6 +32,7 @@ class SendMessage {
     required void Function(String channelId, String eventId) removeLocalMessage,
   }) : _signedEventRelay = signedEventRelay,
        _fetchMembers = fetchMembers,
+       _fetchImplicitRecipients = fetchImplicitRecipients,
        _readUserCache = readUserCache,
        _addLocalMessage = addLocalMessage,
        _completeLocalMessage = completeLocalMessage,
@@ -47,10 +53,15 @@ class SendMessage {
     List<String>? mentionPubkeys,
     List<List<String>> mediaTags = const [],
   }) async {
-    // Use explicitly passed pubkeys, or resolve @mentions against
-    // channel members to avoid matching the wrong user.
-    final resolvedMentions =
-        mentionPubkeys ?? await _resolveMentions(content, channelId);
+    // Use explicitly passed pubkeys, or resolve @mentions against channel
+    // members to avoid matching the wrong user. DMs also address every other
+    // participant implicitly, matching desktop behavior and allowing agent
+    // DMs (including multi-person group DMs) to work without visible @mentions.
+    final resolvedMentions = <String>[
+      ...?mentionPubkeys,
+      if (mentionPubkeys == null) ...await _resolveMentions(content, channelId),
+      ...await _fetchImplicitRecipients(channelId),
+    ];
     final authorPubkey = _signedEventRelay.pubkey;
 
     // Normalize mentions: lowercase, deduplicate, exclude self (matching
@@ -59,7 +70,7 @@ class SendMessage {
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[
       for (final pk in resolvedMentions)
-        if (seenMentions.add(pk.toLowerCase())) pk,
+        if (seenMentions.add(pk.toLowerCase())) pk.toLowerCase(),
     ];
 
     final tags = <List<String>>[
@@ -169,6 +180,15 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
     ),
     fetchMembers: (channelId) =>
         ref.read(channelMembersProvider(channelId).future),
+    fetchImplicitRecipients: (channelId) async {
+      final channels = await ref.read(channelsProvider.future);
+      for (final channel in channels) {
+        if (channel.id == channelId) {
+          return channel.isDm ? channel.participantPubkeys : const [];
+        }
+      }
+      return const [];
+    },
     readUserCache: () => ref.read(userCacheProvider),
     addLocalMessage: (channelId, event) => ref
         .read(channelMessagesProvider(channelId).notifier)

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -19,6 +19,7 @@ void main() {
           nsec: nostr.Keys.generate().nsec,
         ),
         fetchMembers: (_) async => const [],
+        fetchImplicitRecipients: (_) async => const [],
         readUserCache: () => const {},
         addLocalMessage: (_, event) => localMessages.add(event),
         completeLocalMessage: (_, eventId) => completedIds.add(eventId),
@@ -52,6 +53,7 @@ void main() {
         nsec: nostr.Keys.generate().nsec,
       ),
       fetchMembers: (_) async => const [],
+      fetchImplicitRecipients: (_) async => const [],
       readUserCache: () => const {},
       addLocalMessage: (_, event) => localMessages.add(event),
       completeLocalMessage: (_, eventId) => completedIds.add(eventId),
@@ -66,9 +68,76 @@ void main() {
     expect(completedIds, isEmpty);
     expect(removedIds, [localMessages.single.id]);
   });
+
+  test(
+    'adds DM participants as implicit recipients without @mentions',
+    () async {
+      final keys = nostr.Keys.generate();
+      final session = _PendingPublishRelaySession();
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(session: session, nsec: keys.nsec),
+        fetchMembers: (_) async => const [],
+        fetchImplicitRecipients: (_) async => [
+          keys.public.toUpperCase(),
+          _agentPubkey.toUpperCase(),
+          _agentPubkey,
+          _humanPubkey,
+        ],
+        readUserCache: () => const {},
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      final result = send(channelId: _channelId, content: 'status?');
+      await session.published;
+
+      expect(_pTags(session.event), [_agentPubkey, _humanPubkey]);
+
+      session.accept();
+      await result;
+    },
+  );
+
+  test('merges explicit mentions with implicit DM recipients', () async {
+    final session = _PendingPublishRelaySession();
+    final send = SendMessage(
+      signedEventRelay: SignedEventRelay(
+        session: session,
+        nsec: nostr.Keys.generate().nsec,
+      ),
+      fetchMembers: (_) async => const [],
+      fetchImplicitRecipients: (_) async => const [_agentPubkey],
+      readUserCache: () => const {},
+      addLocalMessage: (_, _) {},
+      completeLocalMessage: (_, _) {},
+      removeLocalMessage: (_, _) {},
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hello',
+      mentionPubkeys: const [_humanPubkey, _agentPubkey],
+    );
+    await session.published;
+
+    expect(_pTags(session.event), [_humanPubkey, _agentPubkey]);
+
+    session.accept();
+    await result;
+  });
 }
 
 const _channelId = '11111111-1111-4111-8111-111111111111';
+const _agentPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _humanPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+List<String> _pTags(NostrEvent event) => [
+  for (final tag in event.tags)
+    if (tag.length >= 2 && tag[0] == 'p') tag[1],
+];
 
 class _PendingPublishRelaySession extends RelaySessionNotifier {
   final Completer<NostrEvent> _result = Completer<NostrEvent>();


### PR DESCRIPTION
## Summary

- add every other DM participant as an implicit `p` recipient when mobile sends a message
- make one-to-one and multi-person agent DMs work without redundant visible `@mentions`
- preserve explicit mention routing in non-DM channels and normalize/deduplicate recipient keys

### Related issue

Complements #4185, which removes the mentions-mode gate for DMs in the agent runtime and relay subscription filter.

### Testing

- `just mobile-check`
- `flutter test test/features/channels/send_message_provider_test.dart`
- `cargo test -p buzz-acp dm_mention -- --nocapture` (with #4185 applied locally)