### PR TITLE
feat(relay): bootstrap managed administrator identities

### DIFF
--- a/NOSTR.md
+++ b/NOSTR.md
@@ -215,7 +215,9 @@ nak req -k 1059 --tag "p=<your-hex-pubkey>" \
 
 When `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`, every authenticated connection is checked against the
 `relay_members` table. In today's single-community deployment this is the relay-wide member list; in multi-community mode the same rule is scoped to the host-derived community. Only pubkeys with a row for that community may use that community. The relay owner
-is bootstrapped automatically from `RELAY_OWNER_PUBKEY` on startup.
+is bootstrapped automatically from `RELAY_OWNER_PUBKEY` on startup. Deployment
+control planes can be bootstrapped as relay administrators with
+`RELAY_BOOTSTRAP_ADMIN_PUBKEYS`; they do not need the owner's private key.
 
 ### CLI: Managing Members
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -281,6 +281,7 @@ out of the box with `just setup` or `just relay`. Common overrides:
 | `BUZZ_AUDIT_ENABLED`            | `true`                      | Tamper-evident event/media audit log. Set `false`/`0`/`off` to skip its DB pool and writes. Does not disable the separate moderation audit trail. |
 | `BUZZ_AUTO_MIGRATE`             | `false`                     | Opt in with `true`/`1`/`yes`/`on` to run embedded SQLx migrations on relay startup |
 | `RELAY_OWNER_PUBKEY`              | unset                       | Bootstrapped as `owner` in `relay_members` at first start |
+| `RELAY_BOOTSTRAP_ADMIN_PUBKEYS`   | unset                       | Comma-separated deployment identities ensured as relay admins |
 | `BUZZ_ALLOW_NIP_OA_AUTH`        | `false`                     | Enable NIP-OA owner attestation for membership |
 | `BUZZ_WEB_DIR`                  | unset (source), `/srv/buzz/web` (container) | Directory containing the invite landing bundle; the production container enables it so `/invite/{code}` always works |
 | `BUZZ_SERVE_GIT_WEB_GUI`        | `false`                     | Set to `true` or `1` to expose the bundled Git repository browser at `/` and `/repos/...`; invite routes do not depend on this flag |

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -4127,6 +4127,11 @@ impl Db {
         relay_members::has_admin_or_owner(&self.pool, community).await
     }
 
+    /// Ensures a deployment-managed identity holds the relay `admin` role.
+    pub async fn bootstrap_admin(&self, community: CommunityId, admin_pubkey: &str) -> Result<()> {
+        relay_members::bootstrap_admin(&self.pool, community, admin_pubkey).await
+    }
+
     /// Atomically transfers ownership of `community` to `new_owner_pubkey`,
     /// demoting the previous owner(s) to `member`. Verifies
     /// `expected_owner_pubkey` matches the current owner inside the same

--- a/crates/buzz-db/src/relay_members.rs
+++ b/crates/buzz-db/src/relay_members.rs
@@ -377,6 +377,29 @@ pub async fn bootstrap_owner(
     Ok(())
 }
 
+/// Ensures a deployment-managed pubkey holds the `admin` role in `community`.
+/// An existing owner is left as owner; every other existing role is promoted
+/// to admin. Safe to call on every startup.
+pub async fn bootstrap_admin(
+    pool: &PgPool,
+    community: CommunityId,
+    admin_pubkey: &str,
+) -> Result<()> {
+    let pubkey = admin_pubkey.to_ascii_lowercase();
+    sqlx::query(
+        "INSERT INTO relay_members (community_id, pubkey, role, added_by) \
+         VALUES ($1, $2, 'admin', NULL) \
+         ON CONFLICT (community_id, pubkey) DO UPDATE SET \
+           role = CASE WHEN relay_members.role = 'owner' THEN 'owner' ELSE 'admin' END, \
+           updated_at = now()",
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// The result of a transfer-ownership attempt.
 #[derive(Debug, PartialEq)]
 pub enum TransferResult {
@@ -682,6 +705,31 @@ mod tests {
             .await
             .expect("bootstrap owner");
         (community, owner)
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn bootstrap_admin_is_idempotent_and_never_demotes_owner() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let owner = test_pubkey();
+        let admin = test_pubkey();
+
+        bootstrap_owner(&pool, community, &owner)
+            .await
+            .expect("bootstrap owner");
+        bootstrap_admin(&pool, community, &admin)
+            .await
+            .expect("bootstrap admin");
+        bootstrap_admin(&pool, community, &admin)
+            .await
+            .expect("repeat bootstrap admin");
+        bootstrap_admin(&pool, community, &owner)
+            .await
+            .expect("owner listed as bootstrap admin");
+
+        assert_role(&pool, community, &admin, "admin").await;
+        assert_role(&pool, community, &owner, "owner").await;
     }
 
     #[tokio::test]

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -165,6 +165,15 @@ pub struct Config {
     /// with the `owner` role on first startup.
     pub relay_owner_pubkey: Option<String>,
 
+    /// Deployment-managed identities that must hold the `admin` role in the
+    /// deployment community. This is intended for control-plane connectors
+    /// that reconcile relay and channel membership without holding the relay
+    /// owner's private key.
+    ///
+    /// Set via `RELAY_BOOTSTRAP_ADMIN_PUBKEYS` as a comma-separated list of
+    /// 64-character hex pubkeys. Invalid entries fail startup.
+    pub relay_bootstrap_admin_pubkeys: Vec<String>,
+
     /// Canonical HTTP origin of the deployment-global operator API.
     ///
     /// Every operator NIP-98 `u` tag is verified against this origin, independent
@@ -590,6 +599,29 @@ impl Config {
                 }
             });
 
+        let relay_bootstrap_admin_pubkeys = match std::env::var("RELAY_BOOTSTRAP_ADMIN_PUBKEYS") {
+            Ok(raw) => {
+                let mut pubkeys = Vec::new();
+                for entry in raw.split(',') {
+                    let entry = entry.trim().to_lowercase();
+                    if entry.is_empty() {
+                        continue;
+                    }
+                    let valid = entry.len() == 64 && entry.chars().all(|c| c.is_ascii_hexdigit());
+                    if !valid {
+                        return Err(ConfigError::InvalidValue(format!(
+                                "RELAY_BOOTSTRAP_ADMIN_PUBKEYS entry is not a valid 64-char hex pubkey: {entry:?}"
+                            )));
+                    }
+                    if !pubkeys.contains(&entry) {
+                        pubkeys.push(entry);
+                    }
+                }
+                pubkeys
+            }
+            Err(_) => Vec::new(),
+        };
+
         // Note: intentionally not prefixed with BUZZ_ — same relay-identity
         // config family as RELAY_OWNER_PUBKEY. Comma-separated 64-char hex
         // pubkeys. Unlike RELAY_OWNER_PUBKEY (warn-and-ignore), an invalid
@@ -958,6 +990,7 @@ impl Config {
             mesh,
             mesh_demo_echo,
             relay_owner_pubkey,
+            relay_bootstrap_admin_pubkeys,
             relay_operator_api_origin,
             relay_operator_pubkeys,
             allow_nip_oa_auth,
@@ -1021,6 +1054,10 @@ mod tests {
         assert!(
             config.relay_owner_pubkey.is_none(),
             "relay_owner_pubkey should default to None"
+        );
+        assert!(
+            config.relay_bootstrap_admin_pubkeys.is_empty(),
+            "relay_bootstrap_admin_pubkeys should default empty"
         );
         assert!(
             config.relay_operator_pubkeys.is_empty(),
@@ -1371,6 +1408,38 @@ mod tests {
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn relay_bootstrap_admin_pubkeys_parse_dedupe_and_normalize() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        std::env::set_var(
+            "RELAY_BOOTSTRAP_ADMIN_PUBKEYS",
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+        let config = Config::from_env().expect("config");
+        std::env::remove_var("RELAY_BOOTSTRAP_ADMIN_PUBKEYS");
+
+        assert_eq!(
+            config.relay_bootstrap_admin_pubkeys,
+            vec![
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn relay_bootstrap_admin_pubkeys_invalid_entry_is_error() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        std::env::set_var("RELAY_BOOTSTRAP_ADMIN_PUBKEYS", "not-a-pubkey");
+        let result = Config::from_env();
+        std::env::remove_var("RELAY_BOOTSTRAP_ADMIN_PUBKEYS");
+
+        assert!(matches!(
+            result,
+            Err(ConfigError::InvalidValue(ref msg)) if msg.contains("RELAY_BOOTSTRAP_ADMIN_PUBKEYS")
+        ));
     }
 
     #[test]

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -338,6 +338,20 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    if let Some(community) = deployment_community {
+        for admin_pubkey in &config.relay_bootstrap_admin_pubkeys {
+            match db.bootstrap_admin(community, admin_pubkey).await {
+                Ok(()) => info!(pubkey = %admin_pubkey, "Relay bootstrap admin ensured"),
+                Err(e) => {
+                    error!(pubkey = %admin_pubkey, "Fatal: failed to bootstrap relay admin: {e}");
+                    return Err(anyhow::anyhow!(
+                        "Failed to bootstrap relay admin {admin_pubkey}: {e}"
+                    ));
+                }
+            }
+        }
+    }
+
     // NIP-33: backfill d_tag for any existing parameterized replaceable events
     // that predate the column addition. Idempotent — no-ops when fully populated.
     match db.backfill_d_tags().await {

--- a/deploy/charts/buzz/Chart.yaml
+++ b/deploy/charts/buzz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PostgreSQL and Redis. Configurable for single-node evaluation
   (subcharts on) and HA production (external services, existingSecret).
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "0.1.0"
 home: https://github.com/block/buzz
 sources:
@@ -24,7 +24,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Generic init-container, volume, volume-mount, command, and args extension points for the relay Pod.
+      description: Deployment-managed relay administrator bootstrap identities for control-plane connectors.
   artifacthub.io/license: Apache-2.0
 
 # Optional eval-only subcharts. Production deploys disable both and point

--- a/deploy/charts/buzz/README.md
+++ b/deploy/charts/buzz/README.md
@@ -47,6 +47,7 @@ See:
 |---|---|---|
 | `relayUrl` | Public `wss://` URL clients connect to | Always |
 | `ownerPubkey` | 64-char lowercase hex Nostr pubkey of the relay operator | When `relay.requireRelayMembership=true` (default) |
+| `bootstrapAdminPubkeys` | Comma-separated control-plane pubkeys ensured as relay admins | Optional |
 | `secrets.existingSecret` | Name of pre-created Secret | Production / GitOps |
 | `externalPostgresql.url` / `externalRedis.url` / `s3.endpoint` | External service URLs | Production — when the matching bundled service is disabled (the default) |
 

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -151,6 +151,7 @@ spec:
 
             # ── Owner ────────────────────────────────────────────────
             - { name: RELAY_OWNER_PUBKEY, value: {{ .Values.ownerPubkey | quote }} }
+            - { name: RELAY_BOOTSTRAP_ADMIN_PUBKEYS, value: {{ .Values.bootstrapAdminPubkeys | quote }} }
 
             # ── Migrations ───────────────────────────────────────────
             - { name: BUZZ_AUTO_MIGRATE, value: {{ .Values.migrate.autoMigrate | quote }} }

--- a/deploy/charts/buzz/tests/secrets_test.yaml
+++ b/deploy/charts/buzz/tests/secrets_test.yaml
@@ -121,6 +121,23 @@ tests:
             name: BUZZ_RELAY_OWNER_PUBKEY
         template: templates/deployment.yaml
 
+  - it: RELAY_BOOTSTRAP_ADMIN_PUBKEYS env is set
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+      bootstrapAdminPubkeys: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RELAY_BOOTSTRAP_ADMIN_PUBKEYS
+            value: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        template: templates/deployment.yaml
+
   - it: BUZZ_AUTO_MIGRATE defaults to "true"
     set:
       relayUrl: wss://buzz.example.com

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -80,6 +80,10 @@ mediaBaseUrl: ""
 # relay.requireRelayMembership=true (the production default).
 ownerPubkey: ""
 
+# Comma-separated control-plane pubkeys ensured as relay administrators at
+# startup. These identities can reconcile membership without the owner key.
+bootstrapAdminPubkeys: ""
+
 # ── Chart-managed secrets ────────────────────────────────────────────────────
 # Production / GitOps path: create a Secret out-of-band with these keys and
 # point `secrets.existingSecret` at it. Any key omitted from the existing


### PR DESCRIPTION
## Summary

- add a strict RELAY_BOOTSTRAP_ADMIN_PUBKEYS configuration value
- idempotently ensure deployment-managed identities hold relay admin access without demoting owners
- expose the setting through the Helm chart and bump it to 0.1.8

This gives an external control plane a narrowly scoped relay identity for reconciling members and private workspace channels without distributing the relay owner key.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- just test
- cargo test -p buzz-db bootstrap_admin_is_idempotent_and_never_demotes_owner -- --ignored --nocapture
- Helm template unit test for RELAY_BOOTSTRAP_ADMIN_PUBKEYS