### PR TITLE
fix(desktop): fall back to native image clipboard

### DIFF
--- a/desktop/src-tauri/src/commands/clipboard.rs
+++ b/desktop/src-tauri/src/commands/clipboard.rs
@@ -53,3 +53,25 @@ pub async fn read_clipboard_text(app: tauri::AppHandle) -> Result<String, String
     rx.recv()
         .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
 }
+
+/// Read the system clipboard image, treating a non-image clipboard as an
+/// expected empty result rather than an error. WebKitGTK does not always
+/// surface Wayland image clipboard offers as `ClipboardEvent` file items.
+pub fn read_system_clipboard_image(
+    app: &tauri::AppHandle,
+) -> Result<Option<arboard::ImageData<'static>>, String> {
+    let state = app.state::<ClipboardState>();
+    let mut stored = state
+        .0
+        .lock()
+        .map_err(|_| "clipboard state lock poisoned".to_string())?;
+    if stored.is_none() {
+        *stored = Some(arboard::Clipboard::new().map_err(|e| format!("clipboard error: {e}"))?);
+    }
+
+    match stored.as_mut().expect("clipboard initialized").get_image() {
+        Ok(image) => Ok(Some(image)),
+        Err(arboard::Error::ContentNotAvailable) => Ok(None),
+        Err(error) => Err(format!("clipboard error: {error}")),
+    }
+}

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -3,7 +3,7 @@ use sha2::{Digest, Sha256};
 use tauri::State;
 
 use crate::app_state::AppState;
-use crate::commands::clipboard::with_clipboard;
+use crate::commands::clipboard::{read_system_clipboard_image, with_clipboard};
 use crate::commands::export_util::save_bytes_with_dialog;
 use crate::commands::media::{detect_and_validate_mime, mint_media_get_auth, sanitize_filename};
 use crate::commands::{
@@ -19,6 +19,38 @@ use crate::relay::{classify_request_error, relay_api_base_url_with_override, rel
 
 /// Maximum download size: 50 MiB. Prevents OOM from oversized responses.
 const MAX_DOWNLOAD_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Encode an RGBA clipboard image as PNG before returning it across IPC.
+fn encode_clipboard_image_as_png(image: arboard::ImageData<'static>) -> Result<Vec<u8>, String> {
+    let width =
+        u32::try_from(image.width).map_err(|_| "clipboard image is too wide".to_string())?;
+    let height =
+        u32::try_from(image.height).map_err(|_| "clipboard image is too tall".to_string())?;
+    let expected_bytes = image
+        .width
+        .checked_mul(image.height)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or("clipboard image dimensions overflow")?;
+    if expected_bytes > MAX_DOWNLOAD_BYTES as usize {
+        return Err("clipboard image is too large".to_string());
+    }
+    if image.bytes.len() != expected_bytes {
+        return Err("clipboard image has invalid RGBA data".to_string());
+    }
+
+    let mut encoded = Vec::new();
+    let mut encoder = png::Encoder::new(&mut encoded, width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .map_err(|error| format!("failed to encode clipboard image: {error}"))?;
+    writer
+        .write_image_data(&image.bytes)
+        .map_err(|error| format!("failed to encode clipboard image: {error}"))?;
+    drop(writer);
+    Ok(encoded)
+}
 
 /// Download request timeout.
 const DOWNLOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
@@ -217,6 +249,25 @@ pub async fn copy_image_to_clipboard(
         let _ = tx.send(result);
     })
     .map_err(|e| format!("main thread dispatch failed: {e}"))?;
+
+    rx.recv()
+        .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
+}
+
+/// Read an image directly from the native system clipboard.
+///
+/// This is a fallback for Linux WebKitGTK, which can receive a paste event
+/// without exposing the Wayland `image/png` offer as a `DataTransferItem`.
+#[tauri::command]
+pub async fn read_clipboard_image(app: tauri::AppHandle) -> Result<Option<Vec<u8>>, String> {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    let clipboard_app = app.clone();
+    app.run_on_main_thread(move || {
+        let result = read_system_clipboard_image(&clipboard_app)
+            .and_then(|image| image.map(encode_clipboard_image_as_png).transpose());
+        let _ = tx.send(result);
+    })
+    .map_err(|error| format!("main thread dispatch failed: {error}"))?;
 
     rx.recv()
         .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
@@ -526,6 +577,23 @@ pub async fn fetch_snapshot_bytes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clipboard_rgba_is_encoded_as_a_valid_png() {
+        let rgba = vec![255, 0, 0, 255, 0, 255, 0, 255];
+        let encoded = encode_clipboard_image_as_png(arboard::ImageData {
+            width: 2,
+            height: 1,
+            bytes: std::borrow::Cow::Owned(rgba.clone()),
+        })
+        .expect("valid RGBA clipboard data must encode");
+
+        let decoded = image::load_from_memory(&encoded)
+            .expect("encoded clipboard image must be a PNG")
+            .to_rgba8();
+        assert_eq!(decoded.dimensions(), (2, 1));
+        assert_eq!(decoded.into_raw(), rgba);
+    }
 
     #[test]
     fn snapshot_kind_json_returns_json_kind_and_correct_cap() {

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -22,6 +22,13 @@ use crate::relay::{classify_request_error, relay_api_base_url_with_override, rel
 /// Maximum download size: 50 MiB. Prevents OOM from oversized responses.
 pub(super) const MAX_DOWNLOAD_BYTES: u64 = 50 * 1024 * 1024;
 
+fn ensure_clipboard_png_size(encoded_len: usize) -> Result<(), String> {
+    if encoded_len > MAX_DOWNLOAD_BYTES as usize {
+        return Err("encoded clipboard image is too large".to_string());
+    }
+    Ok(())
+}
+
 /// Encode an RGBA clipboard image as PNG before returning it across IPC.
 fn encode_clipboard_image_as_png(image: arboard::ImageData<'static>) -> Result<Vec<u8>, String> {
     let width =
@@ -51,6 +58,7 @@ fn encode_clipboard_image_as_png(image: arboard::ImageData<'static>) -> Result<V
         .write_image_data(&image.bytes)
         .map_err(|error| format!("failed to encode clipboard image: {error}"))?;
     drop(writer);
+    ensure_clipboard_png_size(encoded.len())?;
     Ok(encoded)
 }
 
@@ -235,18 +243,23 @@ pub async fn copy_image_to_clipboard(
 /// This is a fallback for Linux WebKitGTK, which can receive a paste event
 /// without exposing the Wayland `image/png` offer as a `DataTransferItem`.
 #[tauri::command]
-pub async fn read_clipboard_image(app: tauri::AppHandle) -> Result<Option<Vec<u8>>, String> {
+pub async fn read_clipboard_image(app: tauri::AppHandle) -> Result<tauri::ipc::Response, String> {
     let (tx, rx) = std::sync::mpsc::sync_channel(1);
     let clipboard_app = app.clone();
     app.run_on_main_thread(move || {
-        let result = read_system_clipboard_image(&clipboard_app)
-            .and_then(|image| image.map(encode_clipboard_image_as_png).transpose());
+        let result = read_system_clipboard_image(&clipboard_app).and_then(|image| {
+            image
+                .ok_or_else(|| "clipboard contains no image".to_string())
+                .and_then(encode_clipboard_image_as_png)
+        });
         let _ = tx.send(result);
     })
     .map_err(|error| format!("main thread dispatch failed: {error}"))?;
 
-    rx.recv()
-        .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
+    let png = rx
+        .recv()
+        .map_err(|_| "clipboard result channel closed unexpectedly".to_string())??;
+    Ok(tauri::ipc::Response::new(png))
 }
 
 /// Write text to the system clipboard through the native shell.
@@ -590,6 +603,12 @@ mod tests {
             .to_rgba8();
         assert_eq!(decoded.dimensions(), (2, 1));
         assert_eq!(decoded.into_raw(), rgba);
+    }
+
+    #[test]
+    fn clipboard_encoded_png_cap_rejects_only_oversized_output() {
+        assert!(ensure_clipboard_png_size(MAX_DOWNLOAD_BYTES as usize).is_ok());
+        assert!(ensure_clipboard_png_size(MAX_DOWNLOAD_BYTES as usize + 1).is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -4,7 +4,7 @@ use tauri::State;
 use tokio_util::sync::CancellationToken;
 
 use crate::app_state::AppState;
-use crate::commands::clipboard::with_clipboard;
+use crate::commands::clipboard::{read_system_clipboard_image, with_clipboard};
 use crate::commands::export_util::save_bytes_with_dialog;
 use crate::commands::media::{detect_and_validate_mime, mint_media_get_auth};
 use crate::commands::media_filename::sanitize_filename;
@@ -21,6 +21,38 @@ use crate::relay::{classify_request_error, relay_api_base_url_with_override, rel
 
 /// Maximum download size: 50 MiB. Prevents OOM from oversized responses.
 pub(super) const MAX_DOWNLOAD_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Encode an RGBA clipboard image as PNG before returning it across IPC.
+fn encode_clipboard_image_as_png(image: arboard::ImageData<'static>) -> Result<Vec<u8>, String> {
+    let width =
+        u32::try_from(image.width).map_err(|_| "clipboard image is too wide".to_string())?;
+    let height =
+        u32::try_from(image.height).map_err(|_| "clipboard image is too tall".to_string())?;
+    let expected_bytes = image
+        .width
+        .checked_mul(image.height)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or("clipboard image dimensions overflow")?;
+    if expected_bytes > MAX_DOWNLOAD_BYTES as usize {
+        return Err("clipboard image is too large".to_string());
+    }
+    if image.bytes.len() != expected_bytes {
+        return Err("clipboard image has invalid RGBA data".to_string());
+    }
+
+    let mut encoded = Vec::new();
+    let mut encoder = png::Encoder::new(&mut encoded, width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .map_err(|error| format!("failed to encode clipboard image: {error}"))?;
+    writer
+        .write_image_data(&image.bytes)
+        .map_err(|error| format!("failed to encode clipboard image: {error}"))?;
+    drop(writer);
+    Ok(encoded)
+}
 
 /// Download request timeout.
 const DOWNLOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
@@ -193,6 +225,25 @@ pub async fn copy_image_to_clipboard(
         let _ = tx.send(result);
     })
     .map_err(|e| format!("main thread dispatch failed: {e}"))?;
+
+    rx.recv()
+        .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
+}
+
+/// Read an image directly from the native system clipboard.
+///
+/// This is a fallback for Linux WebKitGTK, which can receive a paste event
+/// without exposing the Wayland `image/png` offer as a `DataTransferItem`.
+#[tauri::command]
+pub async fn read_clipboard_image(app: tauri::AppHandle) -> Result<Option<Vec<u8>>, String> {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    let clipboard_app = app.clone();
+    app.run_on_main_thread(move || {
+        let result = read_system_clipboard_image(&clipboard_app)
+            .and_then(|image| image.map(encode_clipboard_image_as_png).transpose());
+        let _ = tx.send(result);
+    })
+    .map_err(|error| format!("main thread dispatch failed: {error}"))?;
 
     rx.recv()
         .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
@@ -523,6 +574,23 @@ pub async fn fetch_snapshot_bytes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clipboard_rgba_is_encoded_as_a_valid_png() {
+        let rgba = vec![255, 0, 0, 255, 0, 255, 0, 255];
+        let encoded = encode_clipboard_image_as_png(arboard::ImageData {
+            width: 2,
+            height: 1,
+            bytes: std::borrow::Cow::Owned(rgba.clone()),
+        })
+        .expect("valid RGBA clipboard data must encode");
+
+        let decoded = image::load_from_memory(&encoded)
+            .expect("encoded clipboard image must be a PNG")
+            .to_rgba8();
+        assert_eq!(decoded.dimensions(), (2, 1));
+        assert_eq!(decoded.into_raw(), rgba);
+    }
 
     #[test]
     fn snapshot_kind_json_returns_json_kind_and_correct_cap() {

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -20,6 +20,13 @@ use crate::relay::{classify_request_error, relay_api_base_url_with_override, rel
 /// Maximum download size: 50 MiB. Prevents OOM from oversized responses.
 const MAX_DOWNLOAD_BYTES: u64 = 50 * 1024 * 1024;
 
+fn ensure_clipboard_png_size(encoded_len: usize) -> Result<(), String> {
+    if encoded_len > MAX_DOWNLOAD_BYTES as usize {
+        return Err("encoded clipboard image is too large".to_string());
+    }
+    Ok(())
+}
+
 /// Encode an RGBA clipboard image as PNG before returning it across IPC.
 fn encode_clipboard_image_as_png(image: arboard::ImageData<'static>) -> Result<Vec<u8>, String> {
     let width =
@@ -49,6 +56,7 @@ fn encode_clipboard_image_as_png(image: arboard::ImageData<'static>) -> Result<V
         .write_image_data(&image.bytes)
         .map_err(|error| format!("failed to encode clipboard image: {error}"))?;
     drop(writer);
+    ensure_clipboard_png_size(encoded.len())?;
     Ok(encoded)
 }
 
@@ -259,18 +267,23 @@ pub async fn copy_image_to_clipboard(
 /// This is a fallback for Linux WebKitGTK, which can receive a paste event
 /// without exposing the Wayland `image/png` offer as a `DataTransferItem`.
 #[tauri::command]
-pub async fn read_clipboard_image(app: tauri::AppHandle) -> Result<Option<Vec<u8>>, String> {
+pub async fn read_clipboard_image(app: tauri::AppHandle) -> Result<tauri::ipc::Response, String> {
     let (tx, rx) = std::sync::mpsc::sync_channel(1);
     let clipboard_app = app.clone();
     app.run_on_main_thread(move || {
-        let result = read_system_clipboard_image(&clipboard_app)
-            .and_then(|image| image.map(encode_clipboard_image_as_png).transpose());
+        let result = read_system_clipboard_image(&clipboard_app).and_then(|image| {
+            image
+                .ok_or_else(|| "clipboard contains no image".to_string())
+                .and_then(encode_clipboard_image_as_png)
+        });
         let _ = tx.send(result);
     })
     .map_err(|error| format!("main thread dispatch failed: {error}"))?;
 
-    rx.recv()
-        .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
+    let png = rx
+        .recv()
+        .map_err(|_| "clipboard result channel closed unexpectedly".to_string())??;
+    Ok(tauri::ipc::Response::new(png))
 }
 
 /// Write text to the system clipboard through the native shell.
@@ -593,6 +606,12 @@ mod tests {
             .to_rgba8();
         assert_eq!(decoded.dimensions(), (2, 1));
         assert_eq!(decoded.into_raw(), rgba);
+    }
+
+    #[test]
+    fn clipboard_encoded_png_cap_rejects_only_oversized_output() {
+        assert!(ensure_clipboard_png_size(MAX_DOWNLOAD_BYTES as usize).is_ok());
+        assert!(ensure_clipboard_png_size(MAX_DOWNLOAD_BYTES as usize + 1).is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -675,6 +675,7 @@ pub fn run() {
             cancel_media_fetch,
             release_media_fetch,
             copy_image_to_clipboard,
+            read_clipboard_image,
             copy_text_to_clipboard,
             read_clipboard_text,
             fetch_snapshot_bytes,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -746,6 +746,7 @@ pub fn run() {
             download_file,
             fetch_media_bytes,
             copy_image_to_clipboard,
+            read_clipboard_image,
             copy_text_to_clipboard,
             read_clipboard_text,
             fetch_snapshot_bytes,

--- a/desktop/src/features/messages/lib/clipboardFile.test.mjs
+++ b/desktop/src/features/messages/lib/clipboardFile.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clipboardPasteErrorMessage,
+  firstClipboardFile,
+  hasClipboardImageType,
+  shouldReadNativeClipboardImage,
+} from "./clipboardFile.ts";
+
+const screenshot = { name: "screenshot.png", type: "image/png" };
+
+test("firstClipboardFile returns a file exposed through clipboard items", () => {
+  assert.equal(
+    firstClipboardFile({
+      files: [],
+      items: [{ getAsFile: () => screenshot, kind: "file", type: "image/png" }],
+    }),
+    screenshot,
+  );
+});
+
+test("firstClipboardFile falls back to clipboard files", () => {
+  assert.equal(
+    firstClipboardFile({
+      files: [screenshot],
+      items: [{ getAsFile: () => null, kind: "string", type: "text/plain" }],
+    }),
+    screenshot,
+  );
+});
+
+test("hasClipboardImageType recognizes image MIME without a file", () => {
+  assert.equal(
+    hasClipboardImageType({ files: [], items: [], types: ["image/png"] }),
+    true,
+  );
+});
+
+test("native image fallback handles an empty WebKit paste payload", () => {
+  assert.equal(
+    shouldReadNativeClipboardImage({
+      files: [],
+      getData: () => "",
+      items: [],
+      types: [],
+    }),
+    true,
+  );
+});
+
+test("native image fallback preserves ordinary text paste", () => {
+  assert.equal(
+    shouldReadNativeClipboardImage({
+      files: [],
+      getData: (type) => (type === "text/plain" ? "hello" : ""),
+      items: [],
+      types: ["text/plain"],
+    }),
+    false,
+  );
+});
+
+test("native image fallback preserves non-image clipboard formats", () => {
+  assert.equal(
+    shouldReadNativeClipboardImage({
+      files: [],
+      getData: () => "",
+      items: [],
+      types: ["text/uri-list"],
+    }),
+    false,
+  );
+});
+
+test("native image fallback preserves HTML-only paste", () => {
+  assert.equal(
+    shouldReadNativeClipboardImage({
+      files: [],
+      getData: (type) => (type === "text/html" ? "<strong>hello</strong>" : ""),
+      items: [],
+      types: ["text/html"],
+    }),
+    false,
+  );
+});
+
+test("native image fallback prefers an advertised image in mixed clipboard data", () => {
+  assert.equal(
+    shouldReadNativeClipboardImage({
+      files: [],
+      getData: (type) => (type === "text/plain" ? "screenshot" : ""),
+      items: [],
+      types: ["text/plain", "image/png"],
+    }),
+    true,
+  );
+});
+
+test("native image fallback recognizes an image item that WebKit cannot materialize", () => {
+  assert.equal(
+    shouldReadNativeClipboardImage({
+      files: [],
+      getData: () => "",
+      items: [
+        {
+          getAsFile: () => null,
+          kind: "file",
+          type: "image/png",
+        },
+      ],
+      types: ["Files"],
+    }),
+    true,
+  );
+});
+
+test("clipboardPasteErrorMessage distinguishes empty clipboard from failures", () => {
+  assert.equal(
+    clipboardPasteErrorMessage("clipboard contains no image"),
+    "Clipboard does not contain an image.",
+  );
+  assert.equal(
+    clipboardPasteErrorMessage(new Error("IPC channel closed")),
+    "Could not paste the clipboard image.",
+  );
+});

--- a/desktop/src/features/messages/lib/clipboardFile.ts
+++ b/desktop/src/features/messages/lib/clipboardFile.ts
@@ -1,0 +1,75 @@
+type ClipboardFileItem = {
+  getAsFile(): File | null;
+  kind: string;
+  type: string;
+};
+
+type ClipboardFileSource = {
+  files?: Iterable<File> | null;
+  getData?(format: string): string;
+  items?: Iterable<ClipboardFileItem> | null;
+  types?: Iterable<string> | null;
+};
+
+/** Return a real file payload from a paste event. */
+export function firstClipboardFile(
+  clipboardData: ClipboardFileSource | null | undefined,
+): File | null {
+  if (!clipboardData) return null;
+  for (const item of clipboardData.items ?? []) {
+    if (item.kind !== "file") continue;
+    const file = item.getAsFile();
+    if (file) return file;
+  }
+  for (const file of clipboardData.files ?? []) {
+    if (file) return file;
+  }
+  return null;
+}
+
+/** Whether the browser advertised an image clipboard MIME type. */
+export function hasClipboardImageType(
+  clipboardData: ClipboardFileSource | null | undefined,
+): boolean {
+  if (!clipboardData) return false;
+  for (const type of clipboardData.types ?? []) {
+    if (type.toLowerCase().startsWith("image/")) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether paste should use the native image bridge.
+ *
+ * WebKitGTK can expose a Wayland screenshot as an empty DataTransfer. Empty
+ * browser payloads have no useful default paste behavior, so they may safely
+ * fall back to the native clipboard. Non-empty text/HTML stays on the editor
+ * paste path.
+ */
+export function shouldReadNativeClipboardImage(
+  clipboardData: ClipboardFileSource | null | undefined,
+): boolean {
+  if (!clipboardData || firstClipboardFile(clipboardData)) return false;
+  for (const item of clipboardData.items ?? []) {
+    if (item.kind === "file" && item.type.toLowerCase().startsWith("image/")) {
+      return true;
+    }
+  }
+  let hasAdvertisedType = false;
+  for (const type of clipboardData.types ?? []) {
+    hasAdvertisedType = true;
+    if (type.toLowerCase().startsWith("image/")) return true;
+  }
+  if (hasAdvertisedType) return false;
+  const plainText = clipboardData.getData?.("text/plain") ?? "";
+  const html = clipboardData.getData?.("text/html") ?? "";
+  return plainText.length === 0 && html.length === 0;
+}
+
+/** Convert native clipboard failures into concise composer feedback. */
+export function clipboardPasteErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return message.toLowerCase().includes("clipboard contains no image")
+    ? "Clipboard does not contain an image."
+    : "Could not paste the clipboard image.";
+}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { EditorContent } from "@tiptap/react";
+import { toast } from "sonner";
 import { useChannelLinks } from "@/features/messages/lib/useChannelLinks";
 import { handleAgentSnapshotPaste } from "@/features/messages/lib/agentSnapshotClipboard";
 import { useComposerAutofocus } from "@/features/messages/lib/useComposerAutofocus";
@@ -42,6 +43,11 @@ import { useTypingBroadcast } from "@/features/messages/useTypingBroadcast";
 import { getBuzzCodeBlockClipboardText } from "@/shared/lib/codeBlockClipboard";
 import { cn } from "@/shared/lib/cn";
 import { readClipboardImage } from "@/shared/api/tauriMedia";
+import {
+  clipboardPasteErrorMessage,
+  firstClipboardFile,
+  shouldReadNativeClipboardImage,
+} from "@/features/messages/lib/clipboardFile";
 import { ChannelAutocomplete } from "./ChannelAutocomplete";
 import { ComposerReplyEditBanner } from "./ComposerReplyEditBanner";
 import { ComposerAttachments, DropZoneOverlay } from "./ComposerAttachments";
@@ -735,6 +741,23 @@ function MessageComposerImpl({
   // ── Media paste + ⌘K link shortcut via Tiptap editorProps ──────────
   const uploadFileRef = React.useRef(media.uploadFile);
   uploadFileRef.current = media.uploadFile;
+  const uploadNativeClipboardImage = React.useCallback(async () => {
+    try {
+      const bytes = await readClipboardImage();
+      // Copy into a browser-owned ArrayBuffer: Tauri's Uint8Array is typed as
+      // ArrayBufferLike, while File accepts ArrayBuffer.
+      const imageBytes = new Uint8Array(bytes.byteLength);
+      imageBytes.set(bytes);
+      await uploadFileRef.current(
+        new File([imageBytes.buffer], "clipboard-image.png", {
+          type: "image/png",
+        }),
+      );
+    } catch (error) {
+      toast.error(clipboardPasteErrorMessage(error));
+    }
+  }, []);
+
   React.useEffect(() => {
     if (!richText.editor) return;
     richText.editor.setOptions({
@@ -745,43 +768,18 @@ function MessageComposerImpl({
           // Any actual file (image, video, document, …) pastes as an
           // attachment. String/text items have kind "string", so plain-text
           // and code-block paste fall through to the handlers below.
-          const items = Array.from(event.clipboardData?.items ?? []);
-          const mediaItem = items.find((item) => item.kind === "file");
-          if (mediaItem) {
-            const file = mediaItem.getAsFile();
-            if (file) {
-              void uploadFileRef.current(file);
-            }
+          const mediaFile = firstClipboardFile(event.clipboardData);
+          if (mediaFile) {
+            void uploadFileRef.current(mediaFile);
             return true;
           }
-          // WebKitGTK can dispatch a paste event without turning a Wayland
-          // image offer into a `DataTransferItem`. Fall back to the native
-          // clipboard only when the webview did not expose normal text, so
-          // ordinary text and code-block paste keep their existing behavior.
-          const hasTextItem = items.some((item) =>
-            item.type.startsWith("text/"),
-          );
-          const hasImageMime = items.some((item) =>
-            item.type.startsWith("image/"),
-          );
-          if ((items.length === 0 && !hasTextItem) || hasImageMime) {
+          // WebKitGTK can withhold both the File and MIME type for a valid
+          // Wayland screenshot. Empty browser payloads have no useful default
+          // paste behavior, so ask the native clipboard while preserving
+          // ordinary non-empty text/HTML paste.
+          if (shouldReadNativeClipboardImage(event.clipboardData)) {
             event.preventDefault();
-            void readClipboardImage()
-              .then((bytes) => {
-                if (!bytes) return;
-                // Copy into a browser-owned ArrayBuffer: Tauri's Uint8Array
-                // is typed as ArrayBufferLike, while File accepts ArrayBuffer.
-                const imageBytes = new Uint8Array(bytes.byteLength);
-                imageBytes.set(bytes);
-                return uploadFileRef.current(
-                  new File([imageBytes.buffer], "clipboard-image.png", {
-                    type: "image/png",
-                  }),
-                );
-              })
-              // A non-image clipboard is normal; leave it to the existing
-              // webview paste path rather than surfacing an upload error.
-              .catch(() => undefined);
+            void uploadNativeClipboardImage();
             return true;
           }
 
@@ -830,7 +828,30 @@ function MessageComposerImpl({
         },
       },
     });
-  }, [media.setPendingImeta, richText.editor, scrollComposerToBottom]);
+  }, [
+    media.setPendingImeta,
+    richText.editor,
+    scrollComposerToBottom,
+    uploadNativeClipboardImage,
+  ]);
+
+  // WebKitGTK can consume image clipboard events before ProseMirror reaches
+  // editorProps.handlePaste. Intercept native-image candidates at the editor
+  // DOM capture phase.
+  React.useEffect(() => {
+    const editor = richText.editor;
+    if (!editor) return;
+    const handleNativeImagePaste = (event: ClipboardEvent) => {
+      if (!shouldReadNativeClipboardImage(event.clipboardData)) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      void uploadNativeClipboardImage();
+    };
+    const dom = editor.view.dom;
+    dom.addEventListener("paste", handleNativeImagePaste, true);
+    return () => dom.removeEventListener("paste", handleNativeImagePaste, true);
+  }, [richText.editor, uploadNativeClipboardImage]);
+
   // ── Send button state ───────────────────────────────────────────────
   const sendDisabled =
     composerDisabled ||

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -41,6 +41,7 @@ import { useComposerSpoilerParticles } from "@/features/messages/lib/useComposer
 import { useTypingBroadcast } from "@/features/messages/useTypingBroadcast";
 import { getBuzzCodeBlockClipboardText } from "@/shared/lib/codeBlockClipboard";
 import { cn } from "@/shared/lib/cn";
+import { readClipboardImage } from "@/shared/api/tauriMedia";
 import { ChannelAutocomplete } from "./ChannelAutocomplete";
 import { ComposerReplyEditBanner } from "./ComposerReplyEditBanner";
 import { ComposerAttachments, DropZoneOverlay } from "./ComposerAttachments";
@@ -753,6 +754,37 @@ function MessageComposerImpl({
             }
             return true;
           }
+          // WebKitGTK can dispatch a paste event without turning a Wayland
+          // image offer into a `DataTransferItem`. Fall back to the native
+          // clipboard only when the webview did not expose normal text, so
+          // ordinary text and code-block paste keep their existing behavior.
+          const hasTextItem = items.some((item) =>
+            item.type.startsWith("text/"),
+          );
+          const hasImageMime = items.some((item) =>
+            item.type.startsWith("image/"),
+          );
+          if ((items.length === 0 && !hasTextItem) || hasImageMime) {
+            event.preventDefault();
+            void readClipboardImage()
+              .then((bytes) => {
+                if (!bytes) return;
+                // Copy into a browser-owned ArrayBuffer: Tauri's Uint8Array
+                // is typed as ArrayBufferLike, while File accepts ArrayBuffer.
+                const imageBytes = new Uint8Array(bytes.byteLength);
+                imageBytes.set(bytes);
+                return uploadFileRef.current(
+                  new File([imageBytes.buffer], "clipboard-image.png", {
+                    type: "image/png",
+                  }),
+                );
+              })
+              // A non-image clipboard is normal; leave it to the existing
+              // webview paste path rather than surfacing an upload error.
+              .catch(() => undefined);
+            return true;
+          }
+
           // --- Buzz code-block paste ---
           // The code block copy button writes a small Buzz marker alongside
           // plain text. Use it to paste back as a literal code block so Markdown

--- a/desktop/src/features/messages/ui/useComposerPasteHandler.ts
+++ b/desktop/src/features/messages/ui/useComposerPasteHandler.ts
@@ -1,7 +1,14 @@
 import * as React from "react";
 import type { Editor } from "@tiptap/react";
+import { toast } from "sonner";
 import { handleAgentSnapshotPaste } from "@/features/messages/lib/agentSnapshotClipboard";
+import {
+  clipboardPasteErrorMessage,
+  firstClipboardFile,
+  shouldReadNativeClipboardImage,
+} from "@/features/messages/lib/clipboardFile";
 import type { BlobDescriptor } from "@/shared/api/tauri";
+import { readClipboardImage } from "@/shared/api/tauriMedia";
 import {
   hasMentionClipboardHtml,
   normalizeMentionClipboardHtml,
@@ -18,6 +25,23 @@ export function useComposerPasteHandler(options: {
 }) {
   const uploadFileRef = React.useRef(options.uploadFile);
   uploadFileRef.current = options.uploadFile;
+  const uploadNativeClipboardImage = React.useCallback(async () => {
+    try {
+      const bytes = await readClipboardImage();
+      // Copy into a browser-owned ArrayBuffer: Tauri's Uint8Array is typed as
+      // ArrayBufferLike, while File accepts ArrayBuffer.
+      const imageBytes = new Uint8Array(bytes.byteLength);
+      imageBytes.set(bytes);
+      await uploadFileRef.current(
+        new File([imageBytes.buffer], "clipboard-image.png", {
+          type: "image/png",
+        }),
+      );
+    } catch (error) {
+      toast.error(clipboardPasteErrorMessage(error));
+    }
+  }, []);
+
   React.useEffect(() => {
     const editor = options.editor;
     if (!editor) return;
@@ -25,12 +49,14 @@ export function useComposerPasteHandler(options: {
       editorProps: {
         ...editor.options.editorProps,
         handlePaste: (view, event) => {
-          const mediaItem = Array.from(event.clipboardData?.items ?? []).find(
-            (item) => item.kind === "file",
-          );
-          if (mediaItem) {
-            const file = mediaItem.getAsFile();
-            if (file) void uploadFileRef.current(file);
+          const mediaFile = firstClipboardFile(event.clipboardData);
+          if (mediaFile) {
+            void uploadFileRef.current(mediaFile);
+            return true;
+          }
+          if (shouldReadNativeClipboardImage(event.clipboardData)) {
+            event.preventDefault();
+            void uploadNativeClipboardImage();
             return true;
           }
           const codeBlockText = getBuzzCodeBlockClipboardText(
@@ -69,5 +95,27 @@ export function useComposerPasteHandler(options: {
         },
       },
     });
-  }, [options.editor, options.scrollToBottom, options.setPendingImeta]);
+  }, [
+    options.editor,
+    options.scrollToBottom,
+    options.setPendingImeta,
+    uploadNativeClipboardImage,
+  ]);
+
+  // WebKitGTK can consume image clipboard events before ProseMirror reaches
+  // editorProps.handlePaste. Intercept native-image candidates at the editor
+  // DOM capture phase.
+  React.useEffect(() => {
+    const editor = options.editor;
+    if (!editor) return;
+    const handleNativeImagePaste = (event: ClipboardEvent) => {
+      if (!shouldReadNativeClipboardImage(event.clipboardData)) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      void uploadNativeClipboardImage();
+    };
+    const dom = editor.view.dom;
+    dom.addEventListener("paste", handleNativeImagePaste, true);
+    return () => dom.removeEventListener("paste", handleNativeImagePaste, true);
+  }, [options.editor, uploadNativeClipboardImage]);
 }

--- a/desktop/src/shared/api/tauriMedia.test.mjs
+++ b/desktop/src/shared/api/tauriMedia.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { clipboardArrayBufferToBytes } from "./tauriMedia.ts";
+
+test("clipboardArrayBufferToBytes preserves raw PNG IPC bytes", () => {
+  const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+  assert.deepEqual([...clipboardArrayBufferToBytes(png.buffer)], [...png]);
+});

--- a/desktop/src/shared/api/tauriMedia.ts
+++ b/desktop/src/shared/api/tauriMedia.ts
@@ -89,6 +89,15 @@ export async function readTextFromSystemClipboard(): Promise<string> {
   return clipboard.readText();
 }
 
+/**
+ * Read a system clipboard image through the native shell. WebKitGTK does not
+ * always expose a Wayland image offer through `ClipboardEvent.clipboardData`.
+ */
+export async function readClipboardImage(): Promise<Uint8Array | null> {
+  const bytes = await invokeTauri<number[] | null>("read_clipboard_image", {});
+  return bytes === null ? null : new Uint8Array(bytes);
+}
+
 /** Write text through the native clipboard after an asynchronous workflow. */
 export async function copyTextToSystemClipboard(
   text: string,

--- a/desktop/src/shared/api/tauriMedia.ts
+++ b/desktop/src/shared/api/tauriMedia.ts
@@ -142,6 +142,15 @@ export async function readTextFromSystemClipboard(): Promise<string> {
   return clipboard.readText();
 }
 
+/**
+ * Read a system clipboard image through the native shell. WebKitGTK does not
+ * always expose a Wayland image offer through `ClipboardEvent.clipboardData`.
+ */
+export async function readClipboardImage(): Promise<Uint8Array | null> {
+  const bytes = await invokeTauri<number[] | null>("read_clipboard_image", {});
+  return bytes === null ? null : new Uint8Array(bytes);
+}
+
 /** Write text through the native clipboard after an asynchronous workflow. */
 export async function copyTextToSystemClipboard(
   text: string,

--- a/desktop/src/shared/api/tauriMedia.ts
+++ b/desktop/src/shared/api/tauriMedia.ts
@@ -128,7 +128,7 @@ export async function fetchMediaBytes(
 /** Read plain text without depending on embedded-webview clipboard grants. */
 export async function readTextFromSystemClipboard(): Promise<string> {
   // E2E installs Tauri's mocked IPC surface in a browser page, where the SDK's
-  // `isTauri()` marker remains false. Exercise the packaged-app command path in
+  // isTauri() marker remains false. Exercise the packaged-app command path in
   // that build so tests detect accidental regressions to permission-gated DOM
   // clipboard reads.
   if (isTauri() || import.meta.env.MODE === "e2e") {
@@ -142,13 +142,18 @@ export async function readTextFromSystemClipboard(): Promise<string> {
   return clipboard.readText();
 }
 
+/** Convert Tauri's raw binary IPC response into upload-ready bytes. */
+export function clipboardArrayBufferToBytes(buffer: ArrayBuffer): Uint8Array {
+  return new Uint8Array(buffer);
+}
+
 /**
  * Read a system clipboard image through the native shell. WebKitGTK does not
  * always expose a Wayland image offer through `ClipboardEvent.clipboardData`.
  */
-export async function readClipboardImage(): Promise<Uint8Array | null> {
-  const bytes = await invokeTauri<number[] | null>("read_clipboard_image", {});
-  return bytes === null ? null : new Uint8Array(bytes);
+export async function readClipboardImage(): Promise<Uint8Array> {
+  const buffer = await invokeTauri<ArrayBuffer>("read_clipboard_image", {});
+  return clipboardArrayBufferToBytes(buffer);
 }
 
 /** Write text through the native clipboard after an asynchronous workflow. */

--- a/desktop/src/shared/api/tauriMedia.ts
+++ b/desktop/src/shared/api/tauriMedia.ts
@@ -75,7 +75,7 @@ export async function fetchMediaBytes(
 /** Read plain text without depending on embedded-webview clipboard grants. */
 export async function readTextFromSystemClipboard(): Promise<string> {
   // E2E installs Tauri's mocked IPC surface in a browser page, where the SDK's
-  // `isTauri()` marker remains false. Exercise the packaged-app command path in
+  // isTauri() marker remains false. Exercise the packaged-app command path in
   // that build so tests detect accidental regressions to permission-gated DOM
   // clipboard reads.
   if (isTauri() || import.meta.env.MODE === "e2e") {
@@ -89,13 +89,18 @@ export async function readTextFromSystemClipboard(): Promise<string> {
   return clipboard.readText();
 }
 
+/** Convert Tauri's raw binary IPC response into upload-ready bytes. */
+export function clipboardArrayBufferToBytes(buffer: ArrayBuffer): Uint8Array {
+  return new Uint8Array(buffer);
+}
+
 /**
  * Read a system clipboard image through the native shell. WebKitGTK does not
  * always expose a Wayland image offer through `ClipboardEvent.clipboardData`.
  */
-export async function readClipboardImage(): Promise<Uint8Array | null> {
-  const bytes = await invokeTauri<number[] | null>("read_clipboard_image", {});
-  return bytes === null ? null : new Uint8Array(bytes);
+export async function readClipboardImage(): Promise<Uint8Array> {
+  const buffer = await invokeTauri<ArrayBuffer>("read_clipboard_image", {});
+  return clipboardArrayBufferToBytes(buffer);
 }
 
 /** Write text through the native clipboard after an asynchronous workflow. */


### PR DESCRIPTION
Fixes #4592.

## Summary

- Fall back to the native clipboard when Linux WebKitGTK does not expose a pasted image as a `DataTransferItem`.
- Encode the native RGBA image as PNG and feed it into the existing composer attachment/upload path.
- Preserve ordinary text, HTML, code-block, and browser-exposed file paste behavior.

## Validation

- `pnpm --dir desktop typecheck`
- `biome check` on the changed TypeScript files
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml --locked --lib`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --locked --lib clipboard_rgba_is_encoded_as_a_valid_png`
- Manual verification on CachyOS / COSMIC Wayland / AMD RX 9070 XT: copying a PNG to the system clipboard, pasting it in the patched Buzz composer, and sending the resulting image message succeeds.

Related: #2338
