### PR TITLE
Confirm Run402 ownership completion in Buzz

### DIFF
--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod mesh_llm;
 #[cfg(feature = "mesh-llm")]
 pub(crate) mod mesh_readiness;
 mod messages;
+mod nostr_bind_result;
 mod notifications;
 mod observer_archive;
 mod os_idle;
@@ -98,6 +99,7 @@ pub use media_raw::*;
 #[cfg(feature = "mesh-llm")]
 pub use mesh_llm::*;
 pub use messages::*;
+pub use nostr_bind_result::*;
 pub use notifications::*;
 pub use observer_archive::*;
 pub use os_idle::*;

--- a/desktop/src-tauri/src/commands/nostr_bind_result.rs
+++ b/desktop/src-tauri/src/commands/nostr_bind_result.rs
@@ -1,0 +1,439 @@
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    time::Duration,
+};
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::net::lookup_host;
+use url::Url;
+
+const MAX_RESULT_RESPONSE_BYTES: usize = 4_096;
+const MAX_RESOLVED_ADDRESSES: usize = 16;
+const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+const ACTION_REQUIRED_CODES: &[&str] = &[
+    "BUZZ_ADOPTION_CALLBACK_INVALID",
+    "BUZZ_ADOPTION_OFFER_NOT_ACTIVE",
+    "BUZZ_ADOPTION_TARGET_MISMATCH",
+    "BUZZ_IDEMPOTENCY_CONFLICT",
+    "BUZZ_OWNER_PROOF_INVALID",
+    "STEP_UP_REQUIRED",
+    "BUZZ_ADOPTION_COMPLETION_REJECTED",
+];
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireResultResponse {
+    status: String,
+    result_code: Option<String>,
+}
+
+/// Minimal authoritative result returned to the consent UI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NostrBindResult {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result_code: Option<String>,
+}
+
+/// Stable, non-sensitive failure classification returned to the consent UI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NostrBindResultError {
+    kind: &'static str,
+    message: &'static str,
+}
+
+impl NostrBindResultError {
+    fn unsafe_endpoint() -> Self {
+        Self {
+            kind: "unsafe_endpoint",
+            message: "The confirmation endpoint is not safe to contact.",
+        }
+    }
+
+    fn unreachable() -> Self {
+        Self {
+            kind: "unreachable",
+            message: "Run402 could not be reached to confirm the result.",
+        }
+    }
+
+    fn invalid_response() -> Self {
+        Self {
+            kind: "invalid_response",
+            message: "Run402 returned an invalid confirmation response.",
+        }
+    }
+}
+
+fn validate_result_url(input: &str) -> Result<Url, NostrBindResultError> {
+    if input
+        .strip_prefix("https://")
+        .is_some_and(|authority| authority.starts_with('/'))
+    {
+        return Err(NostrBindResultError::unsafe_endpoint());
+    }
+    let url = Url::parse(input).map_err(|_| NostrBindResultError::unsafe_endpoint())?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(NostrBindResultError::unsafe_endpoint());
+    }
+    Ok(url)
+}
+
+fn is_public_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, c, _] = ip.octets();
+    !(a == 0
+        || a == 10
+        || a == 127
+        || a >= 224
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 169 && b == 254)
+        || (a == 172 && (16..=31).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 192 && b == 0 && c == 2)
+        || (a == 192 && b == 88 && c == 99)
+        || (a == 192 && b == 168)
+        || (a == 198 && (18..=19).contains(&b))
+        || (a == 198 && b == 51 && c == 100)
+        || (a == 203 && b == 0 && c == 113))
+}
+
+fn is_public_ipv6(ip: Ipv6Addr) -> bool {
+    if let Some(mapped) = ip.to_ipv4_mapped() {
+        return is_public_ipv4(mapped);
+    }
+
+    let segments = ip.segments();
+    !(ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_multicast()
+        || segments[..6] == [0, 0, 0, 0, 0, 0]
+        || (segments[0] & 0xfe00) == 0xfc00
+        || (segments[0] & 0xffc0) == 0xfe80
+        || (segments[0] & 0xffc0) == 0xfec0
+        || (segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 1)
+        || (segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0)
+        || (segments[0] == 0x2001 && segments[1] <= 0x01ff)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        || segments[0] == 0x2002
+        || (segments[0] == 0x3fff && (segments[1] & 0xf000) == 0)
+        || segments[0] == 0x5f00)
+}
+
+fn is_public_endpoint_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_public_ipv4(ip),
+        IpAddr::V6(ip) => is_public_ipv6(ip),
+    }
+}
+
+fn parse_result_response(body: &[u8]) -> Result<NostrBindResult, NostrBindResultError> {
+    if body.len() > MAX_RESULT_RESPONSE_BYTES {
+        return Err(NostrBindResultError::invalid_response());
+    }
+    let response: WireResultResponse =
+        serde_json::from_slice(body).map_err(|_| NostrBindResultError::invalid_response())?;
+
+    let valid = match response.status.as_str() {
+        "pending" | "completed" | "expired" | "cancelled" => response.result_code.is_none(),
+        "action_required" => response
+            .result_code
+            .as_deref()
+            .is_some_and(|code| ACTION_REQUIRED_CODES.contains(&code)),
+        _ => false,
+    };
+    if !valid {
+        return Err(NostrBindResultError::invalid_response());
+    }
+
+    Ok(NostrBindResult {
+        status: response.status,
+        result_code: response.result_code,
+    })
+}
+
+async fn resolve_public_addresses(url: &Url) -> Result<Vec<SocketAddr>, NostrBindResultError> {
+    let host = url
+        .host_str()
+        .ok_or_else(NostrBindResultError::unsafe_endpoint)?;
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(NostrBindResultError::unsafe_endpoint)?;
+    let resolved = tokio::time::timeout(DNS_TIMEOUT, lookup_host((host, port)))
+        .await
+        .map_err(|_| NostrBindResultError::unreachable())?
+        .map_err(|_| NostrBindResultError::unreachable())?;
+    let addresses: Vec<_> = resolved.take(MAX_RESOLVED_ADDRESSES + 1).collect();
+
+    validate_resolved_addresses(addresses)
+}
+
+fn validate_resolved_addresses(
+    addresses: Vec<SocketAddr>,
+) -> Result<Vec<SocketAddr>, NostrBindResultError> {
+    if addresses.is_empty()
+        || addresses.len() > MAX_RESOLVED_ADDRESSES
+        || addresses
+            .iter()
+            .any(|address| !is_public_endpoint_ip(address.ip()))
+    {
+        return Err(NostrBindResultError::unsafe_endpoint());
+    }
+    Ok(addresses)
+}
+
+async fn read_result_response(
+    response: reqwest::Response,
+) -> Result<NostrBindResult, NostrBindResultError> {
+    if response.status() != reqwest::StatusCode::OK {
+        return Err(
+            if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+                || response.status().is_server_error()
+            {
+                NostrBindResultError::unreachable()
+            } else {
+                NostrBindResultError::invalid_response()
+            },
+        );
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_RESULT_RESPONSE_BYTES as u64)
+    {
+        return Err(NostrBindResultError::invalid_response());
+    }
+
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| NostrBindResultError::invalid_response())?;
+        if body.len().saturating_add(chunk.len()) > MAX_RESULT_RESPONSE_BYTES {
+            return Err(NostrBindResultError::invalid_response());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    parse_result_response(&body)
+}
+
+/// Post the in-memory signed approval to its issuer's result endpoint.
+///
+/// This command performs one bounded read. Poll timing and active-request
+/// isolation remain in the frontend, while URL, DNS, redirect, and body-size
+/// enforcement stay in native code where browser policy cannot be bypassed.
+#[tauri::command]
+pub async fn fetch_nostr_bind_result(
+    result_url: String,
+    owner_proof_event: Value,
+) -> Result<NostrBindResult, NostrBindResultError> {
+    let url = validate_result_url(&result_url)?;
+    let host = url
+        .host_str()
+        .ok_or_else(NostrBindResultError::unsafe_endpoint)?
+        .to_owned();
+    let addresses = resolve_public_addresses(&url).await?;
+    let client = reqwest::Client::builder()
+        .https_only(true)
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(CONNECT_TIMEOUT)
+        .pool_max_idle_per_host(0)
+        .resolve_to_addrs(&host, &addresses)
+        .build()
+        .map_err(|_| NostrBindResultError::unreachable())?;
+    let response = client
+        .post(url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .json(&serde_json::json!({ "owner_proof_event": owner_proof_event }))
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|_| NostrBindResultError::unreachable())?;
+
+    read_result_response(response).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    use super::{
+        fetch_nostr_bind_result, is_public_endpoint_ip, parse_result_response,
+        read_result_response, validate_resolved_addresses, validate_result_url,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn local_http_response(wire_response: Vec<u8>) -> reqwest::Response {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1_024];
+            let _ = socket.read(&mut request).await.unwrap();
+            socket.write_all(&wire_response).await.unwrap();
+        });
+        let response = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap()
+            .get(format!("http://{address}/result"))
+            .send()
+            .await
+            .unwrap();
+        server.await.unwrap();
+        response
+    }
+
+    #[test]
+    fn result_url_requires_a_credential_free_https_origin_without_query_or_fragment() {
+        assert!(
+            validate_result_url("https://api.run402.com/buzz-human-adoption-results/v1").is_ok()
+        );
+
+        for unsafe_url in [
+            "http://api.run402.com/result",
+            "https://user:pass@api.run402.com/result",
+            "https://api.run402.com/result?token=secret",
+            "https://api.run402.com/result#fragment",
+            "https:///result",
+            "not a url",
+        ] {
+            assert!(validate_result_url(unsafe_url).is_err(), "{unsafe_url}");
+        }
+    }
+
+    #[test]
+    fn result_endpoint_allows_only_publicly_routable_addresses() {
+        assert!(is_public_endpoint_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(is_public_endpoint_ip(IpAddr::V6(
+            "2606:4700:4700::1111".parse::<Ipv6Addr>().unwrap()
+        )));
+
+        for unsafe_ip in [
+            "0.0.0.0",
+            "10.0.0.1",
+            "100.64.0.1",
+            "127.0.0.1",
+            "169.254.169.254",
+            "172.16.0.1",
+            "192.0.2.1",
+            "192.168.1.1",
+            "198.18.0.1",
+            "198.51.100.1",
+            "203.0.113.1",
+            "224.0.0.1",
+            "240.0.0.1",
+            "::",
+            "::1",
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+            "::a00:1",
+            "100::1",
+            "2001:db8::1",
+            "fc00::1",
+            "fe80::1",
+            "ff02::1",
+        ] {
+            let parsed = unsafe_ip.parse::<IpAddr>().unwrap();
+            assert!(!is_public_endpoint_ip(parsed), "{unsafe_ip}");
+        }
+    }
+
+    #[test]
+    fn result_endpoint_rejects_mixed_or_oversized_dns_answers() {
+        let public: SocketAddr = "8.8.8.8:443".parse().unwrap();
+        let private: SocketAddr = "127.0.0.1:443".parse().unwrap();
+        assert!(validate_resolved_addresses(vec![public]).is_ok());
+        assert!(validate_resolved_addresses(vec![public, private]).is_err());
+        assert!(validate_resolved_addresses(vec![public; 17]).is_err());
+    }
+
+    #[test]
+    fn result_response_accepts_only_the_exact_bounded_contract() {
+        for body in [
+            br#"{"status":"pending"}"#.as_slice(),
+            br#"{"status":"completed"}"#.as_slice(),
+            br#"{"status":"expired"}"#.as_slice(),
+            br#"{"status":"cancelled"}"#.as_slice(),
+            br#"{"status":"action_required","result_code":"STEP_UP_REQUIRED"}"#.as_slice(),
+            br#"{"status":"action_required","result_code":"BUZZ_OWNER_PROOF_INVALID"}"#.as_slice(),
+        ] {
+            assert!(parse_result_response(body).is_ok());
+        }
+
+        for body in [
+            br#"{"status":"completed","extra":true}"#.as_slice(),
+            br#"{"status":"completed","result_code":"STEP_UP_REQUIRED"}"#.as_slice(),
+            br#"{"status":"action_required"}"#.as_slice(),
+            br#"{"status":"action_required","result_code":"INTERNAL_ERROR"}"#.as_slice(),
+            br#"{"status":"unknown"}"#.as_slice(),
+            br#"not json"#.as_slice(),
+        ] {
+            assert!(parse_result_response(body).is_err());
+        }
+
+        let oversized = vec![b' '; 4_097];
+        assert!(parse_result_response(&oversized).is_err());
+    }
+
+    #[test]
+    fn result_response_serializes_for_the_frontend_without_extra_state() {
+        let parsed = parse_result_response(
+            br#"{"status":"action_required","result_code":"BUZZ_ADOPTION_TARGET_MISMATCH"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(parsed).unwrap(),
+            serde_json::json!({
+                "status": "action_required",
+                "resultCode": "BUZZ_ADOPTION_TARGET_MISMATCH"
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn result_response_rejects_redirects_and_streamed_oversize_bodies() {
+        let redirect = local_http_response(
+            b"HTTP/1.1 302 Found\r\nLocation: https://example.com/result\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .to_vec(),
+        )
+        .await;
+        assert_eq!(
+            read_result_response(redirect).await.unwrap_err().kind,
+            "invalid_response"
+        );
+
+        let mut oversized =
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n"
+                .to_vec();
+        oversized.extend(std::iter::repeat_n(b' ', 4_097));
+        let response = local_http_response(oversized).await;
+        assert_eq!(
+            read_result_response(response).await.unwrap_err().kind,
+            "invalid_response"
+        );
+    }
+
+    #[tokio::test]
+    async fn result_command_rejects_loopback_before_contacting_it() {
+        let error = fetch_nostr_bind_result(
+            "https://127.0.0.1/result".to_owned(),
+            serde_json::json!({ "id": "signed-event" }),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind, "unsafe_endpoint");
+    }
+}

--- a/desktop/src-tauri/src/deep_link.rs
+++ b/desktop/src-tauri/src/deep_link.rs
@@ -499,7 +499,11 @@ struct NostrBindDeepLinkPayload {
     expires_at: String,
     return_mode: String,
     callback_url: Option<String>,
+    result_protocol: Option<String>,
+    result_url: Option<String>,
 }
+
+const RUN402_ADOPTION_RESULT_PROTOCOL: &str = "run402_adoption_result_v1";
 
 fn non_empty_param(url: &Url, name: &str) -> Result<String, String> {
     url.query_pairs()
@@ -538,6 +542,18 @@ fn validate_nostr_bind_callback_url(callback_url: &str, origin: &str) -> Result<
     Ok(())
 }
 
+fn is_structurally_safe_result_url(result_url: &str) -> bool {
+    let Ok(result_url) = Url::parse(result_url) else {
+        return false;
+    };
+    result_url.scheme() == "https"
+        && result_url.host_str().is_some()
+        && result_url.username().is_empty()
+        && result_url.password().is_none()
+        && result_url.query().is_none()
+        && result_url.fragment().is_none()
+}
+
 fn parse_nostr_bind_deep_link(url: &Url) -> Result<NostrBindDeepLinkPayload, String> {
     let challenge_id = non_empty_param(url, "challenge_id")?;
     let nonce = non_empty_param(url, "nonce")?;
@@ -550,6 +566,8 @@ fn parse_nostr_bind_deep_link(url: &Url) -> Result<NostrBindDeepLinkPayload, Str
     let expires_at = non_empty_param(url, "expires_at")?;
     let return_mode = non_empty_param(url, "return")?;
     let callback_url = optional_non_empty_param(url, "callback_url");
+    let requested_result_protocol = optional_non_empty_param(url, "result_protocol");
+    let requested_result_url = optional_non_empty_param(url, "result_url");
 
     nostr_bind::validate_challenge_id(&challenge_id)?;
     nostr_bind::validate_nonce(&nonce)?;
@@ -571,6 +589,24 @@ fn parse_nostr_bind_deep_link(url: &Url) -> Result<NostrBindDeepLinkPayload, Str
         validate_nostr_bind_callback_url(callback_url, &origin)?;
     }
 
+    // Result acknowledgement is an optional extension. Unknown or malformed
+    // extensions preserve the legacy manual flow instead of rejecting an
+    // otherwise valid identity approval.
+    let (result_protocol, result_url) = match (
+        requested_result_protocol.as_deref(),
+        requested_result_url.as_deref(),
+    ) {
+        (Some(RUN402_ADOPTION_RESULT_PROTOCOL), Some(result_url))
+            if is_structurally_safe_result_url(result_url) =>
+        {
+            (
+                Some(RUN402_ADOPTION_RESULT_PROTOCOL.to_owned()),
+                Some(result_url.to_owned()),
+            )
+        }
+        _ => (None, None),
+    };
+
     Ok(NostrBindDeepLinkPayload {
         challenge_id,
         nonce,
@@ -583,6 +619,8 @@ fn parse_nostr_bind_deep_link(url: &Url) -> Result<NostrBindDeepLinkPayload, Str
         expires_at,
         return_mode,
         callback_url,
+        result_protocol,
+        result_url,
     })
 }
 
@@ -595,7 +633,7 @@ pub(crate) fn handle_deep_link_url(app: &tauri::AppHandle, url_str: &str) {
     let url = match Url::parse(url_str) {
         Ok(u) => u,
         Err(e) => {
-            eprintln!("buzz-desktop: invalid deep link URL {url_str:?}: {e}");
+            eprintln!("buzz-desktop: invalid deep link URL: {e}");
             return;
         }
     };
@@ -697,7 +735,9 @@ pub(crate) fn handle_deep_link_url(app: &tauri::AppHandle, url_str: &str) {
                 let _ = app.emit("deep-link-nostr-bind", payload);
             }
             Err(error) => {
-                eprintln!("buzz-desktop: rejecting nostr-bind deep link: {error}: {url_str}");
+                // Do not print the deep link: it contains the signed-attempt
+                // challenge material and may contain an issuer result URL.
+                eprintln!("buzz-desktop: rejecting nostr-bind deep link: {error}");
             }
         },
         Some(action) => {

--- a/desktop/src-tauri/src/deep_link_tests.rs
+++ b/desktop/src-tauri/src/deep_link_tests.rs
@@ -574,3 +574,34 @@ fn parse_nostr_bind_deep_link_accepts_expired_link_for_user_facing_error() {
     let payload = parse_nostr_bind_deep_link(&url).unwrap();
     assert_eq!(payload.expires_at, "2000-01-01T00:00:00Z");
 }
+
+#[test]
+fn parse_nostr_bind_deep_link_accepts_optional_run402_result_acknowledgement() {
+    let url = Url::parse("buzz://nostr-bind?challenge_id=550e8400-e29b-41d4-a716-446655440000&nonce=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi01234567&verification_code=123456&audience=buzz%3Anostr-identity&action=bind_nostr_identity&protocol=buzz-nostr-identity&version=1&origin=https%3A%2F%2Fexample.com&expires_at=2999-01-01T00%3A00%3A00Z&return=browser_fragment_v1&callback_url=https%3A%2F%2Fexample.com%2Fbuzz&result_protocol=run402_adoption_result_v1&result_url=https%3A%2F%2Fapi.run402.com%2Fbuzz-human-adoption-results%2Fv1").unwrap();
+    let payload = parse_nostr_bind_deep_link(&url).unwrap();
+
+    assert_eq!(
+        payload.result_protocol.as_deref(),
+        Some("run402_adoption_result_v1")
+    );
+    assert_eq!(
+        payload.result_url.as_deref(),
+        Some("https://api.run402.com/buzz-human-adoption-results/v1")
+    );
+}
+
+#[test]
+fn parse_nostr_bind_deep_link_ignores_unknown_or_unsafe_result_extensions() {
+    for suffix in [
+        "&result_protocol=future_result_v2&result_url=https%3A%2F%2Fapi.run402.com%2Fresult",
+        "&result_protocol=run402_adoption_result_v1&result_url=http%3A%2F%2Fapi.run402.com%2Fresult",
+        "&result_protocol=run402_adoption_result_v1&result_url=https%3A%2F%2Fuser%3Apass%40api.run402.com%2Fresult",
+        "&result_protocol=run402_adoption_result_v1&result_url=https%3A%2F%2Fapi.run402.com%2Fresult%3Ftoken%3Dsecret",
+        "&result_protocol=run402_adoption_result_v1&result_url=https%3A%2F%2Fapi.run402.com%2Fresult%23fragment",
+    ] {
+        let base = "buzz://nostr-bind?challenge_id=550e8400-e29b-41d4-a716-446655440000&nonce=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi01234567&verification_code=123456&audience=buzz%3Anostr-identity&action=bind_nostr_identity&protocol=buzz-nostr-identity&version=1&origin=https%3A%2F%2Fexample.com&expires_at=2999-01-01T00%3A00%3A00Z&return=browser_fragment_v1&callback_url=https%3A%2F%2Fexample.com%2Fbuzz";
+        let payload = parse_nostr_bind_deep_link(&Url::parse(&format!("{base}{suffix}")).unwrap()).unwrap();
+        assert_eq!(payload.result_protocol, None);
+        assert_eq!(payload.result_url, None);
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -539,6 +539,7 @@ pub fn run() {
             clear_pending_navigation_deep_links,
             take_pending_entity_deep_link,
             acknowledge_pending_entity_deep_link,
+            fetch_nostr_bind_result,
             start_builderlab_login,
             cancel_builderlab_login,
             get_builderlab_auth,

--- a/desktop/src/features/profile/lib/nostrBindResult.test.mjs
+++ b/desktop/src/features/profile/lib/nostrBindResult.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getNostrBindResultPresentation,
+  hasNostrBindResultAcknowledgement,
+  observeNostrBindResult,
+} from "./nostrBindResult.ts";
+
+const baseOptions = {
+  resultUrl: "https://api.run402.com/buzz-human-adoption-results/v1",
+  ownerProofEvent: { id: "signed-event" },
+  expiresAt: "2099-01-01T00:00:00Z",
+};
+
+function clock(start = 1_000) {
+  let now = start;
+  return {
+    now: () => now,
+    sleep: async (milliseconds) => {
+      now += milliseconds;
+    },
+  };
+}
+
+test("observes pending until the exact approval is authoritatively completed", async () => {
+  const states = [];
+  const reads = [{ status: "pending" }, { status: "completed" }];
+  const result = await observeNostrBindResult({
+    ...baseOptions,
+    ...clock(),
+    isActive: () => true,
+    onState: (state) => states.push(state),
+    readResult: async () => reads.shift(),
+  });
+
+  assert.deepEqual(states, [{ status: "waiting" }, { status: "completed" }]);
+  assert.deepEqual(result, { status: "completed" });
+});
+
+test("keeps explicit action-required, expired, and cancelled outcomes open", async () => {
+  for (const response of [
+    {
+      status: "action_required",
+      resultCode: "BUZZ_OWNER_PROOF_INVALID",
+    },
+    { status: "expired" },
+    { status: "cancelled" },
+  ]) {
+    const result = await observeNostrBindResult({
+      ...baseOptions,
+      ...clock(),
+      isActive: () => true,
+      onState: () => {},
+      readResult: async () => response,
+    });
+    assert.deepEqual(result, response);
+  }
+});
+
+test("retries transient reachability failures within a bounded observation window", async () => {
+  let attempts = 0;
+  const result = await observeNostrBindResult({
+    ...baseOptions,
+    ...clock(),
+    isActive: () => true,
+    onState: () => {},
+    readResult: async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw { kind: "unreachable" };
+      }
+      return { status: "completed" };
+    },
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(result, { status: "completed" });
+});
+
+test("reports uncertainty rather than success when the endpoint remains unreachable", async () => {
+  let attempts = 0;
+  const result = await observeNostrBindResult({
+    ...baseOptions,
+    ...clock(),
+    maxObservationMs: 2_000,
+    pollIntervalMs: 1_000,
+    isActive: () => true,
+    onState: () => {},
+    readResult: async () => {
+      attempts += 1;
+      throw { kind: "unreachable" };
+    },
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(result, {
+    status: "unable_to_confirm",
+    reason: "unreachable",
+  });
+});
+
+test("distinguishes a reachable endpoint that never returns a final result", async () => {
+  const result = await observeNostrBindResult({
+    ...baseOptions,
+    ...clock(),
+    maxObservationMs: 2_000,
+    pollIntervalMs: 1_000,
+    isActive: () => true,
+    onState: () => {},
+    readResult: async () => ({ status: "pending" }),
+  });
+
+  assert.deepEqual(result, {
+    status: "unable_to_confirm",
+    reason: "no_final_result",
+  });
+  assert.match(
+    getNostrBindResultPresentation(result).description,
+    /did not return a final result/,
+  );
+});
+
+test("fails closed on malformed or non-allowlisted native responses", async () => {
+  for (const response of [
+    { status: "completed", extra: true },
+    { status: "action_required", resultCode: "INTERNAL_ERROR" },
+    { status: "future_status" },
+  ]) {
+    const result = await observeNostrBindResult({
+      ...baseOptions,
+      ...clock(),
+      isActive: () => true,
+      onState: () => {},
+      readResult: async () => response,
+    });
+    assert.deepEqual(result, {
+      status: "unable_to_confirm",
+      reason: "invalid_response",
+    });
+  }
+});
+
+test("ignores a completed response from a superseded deep-link request", async () => {
+  let active = true;
+  let releaseRead;
+  const states = [];
+  const read = new Promise((resolve) => {
+    releaseRead = resolve;
+  });
+  const observation = observeNostrBindResult({
+    ...baseOptions,
+    ...clock(),
+    isActive: () => active,
+    onState: (state) => states.push(state),
+    readResult: async () => read,
+  });
+
+  active = false;
+  releaseRead({ status: "completed" });
+  const result = await observation;
+
+  assert.deepEqual(result, { status: "superseded" });
+  assert.deepEqual(states, [{ status: "waiting" }]);
+});
+
+test("uses the released legacy flow unless both recognized result fields exist", () => {
+  assert.equal(hasNostrBindResultAcknowledgement({}), false);
+  assert.equal(
+    hasNostrBindResultAcknowledgement({
+      resultProtocol: "run402_adoption_result_v1",
+    }),
+    false,
+  );
+  assert.equal(
+    hasNostrBindResultAcknowledgement({
+      resultProtocol: "future_protocol",
+      resultUrl: "https://api.run402.com/result",
+    }),
+    false,
+  );
+  assert.equal(
+    hasNostrBindResultAcknowledgement({
+      resultProtocol: "run402_adoption_result_v1",
+      resultUrl: "https://api.run402.com/result",
+    }),
+    true,
+  );
+});
+
+test("gives every terminal outcome an explicit status and next action", () => {
+  const states = [
+    { status: "waiting" },
+    { status: "completed" },
+    { status: "expired" },
+    { status: "cancelled" },
+    { status: "unable_to_confirm", reason: "no_final_result" },
+    { status: "unable_to_confirm", reason: "unreachable" },
+    { status: "unable_to_confirm", reason: "invalid_response" },
+    { status: "unable_to_confirm", reason: "unsafe_endpoint" },
+    ...[
+      "BUZZ_ADOPTION_CALLBACK_INVALID",
+      "BUZZ_ADOPTION_OFFER_NOT_ACTIVE",
+      "BUZZ_ADOPTION_TARGET_MISMATCH",
+      "BUZZ_IDEMPOTENCY_CONFLICT",
+      "BUZZ_OWNER_PROOF_INVALID",
+      "STEP_UP_REQUIRED",
+      "BUZZ_ADOPTION_COMPLETION_REJECTED",
+    ].map((resultCode) => ({ status: "action_required", resultCode })),
+  ];
+
+  for (const state of states) {
+    const presentation = getNostrBindResultPresentation(state);
+    assert.ok(presentation.title.length > 0);
+    assert.ok(presentation.description.length > 0);
+    assert.ok(presentation.nextAction.length > 0);
+    assert.ok(presentation.closeLabel.length > 0);
+  }
+});

--- a/desktop/src/features/profile/lib/nostrBindResult.ts
+++ b/desktop/src/features/profile/lib/nostrBindResult.ts
@@ -1,0 +1,366 @@
+const RESULT_PROTOCOL = "run402_adoption_result_v1";
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_OBSERVATION_MS = 5 * 60_000;
+const EXPIRY_GRACE_MS = 15_000;
+
+const ACTION_REQUIRED_CODES = new Set([
+  "BUZZ_ADOPTION_CALLBACK_INVALID",
+  "BUZZ_ADOPTION_OFFER_NOT_ACTIVE",
+  "BUZZ_ADOPTION_TARGET_MISMATCH",
+  "BUZZ_IDEMPOTENCY_CONFLICT",
+  "BUZZ_OWNER_PROOF_INVALID",
+  "STEP_UP_REQUIRED",
+  "BUZZ_ADOPTION_COMPLETION_REJECTED",
+] as const);
+
+export type NostrBindActionRequiredCode =
+  | "BUZZ_ADOPTION_CALLBACK_INVALID"
+  | "BUZZ_ADOPTION_OFFER_NOT_ACTIVE"
+  | "BUZZ_ADOPTION_TARGET_MISMATCH"
+  | "BUZZ_IDEMPOTENCY_CONFLICT"
+  | "BUZZ_OWNER_PROOF_INVALID"
+  | "STEP_UP_REQUIRED"
+  | "BUZZ_ADOPTION_COMPLETION_REJECTED";
+
+export type NostrBindResultState =
+  | { status: "waiting" }
+  | { status: "completed" }
+  | {
+      status: "action_required";
+      resultCode: NostrBindActionRequiredCode;
+    }
+  | { status: "expired" }
+  | { status: "cancelled" }
+  | {
+      status: "unable_to_confirm";
+      reason:
+        | "no_final_result"
+        | "unreachable"
+        | "invalid_response"
+        | "unsafe_endpoint";
+    };
+
+export type NostrBindResultObservation =
+  | NostrBindResultState
+  | { status: "superseded" };
+
+export type NostrBindResultPresentation = {
+  title: string;
+  description: string;
+  nextAction: string;
+  closeLabel: string;
+  tone: "neutral" | "success" | "warning";
+};
+
+type NostrBindResultExtension = {
+  resultProtocol?: string;
+  resultUrl?: string;
+};
+
+type ObserveNostrBindResultOptions = {
+  resultUrl: string;
+  ownerProofEvent: unknown;
+  expiresAt: string;
+  readResult: (input: {
+    resultUrl: string;
+    ownerProofEvent: unknown;
+  }) => Promise<unknown>;
+  isActive: () => boolean;
+  onState: (state: NostrBindResultState) => void;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  pollIntervalMs?: number;
+  maxObservationMs?: number;
+};
+
+export function hasNostrBindResultAcknowledgement(
+  payload: NostrBindResultExtension,
+): payload is NostrBindResultExtension & {
+  resultProtocol: typeof RESULT_PROTOCOL;
+  resultUrl: string;
+} {
+  return (
+    payload.resultProtocol === RESULT_PROTOCOL &&
+    typeof payload.resultUrl === "string" &&
+    payload.resultUrl.length > 0
+  );
+}
+
+const ACTION_REQUIRED_COPY: Record<
+  NostrBindActionRequiredCode,
+  Pick<NostrBindResultPresentation, "description" | "nextAction">
+> = {
+  BUZZ_ADOPTION_CALLBACK_INVALID: {
+    description:
+      "Run402 could not verify the browser return for this approval.",
+    nextAction:
+      "Return to the original Run402 tab and start a fresh approval. Keep that new tab open until Buzz confirms it.",
+  },
+  BUZZ_ADOPTION_OFFER_NOT_ACTIVE: {
+    description: "The Run402 ownership invitation is no longer active.",
+    nextAction:
+      "Ask the agent that created the deployment to create a new ownership invitation, then use its new Buzz link.",
+  },
+  BUZZ_ADOPTION_TARGET_MISMATCH: {
+    description:
+      "This approval does not match the Run402 organization that requested it.",
+    nextAction:
+      "Return to the original Run402 tab and start again from the invitation for the intended organization.",
+  },
+  BUZZ_IDEMPOTENCY_CONFLICT: {
+    description:
+      "Run402 found a different request already using this approval attempt.",
+    nextAction:
+      "Return to the original Run402 tab and start a new approval. Do not reuse the old Buzz link.",
+  },
+  BUZZ_OWNER_PROOF_INVALID: {
+    description:
+      "Run402 could not match this signature to the linked Buzz owner.",
+    nextAction:
+      "Make sure Buzz is using the identity named in Run402, then start a fresh approval from the original Run402 tab.",
+  },
+  STEP_UP_REQUIRED: {
+    description:
+      "Run402 needs a fresh security check before it can add you as a co-owner.",
+    nextAction:
+      "Return to the original Run402 tab, complete its passkey check, and then start a fresh Buzz approval if requested.",
+  },
+  BUZZ_ADOPTION_COMPLETION_REJECTED: {
+    description: "Run402 did not complete this co-ownership request.",
+    nextAction:
+      "Return to the original Run402 tab for the specific recovery step. Start a fresh approval only if Run402 asks you to.",
+  },
+};
+
+export function getNostrBindResultPresentation(
+  state: NostrBindResultState,
+): NostrBindResultPresentation {
+  switch (state.status) {
+    case "waiting":
+      return {
+        title: "Waiting for Run402 confirmation",
+        description:
+          "Buzz sent your signed approval to the browser. Run402 is now checking it and adding you as a co-owner.",
+        nextAction:
+          "Keep this window open. If you close it, the handoff may still finish in Run402, but Buzz will stop checking automatically.",
+        closeLabel: "Stop waiting and close",
+        tone: "neutral",
+      };
+    case "completed":
+      return {
+        title: "You’re now a Run402 co-owner",
+        description:
+          "Run402 confirmed this exact Buzz approval and completed the ownership handoff.",
+        nextAction: "This window will close automatically.",
+        closeLabel: "Close now",
+        tone: "success",
+      };
+    case "action_required": {
+      const copy = ACTION_REQUIRED_COPY[state.resultCode];
+      return {
+        title: "Run402 needs another step",
+        ...copy,
+        closeLabel: "Close and return to Run402",
+        tone: "warning",
+      };
+    }
+    case "expired":
+      return {
+        title: "This approval expired",
+        description:
+          "Run402 did not complete the ownership handoff before this one-time approval expired.",
+        nextAction:
+          "Return to the original Run402 tab and start a fresh approval. The expired approval cannot be reused.",
+        closeLabel: "Close and return to Run402",
+        tone: "warning",
+      };
+    case "cancelled":
+      return {
+        title: "This handoff was cancelled",
+        description:
+          "Run402 cancelled this ownership attempt. No completion was confirmed.",
+        nextAction:
+          "Return to the original Run402 tab. Start a new approval only if you still want to become a co-owner.",
+        closeLabel: "Close and return to Run402",
+        tone: "warning",
+      };
+    case "unable_to_confirm": {
+      const reasonCopy = {
+        no_final_result:
+          "Run402 did not return a final result before the confirmation window ended.",
+        unreachable:
+          "Buzz could not reach Run402 before the confirmation window ended.",
+        invalid_response:
+          "Run402 returned a response Buzz could not safely recognize.",
+        unsafe_endpoint:
+          "Buzz refused to contact an unsafe confirmation endpoint.",
+      }[state.reason];
+      return {
+        title: "Couldn’t confirm the Run402 result",
+        description: `${reasonCopy} This does not prove that ownership succeeded or failed.`,
+        nextAction:
+          "Check the original Run402 tab for the authoritative status before starting another approval.",
+        closeLabel: "Close and check Run402",
+        tone: "warning",
+      };
+    }
+  }
+}
+
+function isExactKeySet(
+  value: Record<string, unknown>,
+  keys: string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  return (
+    actual.length === keys.length &&
+    actual.every((key, index) => key === keys[index])
+  );
+}
+
+function parseNativeResult(value: unknown): NostrBindResultState | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.status === "action_required") {
+    if (
+      !isExactKeySet(record, ["resultCode", "status"]) ||
+      typeof record.resultCode !== "string" ||
+      !ACTION_REQUIRED_CODES.has(
+        record.resultCode as NostrBindActionRequiredCode,
+      )
+    ) {
+      return null;
+    }
+    return {
+      status: "action_required",
+      resultCode: record.resultCode as NostrBindActionRequiredCode,
+    };
+  }
+  if (
+    !isExactKeySet(record, ["status"]) ||
+    !["pending", "completed", "expired", "cancelled"].includes(
+      record.status as string,
+    )
+  ) {
+    return null;
+  }
+  if (record.status === "pending") {
+    return { status: "waiting" };
+  }
+  return record as
+    | { status: "completed" }
+    | { status: "expired" }
+    | { status: "cancelled" };
+}
+
+function resultErrorReason(
+  error: unknown,
+): "unreachable" | "invalid_response" | "unsafe_endpoint" {
+  if (typeof error === "object" && error !== null && "kind" in error) {
+    const kind = (error as { kind?: unknown }).kind;
+    if (kind === "invalid_response" || kind === "unsafe_endpoint") {
+      return kind;
+    }
+  }
+  return "unreachable";
+}
+
+function defaultSleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/**
+ * Observe one signed approval until its issuer reports a terminal state.
+ * The caller owns active-request identity; a superseded request never emits a
+ * terminal state, even if its in-flight native read later returns completed.
+ */
+export async function observeNostrBindResult(
+  options: ObserveNostrBindResultOptions,
+): Promise<NostrBindResultObservation> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxObservationMs =
+    options.maxObservationMs ?? DEFAULT_MAX_OBSERVATION_MS;
+  const startedAt = now();
+  const expiresAt = Date.parse(options.expiresAt);
+  if (!Number.isFinite(expiresAt)) {
+    return {
+      status: "unable_to_confirm",
+      reason: "invalid_response",
+    };
+  }
+  const deadline = Math.min(
+    startedAt + maxObservationMs,
+    expiresAt + EXPIRY_GRACE_MS,
+  );
+  let lastTransientReason: "unreachable" | null = null;
+
+  if (!options.isActive()) {
+    return { status: "superseded" };
+  }
+  options.onState({ status: "waiting" });
+
+  while (options.isActive()) {
+    try {
+      const value = await options.readResult({
+        resultUrl: options.resultUrl,
+        ownerProofEvent: options.ownerProofEvent,
+      });
+      if (!options.isActive()) {
+        return { status: "superseded" };
+      }
+      const state = parseNativeResult(value);
+      if (!state) {
+        const invalid = {
+          status: "unable_to_confirm",
+          reason: "invalid_response",
+        } as const;
+        options.onState(invalid);
+        return invalid;
+      }
+      if (state.status !== "waiting") {
+        options.onState(state);
+        return state;
+      }
+      lastTransientReason = null;
+    } catch (error) {
+      if (!options.isActive()) {
+        return { status: "superseded" };
+      }
+      const reason = resultErrorReason(error);
+      if (reason !== "unreachable") {
+        const unable = { status: "unable_to_confirm", reason } as const;
+        options.onState(unable);
+        return unable;
+      }
+      lastTransientReason = reason;
+    }
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      const unable = {
+        status: "unable_to_confirm",
+        reason: lastTransientReason ?? "no_final_result",
+      } as const;
+      options.onState(unable);
+      return unable;
+    }
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+    if (!options.isActive()) {
+      return { status: "superseded" };
+    }
+    if (now() >= deadline) {
+      const unable = {
+        status: "unable_to_confirm",
+        reason: lastTransientReason ?? "no_final_result",
+      } as const;
+      options.onState(unable);
+      return unable;
+    }
+  }
+
+  return { status: "superseded" };
+}

--- a/desktop/src/features/profile/ui/NostrBindConsentDialog.tsx
+++ b/desktop/src/features/profile/ui/NostrBindConsentDialog.tsx
@@ -1,4 +1,5 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ChevronDown } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -11,7 +12,14 @@ import type { NostrBindDeepLinkPayload } from "@/shared/deep-link";
 import { listenForNostrBindDeepLinks } from "@/shared/deep-link";
 import { OnboardingSlideTransition } from "@/features/onboarding/ui/OnboardingSlideTransition";
 import { buildNostrBindCallbackUrl } from "@/features/profile/lib/nostrBindCallback";
+import {
+  hasNostrBindResultAcknowledgement,
+  observeNostrBindResult,
+  type NostrBindResultState,
+} from "@/features/profile/lib/nostrBindResult";
 import { signNostrIdentityBinding } from "@/features/profile/lib/nostrIdentityBinding";
+import { NostrBindResultStep } from "@/features/profile/ui/NostrBindResultStep";
+import { NostrBindSignedResponseControls } from "@/features/profile/ui/NostrBindSignedResponseControls";
 import { cn } from "@/shared/lib/cn";
 import { useSystemColorScheme } from "@/shared/theme/useSystemColorScheme";
 import { Button } from "@/shared/ui/button";
@@ -142,74 +150,6 @@ async function returnSignedResponseToBrowser(
   }
 }
 
-function SignedResponseControls({
-  copyFailed,
-  copyLabel,
-  onCopy,
-  signedResponse,
-}: {
-  copyFailed: boolean;
-  copyLabel: string;
-  onCopy: () => void;
-  signedResponse: string;
-}) {
-  return (
-    <div className="space-y-4" data-testid="nostr-bind-manual-fallback-content">
-      <pre
-        className="max-h-56 w-full overflow-auto rounded-2xl border border-border/70 bg-muted/60 p-4 text-left shadow-xs"
-        data-testid="nostr-bind-signed-response"
-      >
-        <code className="whitespace-pre-wrap break-all font-mono text-xs leading-5 text-foreground">
-          {signedResponse}
-        </code>
-      </pre>
-
-      {copyFailed ? (
-        <p className="w-full rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-left text-sm text-destructive">
-          {COPY_FAILURE_MESSAGE}
-        </p>
-      ) : null}
-
-      <Button
-        aria-label={copyLabel}
-        className="h-10 w-full"
-        data-testid="nostr-bind-copy-response"
-        onClick={onCopy}
-        type="button"
-      >
-        <span aria-live="polite" className="sr-only">
-          {copyLabel}
-        </span>
-        <span
-          aria-hidden="true"
-          className="inline-grid h-5 place-items-center overflow-hidden"
-        >
-          <span
-            className={cn(
-              COPY_BUTTON_LABEL_CLASS,
-              copyLabel === "Copy response"
-                ? "translate-y-0 opacity-100"
-                : "-translate-y-0.5 opacity-0",
-            )}
-          >
-            Copy response
-          </span>
-          <span
-            className={cn(
-              COPY_BUTTON_LABEL_CLASS,
-              copyLabel === "Copied"
-                ? "translate-y-0 opacity-100"
-                : "translate-y-0.5 opacity-0",
-            )}
-          >
-            Copied
-          </span>
-        </span>
-      </Button>
-    </div>
-  );
-}
-
 export function NostrBindConsentDialog() {
   const isPreview = isNostrBindPreviewEnabled();
   const [payload, setPayload] = React.useState<NostrBindDeepLinkPayload | null>(
@@ -229,6 +169,8 @@ export function NostrBindConsentDialog() {
   const [hasCodeMismatch, setHasCodeMismatch] = React.useState(false);
   const [copyFailed, setCopyFailed] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [resultState, setResultState] =
+    React.useState<NostrBindResultState | null>(null);
   const [isManualFallbackOpen, setIsManualFallbackOpen] = React.useState(false);
   const codeInputRefs = React.useRef<Array<HTMLInputElement | null>>([]);
   const codeShakeRef = React.useRef<HTMLDivElement | null>(null);
@@ -238,6 +180,10 @@ export function NostrBindConsentDialog() {
   );
   const autoSignAttemptRef = React.useRef<string | null>(null);
   const activeSignAttemptRef = React.useRef<symbol | null>(null);
+  const activeResultAttemptRef = React.useRef<symbol | null>(null);
+  const resultDismissTimerRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
   const systemColorScheme = useSystemColorScheme();
   const shouldReduceMotion = useReducedMotion();
   const enteredVerificationCode = verificationCode.join("");
@@ -271,6 +217,10 @@ export function NostrBindConsentDialog() {
       if (copiedTimerRef.current) {
         clearTimeout(copiedTimerRef.current);
       }
+      if (resultDismissTimerRef.current) {
+        clearTimeout(resultDismissTimerRef.current);
+      }
+      activeResultAttemptRef.current = null;
     },
     [],
   );
@@ -284,6 +234,11 @@ export function NostrBindConsentDialog() {
       clearCopiedState();
       autoSignAttemptRef.current = null;
       activeSignAttemptRef.current = null;
+      activeResultAttemptRef.current = null;
+      if (resultDismissTimerRef.current) {
+        clearTimeout(resultDismissTimerRef.current);
+        resultDismissTimerRef.current = null;
+      }
       setPayload(nextPayload);
       setIdentity(null);
       setIsSigning(false);
@@ -292,6 +247,7 @@ export function NostrBindConsentDialog() {
       setHasCodeMismatch(false);
       setCopyFailed(false);
       setError(null);
+      setResultState(null);
       setIsManualFallbackOpen(false);
       getIdentity()
         .then(setIdentity)
@@ -313,16 +269,75 @@ export function NostrBindConsentDialog() {
     clearCopiedState();
     autoSignAttemptRef.current = null;
     activeSignAttemptRef.current = null;
+    activeResultAttemptRef.current = null;
+    if (resultDismissTimerRef.current) {
+      clearTimeout(resultDismissTimerRef.current);
+      resultDismissTimerRef.current = null;
+    }
     setPayload(null);
     setSignedResponse(null);
     setVerificationCode(createEmptyVerificationCode());
     setHasCodeMismatch(false);
     setCopyFailed(false);
     setError(null);
+    setResultState(null);
     setIsManualFallbackOpen(false);
     setIdentity(null);
     setIsSigning(false);
   }, [clearCopiedState]);
+
+  const startResultObservation = React.useCallback(
+    (activePayload: NostrBindDeepLinkPayload, signed: string) => {
+      if (!hasNostrBindResultAcknowledgement(activePayload)) {
+        return;
+      }
+
+      let ownerProofEvent: unknown;
+      try {
+        ownerProofEvent = JSON.parse(signed);
+      } catch {
+        setResultState({
+          status: "unable_to_confirm",
+          reason: "invalid_response",
+        });
+        return;
+      }
+
+      const attempt = Symbol(activePayload.challengeId);
+      activeResultAttemptRef.current = attempt;
+      setResultState({ status: "waiting" });
+      void observeNostrBindResult({
+        resultUrl: activePayload.resultUrl,
+        ownerProofEvent,
+        expiresAt: activePayload.expiresAt,
+        isActive: () => activeResultAttemptRef.current === attempt,
+        onState: (state) => {
+          if (activeResultAttemptRef.current === attempt) {
+            setResultState(state);
+          }
+        },
+        readResult: ({ resultUrl, ownerProofEvent }) =>
+          invoke("fetch_nostr_bind_result", {
+            resultUrl,
+            ownerProofEvent,
+          }),
+      }).then((result) => {
+        if (
+          activeResultAttemptRef.current !== attempt ||
+          result.status !== "completed"
+        ) {
+          return;
+        }
+        toast.success("Run402 confirmed you as a co-owner.");
+        resultDismissTimerRef.current = setTimeout(() => {
+          if (activeResultAttemptRef.current === attempt) {
+            resetDialog();
+          }
+        }, 900);
+      });
+    },
+    [resetDialog],
+  );
 
   const handleOpenChange = React.useCallback(
     (open: boolean) => {
@@ -551,6 +566,9 @@ export function NostrBindConsentDialog() {
 
       setSignedResponse(signed);
       if (payload.returnMode === "browser_fragment_v1" && payload.callbackUrl) {
+        if (hasNostrBindResultAcknowledgement(payload)) {
+          setResultState({ status: "waiting" });
+        }
         const callbackError = await returnSignedResponseToBrowser(
           payload.callbackUrl,
           signed,
@@ -560,6 +578,11 @@ export function NostrBindConsentDialog() {
         }
         setError(callbackError);
         setIsManualFallbackOpen(callbackError !== null);
+        if (callbackError === null) {
+          startResultObservation(payload, signed);
+        } else {
+          setResultState(null);
+        }
       }
     } catch (error) {
       if (activeSignAttemptRef.current === attempt) {
@@ -579,6 +602,7 @@ export function NostrBindConsentDialog() {
     isVerificationCodeValid,
     payload,
     showVerificationCodeMismatch,
+    startResultObservation,
     verificationCode,
   ]);
 
@@ -665,72 +689,82 @@ export function NostrBindConsentDialog() {
                   direction="forward"
                   transitionKey="nostr-bind-finish"
                 >
-                  <DialogPrimitive.Title className="mt-6 text-3xl font-semibold tracking-tight">
-                    {payload.returnMode === "browser_fragment_v1"
-                      ? "Continue in your browser"
-                      : "Finish on the Buzz website"}
-                  </DialogPrimitive.Title>
-                  <DialogPrimitive.Description
-                    className="mt-3 max-w-[440px] text-sm leading-6 text-muted-foreground"
-                    id="nostr-bind-description"
-                  >
-                    {payload.returnMode === "browser_fragment_v1"
-                      ? "Buzz opened your browser to finish verification."
-                      : "Copy the response below, then paste it into the Buzz website to finish verification."}
-                  </DialogPrimitive.Description>
-
-                  {error ? (
-                    <p className="mt-4 w-full rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-left text-sm text-destructive">
-                      {error}
-                    </p>
-                  ) : null}
-
-                  {payload.returnMode === "browser_fragment_v1" ? (
-                    <details
-                      className="group mt-10 w-full overflow-hidden rounded-2xl border border-border/70 bg-muted/30 text-left shadow-xs"
-                      data-testid="nostr-bind-manual-fallback"
-                      onToggle={(event) =>
-                        setIsManualFallbackOpen(event.currentTarget.open)
-                      }
-                      open={isManualFallbackOpen}
-                    >
-                      <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-                        <span>Pairing didn’t finish automatically?</span>
-                        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-150 group-open:rotate-180" />
-                      </summary>
-                      <div className="space-y-4 border-t border-border/55 p-4">
-                        <p className="text-sm leading-6 text-muted-foreground">
-                          Copy this response and paste it into the pairing page.
-                        </p>
-                        <SignedResponseControls
-                          copyFailed={copyFailed}
-                          copyLabel={finishCopyButtonLabel}
-                          onCopy={handleCopyAgain}
-                          signedResponse={signedResponse}
-                        />
-                      </div>
-                    </details>
+                  {resultState ? (
+                    <NostrBindResultStep
+                      onClose={() => handleOpenChange(false)}
+                      state={resultState}
+                    />
                   ) : (
-                    <div className="mt-10 w-full">
-                      <SignedResponseControls
-                        copyFailed={copyFailed}
-                        copyLabel={finishCopyButtonLabel}
-                        onCopy={handleCopyAgain}
-                        signedResponse={signedResponse}
-                      />
-                    </div>
-                  )}
+                    <>
+                      <DialogPrimitive.Title className="mt-6 text-3xl font-semibold tracking-tight">
+                        {payload.returnMode === "browser_fragment_v1"
+                          ? "Continue in your browser"
+                          : "Finish on the Buzz website"}
+                      </DialogPrimitive.Title>
+                      <DialogPrimitive.Description
+                        className="mt-3 max-w-[440px] text-sm leading-6 text-muted-foreground"
+                        id="nostr-bind-description"
+                      >
+                        {payload.returnMode === "browser_fragment_v1"
+                          ? "Buzz opened your browser to finish verification."
+                          : "Copy the response below, then paste it into the Buzz website to finish verification."}
+                      </DialogPrimitive.Description>
 
-                  <div className="mt-8 flex w-full flex-col gap-3">
-                    <Button
-                      className="h-10 w-full text-muted-foreground hover:text-accent-foreground"
-                      onClick={() => handleOpenChange(false)}
-                      type="button"
-                      variant="ghost"
-                    >
-                      Continue
-                    </Button>
-                  </div>
+                      {error ? (
+                        <p className="mt-4 w-full rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-left text-sm text-destructive">
+                          {error}
+                        </p>
+                      ) : null}
+
+                      {payload.returnMode === "browser_fragment_v1" ? (
+                        <details
+                          className="group mt-10 w-full overflow-hidden rounded-2xl border border-border/70 bg-muted/30 text-left shadow-xs"
+                          data-testid="nostr-bind-manual-fallback"
+                          onToggle={(event) =>
+                            setIsManualFallbackOpen(event.currentTarget.open)
+                          }
+                          open={isManualFallbackOpen}
+                        >
+                          <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+                            <span>Pairing didn’t finish automatically?</span>
+                            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-150 group-open:rotate-180" />
+                          </summary>
+                          <div className="space-y-4 border-t border-border/55 p-4">
+                            <p className="text-sm leading-6 text-muted-foreground">
+                              Copy this response and paste it into the pairing
+                              page.
+                            </p>
+                            <NostrBindSignedResponseControls
+                              copyFailed={copyFailed}
+                              copyLabel={finishCopyButtonLabel}
+                              onCopy={handleCopyAgain}
+                              signedResponse={signedResponse}
+                            />
+                          </div>
+                        </details>
+                      ) : (
+                        <div className="mt-10 w-full">
+                          <NostrBindSignedResponseControls
+                            copyFailed={copyFailed}
+                            copyLabel={finishCopyButtonLabel}
+                            onCopy={handleCopyAgain}
+                            signedResponse={signedResponse}
+                          />
+                        </div>
+                      )}
+
+                      <div className="mt-8 flex w-full flex-col gap-3">
+                        <Button
+                          className="h-10 w-full text-muted-foreground hover:text-accent-foreground"
+                          onClick={() => handleOpenChange(false)}
+                          type="button"
+                          variant="ghost"
+                        >
+                          Continue
+                        </Button>
+                      </div>
+                    </>
+                  )}
                 </OnboardingSlideTransition>
               ) : (
                 <OnboardingSlideTransition

--- a/desktop/src/features/profile/ui/NostrBindResultStep.tsx
+++ b/desktop/src/features/profile/ui/NostrBindResultStep.tsx
@@ -1,0 +1,102 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { CheckCircle2, TriangleAlert } from "lucide-react";
+
+import {
+  getNostrBindResultPresentation,
+  type NostrBindResultState,
+} from "@/features/profile/lib/nostrBindResult";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { Spinner } from "@/shared/ui/spinner";
+
+export function NostrBindResultStep({
+  onClose,
+  state,
+}: {
+  onClose: () => void;
+  state: NostrBindResultState;
+}) {
+  const presentation = getNostrBindResultPresentation(state);
+
+  return (
+    <>
+      <DialogPrimitive.Title
+        className="mt-6 text-3xl font-semibold tracking-tight"
+        data-testid="nostr-bind-result-title"
+      >
+        {presentation.title}
+      </DialogPrimitive.Title>
+      <DialogPrimitive.Description
+        className="mt-3 max-w-[440px] text-sm leading-6 text-muted-foreground"
+        id="nostr-bind-description"
+      >
+        {presentation.description}
+      </DialogPrimitive.Description>
+
+      <div
+        aria-live="polite"
+        className={cn(
+          "mt-8 flex w-full items-start gap-3 rounded-2xl border px-4 py-4 text-left shadow-xs",
+          presentation.tone === "success" &&
+            "border-emerald-500/30 bg-emerald-500/10",
+          presentation.tone === "warning" &&
+            "border-amber-500/30 bg-amber-500/10",
+          presentation.tone === "neutral" && "border-border/70 bg-muted/35",
+        )}
+        data-result-status={state.status}
+        data-testid="nostr-bind-result-status"
+        role="status"
+      >
+        {state.status === "waiting" ? (
+          <Spinner
+            aria-hidden="true"
+            className="mt-0.5 h-5 w-5 shrink-0 border-2"
+          />
+        ) : state.status === "completed" ? (
+          <CheckCircle2
+            aria-hidden="true"
+            className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400"
+          />
+        ) : (
+          <TriangleAlert
+            aria-hidden="true"
+            className="mt-0.5 h-5 w-5 shrink-0 text-amber-700 dark:text-amber-400"
+          />
+        )}
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground">
+            {state.status === "waiting"
+              ? "Ownership is not confirmed yet."
+              : state.status === "completed"
+                ? "Ownership is confirmed."
+                : "Ownership was not confirmed by Buzz."}
+          </p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {presentation.nextAction}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-8 flex w-full flex-col gap-2">
+        <Button
+          className={cn(
+            "h-10 w-full",
+            state.status === "waiting" &&
+              "text-muted-foreground hover:text-accent-foreground",
+          )}
+          data-testid="nostr-bind-result-close"
+          onClick={onClose}
+          type="button"
+          variant={state.status === "completed" ? "default" : "ghost"}
+        >
+          {presentation.closeLabel}
+        </Button>
+        {state.status !== "completed" ? (
+          <p className="text-xs leading-5 text-muted-foreground">
+            Closing Buzz does not cancel, retry, or change anything in Run402.
+          </p>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/desktop/src/features/profile/ui/NostrBindSignedResponseControls.tsx
+++ b/desktop/src/features/profile/ui/NostrBindSignedResponseControls.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+
+const COPY_BUTTON_LABEL_CLASS =
+  "col-start-1 row-start-1 transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:translate-y-0 motion-reduce:duration-0";
+
+export function NostrBindSignedResponseControls({
+  copyFailed,
+  copyLabel,
+  onCopy,
+  signedResponse,
+}: {
+  copyFailed: boolean;
+  copyLabel: string;
+  onCopy: () => void;
+  signedResponse: string;
+}) {
+  return (
+    <div className="space-y-4" data-testid="nostr-bind-manual-fallback-content">
+      <pre
+        className="max-h-56 w-full overflow-auto rounded-2xl border border-border/70 bg-muted/60 p-4 text-left shadow-xs"
+        data-testid="nostr-bind-signed-response"
+      >
+        <code className="whitespace-pre-wrap break-all font-mono text-xs leading-5 text-foreground">
+          {signedResponse}
+        </code>
+      </pre>
+
+      {copyFailed ? (
+        <p className="w-full rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-left text-sm text-destructive">
+          Buzz couldn't access the clipboard. Try again.
+        </p>
+      ) : null}
+
+      <Button
+        aria-label={copyLabel}
+        className="h-10 w-full"
+        data-testid="nostr-bind-copy-response"
+        onClick={onCopy}
+        type="button"
+      >
+        <span aria-live="polite" className="sr-only">
+          {copyLabel}
+        </span>
+        <span
+          aria-hidden="true"
+          className="inline-grid h-5 place-items-center overflow-hidden"
+        >
+          <span
+            className={cn(
+              COPY_BUTTON_LABEL_CLASS,
+              copyLabel === "Copy response"
+                ? "translate-y-0 opacity-100"
+                : "-translate-y-0.5 opacity-0",
+            )}
+          >
+            Copy response
+          </span>
+          <span
+            className={cn(
+              COPY_BUTTON_LABEL_CLASS,
+              copyLabel === "Copied"
+                ? "translate-y-0 opacity-100"
+                : "translate-y-0.5 opacity-0",
+            )}
+          >
+            Copied
+          </span>
+        </span>
+      </Button>
+    </div>
+  );
+}

--- a/desktop/src/shared/deep-link.ts
+++ b/desktop/src/shared/deep-link.ts
@@ -47,6 +47,8 @@ export type NostrBindDeepLinkPayload = {
   expiresAt: string;
   returnMode: "clipboard" | "browser_fragment_v1";
   callbackUrl?: string;
+  resultProtocol?: "run402_adoption_result_v1";
+  resultUrl?: string;
 };
 
 /**

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -423,6 +423,10 @@ type E2eConfig = {
     openerError?: string;
     /** Delay binding signatures so specs can exercise request supersession. */
     nostrBindSignDelayMs?: number;
+    /** Sequenced authoritative results returned to the Run402 handoff UI. */
+    nostrBindResultResponses?: Array<Record<string, unknown>>;
+    /** Delay each result read so specs can supersede an in-flight request. */
+    nostrBindResultDelayMs?: number;
     /** Reject successive mock WebSocket connect attempts, then resume. */
     websocketConnectErrors?: string[];
     /** Deliver AUTH synchronously, before the mock connect command resolves. */
@@ -8139,6 +8143,7 @@ let mockGlobalAgentConfig: {
 let nsecCallCount = 0;
 let backupVerificationCallCount = 0;
 let backupSaveCallCount = 0;
+let nostrBindResultCallCount = 0;
 
 const MOCK_NCRYPTSEC =
   "ncryptsec1qgg9947rlpvqu76pj5ecreduf9jxhselq2nae2kghhvd5g7dgjtcxfqtd67p9m0w57lspw8gsq6yphnm8623nsl8xn9j4jdzz84zm3frztj3z7s35vpzmqf6ksu8r89qk5z2zxfmu5gv8th8wclt0h4p";
@@ -11688,6 +11693,21 @@ export function maybeInstallE2eTauriMocks() {
           content: "",
           sig: "e2e-signed-nostr-binding",
         });
+      }
+      case "fetch_nostr_bind_result": {
+        const delayMs = activeConfig?.mock?.nostrBindResultDelayMs ?? 0;
+        if (delayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+        const responses = activeConfig?.mock?.nostrBindResultResponses ?? [
+          { status: "pending" },
+        ];
+        const index = Math.min(
+          nostrBindResultCallCount,
+          Math.max(responses.length - 1, 0),
+        );
+        nostrBindResultCallCount += 1;
+        return responses[index] ?? { status: "pending" };
       }
       case "sign_out":
         // Production wipes local state and restarts the app. In the browser

--- a/desktop/tests/e2e/nostr-bind.spec.ts
+++ b/desktop/tests/e2e/nostr-bind.spec.ts
@@ -10,6 +10,8 @@ type NostrBindPayload = {
   nonce: string;
   origin: string;
   protocol: string;
+  resultProtocol?: string;
+  resultUrl?: string;
   returnMode: string;
   verificationCode: string;
   version: string;
@@ -26,6 +28,14 @@ const VALID_REQUEST: NostrBindPayload = {
   returnMode: "clipboard",
   verificationCode: "123456",
   version: "1",
+};
+
+const RESULT_REQUEST: NostrBindPayload = {
+  ...VALID_REQUEST,
+  callbackUrl: "https://admin.example.com/buzz",
+  resultProtocol: "run402_adoption_result_v1",
+  resultUrl: "https://api.run402.com/buzz-human-adoption-results/v1",
+  returnMode: "browser_fragment_v1",
 };
 
 async function emitNostrBind(page: Page, payload: NostrBindPayload) {
@@ -96,6 +106,23 @@ async function signCommandPayloads(page: Page): Promise<unknown[]> {
       ).__BUZZ_E2E_COMMAND_LOG__ ?? []
     )
       .filter(({ command }) => command === "sign_nostr_identity_binding")
+      .map(({ payload }) => payload),
+  );
+}
+
+async function resultCommandPayloads(page: Page): Promise<unknown[]> {
+  return page.evaluate(() =>
+    (
+      (
+        window as Window & {
+          __BUZZ_E2E_COMMAND_LOG__?: Array<{
+            command: string;
+            payload: unknown;
+          }>;
+        }
+      ).__BUZZ_E2E_COMMAND_LOG__ ?? []
+    )
+      .filter(({ command }) => command === "fetch_nostr_bind_result")
       .map(({ payload }) => payload),
   );
 }
@@ -412,6 +439,135 @@ test("returns a signed response in the callback fragment after consent", async (
   expect(callbackUrl.search).toBe("?source=bind");
   expect(callbackUrl.searchParams.has("buzz_bind")).toBe(false);
   expect(callbackUrl.hash).toMatch(/^#buzz_bind=v1\.[A-Za-z0-9_-]+$/);
+});
+
+test("waits for Run402 completion, confirms it, and closes automatically", async ({
+  page,
+}) => {
+  await openNostrBind(page, RESULT_REQUEST, {
+    nostrBindResultResponses: [{ status: "pending" }, { status: "completed" }],
+  });
+  await pasteCode(
+    page.getByTestId("nostr-bind-code-digit-1"),
+    RESULT_REQUEST.verificationCode,
+  );
+
+  await expect(
+    page.getByRole("heading", { name: "Waiting for Run402 confirmation" }),
+  ).toBeVisible();
+  await expect(page.getByText("Ownership is not confirmed yet.")).toBeVisible();
+  await expect.poll(() => resultCommandPayloads(page)).toHaveLength(2);
+  await expect(
+    page.getByRole("heading", { name: "You’re now a Run402 co-owner" }),
+  ).toBeVisible();
+  await expect(page.getByText("Ownership is confirmed.")).toBeVisible();
+  await expect(page.getByTestId("nostr-bind-page")).toBeHidden({
+    timeout: 3_000,
+  });
+});
+
+test("keeps a wrong-owner result open with a specific recovery step", async ({
+  page,
+}) => {
+  await openNostrBind(page, RESULT_REQUEST, {
+    nostrBindResultResponses: [
+      {
+        status: "action_required",
+        resultCode: "BUZZ_OWNER_PROOF_INVALID",
+      },
+    ],
+  });
+  await pasteCode(
+    page.getByTestId("nostr-bind-code-digit-1"),
+    RESULT_REQUEST.verificationCode,
+  );
+
+  await expect(
+    page.getByRole("heading", { name: "Run402 needs another step" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Run402 could not match this signature to the linked Buzz owner.",
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/Make sure Buzz is using the identity named in Run402/),
+  ).toBeVisible();
+  await page.waitForTimeout(1_100);
+  await expect(page.getByTestId("nostr-bind-page")).toBeVisible();
+});
+
+for (const [status, heading] of [
+  ["expired", "This approval expired"],
+  ["cancelled", "This handoff was cancelled"],
+] as const) {
+  test(`keeps an authoritative ${status} result open`, async ({ page }) => {
+    await openNostrBind(page, RESULT_REQUEST, {
+      nostrBindResultResponses: [{ status }],
+    });
+    await pasteCode(
+      page.getByTestId("nostr-bind-code-digit-1"),
+      RESULT_REQUEST.verificationCode,
+    );
+
+    await expect(page.getByRole("heading", { name: heading })).toBeVisible();
+    await expect(page.getByTestId("nostr-bind-page")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Closing Buzz does not cancel, retry, or change anything in Run402.",
+      ),
+    ).toBeVisible();
+  });
+}
+
+test("shows uncertainty instead of success for an unrecognized result", async ({
+  page,
+}) => {
+  await openNostrBind(page, RESULT_REQUEST, {
+    nostrBindResultResponses: [{ status: "completed", extra: true }],
+  });
+  await pasteCode(
+    page.getByTestId("nostr-bind-code-digit-1"),
+    RESULT_REQUEST.verificationCode,
+  );
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Couldn’t confirm the Run402 result",
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/does not prove that ownership succeeded/),
+  ).toBeVisible();
+  await expect(page.getByTestId("nostr-bind-page")).toBeVisible();
+});
+
+test("ignores a completed result from a superseded approval", async ({
+  page,
+}) => {
+  await openNostrBind(page, RESULT_REQUEST, {
+    nostrBindResultDelayMs: 300,
+    nostrBindResultResponses: [{ status: "completed" }],
+  });
+  await pasteCode(
+    page.getByTestId("nostr-bind-code-digit-1"),
+    RESULT_REQUEST.verificationCode,
+  );
+  await expect.poll(() => resultCommandPayloads(page)).toHaveLength(1);
+
+  const nextRequest = {
+    ...RESULT_REQUEST,
+    challengeId: "550e8400-e29b-41d4-a716-446655440099",
+    verificationCode: "654321",
+  };
+  await emitNostrBind(page, nextRequest);
+  await page.waitForTimeout(400);
+
+  await expect(page.getByTestId("nostr-bind-code-step")).toBeVisible();
+  await expect(page.getByTestId("nostr-bind-code-digit-1")).toHaveValue("");
+  await expect(
+    page.getByRole("heading", { name: "You’re now a Run402 co-owner" }),
+  ).toBeHidden();
 });
 
 test("opens the manual fallback when returning to the browser fails", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -355,6 +355,10 @@ type MockBridgeOptions = {
   openerError?: string;
   /** Delay binding signatures so specs can exercise request supersession. */
   nostrBindSignDelayMs?: number;
+  /** Sequenced authoritative results returned to the Run402 handoff UI. */
+  nostrBindResultResponses?: Array<Record<string, unknown>>;
+  /** Delay each result read so specs can supersede an in-flight request. */
+  nostrBindResultDelayMs?: number;
   /** Reject successive mock WebSocket connect attempts, then resume. */
   websocketConnectErrors?: string[];
   /** Deliver AUTH synchronously, before the mock connect command resolves. */


### PR DESCRIPTION
## What changed

- parse the optional Run402 result acknowledgement extension while preserving the legacy manual flow
- add a no-proxy, no-redirect, HTTPS-only native result client with public-address DNS pinning and strict time/body bounds
- keep the signed approval memory-only and ignore stale/superseded result reads
- show explicit waiting, completed, action-required, expired, cancelled, unsafe, malformed, and unreachable states
- auto-dismiss only after Run402 confirms the exact approval as `completed`

## Why

The browser callback confirms proof delivery, not Run402 ownership completion. The previous copy-only proposal (#4683) could explain the stale screen but could not make it correct, so it was closed. This replacement observes the authoritative Run402 result and keeps every uncertain or unsuccessful state open with a specific recovery action.

## Compatibility and security

Older Run402 links retain the existing manual-close behavior. Unknown or unsafe acknowledgement extensions are ignored or rejected safely. Result URLs cannot use credentials, query tokens, fragments, redirects, proxies, private/reserved addresses, oversized DNS answer sets, or oversized responses.

## Validation

- desktop unit suite — 4,138 passed
- native suite — 2,178 passed, 14 ignored, 0 failed, plus all companion crate tests
- Nostr-bind E2E suite — 17 passed
- deep-link parser suite — 21 passed
- native result-client suite — 7 passed
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check`
- `pnpm build:e2e`
- `just desktop-tauri-fmt-check desktop-build desktop-tauri-check desktop-tauri-test`
