### PR TITLE
fix(sdk): allow self-tagging in build_add_member so self-targeted kind 9000 keeps its p tag

### DIFF
--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -562,6 +562,12 @@ pub fn build_profile(
 }
 
 /// Build a NIP-29 add-member event (kind 9000).
+///
+/// `.allow_self_tagging()` is required: PUT_USER's self path has
+/// `actor == target` (e.g. an owner adjusting their own role), so the
+/// request's `["p", target]` matches the signer. nostr 0.44 strips matching
+/// `p` tags by default — without this the event goes on the wire without its
+/// `p` tag and the relay rejects it with "missing p tag".
 pub fn build_add_member(
     channel_id: Uuid,
     target_pubkey: &str,
@@ -575,7 +581,9 @@ pub fn build_add_member(
     if let Some(r) = role {
         tags.push(tag(&["role", r.as_str()])?);
     }
-    Ok(EventBuilder::new(Kind::Custom(9000), "").tags(tags))
+    Ok(EventBuilder::new(Kind::Custom(9000), "")
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Build a NIP-29 remove-member event (kind 9001).
@@ -2740,6 +2748,25 @@ mod tests {
         let ev = sign(build_add_member(cid, pubkey, None::<MemberRole>).unwrap());
         assert_eq!(ev.kind.as_u16(), 9000);
         assert!(tag_values(&ev, "role").is_empty());
+    }
+
+    #[test]
+    fn add_member_self_target_keeps_p_tag() {
+        // Self-add: actor == target (e.g. an owner adjusting their own role,
+        // or an admin agent adding itself with an explicit role). Pins that
+        // `.allow_self_tagging()` survives nostr 0.44's default same-pubkey
+        // `p`-tag scrub — without it the event reaches the relay without its
+        // `p` tag and is rejected with "missing p tag".
+        let keys = keys();
+        let self_pk = keys.public_key().to_hex();
+        let cid = uuid();
+        let ev = build_add_member(cid, &self_pk, Some(MemberRole::Bot))
+            .unwrap()
+            .sign_with_keys(&keys)
+            .expect("sign");
+        assert_eq!(ev.kind.as_u16(), 9000);
+        assert!(has_tag(&ev, "p", &self_pk));
+        assert!(has_tag(&ev, "role", "bot"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`buzz_sdk::builders::build_add_member` builds kind:9000 without `.allow_self_tagging()`, so a **self-targeted** add-member (actor == target — e.g. an owner adjusting their own role, or an admin agent adding itself with an explicit role) silently loses its `["p", target]` tag at signing time: nostr 0.44 strips `p` tags that match the signer's own pubkey by default (verified against the resolved `nostr-0.44.7`, `builder.rs:435-449`). The event then reaches the relay without a `p` tag and is rejected by `handlers/side_effects.rs` with `invalid: missing p tag`.

The codebase already recognizes this exact interaction in two places:

- The NIP-IA builders apply `.allow_self_tagging()` for their self paths, with a comment documenting the nostr 0.44 scrub (`crates/buzz-sdk/src/builders.rs` — `build_archive_identity_request` / `build_unarchive_identity_request`).
- The e2e suite's self-targeted PUT_USER probe hand-builds its kind:9000 with `.allow_self_tagging()` instead of using `build_add_member`, with a comment noting the builder would otherwise drop the tag (`crates/buzz-test-client/tests/e2e_relay.rs`, "The probe: owner_b sends a bare self-targeted PUT_USER").

This PR applies the same one-line fix to `build_add_member` itself, so SDK/CLI callers get the correct wire form. Non-self adds are unaffected (`allow_self_tagging` only changes behavior when a `p` tag matches the signer).

Observed in production: a relay-admin agent running the CLI's `add-member` against its own pubkey (to set an explicit `bot` role) was rejected with `invalid: missing p tag`; adding a *different* pubkey with the same CLI worked fine.

Note: `build_remove_member` (9001) and `build_dm_add_member` (41011) share the same shape and would also scrub a self `p` tag — and the relay does support guarded self-removal (`handle_remove_user`: self-remove allowed unless the actor is the last owner). I left them unchanged only to keep this PR scoped to the observed add-member failure — happy to extend it to the whole class if you prefer.

### Related issue

None found (searched open issues/PRs for `allow_self_tagging` / "missing p tag" / add-member self).

### Testing

- New unit test `add_member_self_target_keeps_p_tag` pins the fixed wire form (signs a self-targeted build_add_member and asserts the `p` and `role` tags survive), mirroring the existing `unarchive_request_layout_self_path` pin. Verified red without the fix: it fails on exactly `assertion failed: has_tag(&ev, "p", &self_pk)`.
- Existing `add_member_with_role` / `add_member_without_role` tests still pass (non-self path unchanged). `cargo test -p buzz-sdk` green (253 tests).
- Rust legs of `just ci` run locally and green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the full `test-unit` package set (buzz-core, buzz-auth, buzz-voice, buzz-cli, buzz-db --lib, buzz-conformance, buzz-push-gateway, buzz-backend-kubernetes) — 0 failures. The desktop/web/mobile legs weren't run locally (toolchains not installed here); the change is confined to `crates/buzz-sdk`, so deferring those to PR CI.
- Verified against live relays running block/buzz @ a5dbdf5e, both self-add paths:
  - Privileged path (signer is channel owner): self-targeted `channels add-member --role admin` is **accepted** and `channels members` shows the signer's pubkey at the requested role.
  - Unprivileged path (signer is a plain channel member): the rejection changes from the pre-fix `invalid: missing p tag` (wire-form, before the relay can even evaluate the request) to `invalid: only owners/admins may change an active member's role` (authorization) — i.e. the `p` tag now reaches the relay and the request is judged on its merits.
