### PR TITLE
feat(git-relay): add deterministic Rust core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ access information.
 crates/
   # Relay + core
   buzz-relay          # WebSocket relay server — main entry point; also hosts git + huddle audio
+  buzz-git-relay      # Deterministic GitHub-to-Buzz reconciliation core
   buzz-core           # Core types, event verification, filter matching, kind registry
   buzz-db             # Postgres event store and data access layer
   buzz-auth           # Authentication and authorization

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-git-relay"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "buzz-media"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/buzz-relay",
+    "crates/buzz-git-relay",
     "crates/buzz-core",
     "crates/buzz-conformance",
     "crates/buzz-push-gateway",

--- a/Justfile
+++ b/Justfile
@@ -298,6 +298,7 @@ test-unit:
         # replay — so it belongs in the unit job. Run all targets (lib + the
         # tests/replay_fixtures.rs integration test), not just --lib.
         cargo nextest run -p buzz-conformance
+        cargo nextest run -p buzz-git-relay
         # Gateway unit and black-box HTTP tests are infra-free. Postgres-backed
         # contract/race tests run in the dedicated CI job below.
         cargo nextest run -p buzz-push-gateway

--- a/crates/buzz-git-relay/Cargo.toml
+++ b/crates/buzz-git-relay/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "buzz-git-relay"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Deterministic GitHub-to-Buzz repository reconciliation core"
+
+[dependencies]
+async-trait = "0.1"
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tempfile = "3"
+tokio = { workspace = true }

--- a/crates/buzz-git-relay/src/domain.rs
+++ b/crates/buzz-git-relay/src/domain.rs
@@ -371,6 +371,44 @@ pub enum ExitOutcome {
     Failure,
 }
 
+/// Stable operator action selected by the reconciliation core.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NextAction {
+    /// No operator action is required.
+    None,
+    /// Approve the exact eligible fast-forward.
+    ApproveExactFastForward,
+    /// Approve the newly observed GitHub target before applying it.
+    ApproveNewGithubTarget,
+    /// Repair invalid enrollment or repository configuration.
+    FixConfiguration,
+    /// Inspect a push whose mutation could not be determined.
+    InspectAmbiguousPush,
+    /// Inspect failed session or lock cleanup.
+    InspectCleanupFailure,
+    /// Inspect refs that did not match after a completed push.
+    InspectPostPushRefs,
+    /// Inspect commits present only in the Buzz repository.
+    InspectRelayOnlyCommits,
+    /// Inspect an unexpected trusted-boundary failure.
+    InspectUnexpectedFailure,
+    /// Provide an exact target and approval event for apply mode.
+    ProvideExactTargetAndApproval,
+    /// Repair append-only audit persistence.
+    RepairAuditStore,
+    /// Repair repository credentials or access control.
+    RepairCredentialsOrAcl,
+    /// Retry after the currently active reconciliation finishes.
+    RetryAfterActiveRun,
+    /// Retry after a concurrent repository change.
+    RetryAfterConcurrentChange,
+    /// Retry a transient boundary failure with backoff.
+    RetryWithBackoff,
+    /// Review histories that have diverged.
+    ReviewDivergentHistories,
+}
+
 /// Fixed-schema, secret-free reconciliation evidence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReconcileResult {
@@ -394,7 +432,7 @@ pub struct ReconcileResult {
     pub github_before: Option<CommitOid>,
     /// Initial Buzz tip, when read.
     pub buzz_before: Option<CommitOid>,
-    /// Current/approved GitHub target, when known.
+    /// Approved or requested GitHub target, when supplied.
     pub github_target: Option<CommitOid>,
     /// Trusted Buzz after-tip, when verified.
     pub buzz_after: Option<CommitOid>,
@@ -408,7 +446,7 @@ pub struct ReconcileResult {
     /// Whether deterministic retry is appropriate.
     pub retryable: bool,
     /// Stable operator action token.
-    pub next_action: String,
+    pub next_action: NextAction,
     /// Sanitized human summary.
     pub summary: String,
     /// Stable process outcome.

--- a/crates/buzz-git-relay/src/domain.rs
+++ b/crates/buzz-git-relay/src/domain.rs
@@ -1,0 +1,411 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A validated domain value was malformed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid {field}")]
+pub struct ValidationError {
+    field: &'static str,
+}
+
+macro_rules! nonempty_id {
+    ($name:ident, $field:literal, $docs:literal) => {
+        #[doc = $docs]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Validates and constructs the value.
+            pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+                let value = value.into();
+                if value.trim().is_empty() || value.chars().any(char::is_whitespace) {
+                    return Err(ValidationError { field: $field });
+                }
+                Ok(Self(value))
+            }
+
+            /// Returns the validated string.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+    };
+}
+
+nonempty_id!(
+    EnrollmentId,
+    "enrollment_id",
+    "Host-assigned enrollment identity."
+);
+nonempty_id!(
+    GithubRepositoryId,
+    "github_repository_id",
+    "Immutable GitHub repository identity."
+);
+nonempty_id!(
+    RunId,
+    "run_id",
+    "Unique reconciliation invocation identity."
+);
+
+/// A full Git object ID accepted by the v1 controller.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CommitOid(String);
+
+impl CommitOid {
+    /// Validates a lower-case, 40-character SHA-1 object ID.
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        if value.len() != 40
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(ValidationError {
+                field: "commit_oid",
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the validated object ID.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CommitOid {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// A validated 32-byte Nostr event ID.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ApprovalEventId(String);
+
+impl ApprovalEventId {
+    /// Validates a lower-case, 64-character hexadecimal event ID.
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        if value.len() != 64
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(ValidationError {
+                field: "approval_event_id",
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the validated event ID.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The one exact destination ref managed by an enrollment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ManagedRef(String);
+
+impl ManagedRef {
+    /// Constructs the initial supported managed ref.
+    pub fn main() -> Self {
+        Self("refs/heads/main".to_owned())
+    }
+
+    /// Validates the exact v1 managed ref allowlist.
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        if value != "refs/heads/main" {
+            return Err(ValidationError {
+                field: "managed_ref",
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the full destination ref.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Rollout gate for one enrolled repository.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RolloutPhase {
+    /// Observe only; mutation is disabled.
+    ObserveOnly,
+    /// Owner-approved exact fast-forwards may run.
+    OwnerApprovedApply,
+}
+
+/// Explicit host-side enrollment for one repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Enrollment {
+    /// Host-assigned enrollment identity.
+    pub id: EnrollmentId,
+    /// Immutable GitHub repository identity.
+    pub github_repository_id: GithubRepositoryId,
+    /// The only destination ref this enrollment may manage.
+    pub managed_ref: ManagedRef,
+    /// Whether this repository is opted in.
+    pub enabled: bool,
+    /// Current rollout phase.
+    pub rollout_phase: RolloutPhase,
+    /// Independent host-side apply gate.
+    pub apply_enabled: bool,
+    /// Whether apply requires an owner approval event.
+    pub approval_required: bool,
+}
+
+impl Enrollment {
+    /// Creates an enabled observe-only enrollment.
+    pub fn enabled(
+        id: EnrollmentId,
+        github_repository_id: GithubRepositoryId,
+        managed_ref: ManagedRef,
+    ) -> Self {
+        Self {
+            id,
+            github_repository_id,
+            managed_ref,
+            enabled: true,
+            rollout_phase: RolloutPhase::ObserveOnly,
+            apply_enabled: false,
+            approval_required: true,
+        }
+    }
+
+    /// Enables owner-approved apply for testable host policy construction.
+    pub fn with_owner_approved_apply(mut self) -> Self {
+        self.rollout_phase = RolloutPhase::OwnerApprovedApply;
+        self.apply_enabled = true;
+        self
+    }
+
+    /// Marks the repository as unenrolled without discarding its identity.
+    pub fn disabled(mut self) -> Self {
+        self.enabled = false;
+        self
+    }
+
+    pub(crate) fn policy_is_valid(&self) -> bool {
+        self.approval_required
+            && (self.rollout_phase != RolloutPhase::ObserveOnly || !self.apply_enabled)
+    }
+}
+
+/// Reconciliation execution mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconcileMode {
+    /// Classify and report only.
+    Observe,
+    /// Attempt an exact, approved fast-forward when proven safe.
+    Apply,
+}
+
+/// Origin of a reconciliation invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconcileTrigger {
+    /// Explicit owner/operator request.
+    Manual,
+    /// Scheduled deterministic audit.
+    Audit,
+    /// Future GitHub webhook adapter.
+    GithubWebhook,
+}
+
+/// Input to the single reconciliation operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconcileRequest {
+    /// Requested execution mode.
+    pub mode: ReconcileMode,
+    /// Invocation origin.
+    pub trigger: ReconcileTrigger,
+    /// Exact GitHub target approved by the owner, for apply only.
+    pub expected_target: Option<CommitOid>,
+    /// Owner approval event, for apply only.
+    pub approval_event: Option<ApprovalEventId>,
+}
+
+impl ReconcileRequest {
+    /// Creates the default manual observe request.
+    pub fn observe() -> Self {
+        Self {
+            mode: ReconcileMode::Observe,
+            trigger: ReconcileTrigger::Manual,
+            expected_target: None,
+            approval_event: None,
+        }
+    }
+
+    /// Creates a manual apply request bound to an exact target and approval.
+    pub fn apply(target: CommitOid, approval_event: ApprovalEventId) -> Self {
+        Self {
+            mode: ReconcileMode::Apply,
+            trigger: ReconcileTrigger::Manual,
+            expected_target: Some(target),
+            approval_event: Some(approval_event),
+        }
+    }
+}
+
+/// The two authoritative tips read during reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tips {
+    /// Current canonical GitHub tip.
+    pub github: CommitOid,
+    /// Current Buzz managed-ref tip.
+    pub buzz: CommitOid,
+}
+
+/// Closed reconciliation state alphabet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Classification {
+    /// Repository is not opted in.
+    Unmanaged,
+    /// Enrollment or request policy is invalid.
+    ConfigError,
+    /// Both managed refs are exactly equal.
+    InSync,
+    /// Buzz is a strict ancestor of GitHub.
+    RelayBehind,
+    /// GitHub is a strict ancestor of Buzz.
+    GithubBehind,
+    /// Neither managed tip is an ancestor of the other.
+    Diverged,
+    /// Retryable boundary failure.
+    TransientError,
+    /// Credential or access failure.
+    AuthError,
+    /// Execution outcome could not be safely verified.
+    VerifyError,
+}
+
+impl Classification {
+    /// Stable machine spelling.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unmanaged => "unmanaged",
+            Self::ConfigError => "config_error",
+            Self::InSync => "in_sync",
+            Self::RelayBehind => "relay_behind",
+            Self::GithubBehind => "github_behind",
+            Self::Diverged => "diverged",
+            Self::TransientError => "transient_error",
+            Self::AuthError => "auth_error",
+            Self::VerifyError => "verify_error",
+        }
+    }
+}
+
+/// Truthful evidence about a possible Buzz ref mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationEvidence {
+    /// No mutation was observed and no ambiguous push remains.
+    None,
+    /// Buzz was verified at the approved target.
+    FastForward,
+    /// A push was attempted but mutation attribution is not provable.
+    Unknown,
+}
+
+impl MutationEvidence {
+    /// Stable machine spelling.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::FastForward => "fast_forward",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Stable process-level outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExitOutcome {
+    /// Reconciliation reached its requested safe state.
+    Success,
+    /// Reconciliation froze or failed and requires attention/retry.
+    Failure,
+}
+
+/// Fixed-schema, secret-free reconciliation evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconcileResult {
+    /// Evidence schema version.
+    pub schema_version: u32,
+    /// Current invocation ID.
+    pub run_id: RunId,
+    /// Enrollment identity.
+    pub enrollment_id: EnrollmentId,
+    /// Immutable GitHub repository identity.
+    pub github_repository_id: GithubRepositoryId,
+    /// Exact managed destination ref.
+    pub managed_ref: ManagedRef,
+    /// Requested mode.
+    pub mode: ReconcileMode,
+    /// Invocation origin.
+    pub trigger: ReconcileTrigger,
+    /// Final classification.
+    pub classification: Classification,
+    /// Initial GitHub tip, when read.
+    pub github_before: Option<CommitOid>,
+    /// Initial Buzz tip, when read.
+    pub buzz_before: Option<CommitOid>,
+    /// Current/approved GitHub target, when known.
+    pub github_target: Option<CommitOid>,
+    /// Trusted Buzz after-tip, when verified.
+    pub buzz_after: Option<CommitOid>,
+    /// Mutation evidence.
+    pub mutation: MutationEvidence,
+    /// Whether the controller reached the push seam; `None` is reserved for
+    /// outer adapters that cannot determine entry into the core.
+    pub push_attempted: Option<bool>,
+    /// Approval event bound to the invocation.
+    pub approval_event: Option<ApprovalEventId>,
+    /// Whether deterministic retry is appropriate.
+    pub retryable: bool,
+    /// Stable operator action token.
+    pub next_action: String,
+    /// Sanitized human summary.
+    pub summary: String,
+    /// Stable process outcome.
+    pub outcome: ExitOutcome,
+    /// Conventional machine exit code.
+    pub exit_code: u8,
+}
+
+/// Immutable key for a previously verified apply delivery.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReplayKey {
+    /// Enrollment identity.
+    pub enrollment_id: EnrollmentId,
+    /// Immutable repository identity prevents state reuse after repointing.
+    pub github_repository_id: GithubRepositoryId,
+    /// Exact destination ref.
+    pub managed_ref: ManagedRef,
+    /// Exact delivered target.
+    pub target: CommitOid,
+    /// Exact owner approval event.
+    pub approval_event: ApprovalEventId,
+}

--- a/crates/buzz-git-relay/src/domain.rs
+++ b/crates/buzz-git-relay/src/domain.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 /// A validated domain value was malformed.
@@ -8,10 +8,24 @@ pub struct ValidationError {
     field: &'static str,
 }
 
+macro_rules! validated_deserialize {
+    ($name:ident) => {
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
 macro_rules! nonempty_id {
     ($name:ident, $field:literal, $docs:literal) => {
         #[doc = $docs]
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
         #[serde(transparent)]
         pub struct $name(String);
 
@@ -36,6 +50,8 @@ macro_rules! nonempty_id {
                 formatter.write_str(&self.0)
             }
         }
+
+        validated_deserialize!($name);
     };
 }
 
@@ -56,7 +72,7 @@ nonempty_id!(
 );
 
 /// A full Git object ID accepted by the v1 controller.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct CommitOid(String);
 
@@ -88,8 +104,10 @@ impl fmt::Display for CommitOid {
     }
 }
 
+validated_deserialize!(CommitOid);
+
 /// A validated 32-byte Nostr event ID.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct ApprovalEventId(String);
 
@@ -115,8 +133,10 @@ impl ApprovalEventId {
     }
 }
 
+validated_deserialize!(ApprovalEventId);
+
 /// The one exact destination ref managed by an enrollment.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct ManagedRef(String);
 
@@ -142,6 +162,8 @@ impl ManagedRef {
         &self.0
     }
 }
+
+validated_deserialize!(ManagedRef);
 
 /// Rollout gate for one enrolled repository.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/buzz-git-relay/src/lib.rs
+++ b/crates/buzz-git-relay/src/lib.rs
@@ -13,7 +13,7 @@ mod reconciler;
 
 pub use domain::{
     ApprovalEventId, Classification, CommitOid, Enrollment, EnrollmentId, ExitOutcome,
-    GithubRepositoryId, ManagedRef, MutationEvidence, ReconcileMode, ReconcileRequest,
+    GithubRepositoryId, ManagedRef, MutationEvidence, NextAction, ReconcileMode, ReconcileRequest,
     ReconcileResult, ReconcileTrigger, ReplayKey, RolloutPhase, RunId, Tips, ValidationError,
 };
 pub use ports::{PortError, PortErrorKind, RunIdGenerator};

--- a/crates/buzz-git-relay/src/lib.rs
+++ b/crates/buzz-git-relay/src/lib.rs
@@ -1,0 +1,20 @@
+//! Deterministic GitHub-to-Buzz repository reconciliation.
+//!
+//! This crate owns the reconciliation state machine and its safety ordering.
+//! Network, persistence, Nostr, UI, and process concerns enter only through
+//! the boundary traits in [`ports`].
+
+#![deny(unsafe_code)]
+#![warn(missing_docs)]
+
+mod domain;
+pub mod ports;
+mod reconciler;
+
+pub use domain::{
+    ApprovalEventId, Classification, CommitOid, Enrollment, EnrollmentId, ExitOutcome,
+    GithubRepositoryId, ManagedRef, MutationEvidence, ReconcileMode, ReconcileRequest,
+    ReconcileResult, ReconcileTrigger, ReplayKey, RolloutPhase, RunId, Tips, ValidationError,
+};
+pub use ports::{PortError, PortErrorKind, RunIdGenerator};
+pub use reconciler::Reconciler;

--- a/crates/buzz-git-relay/src/ports.rs
+++ b/crates/buzz-git-relay/src/ports.rs
@@ -62,9 +62,9 @@ pub trait RepositorySession: Send {
         ancestor: &CommitOid,
         descendant: &CommitOid,
     ) -> Result<bool, PortError>;
-    /// Re-reads only the Buzz managed tip immediately before mutation.
+    /// Re-reads only the Buzz managed tip for concurrent-change classification.
     async fn refresh_buzz(&mut self) -> Result<CommitOid, PortError>;
-    /// Re-reads both tips for race detection and verification.
+    /// Re-reads both tips for the final pre-mutation race check and verification.
     async fn refresh_both(&mut self) -> Result<Tips, PortError>;
     /// Pushes one exact source SHA to one exact destination ref.
     async fn push_exact(

--- a/crates/buzz-git-relay/src/ports.rs
+++ b/crates/buzz-git-relay/src/ports.rs
@@ -1,0 +1,100 @@
+//! Boundary ports used by the deterministic reconciler.
+
+use crate::{CommitOid, Enrollment, ManagedRef, ReconcileResult, ReplayKey, RunId, Tips};
+use async_trait::async_trait;
+
+/// Sanitized boundary failure category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortErrorKind {
+    /// Invalid/missing repository configuration, including a missing managed ref.
+    Config,
+    /// Credential or ACL rejection.
+    Auth,
+    /// Retryable transport or lock failure.
+    Transient,
+    /// Known verification failure.
+    Verify,
+    /// Unexpected adapter or cleanup failure.
+    Unexpected,
+}
+
+/// Secret-free boundary error presented to the state machine.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("git-relay boundary failed ({kind:?})")]
+pub struct PortError {
+    kind: PortErrorKind,
+}
+
+impl PortError {
+    /// Constructs a sanitized boundary error.
+    pub const fn new(kind: PortErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Returns the stable category.
+    pub const fn kind(&self) -> PortErrorKind {
+        self.kind
+    }
+}
+
+/// Creates invocation IDs without coupling the core to a UUID implementation.
+pub trait RunIdGenerator: Send + Sync {
+    /// Returns the next unique invocation ID.
+    fn next(&self) -> RunId;
+}
+
+/// Opens a scoped repository session for one enrollment.
+#[async_trait]
+pub trait RepositoryPort: Send + Sync {
+    /// Opens a session whose credentials and repository identity were resolved
+    /// by the host adapter.
+    async fn open(&self, enrollment: &Enrollment) -> Result<Box<dyn RepositorySession>, PortError>;
+}
+
+/// Git operations whose ordering is owned by [`crate::Reconciler`].
+#[async_trait]
+pub trait RepositorySession: Send {
+    /// Reads both managed tips.
+    async fn tips(&mut self) -> Result<Tips, PortError>;
+    /// Tests commit ancestry using the hydrated repository graph.
+    async fn is_ancestor(
+        &mut self,
+        ancestor: &CommitOid,
+        descendant: &CommitOid,
+    ) -> Result<bool, PortError>;
+    /// Re-reads only the Buzz managed tip immediately before mutation.
+    async fn refresh_buzz(&mut self) -> Result<CommitOid, PortError>;
+    /// Re-reads both tips for race detection and verification.
+    async fn refresh_both(&mut self) -> Result<Tips, PortError>;
+    /// Pushes one exact source SHA to one exact destination ref.
+    async fn push_exact(
+        &mut self,
+        target: &CommitOid,
+        managed_ref: &ManagedRef,
+    ) -> Result<(), PortError>;
+    /// Closes and cleans up the repository session.
+    async fn close(self: Box<Self>) -> Result<(), PortError>;
+}
+
+/// Acquires a per-enrollment/ref single-flight lock.
+#[async_trait]
+pub trait LockManager: Send + Sync {
+    /// Acquires the lock or returns a sanitized boundary error.
+    async fn acquire(&self, key: &str) -> Result<Box<dyn LockLease>, PortError>;
+}
+
+/// Owned lock lease released during reconciliation cleanup.
+#[async_trait]
+pub trait LockLease: Send {
+    /// Releases the lease.
+    async fn release(self: Box<Self>) -> Result<(), PortError>;
+}
+
+/// Append-only evidence and exact verified-delivery replay lookup.
+#[async_trait]
+pub trait EvidenceStore: Send + Sync {
+    /// Finds a successful prior apply for the complete immutable replay key.
+    async fn find_verified(&self, key: &ReplayKey) -> Result<Option<ReconcileResult>, PortError>;
+    /// Appends current invocation evidence.
+    async fn append(&self, result: &ReconcileResult) -> Result<(), PortError>;
+}

--- a/crates/buzz-git-relay/src/reconciler.rs
+++ b/crates/buzz-git-relay/src/reconciler.rs
@@ -1,0 +1,661 @@
+use crate::ports::{
+    EvidenceStore, LockLease, LockManager, PortError, PortErrorKind, RepositoryPort,
+    RepositorySession, RunIdGenerator,
+};
+use crate::{
+    Classification, CommitOid, Enrollment, ExitOutcome, MutationEvidence, ReconcileMode,
+    ReconcileRequest, ReconcileResult, ReplayKey, RolloutPhase, RunId, Tips,
+};
+use std::sync::Arc;
+
+/// Deterministic reconciliation state machine.
+pub struct Reconciler {
+    repositories: Arc<dyn RepositoryPort>,
+    locks: Arc<dyn LockManager>,
+    evidence: Arc<dyn EvidenceStore>,
+    run_ids: Arc<dyn RunIdGenerator>,
+}
+
+impl Reconciler {
+    /// Constructs a reconciler over host-provided boundary adapters.
+    pub fn new(
+        repositories: Arc<dyn RepositoryPort>,
+        locks: Arc<dyn LockManager>,
+        evidence: Arc<dyn EvidenceStore>,
+        run_ids: Arc<dyn RunIdGenerator>,
+    ) -> Self {
+        Self {
+            repositories,
+            locks,
+            evidence,
+            run_ids,
+        }
+    }
+
+    /// Classifies one enrolled repository and, when explicitly authorized,
+    /// performs only a proven exact fast-forward.
+    pub async fn reconcile(
+        &self,
+        enrollment: &Enrollment,
+        request: ReconcileRequest,
+    ) -> ReconcileResult {
+        let run_id = self.run_ids.next();
+        if !enrollment.enabled {
+            return self
+                .record(base_result(
+                    run_id,
+                    enrollment,
+                    &request,
+                    Classification::Unmanaged,
+                    "none",
+                    "Git-relay is disabled for this repository.",
+                    false,
+                ))
+                .await;
+        }
+        if !enrollment.policy_is_valid() {
+            return self
+                .record(base_result(
+                    run_id,
+                    enrollment,
+                    &request,
+                    Classification::ConfigError,
+                    "fix_configuration",
+                    "Enrollment policy validation failed; Git-relay made no changes.",
+                    false,
+                ))
+                .await;
+        }
+
+        let lock_key = format!("{}:{}", enrollment.id, enrollment.managed_ref.as_str());
+        let lease = match self.locks.acquire(&lock_key).await {
+            Ok(lease) => lease,
+            Err(error) => {
+                let (classification, retryable, action, summary) = match error.kind() {
+                    PortErrorKind::Transient => (
+                        Classification::TransientError,
+                        true,
+                        "retry_after_active_run",
+                        "Another Git-relay run holds this repository/ref lock.",
+                    ),
+                    _ => (
+                        Classification::VerifyError,
+                        false,
+                        "inspect_unexpected_failure",
+                        "An unexpected lock boundary failed; inspect trusted host logs.",
+                    ),
+                };
+                let mut result = base_result(
+                    run_id,
+                    enrollment,
+                    &request,
+                    classification,
+                    action,
+                    summary,
+                    false,
+                );
+                result.retryable = retryable;
+                return self.record(result).await;
+            }
+        };
+
+        let session = self.repositories.open(enrollment).await;
+        let mut session = match session {
+            Ok(session) => session,
+            Err(error) => {
+                let result =
+                    boundary_result(run_id, enrollment, &request, &error, false, None, None);
+                return self.finalize(result, None, Some(lease), false, false).await;
+            }
+        };
+
+        let tips = match session.tips().await {
+            Ok(tips) => tips,
+            Err(error) => {
+                let result =
+                    boundary_result(run_id, enrollment, &request, &error, false, None, None);
+                return self
+                    .finalize(result, Some(session), Some(lease), false, false)
+                    .await;
+            }
+        };
+
+        let github_before = Some(tips.github.clone());
+        let buzz_before = Some(tips.buzz.clone());
+        let mut result = classified_result(run_id, enrollment, &request, &tips);
+
+        if request.mode == ReconcileMode::Apply
+            && !apply_authorized(enrollment, &request, &tips.github)
+        {
+            result.classification = Classification::ConfigError;
+            result.next_action = "provide_exact_target_and_approval".to_owned();
+            result.summary = "Apply requires Phase 2 enablement, the current GitHub target, and a valid approval event ID.".to_owned();
+            result.outcome = ExitOutcome::Failure;
+            result.exit_code = 1;
+            return self
+                .finalize(result, Some(session), Some(lease), false, false)
+                .await;
+        }
+
+        if request.mode == ReconcileMode::Apply && tips.github == tips.buzz {
+            if let Some(approval_event) = request.approval_event.clone() {
+                let key = ReplayKey {
+                    enrollment_id: enrollment.id.clone(),
+                    github_repository_id: enrollment.github_repository_id.clone(),
+                    managed_ref: enrollment.managed_ref.clone(),
+                    target: tips.github.clone(),
+                    approval_event,
+                };
+                match self.evidence.find_verified(&key).await {
+                    Ok(Some(prior)) => {
+                        return self
+                            .finalize_replay(
+                                prior,
+                                result.run_id.clone(),
+                                Some(session),
+                                Some(lease),
+                            )
+                            .await;
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        let result = boundary_result(
+                            result.run_id.clone(),
+                            enrollment,
+                            &request,
+                            &error,
+                            false,
+                            github_before,
+                            buzz_before,
+                        );
+                        return self
+                            .finalize(result, Some(session), Some(lease), false, false)
+                            .await;
+                    }
+                }
+            }
+        }
+
+        let classification = match self.classify(&mut *session, &tips).await {
+            Ok(classification) => classification,
+            Err(error) => {
+                let result = boundary_result(
+                    result.run_id.clone(),
+                    enrollment,
+                    &request,
+                    &error,
+                    false,
+                    github_before,
+                    buzz_before,
+                );
+                return self
+                    .finalize(result, Some(session), Some(lease), false, false)
+                    .await;
+            }
+        };
+        apply_classification(&mut result, classification, request.mode);
+
+        if request.mode != ReconcileMode::Apply || classification != Classification::RelayBehind {
+            return self
+                .finalize(result, Some(session), Some(lease), false, false)
+                .await;
+        }
+
+        let before_push = match session.refresh_both().await {
+            Ok(tips) => tips,
+            Err(error) => {
+                let result = boundary_result(
+                    result.run_id.clone(),
+                    enrollment,
+                    &request,
+                    &error,
+                    false,
+                    github_before,
+                    buzz_before,
+                );
+                return self
+                    .finalize(result, Some(session), Some(lease), false, false)
+                    .await;
+            }
+        };
+        if before_push.github != tips.github {
+            result.classification = Classification::ConfigError;
+            result.github_target = Some(before_push.github);
+            result.buzz_after = Some(before_push.buzz);
+            fail(
+                &mut result,
+                "approve_new_github_target",
+                "GitHub advanced after approval; Git-relay froze the old target.",
+            );
+            return self
+                .finalize(result, Some(session), Some(lease), false, false)
+                .await;
+        }
+
+        let current_buzz = match session.refresh_buzz().await {
+            Ok(tip) => tip,
+            Err(error) => {
+                let result = boundary_result(
+                    result.run_id.clone(),
+                    enrollment,
+                    &request,
+                    &error,
+                    false,
+                    github_before,
+                    buzz_before,
+                );
+                return self
+                    .finalize(result, Some(session), Some(lease), false, false)
+                    .await;
+            }
+        };
+        if current_buzz == tips.github {
+            result.classification = Classification::InSync;
+            result.buzz_after = Some(current_buzz);
+            succeed(
+                &mut result,
+                "Buzz reached the target before Git-relay pushed.",
+            );
+            return self
+                .finalize(result, Some(session), Some(lease), false, false)
+                .await;
+        }
+        let still_safe = match session.is_ancestor(&current_buzz, &tips.github).await {
+            Ok(value) => value,
+            Err(error) => {
+                let result = boundary_result(
+                    result.run_id.clone(),
+                    enrollment,
+                    &request,
+                    &error,
+                    false,
+                    github_before,
+                    buzz_before,
+                );
+                return self
+                    .finalize(result, Some(session), Some(lease), false, false)
+                    .await;
+            }
+        };
+        if !still_safe {
+            let github_behind = match session.is_ancestor(&tips.github, &current_buzz).await {
+                Ok(value) => value,
+                Err(error) => {
+                    let result = boundary_result(
+                        result.run_id.clone(),
+                        enrollment,
+                        &request,
+                        &error,
+                        false,
+                        github_before,
+                        buzz_before,
+                    );
+                    return self
+                        .finalize(result, Some(session), Some(lease), false, false)
+                        .await;
+                }
+            };
+            result.classification = if github_behind {
+                Classification::GithubBehind
+            } else {
+                Classification::Diverged
+            };
+            result.buzz_after = Some(current_buzz);
+            if github_behind {
+                fail(
+                    &mut result,
+                    "inspect_relay_only_commits",
+                    "Buzz advanced after classification and now contains relay-only commits.",
+                );
+            } else {
+                fail(
+                    &mut result,
+                    "review_divergent_histories",
+                    "Buzz changed after classification and the histories now diverge.",
+                );
+            }
+            return self
+                .finalize(result, Some(session), Some(lease), false, false)
+                .await;
+        }
+
+        result.push_attempted = Some(true);
+        let push_error = session
+            .push_exact(&tips.github, &enrollment.managed_ref)
+            .await
+            .err();
+        let after = session.refresh_both().await;
+        match after {
+            Ok(after) => {
+                result.buzz_after = Some(after.buzz.clone());
+                result.mutation = if after.buzz == tips.github {
+                    MutationEvidence::FastForward
+                } else if after.buzz == current_buzz {
+                    MutationEvidence::None
+                } else {
+                    MutationEvidence::Unknown
+                };
+                if after.github == tips.github && after.buzz == tips.github {
+                    result.classification = Classification::InSync;
+                    let summary = if push_error.is_some() {
+                        "The push response was ambiguous, but an immediate reread verified exact target equality."
+                    } else {
+                        "Buzz was fast-forwarded to the exact GitHub target and verified."
+                    };
+                    succeed(&mut result, summary);
+                } else if let Some(error) = push_error {
+                    if after.buzz == current_buzz {
+                        let (classification, retryable, action) = mapped_error(&error);
+                        result.classification = classification;
+                        result.retryable = retryable;
+                        fail(&mut result, action, "The push failed and an immediate reread confirmed that Buzz did not change.");
+                    } else {
+                        result.classification = Classification::VerifyError;
+                        fail(&mut result, "inspect_ambiguous_push", "Buzz changed to an unexpected SHA during an attempted push; mutation attribution is unknown.");
+                    }
+                } else {
+                    result.classification = Classification::VerifyError;
+                    let (action, summary) = if after.github != tips.github {
+                        (
+                            "approve_new_github_target",
+                            if result.mutation == MutationEvidence::FastForward {
+                                "Buzz reached the approved target, but GitHub advanced before post-push verification."
+                            } else {
+                                "GitHub advanced before delivery could be verified."
+                            },
+                        )
+                    } else {
+                        (
+                            "inspect_post_push_refs",
+                            "The push completed but post-push refs did not match the target.",
+                        )
+                    };
+                    fail(&mut result, action, summary);
+                }
+            }
+            Err(error) => {
+                result.classification = Classification::VerifyError;
+                result.buzz_after = None;
+                result.mutation = MutationEvidence::Unknown;
+                result.retryable = push_error
+                    .as_ref()
+                    .is_some_and(|value| value.kind() == PortErrorKind::Transient)
+                    || error.kind() == PortErrorKind::Transient;
+                fail(&mut result, "inspect_ambiguous_push", "A push was attempted, but its outcome could not be reread; mutation is unknown.");
+            }
+        }
+        self.finalize(result, Some(session), Some(lease), true, false)
+            .await
+    }
+
+    async fn classify(
+        &self,
+        session: &mut dyn RepositorySession,
+        tips: &Tips,
+    ) -> Result<Classification, PortError> {
+        if tips.github == tips.buzz {
+            return Ok(Classification::InSync);
+        }
+        if session.is_ancestor(&tips.buzz, &tips.github).await? {
+            return Ok(Classification::RelayBehind);
+        }
+        if session.is_ancestor(&tips.github, &tips.buzz).await? {
+            return Ok(Classification::GithubBehind);
+        }
+        Ok(Classification::Diverged)
+    }
+
+    async fn finalize(
+        &self,
+        mut result: ReconcileResult,
+        session: Option<Box<dyn RepositorySession>>,
+        lease: Option<Box<dyn LockLease>>,
+        push_attempted: bool,
+        replayed: bool,
+    ) -> ReconcileResult {
+        let session_failed = match session {
+            Some(session) => session.close().await.is_err(),
+            None => false,
+        };
+        let lease_failed = match lease {
+            Some(lease) => lease.release().await.is_err(),
+            None => false,
+        };
+        if session_failed || lease_failed {
+            result.classification = Classification::VerifyError;
+            result.push_attempted = Some(push_attempted);
+            result.mutation = if push_attempted {
+                MutationEvidence::Unknown
+            } else {
+                MutationEvidence::None
+            };
+            if push_attempted {
+                result.buzz_after = None;
+            }
+            fail(
+                &mut result,
+                "inspect_cleanup_failure",
+                "Repository session cleanup failed; inspect trusted host logs.",
+            );
+            return self.record(result).await;
+        }
+        if replayed {
+            return result;
+        }
+        self.record(result).await
+    }
+
+    async fn finalize_replay(
+        &self,
+        prior: ReconcileResult,
+        current_run_id: RunId,
+        session: Option<Box<dyn RepositorySession>>,
+        lease: Option<Box<dyn LockLease>>,
+    ) -> ReconcileResult {
+        let session_failed = match session {
+            Some(session) => session.close().await.is_err(),
+            None => false,
+        };
+        let lease_failed = match lease {
+            Some(lease) => lease.release().await.is_err(),
+            None => false,
+        };
+        if !session_failed && !lease_failed {
+            return prior;
+        }
+
+        let mut result = prior;
+        result.run_id = current_run_id;
+        result.classification = Classification::VerifyError;
+        result.push_attempted = Some(false);
+        result.mutation = MutationEvidence::None;
+        fail(
+            &mut result,
+            "inspect_cleanup_failure",
+            "Repository session cleanup failed; inspect trusted host logs.",
+        );
+        self.record(result).await
+    }
+
+    async fn record(&self, mut result: ReconcileResult) -> ReconcileResult {
+        if self.evidence.append(&result).await.is_err() {
+            result.classification = Classification::VerifyError;
+            if result.push_attempted == Some(true) {
+                result.mutation = MutationEvidence::Unknown;
+                result.buzz_after = None;
+            }
+            fail(
+                &mut result,
+                "repair_audit_store",
+                "Audit evidence could not be persisted; inspect trusted host logs.",
+            );
+        }
+        result
+    }
+}
+
+fn apply_authorized(
+    enrollment: &Enrollment,
+    request: &ReconcileRequest,
+    current: &CommitOid,
+) -> bool {
+    enrollment.rollout_phase == RolloutPhase::OwnerApprovedApply
+        && enrollment.apply_enabled
+        && enrollment.approval_required
+        && request.expected_target.as_ref() == Some(current)
+        && request.approval_event.is_some()
+}
+
+fn classified_result(
+    run_id: RunId,
+    enrollment: &Enrollment,
+    request: &ReconcileRequest,
+    tips: &Tips,
+) -> ReconcileResult {
+    let mut result = base_result(
+        run_id,
+        enrollment,
+        request,
+        Classification::InSync,
+        "none",
+        "GitHub and Buzz refs are in sync.",
+        false,
+    );
+    result.github_before = Some(tips.github.clone());
+    result.buzz_before = Some(tips.buzz.clone());
+    result.github_target = Some(tips.github.clone());
+    result.buzz_after = Some(tips.buzz.clone());
+    result
+}
+
+fn apply_classification(
+    result: &mut ReconcileResult,
+    classification: Classification,
+    mode: ReconcileMode,
+) {
+    result.classification = classification;
+    match classification {
+        Classification::InSync => succeed(result, "GitHub and Buzz refs are in sync."),
+        Classification::RelayBehind => fail(
+            result,
+            "approve_exact_fast_forward",
+            if mode == ReconcileMode::Observe {
+                "Buzz is behind GitHub; observe mode made no changes."
+            } else {
+                "Buzz is behind GitHub; an exact fast-forward is eligible."
+            },
+        ),
+        Classification::GithubBehind => fail(
+            result,
+            "inspect_relay_only_commits",
+            "Buzz contains commits not present on GitHub; Git-relay froze.",
+        ),
+        Classification::Diverged => fail(
+            result,
+            "review_divergent_histories",
+            "GitHub and Buzz histories diverged; Git-relay froze.",
+        ),
+        _ => {}
+    }
+}
+
+fn boundary_result(
+    run_id: RunId,
+    enrollment: &Enrollment,
+    request: &ReconcileRequest,
+    error: &PortError,
+    push_attempted: bool,
+    github_before: Option<CommitOid>,
+    buzz_before: Option<CommitOid>,
+) -> ReconcileResult {
+    let (classification, retryable, action) = mapped_error(error);
+    let mut result = base_result(
+        run_id,
+        enrollment,
+        request,
+        if push_attempted {
+            Classification::VerifyError
+        } else {
+            classification
+        },
+        action,
+        "A reconciliation boundary failed; inspect trusted host logs.",
+        false,
+    );
+    result.github_before = github_before.clone();
+    result.buzz_before = buzz_before.clone();
+    result.github_target = request.expected_target.clone().or(github_before);
+    result.buzz_after = if push_attempted { None } else { buzz_before };
+    result.push_attempted = Some(push_attempted);
+    result.mutation = if push_attempted {
+        MutationEvidence::Unknown
+    } else {
+        MutationEvidence::None
+    };
+    result.retryable = retryable;
+    result
+}
+
+fn mapped_error(error: &PortError) -> (Classification, bool, &'static str) {
+    match error.kind() {
+        PortErrorKind::Config => (Classification::ConfigError, false, "fix_configuration"),
+        PortErrorKind::Auth => (
+            Classification::AuthError,
+            false,
+            "repair_credentials_or_acl",
+        ),
+        PortErrorKind::Transient => (Classification::TransientError, true, "retry_with_backoff"),
+        PortErrorKind::Verify | PortErrorKind::Unexpected => (
+            Classification::VerifyError,
+            false,
+            "inspect_unexpected_failure",
+        ),
+    }
+}
+
+fn base_result(
+    run_id: RunId,
+    enrollment: &Enrollment,
+    request: &ReconcileRequest,
+    classification: Classification,
+    next_action: &str,
+    summary: &str,
+    retryable: bool,
+) -> ReconcileResult {
+    ReconcileResult {
+        schema_version: 1,
+        run_id,
+        enrollment_id: enrollment.id.clone(),
+        github_repository_id: enrollment.github_repository_id.clone(),
+        managed_ref: enrollment.managed_ref.clone(),
+        mode: request.mode,
+        trigger: request.trigger,
+        classification,
+        github_before: None,
+        buzz_before: None,
+        github_target: request.expected_target.clone(),
+        buzz_after: None,
+        mutation: MutationEvidence::None,
+        push_attempted: Some(false),
+        approval_event: request.approval_event.clone(),
+        retryable,
+        next_action: next_action.to_owned(),
+        summary: summary.to_owned(),
+        outcome: ExitOutcome::Failure,
+        exit_code: 1,
+    }
+}
+
+fn succeed(result: &mut ReconcileResult, summary: &str) {
+    result.next_action = "none".to_owned();
+    result.summary = summary.to_owned();
+    result.outcome = ExitOutcome::Success;
+    result.exit_code = 0;
+}
+
+fn fail(result: &mut ReconcileResult, action: &str, summary: &str) {
+    result.next_action = action.to_owned();
+    result.summary = summary.to_owned();
+    result.outcome = ExitOutcome::Failure;
+    result.exit_code = 1;
+}

--- a/crates/buzz-git-relay/src/reconciler.rs
+++ b/crates/buzz-git-relay/src/reconciler.rs
@@ -201,37 +201,6 @@ impl Reconciler {
                 .await;
         }
 
-        let before_push = match session.refresh_both().await {
-            Ok(tips) => tips,
-            Err(error) => {
-                let result = boundary_result(
-                    result.run_id.clone(),
-                    enrollment,
-                    &request,
-                    &error,
-                    false,
-                    github_before,
-                    buzz_before,
-                );
-                return self
-                    .finalize(result, Some(session), Some(lease), false, false)
-                    .await;
-            }
-        };
-        if before_push.github != tips.github {
-            result.classification = Classification::ConfigError;
-            result.github_target = Some(before_push.github);
-            result.buzz_after = Some(before_push.buzz);
-            fail(
-                &mut result,
-                "approve_new_github_target",
-                "GitHub advanced after approval; Git-relay froze the old target.",
-            );
-            return self
-                .finalize(result, Some(session), Some(lease), false, false)
-                .await;
-        }
-
         let current_buzz = match session.refresh_buzz().await {
             Ok(tip) => tip,
             Err(error) => {
@@ -312,6 +281,57 @@ impl Reconciler {
                     &mut result,
                     "review_divergent_histories",
                     "Buzz changed after classification and the histories now diverge.",
+                );
+            }
+            return self
+                .finalize(result, Some(session), Some(lease), false, false)
+                .await;
+        }
+
+        let before_push = match session.refresh_both().await {
+            Ok(tips) => tips,
+            Err(error) => {
+                let result = boundary_result(
+                    result.run_id.clone(),
+                    enrollment,
+                    &request,
+                    &error,
+                    false,
+                    github_before,
+                    buzz_before,
+                );
+                return self
+                    .finalize(result, Some(session), Some(lease), false, false)
+                    .await;
+            }
+        };
+        if before_push.github != tips.github {
+            result.classification = Classification::ConfigError;
+            result.github_target = Some(before_push.github);
+            result.buzz_after = Some(before_push.buzz);
+            fail(
+                &mut result,
+                "approve_new_github_target",
+                "GitHub advanced after approval; Git-relay froze the old target.",
+            );
+            return self
+                .finalize(result, Some(session), Some(lease), false, false)
+                .await;
+        }
+        if before_push.buzz != current_buzz {
+            result.buzz_after = Some(before_push.buzz.clone());
+            if before_push.buzz == tips.github {
+                result.classification = Classification::InSync;
+                succeed(
+                    &mut result,
+                    "Buzz reached the target before Git-relay pushed.",
+                );
+            } else {
+                result.classification = Classification::VerifyError;
+                fail(
+                    &mut result,
+                    "retry_after_concurrent_change",
+                    "Buzz changed during the final pre-push check; Git-relay froze without pushing.",
                 );
             }
             return self

--- a/crates/buzz-git-relay/src/reconciler.rs
+++ b/crates/buzz-git-relay/src/reconciler.rs
@@ -3,8 +3,8 @@ use crate::ports::{
     RepositorySession, RunIdGenerator,
 };
 use crate::{
-    Classification, CommitOid, Enrollment, ExitOutcome, MutationEvidence, ReconcileMode,
-    ReconcileRequest, ReconcileResult, ReplayKey, RolloutPhase, RunId, Tips,
+    Classification, CommitOid, Enrollment, ExitOutcome, MutationEvidence, NextAction,
+    ReconcileMode, ReconcileRequest, ReconcileResult, ReplayKey, RolloutPhase, RunId, Tips,
 };
 use std::sync::Arc;
 
@@ -47,7 +47,7 @@ impl Reconciler {
                     enrollment,
                     &request,
                     Classification::Unmanaged,
-                    "none",
+                    NextAction::None,
                     "Git-relay is disabled for this repository.",
                     false,
                 ))
@@ -60,7 +60,7 @@ impl Reconciler {
                     enrollment,
                     &request,
                     Classification::ConfigError,
-                    "fix_configuration",
+                    NextAction::FixConfiguration,
                     "Enrollment policy validation failed; Git-relay made no changes.",
                     false,
                 ))
@@ -75,13 +75,13 @@ impl Reconciler {
                     PortErrorKind::Transient => (
                         Classification::TransientError,
                         true,
-                        "retry_after_active_run",
+                        NextAction::RetryAfterActiveRun,
                         "Another Git-relay run holds this repository/ref lock.",
                     ),
                     _ => (
                         Classification::VerifyError,
                         false,
-                        "inspect_unexpected_failure",
+                        NextAction::InspectUnexpectedFailure,
                         "An unexpected lock boundary failed; inspect trusted host logs.",
                     ),
                 };
@@ -105,7 +105,7 @@ impl Reconciler {
             Err(error) => {
                 let result =
                     boundary_result(run_id, enrollment, &request, &error, false, None, None);
-                return self.finalize(result, None, Some(lease), false, false).await;
+                return self.finalize(result, None, Some(lease), false).await;
             }
         };
 
@@ -115,7 +115,7 @@ impl Reconciler {
                 let result =
                     boundary_result(run_id, enrollment, &request, &error, false, None, None);
                 return self
-                    .finalize(result, Some(session), Some(lease), false, false)
+                    .finalize(result, Some(session), Some(lease), false)
                     .await;
             }
         };
@@ -128,12 +128,12 @@ impl Reconciler {
             && !apply_authorized(enrollment, &request, &tips.github)
         {
             result.classification = Classification::ConfigError;
-            result.next_action = "provide_exact_target_and_approval".to_owned();
+            result.next_action = NextAction::ProvideExactTargetAndApproval;
             result.summary = "Apply requires Phase 2 enablement, the current GitHub target, and a valid approval event ID.".to_owned();
             result.outcome = ExitOutcome::Failure;
             result.exit_code = 1;
             return self
-                .finalize(result, Some(session), Some(lease), false, false)
+                .finalize(result, Some(session), Some(lease), false)
                 .await;
         }
 
@@ -146,6 +146,7 @@ impl Reconciler {
                     target: tips.github.clone(),
                     approval_event,
                 };
+                // Replay is valid only for the complete immutable delivery key.
                 match self.evidence.find_verified(&key).await {
                     Ok(Some(prior)) => {
                         return self
@@ -169,7 +170,7 @@ impl Reconciler {
                             buzz_before,
                         );
                         return self
-                            .finalize(result, Some(session), Some(lease), false, false)
+                            .finalize(result, Some(session), Some(lease), false)
                             .await;
                     }
                 }
@@ -189,7 +190,7 @@ impl Reconciler {
                     buzz_before,
                 );
                 return self
-                    .finalize(result, Some(session), Some(lease), false, false)
+                    .finalize(result, Some(session), Some(lease), false)
                     .await;
             }
         };
@@ -197,7 +198,7 @@ impl Reconciler {
 
         if request.mode != ReconcileMode::Apply || classification != Classification::RelayBehind {
             return self
-                .finalize(result, Some(session), Some(lease), false, false)
+                .finalize(result, Some(session), Some(lease), false)
                 .await;
         }
 
@@ -214,7 +215,7 @@ impl Reconciler {
                     buzz_before,
                 );
                 return self
-                    .finalize(result, Some(session), Some(lease), false, false)
+                    .finalize(result, Some(session), Some(lease), false)
                     .await;
             }
         };
@@ -226,7 +227,7 @@ impl Reconciler {
                 "Buzz reached the target before Git-relay pushed.",
             );
             return self
-                .finalize(result, Some(session), Some(lease), false, false)
+                .finalize(result, Some(session), Some(lease), false)
                 .await;
         }
         let still_safe = match session.is_ancestor(&current_buzz, &tips.github).await {
@@ -242,7 +243,7 @@ impl Reconciler {
                     buzz_before,
                 );
                 return self
-                    .finalize(result, Some(session), Some(lease), false, false)
+                    .finalize(result, Some(session), Some(lease), false)
                     .await;
             }
         };
@@ -260,7 +261,7 @@ impl Reconciler {
                         buzz_before,
                     );
                     return self
-                        .finalize(result, Some(session), Some(lease), false, false)
+                        .finalize(result, Some(session), Some(lease), false)
                         .await;
                 }
             };
@@ -273,21 +274,22 @@ impl Reconciler {
             if github_behind {
                 fail(
                     &mut result,
-                    "inspect_relay_only_commits",
+                    NextAction::InspectRelayOnlyCommits,
                     "Buzz advanced after classification and now contains relay-only commits.",
                 );
             } else {
                 fail(
                     &mut result,
-                    "review_divergent_histories",
+                    NextAction::ReviewDivergentHistories,
                     "Buzz changed after classification and the histories now diverge.",
                 );
             }
             return self
-                .finalize(result, Some(session), Some(lease), false, false)
+                .finalize(result, Some(session), Some(lease), false)
                 .await;
         }
 
+        // Keep this as the final remote read before the exact-ref push race fence.
         let before_push = match session.refresh_both().await {
             Ok(tips) => tips,
             Err(error) => {
@@ -301,21 +303,20 @@ impl Reconciler {
                     buzz_before,
                 );
                 return self
-                    .finalize(result, Some(session), Some(lease), false, false)
+                    .finalize(result, Some(session), Some(lease), false)
                     .await;
             }
         };
         if before_push.github != tips.github {
             result.classification = Classification::ConfigError;
-            result.github_target = Some(before_push.github);
             result.buzz_after = Some(before_push.buzz);
             fail(
                 &mut result,
-                "approve_new_github_target",
+                NextAction::ApproveNewGithubTarget,
                 "GitHub advanced after approval; Git-relay froze the old target.",
             );
             return self
-                .finalize(result, Some(session), Some(lease), false, false)
+                .finalize(result, Some(session), Some(lease), false)
                 .await;
         }
         if before_push.buzz != current_buzz {
@@ -330,12 +331,12 @@ impl Reconciler {
                 result.classification = Classification::VerifyError;
                 fail(
                     &mut result,
-                    "retry_after_concurrent_change",
+                    NextAction::RetryAfterConcurrentChange,
                     "Buzz changed during the final pre-push check; Git-relay froze without pushing.",
                 );
             }
             return self
-                .finalize(result, Some(session), Some(lease), false, false)
+                .finalize(result, Some(session), Some(lease), false)
                 .await;
         }
 
@@ -344,6 +345,7 @@ impl Reconciler {
             .push_exact(&tips.github, &enrollment.managed_ref)
             .await
             .err();
+        // A push response is not mutation evidence; only this immediate reread is.
         let after = session.refresh_both().await;
         match after {
             Ok(after) => {
@@ -371,13 +373,13 @@ impl Reconciler {
                         fail(&mut result, action, "The push failed and an immediate reread confirmed that Buzz did not change.");
                     } else {
                         result.classification = Classification::VerifyError;
-                        fail(&mut result, "inspect_ambiguous_push", "Buzz changed to an unexpected SHA during an attempted push; mutation attribution is unknown.");
+                        fail(&mut result, NextAction::InspectAmbiguousPush, "Buzz changed to an unexpected SHA during an attempted push; mutation attribution is unknown.");
                     }
                 } else {
                     result.classification = Classification::VerifyError;
                     let (action, summary) = if after.github != tips.github {
                         (
-                            "approve_new_github_target",
+                            NextAction::ApproveNewGithubTarget,
                             if result.mutation == MutationEvidence::FastForward {
                                 "Buzz reached the approved target, but GitHub advanced before post-push verification."
                             } else {
@@ -386,7 +388,7 @@ impl Reconciler {
                         )
                     } else {
                         (
-                            "inspect_post_push_refs",
+                            NextAction::InspectPostPushRefs,
                             "The push completed but post-push refs did not match the target.",
                         )
                     };
@@ -401,10 +403,10 @@ impl Reconciler {
                     .as_ref()
                     .is_some_and(|value| value.kind() == PortErrorKind::Transient)
                     || error.kind() == PortErrorKind::Transient;
-                fail(&mut result, "inspect_ambiguous_push", "A push was attempted, but its outcome could not be reread; mutation is unknown.");
+                fail(&mut result, NextAction::InspectAmbiguousPush, "A push was attempted, but its outcome could not be reread; mutation is unknown.");
             }
         }
-        self.finalize(result, Some(session), Some(lease), true, false)
+        self.finalize(result, Some(session), Some(lease), true)
             .await
     }
 
@@ -431,36 +433,17 @@ impl Reconciler {
         session: Option<Box<dyn RepositorySession>>,
         lease: Option<Box<dyn LockLease>>,
         push_attempted: bool,
-        replayed: bool,
     ) -> ReconcileResult {
-        let session_failed = match session {
-            Some(session) => session.close().await.is_err(),
-            None => false,
-        };
-        let lease_failed = match lease {
-            Some(lease) => lease.release().await.is_err(),
-            None => false,
-        };
-        if session_failed || lease_failed {
+        // Record after cleanup so cleanup failure and proved mutation remain one result.
+        if cleanup_failed(session, lease).await {
             result.classification = Classification::VerifyError;
             result.push_attempted = Some(push_attempted);
-            result.mutation = if push_attempted {
-                MutationEvidence::Unknown
-            } else {
-                MutationEvidence::None
-            };
-            if push_attempted {
-                result.buzz_after = None;
-            }
             fail(
                 &mut result,
-                "inspect_cleanup_failure",
+                NextAction::InspectCleanupFailure,
                 "Repository session cleanup failed; inspect trusted host logs.",
             );
             return self.record(result).await;
-        }
-        if replayed {
-            return result;
         }
         self.record(result).await
     }
@@ -472,15 +455,7 @@ impl Reconciler {
         session: Option<Box<dyn RepositorySession>>,
         lease: Option<Box<dyn LockLease>>,
     ) -> ReconcileResult {
-        let session_failed = match session {
-            Some(session) => session.close().await.is_err(),
-            None => false,
-        };
-        let lease_failed = match lease {
-            Some(lease) => lease.release().await.is_err(),
-            None => false,
-        };
-        if !session_failed && !lease_failed {
+        if !cleanup_failed(session, lease).await {
             return prior;
         }
 
@@ -491,7 +466,7 @@ impl Reconciler {
         result.mutation = MutationEvidence::None;
         fail(
             &mut result,
-            "inspect_cleanup_failure",
+            NextAction::InspectCleanupFailure,
             "Repository session cleanup failed; inspect trusted host logs.",
         );
         self.record(result).await
@@ -500,18 +475,29 @@ impl Reconciler {
     async fn record(&self, mut result: ReconcileResult) -> ReconcileResult {
         if self.evidence.append(&result).await.is_err() {
             result.classification = Classification::VerifyError;
-            if result.push_attempted == Some(true) {
-                result.mutation = MutationEvidence::Unknown;
-                result.buzz_after = None;
-            }
             fail(
                 &mut result,
-                "repair_audit_store",
+                NextAction::RepairAuditStore,
                 "Audit evidence could not be persisted; inspect trusted host logs.",
             );
         }
         result
     }
+}
+
+async fn cleanup_failed(
+    session: Option<Box<dyn RepositorySession>>,
+    lease: Option<Box<dyn LockLease>>,
+) -> bool {
+    let session_failed = match session {
+        Some(session) => session.close().await.is_err(),
+        None => false,
+    };
+    let lease_failed = match lease {
+        Some(lease) => lease.release().await.is_err(),
+        None => false,
+    };
+    session_failed || lease_failed
 }
 
 fn apply_authorized(
@@ -537,13 +523,12 @@ fn classified_result(
         enrollment,
         request,
         Classification::InSync,
-        "none",
+        NextAction::None,
         "GitHub and Buzz refs are in sync.",
         false,
     );
     result.github_before = Some(tips.github.clone());
     result.buzz_before = Some(tips.buzz.clone());
-    result.github_target = Some(tips.github.clone());
     result.buzz_after = Some(tips.buzz.clone());
     result
 }
@@ -558,7 +543,7 @@ fn apply_classification(
         Classification::InSync => succeed(result, "GitHub and Buzz refs are in sync."),
         Classification::RelayBehind => fail(
             result,
-            "approve_exact_fast_forward",
+            NextAction::ApproveExactFastForward,
             if mode == ReconcileMode::Observe {
                 "Buzz is behind GitHub; observe mode made no changes."
             } else {
@@ -567,12 +552,12 @@ fn apply_classification(
         ),
         Classification::GithubBehind => fail(
             result,
-            "inspect_relay_only_commits",
+            NextAction::InspectRelayOnlyCommits,
             "Buzz contains commits not present on GitHub; Git-relay froze.",
         ),
         Classification::Diverged => fail(
             result,
-            "review_divergent_histories",
+            NextAction::ReviewDivergentHistories,
             "GitHub and Buzz histories diverged; Git-relay froze.",
         ),
         _ => {}
@@ -604,7 +589,7 @@ fn boundary_result(
     );
     result.github_before = github_before.clone();
     result.buzz_before = buzz_before.clone();
-    result.github_target = request.expected_target.clone().or(github_before);
+    result.github_target = request.expected_target.clone();
     result.buzz_after = if push_attempted { None } else { buzz_before };
     result.push_attempted = Some(push_attempted);
     result.mutation = if push_attempted {
@@ -616,19 +601,27 @@ fn boundary_result(
     result
 }
 
-fn mapped_error(error: &PortError) -> (Classification, bool, &'static str) {
+fn mapped_error(error: &PortError) -> (Classification, bool, NextAction) {
     match error.kind() {
-        PortErrorKind::Config => (Classification::ConfigError, false, "fix_configuration"),
+        PortErrorKind::Config => (
+            Classification::ConfigError,
+            false,
+            NextAction::FixConfiguration,
+        ),
         PortErrorKind::Auth => (
             Classification::AuthError,
             false,
-            "repair_credentials_or_acl",
+            NextAction::RepairCredentialsOrAcl,
         ),
-        PortErrorKind::Transient => (Classification::TransientError, true, "retry_with_backoff"),
+        PortErrorKind::Transient => (
+            Classification::TransientError,
+            true,
+            NextAction::RetryWithBackoff,
+        ),
         PortErrorKind::Verify | PortErrorKind::Unexpected => (
             Classification::VerifyError,
             false,
-            "inspect_unexpected_failure",
+            NextAction::InspectUnexpectedFailure,
         ),
     }
 }
@@ -638,7 +631,7 @@ fn base_result(
     enrollment: &Enrollment,
     request: &ReconcileRequest,
     classification: Classification,
-    next_action: &str,
+    next_action: NextAction,
     summary: &str,
     retryable: bool,
 ) -> ReconcileResult {
@@ -659,7 +652,7 @@ fn base_result(
         push_attempted: Some(false),
         approval_event: request.approval_event.clone(),
         retryable,
-        next_action: next_action.to_owned(),
+        next_action,
         summary: summary.to_owned(),
         outcome: ExitOutcome::Failure,
         exit_code: 1,
@@ -667,14 +660,14 @@ fn base_result(
 }
 
 fn succeed(result: &mut ReconcileResult, summary: &str) {
-    result.next_action = "none".to_owned();
+    result.next_action = NextAction::None;
     result.summary = summary.to_owned();
     result.outcome = ExitOutcome::Success;
     result.exit_code = 0;
 }
 
-fn fail(result: &mut ReconcileResult, action: &str, summary: &str) {
-    result.next_action = action.to_owned();
+fn fail(result: &mut ReconcileResult, action: NextAction, summary: &str) {
+    result.next_action = action;
     result.summary = summary.to_owned();
     result.outcome = ExitOutcome::Failure;
     result.exit_code = 1;

--- a/crates/buzz-git-relay/tests/domain.rs
+++ b/crates/buzz-git-relay/tests/domain.rs
@@ -1,6 +1,6 @@
 use buzz_git_relay::{
     ApprovalEventId, CommitOid, Enrollment, EnrollmentId, GithubRepositoryId, ManagedRef,
-    ReconcileRequest, RolloutPhase,
+    ReconcileRequest, RolloutPhase, RunId,
 };
 
 const SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -33,6 +33,19 @@ fn managed_ref_is_an_exact_allowlist() {
     assert_eq!(ManagedRef::main().as_str(), "refs/heads/main");
     assert!(ManagedRef::new("refs/heads/other").is_err());
     assert!(ManagedRef::new("refs/heads/*").is_err());
+}
+
+#[test]
+fn deserialization_preserves_validated_domain_invariants() {
+    assert!(serde_json::from_str::<EnrollmentId>(r#""bad id""#).is_err());
+    assert!(serde_json::from_str::<GithubRepositoryId>(r#""""#).is_err());
+    assert!(serde_json::from_str::<RunId>(r#""run id""#).is_err());
+    assert!(serde_json::from_str::<CommitOid>(r#""abc""#).is_err());
+    assert!(serde_json::from_str::<ApprovalEventId>(r#""not-an-event""#).is_err());
+    assert!(serde_json::from_str::<ManagedRef>(r#""refs/heads/other""#).is_err());
+
+    let managed_ref = serde_json::from_str::<ManagedRef>(r#""refs/heads/main""#).unwrap();
+    assert_eq!(managed_ref, ManagedRef::main());
 }
 
 #[test]

--- a/crates/buzz-git-relay/tests/domain.rs
+++ b/crates/buzz-git-relay/tests/domain.rs
@@ -1,6 +1,6 @@
 use buzz_git_relay::{
     ApprovalEventId, CommitOid, Enrollment, EnrollmentId, GithubRepositoryId, ManagedRef,
-    ReconcileRequest, RolloutPhase, RunId,
+    NextAction, ReconcileRequest, RolloutPhase, RunId,
 };
 
 const SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -72,6 +72,15 @@ fn serialized_enrollment_contains_no_credentials_or_clone_urls() {
     assert!(!json.contains("token"));
     assert!(!json.contains("clone_url"));
     assert!(json.contains("github_repository_id"));
+}
+
+#[test]
+fn next_actions_serialize_as_closed_snake_case_tokens() {
+    assert_eq!(
+        serde_json::to_string(&NextAction::InspectCleanupFailure).unwrap(),
+        r#""inspect_cleanup_failure""#
+    );
+    assert!(serde_json::from_str::<NextAction>(r#""invented_action""#).is_err());
 }
 
 fn enrollment() -> Enrollment {

--- a/crates/buzz-git-relay/tests/domain.rs
+++ b/crates/buzz-git-relay/tests/domain.rs
@@ -1,0 +1,70 @@
+use buzz_git_relay::{
+    ApprovalEventId, CommitOid, Enrollment, EnrollmentId, GithubRepositoryId, ManagedRef,
+    ReconcileRequest, RolloutPhase,
+};
+
+const SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const APPROVAL: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+#[test]
+fn rejects_empty_enrollment_identity() {
+    assert!(EnrollmentId::new(" ").is_err());
+}
+
+#[test]
+fn rejects_empty_repository_identity() {
+    assert!(GithubRepositoryId::new("").is_err());
+}
+
+#[test]
+fn rejects_uppercase_or_short_commit_ids() {
+    assert!(CommitOid::new("A".repeat(40)).is_err());
+    assert!(CommitOid::new("a".repeat(39)).is_err());
+}
+
+#[test]
+fn rejects_malformed_approval_event_ids() {
+    assert!(ApprovalEventId::new("c".repeat(63)).is_err());
+    assert!(ApprovalEventId::new("z".repeat(64)).is_err());
+}
+
+#[test]
+fn managed_ref_is_an_exact_allowlist() {
+    assert_eq!(ManagedRef::main().as_str(), "refs/heads/main");
+    assert!(ManagedRef::new("refs/heads/other").is_err());
+    assert!(ManagedRef::new("refs/heads/*").is_err());
+}
+
+#[test]
+fn enrollment_defaults_to_observe_only_and_requires_approval() {
+    let enrollment = enrollment();
+    assert_eq!(enrollment.rollout_phase, RolloutPhase::ObserveOnly);
+    assert!(!enrollment.apply_enabled);
+    assert!(enrollment.approval_required);
+}
+
+#[test]
+fn apply_request_binds_exact_target_and_approval() {
+    let target = CommitOid::new(SHA).unwrap();
+    let approval = ApprovalEventId::new(APPROVAL).unwrap();
+    let request = ReconcileRequest::apply(target.clone(), approval.clone());
+    assert_eq!(request.expected_target, Some(target));
+    assert_eq!(request.approval_event, Some(approval));
+}
+
+#[test]
+fn serialized_enrollment_contains_no_credentials_or_clone_urls() {
+    let json = serde_json::to_string(&enrollment()).unwrap();
+    assert!(!json.contains("credential"));
+    assert!(!json.contains("token"));
+    assert!(!json.contains("clone_url"));
+    assert!(json.contains("github_repository_id"));
+}
+
+fn enrollment() -> Enrollment {
+    Enrollment::enabled(
+        EnrollmentId::new("example").unwrap(),
+        GithubRepositoryId::new("12345").unwrap(),
+        ManagedRef::main(),
+    )
+}

--- a/crates/buzz-git-relay/tests/real_git.rs
+++ b/crates/buzz-git-relay/tests/real_git.rs
@@ -1,0 +1,417 @@
+use buzz_git_relay::{
+    ports::{EvidenceStore, LockLease, LockManager, RepositoryPort, RepositorySession},
+    ApprovalEventId, Classification, CommitOid, Enrollment, EnrollmentId, GithubRepositoryId,
+    ManagedRef, MutationEvidence, PortError, PortErrorKind, ReconcileRequest, ReconcileResult,
+    Reconciler, ReplayKey, RunId, RunIdGenerator, Tips,
+};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    sync::{Arc, Mutex},
+};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn real_git_fast_forward_preserves_unlisted_branch() {
+    let repositories = Repositories::with_history();
+    let harness = Harness::new(&repositories);
+    let result = harness.apply(&repositories.github_tip).await;
+
+    assert_eq!(result.classification, Classification::InSync);
+    assert_eq!(result.mutation, MutationEvidence::FastForward);
+    assert_eq!(
+        remote_tip(&repositories.buzz, "refs/heads/main"),
+        Some(repositories.github_tip.clone())
+    );
+    assert_eq!(
+        remote_tip(&repositories.buzz, "refs/heads/unlisted"),
+        Some(repositories.unlisted_tip.clone())
+    );
+}
+
+#[tokio::test]
+async fn real_git_push_uses_only_exact_sha_to_exact_refspec() {
+    let repositories = Repositories::with_history();
+    let harness = Harness::new(&repositories);
+    let result = harness.apply(&repositories.github_tip).await;
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(
+        harness.adapter.refspecs.lock().unwrap().as_slice(),
+        &[format!("{}:refs/heads/main", repositories.github_tip)]
+    );
+}
+
+#[tokio::test]
+async fn missing_github_main_never_creates_either_managed_ref() {
+    let repositories = Repositories::without_github_main();
+    let harness = Harness::new(&repositories);
+    let result = harness.observe().await;
+
+    assert_eq!(result.classification, Classification::ConfigError);
+    assert_eq!(remote_tip(&repositories.github, "refs/heads/main"), None);
+    assert_eq!(
+        remote_tip(&repositories.buzz, "refs/heads/main"),
+        Some(repositories.buzz_tip)
+    );
+    assert!(harness.adapter.refspecs.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn missing_buzz_main_never_creates_either_managed_ref() {
+    let repositories = Repositories::without_buzz_main();
+    let harness = Harness::new(&repositories);
+    let result = harness.observe().await;
+
+    assert_eq!(result.classification, Classification::ConfigError);
+    assert_eq!(
+        remote_tip(&repositories.github, "refs/heads/main"),
+        Some(repositories.github_tip)
+    );
+    assert_eq!(remote_tip(&repositories.buzz, "refs/heads/main"), None);
+    assert!(harness.adapter.refspecs.lock().unwrap().is_empty());
+}
+
+struct Harness {
+    enrollment: Enrollment,
+    reconciler: Reconciler,
+    adapter: Arc<LocalGitPort>,
+}
+
+impl Harness {
+    fn new(repositories: &Repositories) -> Self {
+        let adapter = Arc::new(LocalGitPort {
+            github: repositories.github.clone(),
+            buzz: repositories.buzz.clone(),
+            refspecs: Arc::new(Mutex::new(Vec::new())),
+        });
+        Self {
+            enrollment: Enrollment::enabled(
+                EnrollmentId::new("disposable").unwrap(),
+                GithubRepositoryId::new("98765").unwrap(),
+                ManagedRef::main(),
+            )
+            .with_owner_approved_apply(),
+            reconciler: Reconciler::new(
+                adapter.clone(),
+                Arc::new(OpenLock),
+                Arc::new(NoopEvidence),
+                Arc::new(FixedRunId),
+            ),
+            adapter,
+        }
+    }
+
+    async fn observe(&self) -> ReconcileResult {
+        self.reconciler
+            .reconcile(&self.enrollment, ReconcileRequest::observe())
+            .await
+    }
+
+    async fn apply(&self, target: &str) -> ReconcileResult {
+        self.reconciler
+            .reconcile(
+                &self.enrollment,
+                ReconcileRequest::apply(
+                    CommitOid::new(target).unwrap(),
+                    ApprovalEventId::new("c".repeat(64)).unwrap(),
+                ),
+            )
+            .await
+    }
+}
+
+struct Repositories {
+    _root: TempDir,
+    github: PathBuf,
+    buzz: PathBuf,
+    github_tip: String,
+    buzz_tip: String,
+    unlisted_tip: String,
+}
+
+impl Repositories {
+    fn with_history() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let work = root.path().join("work");
+        let github = root.path().join("github.git");
+        let buzz = root.path().join("buzz.git");
+        init_work(&work);
+        init_bare(&github);
+        init_bare(&buzz);
+
+        write_file(&work, "history.txt", "a\n");
+        git(&work, &["add", "history.txt"]);
+        git(&work, &["commit", "-m", "A"]);
+        let a = git_output(&work, &["rev-parse", "HEAD"]);
+        git(
+            &work,
+            &[
+                "push",
+                github.to_str().unwrap(),
+                &format!("{a}:refs/heads/main"),
+            ],
+        );
+        git(
+            &work,
+            &[
+                "push",
+                buzz.to_str().unwrap(),
+                &format!("{a}:refs/heads/main"),
+            ],
+        );
+        git(
+            &work,
+            &[
+                "push",
+                buzz.to_str().unwrap(),
+                &format!("{a}:refs/heads/unlisted"),
+            ],
+        );
+
+        write_file(&work, "history.txt", "a\nb\n");
+        git(&work, &["add", "history.txt"]);
+        git(&work, &["commit", "-m", "B"]);
+        let b = git_output(&work, &["rev-parse", "HEAD"]);
+        git(
+            &work,
+            &[
+                "push",
+                github.to_str().unwrap(),
+                &format!("{b}:refs/heads/main"),
+            ],
+        );
+
+        Self {
+            _root: root,
+            github,
+            buzz,
+            github_tip: b,
+            buzz_tip: a.clone(),
+            unlisted_tip: a,
+        }
+    }
+
+    fn without_github_main() -> Self {
+        let mut repositories = Self::with_history();
+        git(
+            &repositories.github,
+            &["update-ref", "-d", "refs/heads/main"],
+        );
+        repositories.github_tip.clear();
+        repositories
+    }
+
+    fn without_buzz_main() -> Self {
+        let mut repositories = Self::with_history();
+        git(&repositories.buzz, &["update-ref", "-d", "refs/heads/main"]);
+        repositories.buzz_tip.clear();
+        repositories
+    }
+}
+
+struct LocalGitPort {
+    github: PathBuf,
+    buzz: PathBuf,
+    refspecs: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl RepositoryPort for LocalGitPort {
+    async fn open(&self, enrollment: &Enrollment) -> Result<Box<dyn RepositorySession>, PortError> {
+        let root = tempfile::tempdir().map_err(|_| PortError::new(PortErrorKind::Unexpected))?;
+        let local = root.path().join("session.git");
+        if !git_ok(root.path(), &["init", "--bare", local.to_str().unwrap()]) {
+            return Err(PortError::new(PortErrorKind::Unexpected));
+        }
+        let mut session = LocalGitSession {
+            _root: root,
+            local,
+            github: self.github.clone(),
+            buzz: self.buzz.clone(),
+            managed_ref: enrollment.managed_ref.clone(),
+            refspecs: self.refspecs.clone(),
+        };
+        session.refresh_both_sync()?;
+        Ok(Box::new(session))
+    }
+}
+
+struct LocalGitSession {
+    _root: TempDir,
+    local: PathBuf,
+    github: PathBuf,
+    buzz: PathBuf,
+    managed_ref: ManagedRef,
+    refspecs: Arc<Mutex<Vec<String>>>,
+}
+
+impl LocalGitSession {
+    fn fetch(&self, remote: &Path, destination: &str) -> Result<CommitOid, PortError> {
+        let refspec = format!("+{}:{destination}", self.managed_ref.as_str());
+        if !git_ok(
+            &self.local,
+            &["fetch", "--no-tags", remote.to_str().unwrap(), &refspec],
+        ) {
+            return Err(PortError::new(PortErrorKind::Config));
+        }
+        CommitOid::new(git_output(&self.local, &["rev-parse", destination]))
+            .map_err(|_| PortError::new(PortErrorKind::Verify))
+    }
+
+    fn refresh_both_sync(&mut self) -> Result<Tips, PortError> {
+        Ok(Tips {
+            github: self.fetch(&self.github, "refs/git-relay/github")?,
+            buzz: self.fetch(&self.buzz, "refs/git-relay/buzz")?,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl RepositorySession for LocalGitSession {
+    async fn tips(&mut self) -> Result<Tips, PortError> {
+        self.refresh_both_sync()
+    }
+
+    async fn is_ancestor(
+        &mut self,
+        ancestor: &CommitOid,
+        descendant: &CommitOid,
+    ) -> Result<bool, PortError> {
+        let status = Command::new("git")
+            .args([
+                "merge-base",
+                "--is-ancestor",
+                ancestor.as_str(),
+                descendant.as_str(),
+            ])
+            .current_dir(&self.local)
+            .status()
+            .map_err(|_| PortError::new(PortErrorKind::Unexpected))?;
+        match status.code() {
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
+            _ => Err(PortError::new(PortErrorKind::Verify)),
+        }
+    }
+
+    async fn refresh_buzz(&mut self) -> Result<CommitOid, PortError> {
+        self.fetch(&self.buzz, "refs/git-relay/buzz")
+    }
+
+    async fn refresh_both(&mut self) -> Result<Tips, PortError> {
+        self.refresh_both_sync()
+    }
+
+    async fn push_exact(
+        &mut self,
+        target: &CommitOid,
+        managed_ref: &ManagedRef,
+    ) -> Result<(), PortError> {
+        let refspec = format!("{}:{}", target.as_str(), managed_ref.as_str());
+        self.refspecs.lock().unwrap().push(refspec.clone());
+        if git_ok(
+            &self.local,
+            &["push", self.buzz.to_str().unwrap(), &refspec],
+        ) {
+            Ok(())
+        } else {
+            Err(PortError::new(PortErrorKind::Verify))
+        }
+    }
+
+    async fn close(self: Box<Self>) -> Result<(), PortError> {
+        Ok(())
+    }
+}
+
+struct OpenLock;
+struct OpenLease;
+
+#[async_trait::async_trait]
+impl LockManager for OpenLock {
+    async fn acquire(&self, _key: &str) -> Result<Box<dyn LockLease>, PortError> {
+        Ok(Box::new(OpenLease))
+    }
+}
+
+#[async_trait::async_trait]
+impl LockLease for OpenLease {
+    async fn release(self: Box<Self>) -> Result<(), PortError> {
+        Ok(())
+    }
+}
+
+struct NoopEvidence;
+
+#[async_trait::async_trait]
+impl EvidenceStore for NoopEvidence {
+    async fn find_verified(&self, _key: &ReplayKey) -> Result<Option<ReconcileResult>, PortError> {
+        Ok(None)
+    }
+
+    async fn append(&self, _result: &ReconcileResult) -> Result<(), PortError> {
+        Ok(())
+    }
+}
+
+struct FixedRunId;
+
+impl RunIdGenerator for FixedRunId {
+    fn next(&self) -> RunId {
+        RunId::new("real-git-run").unwrap()
+    }
+}
+
+fn init_work(path: &Path) {
+    git(path.parent().unwrap(), &["init", path.to_str().unwrap()]);
+    git(path, &["config", "user.name", "Git Relay Test"]);
+    git(path, &["config", "user.email", "git-relay@example.invalid"]);
+}
+
+fn init_bare(path: &Path) {
+    git(
+        path.parent().unwrap(),
+        &["init", "--bare", path.to_str().unwrap()],
+    );
+}
+
+fn write_file(repo: &Path, name: &str, content: &str) {
+    std::fs::write(repo.join(name), content).unwrap();
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    assert!(git_ok(cwd, args), "git command failed: {args:?}");
+}
+
+fn git_ok(cwd: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .status()
+        .unwrap()
+        .success()
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "git command failed: {args:?}");
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
+}
+
+fn remote_tip(repo: &Path, managed_ref: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", managed_ref])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8(output.stdout).unwrap().trim().to_owned())
+}

--- a/crates/buzz-git-relay/tests/reconcile.rs
+++ b/crates/buzz-git-relay/tests/reconcile.rs
@@ -235,6 +235,23 @@ async fn github_change_before_push_freezes_old_approval() {
 }
 
 #[tokio::test]
+async fn buzz_change_during_final_pre_push_check_freezes_without_push() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_both(vec![Ok(tips(SHA_B, SHA_D))])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(result.buzz_after, Some(oid(SHA_D)));
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
 async fn rejected_push_with_unchanged_buzz_records_no_mutation() {
     let fixture = Fixture::new(SHA_B, SHA_A)
         .ancestor(SHA_A, SHA_B)

--- a/crates/buzz-git-relay/tests/reconcile.rs
+++ b/crates/buzz-git-relay/tests/reconcile.rs
@@ -1,8 +1,8 @@
 use buzz_git_relay::{
     ports::{EvidenceStore, LockLease, LockManager, RepositoryPort, RepositorySession},
     ApprovalEventId, Classification, CommitOid, Enrollment, EnrollmentId, GithubRepositoryId,
-    ManagedRef, MutationEvidence, PortError, PortErrorKind, ReconcileRequest, ReconcileResult,
-    Reconciler, ReplayKey, RunId, RunIdGenerator, Tips,
+    ManagedRef, MutationEvidence, NextAction, PortError, PortErrorKind, ReconcileRequest,
+    ReconcileResult, Reconciler, ReplayKey, RunId, RunIdGenerator, Tips,
 };
 use std::{
     collections::{HashSet, VecDeque},
@@ -33,7 +33,7 @@ async fn observe_reports_relay_behind_without_mutation() {
         MutationEvidence::None,
         1,
     );
-    assert_eq!(result.next_action, "approve_exact_fast_forward");
+    assert_eq!(result.next_action, NextAction::ApproveExactFastForward);
     assert!(fixture.state().pushes.is_empty());
 }
 
@@ -155,6 +155,7 @@ async fn apply_target_must_equal_fresh_github_tip() {
         MutationEvidence::None,
         1,
     );
+    assert_eq!(result.github_target, Some(oid(SHA_A)));
     assert!(fixture.state().pushes.is_empty());
 }
 
@@ -231,7 +232,7 @@ async fn github_change_before_push_freezes_old_approval() {
         MutationEvidence::None,
         1,
     );
-    assert_eq!(result.github_target, Some(oid(SHA_D)));
+    assert_eq!(result.github_target, Some(oid(SHA_B)));
 }
 
 #[tokio::test]
@@ -466,12 +467,12 @@ async fn session_close_failure_cannot_mask_machine_result() {
         MutationEvidence::None,
         1,
     );
-    assert_eq!(result.next_action, "inspect_cleanup_failure");
+    assert_eq!(result.next_action, NextAction::InspectCleanupFailure);
     assert_secret_free(&result);
 }
 
 #[tokio::test]
-async fn close_failure_after_push_preserves_unknown_mutation() {
+async fn close_failure_after_verified_push_preserves_fast_forward_evidence() {
     let fixture = Fixture::new(SHA_B, SHA_A)
         .ancestor(SHA_A, SHA_B)
         .close_error()
@@ -480,10 +481,10 @@ async fn close_failure_after_push_preserves_unknown_mutation() {
     assert_result(
         &result,
         Classification::VerifyError,
-        MutationEvidence::Unknown,
+        MutationEvidence::FastForward,
         1,
     );
-    assert_eq!(result.buzz_after, None);
+    assert_eq!(result.buzz_after, Some(oid(SHA_B)));
 }
 
 #[tokio::test]
@@ -500,6 +501,22 @@ async fn release_failure_cannot_mask_machine_result() {
 }
 
 #[tokio::test]
+async fn release_failure_after_verified_push_preserves_fast_forward_evidence() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .release_error()
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::FastForward,
+        1,
+    );
+    assert_eq!(result.buzz_after, Some(oid(SHA_B)));
+}
+
+#[tokio::test]
 async fn audit_failure_returns_stable_secret_free_result() {
     let fixture = Fixture::new(SHA_A, SHA_A).append_error();
     let result = fixture.observe().await;
@@ -509,12 +526,12 @@ async fn audit_failure_returns_stable_secret_free_result() {
         MutationEvidence::None,
         1,
     );
-    assert_eq!(result.next_action, "repair_audit_store");
+    assert_eq!(result.next_action, NextAction::RepairAuditStore);
     assert_secret_free(&result);
 }
 
 #[tokio::test]
-async fn audit_failure_after_push_preserves_unknown_mutation() {
+async fn audit_failure_after_verified_push_preserves_fast_forward_evidence() {
     let fixture = Fixture::new(SHA_B, SHA_A)
         .ancestor(SHA_A, SHA_B)
         .append_error()
@@ -523,10 +540,10 @@ async fn audit_failure_after_push_preserves_unknown_mutation() {
     assert_result(
         &result,
         Classification::VerifyError,
-        MutationEvidence::Unknown,
+        MutationEvidence::FastForward,
         1,
     );
-    assert_eq!(result.buzz_after, None);
+    assert_eq!(result.buzz_after, Some(oid(SHA_B)));
 }
 
 #[tokio::test]

--- a/crates/buzz-git-relay/tests/reconcile.rs
+++ b/crates/buzz-git-relay/tests/reconcile.rs
@@ -1,0 +1,988 @@
+use buzz_git_relay::{
+    ports::{EvidenceStore, LockLease, LockManager, RepositoryPort, RepositorySession},
+    ApprovalEventId, Classification, CommitOid, Enrollment, EnrollmentId, GithubRepositoryId,
+    ManagedRef, MutationEvidence, PortError, PortErrorKind, ReconcileRequest, ReconcileResult,
+    Reconciler, ReplayKey, RunId, RunIdGenerator, Tips,
+};
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::{Arc, Mutex},
+};
+
+const SHA_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SHA_D: &str = "dddddddddddddddddddddddddddddddddddddddd";
+const APPROVAL: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const OTHER_APPROVAL: &str = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+#[tokio::test]
+async fn equal_tips_are_in_sync_without_mutation() {
+    let fixture = Fixture::new(SHA_A, SHA_A);
+    let result = fixture.observe().await;
+    assert_result(&result, Classification::InSync, MutationEvidence::None, 0);
+    assert_eq!(fixture.state().pushes.len(), 0);
+}
+
+#[tokio::test]
+async fn observe_reports_relay_behind_without_mutation() {
+    let fixture = Fixture::new(SHA_B, SHA_A).ancestor(SHA_A, SHA_B);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::RelayBehind,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(result.next_action, "approve_exact_fast_forward");
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn approved_apply_fast_forwards_exact_ref_and_verifies() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::InSync,
+        MutationEvidence::FastForward,
+        0,
+    );
+    assert_eq!(
+        fixture.state().pushes,
+        vec![(SHA_B.to_owned(), "refs/heads/main".to_owned())]
+    );
+}
+
+#[tokio::test]
+async fn github_behind_freezes_without_mutation() {
+    let fixture = Fixture::new(SHA_A, SHA_B).ancestor(SHA_A, SHA_B);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::GithubBehind,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn diverged_histories_freeze_without_mutation() {
+    let fixture = Fixture::new(SHA_A, SHA_B);
+    let result = fixture.observe().await;
+    assert_result(&result, Classification::Diverged, MutationEvidence::None, 1);
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn invalid_enrollment_policy_returns_config_error() {
+    let mut fixture = Fixture::new(SHA_A, SHA_A);
+    fixture.enrollment.approval_required = false;
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(fixture.state().open_calls, 0);
+}
+
+#[tokio::test]
+async fn disabled_enrollment_is_unmanaged_and_never_opens_repository() {
+    let mut fixture = Fixture::new(SHA_A, SHA_A);
+    fixture.enrollment = fixture.enrollment.clone().disabled();
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::Unmanaged,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(fixture.state().open_calls, 0);
+}
+
+#[tokio::test]
+async fn authentication_failure_freezes_without_retry() {
+    let fixture = Fixture::new(SHA_A, SHA_A).open_error(PortErrorKind::Auth);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::AuthError,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(!result.retryable);
+}
+
+#[tokio::test]
+async fn temporary_remote_failure_is_retryable_without_mutation() {
+    let fixture = Fixture::new(SHA_A, SHA_A).open_error(PortErrorKind::Transient);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::TransientError,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(result.retryable);
+}
+
+#[tokio::test]
+async fn unexpected_adapter_failure_is_stable_and_secret_free() {
+    let fixture = Fixture::new(SHA_A, SHA_A).open_error(PortErrorKind::Unexpected);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_secret_free(&result);
+}
+
+#[tokio::test]
+async fn apply_target_must_equal_fresh_github_tip() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .apply_enabled();
+    let result = fixture.apply(SHA_A, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn apply_requires_an_approval_event() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .apply_enabled();
+    let mut request = ReconcileRequest::observe();
+    request.mode = buzz_git_relay::ReconcileMode::Apply;
+    request.expected_target = Some(oid(SHA_B));
+    let result = fixture
+        .reconciler
+        .reconcile(&fixture.enrollment, request)
+        .await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+}
+
+#[tokio::test]
+async fn already_equal_apply_still_requires_exact_approval() {
+    let fixture = Fixture::new(SHA_A, SHA_A).apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+}
+
+#[tokio::test]
+async fn concurrent_relay_only_change_is_reclassified_without_push() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .ancestor(SHA_B, SHA_D)
+        .refresh_buzz(SHA_D)
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::GithubBehind,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn concurrent_divergent_change_is_reclassified_without_push() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_buzz(SHA_D)
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(&result, Classification::Diverged, MutationEvidence::None, 1);
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn github_change_before_push_freezes_old_approval() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_both(vec![Ok(tips(SHA_D, SHA_A))])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(result.github_target, Some(oid(SHA_D)));
+}
+
+#[tokio::test]
+async fn rejected_push_with_unchanged_buzz_records_no_mutation() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .push_error(PortErrorKind::Config, false)
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(result.push_attempted, Some(true));
+}
+
+#[tokio::test]
+async fn ambiguous_push_is_resolved_by_exact_reread() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .push_error(PortErrorKind::Transient, true)
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::InSync,
+        MutationEvidence::FastForward,
+        0,
+    );
+}
+
+#[tokio::test]
+async fn attempted_push_with_unreadable_outcome_is_unknown() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .push_error(PortErrorKind::Transient, false)
+        .refresh_both(vec![
+            Ok(tips(SHA_B, SHA_A)),
+            Err(port(PortErrorKind::Transient)),
+        ])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::Unknown,
+        1,
+    );
+    assert_eq!(result.buzz_after, None);
+    assert!(result.retryable);
+}
+
+#[tokio::test]
+async fn successful_push_with_failed_reread_is_unknown() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_both(vec![
+            Ok(tips(SHA_B, SHA_A)),
+            Err(port(PortErrorKind::Verify)),
+        ])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::Unknown,
+        1,
+    );
+    assert_eq!(result.buzz_after, None);
+}
+
+#[tokio::test]
+async fn unexpected_failure_after_push_is_unknown_and_secret_free() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .push_error(PortErrorKind::Unexpected, false)
+        .refresh_both(vec![
+            Ok(tips(SHA_B, SHA_A)),
+            Err(port(PortErrorKind::Unexpected)),
+        ])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::Unknown,
+        1,
+    );
+    assert_secret_free(&result);
+}
+
+#[tokio::test]
+async fn successful_push_with_unequal_refs_is_verify_error() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_both(vec![Ok(tips(SHA_B, SHA_A)), Ok(tips(SHA_B, SHA_D))])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::Unknown,
+        1,
+    );
+}
+
+#[tokio::test]
+async fn github_advance_after_delivery_records_confirmed_fast_forward() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_both(vec![Ok(tips(SHA_B, SHA_A)), Ok(tips(SHA_D, SHA_B))])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::FastForward,
+        1,
+    );
+}
+
+#[tokio::test]
+async fn github_advance_with_unchanged_buzz_does_not_claim_delivery() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_both(vec![Ok(tips(SHA_B, SHA_A)), Ok(tips(SHA_D, SHA_A))])
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+}
+
+#[tokio::test]
+async fn duplicate_verified_apply_returns_prior_without_duplicate_evidence() {
+    let fixture = Fixture::new(SHA_A, SHA_A).apply_enabled();
+    let first = fixture.apply(SHA_A, APPROVAL).await;
+    let second = fixture.apply(SHA_A, APPROVAL).await;
+    assert_eq!(second.run_id, first.run_id);
+    assert_eq!(fixture.evidence.records().len(), 1);
+}
+
+#[tokio::test]
+async fn cleanup_failure_during_replay_describes_current_no_push_invocation() {
+    let fixture = Fixture::new(SHA_A, SHA_A).apply_enabled();
+    let first = fixture.apply(SHA_A, APPROVAL).await;
+    fixture.locks.state.lock().unwrap().release_error = true;
+
+    let replay_cleanup = fixture.apply(SHA_A, APPROVAL).await;
+
+    assert_ne!(replay_cleanup.run_id, first.run_id);
+    assert_result(
+        &replay_cleanup,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(replay_cleanup.push_attempted, Some(false));
+}
+
+#[tokio::test]
+async fn observe_record_cannot_satisfy_later_apply() {
+    let fixture = Fixture::new(SHA_A, SHA_A).apply_enabled();
+    let observed = fixture.observe().await;
+    let applied = fixture.apply(SHA_A, APPROVAL).await;
+    assert_ne!(applied.run_id, observed.run_id);
+    assert_eq!(fixture.evidence.records().len(), 2);
+}
+
+#[tokio::test]
+async fn new_approval_gets_a_new_apply_record() {
+    let fixture = Fixture::new(SHA_A, SHA_A).apply_enabled();
+    let first = fixture.apply(SHA_A, APPROVAL).await;
+    let second = fixture.apply(SHA_A, OTHER_APPROVAL).await;
+    assert_ne!(first.run_id, second.run_id);
+    assert_eq!(fixture.evidence.records().len(), 2);
+}
+
+#[tokio::test]
+async fn repointed_repository_identity_cannot_reuse_old_evidence() {
+    let mut fixture = Fixture::new(SHA_A, SHA_A).apply_enabled();
+    let first = fixture.apply(SHA_A, APPROVAL).await;
+    fixture.enrollment.github_repository_id = GithubRepositoryId::new("67890").unwrap();
+    let second = fixture.apply(SHA_A, APPROVAL).await;
+    assert_ne!(first.run_id, second.run_id);
+    assert_eq!(fixture.evidence.records().len(), 2);
+}
+
+#[tokio::test]
+async fn busy_lock_is_retryable_and_does_not_open_repository() {
+    let fixture = Fixture::new(SHA_A, SHA_A).lock_error(PortErrorKind::Transient);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::TransientError,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(result.retryable);
+    assert_eq!(fixture.state().open_calls, 0);
+}
+
+#[tokio::test]
+async fn session_close_failure_cannot_mask_machine_result() {
+    let fixture = Fixture::new(SHA_A, SHA_A).close_error();
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(result.next_action, "inspect_cleanup_failure");
+    assert_secret_free(&result);
+}
+
+#[tokio::test]
+async fn close_failure_after_push_preserves_unknown_mutation() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .close_error()
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::Unknown,
+        1,
+    );
+    assert_eq!(result.buzz_after, None);
+}
+
+#[tokio::test]
+async fn release_failure_cannot_mask_machine_result() {
+    let fixture = Fixture::new(SHA_A, SHA_A).release_error();
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_secret_free(&result);
+}
+
+#[tokio::test]
+async fn audit_failure_returns_stable_secret_free_result() {
+    let fixture = Fixture::new(SHA_A, SHA_A).append_error();
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(result.next_action, "repair_audit_store");
+    assert_secret_free(&result);
+}
+
+#[tokio::test]
+async fn audit_failure_after_push_preserves_unknown_mutation() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .append_error()
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::Unknown,
+        1,
+    );
+    assert_eq!(result.buzz_after, None);
+}
+
+#[tokio::test]
+async fn missing_github_main_fails_closed_as_configuration_error() {
+    let fixture = Fixture::new(SHA_A, SHA_A).tips_error(PortErrorKind::Config);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn missing_buzz_main_fails_closed_as_configuration_error() {
+    let fixture = Fixture::new(SHA_A, SHA_A).tips_error(PortErrorKind::Config);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::ConfigError,
+        MutationEvidence::None,
+        1,
+    );
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn evidence_lookup_failure_emits_stable_machine_result() {
+    let fixture = Fixture::new(SHA_A, SHA_A)
+        .apply_enabled()
+        .find_error(PortErrorKind::Unexpected);
+    let result = fixture.apply(SHA_A, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_secret_free(&result);
+}
+
+#[tokio::test]
+async fn unexpected_ancestry_failure_emits_stable_machine_result() {
+    let fixture = Fixture::new(SHA_B, SHA_A).ancestor_error(PortErrorKind::Unexpected);
+    let result = fixture.observe().await;
+    assert_result(
+        &result,
+        Classification::VerifyError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_secret_free(&result);
+}
+
+#[tokio::test]
+async fn pre_push_refresh_failure_never_attempts_a_push() {
+    let fixture = Fixture::new(SHA_B, SHA_A)
+        .ancestor(SHA_A, SHA_B)
+        .refresh_buzz_error(PortErrorKind::Transient)
+        .apply_enabled();
+    let result = fixture.apply(SHA_B, APPROVAL).await;
+    assert_result(
+        &result,
+        Classification::TransientError,
+        MutationEvidence::None,
+        1,
+    );
+    assert_eq!(result.push_attempted, Some(false));
+    assert!(fixture.state().pushes.is_empty());
+}
+
+#[tokio::test]
+async fn one_repository_failure_does_not_poison_a_later_invocation() {
+    let failing = Fixture::new(SHA_A, SHA_A).open_error(PortErrorKind::Auth);
+    let healthy = Fixture::new(SHA_A, SHA_A);
+    let failed = failing.observe().await;
+    let succeeded = healthy.observe().await;
+    assert_eq!(failed.classification, Classification::AuthError);
+    assert_eq!(succeeded.classification, Classification::InSync);
+}
+
+fn assert_result(
+    result: &ReconcileResult,
+    classification: Classification,
+    mutation: MutationEvidence,
+    exit_code: u8,
+) {
+    assert_eq!(result.classification, classification);
+    assert_eq!(result.mutation, mutation);
+    assert_eq!(result.exit_code, exit_code);
+}
+
+fn assert_secret_free(result: &ReconcileResult) {
+    let json = serde_json::to_string(result).unwrap();
+    assert!(!json.contains("secret"));
+    assert!(!json.contains("credential"));
+}
+
+fn oid(value: &str) -> CommitOid {
+    CommitOid::new(value).unwrap()
+}
+
+fn tips(github: &str, buzz: &str) -> Tips {
+    Tips {
+        github: oid(github),
+        buzz: oid(buzz),
+    }
+}
+
+fn port(kind: PortErrorKind) -> PortError {
+    PortError::new(kind)
+}
+
+struct Fixture {
+    enrollment: Enrollment,
+    reconciler: Reconciler,
+    repository: Arc<FakeRepository>,
+    evidence: Arc<MemoryEvidence>,
+    locks: Arc<FakeLocks>,
+}
+
+impl Fixture {
+    fn new(github: &str, buzz: &str) -> Self {
+        let repository = Arc::new(FakeRepository::new(github, buzz));
+        let evidence = Arc::new(MemoryEvidence::default());
+        let locks = Arc::new(FakeLocks::default());
+        let reconciler = Reconciler::new(
+            repository.clone(),
+            locks.clone(),
+            evidence.clone(),
+            Arc::new(SequentialRunIds::default()),
+        );
+        Self {
+            enrollment: Enrollment::enabled(
+                EnrollmentId::new("buzz-workspace").unwrap(),
+                GithubRepositoryId::new("12345").unwrap(),
+                ManagedRef::main(),
+            ),
+            reconciler,
+            repository,
+            evidence,
+            locks,
+        }
+    }
+
+    fn state(&self) -> FakeState {
+        self.repository.state.lock().unwrap().clone()
+    }
+
+    fn ancestor(self, ancestor: &str, descendant: &str) -> Self {
+        self.repository
+            .state
+            .lock()
+            .unwrap()
+            .ancestors
+            .insert((oid(ancestor), oid(descendant)));
+        self
+    }
+
+    fn apply_enabled(mut self) -> Self {
+        self.enrollment = self.enrollment.clone().with_owner_approved_apply();
+        self
+    }
+
+    fn open_error(self, kind: PortErrorKind) -> Self {
+        self.repository.state.lock().unwrap().open_error = Some(port(kind));
+        self
+    }
+
+    fn tips_error(self, kind: PortErrorKind) -> Self {
+        self.repository.state.lock().unwrap().tips_error = Some(port(kind));
+        self
+    }
+
+    fn ancestor_error(self, kind: PortErrorKind) -> Self {
+        self.repository.state.lock().unwrap().ancestor_error = Some(port(kind));
+        self
+    }
+
+    fn refresh_buzz(self, value: &str) -> Self {
+        self.repository.state.lock().unwrap().refresh_buzz = Some(Ok(oid(value)));
+        self
+    }
+
+    fn refresh_buzz_error(self, kind: PortErrorKind) -> Self {
+        self.repository.state.lock().unwrap().refresh_buzz = Some(Err(port(kind)));
+        self
+    }
+
+    fn refresh_both(self, values: Vec<Result<Tips, PortError>>) -> Self {
+        self.repository.state.lock().unwrap().refresh_both = values.into();
+        self
+    }
+
+    fn push_error(self, kind: PortErrorKind, apply_target_before_error: bool) -> Self {
+        let mut state = self.repository.state.lock().unwrap();
+        state.push_error = Some(port(kind));
+        state.apply_target_before_push_error = apply_target_before_error;
+        drop(state);
+        self
+    }
+
+    fn close_error(self) -> Self {
+        self.repository.state.lock().unwrap().close_error = true;
+        self
+    }
+
+    fn lock_error(self, kind: PortErrorKind) -> Self {
+        self.locks.state.lock().unwrap().acquire_error = Some(port(kind));
+        self
+    }
+
+    fn release_error(self) -> Self {
+        self.locks.state.lock().unwrap().release_error = true;
+        self
+    }
+
+    fn append_error(self) -> Self {
+        self.evidence.state.lock().unwrap().append_error = true;
+        self
+    }
+
+    fn find_error(self, kind: PortErrorKind) -> Self {
+        self.evidence.state.lock().unwrap().find_error = Some(port(kind));
+        self
+    }
+
+    async fn observe(&self) -> ReconcileResult {
+        self.reconciler
+            .reconcile(&self.enrollment, ReconcileRequest::observe())
+            .await
+    }
+
+    async fn apply(&self, target: &str, approval: &str) -> ReconcileResult {
+        self.reconciler
+            .reconcile(
+                &self.enrollment,
+                ReconcileRequest::apply(oid(target), ApprovalEventId::new(approval).unwrap()),
+            )
+            .await
+    }
+}
+
+#[derive(Clone)]
+struct FakeState {
+    tips: Tips,
+    ancestors: HashSet<(CommitOid, CommitOid)>,
+    refresh_buzz: Option<Result<CommitOid, PortError>>,
+    refresh_both: VecDeque<Result<Tips, PortError>>,
+    open_error: Option<PortError>,
+    tips_error: Option<PortError>,
+    ancestor_error: Option<PortError>,
+    push_error: Option<PortError>,
+    apply_target_before_push_error: bool,
+    close_error: bool,
+    pushes: Vec<(String, String)>,
+    open_calls: usize,
+}
+
+struct FakeRepository {
+    state: Arc<Mutex<FakeState>>,
+}
+
+impl FakeRepository {
+    fn new(github: &str, buzz: &str) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FakeState {
+                tips: tips(github, buzz),
+                ancestors: HashSet::new(),
+                refresh_buzz: None,
+                refresh_both: VecDeque::new(),
+                open_error: None,
+                tips_error: None,
+                ancestor_error: None,
+                push_error: None,
+                apply_target_before_push_error: false,
+                close_error: false,
+                pushes: Vec::new(),
+                open_calls: 0,
+            })),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RepositoryPort for FakeRepository {
+    async fn open(
+        &self,
+        _enrollment: &Enrollment,
+    ) -> Result<Box<dyn RepositorySession>, PortError> {
+        let mut state = self.state.lock().unwrap();
+        state.open_calls += 1;
+        if let Some(error) = state.open_error.clone() {
+            return Err(error);
+        }
+        Ok(Box::new(FakeSession {
+            state: self.state.clone(),
+        }))
+    }
+}
+
+struct FakeSession {
+    state: Arc<Mutex<FakeState>>,
+}
+
+#[async_trait::async_trait]
+impl RepositorySession for FakeSession {
+    async fn tips(&mut self) -> Result<Tips, PortError> {
+        let state = self.state.lock().unwrap();
+        if let Some(error) = state.tips_error.clone() {
+            return Err(error);
+        }
+        Ok(state.tips.clone())
+    }
+
+    async fn is_ancestor(
+        &mut self,
+        ancestor: &CommitOid,
+        descendant: &CommitOid,
+    ) -> Result<bool, PortError> {
+        let state = self.state.lock().unwrap();
+        if let Some(error) = state.ancestor_error.clone() {
+            return Err(error);
+        }
+        Ok(state
+            .ancestors
+            .contains(&(ancestor.clone(), descendant.clone())))
+    }
+
+    async fn refresh_buzz(&mut self) -> Result<CommitOid, PortError> {
+        let state = self.state.lock().unwrap();
+        state
+            .refresh_buzz
+            .clone()
+            .unwrap_or_else(|| Ok(state.tips.buzz.clone()))
+    }
+
+    async fn refresh_both(&mut self) -> Result<Tips, PortError> {
+        let mut state = self.state.lock().unwrap();
+        state
+            .refresh_both
+            .pop_front()
+            .unwrap_or_else(|| Ok(state.tips.clone()))
+    }
+
+    async fn push_exact(
+        &mut self,
+        target: &CommitOid,
+        managed_ref: &ManagedRef,
+    ) -> Result<(), PortError> {
+        let mut state = self.state.lock().unwrap();
+        state
+            .pushes
+            .push((target.as_str().to_owned(), managed_ref.as_str().to_owned()));
+        if state.push_error.is_none() || state.apply_target_before_push_error {
+            state.tips.buzz = target.clone();
+        }
+        match state.push_error.clone() {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    async fn close(self: Box<Self>) -> Result<(), PortError> {
+        if self.state.lock().unwrap().close_error {
+            Err(port(PortErrorKind::Unexpected))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Default)]
+struct EvidenceState {
+    records: Vec<ReconcileResult>,
+    find_error: Option<PortError>,
+    append_error: bool,
+}
+
+#[derive(Default)]
+struct MemoryEvidence {
+    state: Mutex<EvidenceState>,
+}
+
+impl MemoryEvidence {
+    fn records(&self) -> Vec<ReconcileResult> {
+        self.state.lock().unwrap().records.clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl EvidenceStore for MemoryEvidence {
+    async fn find_verified(&self, key: &ReplayKey) -> Result<Option<ReconcileResult>, PortError> {
+        let state = self.state.lock().unwrap();
+        if let Some(error) = state.find_error.clone() {
+            return Err(error);
+        }
+        Ok(state
+            .records
+            .iter()
+            .find(|record| {
+                record.enrollment_id == key.enrollment_id
+                    && record.github_repository_id == key.github_repository_id
+                    && record.managed_ref == key.managed_ref
+                    && record.github_target.as_ref() == Some(&key.target)
+                    && record.buzz_after.as_ref() == Some(&key.target)
+                    && record.approval_event.as_ref() == Some(&key.approval_event)
+                    && record.classification == Classification::InSync
+                    && record.mode == buzz_git_relay::ReconcileMode::Apply
+                    && record.exit_code == 0
+            })
+            .cloned())
+    }
+
+    async fn append(&self, result: &ReconcileResult) -> Result<(), PortError> {
+        let mut state = self.state.lock().unwrap();
+        if state.append_error {
+            return Err(port(PortErrorKind::Unexpected));
+        }
+        state.records.push(result.clone());
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct LockState {
+    acquire_error: Option<PortError>,
+    release_error: bool,
+}
+
+#[derive(Default)]
+struct FakeLocks {
+    state: Arc<Mutex<LockState>>,
+}
+
+#[async_trait::async_trait]
+impl LockManager for FakeLocks {
+    async fn acquire(&self, _key: &str) -> Result<Box<dyn LockLease>, PortError> {
+        if let Some(error) = self.state.lock().unwrap().acquire_error.clone() {
+            return Err(error);
+        }
+        Ok(Box::new(FakeLease {
+            state: self.state.clone(),
+        }))
+    }
+}
+
+struct FakeLease {
+    state: Arc<Mutex<LockState>>,
+}
+
+#[async_trait::async_trait]
+impl LockLease for FakeLease {
+    async fn release(self: Box<Self>) -> Result<(), PortError> {
+        if self.state.lock().unwrap().release_error {
+            Err(port(PortErrorKind::Unexpected))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Default)]
+struct SequentialRunIds {
+    next: Mutex<u64>,
+}
+
+impl RunIdGenerator for SequentialRunIds {
+    fn next(&self) -> RunId {
+        let mut next = self.next.lock().unwrap();
+        *next += 1;
+        RunId::new(format!("run-{next}")).unwrap()
+    }
+}

--- a/docs/git-relay/R1_PARITY.md
+++ b/docs/git-relay/R1_PARITY.md
@@ -64,9 +64,10 @@ native parsing and command integration remain R2 work.
 | Repointed repository identity cannot replay | `repointed_repository_identity_cannot_reuse_old_evidence` |
 | Busy lock is retryable | `busy_lock_is_retryable_and_does_not_open_repository` |
 | Session close failure is structured | `session_close_failure_cannot_mask_machine_result` |
-| Cleanup failure after push is unknown | `close_failure_after_push_preserves_unknown_mutation` |
+| Session close after verified delivery preserves fast-forward evidence | `close_failure_after_verified_push_preserves_fast_forward_evidence` |
 | Lock release failure is structured | `release_failure_cannot_mask_machine_result` |
-| Evidence append failure is structured | `audit_failure_returns_stable_secret_free_result` and `audit_failure_after_push_preserves_unknown_mutation` |
+| Lock release after verified delivery preserves fast-forward evidence | `release_failure_after_verified_push_preserves_fast_forward_evidence` |
+| Evidence append failure is structured without erasing verified delivery | `audit_failure_returns_stable_secret_free_result` and `audit_failure_after_verified_push_preserves_fast_forward_evidence` |
 
 The Rust suite additionally exercises missing-ref boundary classification,
 evidence lookup failure, ancestry failure, pre-push refresh failure, a Buzz
@@ -89,11 +90,12 @@ must perform channel/repository/ACL lookup before constructing it.
 | Buzz owner/repository mismatch is rejected | host adapter responsibility; no owner/URL strings can enter the R1 state machine |
 | Inert credential profiles are rejected | no credential-profile field or credential material exists in the R1 API |
 
-The remaining value-validation cases are covered by all nine tests in
+The remaining value-validation cases are covered by all ten tests in
 `tests/domain.rs`: opaque identity validation, exact 40-hex commit IDs, exact
 64-hex approval IDs, the one-ref allowlist, observe-only defaults, exact apply
-binding, absence of credential/URL fields, and rejection of malformed values
-at the Serde boundary so deserialization cannot bypass the constructors.
+binding, closed next-action serialization, absence of credential/URL fields,
+and rejection of malformed values at the Serde boundary so deserialization
+cannot bypass the constructors.
 
 ### Real Git transport (4 TypeScript tests)
 
@@ -125,8 +127,8 @@ publication path instead of adding another production ref writer.
 
 ## R1 acceptance evidence
 
-- Exactly 55 Rust tests cover the mapped prototype matrix and added race
-  regressions: 42 reconciliation, 9 domain, and 4 disposable-real-Git tests.
+- Exactly 57 Rust tests cover the mapped prototype matrix and added race
+  regressions: 43 reconciliation, 10 domain, and 4 disposable-real-Git tests.
 - `ManagedRef` accepts only `refs/heads/main`.
 - `CommitOid` and `ApprovalEventId` reject malformed values.
 - Deserialization preserves every validated ID, SHA, approval, and ref

--- a/docs/git-relay/R1_PARITY.md
+++ b/docs/git-relay/R1_PARITY.md
@@ -69,8 +69,9 @@ native parsing and command integration remain R2 work.
 | Evidence append failure is structured | `audit_failure_returns_stable_secret_free_result` and `audit_failure_after_push_preserves_unknown_mutation` |
 
 The Rust suite additionally exercises missing-ref boundary classification,
-evidence lookup failure, ancestry failure, pre-push refresh failure, and
-independent sequential invocations in `tests/reconcile.rs`.
+evidence lookup failure, ancestry failure, pre-push refresh failure, a Buzz
+change during the final pre-push read, and independent sequential invocations
+in `tests/reconcile.rs`.
 
 ### Configuration and enrollment (8 TypeScript tests)
 
@@ -88,10 +89,11 @@ must perform channel/repository/ACL lookup before constructing it.
 | Buzz owner/repository mismatch is rejected | host adapter responsibility; no owner/URL strings can enter the R1 state machine |
 | Inert credential profiles are rejected | no credential-profile field or credential material exists in the R1 API |
 
-The remaining value-validation cases are covered by all eight tests in
+The remaining value-validation cases are covered by all nine tests in
 `tests/domain.rs`: opaque identity validation, exact 40-hex commit IDs, exact
 64-hex approval IDs, the one-ref allowlist, observe-only defaults, exact apply
-binding, and absence of credential/URL fields.
+binding, absence of credential/URL fields, and rejection of malformed values
+at the Serde boundary so deserialization cannot bypass the constructors.
 
 ### Real Git transport (4 TypeScript tests)
 
@@ -123,10 +125,12 @@ publication path instead of adding another production ref writer.
 
 ## R1 acceptance evidence
 
-- Exactly 53 Rust tests cover the mapped prototype matrix: 41 reconciliation,
-  8 domain, and 4 disposable-real-Git tests.
+- Exactly 55 Rust tests cover the mapped prototype matrix and added race
+  regressions: 42 reconciliation, 9 domain, and 4 disposable-real-Git tests.
 - `ManagedRef` accepts only `refs/heads/main`.
 - `CommitOid` and `ApprovalEventId` reject malformed values.
+- Deserialization preserves every validated ID, SHA, approval, and ref
+  invariant rather than constructing unchecked private strings.
 - Apply requires Phase 2, host apply enablement, the freshly observed exact
   GitHub SHA, and an approval event.
 - The replay key includes enrollment ID, immutable GitHub repository ID, exact
@@ -136,6 +140,8 @@ publication path instead of adding another production ref writer.
 - Missing managed refs are configuration errors; neither real-Git test creates
   them.
 - The real-Git fast-forward test proves an unlisted branch remains unchanged.
+- The final remote read checks both GitHub and Buzz immediately before the
+  push seam; either side changing freezes without mutation.
 - Boundary errors have only a closed category and cannot carry raw adapter
   messages into results.
 - R1 production sources contain no `unsafe`, `unwrap`, or `expect`.

--- a/docs/git-relay/R1_PARITY.md
+++ b/docs/git-relay/R1_PARITY.md
@@ -1,0 +1,154 @@
+# Git-relay R1 Rust parity
+
+R1 ports the deterministic reconciliation behavior from the frozen TypeScript
+prototype at `billy-armstrong/buzz-workspace#4`, commit
+`83a03ad3941854c1912eecc9dda8983b12df3038`.
+
+Rust is the only intended production implementation. The prototype remains a
+behavioral oracle until native relay integration supersedes it; R1 does not
+deploy or call it.
+
+## Boundary
+
+The crate exposes one behavioral operation:
+
+```rust
+Reconciler::reconcile(&Enrollment, ReconcileRequest) -> ReconcileResult
+```
+
+The reconciler owns ordering, classification, exact-target authorization,
+single-flight acquisition, replay keys, cleanup, and truthful evidence. Host
+adapters own repository access, persistence, identity/ACL resolution, and run
+ID creation through the traits in `ports`.
+
+R1 deliberately contains no GitHub client, Nostr event handling, Postgres,
+webhook, scheduler, CLI, Desktop, or live-repository code. The disposable Git
+adapter is test-only. Consequently, TypeScript tests that exercised YAML/JSON
+or CLI mechanics map to the Rust core's typed/sanitized boundary contract;
+native parsing and command integration remain R2 work.
+
+## Oracle mapping
+
+### Controller state machine (34 TypeScript tests)
+
+| TypeScript oracle behavior | Rust public-seam test |
+| --- | --- |
+| Equal tips are in sync | `equal_tips_are_in_sync_without_mutation` |
+| Observe reports relay behind | `observe_reports_relay_behind_without_mutation` |
+| Approved exact apply | `approved_apply_fast_forwards_exact_ref_and_verifies` |
+| GitHub behind freezes | `github_behind_freezes_without_mutation` |
+| Diverged freezes | `diverged_histories_freeze_without_mutation` |
+| Invalid configuration freezes | `invalid_enrollment_policy_returns_config_error` |
+| Disabled repository is unmanaged | `disabled_enrollment_is_unmanaged_and_never_opens_repository` |
+| Authentication failure | `authentication_failure_freezes_without_retry` |
+| Temporary remote failure | `temporary_remote_failure_is_retryable_without_mutation` |
+| Unexpected adapter failure is sanitized | `unexpected_adapter_failure_is_stable_and_secret_free` |
+| Apply target must be fresh/exact | `apply_target_must_equal_fresh_github_tip` |
+| Valid approval is required | `apply_requires_an_approval_event` |
+| Equal-tip apply remains gated | `already_equal_apply_still_requires_exact_approval` |
+| Concurrent relay-only change freezes | `concurrent_relay_only_change_is_reclassified_without_push` |
+| Concurrent divergence freezes | `concurrent_divergent_change_is_reclassified_without_push` |
+| GitHub advances before push | `github_change_before_push_freezes_old_approval` |
+| Rejected push + unchanged Buzz means no mutation | `rejected_push_with_unchanged_buzz_records_no_mutation` |
+| Ambiguous push verified at exact target | `ambiguous_push_is_resolved_by_exact_reread` |
+| Attempted push cannot be reread | `attempted_push_with_unreadable_outcome_is_unknown` |
+| Successful push cannot be reread | `successful_push_with_failed_reread_is_unknown` |
+| Unexpected post-attempt boundary | `unexpected_failure_after_push_is_unknown_and_secret_free` |
+| Unequal post-push refs | `successful_push_with_unequal_refs_is_verify_error` |
+| GitHub advances after confirmed delivery | `github_advance_after_delivery_records_confirmed_fast_forward` |
+| GitHub advances without delivery | `github_advance_with_unchanged_buzz_does_not_claim_delivery` |
+| Exact verified replay is deduplicated | `duplicate_verified_apply_returns_prior_without_duplicate_evidence` |
+| Replay cleanup describes current invocation | `cleanup_failure_during_replay_describes_current_no_push_invocation` |
+| Observe evidence cannot satisfy apply | `observe_record_cannot_satisfy_later_apply` |
+| New approval creates new evidence | `new_approval_gets_a_new_apply_record` |
+| Repointed repository identity cannot replay | `repointed_repository_identity_cannot_reuse_old_evidence` |
+| Busy lock is retryable | `busy_lock_is_retryable_and_does_not_open_repository` |
+| Session close failure is structured | `session_close_failure_cannot_mask_machine_result` |
+| Cleanup failure after push is unknown | `close_failure_after_push_preserves_unknown_mutation` |
+| Lock release failure is structured | `release_failure_cannot_mask_machine_result` |
+| Evidence append failure is structured | `audit_failure_returns_stable_secret_free_result` and `audit_failure_after_push_preserves_unknown_mutation` |
+
+The Rust suite additionally exercises missing-ref boundary classification,
+evidence lookup failure, ancestry failure, pre-push refresh failure, and
+independent sequential invocations in `tests/reconcile.rs`.
+
+### Configuration and enrollment (8 TypeScript tests)
+
+The prototype accepted untrusted manifest/enrollment files inside its package.
+R1 instead accepts a host-resolved typed `Enrollment`; the future relay adapter
+must perform channel/repository/ACL lookup before constructing it.
+
+| TypeScript oracle category | Rust equivalent |
+| --- | --- |
+| Matching manifest + host enrollment | `enrollment_defaults_to_observe_only_and_requires_approval` |
+| Missing channel / redirected authority fail closed | typed `Enrollment` contains no URL or credential authority; `invalid_enrollment_policy_returns_config_error` proves invalid host policy freezes before repository open |
+| Clone URLs with credentials are rejected | `serialized_enrollment_contains_no_credentials_or_clone_urls`; URLs are absent from the core API |
+| GitHub identity mismatch is rejected | immutable typed `GithubRepositoryId`; `repointed_repository_identity_cannot_reuse_old_evidence` |
+| Approval is mandatory | `enrollment_defaults_to_observe_only_and_requires_approval` and `apply_requires_an_approval_event` |
+| Buzz owner/repository mismatch is rejected | host adapter responsibility; no owner/URL strings can enter the R1 state machine |
+| Inert credential profiles are rejected | no credential-profile field or credential material exists in the R1 API |
+
+The remaining value-validation cases are covered by all eight tests in
+`tests/domain.rs`: opaque identity validation, exact 40-hex commit IDs, exact
+64-hex approval IDs, the one-ref allowlist, observe-only defaults, exact apply
+binding, and absence of credential/URL fields.
+
+### Real Git transport (4 TypeScript tests)
+
+All four behaviors run against disposable local bare repositories in
+`tests/real_git.rs`:
+
+| Oracle behavior | Rust test |
+| --- | --- |
+| Exact managed-ref fast-forward; unlisted ref preserved | `real_git_fast_forward_preserves_unlisted_branch` |
+| Exact SHA-to-ref refspec only | `real_git_push_uses_only_exact_sha_to_exact_refspec` |
+| Missing GitHub main creates nothing | `missing_github_main_never_creates_either_managed_ref` |
+| Missing Buzz main creates nothing | `missing_buzz_main_never_creates_either_managed_ref` |
+
+The adapter exists only in the integration test. R2 must send the same typed
+operation through Buzz's existing receive-pack, policy-hook, and CAS manifest
+publication path instead of adding another production ref writer.
+
+### Lock, evidence, batch, and CLI categories (7 TypeScript tests)
+
+| Prototype category | R1 equivalent |
+| --- | --- |
+| Lock acquisition/release | `busy_lock_is_retryable_and_does_not_open_repository`, `release_failure_cannot_mask_machine_result` |
+| Persist and replay exact secret-free evidence | `duplicate_verified_apply_returns_prior_without_duplicate_evidence`, `repointed_repository_identity_cannot_reuse_old_evidence`, `serialized_enrollment_contains_no_credentials_or_clone_urls` |
+| One repository failure does not stop another | `one_repository_failure_does_not_poison_a_later_invocation`; R1 intentionally has no shared batch operation |
+| Invalid config emits nonzero machine result | `invalid_enrollment_policy_returns_config_error` |
+| Unexpected outer boundary is secret-free | every `ReconcileResult` is serialized from a closed schema; unexpected adapter/cleanup/evidence tests assert sanitization |
+| Audit reports independent enrollments | one `reconcile` call per enrollment; R2 scheduler owns iteration and persistence |
+| Malformed job does not stop later job | malformed enrollment never enters the typed core; `one_repository_failure_does_not_poison_a_later_invocation` proves invocation isolation |
+
+## R1 acceptance evidence
+
+- Exactly 53 Rust tests cover the mapped prototype matrix: 41 reconciliation,
+  8 domain, and 4 disposable-real-Git tests.
+- `ManagedRef` accepts only `refs/heads/main`.
+- `CommitOid` and `ApprovalEventId` reject malformed values.
+- Apply requires Phase 2, host apply enablement, the freshly observed exact
+  GitHub SHA, and an approval event.
+- The replay key includes enrollment ID, immutable GitHub repository ID, exact
+  ref, exact target, and exact approval event.
+- Any unverified failure after `push_exact` sets `mutation = unknown` and
+  clears `buzz_after`.
+- Missing managed refs are configuration errors; neither real-Git test creates
+  them.
+- The real-Git fast-forward test proves an unlisted branch remains unchanged.
+- Boundary errors have only a closed category and cannot carry raw adapter
+  messages into results.
+- R1 production sources contain no `unsafe`, `unwrap`, or `expect`.
+
+Static safety scan:
+
+```sh
+rg -n --glob '*.rs' '(--mirror|--prune|force-with-lease|force_push|wildcard|delete-ref|refs/heads/\*)' crates/buzz-git-relay/src
+rg -n '\.(unwrap|expect)\(' crates/buzz-git-relay/src
+rg -n 'unsafe\s*\{' crates/buzz-git-relay/src
+```
+
+All three searches must be empty. The test-only Git adapter contains the
+literal exact destination `refs/heads/main` and uses a leading `+` only for
+local fetch scratch refs; its push refspec is always `<validated SHA>:<typed
+ManagedRef>` and never contains `+`, a wildcard, deletion, or mirror option.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -104,6 +104,9 @@ run_unit_tests() {
   run_test_step "buzz-conformance tests" \
     cargo test -p buzz-conformance -- --nocapture
 
+  run_test_step "buzz-git-relay tests" \
+    cargo test -p buzz-git-relay -- --nocapture
+
   run_test_step "buzz-push-gateway tests" \
     cargo test -p buzz-push-gateway -- --nocapture
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft: upstream product direction is still undecided.** R2 wiring is paused. This PR is a reviewable R1 safety core, not a request to ship an unconsumed feature as-is.

## Summary

- Add `buzz-git-relay`, a deterministic Rust reconciliation core with one public `Reconciler::reconcile(...)` interface.
- Port the validated TypeScript prototype behavior into typed Rust domain values, closed ports, guarded exact-ref apply ordering, replay safety, and truthful mutation evidence.
- Register the crate's tests in both enforced `just test-unit` paths.
- Document the 57-test parity/race matrix and keep R1 free of relay, database, GitHub, Nostr, scheduler, CLI, Desktop, deployment, and live-repository wiring.

## Product decision requested before R2

No matching public issue or duplicate Git-relay PR was found. Before adding a consumer, we want maintainer direction on whether Git-relay should be:

1. a staged native core,
2. a smaller native core submitted with an observe-only consumer, or
3. an external companion service.

Until that direction is agreed, this PR remains draft and R2 is paused.

## Safety and scope

- GitHub `main` remains canonical; only a proven behind ref can reach the exact-ref push port.
- Validated IDs, commit SHAs, approval events, and the managed ref enforce their invariants through deserialization as well as constructors.
- The final remote read checks both GitHub and Buzz immediately before the push seam; either side changing freezes without mutation.
- A successful post-push reread remains authoritative even if session close, lock release, or audit persistence later fails.
- `github_target` remains the approved requested target; an unapproved later GitHub read cannot replace it.
- Missing managed refs are never created.
- Immutable GitHub repository identity participates in replay matching.
- Any unverified failure after a push attempt reports `mutation: unknown` and omits an unverified after-SHA.
- Unlisted refs are preserved in disposable-real-Git proofs.
- Healthy reconciliation is deterministic and uses no LLM or model tokens.

## Validation at `3388bd86815c001af2e799d75870cabccad8ff1c`

- `cargo test -p buzz-git-relay`: 57 passed, including doctests.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `just test-unit`: passed; both primary and fallback runners include `buzz-git-relay`.
- `scripts/check-branch-skew.sh`: passed; branch is rebased on `a5dbdf5e61e4c512acd99c219c79c154ddb57295`.
- Production scans found no `unsafe`, `unwrap`, `expect`, force/mirror/wildcard/delete refspecs in `crates/buzz-git-relay/src`.
- Independent standards and specification rereviews found no remaining high-confidence Phase A findings.
- Worktree clean at the exact commit.

## Full repository CI caveat

Local `just ci` passed formatting, workspace Clippy, Desktop/Web checks and builds, Flutter analysis, all registered unit suites, and the Desktop Tauri suite. Its final mobile suite failed one test:

`ChannelDetailPage keeps follow mode off while a tall newest message stays visible`

That exact test also fails in isolation on unmodified upstream `a5dbdf5e61e4c512acd99c219c79c154ddb57295`; this PR has no `mobile/` diff. The PR remains draft, and upstream merge-tree CI is still required before acceptance.

No deployment, live repository access, or relay mutation was performed.
