### PR TITLE
feat(git): add explicit actor push grants

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,15 @@ REST endpoints authenticate via
 the client signs a `kind:27235` event containing the request URL and method.
 The relay verifies the Schnorr signature and extracts the pubkey.
 
+Git Smart HTTP is a deliberate exception to per-request method and payload
+binding. The Git credential protocol reuses one repository-root NIP-98 token
+across ref discovery and pack requests, so Git tokens are URL-bound and valid
+only inside the 60-second timestamp window, but are not event-ID deduplicated
+or bound to an individual pack body. Production Git transport therefore
+requires HTTPS; a stolen token can otherwise be replayed against the same
+repository while that short window and the actor's current authorization are
+both still valid.
+
 ### Authorization — Channel Membership as the Foundational Gate
 
 Channel membership is the foundational access control mechanism. If a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,12 +62,21 @@ REST endpoints authenticate via
 the client signs a `kind:27235` event containing the request URL and method.
 The relay verifies the Schnorr signature and extracts the pubkey.
 
-### Authorization — Channel Membership as the Gate
+### Authorization — Channel Membership as the Foundational Gate
 
-Channel membership is the **only** access control mechanism. There are no
-separate ACL lists or capability taxonomies. If a principal (human or agent)
-is a member of a channel, they can read and write to it. If they are not a
-member, the relay rejects their requests — even if they are authenticated.
+Channel membership is the foundational access control mechanism. If a
+principal (human or agent) is not a member of a channel, the relay rejects its
+channel requests even when it is authenticated. Channel roles may further
+constrain writes.
+
+Git repositories may opt in to an explicit push-capability policy signed into
+their kind:30617 announcement. That policy binds an authenticated Nostr actor
+to an expiring Git ref pattern and becomes the write-authorization gate for
+matching pushes. A current grant satisfies role-based push thresholds for its
+matching refs, including the built-in update-role minimum; non-role protections
+such as `require-patch`, `no-force-push`, and `no-delete` still apply. The
+policy cannot grant channel membership or read access. Repositories without
+the opt-in keep the legacy channel-role behavior.
 
 Private channels are invisible to non-members: they do not appear in channel
 listings, and subscription filters for private channel events return nothing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,12 +53,21 @@ REST endpoints authenticate via
 the client signs a `kind:27235` event containing the request URL and method.
 The relay verifies the Schnorr signature and extracts the pubkey.
 
-### Authorization — Channel Membership as the Gate
+### Authorization — Channel Membership as the Foundational Gate
 
-Channel membership is the **only** access control mechanism. There are no
-separate ACL lists or capability taxonomies. If a principal (human or agent)
-is a member of a channel, they can read and write to it. If they are not a
-member, the relay rejects their requests — even if they are authenticated.
+Channel membership is the foundational access control mechanism. If a
+principal (human or agent) is not a member of a channel, the relay rejects its
+channel requests even when it is authenticated. Channel roles may further
+constrain writes.
+
+Git repositories may opt in to an explicit push-capability policy signed into
+their kind:30617 announcement. That policy binds an authenticated Nostr actor
+to an expiring Git ref pattern and becomes the write-authorization gate for
+matching pushes. A current grant satisfies role-based push thresholds for its
+matching refs, including the built-in update-role minimum; non-role protections
+such as `require-patch`, `no-force-push`, and `no-delete` still apply. The
+policy cannot grant channel membership or read access. Repositories without
+the opt-in keep the legacy channel-role behavior.
 
 Private channels are invisible to non-members: they do not appear in channel
 listings, and subscription filters for private channel events return nothing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,15 @@ REST endpoints authenticate via
 the client signs a `kind:27235` event containing the request URL and method.
 The relay verifies the Schnorr signature and extracts the pubkey.
 
+Git Smart HTTP is a deliberate exception to per-request method and payload
+binding. The Git credential protocol reuses one repository-root NIP-98 token
+across ref discovery and pack requests, so Git tokens are URL-bound and valid
+only inside the 60-second timestamp window, but are not event-ID deduplicated
+or bound to an individual pack body. Production Git transport therefore
+requires HTTPS; a stolen token can otherwise be replayed against the same
+repository while that short window and the actor's current authorization are
+both still valid.
+
 ### Authorization — Channel Membership as the Foundational Gate
 
 Channel membership is the foundational access control mechanism. If a

--- a/crates/buzz-core/src/git_perms.rs
+++ b/crates/buzz-core/src/git_perms.rs
@@ -1,8 +1,10 @@
 //! Git permission types — ref patterns, protection rules, and policy evaluation inputs.
 //!
 //! This module defines the core data types for the Buzz git permission system.
-//! The permission model: channel role = repo role; `buzz-protect` tags on
-//! kind:30617 add constraints that apply to everyone (including the owner).
+//! The legacy permission model maps channel role to repository role, while
+//! `buzz-protect` tags on kind:30617 add constraints that apply to everyone
+//! (including the owner). Repositories may opt in to explicit, expiring actor
+//! grants; those grants are checked before the existing protection rules.
 //!
 //! # Architecture
 //!
@@ -45,6 +47,10 @@ pub const MAX_PROTECTION_RULES: usize = 50;
 pub const MAX_PATTERN_LENGTH: usize = 256;
 /// Maximum number of wildcard segments per pattern.
 pub const MAX_WILDCARDS_PER_PATTERN: usize = 3;
+/// Maximum number of explicit Git push grants on one repository announcement.
+pub const MAX_GIT_PUSH_GRANTS: usize = 50;
+/// Maximum lifetime of an explicit Git push grant: 24 hours.
+pub const MAX_GIT_PUSH_GRANT_TTL_SECS: u64 = 24 * 60 * 60;
 
 /// A validated ref pattern for matching git refs.
 ///
@@ -421,6 +427,253 @@ pub fn parse_protection_tags(tags: &[Vec<String>]) -> Result<ParsedProtection, R
         rules,
         unknown_rules,
     })
+}
+
+/// A single explicit push grant from a signed kind:30617 announcement.
+///
+/// The containing announcement supplies the repository scope. The grant binds
+/// one lowercase Nostr public key to one validated ref pattern until the
+/// absolute Unix timestamp in [`Self::expires_at`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitPushGrant {
+    /// Lowercase hex-encoded 32-byte Nostr public key.
+    pub actor_pubkey: String,
+    /// Git refs this actor may update.
+    pub pattern: RefPattern,
+    /// Exclusive Unix timestamp after which the grant is invalid.
+    pub expires_at: u64,
+}
+
+/// Repository-level Git capability mode parsed from kind:30617 tags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitCapabilityPolicy {
+    /// No capability opt-in; preserve the existing channel-role behavior.
+    Legacy,
+    /// Every pusher and every updated ref requires an explicit current grant.
+    ExplicitGrantsV1 {
+        /// Grants signed into the repository announcement.
+        grants: Vec<GitPushGrant>,
+    },
+}
+
+/// Result of evaluating the capability layer for one atomic push.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitCapabilityDecision {
+    /// Continue with the pusher's existing channel-derived role.
+    Legacy,
+    /// Every ref is covered by an explicit grant; role-only protection may be
+    /// evaluated as Owner while non-role protection remains in force.
+    ExplicitGrant,
+}
+
+/// Errors from parsing versioned Git capability tags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitCapabilityParseError {
+    /// A grant was present without an explicit policy version.
+    GrantWithoutPolicy,
+    /// More than one policy selector was present.
+    DuplicatePolicy,
+    /// The policy tag did not have exactly a name and version.
+    MalformedPolicy,
+    /// The policy version is not supported by this relay.
+    UnsupportedPolicy(String),
+    /// Explicit mode omitted the legacy-safe owner-only protection baseline.
+    MissingLegacyProtection,
+    /// The repository contains more grants than the hard limit.
+    TooManyGrants,
+    /// A grant did not have exactly actor, pattern, capability, and expiry.
+    MalformedGrant,
+    /// The actor was not a lowercase hex-encoded 32-byte public key.
+    InvalidActorPubkey,
+    /// The grant ref pattern was invalid.
+    InvalidGrantPattern(PatternError),
+    /// The grant requested a capability other than `push`.
+    UnsupportedCapability(String),
+    /// The expiry was not an unsigned Unix timestamp.
+    InvalidExpiry(String),
+}
+
+impl fmt::Display for GitCapabilityParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GrantWithoutPolicy => write!(f, "buzz-git-grant requires buzz-git-policy"),
+            Self::DuplicatePolicy => write!(f, "multiple buzz-git-policy tags"),
+            Self::MalformedPolicy => write!(f, "malformed buzz-git-policy tag"),
+            Self::UnsupportedPolicy(version) => {
+                write!(f, "unsupported buzz-git-policy version: {version:?}")
+            }
+            Self::MissingLegacyProtection => {
+                write!(f, "explicit grants require buzz-protect refs/** push:owner")
+            }
+            Self::TooManyGrants => {
+                write!(f, "exceeds max {MAX_GIT_PUSH_GRANTS} Git push grants")
+            }
+            Self::MalformedGrant => write!(f, "malformed buzz-git-grant tag"),
+            Self::InvalidActorPubkey => write!(f, "invalid Git grant actor pubkey"),
+            Self::InvalidGrantPattern(error) => {
+                write!(f, "invalid Git grant pattern: {error}")
+            }
+            Self::UnsupportedCapability(capability) => {
+                write!(f, "unsupported Git grant capability: {capability:?}")
+            }
+            Self::InvalidExpiry(expiry) => {
+                write!(f, "invalid Git grant expiry: {expiry:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GitCapabilityParseError {}
+
+/// Parse the versioned, explicit Git capability policy from kind:30617 tags.
+///
+/// Tag grammar:
+///
+/// ```text
+/// ["buzz-git-policy", "explicit-grants-v1"]
+/// ["buzz-git-grant", "<pubkey-hex>", "<ref-pattern>", "push", "<expires-at>"]
+/// ```
+///
+/// Explicit mode also requires a `buzz-protect` tag whose pattern is exactly
+/// `refs/**` and whose rules contain `push:owner`. Older relays ignore the new
+/// tags but understand that baseline, so ordinary channel members fail closed.
+pub fn parse_git_capability_policy(
+    tags: &[Vec<String>],
+) -> Result<GitCapabilityPolicy, GitCapabilityParseError> {
+    let policy_tags: Vec<&Vec<String>> = tags
+        .iter()
+        .filter(|tag| tag.first().map(String::as_str) == Some("buzz-git-policy"))
+        .collect();
+    let grant_tags: Vec<&Vec<String>> = tags
+        .iter()
+        .filter(|tag| tag.first().map(String::as_str) == Some("buzz-git-grant"))
+        .collect();
+
+    if policy_tags.is_empty() {
+        return if grant_tags.is_empty() {
+            Ok(GitCapabilityPolicy::Legacy)
+        } else {
+            Err(GitCapabilityParseError::GrantWithoutPolicy)
+        };
+    }
+    if policy_tags.len() > 1 {
+        return Err(GitCapabilityParseError::DuplicatePolicy);
+    }
+
+    let policy_tag = policy_tags[0];
+    if policy_tag.len() != 2 {
+        return Err(GitCapabilityParseError::MalformedPolicy);
+    }
+    if policy_tag[1] != "explicit-grants-v1" {
+        return Err(GitCapabilityParseError::UnsupportedPolicy(
+            policy_tag[1].clone(),
+        ));
+    }
+
+    let has_legacy_protection = tags.iter().any(|tag| {
+        tag.first().map(String::as_str) == Some("buzz-protect")
+            && tag.get(1).map(String::as_str) == Some("refs/**")
+            && tag[2..].iter().any(|rule| rule == "push:owner")
+    });
+    if !has_legacy_protection {
+        return Err(GitCapabilityParseError::MissingLegacyProtection);
+    }
+    if grant_tags.len() > MAX_GIT_PUSH_GRANTS {
+        return Err(GitCapabilityParseError::TooManyGrants);
+    }
+
+    let mut grants = Vec::with_capacity(grant_tags.len());
+    for tag in grant_tags {
+        if tag.len() != 5 {
+            return Err(GitCapabilityParseError::MalformedGrant);
+        }
+        let actor_pubkey = &tag[1];
+        if actor_pubkey.len() != 64
+            || !actor_pubkey
+                .chars()
+                .all(|character| character.is_ascii_digit() || ('a'..='f').contains(&character))
+        {
+            return Err(GitCapabilityParseError::InvalidActorPubkey);
+        }
+        let pattern =
+            RefPattern::parse(&tag[2]).map_err(GitCapabilityParseError::InvalidGrantPattern)?;
+        if tag[3] != "push" {
+            return Err(GitCapabilityParseError::UnsupportedCapability(
+                tag[3].clone(),
+            ));
+        }
+        let expires_at = tag[4]
+            .parse::<u64>()
+            .map_err(|_| GitCapabilityParseError::InvalidExpiry(tag[4].clone()))?;
+        grants.push(GitPushGrant {
+            actor_pubkey: actor_pubkey.clone(),
+            pattern,
+            expires_at,
+        });
+    }
+
+    Ok(GitCapabilityPolicy::ExplicitGrantsV1 { grants })
+}
+
+/// Evaluate one atomic push against a parsed Git capability policy.
+///
+/// `issued_at` is the signed repository announcement timestamp and `now` is
+/// the relay hook time. In explicit mode every grant must have a positive
+/// lifetime of at most 24 hours, and every ref update must match a current
+/// grant for the authenticated actor. One uncovered ref denies the whole push.
+pub fn evaluate_git_push_capabilities(
+    policy: &GitCapabilityPolicy,
+    actor_pubkey: &str,
+    updates: &[RefUpdate],
+    issued_at: u64,
+    now: u64,
+) -> Result<GitCapabilityDecision, Vec<Denial>> {
+    let GitCapabilityPolicy::ExplicitGrantsV1 { grants } = policy else {
+        return Ok(GitCapabilityDecision::Legacy);
+    };
+
+    let deny_every_ref = |reason: &str| {
+        updates
+            .iter()
+            .map(|update| Denial {
+                ref_name: update.ref_name.clone(),
+                reason: reason.to_string(),
+            })
+            .collect::<Vec<_>>()
+    };
+
+    if issued_at > now {
+        return Err(deny_every_ref(
+            "Git capability policy timestamp is in the future",
+        ));
+    }
+    if grants.iter().any(|grant| {
+        grant.expires_at <= issued_at
+            || grant.expires_at.saturating_sub(issued_at) > MAX_GIT_PUSH_GRANT_TTL_SECS
+    }) {
+        return Err(deny_every_ref("invalid Git capability grant lifetime"));
+    }
+
+    let denials: Vec<Denial> = updates
+        .iter()
+        .filter(|update| {
+            !grants.iter().any(|grant| {
+                grant.actor_pubkey == actor_pubkey
+                    && grant.expires_at > now
+                    && grant.pattern.matches(&update.ref_name)
+            })
+        })
+        .map(|update| Denial {
+            ref_name: update.ref_name.clone(),
+            reason: "no current Git capability grant for actor and ref".to_string(),
+        })
+        .collect();
+
+    if denials.is_empty() {
+        Ok(GitCapabilityDecision::ExplicitGrant)
+    } else {
+        Err(denials)
+    }
 }
 
 /// Built-in default minimum role for an operation when no `buzz-protect` tag matches.
@@ -1023,5 +1276,306 @@ mod tests {
         let denials = result.unwrap_err();
         assert_eq!(denials.len(), 1);
         assert_eq!(denials[0].ref_name, "refs/heads/main");
+    }
+
+    fn capability_tags(actor_a: &str, actor_b: &str, expires_at: u64) -> Vec<Vec<String>> {
+        vec![
+            vec!["buzz-protect".into(), "refs/**".into(), "push:owner".into()],
+            vec!["buzz-git-policy".into(), "explicit-grants-v1".into()],
+            vec![
+                "buzz-git-grant".into(),
+                actor_a.into(),
+                "refs/heads/agent/a/**".into(),
+                "push".into(),
+                expires_at.to_string(),
+            ],
+            vec![
+                "buzz-git-grant".into(),
+                actor_b.into(),
+                "refs/heads/agent/b/**".into(),
+                "push".into(),
+                expires_at.to_string(),
+            ],
+        ]
+    }
+
+    fn create_update(ref_name: &str) -> RefUpdate {
+        RefUpdate {
+            ref_name: ref_name.to_string(),
+            kind: UpdateKind::Create,
+            old_oid: "0".repeat(40),
+            new_oid: "a".repeat(40),
+        }
+    }
+
+    #[test]
+    fn git_capability_policy_preserves_legacy_without_opt_in() {
+        assert_eq!(
+            parse_git_capability_policy(&[]).unwrap(),
+            GitCapabilityPolicy::Legacy
+        );
+    }
+
+    #[test]
+    fn git_capability_policy_rejects_orphan_duplicate_and_unknown_policy() {
+        let actor = "a".repeat(64);
+        let orphan = vec![vec![
+            "buzz-git-grant".into(),
+            actor,
+            "refs/heads/agent/a/**".into(),
+            "push".into(),
+            "100".into(),
+        ]];
+        assert_eq!(
+            parse_git_capability_policy(&orphan),
+            Err(GitCapabilityParseError::GrantWithoutPolicy)
+        );
+
+        let duplicate = vec![
+            vec!["buzz-git-policy".into(), "explicit-grants-v1".into()],
+            vec!["buzz-git-policy".into(), "explicit-grants-v1".into()],
+        ];
+        assert_eq!(
+            parse_git_capability_policy(&duplicate),
+            Err(GitCapabilityParseError::DuplicatePolicy)
+        );
+
+        let unknown = vec![vec!["buzz-git-policy".into(), "future-v2".into()]];
+        assert_eq!(
+            parse_git_capability_policy(&unknown),
+            Err(GitCapabilityParseError::UnsupportedPolicy(
+                "future-v2".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn git_capability_policy_requires_legacy_owner_protection() {
+        let tags = vec![vec!["buzz-git-policy".into(), "explicit-grants-v1".into()]];
+        assert_eq!(
+            parse_git_capability_policy(&tags),
+            Err(GitCapabilityParseError::MissingLegacyProtection)
+        );
+    }
+
+    #[test]
+    fn git_capability_policy_parses_two_actor_grants() {
+        let actor_a = "a".repeat(64);
+        let actor_b = "b".repeat(64);
+        let policy = parse_git_capability_policy(&capability_tags(&actor_a, &actor_b, 86_500))
+            .expect("valid capability policy");
+        let GitCapabilityPolicy::ExplicitGrantsV1 { grants } = policy else {
+            panic!("expected explicit grants");
+        };
+        assert_eq!(grants.len(), 2);
+        assert_eq!(grants[0].actor_pubkey, actor_a);
+        assert_eq!(grants[0].pattern.as_str(), "refs/heads/agent/a/**");
+        assert_eq!(grants[0].expires_at, 86_500);
+    }
+
+    #[test]
+    fn git_capability_policy_rejects_malformed_grants() {
+        let base = vec![
+            vec!["buzz-protect".into(), "refs/**".into(), "push:owner".into()],
+            vec!["buzz-git-policy".into(), "explicit-grants-v1".into()],
+        ];
+        let lowercase_actor = "a".repeat(64);
+        let uppercase_actor = "A".repeat(64);
+        let cases = [
+            vec![
+                "buzz-git-grant".into(),
+                "abc".into(),
+                "refs/heads/a/**".into(),
+                "push".into(),
+                "10".into(),
+            ],
+            vec![
+                "buzz-git-grant".into(),
+                uppercase_actor,
+                "refs/heads/a/**".into(),
+                "push".into(),
+                "10".into(),
+            ],
+            vec![
+                "buzz-git-grant".into(),
+                lowercase_actor.clone(),
+                "heads/a/**".into(),
+                "push".into(),
+                "10".into(),
+            ],
+            vec![
+                "buzz-git-grant".into(),
+                lowercase_actor.clone(),
+                "refs/heads/a/**".into(),
+                "merge".into(),
+                "10".into(),
+            ],
+            vec![
+                "buzz-git-grant".into(),
+                lowercase_actor,
+                "refs/heads/a/**".into(),
+                "push".into(),
+                "later".into(),
+            ],
+        ];
+        for case in cases {
+            let mut tags = base.clone();
+            tags.push(case);
+            assert!(
+                parse_git_capability_policy(&tags).is_err(),
+                "case: {tags:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_capability_policy_enforces_grant_limit() {
+        let mut tags = vec![
+            vec!["buzz-protect".into(), "refs/**".into(), "push:owner".into()],
+            vec!["buzz-git-policy".into(), "explicit-grants-v1".into()],
+        ];
+        for index in 0..=MAX_GIT_PUSH_GRANTS {
+            tags.push(vec![
+                "buzz-git-grant".into(),
+                format!("{index:064x}"),
+                format!("refs/heads/agent/{index}/**"),
+                "push".into(),
+                "100".into(),
+            ]);
+        }
+        assert_eq!(
+            parse_git_capability_policy(&tags),
+            Err(GitCapabilityParseError::TooManyGrants)
+        );
+    }
+
+    #[test]
+    fn git_capability_policy_isolates_actor_prefixes_and_main() {
+        let actor_a = "a".repeat(64);
+        let actor_b = "b".repeat(64);
+        let policy =
+            parse_git_capability_policy(&capability_tags(&actor_a, &actor_b, 86_500)).unwrap();
+
+        assert_eq!(
+            evaluate_git_push_capabilities(
+                &policy,
+                &actor_a,
+                &[create_update("refs/heads/agent/a/task-1")],
+                100,
+                200,
+            ),
+            Ok(GitCapabilityDecision::ExplicitGrant)
+        );
+        assert!(evaluate_git_push_capabilities(
+            &policy,
+            &actor_a,
+            &[create_update("refs/heads/main")],
+            100,
+            200,
+        )
+        .is_err());
+        assert!(evaluate_git_push_capabilities(
+            &policy,
+            &actor_a,
+            &[create_update("refs/heads/agent/b/task-1")],
+            100,
+            200,
+        )
+        .is_err());
+        assert_eq!(
+            evaluate_git_push_capabilities(
+                &policy,
+                &actor_b,
+                &[create_update("refs/heads/agent/b/task-1")],
+                100,
+                200,
+            ),
+            Ok(GitCapabilityDecision::ExplicitGrant)
+        );
+    }
+
+    #[test]
+    fn git_capability_policy_denies_expired_overlong_and_future_issued_grants() {
+        let actor = "a".repeat(64);
+        let update = create_update("refs/heads/agent/a/task-1");
+
+        let expired =
+            parse_git_capability_policy(&capability_tags(&actor, &"b".repeat(64), 200)).unwrap();
+        assert!(evaluate_git_push_capabilities(
+            &expired,
+            &actor,
+            std::slice::from_ref(&update),
+            100,
+            200
+        )
+        .is_err());
+
+        let overlong = parse_git_capability_policy(&capability_tags(
+            &actor,
+            &"b".repeat(64),
+            100 + MAX_GIT_PUSH_GRANT_TTL_SECS + 1,
+        ))
+        .unwrap();
+        assert!(evaluate_git_push_capabilities(
+            &overlong,
+            &actor,
+            std::slice::from_ref(&update),
+            100,
+            200,
+        )
+        .is_err());
+
+        let current =
+            parse_git_capability_policy(&capability_tags(&actor, &"b".repeat(64), 500)).unwrap();
+        assert!(evaluate_git_push_capabilities(&current, &actor, &[update], 300, 200).is_err());
+    }
+
+    #[test]
+    fn git_capability_policy_denies_atomic_push_with_uncovered_ref() {
+        let actor = "a".repeat(64);
+        let policy =
+            parse_git_capability_policy(&capability_tags(&actor, &"b".repeat(64), 500)).unwrap();
+        let result = evaluate_git_push_capabilities(
+            &policy,
+            &actor,
+            &[
+                create_update("refs/heads/agent/a/task-1"),
+                create_update("refs/heads/main"),
+            ],
+            100,
+            200,
+        );
+        let denials = result.expect_err("one uncovered ref denies the push");
+        assert_eq!(denials.len(), 1);
+        assert_eq!(denials[0].ref_name, "refs/heads/main");
+    }
+
+    #[test]
+    fn explicit_grant_does_not_bypass_non_role_protection() {
+        let actor = "a".repeat(64);
+        let policy =
+            parse_git_capability_policy(&capability_tags(&actor, &"b".repeat(64), 500)).unwrap();
+        let update = RefUpdate {
+            ref_name: "refs/heads/agent/a/task-1".into(),
+            kind: UpdateKind::NonFastForward,
+            old_oid: "a".repeat(40),
+            new_oid: "b".repeat(40),
+        };
+        assert_eq!(
+            evaluate_git_push_capabilities(
+                &policy,
+                &actor,
+                std::slice::from_ref(&update),
+                100,
+                200,
+            ),
+            Ok(GitCapabilityDecision::ExplicitGrant)
+        );
+        let rules =
+            vec![
+                parse_protection_tag(&["refs/heads/agent/a/**", "push:owner", "no-force-push"])
+                    .unwrap(),
+            ];
+        assert!(evaluate_push(&[update], MemberRole::Owner, &rules).is_err());
     }
 }

--- a/crates/buzz-relay/src/api/git/policy.rs
+++ b/crates/buzz-relay/src/api/git/policy.rs
@@ -4,20 +4,21 @@
 //! the pusher's pubkey, repo ID, and ref updates. This endpoint:
 //!
 //! 1. Validates HMAC signature + 30s TTL (fail-closed)
-//! 2. Resolves kind:30617 → protection rules
-//! 3. Grants owner authority to the repo key or its verified managed-agent owner
-//! 4. Otherwise resolves the pusher's channel role via buzz-channel binding
-//! 5. Promotes Bot → Member (bots in a channel push as members)
+//! 2. Resolves kind:30617 → protection rules and optional explicit grants
+//! 3. Resolves repo-owner or channel membership authority
+//! 4. Requires actor/ref/expiry coverage for repositories in explicit-grant mode
+//! 5. Promotes Bot → Member only for legacy repositories
 //! 6. Calls `buzz_core::git_perms::evaluate_push()`
 //! 7. Returns 200 (allow) or 403 (deny with reasons)
 //!
 //! # Bot Role Model
 //!
 //! Bots are intentionally added to channels by members/admins. For git push,
-//! they're promoted to Member — protection rules still apply. Bot is a
-//! designation (what it is), not a permission tier (what it can do). The
-//! promotion is scoped to this module; the core `MemberRole::Bot` hierarchy
-//! is unchanged.
+//! they're promoted to Member on legacy repositories — protection rules still
+//! apply. Repositories using explicit grants require a current actor/ref grant
+//! for bots just like every other pusher. Bot is a designation (what it is),
+//! not a permission tier (what it can do). The legacy promotion is scoped to
+//! this module; the core `MemberRole::Bot` hierarchy is unchanged.
 //!
 //! # Security invariants
 //!
@@ -43,7 +44,8 @@ use uuid::Uuid;
 
 use buzz_core::channel::MemberRole;
 use buzz_core::git_perms::{
-    evaluate_push, parse_protection_tags, Denial, RefUpdate, UpdateKind,
+    evaluate_git_push_capabilities, evaluate_push, parse_git_capability_policy,
+    parse_protection_tags, Denial, GitCapabilityDecision, RefUpdate, UpdateKind,
     GIT_NO_CHANNEL_BINDING_BODY,
 };
 use buzz_db::EventQuery;
@@ -300,6 +302,14 @@ pub async fn hook_policy_check(
         }
     };
 
+    let capability_policy = match parse_git_capability_policy(&tags) {
+        Ok(policy) => policy,
+        Err(error) => {
+            warn!(repo = %req.repo_id, error = %error, "hook callback: malformed Git capability policy");
+            return (StatusCode::FORBIDDEN, "malformed Git capability policy").into_response();
+        }
+    };
+
     // 6. Resolve channel binding via the shared resolver (same first-tag,
     // fail-closed semantics as the read gate) and check archived state
     // (applies to ALL pushers including owner).
@@ -400,15 +410,7 @@ pub async fn hook_policy_check(
         }
     };
 
-    // 8. Effective git role: bots intentionally added to a channel push as members.
-    // Protection rules (push:admin, no-force-push, require-patch, etc.) still apply.
-    // Bot is a designation (what it is), not a permission tier (what it can do).
-    let git_role = match role {
-        MemberRole::Bot => MemberRole::Member,
-        other => other,
-    };
-
-    // 9. Classify ref updates and evaluate policy.
+    // 8. Classify ref updates before capability and protection evaluation.
     let updates: Vec<RefUpdate> = req
         .ref_updates
         .iter()
@@ -419,6 +421,34 @@ pub async fn hook_policy_check(
             new_oid: r.new_oid.clone(),
         })
         .collect();
+
+    // 9. Explicit mode requires every pusher (including repo/managed-agent
+    // owners) and every ref to have a current grant. A covered push is treated
+    // as Owner only for the role threshold; non-role protection remains in
+    // force below. Legacy mode preserves the existing Bot → Member behavior.
+    let capability_decision = match evaluate_git_push_capabilities(
+        &capability_policy,
+        &req.pusher_pubkey,
+        &updates,
+        repo_event.event.created_at.as_secs(),
+        now,
+    ) {
+        Ok(decision) => decision,
+        Err(denials) => {
+            let response = HookCallbackResponse {
+                allowed: false,
+                denials: denials.into_iter().map(DenialResponse::from).collect(),
+            };
+            return (StatusCode::FORBIDDEN, Json(response)).into_response();
+        }
+    };
+    let git_role = match capability_decision {
+        GitCapabilityDecision::Legacy => match role {
+            MemberRole::Bot => MemberRole::Member,
+            other => other,
+        },
+        GitCapabilityDecision::ExplicitGrant => MemberRole::Owner,
+    };
 
     match evaluate_push(&updates, git_role, &rules) {
         Ok(()) => Json(HookCallbackResponse {
@@ -912,6 +942,62 @@ printf '%s' "$HMAC_INPUT" | openssl dgst -sha256 -hmac "{secret}" -hex 2>/dev/nu
         hook_policy_check(State(Arc::clone(state)), Json(req)).await
     }
 
+    async fn insert_repo_announcement(
+        state: &Arc<AppState>,
+        community: buzz_core::CommunityId,
+        owner_keys: &nostr::Keys,
+        repo_id: &str,
+        created_at: u64,
+        tags: Vec<nostr::Tag>,
+    ) {
+        use nostr::{EventBuilder, Kind, Tag, Timestamp};
+
+        let mut announcement_tags = vec![Tag::parse(["d", repo_id]).unwrap()];
+        announcement_tags.extend(tags);
+        let event = EventBuilder::new(Kind::Custom(30617), "")
+            .tags(announcement_tags)
+            .custom_created_at(Timestamp::from(created_at))
+            .sign_with_keys(owner_keys)
+            .expect("sign 30617");
+        state
+            .db
+            .insert_event(community, &event, None)
+            .await
+            .expect("insert 30617");
+    }
+
+    async fn actor_push_response(
+        state: &Arc<AppState>,
+        community: buzz_core::CommunityId,
+        owner_keys: &nostr::Keys,
+        repo_id: &str,
+        pusher_keys: &nostr::Keys,
+        ref_updates: Vec<HookRefUpdate>,
+        timestamp: u64,
+    ) -> axum::response::Response {
+        let mut req = HookCallbackRequest {
+            repo_id: repo_id.to_string(),
+            repo_owner: owner_keys.public_key().to_hex(),
+            community_id: community.as_uuid().to_string(),
+            pusher_pubkey: pusher_keys.public_key().to_hex(),
+            ref_updates,
+            timestamp,
+            signature: String::new(),
+        };
+        let secret = state.config.git_hook_hmac_secret.clone();
+        sign_request(&mut req, secret.as_bytes());
+        hook_policy_check(State(Arc::clone(state)), Json(req)).await
+    }
+
+    fn create_ref(ref_name: &str) -> HookRefUpdate {
+        HookRefUpdate {
+            old_oid: "0".repeat(40),
+            new_oid: "2".repeat(40),
+            ref_name: ref_name.to_string(),
+            is_ancestor: false,
+        }
+    }
+
     async fn body_string(response: axum::response::Response) -> (StatusCode, String) {
         let status = response.status();
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -982,6 +1068,241 @@ printf '%s' "$HMAC_INPUT" | openssl dgst -sha256 -hmac "{secret}" -hex 2>/dev/nu
             status,
             StatusCode::OK,
             "owner push to a never-bound repo must remain allowed (got body: {body})"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn explicit_git_grants_isolate_two_actors_and_deny_role_bypasses() {
+        use nostr::{Keys, Tag};
+
+        let state = policy_test_state().await;
+        let host = format!("capability-{}.example", uuid::Uuid::new_v4().simple());
+        let community = state
+            .db
+            .ensure_configured_community(&host)
+            .await
+            .expect("community")
+            .id;
+        let repo_owner = Keys::generate();
+        let managed_owner = Keys::generate();
+        let actor_a = Keys::generate();
+        let actor_b = Keys::generate();
+        let plain_member = Keys::generate();
+        let bot = Keys::generate();
+        let creator = Keys::generate();
+
+        let repo_owner_bytes = repo_owner.public_key().to_bytes().to_vec();
+        let managed_owner_bytes = managed_owner.public_key().to_bytes().to_vec();
+        let actor_a_bytes = actor_a.public_key().to_bytes().to_vec();
+        let actor_b_bytes = actor_b.public_key().to_bytes().to_vec();
+        let plain_member_bytes = plain_member.public_key().to_bytes().to_vec();
+        let bot_bytes = bot.public_key().to_bytes().to_vec();
+        let creator_bytes = creator.public_key().to_bytes().to_vec();
+        for pubkey in [
+            &repo_owner_bytes,
+            &managed_owner_bytes,
+            &actor_a_bytes,
+            &actor_b_bytes,
+            &plain_member_bytes,
+            &bot_bytes,
+            &creator_bytes,
+        ] {
+            state.db.ensure_user(community, pubkey).await.expect("user");
+        }
+        state
+            .db
+            .set_agent_owner(community, &repo_owner_bytes, &managed_owner_bytes)
+            .await
+            .expect("managed owner binding");
+
+        let channel = uuid::Uuid::new_v4();
+        state
+            .db
+            .create_channel_with_id(
+                community,
+                channel,
+                &format!("capability-{}", channel.simple()),
+                buzz_db::channel::ChannelType::Stream,
+                buzz_db::channel::ChannelVisibility::Open,
+                None,
+                &creator_bytes,
+                None,
+            )
+            .await
+            .expect("channel");
+        for (pubkey, role) in [
+            (&actor_a_bytes, MemberRole::Member),
+            (&actor_b_bytes, MemberRole::Member),
+            (&plain_member_bytes, MemberRole::Member),
+            (&bot_bytes, MemberRole::Bot),
+        ] {
+            state
+                .db
+                .add_member(community, channel, pubkey, role, Some(&creator_bytes))
+                .await
+                .expect("channel member");
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let issued_at = now.saturating_sub(1);
+        let expires_at = now + 3_600;
+        let repo_id = format!("repo-{}", uuid::Uuid::new_v4().simple());
+        let actor_a_hex = actor_a.public_key().to_hex();
+        let actor_b_hex = actor_b.public_key().to_hex();
+        insert_repo_announcement(
+            &state,
+            community,
+            &repo_owner,
+            &repo_id,
+            issued_at,
+            vec![
+                Tag::parse(["buzz-channel", &channel.to_string()]).unwrap(),
+                Tag::parse(["buzz-protect", "refs/**", "push:owner"]).unwrap(),
+                Tag::parse(["buzz-git-policy", "explicit-grants-v1"]).unwrap(),
+                Tag::parse([
+                    "buzz-git-grant",
+                    &actor_a_hex,
+                    "refs/heads/agent/a/**",
+                    "push",
+                    &expires_at.to_string(),
+                ])
+                .unwrap(),
+                Tag::parse([
+                    "buzz-git-grant",
+                    &actor_b_hex,
+                    "refs/heads/agent/b/**",
+                    "push",
+                    &expires_at.to_string(),
+                ])
+                .unwrap(),
+            ],
+        )
+        .await;
+
+        for (pusher, ref_name) in [
+            (&actor_a, "refs/heads/agent/a/task-1"),
+            (&actor_b, "refs/heads/agent/b/task-1"),
+        ] {
+            let response = actor_push_response(
+                &state,
+                community,
+                &repo_owner,
+                &repo_id,
+                pusher,
+                vec![create_ref(ref_name)],
+                now,
+            )
+            .await;
+            let (status, body) = body_string(response).await;
+            assert_eq!(status, StatusCode::OK, "allowed ref {ref_name}: {body}");
+        }
+
+        for (pusher, ref_name) in [
+            (&actor_a, "refs/heads/main"),
+            (&actor_a, "refs/heads/agent/b/task-1"),
+            (&plain_member, "refs/heads/agent/a/task-1"),
+            (&bot, "refs/heads/agent/a/task-1"),
+            (&repo_owner, "refs/heads/agent/a/task-1"),
+            (&managed_owner, "refs/heads/agent/a/task-1"),
+        ] {
+            let response = actor_push_response(
+                &state,
+                community,
+                &repo_owner,
+                &repo_id,
+                pusher,
+                vec![create_ref(ref_name)],
+                now,
+            )
+            .await;
+            let (status, body) = body_string(response).await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "ungranted actor/ref must be denied: {body}"
+            );
+        }
+
+        let response = actor_push_response(
+            &state,
+            community,
+            &repo_owner,
+            &repo_id,
+            &actor_a,
+            vec![
+                create_ref("refs/heads/agent/a/task-2"),
+                create_ref("refs/heads/main"),
+            ],
+            now,
+        )
+        .await;
+        let (status, _) = body_string(response).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "mixed push is atomic");
+
+        let expired_repo = format!("repo-{}", uuid::Uuid::new_v4().simple());
+        insert_repo_announcement(
+            &state,
+            community,
+            &repo_owner,
+            &expired_repo,
+            issued_at,
+            vec![
+                Tag::parse(["buzz-channel", &channel.to_string()]).unwrap(),
+                Tag::parse(["buzz-protect", "refs/**", "push:owner"]).unwrap(),
+                Tag::parse(["buzz-git-policy", "explicit-grants-v1"]).unwrap(),
+                Tag::parse([
+                    "buzz-git-grant",
+                    &actor_a_hex,
+                    "refs/heads/agent/a/**",
+                    "push",
+                    &issued_at.to_string(),
+                ])
+                .unwrap(),
+            ],
+        )
+        .await;
+        let response = actor_push_response(
+            &state,
+            community,
+            &repo_owner,
+            &expired_repo,
+            &actor_a,
+            vec![create_ref("refs/heads/agent/a/task-3")],
+            now,
+        )
+        .await;
+        let (status, _) = body_string(response).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "expired grant is denied");
+
+        let legacy_repo = format!("repo-{}", uuid::Uuid::new_v4().simple());
+        insert_repo_announcement(
+            &state,
+            community,
+            &repo_owner,
+            &legacy_repo,
+            issued_at,
+            vec![Tag::parse(["buzz-channel", &channel.to_string()]).unwrap()],
+        )
+        .await;
+        let response = actor_push_response(
+            &state,
+            community,
+            &repo_owner,
+            &legacy_repo,
+            &actor_a,
+            vec![create_ref("refs/heads/legacy-task")],
+            now,
+        )
+        .await;
+        let (status, body) = body_string(response).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "legacy member behavior changed: {body}"
         );
     }
 }

--- a/crates/buzz-test-client/tests/e2e_git.rs
+++ b/crates/buzz-test-client/tests/e2e_git.rs
@@ -19,7 +19,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use buzz_media::S3AddressingStyle;
 use nostr::{EventBuilder, Keys, Kind, Tag};
@@ -81,6 +81,20 @@ async fn create_test_channel(keys: &Keys) -> String {
         .unwrap();
     post_event(&event).await;
     channel_uuid
+}
+
+/// Add a test identity to a channel so the read gate remains independent from
+/// the explicit push-grant decision exercised below.
+async fn add_test_channel_member(owner: &Keys, channel: &str, member: &Keys) {
+    let event = EventBuilder::new(Kind::Custom(9000), "")
+        .tags(vec![
+            Tag::parse(["h", channel]).unwrap(),
+            Tag::parse(["p", &member.public_key().to_hex()]).unwrap(),
+            Tag::parse(["role", "member"]).unwrap(),
+        ])
+        .sign_with_keys(owner)
+        .unwrap();
+    post_event(&event).await;
 }
 
 /// Run `git` with the Buzz credential helper and isolated config.
@@ -406,6 +420,187 @@ async fn git_clone_push_fetch_force_roundtrip() {
     );
     let tags = git(&["tag"], &tmp.path().join("clone4"), &owner_nsec);
     assert!(tags.contains("v1.0"), "tag v1.0 cloned back: {tags}");
+}
+
+#[tokio::test]
+#[ignore = "requires live relay + MinIO + git"]
+async fn explicit_push_grants_enforce_actor_ref_and_expiry_over_smart_http() {
+    use nostr::ToBech32;
+
+    let owner = Keys::generate();
+    let actor_a = Keys::generate();
+    let actor_b = Keys::generate();
+    let owner_hex = owner.public_key().to_hex();
+    let owner_nsec = owner.secret_key().to_bech32().unwrap();
+    let actor_a_hex = actor_a.public_key().to_hex();
+    let actor_a_nsec = actor_a.secret_key().to_bech32().unwrap();
+    let actor_b_hex = actor_b.public_key().to_hex();
+    let actor_b_nsec = actor_b.secret_key().to_bech32().unwrap();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let repo = format!("e2e-git-capability-{}", std::process::id());
+
+    let channel = create_test_channel(&owner).await;
+    add_test_channel_member(&owner, &channel, &actor_a).await;
+    add_test_channel_member(&owner, &channel, &actor_b).await;
+
+    let announce = EventBuilder::new(Kind::from(30617), "")
+        .tags(vec![
+            Tag::parse(["d", &repo]).unwrap(),
+            Tag::parse(["name", "explicit grant git e2e"]).unwrap(),
+            Tag::parse(["buzz-channel", &channel]).unwrap(),
+            // Older relays fail closed because neither actor is an owner.
+            Tag::parse(["buzz-protect", "refs/**", "push:owner"]).unwrap(),
+            Tag::parse(["buzz-git-policy", "explicit-grants-v1"]).unwrap(),
+            Tag::parse([
+                "buzz-git-grant",
+                &actor_a_hex,
+                "refs/heads/agent/a/**",
+                "push",
+                &(now + 3_600).to_string(),
+            ])
+            .unwrap(),
+            Tag::parse([
+                "buzz-git-grant",
+                &actor_b_hex,
+                "refs/heads/agent/b/**",
+                "push",
+                &(now + 3_600).to_string(),
+            ])
+            .unwrap(),
+        ])
+        .sign_with_keys(&owner)
+        .unwrap();
+    post_event(&announce).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let tmp = tempdir_named("buzz-e2e-git-capability");
+    let url = format!("{}/git/{}/{}", relay_http_url(), owner_hex, repo);
+    git(
+        &["clone", "--quiet", &url, "actor-a"],
+        tmp.path(),
+        &actor_a_nsec,
+    );
+    let worktree = tmp.path().join("actor-a");
+    std::fs::write(worktree.join("README.md"), "explicit capability canary\n").unwrap();
+    git(&["add", "."], &worktree, &actor_a_nsec);
+    git(
+        &["commit", "--quiet", "-m", "capability canary"],
+        &worktree,
+        &actor_a_nsec,
+    );
+    let commit = git(&["rev-parse", "HEAD"], &worktree, &actor_a_nsec)
+        .trim()
+        .to_string();
+
+    git(
+        &[
+            "push",
+            "--quiet",
+            "origin",
+            "HEAD:refs/heads/agent/a/task-1",
+        ],
+        &worktree,
+        &actor_a_nsec,
+    );
+    git(
+        &[
+            "push",
+            "--quiet",
+            "origin",
+            "HEAD:refs/heads/agent/b/task-1",
+        ],
+        &worktree,
+        &actor_b_nsec,
+    );
+
+    for (label, actor_nsec, refspec) in [
+        ("main", &actor_a_nsec, "HEAD:refs/heads/main"),
+        (
+            "other actor prefix",
+            &actor_a_nsec,
+            "HEAD:refs/heads/agent/b/actor-a-cross-prefix",
+        ),
+        (
+            "foreign actor",
+            &actor_b_nsec,
+            "HEAD:refs/heads/agent/a/actor-b-foreign",
+        ),
+    ] {
+        let output = git_status(&["push", "origin", refspec], &worktree, actor_nsec);
+        assert!(
+            !output.status.success(),
+            "{label} push unexpectedly succeeded:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let refs = git(&["ls-remote", &url], tmp.path(), &owner_nsec);
+    assert!(
+        refs.contains(&format!("{commit}\trefs/heads/agent/a/task-1")),
+        "actor A branch missing: {refs}"
+    );
+    assert!(
+        refs.contains(&format!("{commit}\trefs/heads/agent/b/task-1")),
+        "actor B branch missing: {refs}"
+    );
+    assert!(
+        !refs.contains("refs/heads/main"),
+        "main was created: {refs}"
+    );
+    assert!(
+        !refs.contains("cross-prefix") && !refs.contains("foreign"),
+        "a denied ref was created: {refs}"
+    );
+
+    let expired_repo = format!("{repo}-expired");
+    let expired_announce = EventBuilder::new(Kind::from(30617), "")
+        .tags(vec![
+            Tag::parse(["d", &expired_repo]).unwrap(),
+            Tag::parse(["name", "expired explicit grant git e2e"]).unwrap(),
+            Tag::parse(["buzz-channel", &channel]).unwrap(),
+            Tag::parse(["buzz-protect", "refs/**", "push:owner"]).unwrap(),
+            Tag::parse(["buzz-git-policy", "explicit-grants-v1"]).unwrap(),
+            Tag::parse([
+                "buzz-git-grant",
+                &actor_a_hex,
+                "refs/heads/agent/a/**",
+                "push",
+                &(now - 60).to_string(),
+            ])
+            .unwrap(),
+        ])
+        .custom_created_at(nostr::Timestamp::from(now - 120))
+        .sign_with_keys(&owner)
+        .unwrap();
+    post_event(&expired_announce).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let expired_url = format!(
+        "{}/git/{}/{}",
+        relay_http_url(),
+        owner.public_key().to_hex(),
+        expired_repo
+    );
+    let output = git_status(
+        &["push", &expired_url, "HEAD:refs/heads/agent/a/expired"],
+        &worktree,
+        &actor_a_nsec,
+    );
+    assert!(
+        !output.status.success(),
+        "expired grant unexpectedly pushed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let expired_refs = git(&["ls-remote", &expired_url], tmp.path(), &owner_nsec);
+    assert!(
+        expired_refs.trim().is_empty(),
+        "expired push created a ref: {expired_refs}"
+    );
 }
 
 #[tokio::test]

--- a/docs/git-capability-grants.md
+++ b/docs/git-capability-grants.md
@@ -51,6 +51,24 @@ ordinary channel member or bot fails closed instead of inheriting write access.
   A grant tag without a policy tag, duplicate policy tags, or an unknown policy
   version fails closed.
 
+## Authentication and replay boundary
+
+The actor comes from the verified repository-root NIP-98 event and is copied by
+the relay into the pre-receive environment. The internal callback HMAC binds
+the community, repository, owner, actor, timestamp, and every ref/OID/ancestry
+tuple. Replaying that callback inside its 30-second window only repeats the
+read-only authorization decision; it cannot create a ref or substitute a
+different push.
+
+The outer Git credential token follows the existing Smart HTTP contract: Git
+reuses it across discovery and pack requests, so it is repository-URL-bound and
+accepted only inside the 60-second NIP-98 timestamp window, but is not bound to
+one HTTP method or pack body and is not event-ID deduplicated. A stolen token
+may therefore be replayed against the same repository during that short window
+within the actor's current grant scope. HTTPS is mandatory in production; grant
+expiry is an authorization lifetime, not a replacement for transport security
+or per-request anti-replay.
+
 ## Compatibility boundary
 
 The owner-only fallback protects ordinary members and bots on older relays. It

--- a/docs/git-capability-grants.md
+++ b/docs/git-capability-grants.md
@@ -1,0 +1,65 @@
+# Explicit Git Capability Grants
+
+`experimental`
+
+Buzz normally derives Git push authority from the pusher's channel role. A
+repository announcement can opt in to `explicit-grants-v1` when channel
+membership must remain useful for communication without also authorizing every
+member or bot to write the repository.
+
+This mode is a narrow authorization layer in front of the existing branch
+protections. It does not replace `no-force-push`, `no-delete`, or
+`require-patch` rules.
+
+## Tag grammar
+
+The signed kind:30617 repository announcement selects the policy and binds a
+Nostr actor to a repository ref pattern:
+
+```text
+["buzz-git-policy", "explicit-grants-v1"]
+["buzz-git-grant", "<lowercase-pubkey-hex>", "<ref-pattern>", "push", "<expires-at-unix>"]
+["buzz-protect", "refs/**", "push:owner"]
+```
+
+The `buzz-protect` baseline is mandatory. A relay that predates explicit grants
+ignores the two new tag types but understands this owner-only protection, so an
+ordinary channel member or bot fails closed instead of inheriting write access.
+
+## Enforcement
+
+- The NIP-98-authenticated pusher must still belong to the repository channel,
+  except for the existing repository-owner and managed-agent-owner identity
+  relationships.
+- In explicit mode, channel membership and ownership are necessary identity
+  bindings but are not write authorization. Every pusher, including a
+  repository owner or managed-agent owner, needs a current grant.
+- Every ref in one atomic push must match a grant for the authenticated actor.
+  One uncovered ref rejects the entire push.
+- A grant expires at the Unix timestamp in its tag. Expiry is exclusive.
+- A repository announcement may contain at most 50 grants. Every grant must be
+  valid for no more than 24 hours from the announcement's signed `created_at`
+  timestamp. A future announcement timestamp or any invalid grant lifetime
+  rejects the push.
+- A grant satisfies only the role threshold for the matching refs. The relay
+  still evaluates all non-role branch-protection rules.
+- The `push` capability covers create, fast-forward, non-fast-forward, and
+  delete updates inside the granted pattern. Operators that want append-only
+  task branches must add `no-force-push` and `no-delete`; `require-patch`
+  continues to block every direct push.
+- Repositories without `buzz-git-policy` keep the legacy channel-role behavior.
+  A grant tag without a policy tag, duplicate policy tags, or an unknown policy
+  version fails closed.
+
+## Compatibility boundary
+
+The owner-only fallback protects ordinary members and bots on older relays. It
+cannot stop an older relay from honoring its existing repository-owner or
+managed-agent-owner bypass. Operators must therefore verify the relay version
+before publishing a repository announcement that opts in to explicit grants.
+Removing or replacing the kind:30617 announcement revokes the signed grants;
+there is no separate unsigned grant store.
+
+This compatibility boundary makes the policy safe to evaluate in a controlled
+pilot, but it is not a signal to activate it in production without positive
+and negative authorization tests against the exact deployed relay image.

--- a/docs/git-capability-grants.md
+++ b/docs/git-capability-grants.md
@@ -63,3 +63,36 @@ there is no separate unsigned grant store.
 This compatibility boundary makes the policy safe to evaluate in a controlled
 pilot, but it is not a signal to activate it in production without positive
 and negative authorization tests against the exact deployed relay image.
+
+## Verification, rollout, and rollback
+
+The ignored end-to-end test drives the real Git credential helper and Smart
+HTTP transport with two disposable actors:
+
+```text
+cargo build -p buzz-relay --bin buzz-relay \
+  -p git-credential-nostr --bin git-credential-nostr
+RELAY_HTTP_URL=http://127.0.0.1:3000 \
+GIT_CREDENTIAL_NOSTR_BIN="$PWD/target/debug/git-credential-nostr" \
+  cargo test -p buzz-test-client --test e2e_git \
+  explicit_push_grants_enforce_actor_ref_and_expiry_over_smart_http \
+  -- --ignored --exact --nocapture
+```
+
+Run it against an isolated database, Redis, object store, and Git directory.
+Before production activation, repeat the same positive and negative pushes
+against the exact candidate image: both actors' own prefixes must pass, while
+`main`, the other actor's prefix, a foreign actor, and an expired grant must
+all fail without creating refs.
+
+Rollback is an image rollback to the previously pinned relay build. Keep the
+owner-only `buzz-protect` baseline in every opted-in announcement: an older
+relay then denies the granted non-owner actors. Do not automatically remove
+the policy and grant tags during rollback, because returning a repository to
+legacy channel-role authorization can expand write access and requires an
+explicit human decision.
+
+The fork maintenance surface is intentionally limited to the core policy
+parser/evaluator, the relay authorization adapter, tests, and this contract.
+It adds no database migration, unsigned grant store, or alternate Git
+transport, so rebases and rollback remain localized.


### PR DESCRIPTION
## Summary

- add versioned `explicit-grants-v1` push grants to Buzz Git policy events
- bind every grant to the authenticated actor, exact repo announcement, ref pattern, operation, and expiry
- enforce grants atomically across all ref updates, including owner and managed-owner identities
- preserve legacy behavior unless the repository explicitly opts into the new policy version

## Security contract

An opted-in repository publishes `buzz-git-policy explicit-grants-v1` and one or more `buzz-git-grant <actor> <pattern> push <expires>` tags. Parsing fails closed for malformed or unsupported policy data. Expiry is exclusive, grant TTL is capped at 24 hours, and grant count is bounded.

The explicit grant is the write-authorization gate and satisfies role thresholds for matching pushes. Existing non-role protections such as `require-patch`, `no-force-push`, and `no-delete` remain enforceable. Channel membership and repository readability do not grant write access.

The compatibility fallback requires `refs/** push:owner`, so an older relay denies the granted non-owner actors rather than silently accepting the new policy. An older relay still retains its existing repository-owner and managed-agent-owner bypass; opted-in announcements therefore require an exact relay-version pin before activation.

Git Smart HTTP keeps its existing authentication boundary: the NIP-98 actor is repository-URL-bound and accepted inside the 60-second timestamp window, but Git reuses the token across requests, so it is not bound to one method or pack body and is not event-ID deduplicated. HTTPS remains mandatory. The internal pre-receive callback is read-only, limited to 30 seconds, and HMAC-binds the tenant, repository, actor, refs, OIDs, ancestry, and timestamp.

## Verification

- `cargo test -p buzz-core git_capability -- --nocapture` — 9 passed
- `cargo test -p buzz-core explicit_grant_does_not_bypass_non_role_protection` — 1 passed
- `cargo test -p buzz-relay --lib api::git::policy::tests` — 15 passed, 2 Postgres tests ignored by default
- Postgres-backed actor-isolation and broken-binding tests — both passed
- isolated Git Smart HTTP canary with two actors — own branches passed; `main`, cross-prefix, foreign-actor, and expired-grant pushes were rejected without creating refs
- `just fmt-check`, `just clippy`, and `just test-unit` — passed
- `just ci` — passed, including Rust, desktop, web, mobile, and build suites

This PR adds the relay capability only. It does not activate the policy on a production repository.
