### PR TITLE
feat(workflow): make GitHub PR workflow prompts readable and safely actionable

### DIFF
--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -532,6 +532,7 @@ async fn dispatch_persistent_event_inner(
     {
         let workflow_engine = Arc::clone(&state.workflow_engine);
         let workflow_event = stored_event.clone();
+        let workflow_actor_pubkey_hex = actor_pubkey_hex.to_owned();
         let trigger_kind = kind_u32.to_string();
         let workflow_community_host = tenant.host().to_owned();
         // The event was stored under `tenant.community()`; `StoredEvent` does
@@ -542,7 +543,11 @@ async fn dispatch_persistent_event_inner(
         let workflow_community = tenant.community();
         tokio::spawn(async move {
             if let Err(e) = workflow_engine
-                .on_event(workflow_community, &workflow_event)
+                .on_event_as_actor(
+                    workflow_community,
+                    &workflow_event,
+                    &workflow_actor_pubkey_hex,
+                )
                 .await
             {
                 tracing::error!(event_id = ?workflow_event.event.id, "Workflow trigger failed: {e}");

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -17,7 +17,32 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::handlers::event::dispatch_persistent_event;
+use crate::handlers::ingest::resolve_nip10_thread_meta;
 use crate::state::AppState;
+
+/// Recover a legacy parent event's effective thread root when materialized
+/// thread metadata is absent.
+fn legacy_thread_root(event: &nostr::Event) -> Option<Vec<u8>> {
+    event
+        .tags
+        .iter()
+        .find_map(|tag| {
+            let parts = tag.as_slice();
+            (parts.len() >= 4 && parts[0] == "e" && parts[3] == "root")
+                .then(|| hex::decode(&parts[1]).ok())
+                .flatten()
+                .filter(|bytes| bytes.len() == 32)
+        })
+        .or_else(|| {
+            event.tags.iter().find_map(|tag| {
+                let parts = tag.as_slice();
+                (parts.len() >= 4 && parts[0] == "e" && parts[3] == "reply")
+                    .then(|| hex::decode(&parts[1]).ok())
+                    .flatten()
+                    .filter(|bytes| bytes.len() == 32)
+            })
+        })
+}
 
 /// Resolves `@Name` mentions in workflow message text to the pubkeys of the
 /// channel members they name, so the emitted kind:9 carries the `p` tags that
@@ -177,9 +202,21 @@ impl ActionSink for RelayActionSink {
         text: &str,
         author_pubkey: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>> {
+        self.send_message_with_reply(community_id, channel_id, text, author_pubkey, None)
+    }
+
+    fn send_message_with_reply(
+        &self,
+        community_id: CommunityId,
+        channel_id: &str,
+        text: &str,
+        author_pubkey: &str,
+        reply_to: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>> {
         let channel_id = channel_id.to_owned();
         let text = text.to_owned();
         let author_pubkey = author_pubkey.to_owned();
+        let reply_to = reply_to.map(str::to_owned);
 
         Box::pin(async move {
             // 0. Upgrade weak reference — fails only during shutdown.
@@ -266,6 +303,69 @@ impl ActionSink for RelayActionSink {
                     .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
             ];
 
+            if let Some(reply_to) = reply_to.as_deref() {
+                if reply_to.len() != 64 || !reply_to.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return Err(ActionSinkError::InvalidInput(
+                        "reply_to must be a 64-character hex event ID".into(),
+                    ));
+                }
+                let parent_bytes = hex::decode(reply_to).map_err(|_| {
+                    ActionSinkError::InvalidInput("reply_to contains invalid hex".into())
+                })?;
+                let parent = state
+                    .db
+                    .get_event_by_id(tenant.community(), &parent_bytes)
+                    .await
+                    .map_err(|e| ActionSinkError::Database(e.to_string()))?
+                    .ok_or_else(|| {
+                        ActionSinkError::InvalidInput("reply_to event was not found".into())
+                    })?;
+                if parent.channel_id != Some(channel_uuid) {
+                    return Err(ActionSinkError::InvalidInput(
+                        "reply_to event belongs to a different channel".into(),
+                    ));
+                }
+
+                let parent_meta = state
+                    .db
+                    .get_thread_metadata_by_event(tenant.community(), &parent_bytes)
+                    .await
+                    .map_err(|e| ActionSinkError::Database(e.to_string()))?;
+                let root_bytes = parent_meta
+                    .and_then(|meta| meta.root_event_id)
+                    .or_else(|| legacy_thread_root(&parent.event))
+                    .unwrap_or_else(|| parent_bytes.clone());
+                if root_bytes != parent_bytes {
+                    let root = state
+                        .db
+                        .get_event_by_id(tenant.community(), &root_bytes)
+                        .await
+                        .map_err(|e| ActionSinkError::Database(e.to_string()))?
+                        .ok_or_else(|| {
+                            ActionSinkError::InvalidInput(
+                                "reply_to thread root was not found".into(),
+                            )
+                        })?;
+                    if root.channel_id != Some(channel_uuid) {
+                        return Err(ActionSinkError::InvalidInput(
+                            "reply_to thread root belongs to a different channel".into(),
+                        ));
+                    }
+                }
+                let root_hex = hex::encode(root_bytes);
+
+                tags.push(
+                    Tag::parse(["e", &root_hex, "", "root"]).map_err(|e| {
+                        ActionSinkError::EventBuild(format!("thread root tag: {e}"))
+                    })?,
+                );
+                tags.push(
+                    Tag::parse(["e", reply_to, "", "reply"]).map_err(|e| {
+                        ActionSinkError::EventBuild(format!("thread reply tag: {e}"))
+                    })?,
+                );
+            }
+
             // Resolve `@Name` mentions to channel-member pubkeys and append a
             // `p` tag for each (skipping the author, already tagged above). A
             // resolution failure must not drop the message, so log and proceed
@@ -321,8 +421,11 @@ impl ActionSink for RelayActionSink {
             );
 
             // 4. Persist event with thread metadata (matches REST handler path).
-            //    Workflow messages are always top-level: depth=0, no parent/root.
-            let thread_meta = Some(buzz_db::event::ThreadMetadataParams {
+            let resolved_thread_meta =
+                resolve_nip10_thread_meta(tenant.community(), &event, channel_uuid, &state)
+                    .await
+                    .map_err(ActionSinkError::InvalidInput)?;
+            let top_level_thread_meta = buzz_db::event::ThreadMetadataParams {
                 event_id: &event_id_bytes,
                 event_created_at,
                 channel_id: channel_uuid,
@@ -332,7 +435,11 @@ impl ActionSink for RelayActionSink {
                 root_event_created_at: None,
                 depth: 0,
                 broadcast: false,
-            });
+            };
+            let thread_meta = resolved_thread_meta
+                .as_ref()
+                .map(|meta| meta.as_params())
+                .or(Some(top_level_thread_meta));
 
             let (stored_event, was_inserted) = state
                 .db
@@ -375,6 +482,37 @@ mod tests {
     // A 64-char hex pubkey built from a single repeated nibble, for readable tests.
     fn pk(nibble: char) -> String {
         std::iter::repeat_n(nibble, 64).collect()
+    }
+
+    #[test]
+    fn legacy_thread_root_prefers_root_marker_then_reply_marker() {
+        let keys = nostr::Keys::generate();
+        let root = pk('a');
+        let reply = pk('b');
+        let event = EventBuilder::new(Kind::from(KIND_STREAM_MESSAGE as u16), "legacy reply")
+            .tags([
+                Tag::parse(["e", &reply, "", "reply"]).expect("reply tag"),
+                Tag::parse(["e", &root, "", "root"]).expect("root tag"),
+            ])
+            .sign_with_keys(&keys)
+            .expect("sign");
+
+        assert_eq!(legacy_thread_root(&event), Some(hex::decode(root).unwrap()));
+    }
+
+    #[test]
+    fn legacy_thread_root_falls_back_to_reply_marker() {
+        let keys = nostr::Keys::generate();
+        let reply = pk('b');
+        let event = EventBuilder::new(Kind::from(KIND_STREAM_MESSAGE as u16), "legacy reply")
+            .tags([Tag::parse(["e", &reply, "", "reply"]).expect("reply tag")])
+            .sign_with_keys(&keys)
+            .expect("sign");
+
+        assert_eq!(
+            legacy_thread_root(&event),
+            Some(hex::decode(reply).unwrap())
+        );
     }
 
     #[test]
@@ -707,5 +845,196 @@ mod integration_tests {
             p_tag_targets.contains(&agent_hex.as_str()),
             "mentioned member {agent_hex} must be p-tagged so it wakes; got {p_tag_targets:?}"
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn workflow_send_message_can_reply_to_prior_step_event() {
+        let state = test_state().await;
+        let author = nostr::Keys::generate();
+        let author_hex = author.public_key().to_hex();
+        let host = format!("wf-reply-{}.example", uuid::Uuid::new_v4().simple());
+        let community = match state
+            .db
+            .create_community_with_owner(&host, &author_hex)
+            .await
+            .expect("create community")
+        {
+            CreateCommunityWithOwnerResult::Created(rec) => rec.id,
+            other => panic!("expected fresh community, got {other:?}"),
+        };
+        let channel = state
+            .db
+            .create_channel(
+                community,
+                "wf-reply",
+                ChannelType::Stream,
+                ChannelVisibility::Open,
+                None,
+                &author.public_key().to_bytes(),
+                None,
+            )
+            .await
+            .expect("create channel");
+        let sink = RelayActionSink::new(&state);
+
+        let parent_id = sink
+            .send_message(
+                community,
+                &channel.id.to_string(),
+                "PR #123 is ready",
+                &author_hex,
+            )
+            .await
+            .expect("send parent");
+        let reply_id = sink
+            .send_message_with_reply(
+                community,
+                &channel.id.to_string(),
+                "🚦 Review · ✅ Approve · ⛔ Block · 🚀 Merge",
+                &author_hex,
+                Some(&parent_id),
+            )
+            .await
+            .expect("send reply");
+
+        let parent_bytes = hex::decode(&parent_id).expect("parent id hex");
+        let reply_bytes = hex::decode(&reply_id).expect("reply id hex");
+        let metadata = state
+            .db
+            .get_thread_metadata_by_event(community, &reply_bytes)
+            .await
+            .expect("query metadata")
+            .expect("reply metadata");
+
+        assert_eq!(
+            metadata.parent_event_id.as_deref(),
+            Some(parent_bytes.as_slice())
+        );
+        assert_eq!(
+            metadata.root_event_id.as_deref(),
+            Some(parent_bytes.as_slice())
+        );
+        assert_eq!(metadata.depth, 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn workflow_send_message_rejects_invalid_legacy_thread_roots() {
+        let state = test_state().await;
+        let author = nostr::Keys::generate();
+        let author_hex = author.public_key().to_hex();
+        let host = format!("wf-legacy-root-{}.example", uuid::Uuid::new_v4().simple());
+        let community = match state
+            .db
+            .create_community_with_owner(&host, &author_hex)
+            .await
+            .expect("create community")
+        {
+            CreateCommunityWithOwnerResult::Created(rec) => rec.id,
+            other => panic!("expected fresh community, got {other:?}"),
+        };
+        let channel = state
+            .db
+            .create_channel(
+                community,
+                "wf-legacy-parent",
+                ChannelType::Stream,
+                ChannelVisibility::Open,
+                None,
+                &author.public_key().to_bytes(),
+                None,
+            )
+            .await
+            .expect("create parent channel");
+        let other_channel = state
+            .db
+            .create_channel(
+                community,
+                "wf-legacy-root",
+                ChannelType::Stream,
+                ChannelVisibility::Open,
+                None,
+                &author.public_key().to_bytes(),
+                None,
+            )
+            .await
+            .expect("create root channel");
+
+        let cross_channel_root =
+            EventBuilder::new(Kind::from(KIND_STREAM_MESSAGE as u16), "cross-channel root")
+                .tags([Tag::parse(["h", &other_channel.id.to_string()]).expect("root h tag")])
+                .sign_with_keys(&author)
+                .expect("sign root");
+        state
+            .db
+            .insert_event(community, &cross_channel_root, Some(other_channel.id))
+            .await
+            .expect("insert root");
+
+        let legacy_parent =
+            EventBuilder::new(Kind::from(KIND_STREAM_MESSAGE as u16), "legacy parent")
+                .tags([
+                    Tag::parse(["h", &channel.id.to_string()]).expect("parent h tag"),
+                    Tag::parse(["e", &cross_channel_root.id.to_hex(), "", "root"])
+                        .expect("legacy root tag"),
+                ])
+                .sign_with_keys(&author)
+                .expect("sign parent");
+        state
+            .db
+            .insert_event(community, &legacy_parent, Some(channel.id))
+            .await
+            .expect("insert parent");
+
+        let sink = RelayActionSink::new(&state);
+        let cross_channel_error = sink
+            .send_message_with_reply(
+                community,
+                &channel.id.to_string(),
+                "reply",
+                &author_hex,
+                Some(&legacy_parent.id.to_hex()),
+            )
+            .await
+            .expect_err("cross-channel legacy root must fail");
+        assert!(matches!(
+            cross_channel_error,
+            ActionSinkError::InvalidInput(ref message)
+                if message == "reply_to thread root belongs to a different channel"
+        ));
+
+        let missing_root_id = nostr::EventId::from_byte_array([0x42; 32]).to_hex();
+        let missing_root_parent = EventBuilder::new(
+            Kind::from(KIND_STREAM_MESSAGE as u16),
+            "missing-root parent",
+        )
+        .tags([
+            Tag::parse(["h", &channel.id.to_string()]).expect("missing parent h tag"),
+            Tag::parse(["e", &missing_root_id, "", "root"]).expect("missing root tag"),
+        ])
+        .sign_with_keys(&author)
+        .expect("sign missing-root parent");
+        state
+            .db
+            .insert_event(community, &missing_root_parent, Some(channel.id))
+            .await
+            .expect("insert missing-root parent");
+
+        let missing_error = sink
+            .send_message_with_reply(
+                community,
+                &channel.id.to_string(),
+                "reply",
+                &author_hex,
+                Some(&missing_root_parent.id.to_hex()),
+            )
+            .await
+            .expect_err("missing legacy root must fail");
+        assert!(matches!(
+            missing_error,
+            ActionSinkError::InvalidInput(ref message)
+                if message == "reply_to thread root was not found"
+        ));
     }
 }

--- a/crates/buzz-workflow/src/action_sink.rs
+++ b/crates/buzz-workflow/src/action_sink.rs
@@ -66,4 +66,27 @@ pub trait ActionSink: Send + Sync {
         text: &str,
         author_pubkey: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>>;
+
+    /// Post a message with an optional thread parent.
+    ///
+    /// The default preserves compatibility for sinks that only support
+    /// top-level messages. Relay sinks override this method to validate and
+    /// persist `reply_to` as NIP-10 thread metadata.
+    fn send_message_with_reply(
+        &self,
+        community_id: CommunityId,
+        channel_id: &str,
+        text: &str,
+        author_pubkey: &str,
+        reply_to: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>> {
+        match reply_to {
+            None => self.send_message(community_id, channel_id, text, author_pubkey),
+            Some(_) => Box::pin(async {
+                Err(ActionSinkError::InvalidInput(
+                    "this action sink does not support threaded workflow messages".into(),
+                ))
+            }),
+        }
+    }
 }

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -37,6 +37,28 @@ pub struct TriggerContext {
     pub emoji: String,
     /// Event ID of the triggering message (hex string).
     pub message_id: String,
+    /// Human-readable display name for the triggering author.
+    #[serde(default)]
+    pub author_name: String,
+    /// Human-readable name for the triggering channel.
+    #[serde(default)]
+    pub channel_name: String,
+    /// Canonical URL for a code-hosting change request extracted from the
+    /// triggering text.
+    #[serde(default)]
+    pub change_request_url: String,
+    /// Provider-local change-request number extracted from the triggering text.
+    #[serde(default)]
+    pub change_request_number: String,
+    /// Code-hosting provider for the change request (for example, `github`).
+    #[serde(default)]
+    pub change_request_provider: String,
+    /// Provider-neutral change-request kind (for example, `pull_request`).
+    #[serde(default)]
+    pub change_request_kind: String,
+    /// Buzz deep link to the triggering message.
+    #[serde(default)]
+    pub message_url: String,
     /// Arbitrary webhook body fields (webhook trigger).
     pub webhook_fields: HashMap<String, String>,
 }
@@ -54,6 +76,13 @@ impl TriggerContext {
             "timestamp" => Some(&self.timestamp),
             "emoji" => Some(&self.emoji),
             "message_id" => Some(&self.message_id),
+            "author_name" => Some(&self.author_name),
+            "channel_name" => Some(&self.channel_name),
+            "change_request_url" => Some(&self.change_request_url),
+            "change_request_number" => Some(&self.change_request_number),
+            "change_request_provider" => Some(&self.change_request_provider),
+            "change_request_kind" => Some(&self.change_request_kind),
+            "message_url" => Some(&self.message_url),
             other => self.webhook_fields.get(other).map(|s| s.as_str()),
         }
     }
@@ -213,6 +242,11 @@ fn apply_filter(value: String, filter: &str) -> Result<String, WorkflowError> {
 /// | `trigger.timestamp`               | `trigger_timestamp`       |
 /// | `trigger.emoji`                   | `trigger_emoji`           |
 /// | `trigger.message_id`              | `trigger_message_id`      |
+/// | `trigger.change_request_url`       | `trigger_change_request_url` |
+/// | `trigger.change_request_number`    | `trigger_change_request_number` |
+/// | `trigger.change_request_provider`  | `trigger_change_request_provider` |
+/// | `trigger.change_request_kind`      | `trigger_change_request_kind` |
+/// | `trigger.message_url`              | `trigger_message_url`     |
 /// | `steps.STEP_ID.output.FIELD`      | `steps_STEP_ID_output_FIELD` |
 ///
 /// Also registers string helper functions that the `cron` crate's `evalexpr` v11
@@ -293,6 +327,23 @@ pub fn build_eval_context(
         ("trigger_timestamp", trigger_ctx.timestamp.as_str()),
         ("trigger_emoji", trigger_ctx.emoji.as_str()),
         ("trigger_message_id", trigger_ctx.message_id.as_str()),
+        (
+            "trigger_change_request_url",
+            trigger_ctx.change_request_url.as_str(),
+        ),
+        (
+            "trigger_change_request_number",
+            trigger_ctx.change_request_number.as_str(),
+        ),
+        (
+            "trigger_change_request_provider",
+            trigger_ctx.change_request_provider.as_str(),
+        ),
+        (
+            "trigger_change_request_kind",
+            trigger_ctx.change_request_kind.as_str(),
+        ),
+        ("trigger_message_url", trigger_ctx.message_url.as_str()),
     ];
 
     for (name, val) in &trigger_fields {
@@ -403,9 +454,14 @@ pub fn resolve_step_templates(
     };
 
     match &step.action {
-        SendMessage { text, channel } => Ok(SendMessage {
+        SendMessage {
+            text,
+            channel,
+            reply_to,
+        } => Ok(SendMessage {
             text: t(text)?,
             channel: t_opt(channel)?,
+            reply_to: t_opt(reply_to)?,
         }),
         SendDm { to, text } => Ok(SendDm {
             to: t(to)?,
@@ -546,7 +602,11 @@ pub async fn dispatch_action(
     let result = serving_write
         .protect(async {
             match action {
-                SendMessage { text, channel } => {
+                SendMessage {
+                    text,
+                    channel,
+                    reply_to,
+                } => {
                     // Look up workflow metadata for destination validation and
                     // attribution, scoped to the run's community — the same run/workflow
                     // UUID may exist in another community, so a bare-id lookup could
@@ -586,7 +646,13 @@ pub async fn dispatch_action(
 
                     let event_id = engine
                         .action_sink()?
-                        .send_message(community_id, &channel_id, text, &owner_pubkey_hex)
+                        .send_message_with_reply(
+                            community_id,
+                            &channel_id,
+                            text,
+                            &owner_pubkey_hex,
+                            reply_to.as_deref(),
+                        )
                         .await
                         .map_err(WorkflowError::from)?;
 
@@ -1266,6 +1332,13 @@ mod tests {
             timestamp: "1700000000".to_owned(),
             emoji: "fire".to_owned(),
             message_id: "event-id-hex".to_owned(),
+            author_name: "Staff Engineer".to_owned(),
+            channel_name: "engineering".to_owned(),
+            change_request_url: "https://github.com/block/buzz/pull/123".to_owned(),
+            change_request_number: "123".to_owned(),
+            change_request_provider: "github".to_owned(),
+            change_request_kind: "pull_request".to_owned(),
+            message_url: "buzz://message?channel=channel-uuid-here&id=event-id-hex".to_owned(),
             webhook_fields: HashMap::new(),
         }
     }
@@ -1282,6 +1355,50 @@ mod tests {
         let ctx = make_trigger();
         let out = resolve_template("By {{trigger.author}}", &ctx, &HashMap::new()).unwrap();
         assert_eq!(out, "By abc123def456");
+    }
+
+    #[test]
+    fn resolve_human_readable_pr_context() {
+        let ctx = make_trigger();
+        let out = resolve_template(
+            "PR #{{trigger.change_request_number}} by {{trigger.author_name}} in #{{trigger.channel_name}}: [open]({{trigger.change_request_url}}) · [message]({{trigger.message_url}})",
+            &ctx,
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "PR #123 by Staff Engineer in #engineering: [open](https://github.com/block/buzz/pull/123) · [message](buzz://message?channel=channel-uuid-here&id=event-id-hex)"
+        );
+    }
+
+    #[test]
+    fn resolve_send_message_reply_to_from_prior_step() {
+        let ctx = make_trigger();
+        let step = Step {
+            id: "instructions".to_owned(),
+            name: None,
+            if_expr: None,
+            timeout_secs: None,
+            action: ActionDef::SendMessage {
+                text: "Choose an action".to_owned(),
+                channel: None,
+                reply_to: Some("{{steps.prompt.output.event_id}}".to_owned()),
+            },
+        };
+        let outputs = HashMap::from([(
+            "prompt".to_owned(),
+            json!({ "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }),
+        )]);
+
+        let resolved = resolve_step_templates(&step, &ctx, &outputs).unwrap();
+        match resolved {
+            ActionDef::SendMessage { reply_to, .. } => assert_eq!(
+                reply_to.as_deref(),
+                Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            ),
+            other => panic!("expected SendMessage, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1805,10 +1922,23 @@ mod tests {
         let ctx = make_trigger();
         assert_eq!(ctx.get_field("text"), Some("P1 incident in production"));
         assert_eq!(ctx.get_field("author"), Some("abc123def456"));
+        assert_eq!(ctx.get_field("author_name"), Some("Staff Engineer"));
         assert_eq!(ctx.get_field("channel_id"), Some("channel-uuid-here"));
+        assert_eq!(ctx.get_field("channel_name"), Some("engineering"));
         assert_eq!(ctx.get_field("timestamp"), Some("1700000000"));
         assert_eq!(ctx.get_field("emoji"), Some("fire"));
         assert_eq!(ctx.get_field("message_id"), Some("event-id-hex"));
+        assert_eq!(
+            ctx.get_field("change_request_url"),
+            Some("https://github.com/block/buzz/pull/123")
+        );
+        assert_eq!(ctx.get_field("change_request_number"), Some("123"));
+        assert_eq!(ctx.get_field("change_request_provider"), Some("github"));
+        assert_eq!(ctx.get_field("change_request_kind"), Some("pull_request"));
+        assert_eq!(
+            ctx.get_field("message_url"),
+            Some("buzz://message?channel=channel-uuid-here&id=event-id-hex")
+        );
     }
 
     #[test]
@@ -1831,10 +1961,17 @@ mod tests {
         let ctx = TriggerContext::default();
         assert_eq!(ctx.text, "");
         assert_eq!(ctx.author, "");
+        assert_eq!(ctx.author_name, "");
         assert_eq!(ctx.channel_id, "");
+        assert_eq!(ctx.channel_name, "");
         assert_eq!(ctx.timestamp, "");
         assert_eq!(ctx.emoji, "");
         assert_eq!(ctx.message_id, "");
+        assert_eq!(ctx.change_request_url, "");
+        assert_eq!(ctx.change_request_number, "");
+        assert_eq!(ctx.change_request_provider, "");
+        assert_eq!(ctx.change_request_kind, "");
+        assert_eq!(ctx.message_url, "");
         assert!(ctx.webhook_fields.is_empty());
     }
 

--- a/crates/buzz-workflow/src/lib.rs
+++ b/crates/buzz-workflow/src/lib.rs
@@ -316,6 +316,21 @@ impl WorkflowEngine {
         community_id: CommunityId,
         event: &buzz_core::StoredEvent,
     ) -> Result<(), WorkflowError> {
+        self.on_event_as_actor(community_id, event, &event.event.pubkey.to_hex())
+            .await
+    }
+
+    /// Process a stored event using an actor authenticated by the relay ingest path.
+    ///
+    /// Unlike caller-controlled event tags, `actor_pubkey_hex` must come from a
+    /// trusted server-side authentication context. Relay-signed attributed
+    /// events use this entrypoint; ordinary callers should use [`Self::on_event`].
+    pub async fn on_event_as_actor(
+        self: &Arc<Self>,
+        community_id: CommunityId,
+        event: &buzz_core::StoredEvent,
+        actor_pubkey_hex: &str,
+    ) -> Result<(), WorkflowError> {
         let Some(channel_id) = event.channel_id else {
             tracing::debug!(
                 event_id = %event.event.id.to_hex(),
@@ -351,15 +366,10 @@ impl WorkflowEngine {
             return Ok(());
         }
 
-        let trigger_ctx = build_trigger_context(event);
-
-        let trigger_ctx_json: serde_json::Value = match serde_json::to_value(&trigger_ctx) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::error!("Failed to serialize trigger context: {e}");
-                return Ok(());
-            }
-        };
+        let mut trigger_ctx = build_trigger_context(event);
+        trigger_ctx.author = actor_pubkey_hex.to_owned();
+        trigger_ctx.author_name = actor_pubkey_hex.to_owned();
+        let mut hydrated_trigger_ctx: Option<executor::TriggerContext> = None;
 
         for workflow in workflows.iter() {
             let def: WorkflowDef = match serde_json::from_value(workflow.definition.clone()) {
@@ -395,6 +405,28 @@ impl WorkflowEngine {
                 continue;
             }
 
+            let run_trigger_ctx = match hydrated_trigger_ctx.as_ref() {
+                Some(ctx) => ctx.clone(),
+                None => {
+                    let mut ctx = trigger_ctx.clone();
+                    self.hydrate_trigger_display_names(community_id, channel_id, &mut ctx)
+                        .await;
+                    hydrated_trigger_ctx = Some(ctx.clone());
+                    ctx
+                }
+            };
+
+            let trigger_ctx_json: serde_json::Value = match serde_json::to_value(&run_trigger_ctx) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "Failed to serialize workflow trigger context"
+                    );
+                    continue;
+                }
+            };
+
             let trigger_event_id_bytes = event.event.id.as_bytes().to_vec();
             let run_id = match self
                 .db
@@ -421,7 +453,7 @@ impl WorkflowEngine {
 
             let engine = Arc::clone(self);
             let def_clone = def.clone();
-            let ctx_clone = trigger_ctx.clone();
+            let ctx_clone = run_trigger_ctx;
 
             tokio::spawn(async move {
                 let result =
@@ -434,6 +466,54 @@ impl WorkflowEngine {
         }
 
         Ok(())
+    }
+
+    /// Best-effort enrichment for human-readable workflow templates.
+    ///
+    /// Trigger matching stays on the event-only context so ordinary events do
+    /// not pay profile/channel lookup costs. Once a workflow is known to fire,
+    /// resolve names from the same community. Lookup failures retain the
+    /// deterministic pubkey/UUID fallbacks rather than dropping the run.
+    async fn hydrate_trigger_display_names(
+        &self,
+        community_id: CommunityId,
+        channel_id: Uuid,
+        trigger_ctx: &mut executor::TriggerContext,
+    ) {
+        let author_bytes = hex::decode(&trigger_ctx.author).ok();
+        let user_lookup = async {
+            match author_bytes {
+                Some(bytes) => self.db.get_user(community_id, &bytes).await,
+                None => Ok(None),
+            }
+        };
+        let (user_result, channel_result) =
+            tokio::join!(user_lookup, self.db.get_channel(community_id, channel_id));
+
+        match user_result {
+            Ok(Some(user)) => {
+                if let Some(display_name) = user.display_name.filter(|name| !name.trim().is_empty())
+                {
+                    trigger_ctx.author_name = display_name;
+                }
+            }
+            Ok(None) => {}
+            Err(error) => tracing::warn!(
+                error = %error,
+                community_id = %community_id,
+                author = %trigger_ctx.author,
+                "Workflow trigger author-name lookup failed; using pubkey fallback"
+            ),
+        }
+        match channel_result {
+            Ok(channel) => trigger_ctx.channel_name = channel.name,
+            Err(error) => tracing::warn!(
+                error = %error,
+                community_id = %community_id,
+                channel_id = %channel_id,
+                "Workflow trigger channel-name lookup failed; using UUID fallback"
+            ),
+        }
     }
 
     /// Interval prefilter: decide whether the interval workflow should fire this
@@ -956,9 +1036,9 @@ pub fn build_trigger_context(event: &buzz_core::StoredEvent) -> executor::Trigge
     let kind_u32 = event_kind_u32(&event.event);
     let content = event.event.content.clone();
 
-    // Workflow conditions make authorization decisions from `trigger_author`,
-    // so it must come from the event signature. An `actor` tag is ordinary
-    // signer-controlled metadata and cannot speak for another pubkey.
+    // This context is derived from the signed event alone. The relay entrypoint
+    // overwrites it with the authenticated actor supplied by the ingest path;
+    // never trust a caller-controlled `actor` tag for workflow authorization.
     let author = event.event.pubkey.to_hex();
 
     // For reaction events (NIP-25), the content field holds the emoji character
@@ -1000,18 +1080,114 @@ pub fn build_trigger_context(event: &buzz_core::StoredEvent) -> executor::Trigge
         event.event.id.to_hex()
     };
 
+    let channel_id = event
+        .channel_id
+        .map(|id| id.to_string())
+        .unwrap_or_default();
+    let change_request = extract_change_request(&content);
+    let message_url = if channel_id.is_empty() {
+        String::new()
+    } else {
+        format!("buzz://message?channel={channel_id}&id={message_id}")
+    };
+
     executor::TriggerContext {
         text: content,
+        author_name: author.clone(),
         author,
-        channel_id: event
-            .channel_id
-            .map(|id| id.to_string())
-            .unwrap_or_default(),
+        channel_name: channel_id.clone(),
+        channel_id,
         timestamp: event.event.created_at.as_secs().to_string(),
         emoji,
         message_id,
+        change_request_url: change_request
+            .as_ref()
+            .map(|reference| reference.url.clone())
+            .unwrap_or_default(),
+        change_request_number: change_request
+            .as_ref()
+            .map(|reference| reference.number.clone())
+            .unwrap_or_default(),
+        change_request_provider: change_request
+            .as_ref()
+            .map(|reference| reference.provider.clone())
+            .unwrap_or_default(),
+        change_request_kind: change_request
+            .map(|reference| reference.kind)
+            .unwrap_or_default(),
+        message_url,
         webhook_fields: HashMap::new(),
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChangeRequestReference {
+    url: String,
+    number: String,
+    provider: String,
+    kind: String,
+}
+
+/// Extract the first supported code-hosting change request from message text.
+///
+/// Provider-specific parsing stays behind this boundary so workflow templates
+/// remain stable when support expands beyond GitHub pull requests.
+fn extract_change_request(text: &str) -> Option<ChangeRequestReference> {
+    extract_github_pull_request(text)
+}
+
+/// Extract one canonical GitHub pull-request reference.
+///
+/// Message text is intentionally treated as prose rather than HTML. Candidates
+/// are whitespace-delimited URLs with common Markdown punctuation trimmed; the
+/// returned URL drops query/fragment suffixes and normalizes to HTTPS.
+fn extract_github_pull_request(text: &str) -> Option<ChangeRequestReference> {
+    text.split_whitespace().find_map(|word| {
+        let url_start = word
+            .find("https://github.com/")
+            .or_else(|| word.find("http://github.com/"))?;
+        let candidate = word[url_start..].trim_end_matches(|c: char| {
+            matches!(
+                c,
+                '(' | ')' | '[' | ']' | '<' | '>' | '"' | '\'' | ',' | ';' | '.' | ':' | '!'
+            )
+        });
+        let without_scheme = candidate
+            .strip_prefix("https://")
+            .or_else(|| candidate.strip_prefix("http://"))?;
+        let path = without_scheme
+            .strip_prefix("github.com/")?
+            .split(['?', '#'])
+            .next()?;
+        let mut segments = path.split('/');
+        let owner = segments.next()?.trim();
+        let repository = segments.next()?.trim();
+        if segments.next()? != "pull" {
+            return None;
+        }
+        let number = segments.next()?.trim_end_matches(['.', ':', '!']);
+        let valid_owner = !owner.is_empty()
+            && !owner.starts_with('-')
+            && !owner.ends_with('-')
+            && owner.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+        let valid_repository = !repository.is_empty()
+            && repository
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'));
+        if !valid_owner
+            || !valid_repository
+            || number.is_empty()
+            || !number.chars().all(|c| c.is_ascii_digit())
+        {
+            return None;
+        }
+        Some(ChangeRequestReference {
+            url: format!("https://github.com/{owner}/{repository}/pull/{number}"),
+            number: number.to_owned(),
+            provider: "github".to_owned(),
+            kind: "pull_request".to_owned(),
+        })
+    })
 }
 
 /// Pure authority decision for [`WorkflowEngine::check_owner_authority`].
@@ -1048,6 +1224,54 @@ fn trigger_matches_event(trigger: &TriggerDef, kind_u32: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extracts_canonical_github_pull_request_from_markdown_prose() {
+        assert_eq!(
+            extract_change_request("Opened [the fix](https://github.com/block/buzz/pull/987)."),
+            Some(ChangeRequestReference {
+                url: "https://github.com/block/buzz/pull/987".to_owned(),
+                number: "987".to_owned(),
+                provider: "github".to_owned(),
+                kind: "pull_request".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn extracts_github_pull_request_with_query_or_fragment() {
+        assert_eq!(
+            extract_change_request(
+                "Review https://github.com/ascension/hive/pull/631/files?diff=split#discussion"
+            ),
+            Some(ChangeRequestReference {
+                url: "https://github.com/ascension/hive/pull/631".to_owned(),
+                number: "631".to_owned(),
+                provider: "github".to_owned(),
+                kind: "pull_request".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_non_pull_request_github_urls() {
+        assert_eq!(
+            extract_change_request("https://github.com/block/buzz/issues/987"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_markdown_delimiters_inside_github_owner_or_repository() {
+        assert_eq!(
+            extract_change_request("https://github.com/block](evil/buzz/pull/987"),
+            None
+        );
+        assert_eq!(
+            extract_change_request("https://github.com/block/buzz](evil/pull/987"),
+            None
+        );
+    }
 
     #[test]
     fn cron_fire_instant_matches_within_window() {
@@ -1552,9 +1776,22 @@ steps:
 
         assert_eq!(ctx.text, "hello world");
         assert_eq!(ctx.author, stored.event.pubkey.to_hex());
+        assert_eq!(ctx.author_name, ctx.author);
         assert_eq!(ctx.channel_id, stored.channel_id.unwrap().to_string());
+        assert_eq!(ctx.channel_name, ctx.channel_id);
         assert_eq!(ctx.timestamp, stored.event.created_at.as_secs().to_string());
         assert_eq!(ctx.message_id, stored.event.id.to_hex());
+        assert_eq!(
+            ctx.message_url,
+            format!(
+                "buzz://message?channel={}&id={}",
+                ctx.channel_id, ctx.message_id
+            )
+        );
+        assert_eq!(ctx.change_request_url, "");
+        assert_eq!(ctx.change_request_number, "");
+        assert_eq!(ctx.change_request_provider, "");
+        assert_eq!(ctx.change_request_kind, "");
         // Non-reaction events have empty emoji.
         assert_eq!(ctx.emoji, "");
         assert!(ctx.webhook_fields.is_empty());
@@ -1576,6 +1813,30 @@ steps:
     }
 
     #[test]
+    fn build_trigger_context_ignores_forged_actor_tag() {
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+
+        let attacker = Keys::generate();
+        let claimed_actor = Keys::generate().public_key().to_hex();
+        let target = EventBuilder::new(Kind::Custom(9), "target")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign target");
+        let event = EventBuilder::new(Kind::Reaction, "🚀")
+            .tags([
+                Tag::parse(["e", &target.id.to_hex()]).expect("target tag"),
+                Tag::parse(["actor", &claimed_actor]).expect("forged actor tag"),
+            ])
+            .sign_with_keys(&attacker)
+            .expect("sign forged reaction");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+
+        let ctx = build_trigger_context(&stored);
+
+        assert_eq!(ctx.author, attacker.public_key().to_hex());
+        assert_ne!(ctx.author, claimed_actor);
+    }
+
+    #[test]
     fn build_trigger_context_no_channel_id() {
         use nostr::{EventBuilder, Keys, Kind};
         let keys = Keys::generate();
@@ -1589,6 +1850,32 @@ steps:
 
         assert_eq!(ctx.channel_id, "");
         assert_eq!(ctx.text, "msg");
+        assert_eq!(ctx.message_url, "");
+    }
+
+    #[test]
+    fn build_trigger_context_extracts_pull_request_fields() {
+        use nostr::{EventBuilder, Keys, Kind};
+
+        let keys = Keys::generate();
+        let event = EventBuilder::new(
+            Kind::Custom(9),
+            "Ready: https://github.com/block/buzz/pull/123/files",
+        )
+        .tags([])
+        .sign_with_keys(&keys)
+        .expect("sign");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+
+        let ctx = build_trigger_context(&stored);
+
+        assert_eq!(
+            ctx.change_request_url,
+            "https://github.com/block/buzz/pull/123"
+        );
+        assert_eq!(ctx.change_request_number, "123");
+        assert_eq!(ctx.change_request_provider, "github");
+        assert_eq!(ctx.change_request_kind, "pull_request");
     }
 
     #[test]
@@ -1769,6 +2056,15 @@ steps:
         buzz_core::StoredEvent::new(event, Some(channel_id))
     }
 
+    async fn trigger_message(
+        engine: &Arc<WorkflowEngine>,
+        community: CommunityId,
+        channel_id: Uuid,
+    ) -> Result<(), WorkflowError> {
+        let event = message_event(channel_id);
+        engine.on_event(community, &event).await
+    }
+
     /// The event path must stop creating runs the moment the workflow's owner
     /// loses channel membership — even while the workflow row is still
     /// `enabled` (the disable-on-removal side effect is a separate, relay-side
@@ -1803,8 +2099,7 @@ steps:
         let engine = Arc::new(WorkflowEngine::new(db.clone(), WorkflowConfig::default()));
 
         // Owner is an active member: the event fires the workflow.
-        engine
-            .on_event(community, &message_event(channel_id))
+        trigger_message(&engine, community, channel_id)
             .await
             .expect("on_event while member");
         let runs = db
@@ -1819,8 +2114,7 @@ steps:
             .expect("remove member");
 
         // Workflow row is still enabled — only the authority gate stands.
-        engine
-            .on_event(community, &message_event(channel_id))
+        trigger_message(&engine, community, channel_id)
             .await
             .expect("on_event after removal");
         let runs = db
@@ -1878,8 +2172,7 @@ steps:
             .expect("create owner workflow");
 
         let engine = Arc::new(WorkflowEngine::new(db.clone(), WorkflowConfig::default()));
-        engine
-            .on_event(community, &message_event(channel_id))
+        trigger_message(&engine, community, channel_id)
             .await
             .expect("on_event");
 

--- a/crates/buzz-workflow/src/schema.rs
+++ b/crates/buzz-workflow/src/schema.rs
@@ -97,6 +97,12 @@ pub enum ActionDef {
         /// Optional channel UUID override. Must be a valid UUID string.
         #[serde(default)]
         channel: Option<String>,
+        /// Optional event ID to reply to (supports template variables).
+        ///
+        /// The relay validates that the parent exists in the destination
+        /// channel before emitting the reply.
+        #[serde(default)]
+        reply_to: Option<String>,
     },
     /// Send a direct message to a user.
     SendDm {
@@ -296,6 +302,31 @@ mod tests {
 
         let reparsed: WorkflowDef = serde_json::from_str(&json).expect("json round-trip");
         assert_eq!(reparsed.name, def.name);
+    }
+
+    #[test]
+    fn parse_pr_prompt_with_threaded_reaction_legend() {
+        let yaml = concat!(
+            "name: GitHub PR link intake\n",
+            "trigger:\n  on: message_posted\n",
+            "steps:\n",
+            "  - id: present_pr\n",
+            "    action: send_message\n",
+            "    text: '@ascension [PR #{{trigger.change_request_number}}]({{trigger.change_request_url}}) from {{trigger.author_name}} in [#{{trigger.channel_name}}]({{trigger.message_url}}).'\n",
+            "  - id: show_actions\n",
+            "    action: send_message\n",
+            "    reply_to: '{{steps.present_pr.output.event_id}}'\n",
+            "    text: 'React on the [original PR post]({{trigger.message_url}}) or the prompt above: 🚦 Review · ✅ Approve · ⛔ Block · 🚀 Merge'\n",
+        );
+
+        let (def, _) = parse_yaml(yaml).expect("parse failed");
+        match &def.steps[1].action {
+            ActionDef::SendMessage { reply_to, .. } => assert_eq!(
+                reply_to.as_deref(),
+                Some("{{steps.present_pr.output.event_id}}")
+            ),
+            other => panic!("unexpected action: {other:?}"),
+        }
     }
 
     #[test]

--- a/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
@@ -112,6 +112,25 @@ function StepConfigFields({
               </p>
             ) : null}
           </div>
+          <div className="space-y-1.5">
+            <FieldLabel htmlFor={`${prefix}-reply-to`}>
+              Reply to event (optional)
+            </FieldLabel>
+            <Input
+              autoCapitalize="off"
+              disabled={disabled}
+              id={`${prefix}-reply-to`}
+              onChange={(event) =>
+                onUpdate({ ...step, replyTo: event.target.value })
+              }
+              placeholder="e.g. {{steps.step_1.output.event_id}}"
+              value={step.replyTo ?? ""}
+            />
+            <p className="text-xs text-muted-foreground">
+              Use an event ID or a prior send-message step output to post this
+              message as a threaded reply.
+            </p>
+          </div>
         </div>
       );
     case "send_dm":

--- a/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formStateToYaml, yamlToFormState } from "./workflowFormTypes.ts";
+
+test("workflow form preserves send_message reply_to templates", () => {
+  const yaml = `
+name: Threaded prompt
+trigger:
+  on: message_posted
+steps:
+  - id: present_pr
+    action: send_message
+    text: Present the PR
+  - id: show_actions
+    action: send_message
+    text: Show the actions
+    reply_to: "{{steps.present_pr.output.event_id}}"
+`;
+
+  const parsed = yamlToFormState(yaml);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+
+  assert.equal(
+    parsed.state.steps[1].replyTo,
+    "{{steps.present_pr.output.event_id}}",
+  );
+
+  const roundTripped = yamlToFormState(formStateToYaml(parsed.state));
+  assert.equal(roundTripped.ok, true);
+  if (!roundTripped.ok) return;
+  assert.equal(
+    roundTripped.state.steps[1].replyTo,
+    "{{steps.present_pr.output.event_id}}",
+  );
+});

--- a/desktop/src/features/workflows/ui/workflowFormTypes.ts
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.ts
@@ -43,6 +43,7 @@ export type StepFormState = {
   duration?: string;
   text?: string;
   channel?: string;
+  replyTo?: string;
   to?: string;
   url?: string;
   method?: string;
@@ -141,6 +142,7 @@ function actionFieldsForStep(step: StepFormState): Record<string, unknown> {
     case "send_message":
       if (step.text) fields.text = step.text;
       if (step.channel) fields.channel = step.channel;
+      if (step.replyTo) fields.reply_to = step.replyTo;
       break;
     case "send_dm":
       if (step.to) fields.to = step.to;
@@ -274,6 +276,7 @@ export function yamlToFormState(
         duration: step.duration as string | undefined,
         text: step.text as string | undefined,
         channel: step.channel as string | undefined,
+        replyTo: step.reply_to as string | undefined,
         to: step.to as string | undefined,
         url: step.url as string | undefined,
         method: step.method as string | undefined,


### PR DESCRIPTION
## Summary

- Expose provider-neutral change-request trigger fields (`url`, `number`, `provider`, `kind`) so workflow definitions are not GitHub-specific; GitHub pull requests are the first supported parser
- Add human-readable agent/channel display names and Buzz source-message deep links on intake prompts
- Add `send_message.reply_to` with same-community/same-channel NIP-10 ancestry, wired through the Desktop workflow editor
- Keep reaction authorization fail-closed: only the relay-authenticated actor counts; caller-controlled `actor` tags are ignored
- Support a compact parent prompt plus a threaded Unicode action legend (`🚦 ✅ ⛔ 🚀`)

Example intake output:

> @ascension [PR #123](https://github.com/block/buzz/pull/123) from Staff Engineer in [#engineering](buzz://message?channel=CHANNEL&id=EVENT).

> React on the original PR message or this reply: 🚦 Review · ✅ Approve · ⛔ Block · 🚀 Merge

### Related issue

None found. Continues the existing PR-link intake / action-router workflow pair used for GitHub PR review prompts.

### Testing

Exact rebased head `b736f5f4a790329b7e67a488ffa6d2b61734c1f9` on current `main`:

- `OPUS_NO_PKG_CONFIG=1 just ci` — passed (Rust checks/tests, Desktop lint/tests/build, Tauri checks/tests, web build, mobile tests)
- `cargo test -p buzz-workflow` — 163 passed, 2 Postgres tests ignored
- `cargo test -p buzz-relay workflow --lib` — 19 passed, 3 Postgres tests ignored
- `cargo clippy -p buzz-workflow --all-targets --all-features -- -D warnings` — passed
- Desktop workflow `reply_to` round-trip test — passed
- Desktop TypeScript check — passed
- `git diff --check origin/main...HEAD` — passed

The two new Postgres-backed threaded-message integration tests remain ignored by the normal unit gate and were not run separately because the local Docker daemon was unavailable. Their surrounding relay code compiled and all non-Postgres workflow tests passed.

## Follow-up (after this relay/Desktop build deploys)

Do **not** update live tenant workflows until this build is live:

1. Update the PR-link intake workflow to use the provider-neutral trigger fields and two-step threaded prompt
2. Update the action router to accept Unicode reactions while temporarily retaining legacy shortcodes
3. Verify reactions on original PR post, compact prompt, and threaded legend each resolve once; reject unrelated/chained targets
