### PR TITLE
fix(mobile): tag all candidates when an @mention is ambiguous

### DIFF
--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -118,6 +118,16 @@ class SendMessage {
       final name = match.group(1)?.toLowerCase();
       if (name == null || name.isEmpty) continue;
 
+      // Collect every profile whose display name matches, rather than taking
+      // the first one and breaking out. Two members can legitimately share a
+      // display name — a stale identity left behind by a re-key is the common
+      // case — and `cache` is a Map, so "the first match" really means
+      // "whichever entry the map happened to yield first". That made mention
+      // delivery depend on map ordering: for some names the `p` tag landed on
+      // the live identity and the mention worked, for others it landed on a
+      // dead one and the mention silently reached nobody, with nothing in the
+      // UI to distinguish the two.
+      final candidates = <String>[];
       for (final profile in cache.values) {
         final displayName = profile.displayName?.toLowerCase();
         if (displayName == null) continue;
@@ -132,9 +142,16 @@ class SendMessage {
           continue;
         }
 
-        pubkeys.add(profile.pubkey);
-        break;
+        candidates.add(profile.pubkey);
       }
+
+      // An ambiguous @name tags every candidate. `buzz-cli` rejects the send
+      // outright here and tells the user to retry with an explicit
+      // `--mention <pubkey>`, but mobile has no way to supply one, so failing
+      // would leave a duplicated name permanently unmentionable. Tagging all
+      // candidates keeps the intended recipient reachable; the cost is a
+      // redundant `p` tag on the identities sharing that name.
+      pubkeys.addAll(candidates);
     }
 
     return pubkeys.toList();

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/send_message_provider.dart';
+import 'package:buzz/features/profile/user_profile.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
@@ -38,6 +40,59 @@ void main() {
       await result;
       expect(completedIds, [localMessages.single.id]);
       expect(removedIds, isEmpty);
+    },
+  );
+
+  test(
+    'tags every candidate when a display name is ambiguous',
+    () async {
+      // Two channel members share the display name "Neuromancer": a stale
+      // identity left behind by a re-key, and the live one. The stale entry is
+      // deliberately first in the cache — resolution used to take the first
+      // match and stop, so the `p` tag landed on the dead identity and the
+      // real agent was never notified. Nothing surfaced to the sender.
+      const staleP = 'f1a06b925f6705ef530932138664e2dda35fd5d743991f49e96';
+      const liveP = '1667bcebe81f2e5af1e5561a385f1c8a91b84d8d19c5d9c3f1b';
+
+      final session = _PendingPublishRelaySession();
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(
+          session: session,
+          nsec: nostr.Keys.generate().nsec,
+        ),
+        fetchMembers: (_) async => [
+          ChannelMember(
+            pubkey: staleP,
+            role: 'bot',
+            joinedAt: DateTime.utc(2020),
+          ),
+          ChannelMember(
+            pubkey: liveP,
+            role: 'bot',
+            joinedAt: DateTime.utc(2020),
+          ),
+        ],
+        readUserCache: () => const {
+          staleP: UserProfile(pubkey: staleP, displayName: 'Neuromancer'),
+          liveP: UserProfile(pubkey: liveP, displayName: 'Neuromancer'),
+        },
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      final result = send(channelId: _channelId, content: '@Neuromancer hi');
+      await session.published;
+      session.accept();
+      await result;
+
+      final tagged = session.event.tags
+          .where((t) => t.isNotEmpty && t.first == 'p')
+          .map((t) => t[1])
+          .toSet();
+
+      // Both must be tagged; tagging only one is a coin flip on map ordering.
+      expect(tagged, containsAll(<String>[staleP, liveP]));
     },
   );
 


### PR DESCRIPTION
Fixes the mobile half of #4303.

## The bug

`_resolveMentions` in `mobile/lib/features/channels/send_message_provider.dart` took the first profile whose display name matched and stopped:

```dart
for (final profile in cache.values) {
  ...
  pubkeys.add(profile.pubkey);
  break;                          // first match wins
}
```

There is no ambiguity detection. When two channel members share a display name, `cache` is a `Map`, so "the first match" is really "whichever entry the map happened to yield first" — and that decides which pubkey lands in the `p` tag.

## Why it matters

Agents match mentions purely on `p` tags (`event_mentions_agent` in `crates/buzz-acp/src/lib.rs`). If the tag names the wrong identity, the intended agent never sees the mention — and nothing surfaces to the sender.

This was found in a community where five bot display names each resolved to two pubkeys: a live identity and a stale one left behind by a re-key. The observed behaviour was that **some** agents answered `@Name` and others silently never did, consistently, for hours. It read as "the agents are ignoring me". Mentioning the same agent in the same channel with an explicit pubkey got a reply in seconds.

The split was purely map ordering: names whose live profile happened to be enumerated first worked; the rest tagged a dead identity.

`buzz-cli` already handles this correctly — `resolve_names_to_pubkeys` returns a `CliError::Usage` listing the candidates, with the comment:

> Lookup failures are fatal when mention processing is requested: publishing visible mention text without its intended `p` tag is worse than not sending.

Mobile silently did the thing that comment warns against.

## The change

Collect every matching candidate instead of breaking at the first, and tag them all.

Erroring the way the CLI does would be more consistent, but the CLI's remedy is "retry with `--mention <pubkey>`" and mobile has no way to supply one — so failing would leave a duplicated display name permanently unmentionable from the phone. Tagging all candidates keeps the intended recipient reachable; the cost is a redundant `p` tag on the other identities sharing that name.

Channel-member scoping is unchanged, so candidates are still restricted to members of the channel being posted to.

## Tests

Adds `tags every candidate when a display name is ambiguous`, which builds two members sharing a display name with the stale one deliberately ordered first — the production condition. Verified it **fails against the previous behaviour** (`+1 -1 … [E]`) and passes with the change.

- `dart analyze lib test` — no issues
- `flutter test test/features/channels/send_message_provider_test.dart` — 3/3 pass
- Full `flutter test` — 1022 pass, 1 pre-existing failure in `channel_detail_page_test.dart` that reproduces identically on unmodified `upstream/main`

## Note

This fixes mention resolution in the presence of duplicate display names. It does not prevent duplicate display names from existing — #4303 also covers `agents archive` reporting `ok:true` without applying, and archived identities still appearing in `users get --name`, both of which are relay-side and unaddressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZQxkSFrkD6MHCLz6wbYkr

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/
