### PR TITLE
fix(countdown-bot): harden WSS relay sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           filters: |
             rust:
               - 'crates/**'
+              - 'examples/countdown-bot/**'
               - 'migrations/**'
               - 'schema/**'
               - 'Cargo.toml'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,12 +1815,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "buzz-sdk",
+ "buzz-ws-client",
  "futures-util",
  "nostr",
+ "rustls",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "tracing",
+ "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Justfile
+++ b/Justfile
@@ -292,6 +292,7 @@ test-unit:
         cargo nextest run -p buzz-core -p buzz-auth --lib
         cargo nextest run -p buzz-voice --lib
         cargo nextest run -p buzz-cli
+        cargo nextest run -p countdown-bot
         # buzz-db migrator/lint tests: pure SQL-parsing unit tests (no infra).
         # They guard the embedded-migrator invariant (exactly the consolidated
         # 0001; cutover/backfill stays an operator script, not startup state)

--- a/TESTING.md
+++ b/TESTING.md
@@ -206,8 +206,9 @@ AGENT_PUBKEY=$(echo "$AGENT_GEN" | awk '/Public key:/ {print $3}')
 buzz channels add-member --channel "$CHANNEL" --pubkey "$AGENT_PUBKEY" --role member
 
 # 4. Switch to the agent identity and start it.
-#    buzz-acp wants ws:// (not http://). If you set BUZZ_RELAY_URL to an
-#    http:// URL in step 3, set the ws:// equivalent here — same host/port.
+#    buzz-acp requires a WebSocket URL: use ws:// for a local plaintext relay
+#    and wss:// for a hosted TLS relay. Map http:// -> ws:// and
+#    https:// -> wss:// while keeping the same host/port.
 export BUZZ_PRIVATE_KEY="$AGENT_SK"
 export BUZZ_RELAY_URL=ws://localhost:3000   # match step 3 (e.g. ws://localhost:3030 if overridden)
 export BUZZ_ACP_RESPOND_TO=anyone           # default is owner-only; opens the gate for testing
@@ -299,7 +300,9 @@ CLI-side, only two matter for testing:
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `relay error 500` or `400: restricted: not a channel member` after a code change | Stale binary | Rebuild and re-export `PATH`; or `cargo run` directly |
+| CLI or relay behavior does not reflect a local code change | The shell is running an older installed binary | Run `type -a buzz buzz-relay`; use `cargo run -p buzz-cli -- …` or `cargo run -p buzz-relay` to run the workspace code directly |
+| `400: restricted: not a channel member` | The current signing identity is not an active member of the private channel | Have a channel admin run `buzz channels add-member --channel "$CHANNEL" --pubkey "$PUBKEY" --role member`; relay admission alone does not grant channel membership |
+| `relay error 500` | The relay hit an internal error | Inspect the relay log for the recorded cause; the HTTP status alone does not identify it |
 | `Address already in use` on relay start (os error 48 on macOS, 98 on Linux) | Another relay (or stale process) holding `:3000` / `:8080` / `:9102` (or your override ports) | The panic line names the failing port — read it first. Then `lsof -iTCP:3000,8080,9102 -sTCP:LISTEN` (or your override equivalents). Kill the offender (`pkill -f buzz-relay`) or use the port-override block in step 3. If you already overrode and *still* collide, a prior reviewer left a relay running on the same alt ports — kill it or pick fresh ports |
 | `auth_error: BUZZ_PRIVATE_KEY is required` | Env not exported into the CLI's shell | `export BUZZ_PRIVATE_KEY=...` (or pass `--private-key`) |
 | `auth_error: BUZZ_AUTH_TAG verification failed … signature verification failed` | A stale `BUZZ_AUTH_TAG` inherited from a parent shell. The local dev relay rejects it. | `unset BUZZ_AUTH_TAG` (see the scrub block in step 1) |

--- a/examples/countdown-bot/Cargo.toml
+++ b/examples/countdown-bot/Cargo.toml
@@ -6,10 +6,17 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-futures-util = { workspace = true }
 nostr = { workspace = true }
 serde_json = { workspace = true }
 buzz-sdk = { path = "../../crates/buzz-sdk" }
+buzz-ws-client = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "signal"] }
-tokio-tungstenite = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+futures-util = { workspace = true }
+tokio-tungstenite = { workspace = true }

--- a/examples/countdown-bot/README.md
+++ b/examples/countdown-bot/README.md
@@ -13,6 +13,9 @@ It demonstrates that Buzz participants do not have to be LLM agents. Any
 process that can hold a Nostr key, answer NIP-42 auth, publish a kind `0`
 profile, subscribe to events, and publish kind `9` channel messages can be a bot.
 
+`BUZZ_RELAY_URL` must be a WebSocket URL. Use `ws://localhost:3000` for the
+local plaintext relay and `wss://relay.example.com` for a hosted TLS relay.
+
 On startup it publishes a profile named **Countdown Bot** with a small embedded
 SVG clock icon, then best-effort publishes a NIP-29 `kind:9000` self-add with
 `role=bot`. That channel membership is what makes the bot show up in the
@@ -80,6 +83,14 @@ self-add to open channels as a `bot` member on startup. For private channels,
 an owner/admin must add the bot pubkey to the channel membership before expecting
 it to appear in members, resolve in mention autocomplete, or read/write messages.
 
+With `buzz` configured to use an owner/admin identity, add the pubkey that the
+bot prints at startup:
+
+```bash
+buzz channels add-member --channel "$BUZZ_CHANNEL_ID" \
+  --pubkey <countdown-bot-pubkey> --role bot
+```
+
 ## Try it locally
 
 1. Start Buzz:
@@ -111,5 +122,14 @@ it to appear in members, resolve in mention autocomplete, or read/write messages
   for the bot pubkey. The Buzz UI adds that tag when the bot is selected from
   mention autocomplete.
 - The bot ignores its own messages to avoid feedback loops.
+- The bot waits for the matching relay `OK` before logging a profile or reply as
+  published. A rejected `OK` reports the relay's reason.
+- Transient connection failures reconnect after 1, 2, 4, then at most 8 seconds,
+  re-authenticate, and resubscribe from a conservative `EOSE`-committed cursor
+  with 60 seconds of overlap. A bounded event-ID window suppresses overlap
+  replays.
+- A subscription `CLOSED` with `restricted: not a channel member` or
+  `restricted: channel access revoked` is terminal. Add or restore channel
+  membership, then restart the bot.
 - The example uses direct WebSocket + NIP-42 instead of MCP so the protocol path
   is easy to inspect in one small file.

--- a/examples/countdown-bot/src/main.rs
+++ b/examples/countdown-bot/src/main.rs
@@ -12,16 +12,15 @@
 //!   signed by the owner/agent key. On relays that allow NIP-OA membership,
 //!   the bot can connect because its owner is already a relay member.
 
-use std::time::Duration;
+use std::{
+    collections::{HashSet, VecDeque},
+    time::Duration,
+};
 
 use anyhow::{anyhow, bail, Context, Result};
-use futures_util::{SinkExt, StreamExt};
-use nostr::{
-    Alphabet, Event, EventBuilder, Filter, JsonUtil, Keys, Kind, RelayUrl, SingleLetterTag, Tag,
-};
-use serde_json::{json, Value};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
-use url::Url as WsUrl;
+use buzz_ws_client::{NostrWsConnection, RelayMessage, WsClientError};
+use nostr::{Alphabet, Event, EventBuilder, Filter, Keys, Kind, SingleLetterTag, Tag};
+use serde_json::json;
 
 const DEFAULT_RELAY_URL: &str = "ws://localhost:3000";
 const SUBSCRIPTION_ID: &str = "countdown-bot";
@@ -29,46 +28,184 @@ const BOT_NAME: &str = "countdown-bot";
 const BOT_DISPLAY_NAME: &str = "Countdown Bot";
 const BOT_ABOUT: &str =
     "A tiny non-AI Buzz reference bot that replies to !countdown and countdown-style !fib.";
+const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(8);
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(60);
+const REPLAY_WINDOW: usize = 4_096;
+const REPLAY_OVERLAP_SECONDS: u64 = 60;
 const BOT_ICON_DATA_URL: &str = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Crect width='128' height='128' rx='28' fill='%23131622'/%3E%3Ccircle cx='64' cy='64' r='42' fill='none' stroke='%237dd3fc' stroke-width='10'/%3E%3Cpath d='M64 32v32l22 14' fill='none' stroke='%23facc15' stroke-width='10' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M42 96h44' stroke='%23a78bfa' stroke-width='8' stroke-linecap='round'/%3E%3C/svg%3E";
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    install_crypto_provider();
+    tracing_subscriber::fmt::init();
     let config = Config::from_env()?;
 
-    eprintln!(
-        "countdown-bot pubkey: {}",
-        config.bot_keys.public_key().to_hex()
+    tracing::info!(
+        bot_pubkey = %config.bot_keys.public_key().to_hex(),
+        "countdown bot identity"
     );
-    eprintln!("connecting to {}", config.relay_url);
+    tracing::info!(relay_url = %config.relay_url, "connecting to relay");
 
-    let mut ws = connect_and_authenticate(&config).await?;
-    publish_profile(&mut ws, &config).await?;
-    announce_channel_membership(&mut ws, &config).await?;
-    subscribe_to_channel(&mut ws, &config.channel_id).await?;
-
-    let started_at = nostr::Timestamp::now();
-
-    eprintln!(
-        "listening in channel {} for !countdown, !fib, and @mention commands",
-        config.channel_id
+    tracing::info!(
+        channel_id = %config.channel_id,
+        "listening for !countdown, !fib, and @mention commands"
     );
 
-    loop {
-        tokio::select! {
-            _ = tokio::signal::ctrl_c() => {
-                eprintln!("shutting down");
-                return Ok(());
-            }
-            next = ws.next() => {
-                let Some(message) = next else { bail!("relay closed the WebSocket"); };
-                match message? {
-                    Message::Text(text) => handle_relay_text(&mut ws, &config, started_at, &text).await?,
-                    Message::Ping(bytes) => ws.send(Message::Pong(bytes)).await?,
-                    Message::Close(frame) => bail!("relay closed connection: {frame:?}"),
-                    _ => {}
-                }
+    run_bot(&config).await
+}
+
+fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn is_terminal_membership_closed(subscription_id: &str, message: &str) -> bool {
+    subscription_id == SUBSCRIPTION_ID
+        && matches!(
+            message,
+            "restricted: not a channel member" | "restricted: channel access revoked"
+        )
+}
+
+#[derive(Debug)]
+struct SessionFailure {
+    terminal: bool,
+    error: anyhow::Error,
+}
+
+struct ReplayGuard {
+    capacity: usize,
+    order: VecDeque<String>,
+    ids: HashSet<String>,
+}
+
+impl ReplayGuard {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            order: VecDeque::with_capacity(capacity),
+            ids: HashSet::with_capacity(capacity),
+        }
+    }
+
+    fn contains(&self, event_id: &str) -> bool {
+        self.ids.contains(event_id)
+    }
+
+    fn record(&mut self, event_id: String) {
+        if self.capacity == 0 || !self.ids.insert(event_id.clone()) {
+            return;
+        }
+        self.order.push_back(event_id);
+        if self.order.len() > self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.ids.remove(&oldest);
             }
         }
+    }
+}
+
+impl SessionFailure {
+    fn retry(error: impl Into<anyhow::Error>) -> Self {
+        Self {
+            terminal: false,
+            error: error.into(),
+        }
+    }
+
+    fn terminal(error: impl Into<anyhow::Error>) -> Self {
+        Self {
+            terminal: true,
+            error: error.into(),
+        }
+    }
+}
+
+struct BotState {
+    started_at: nostr::Timestamp,
+    subscription_since: nostr::Timestamp,
+    seen_event_ids: ReplayGuard,
+    pending_reply: Option<PendingReply>,
+    profile_published: bool,
+    membership_announced: bool,
+}
+
+struct PendingReply {
+    input_event_id: String,
+    event: Event,
+}
+
+impl BotState {
+    fn new() -> Self {
+        let started_at = nostr::Timestamp::now();
+        Self {
+            started_at,
+            subscription_since: started_at,
+            seen_event_ids: ReplayGuard::new(REPLAY_WINDOW),
+            pending_reply: None,
+            profile_published: false,
+            membership_announced: false,
+        }
+    }
+
+    fn observe_subscription_event(
+        &mut self,
+        caught_up: bool,
+        created_at: nostr::Timestamp,
+        observed_at: nostr::Timestamp,
+    ) {
+        if caught_up {
+            self.advance_cursor(created_at.min(observed_at));
+        }
+    }
+
+    fn finish_catchup(&mut self, session_started_at: nostr::Timestamp) {
+        self.advance_cursor(session_started_at);
+    }
+
+    fn advance_cursor(&mut self, timestamp: nostr::Timestamp) {
+        let with_overlap =
+            nostr::Timestamp::from(timestamp.as_secs().saturating_sub(REPLAY_OVERLAP_SECONDS));
+        self.subscription_since = self.subscription_since.max(with_overlap);
+    }
+
+    fn subscription_since(&self) -> nostr::Timestamp {
+        self.subscription_since
+    }
+}
+
+async fn run_bot(config: &Config) -> Result<()> {
+    let mut state = BotState::new();
+    let mut reconnect_delay = INITIAL_RECONNECT_DELAY;
+
+    loop {
+        let result = tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                tracing::info!("shutting down");
+                return Ok(());
+            }
+            result = run_session(config, &mut state) => result,
+        };
+
+        if let Err(failure) = result {
+            if failure.terminal {
+                return Err(failure.error);
+            }
+            tracing::warn!(
+                error = %failure.error,
+                reconnect_delay_seconds = reconnect_delay.as_secs(),
+                "relay session failed"
+            );
+        }
+
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                tracing::info!("shutting down");
+                return Ok(());
+            }
+            _ = tokio::time::sleep(reconnect_delay) => {}
+        }
+        reconnect_delay = reconnect_delay.saturating_mul(2).min(MAX_RECONNECT_DELAY);
     }
 }
 
@@ -83,6 +220,7 @@ impl Config {
     fn from_env() -> Result<Self> {
         let relay_url =
             std::env::var("BUZZ_RELAY_URL").unwrap_or_else(|_| DEFAULT_RELAY_URL.to_string());
+        validate_relay_url(&relay_url)?;
         let channel_id = required_env("BUZZ_CHANNEL_ID")?;
         let bot_keys = Keys::parse(&required_env("BUZZ_BOT_PRIVATE_KEY")?)
             .context("BUZZ_BOT_PRIVATE_KEY must be an nsec or hex private key")?;
@@ -103,7 +241,7 @@ impl Config {
 
                 let owner = buzz_sdk::nip_oa::verify_auth_tag(&tag_json, &bot_keys.public_key())
                     .context("BUZZ_AUTH_TAG is not valid for BUZZ_BOT_PRIVATE_KEY")?;
-                eprintln!("owner-attested auth tag verified; owner={}", owner.to_hex());
+                tracing::info!(owner_pubkey = %owner.to_hex(), "owner-attested auth tag verified");
                 Some(buzz_sdk::nip_oa::parse_auth_tag(&tag_json)?)
             }
             other => {
@@ -120,112 +258,184 @@ impl Config {
     }
 }
 
-type Ws =
-    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+async fn run_session(config: &Config, state: &mut BotState) -> Result<(), SessionFailure> {
+    let session_started_at = nostr::Timestamp::now();
+    let mut caught_up = false;
+    let mut connection = NostrWsConnection::connect_authenticated(
+        &config.relay_url,
+        &config.bot_keys,
+        config.owner_auth_tag.as_ref(),
+    )
+    .await
+    .map_err(|error| match error {
+        WsClientError::AuthFailed(_) => SessionFailure::terminal(anyhow!(error)),
+        _ => SessionFailure::retry(anyhow!(error)),
+    })?;
 
-async fn connect_and_authenticate(config: &Config) -> Result<Ws> {
-    let parsed = WsUrl::parse(&config.relay_url)?;
-    let (mut ws, _) = connect_async(parsed.as_str()).await?;
+    if !state.profile_published {
+        publish_profile(&mut connection, config).await?;
+        state.profile_published = true;
+    }
+    if !state.membership_announced {
+        announce_channel_membership(&mut connection, config).await?;
+        state.membership_announced = true;
+    }
+    send_pending_reply(&mut connection, state).await?;
+    subscribe_to_channel(
+        &mut connection,
+        &config.channel_id,
+        state.subscription_since(),
+    )
+    .await?;
 
-    let challenge = wait_for_auth_challenge(&mut ws).await?;
-    let auth_event = build_auth_event(config, &challenge)?;
-    let auth_event_id = auth_event.id.to_hex();
+    loop {
+        let message = match connection.next_event(RECEIVE_TIMEOUT).await {
+            Ok(message) => message,
+            Err(WsClientError::Timeout) => continue,
+            Err(error) => return Err(SessionFailure::retry(anyhow!(error))),
+        };
 
-    send_json(&mut ws, json!(["AUTH", auth_event])).await?;
-    wait_for_ok(&mut ws, &auth_event_id).await?;
-    Ok(ws)
-}
-
-fn build_auth_event(config: &Config, challenge: &str) -> Result<Event> {
-    let relay_url: RelayUrl = RelayUrl::parse(&config.relay_url)?;
-    if let Some(auth_tag) = &config.owner_auth_tag {
-        let tags = vec![
-            Tag::parse(["relay", config.relay_url.as_str()])?,
-            Tag::parse(["challenge", challenge])?,
-            auth_tag.clone(),
-        ];
-        Ok(EventBuilder::new(Kind::Authentication, "")
-            .tags(tags)
-            .sign_with_keys(&config.bot_keys)?)
-    } else {
-        Ok(EventBuilder::auth(challenge, relay_url).sign_with_keys(&config.bot_keys)?)
+        match message {
+            RelayMessage::Event {
+                subscription_id,
+                event,
+            } if subscription_id == SUBSCRIPTION_ID => {
+                state.observe_subscription_event(
+                    caught_up,
+                    event.created_at,
+                    nostr::Timestamp::now(),
+                );
+                if !state.seen_event_ids.contains(&event.id.to_hex()) {
+                    maybe_reply(&mut connection, config, state, &event).await?;
+                }
+            }
+            RelayMessage::Eose { subscription_id } if subscription_id == SUBSCRIPTION_ID => {
+                state.finish_catchup(session_started_at);
+                caught_up = true;
+            }
+            RelayMessage::Closed {
+                subscription_id,
+                message,
+            } if is_terminal_membership_closed(&subscription_id, &message) => {
+                return Err(SessionFailure::terminal(anyhow!(
+                    "relay closed channel subscription: {message}; add the bot pubkey as a channel member/admin-invited bot and restart"
+                )));
+            }
+            RelayMessage::Closed {
+                subscription_id,
+                message,
+            } if subscription_id == SUBSCRIPTION_ID => {
+                return Err(SessionFailure::retry(anyhow!(
+                    "relay closed channel subscription: {message}"
+                )));
+            }
+            RelayMessage::Notice { message } => {
+                tracing::warn!(relay_message = %message, "relay notice");
+            }
+            RelayMessage::Auth { .. } => {
+                return Err(SessionFailure::retry(anyhow!(
+                    "relay requested authentication again"
+                )));
+            }
+            RelayMessage::Ok(ok) => {
+                tracing::debug!(event_id = %ok.event_id, "ignored unsolicited relay OK");
+            }
+            RelayMessage::Event { .. }
+            | RelayMessage::Closed { .. }
+            | RelayMessage::Eose { .. }
+            | RelayMessage::Count { .. } => {}
+        }
     }
 }
 
-async fn publish_profile(ws: &mut Ws, config: &Config) -> Result<()> {
+async fn publish_profile(
+    connection: &mut NostrWsConnection,
+    config: &Config,
+) -> Result<(), SessionFailure> {
     let builder = buzz_sdk::builders::build_profile(
         Some(BOT_DISPLAY_NAME),
         Some(BOT_NAME),
         Some(BOT_ICON_DATA_URL),
         Some(BOT_ABOUT),
         None,
-    )?;
-    let profile_event = builder.sign_with_keys(&config.bot_keys)?;
-    let profile_event_id = profile_event.id.to_hex();
-
-    send_json(ws, json!(["EVENT", profile_event])).await?;
-    wait_for_ok(ws, &profile_event_id).await?;
-    eprintln!("published kind:0 profile for {BOT_DISPLAY_NAME}");
-    Ok(())
-}
-
-async fn announce_channel_membership(ws: &mut Ws, config: &Config) -> Result<()> {
-    let builder = EventBuilder::new(Kind::Custom(9000), "").tags([
-        Tag::parse(["h", config.channel_id.as_str()])?,
-        Tag::parse(["p", &config.bot_keys.public_key().to_hex()])?,
-        Tag::parse(["role", "bot"])?,
-    ]);
-    let event = builder.sign_with_keys(&config.bot_keys)?;
-    let event_id = event.id.to_hex();
-
-    send_json(ws, json!(["EVENT", event])).await?;
-    match wait_for_ok(ws, &event_id).await {
-        Ok(()) => eprintln!("announced {BOT_DISPLAY_NAME} as a channel bot member"),
-        Err(err) => eprintln!(
-            "could not self-add {BOT_DISPLAY_NAME} as a channel bot member: {err}. For private channels, add the bot pubkey as a channel member/admin-invited bot."
-        ),
+    )
+    .map_err(|error| SessionFailure::terminal(anyhow!(error)))?;
+    let profile_event = builder
+        .sign_with_keys(&config.bot_keys)
+        .map_err(|error| SessionFailure::terminal(anyhow!(error)))?;
+    let ok = connection
+        .send_event(profile_event)
+        .await
+        .map_err(|error| SessionFailure::retry(anyhow!(error)))?;
+    if !ok.accepted {
+        return Err(SessionFailure::terminal(anyhow!(
+            "relay rejected profile {}: {}",
+            ok.event_id,
+            ok.message
+        )));
     }
+    tracing::info!(display_name = BOT_DISPLAY_NAME, "published kind:0 profile");
     Ok(())
 }
 
-async fn subscribe_to_channel(ws: &mut Ws, channel_id: &str) -> Result<()> {
-    let filter = Filter::new().kind(Kind::Custom(9)).custom_tag(
-        SingleLetterTag::lowercase(Alphabet::H),
-        channel_id.to_string(),
-    );
-    send_json(ws, json!(["REQ", SUBSCRIPTION_ID, filter])).await
-}
-
-async fn handle_relay_text(
-    ws: &mut Ws,
+async fn announce_channel_membership(
+    connection: &mut NostrWsConnection,
     config: &Config,
-    started_at: nostr::Timestamp,
-    text: &str,
-) -> Result<()> {
-    let value: Value = serde_json::from_str(text)?;
-    match value.get(0).and_then(Value::as_str) {
-        Some("EVENT") => {
-            let event_value = value
-                .get(2)
-                .ok_or_else(|| anyhow!("EVENT message missing event payload"))?;
-            let event = Event::from_json(event_value.to_string())?;
-            maybe_reply(ws, config, started_at, &event).await?;
-        }
-        Some("EOSE") => {}
-        Some("NOTICE") | Some("CLOSED") => eprintln!("relay: {value}"),
-        Some(other) => eprintln!("ignored relay message type: {other}"),
-        None => eprintln!("ignored malformed relay message: {text}"),
+) -> Result<(), SessionFailure> {
+    let builder = EventBuilder::new(Kind::Custom(9000), "").tags([
+        Tag::parse(["h", config.channel_id.as_str()])
+            .map_err(|error| SessionFailure::terminal(anyhow!(error)))?,
+        Tag::parse(["p", &config.bot_keys.public_key().to_hex()])
+            .map_err(|error| SessionFailure::terminal(anyhow!(error)))?,
+        Tag::parse(["role", "bot"]).map_err(|error| SessionFailure::terminal(anyhow!(error)))?,
+    ]);
+    let event = builder
+        .sign_with_keys(&config.bot_keys)
+        .map_err(|error| SessionFailure::terminal(anyhow!(error)))?;
+    let ok = connection
+        .send_event(event)
+        .await
+        .map_err(|error| SessionFailure::retry(anyhow!(error)))?;
+    if ok.accepted {
+        tracing::info!(
+            display_name = BOT_DISPLAY_NAME,
+            "announced channel bot membership"
+        );
+    } else {
+        tracing::warn!(
+            display_name = BOT_DISPLAY_NAME,
+            relay_message = %ok.message,
+            "could not self-add channel bot membership; private channels require an owner/admin invitation"
+        );
     }
     Ok(())
+}
+
+async fn subscribe_to_channel(
+    connection: &mut NostrWsConnection,
+    channel_id: &str,
+    since: nostr::Timestamp,
+) -> Result<(), SessionFailure> {
+    let filter = Filter::new()
+        .kind(Kind::Custom(9))
+        .custom_tag(
+            SingleLetterTag::lowercase(Alphabet::H),
+            channel_id.to_string(),
+        )
+        .since(since);
+    connection
+        .send_raw(&json!(["REQ", SUBSCRIPTION_ID, filter]))
+        .await
+        .map_err(|error| SessionFailure::retry(anyhow!(error)))
 }
 
 async fn maybe_reply(
-    ws: &mut Ws,
+    connection: &mut NostrWsConnection,
     config: &Config,
-    started_at: nostr::Timestamp,
+    state: &mut BotState,
     event: &Event,
-) -> Result<()> {
-    if event.pubkey == config.bot_keys.public_key() || event.created_at < started_at {
+) -> Result<(), SessionFailure> {
+    if event.pubkey == config.bot_keys.public_key() || event.created_at < state.started_at {
         return Ok(());
     }
 
@@ -234,18 +444,53 @@ async fn maybe_reply(
     };
 
     let builder = buzz_sdk::builders::build_message(
-        config.channel_id.parse()?,
+        config
+            .channel_id
+            .parse::<uuid::Uuid>()
+            .map_err(|error| SessionFailure::terminal(anyhow!(error)))?,
         &reply,
         None,
         &[&event.pubkey.to_hex()],
         false,
         &[],
-    )?;
-    let reply_event = builder.sign_with_keys(&config.bot_keys)?;
-    let reply_event_id = reply_event.id.to_hex();
+    )
+    .map_err(|error| SessionFailure::terminal(anyhow!(error)))?;
+    let reply_event = builder
+        .sign_with_keys(&config.bot_keys)
+        .map_err(|error| SessionFailure::terminal(anyhow!(error)))?;
+    state.pending_reply = Some(PendingReply {
+        input_event_id: event.id.to_hex(),
+        event: reply_event,
+    });
+    send_pending_reply(connection, state).await
+}
 
-    send_json(ws, json!(["EVENT", reply_event])).await?;
-    eprintln!("replied to {} with {}", event.id.to_hex(), reply_event_id);
+async fn send_pending_reply(
+    connection: &mut NostrWsConnection,
+    state: &mut BotState,
+) -> Result<(), SessionFailure> {
+    let Some(pending) = state.pending_reply.as_ref() else {
+        return Ok(());
+    };
+    let input_event_id = pending.input_event_id.clone();
+    let ok = connection
+        .send_event(pending.event.clone())
+        .await
+        .map_err(|error| SessionFailure::retry(anyhow!(error)))?;
+
+    if !ok.accepted {
+        state.pending_reply = None;
+        return Err(SessionFailure::terminal(anyhow!(
+            "relay rejected reply {} to {}: {}",
+            ok.event_id,
+            input_event_id,
+            ok.message
+        )));
+    }
+
+    state.seen_event_ids.record(input_event_id.clone());
+    state.pending_reply = None;
+    tracing::info!(input_event_id, reply_event_id = %ok.event_id, "published reply");
     Ok(())
 }
 
@@ -330,68 +575,274 @@ fn fibonacci_countdown(count: usize) -> Vec<u128> {
     values
 }
 
-async fn wait_for_ok(ws: &mut Ws, event_id: &str) -> Result<()> {
-    loop {
-        let text = next_text(ws, Duration::from_secs(5)).await?;
-        let value: Value = serde_json::from_str(&text)?;
-        if value.get(0).and_then(Value::as_str) != Some("OK") {
-            continue;
-        }
-        if value.get(1).and_then(Value::as_str) != Some(event_id) {
-            continue;
-        }
-        if value.get(2).and_then(Value::as_bool) == Some(true) {
-            return Ok(());
-        }
-        let reason = value
-            .get(3)
-            .and_then(Value::as_str)
-            .unwrap_or("unknown reason");
-        bail!("relay rejected event {event_id}: {reason}");
-    }
-}
-
-async fn wait_for_auth_challenge(ws: &mut Ws) -> Result<String> {
-    loop {
-        let text = next_text(ws, Duration::from_secs(5)).await?;
-        let value: Value = serde_json::from_str(&text)?;
-        if value.get(0).and_then(Value::as_str) == Some("AUTH") {
-            return value
-                .get(1)
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .ok_or_else(|| anyhow!("AUTH message missing challenge"));
-        }
-    }
-}
-
-async fn next_text(ws: &mut Ws, timeout: Duration) -> Result<String> {
-    loop {
-        let message = tokio::time::timeout(timeout, ws.next())
-            .await
-            .context("timed out waiting for relay message")?
-            .ok_or_else(|| anyhow!("relay closed the WebSocket"))??;
-        match message {
-            Message::Text(text) => return Ok(text.to_string()),
-            Message::Ping(bytes) => ws.send(Message::Pong(bytes)).await?,
-            Message::Close(frame) => bail!("relay closed connection: {frame:?}"),
-            _ => {}
-        }
-    }
-}
-
-async fn send_json(ws: &mut Ws, value: Value) -> Result<()> {
-    ws.send(Message::Text(value.to_string().into())).await?;
-    Ok(())
-}
-
 fn required_env(name: &str) -> Result<String> {
     std::env::var(name).with_context(|| format!("{name} is required"))
+}
+
+fn validate_relay_url(relay_url: &str) -> Result<()> {
+    if !relay_url.contains("://") {
+        bail!("BUZZ_RELAY_URL must use ws:// or wss://");
+    }
+    let parsed = url::Url::parse(relay_url).context("BUZZ_RELAY_URL must be a valid URL")?;
+    if !matches!(parsed.scheme(), "ws" | "wss") {
+        bail!("BUZZ_RELAY_URL must use ws:// or wss://");
+    }
+    if parsed.host_str().is_none() {
+        bail!("BUZZ_RELAY_URL must include a host");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use serde_json::Value;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    async fn recv_json<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>) -> Value
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        let message = ws
+            .next()
+            .await
+            .expect("client should send a frame")
+            .expect("client frame should be valid");
+        let Message::Text(text) = message else {
+            panic!("client should send text, got {message:?}");
+        };
+        serde_json::from_str(&text).expect("client text should be JSON")
+    }
+
+    async fn accept_event<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>, expected_command: &str)
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        let message = recv_json(ws).await;
+        assert_eq!(message[0], expected_command);
+        let event_id = message[1]["id"].as_str().expect("event should have an id");
+        ws.send(Message::Text(
+            json!(["OK", event_id, true, ""]).to_string().into(),
+        ))
+        .await
+        .expect("relay should accept event");
+    }
+
+    fn command_event(keys: &Keys, channel_id: &str, content: &str) -> Event {
+        EventBuilder::new(Kind::Custom(9), content)
+            .tags([Tag::parse(["h", channel_id]).expect("valid h tag")])
+            .sign_with_keys(keys)
+            .expect("sign command")
+    }
+
+    async fn authenticate<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>)
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        ws.send(Message::Text(
+            json!(["AUTH", "test-challenge"]).to_string().into(),
+        ))
+        .await
+        .expect("send challenge");
+        accept_event(ws, "AUTH").await;
+    }
+
+    #[test]
+    fn crypto_provider_is_ready_before_wss_client_config_is_built() {
+        install_crypto_provider();
+        install_crypto_provider();
+
+        let _config = rustls::ClientConfig::builder()
+            .with_root_certificates(rustls::RootCertStore::empty())
+            .with_no_client_auth();
+    }
+
+    #[test]
+    fn membership_closed_is_terminal_only_for_the_bot_subscription() {
+        assert!(is_terminal_membership_closed(
+            SUBSCRIPTION_ID,
+            "restricted: not a channel member"
+        ));
+        assert!(is_terminal_membership_closed(
+            SUBSCRIPTION_ID,
+            "restricted: channel access revoked"
+        ));
+        assert!(!is_terminal_membership_closed(
+            "another-subscription",
+            "restricted: not a channel member"
+        ));
+        assert!(!is_terminal_membership_closed(
+            SUBSCRIPTION_ID,
+            "error: database error"
+        ));
+    }
+
+    #[test]
+    fn replay_guard_keeps_a_bounded_window_of_accepted_inputs() {
+        let mut replay = ReplayGuard::new(2);
+        replay.record("event-a".to_string());
+        replay.record("event-b".to_string());
+        replay.record("event-c".to_string());
+
+        assert!(!replay.contains("event-a"));
+        assert!(replay.contains("event-b"));
+        assert!(replay.contains("event-c"));
+    }
+
+    #[test]
+    fn reconnect_cursor_waits_for_eose_and_then_bounds_overlap() {
+        let mut state = BotState::new();
+        let initial = state.subscription_since();
+        let newest = nostr::Timestamp::from(initial.as_secs() + 120);
+
+        state.observe_subscription_event(false, newest, newest);
+        assert_eq!(state.subscription_since(), initial);
+
+        state.finish_catchup(newest);
+        assert_eq!(
+            state.subscription_since().as_secs(),
+            newest.as_secs() - REPLAY_OVERLAP_SECONDS
+        );
+
+        for offset in 0..=REPLAY_WINDOW {
+            state.seen_event_ids.record(format!("event-{offset}"));
+        }
+
+        assert!(!state.seen_event_ids.contains("event-0"));
+        let latest = nostr::Timestamp::from(newest.as_secs() + 120);
+        state.observe_subscription_event(true, latest, latest);
+        assert_eq!(
+            state.subscription_since().as_secs(),
+            latest.as_secs() - REPLAY_OVERLAP_SECONDS
+        );
+    }
+
+    #[test]
+    fn relay_url_accepts_only_websocket_schemes() {
+        assert!(validate_relay_url("ws://localhost:3000").is_ok());
+        assert!(validate_relay_url("wss://relay.example.com").is_ok());
+        assert!(validate_relay_url("https://relay.example.com").is_err());
+        assert!(validate_relay_url("ws:relative").is_err());
+        assert!(validate_relay_url("not a url").is_err());
+    }
+
+    #[tokio::test]
+    async fn reconnect_resends_the_same_pending_reply_then_deduplicates_replay() {
+        install_crypto_provider();
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind relay");
+        let address = listener.local_addr().expect("relay address");
+        let channel_id = "00000000-0000-0000-0000-000000000001";
+        let inbound = command_event(&Keys::generate(), channel_id, "!countdown 2");
+        let inbound_id = inbound.id.to_hex();
+        let relay_inbound = inbound.clone();
+        let rejected = command_event(&Keys::generate(), channel_id, "!fib 5");
+        let rejected_id = rejected.id.to_hex();
+
+        let relay = tokio::spawn(async move {
+            let (first_stream, _) = listener.accept().await.expect("first connection");
+            let mut first = accept_async(first_stream).await.expect("first WebSocket");
+            authenticate(&mut first).await;
+            accept_event(&mut first, "EVENT").await;
+            accept_event(&mut first, "EVENT").await;
+            let first_req = recv_json(&mut first).await;
+            assert_eq!(first_req[0], "REQ");
+            first
+                .send(Message::Text(
+                    json!(["EOSE", SUBSCRIPTION_ID]).to_string().into(),
+                ))
+                .await
+                .expect("finish historical catch-up");
+            first
+                .send(Message::Text(
+                    json!(["EVENT", SUBSCRIPTION_ID, relay_inbound])
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .expect("send command");
+            let first_reply = recv_json(&mut first).await;
+            assert_eq!(first_reply[0], "EVENT");
+            assert_eq!(first_reply[1]["content"], "2 1 🚀");
+            let reply_id = first_reply[1]["id"].as_str().expect("reply id").to_string();
+            first.close(None).await.expect("drop first connection");
+
+            let (second_stream, _) = listener.accept().await.expect("second connection");
+            let mut second = accept_async(second_stream).await.expect("second WebSocket");
+            authenticate(&mut second).await;
+            let resent_reply = recv_json(&mut second).await;
+            assert_eq!(resent_reply[0], "EVENT");
+            assert_eq!(resent_reply[1]["id"], reply_id);
+            second
+                .send(Message::Text(
+                    json!(["OK", reply_id, true, ""]).to_string().into(),
+                ))
+                .await
+                .expect("accept pending reply");
+
+            let second_req = recv_json(&mut second).await;
+            assert_eq!(second_req[0], "REQ");
+            assert!(second_req[2]["since"].as_u64() >= first_req[2]["since"].as_u64());
+            second
+                .send(Message::Text(
+                    json!(["EVENT", SUBSCRIPTION_ID, inbound])
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .expect("replay command");
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), second.next())
+                    .await
+                    .is_err(),
+                "accepted input replay must not emit another reply"
+            );
+            second
+                .send(Message::Text(
+                    json!(["EVENT", SUBSCRIPTION_ID, rejected])
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .expect("send second command");
+            let rejected_reply = recv_json(&mut second).await;
+            assert_eq!(rejected_reply[1]["content"], "3 2 1 1 0");
+            let rejected_reply_id = rejected_reply[1]["id"].as_str().expect("reply id");
+            second
+                .send(Message::Text(
+                    json!(["OK", rejected_reply_id, false, "restricted: test rejection"])
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .expect("reject second reply");
+        });
+
+        let config = Config {
+            relay_url: format!("ws://{address}"),
+            channel_id: channel_id.to_string(),
+            bot_keys: Keys::generate(),
+            owner_auth_tag: None,
+        };
+        let mut state = BotState::new();
+        let first = run_session(&config, &mut state)
+            .await
+            .expect_err("first socket closes before OK");
+        assert!(!first.terminal);
+        assert!(!state.seen_event_ids.contains(&inbound_id));
+        assert!(state.pending_reply.is_some());
+
+        let second = run_session(&config, &mut state)
+            .await
+            .expect_err("reply rejection is terminal");
+        assert!(second.terminal);
+        assert!(second.error.to_string().contains("test rejection"));
+        assert!(state.seen_event_ids.contains(&inbound_id));
+        assert!(!state.seen_event_ids.contains(&rejected_id));
+        assert!(state.pending_reply.is_none());
+        relay.await.expect("relay script");
+    }
 
     #[test]
     fn countdown_command_is_algorithmic_and_bounded() {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -51,7 +51,7 @@ pre-push:
     branch-skew:
       run: ./scripts/check-branch-skew.sh
     rust-tests:
-      glob: ["crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
+      glob: ["crates/**", "examples/countdown-bot/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
       run: just test-unit
     desktop-check:
       glob: ["desktop/**", "pnpm-lock.yaml"]

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -90,6 +90,9 @@ run_unit_tests() {
   run_test_step "buzz-cli tests" \
     cargo test -p buzz-cli -- --nocapture
 
+  run_test_step "countdown-bot tests" \
+    cargo test -p countdown-bot -- --nocapture
+
   # buzz-db migrator/lint unit tests (no infra): guard the embedded-migrator
   # invariant (exactly the consolidated 0001; cutover/backfill stays an operator
   # script, not startup state) and the tenant-scoping lints. The Postgres-backed


### PR DESCRIPTION
## Summary

- Use the shared `buzz-ws-client`, install the Rustls ring provider before connecting, and reject relay URLs that are not absolute `ws://` or `wss://` URLs.
- Wait for matching relay `OK` responses before reporting profile or reply success, and retain the exact signed pending reply across reconnects until it is accepted or rejected.
- Reauthenticate and resubscribe after transient failures with capped backoff, use an `EOSE`-committed cursor plus bounded replay suppression, and surface channel-membership `CLOSED` responses as terminal errors. Add Countdown coverage to the normal Rust gates and document the operational behavior.

### Related issue

N/A — no matching open issue or pull request found.

### Testing

- `cargo test -p countdown-bot` — 9 passed
- `cargo clippy -p countdown-bot --all-targets -- -D warnings`
- `just ci`

No UI change.
