### PR TITLE
fix(workflows): authorize verified workflow owners

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -264,32 +264,45 @@ async fn author_allowed(
 /// the relay's NIP-11 `self` identity and the event is explicitly marked as a
 /// workflow side effect. Missing or malformed metadata fails closed to the
 /// event's actual signer.
-fn effective_instruction_author(
+pub(crate) fn effective_instruction_author(
     event: &nostr::Event,
     trusted_relay_pubkey: Option<&nostr::PublicKey>,
 ) -> String {
     let signer = event.pubkey.to_hex();
     if trusted_relay_pubkey != Some(&event.pubkey)
-        || !event.tags.iter().any(|tag| {
-            let parts = tag.as_slice();
-            parts.first().map(String::as_str) == Some("buzz:workflow")
-                && parts.get(1).map(String::as_str) == Some("true")
-        })
+        || event.kind.as_u16() as u32 != KIND_STREAM_MESSAGE
+        || event.verify().is_err()
     {
         return signer;
     }
 
-    event
+    let workflow_tags: Vec<&[String]> = event
         .tags
         .iter()
-        .find_map(|tag| {
-            let parts = tag.as_slice();
-            (parts.first().map(String::as_str) == Some("actor"))
-                .then(|| parts.get(1))
-                .flatten()
-                .and_then(|value| nostr::PublicKey::from_hex(value).ok())
-                .map(|pubkey| pubkey.to_hex())
-        })
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("buzz:workflow"))
+        .map(nostr::Tag::as_slice)
+        .collect();
+    if workflow_tags.len() != 1
+        || workflow_tags[0].len() != 2
+        || workflow_tags[0].get(1).map(String::as_str) != Some("true")
+    {
+        return signer;
+    }
+
+    let actor_tags: Vec<&[String]> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("actor"))
+        .map(nostr::Tag::as_slice)
+        .collect();
+    if actor_tags.len() != 1 || actor_tags[0].len() != 2 {
+        return signer;
+    }
+
+    actor_tags[0]
+        .get(1)
+        .and_then(|value| nostr::PublicKey::from_hex(value).ok())
+        .map(|pubkey| pubkey.to_hex())
         .unwrap_or(signer)
 }
 
@@ -4460,20 +4473,37 @@ mod owner_cache_tests {
 mod author_gate_tests {
     use super::*;
 
-    fn workflow_event(
+    fn workflow_event_with(
         signer: &nostr::Keys,
         actor: &nostr::PublicKey,
         include_workflow_marker: bool,
+        kind: u32,
+        extra_tags: Vec<nostr::Tag>,
     ) -> nostr::Event {
         let mut tags =
             vec![nostr::Tag::parse(["actor", &actor.to_hex()]).expect("valid actor tag")];
         if include_workflow_marker {
             tags.push(nostr::Tag::parse(["buzz:workflow", "true"]).expect("valid workflow marker"));
         }
-        nostr::EventBuilder::new(nostr::Kind::Custom(KIND_STREAM_MESSAGE as u16), "test")
+        tags.extend(extra_tags);
+        nostr::EventBuilder::new(nostr::Kind::Custom(kind as u16), "test")
             .tags(tags)
             .sign_with_keys(signer)
             .expect("event signs")
+    }
+
+    fn workflow_event(
+        signer: &nostr::Keys,
+        actor: &nostr::PublicKey,
+        include_workflow_marker: bool,
+    ) -> nostr::Event {
+        workflow_event_with(
+            signer,
+            actor,
+            include_workflow_marker,
+            KIND_STREAM_MESSAGE,
+            vec![],
+        )
     }
 
     #[test]
@@ -4521,6 +4551,61 @@ mod author_gate_tests {
 
         assert_eq!(
             effective_instruction_author(&event, None),
+            relay.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn invalid_signature_fails_closed_to_actual_signer() {
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let mut event = workflow_event(&relay, &owner.public_key(), true);
+        event.content = "tampered".into();
+
+        assert_eq!(
+            effective_instruction_author(&event, Some(&relay.public_key())),
+            relay.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn wrong_kind_fails_closed_to_actual_signer() {
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let event = workflow_event_with(&relay, &owner.public_key(), true, 1, vec![]);
+
+        assert_eq!(
+            effective_instruction_author(&event, Some(&relay.public_key())),
+            relay.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn duplicate_actor_or_workflow_tags_fail_closed_to_actual_signer() {
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let duplicate_actor = workflow_event_with(
+            &relay,
+            &owner.public_key(),
+            true,
+            KIND_STREAM_MESSAGE,
+            vec![nostr::Tag::parse(["actor", &owner.public_key().to_hex()])
+                .expect("duplicate actor tag")],
+        );
+        let duplicate_workflow = workflow_event_with(
+            &relay,
+            &owner.public_key(),
+            true,
+            KIND_STREAM_MESSAGE,
+            vec![nostr::Tag::parse(["buzz:workflow", "true"]).expect("duplicate workflow marker")],
+        );
+
+        assert_eq!(
+            effective_instruction_author(&duplicate_actor, Some(&relay.public_key())),
+            relay.public_key().to_hex()
+        );
+        assert_eq!(
+            effective_instruction_author(&duplicate_workflow, Some(&relay.public_key())),
             relay.public_key().to_hex()
         );
     }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -257,6 +257,42 @@ async fn author_allowed(
     }
 }
 
+/// Resolve the sender used by the agent instruction gate.
+///
+/// Workflow messages are signed by the relay and carry their workflow owner in
+/// the `actor` tag. Trust that attribution only when the event signer matches
+/// the relay's NIP-11 `self` identity and the event is explicitly marked as a
+/// workflow side effect. Missing or malformed metadata fails closed to the
+/// event's actual signer.
+fn effective_instruction_author(
+    event: &nostr::Event,
+    trusted_relay_pubkey: Option<&nostr::PublicKey>,
+) -> String {
+    let signer = event.pubkey.to_hex();
+    if trusted_relay_pubkey != Some(&event.pubkey)
+        || !event.tags.iter().any(|tag| {
+            let parts = tag.as_slice();
+            parts.first().map(String::as_str) == Some("buzz:workflow")
+                && parts.get(1).map(String::as_str) == Some("true")
+        })
+    {
+        return signer;
+    }
+
+    event
+        .tags
+        .iter()
+        .find_map(|tag| {
+            let parts = tag.as_slice();
+            (parts.first().map(String::as_str) == Some("actor"))
+                .then(|| parts.get(1))
+                .flatten()
+                .and_then(|value| nostr::PublicKey::from_hex(value).ok())
+                .map(|pubkey| pubkey.to_hex())
+        })
+        .unwrap_or(signer)
+}
+
 /// Resolve whether `channel_id` is a DM, for the inbound author gate.
 ///
 /// Resolution order:
@@ -1342,6 +1378,7 @@ async fn tokio_main() -> Result<()> {
         HarnessRelay::connect(&config.relay_url, &config.keys, &pubkey_hex, relay_auth_tag)
             .await
             .map_err(|e| anyhow::anyhow!("relay connect error: {e}"))?;
+    let trusted_relay_pubkey = relay.relay_signing_pubkey().cloned();
 
     // Tell the relay background task the watermark so it can use
     // `since = watermark - 5s` on the first REQ instead of `since=now`.
@@ -2143,7 +2180,10 @@ async fn tokio_main() -> Result<()> {
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
                             {
-                                let author = buzz_event.event.pubkey.to_hex();
+                                let author = effective_instruction_author(
+                                    &buzz_event.event,
+                                    trusted_relay_pubkey.as_ref(),
+                                );
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
@@ -4419,6 +4459,71 @@ mod owner_cache_tests {
 #[cfg(test)]
 mod author_gate_tests {
     use super::*;
+
+    fn workflow_event(
+        signer: &nostr::Keys,
+        actor: &nostr::PublicKey,
+        include_workflow_marker: bool,
+    ) -> nostr::Event {
+        let mut tags =
+            vec![nostr::Tag::parse(["actor", &actor.to_hex()]).expect("valid actor tag")];
+        if include_workflow_marker {
+            tags.push(nostr::Tag::parse(["buzz:workflow", "true"]).expect("valid workflow marker"));
+        }
+        nostr::EventBuilder::new(nostr::Kind::Custom(KIND_STREAM_MESSAGE as u16), "test")
+            .tags(tags)
+            .sign_with_keys(signer)
+            .expect("event signs")
+    }
+
+    #[test]
+    fn trusted_relay_workflow_uses_attributed_owner_for_author_gate() {
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let event = workflow_event(&relay, &owner.public_key(), true);
+
+        assert_eq!(
+            effective_instruction_author(&event, Some(&relay.public_key())),
+            owner.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn forged_workflow_marker_cannot_replace_actual_signer() {
+        let relay = nostr::Keys::generate();
+        let attacker = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let event = workflow_event(&attacker, &owner.public_key(), true);
+
+        assert_eq!(
+            effective_instruction_author(&event, Some(&relay.public_key())),
+            attacker.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn relay_signed_non_workflow_event_cannot_replace_actual_signer() {
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let event = workflow_event(&relay, &owner.public_key(), false);
+
+        assert_eq!(
+            effective_instruction_author(&event, Some(&relay.public_key())),
+            relay.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn missing_trusted_relay_identity_fails_closed_to_actual_signer() {
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let event = workflow_event(&relay, &owner.public_key(), true);
+
+        assert_eq!(
+            effective_instruction_author(&event, None),
+            relay.public_key().to_hex()
+        );
+    }
 
     /// A `RestClient` for tests. The author-gate decisions exercised here all
     /// resolve from the owner pubkey or sibling cache before any HTTP call, so

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -436,6 +436,48 @@ impl RestClient {
     }
 }
 
+fn parse_nip11_relay_pubkey(value: &Value) -> Option<nostr::PublicKey> {
+    value
+        .get("self")
+        .and_then(Value::as_str)
+        .and_then(|value| nostr::PublicKey::from_hex(value).ok())
+}
+
+async fn fetch_relay_signing_pubkey(
+    http: &reqwest::Client,
+    relay_url: &str,
+) -> Option<nostr::PublicKey> {
+    let url = format!("{}/", relay_ws_to_http(relay_url));
+    let response = match http
+        .get(&url)
+        .header(reqwest::header::ACCEPT, "application/nostr+json")
+        .send()
+        .await
+    {
+        Ok(response) if response.status().is_success() => response,
+        Ok(response) => {
+            warn!(status = %response.status(), "NIP-11 relay identity lookup failed");
+            return None;
+        }
+        Err(error) => {
+            warn!(%error, "NIP-11 relay identity lookup failed");
+            return None;
+        }
+    };
+    let value = match response.json::<Value>().await {
+        Ok(value) => value,
+        Err(error) => {
+            warn!(%error, "NIP-11 relay identity response was invalid");
+            return None;
+        }
+    };
+    let relay_pubkey = parse_nip11_relay_pubkey(&value);
+    if relay_pubkey.is_none() {
+        warn!("NIP-11 response omitted a valid relay signing identity");
+    }
+    relay_pubkey
+}
+
 /// Events the harness cares about.
 #[derive(Debug, Clone)]
 pub struct BuzzEvent {
@@ -559,6 +601,10 @@ pub struct HarnessRelay {
     keys: Keys,
     /// Optional NIP-OA auth tag for relay membership delegation.
     auth_tag: Option<nostr::Tag>,
+    /// Relay signing identity advertised by NIP-11 `self`.
+    ///
+    /// `None` fails closed for relay-attributed workflow authorization.
+    relay_pubkey: Option<nostr::PublicKey>,
     /// Handle to the background task (for clean shutdown).
     /// Wrapped in `Option` so `shutdown()` can take ownership without conflicting
     /// with `Drop` (which only has `&mut self`).
@@ -645,20 +691,32 @@ impl HarnessRelay {
             .await;
         });
 
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .build()
+            .map_err(|e| RelayError::Http(format!("failed to build HTTP client: {e}")))?;
+        let relay_pubkey = fetch_relay_signing_pubkey(&http, relay_url).await;
+
         Ok(Self {
             event_rx,
             observer_control_rx: Some(observer_control_rx),
             cmd_tx,
-            http: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(10))
-                .connect_timeout(std::time::Duration::from_secs(5))
-                .build()
-                .map_err(|e| RelayError::Http(format!("failed to build HTTP client: {e}")))?,
+            http,
             relay_url: relay_url.to_string(),
             keys: keys.clone(),
             auth_tag,
+            relay_pubkey,
             bg_handle: Some(bg_handle),
         })
+    }
+
+    /// Return the relay signing identity advertised by NIP-11.
+    ///
+    /// The harness uses this only to authenticate relay-signed workflow
+    /// attribution. Missing or invalid NIP-11 metadata fails closed.
+    pub fn relay_signing_pubkey(&self) -> Option<&nostr::PublicKey> {
+        self.relay_pubkey.as_ref()
     }
 
     /// Discover channels the agent is a member of.
@@ -4007,6 +4065,20 @@ async fn wait_for_any_ok(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_valid_nip11_relay_identity() {
+        let relay = nostr::Keys::generate();
+        let value = serde_json::json!({ "self": relay.public_key().to_hex() });
+
+        assert_eq!(parse_nip11_relay_pubkey(&value), Some(relay.public_key()));
+    }
+
+    #[test]
+    fn rejects_missing_or_invalid_nip11_relay_identity() {
+        assert!(parse_nip11_relay_pubkey(&serde_json::json!({})).is_none());
+        assert!(parse_nip11_relay_pubkey(&serde_json::json!({ "self": "not-a-pubkey" })).is_none());
+    }
 
     #[test]
     fn relay_ws_to_http_plain() {

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -73,7 +73,7 @@ pub(crate) enum AcpAvailabilityStatus {
 use crate::{
     author_allowed,
     config::Config,
-    event_mentions_agent, filter,
+    effective_instruction_author, event_mentions_agent, filter,
     relay::{HarnessRelay, RelayEventPublisher},
 };
 
@@ -382,6 +382,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
 
     let publisher = relay.event_publisher();
     let rest_client = relay.rest_client();
+    let trusted_relay_pubkey = relay.relay_signing_pubkey().cloned();
 
     let channel_info = crate::pool::ChannelInfoResolver::new(channel_info_map, rest_client.clone());
 
@@ -428,7 +429,8 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         // Apply the same author gate as normal mode so the nudge only goes
         // to authors the real agent would have answered. Same DM hardening:
         // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
-        let author_hex = buzz_event.event.pubkey.to_hex();
+        let author_hex =
+            effective_instruction_author(&buzz_event.event, trusted_relay_pubkey.as_ref());
         let is_dm = crate::is_dm_channel(buzz_event.channel_id, &channel_info).await;
         let allowed = author_allowed(
             &config.respond_to,

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -258,6 +258,8 @@ impl ActionSink for RelayActionSink {
             //    - one `p` tag per `@Name` that resolves to a channel member,
             //      so mentioned agents are woken (wake is `p`-tag gated)
             let mut tags = vec![
+                Tag::parse(["actor", &author_pubkey_hex])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("actor tag: {e}")))?,
                 Tag::parse(["p", &author_pubkey_hex])
                     .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
                 Tag::parse(["h", &channel_id_canonical])
@@ -698,6 +700,18 @@ mod integration_tests {
             .filter(|t| t.as_slice().first().map(|s| s.as_str()) == Some("p"))
             .filter_map(|t| t.as_slice().get(1).map(|s| s.as_str()))
             .collect();
+        let actor = stored.event.tags.iter().find_map(|tag| {
+            let parts = tag.as_slice();
+            (parts.first().map(String::as_str) == Some("actor"))
+                .then(|| parts.get(1).map(String::as_str))
+                .flatten()
+        });
+
+        assert_eq!(
+            actor,
+            Some(author_hex.as_str()),
+            "workflow owner must be explicitly attributed for ACP authorization"
+        );
 
         assert!(
             p_tag_targets.contains(&author_hex.as_str()),


### PR DESCRIPTION
## Summary

- Attribute relay-signed workflow messages to the workflow owner with an explicit actor tag.
- Authenticate that attribution in the ACP harness against the relay signing key advertised by NIP-11.
- Accept the attributed owner only when the event signature, stream-message kind, and exact single workflow and actor tags verify.
- Apply the same fail-closed authorization in normal and setup-listener modes.
- Keep Selected people agent activation intact; this does not broaden agents to Anyone.

### Security model

Workflow-owner attribution is trusted only when all of these checks pass:

1. The event signer matches the relay identity advertised by NIP-11.
2. The event signature verifies.
3. The event is a stream message.
4. Exactly one `["buzz:workflow", "true"]` tag exists.
5. Exactly one valid actor tag exists.

Missing, malformed, duplicate, forged, or ambiguous metadata falls back to the actual event signer and remains subject to the existing owner or allowlist gate.

### Related work

- #3498 addressed the same owner-only workflow wakeup problem on an earlier tree and was closed without merge.
- This PR carries the current-main implementation and restores the stricter fail-closed checks plus setup-listener coverage.

### Testing

- `cargo test -p buzz-acp`: 670 library tests and 9 pool lifecycle tests passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo test -p buzz-relay --lib workflow_sink`: 17 passed, 1 Postgres integration test ignored
- `cargo fmt --check --all`
- `git diff --check`

The ignored Postgres workflow sink test was previously attempted locally but could not reach a Buzz Postgres instance and stopped at `Sqlx(PoolTimedOut)` before exercising its assertions.