### PR TITLE
fix(acp): preserve routing for edited messages

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2472,7 +2472,7 @@ async fn tokio_main() -> Result<()> {
             // arrive when the channel is silent.
             if queue.has_flushable_work() {
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
@@ -2524,7 +2524,7 @@ async fn tokio_main() -> Result<()> {
         // next relay event arrives — which can be minutes on quiet channels.
         if respawn_collected {
             for (channel_id, thread_tags) in
-                dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
             {
                 typing_channels.insert(channel_id, thread_tags);
             }
@@ -3006,6 +3006,7 @@ async fn tokio_main() -> Result<()> {
                             if pool_ready {
                                 for (channel_id, thread_tags) in
                                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                        .await
                                 {
                                     typing_channels.insert(channel_id, thread_tags);
                                 }
@@ -3106,6 +3107,7 @@ async fn tokio_main() -> Result<()> {
                         tracing::debug!("heartbeat_skipped_events");
                         for (channel_id, thread_tags) in
                             dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                        .await
                         {
                             typing_channels.insert(channel_id, thread_tags);
                         }
@@ -3204,7 +3206,7 @@ async fn tokio_main() -> Result<()> {
                     break;
                 }
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
@@ -3229,7 +3231,7 @@ async fn tokio_main() -> Result<()> {
                     break;
                 }
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
@@ -3384,7 +3386,7 @@ async fn tokio_main() -> Result<()> {
                 // queue drains. We still try here in case the in-flight
                 // task has already returned.
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
@@ -3412,7 +3414,7 @@ async fn tokio_main() -> Result<()> {
                             None,
                         );
                         for (channel_id, thread_tags) in
-                            dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                            dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
                         {
                             typing_channels.insert(channel_id, thread_tags);
                         }
@@ -3825,8 +3827,44 @@ fn try_native_steer(
 
 // ── dispatch_pending ──────────────────────────────────────────────────────────
 
+fn typing_scope_for_event(
+    event: &nostr::Event,
+    resolved_edit: Option<&queue::ResolvedEdit>,
+) -> ThreadTags {
+    resolved_edit
+        .map(|edit| edit.target_thread_tags.clone())
+        .unwrap_or_else(|| queue::parse_thread_tags(event))
+}
+
+#[cfg(test)]
+mod typing_scope_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    #[test]
+    fn edit_typing_scope_uses_the_resolved_original_thread() {
+        let target_id = "11".repeat(32);
+        let root_id = "22".repeat(32);
+        let edit = EventBuilder::new(Kind::Custom(40003), "edited request")
+            .tags([Tag::parse(["e", target_id.as_str()]).expect("edit target")])
+            .sign_with_keys(&Keys::generate())
+            .expect("signed edit");
+        let resolved = queue::ResolvedEdit {
+            target_event_id: target_id,
+            target_thread_tags: ThreadTags {
+                root_event_id: Some(root_id.clone()),
+                parent_event_id: None,
+                mentioned_pubkeys: Vec::new(),
+            },
+        };
+
+        let scope = typing_scope_for_event(&edit, Some(&resolved));
+        assert_eq!(scope.root_event_id.as_deref(), Some(root_id.as_str()));
+    }
+}
+
 /// Flush queued work to available agents.
-fn dispatch_pending(
+async fn dispatch_pending(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
@@ -3839,11 +3877,14 @@ fn dispatch_pending(
             None => break,
         };
         let channel_id = batch.channel_id;
-        let typing_scope = batch
-            .events
-            .last()
-            .map(|event| queue::parse_thread_tags(&event.event))
-            .unwrap_or_default();
+        let typing_scope = match batch.events.last() {
+            Some(event) => {
+                let resolved_edit =
+                    pool::resolve_edit_routing(&event.event, &ctx.rest_client).await;
+                typing_scope_for_event(&event.event, resolved_edit.as_ref())
+            }
+            None => ThreadTags::default(),
+        };
         let affinity_hit = pool.has_session_for(channel_id);
         let mut agent = match pool.try_claim(Some(channel_id)) {
             Some(a) => a,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2323,6 +2323,7 @@ async fn tokio_main() -> Result<()> {
     //      withheld event in `EventQueue::withheld_native_steer` until
     //      `IN_FLIGHT_DEADLINE_SECS` expires.
     let (steer_ack_tx, mut steer_ack_rx) = mpsc::unbounded_channel::<SteerAckEvent>();
+    let (typing_tx, mut typing_rx) = mpsc::unbounded_channel::<(Uuid, String, ThreadTags)>();
 
     // ── Step 7: Shutdown signal ───────────────────────────────────────────────
     let (shutdown_tx, mut shutdown_rx) = watch::channel(());
@@ -2397,6 +2398,7 @@ async fn tokio_main() -> Result<()> {
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
+        Typing(Uuid, String, ThreadTags),
         Wake(u32, Result<AgentPool, String>),
     }
 
@@ -2472,7 +2474,7 @@ async fn tokio_main() -> Result<()> {
             // arrive when the channel is silent.
             if queue.has_flushable_work() {
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
@@ -2524,7 +2526,7 @@ async fn tokio_main() -> Result<()> {
         // next relay event arrives — which can be minutes on quiet channels.
         if respawn_collected {
             for (channel_id, thread_tags) in
-                dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
+                dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
             {
                 typing_channels.insert(channel_id, thread_tags);
             }
@@ -2557,6 +2559,9 @@ async fn tokio_main() -> Result<()> {
                 // locked semantics (Eva + Max + Perci).
                 Some(ack_event) = steer_ack_rx.recv() => {
                     Some(PoolEvent::SteerAck(ack_event))
+                }
+                Some((channel_id, turn_id, scope)) = typing_rx.recv() => {
+                    Some(PoolEvent::Typing(channel_id, turn_id, scope))
                 }
                 Some((attempt, result)) = wake_rx.recv(), if config.lazy_pool && !pool_ready => {
                     Some(PoolEvent::Wake(attempt, result))
@@ -3005,8 +3010,7 @@ async fn tokio_main() -> Result<()> {
                             }
                             if pool_ready {
                                 for (channel_id, thread_tags) in
-                                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
-                        .await
+                                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
                                 {
                                     typing_channels.insert(channel_id, thread_tags);
                                 }
@@ -3106,8 +3110,7 @@ async fn tokio_main() -> Result<()> {
                     } else if queue.has_flushable_work() {
                         tracing::debug!("heartbeat_skipped_events");
                         for (channel_id, thread_tags) in
-                            dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
-                        .await
+                            dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
                         {
                             typing_channels.insert(channel_id, thread_tags);
                         }
@@ -3206,7 +3209,7 @@ async fn tokio_main() -> Result<()> {
                     break;
                 }
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
@@ -3231,10 +3234,19 @@ async fn tokio_main() -> Result<()> {
                     break;
                 }
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
+            }
+            Some(PoolEvent::Typing(channel_id, turn_id, scope)) => {
+                record_typing_scope_if_current(
+                    &pool,
+                    &mut typing_channels,
+                    channel_id,
+                    &turn_id,
+                    scope,
+                );
             }
             Some(PoolEvent::SteerAck(SteerAckEvent {
                 channel_id,
@@ -3386,7 +3398,7 @@ async fn tokio_main() -> Result<()> {
                 // queue drains. We still try here in case the in-flight
                 // task has already returned.
                 for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
                 {
                     typing_channels.insert(channel_id, thread_tags);
                 }
@@ -3413,9 +3425,13 @@ async fn tokio_main() -> Result<()> {
                             "ready",
                             None,
                         );
-                        for (channel_id, thread_tags) in
-                            dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity).await
-                        {
+                        for (channel_id, thread_tags) in dispatch_pending(
+                            &mut pool,
+                            &mut queue,
+                            &ctx,
+                            &typing_tx,
+                            &mut last_activity,
+                        ) {
                             typing_channels.insert(channel_id, thread_tags);
                         }
                     }
@@ -3827,47 +3843,28 @@ fn try_native_steer(
 
 // ── dispatch_pending ──────────────────────────────────────────────────────────
 
-fn typing_scope_for_event(
-    event: &nostr::Event,
-    resolved_edit: Option<&queue::ResolvedEdit>,
-) -> ThreadTags {
-    resolved_edit
-        .map(|edit| edit.target_thread_tags.clone())
-        .unwrap_or_else(|| queue::parse_thread_tags(event))
-}
-
-#[cfg(test)]
-mod typing_scope_tests {
-    use super::*;
-    use nostr::{EventBuilder, Keys, Kind, Tag};
-
-    #[test]
-    fn edit_typing_scope_uses_the_resolved_original_thread() {
-        let target_id = "11".repeat(32);
-        let root_id = "22".repeat(32);
-        let edit = EventBuilder::new(Kind::Custom(40003), "edited request")
-            .tags([Tag::parse(["e", target_id.as_str()]).expect("edit target")])
-            .sign_with_keys(&Keys::generate())
-            .expect("signed edit");
-        let resolved = queue::ResolvedEdit {
-            target_event_id: target_id,
-            target_thread_tags: ThreadTags {
-                root_event_id: Some(root_id.clone()),
-                parent_event_id: None,
-                mentioned_pubkeys: Vec::new(),
-            },
-        };
-
-        let scope = typing_scope_for_event(&edit, Some(&resolved));
-        assert_eq!(scope.root_event_id.as_deref(), Some(root_id.as_str()));
+fn record_typing_scope_if_current(
+    pool: &AgentPool,
+    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+    channel_id: Uuid,
+    turn_id: &str,
+    scope: ThreadTags,
+) {
+    // Edit routing is resolved asynchronously inside the prompt task. Discard
+    // its scope if that exact turn has already completed (or been replaced);
+    // otherwise a result-before-typing schedule can resurrect an indicator
+    // with no remaining cleanup path.
+    if pool.is_turn_in_flight(channel_id, turn_id) {
+        typing_channels.insert(channel_id, scope);
     }
 }
 
 /// Flush queued work to available agents.
-async fn dispatch_pending(
+fn dispatch_pending(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
+    typing_tx: &mpsc::UnboundedSender<(Uuid, String, ThreadTags)>,
     last_activity: &mut tokio::time::Instant,
 ) -> Vec<(Uuid, ThreadTags)> {
     let mut dispatched_channels = Vec::new();
@@ -3877,14 +3874,11 @@ async fn dispatch_pending(
             None => break,
         };
         let channel_id = batch.channel_id;
-        let typing_scope = match batch.events.last() {
-            Some(event) => {
-                let resolved_edit =
-                    pool::resolve_edit_routing(&event.event, &ctx.rest_client).await;
-                typing_scope_for_event(&event.event, resolved_edit.as_ref())
-            }
-            None => ThreadTags::default(),
-        };
+        let typing_scope = batch.events.last().and_then(|event| {
+            queue::edit_target_id(&event.event)
+                .is_none()
+                .then(|| queue::parse_thread_tags(&event.event))
+        });
         let affinity_hit = pool.has_session_for(channel_id);
         let mut agent = match pool.try_claim(Some(channel_id)) {
             Some(a) => a,
@@ -3906,6 +3900,7 @@ async fn dispatch_pending(
         let result_tx = pool.result_tx();
         let ctx_clone = Arc::clone(ctx);
         let agent_index = agent.index;
+        let typing_tx = typing_tx.clone();
 
         // Mid-turn non-cancelling steer seam: install the per-turn steer
         // receiver on the read loop so the main loop's mode-gate fork
@@ -3934,6 +3929,7 @@ async fn dispatch_pending(
                 ctx_clone,
                 result_tx,
                 Some(control_rx),
+                Some(typing_tx),
                 task_turn_id,
             )
             .await;
@@ -3951,7 +3947,9 @@ async fn dispatch_pending(
                 successful_steer_deliveries: HashSet::new(),
             },
         );
-        dispatched_channels.push((channel_id, typing_scope));
+        if let Some(scope) = typing_scope {
+            dispatched_channels.push((channel_id, scope));
+        }
         *last_activity = tokio::time::Instant::now();
     }
     tracing::debug!(
@@ -4569,6 +4567,7 @@ fn dispatch_heartbeat(
             Some(prompt_text),
             ctx_clone,
             result_tx,
+            None,
             None,
             task_turn_id,
         )
@@ -5363,6 +5362,44 @@ mod owner_control_command_tests {
         assert!(
             mode_gate_signal(MultipleEventHandling::OwnerInterrupt, &owner, None).is_none(),
             "owner-interrupt must not fire when the owner is unknown"
+        );
+    }
+
+    #[tokio::test]
+    async fn delayed_typing_scope_after_turn_completion_is_ignored() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let turn_id = "completed-edit-turn";
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: turn_id.into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        // Simulate the biased select consuming Result before the edit task's
+        // delayed Typing event. Result handling removes TaskMeta before the
+        // next select iteration receives the scope.
+        pool.task_map_mut().remove(&task_id);
+        let mut typing_channels = HashMap::new();
+        record_typing_scope_if_current(
+            &pool,
+            &mut typing_channels,
+            channel_id,
+            turn_id,
+            ThreadTags::default(),
+        );
+
+        assert!(
+            !typing_channels.contains_key(&channel_id),
+            "a completed turn must not resurrect its typing indicator"
         );
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2927,7 +2927,8 @@ async fn tokio_main() -> Result<()> {
                             // Capture author pubkey before queue.push() moves
                             // buzz_event.event (needed for mode gate below).
                             let author_hex = buzz_event.event.pubkey.to_hex();
-                            let event_id_hex = buzz_event.event.id.to_hex();
+                            let reaction_event_id =
+                                queue::reaction_target_id(&buzz_event.event);
                             // Clone for the non-cancelling steer fork, which
                             // needs the event to render the steer body. The
                             // clone is unconditional because we don't know
@@ -2953,7 +2954,7 @@ async fn tokio_main() -> Result<()> {
                             // cosmetic stale 👀. Acceptable — see ReactionGuard docs.
                             if accepted {
                                 let rc = ctx.rest_client.clone();
-                                let eid = event_id_hex.clone();
+                                let eid = reaction_event_id.clone();
                                 tokio::spawn(async move {
                                     pool::reaction_add(&rc, &eid, "👀").await;
                                 });

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1851,7 +1851,12 @@ pub async fn run_prompt_task(
     // See `ReactionGuard` docs for ordering guarantees and known edge cases.
     let reaction_ids: Vec<String> = batch
         .as_ref()
-        .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
+        .map(|b| {
+            b.events
+                .iter()
+                .map(|be| crate::queue::reaction_target_id(&be.event))
+                .collect()
+        })
         .unwrap_or_default();
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -734,6 +734,13 @@ impl AgentPool {
         &mut self.task_map
     }
 
+    /// Whether the identified turn still owns the in-flight task for `channel_id`.
+    pub fn is_turn_in_flight(&self, channel_id: Uuid, turn_id: &str) -> bool {
+        self.task_map
+            .values()
+            .any(|meta| meta.channel_id == Some(channel_id) && meta.turn_id == turn_id)
+    }
+
     /// Try to send a goose-native steer request to the in-flight task for
     /// `channel_id`.
     ///
@@ -1767,6 +1774,7 @@ fn send_prompt_result(
 ///
 /// The agent is ALWAYS returned — even on panic the `JoinSet` detects the
 /// abort and the caller uses `task_map` to recover the agent index.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_prompt_task(
     mut agent: OwnedAgent,
     batch: Option<FlushBatch>,
@@ -1774,6 +1782,7 @@ pub async fn run_prompt_task(
     ctx: Arc<PromptContext>,
     result_tx: mpsc::UnboundedSender<PromptResult>,
     control_rx: Option<tokio::sync::oneshot::Receiver<ControlSignal>>,
+    typing_tx: Option<mpsc::UnboundedSender<(Uuid, String, crate::queue::ThreadTags)>>,
     turn_id: String,
 ) {
     // Is this a channel prompt or a heartbeat?
@@ -2339,14 +2348,23 @@ pub async fn run_prompt_task(
         };
         vec![text]
     } else if let Some(ref b) = batch {
-        // Build prompt from batch with context enrichment.
-        // Try startup cache first; lazy-fetch via REST for dynamic channels.
-        let channel_info = ctx.channel_info.resolve(b.channel_id).await;
-
+        // Resolve edit routing once inside the prompt task. This keeps the
+        // network lookup off the shared relay loop and gives typing, prompt,
+        // reply, reaction, and failure routing one authority.
         let resolved_edit = match b.events.last() {
             Some(event) => resolve_edit_routing(&event.event, &ctx.rest_client).await,
             None => None,
         };
+        if let (Some(tx), Some(event)) = (typing_tx.as_ref(), b.events.last()) {
+            if crate::queue::edit_target_id(&event.event).is_some() {
+                let scope = typing_scope_for_event(&event.event, resolved_edit.as_ref());
+                let _ = tx.send((b.channel_id, turn_id.clone(), scope));
+            }
+        }
+
+        // Build prompt from batch with context enrichment.
+        // Try startup cache first; lazy-fetch via REST for dynamic channels.
+        let channel_info = ctx.channel_info.resolve(b.channel_id).await;
 
         let conversation_context = if ctx.context_message_limit > 0 {
             match resolved_edit
@@ -3321,6 +3339,15 @@ fn conversation_context_delta(
             })
         }
     }
+}
+
+fn typing_scope_for_event(
+    event: &nostr::Event,
+    resolved_edit: Option<&crate::queue::ResolvedEdit>,
+) -> crate::queue::ThreadTags {
+    resolved_edit
+        .map(|edit| edit.target_thread_tags.clone())
+        .unwrap_or_else(|| crate::queue::parse_thread_tags(event))
 }
 
 /// Resolve a kind:40003 edit through its original event for reply routing.
@@ -4768,6 +4795,27 @@ mod tests {
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
 
+    #[test]
+    fn edit_typing_scope_uses_resolved_original_thread() {
+        let target_id = "11".repeat(32);
+        let root_id = "22".repeat(32);
+        let edit = EventBuilder::new(Kind::Custom(40003), "edited request")
+            .tags([Tag::parse(["e", target_id.as_str()]).expect("edit target")])
+            .sign_with_keys(&Keys::generate())
+            .expect("signed edit");
+        let resolved = crate::queue::ResolvedEdit {
+            target_event_id: target_id,
+            target_thread_tags: ThreadTags {
+                root_event_id: Some(root_id.clone()),
+                parent_event_id: None,
+                mentioned_pubkeys: Vec::new(),
+            },
+        };
+
+        let scope = typing_scope_for_event(&edit, Some(&resolved));
+        assert_eq!(scope.root_event_id.as_deref(), Some(root_id.as_str()));
+    }
+
     fn test_mcp_server() -> McpServer {
         McpServer {
             name: "dev".into(),
@@ -6073,6 +6121,7 @@ done"#
                 Arc::clone(&ctx),
                 result_tx.clone(),
                 None,
+                None,
                 format!("turn-{turn}"),
             )
             .await;
@@ -6190,6 +6239,7 @@ done"#
                 None,
                 Arc::clone(&ctx),
                 result_tx.clone(),
+                None,
                 None,
                 format!("turn-{turn}"),
             )
@@ -6369,6 +6419,7 @@ done"#
                 Arc::clone(&ctx),
                 result_tx.clone(),
                 None,
+                None,
                 turn_id.into(),
             )
             .await;
@@ -6530,6 +6581,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             None,
             Arc::new(ctx),
             result_tx,
+            None,
             None,
             "next-turn".into(),
         )

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3325,7 +3325,7 @@ fn conversation_context_delta(
 
 /// Resolve a kind:40003 edit through its original event for reply routing.
 /// Failure deliberately falls back to the edit target id in `format_prompt`.
-async fn resolve_edit_routing(
+pub(crate) async fn resolve_edit_routing(
     event: &nostr::Event,
     rest: &RestClient,
 ) -> Option<crate::queue::ResolvedEdit> {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -24,6 +24,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use nostr::EventId;
 use tokio::sync::mpsc;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::timeout;
@@ -2337,8 +2338,28 @@ pub async fn run_prompt_task(
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
         let channel_info = ctx.channel_info.resolve(b.channel_id).await;
 
+        let resolved_edit = match b.events.last() {
+            Some(event) => resolve_edit_routing(&event.event, &ctx.rest_client).await,
+            None => None,
+        };
+
         let conversation_context = if ctx.context_message_limit > 0 {
-            fetch_conversation_context(b, &channel_info, &ctx).await
+            match resolved_edit
+                .as_ref()
+                .and_then(|edit| edit.target_thread_tags.root_event_id.as_deref())
+            {
+                Some(root_id) => {
+                    fetch_thread_context(
+                        b.channel_id,
+                        root_id,
+                        ctx.context_message_limit,
+                        ctx.agent_keys.public_key(),
+                        &ctx.rest_client,
+                    )
+                    .await
+                }
+                None => fetch_conversation_context(b, &channel_info, &ctx).await,
+            }
         } else {
             None
         };
@@ -2396,6 +2417,7 @@ pub async fn run_prompt_task(
                 conversation_context: conversation_context.as_ref(),
                 conversation_context_had_delivered_events,
                 profile_lookup: profile_lookup.as_ref(),
+                resolved_edit: resolved_edit.as_ref(),
                 has_system_prompt_support: agent.has_system_prompt_support(),
                 base_prompt: standing.base_prompt,
                 system_prompt: standing.system_prompt,
@@ -3294,6 +3316,47 @@ fn conversation_context_delta(
             })
         }
     }
+}
+
+/// Resolve a kind:40003 edit through its original event for reply routing.
+/// Failure deliberately falls back to the edit target id in `format_prompt`.
+async fn resolve_edit_routing(
+    event: &nostr::Event,
+    rest: &RestClient,
+) -> Option<crate::queue::ResolvedEdit> {
+    let target_event_id = crate::queue::edit_target_id(event)?;
+    let target_id = EventId::from_hex(&target_event_id).ok()?;
+    let filter = nostr::Filter::new().id(target_id).limit(1);
+    let response = match timeout(Duration::from_millis(2_000), rest.query(&[filter])).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event fetch failed: {error}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event fetch timed out");
+            return None;
+        }
+    };
+    let Some(raw) = response.as_array().and_then(|events| events.first()) else {
+        tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event was not returned");
+        return None;
+    };
+    let original = match serde_json::from_value::<nostr::Event>(raw.clone()) {
+        Ok(original) if original.id == target_id && original.verify().is_ok() => original,
+        Ok(_) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event failed id/signature verification");
+            return None;
+        }
+        Err(error) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: malformed original event: {error}");
+            return None;
+        }
+    };
+    Some(crate::queue::ResolvedEdit {
+        target_event_id,
+        target_thread_tags: crate::queue::parse_thread_tags(&original),
+    })
 }
 
 /// Fetch conversation context (thread or DM) for a batch before prompting.

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1507,6 +1507,16 @@ fn format_conversation_context(
     s
 }
 
+/// Event ID that should own lifecycle reactions for an inbound event.
+///
+/// Kind:40003 edits are auxiliary events that do not render as timeline rows,
+/// so their seen/working reactions belong on the visible original message.
+/// Prompt routing and reaction routing deliberately share `edit_target_id` as
+/// their semantic authority even when fetching the original event later fails.
+pub(crate) fn reaction_target_id(event: &Event) -> String {
+    edit_target_id(event).unwrap_or_else(|| event.id.to_hex())
+}
+
 /// Original-message routing recovered for a kind:40003 edit event.
 #[derive(Debug, Clone)]
 pub struct ResolvedEdit {
@@ -5325,6 +5335,23 @@ mod tests {
         )
         .join("\n");
         assert!(prompt.contains(&format!("--reply-to {root_id}")));
+    }
+
+    #[test]
+    fn edit_reactions_target_visible_original_message() {
+        let original_id = "66".repeat(32);
+        let edit = edit_event(&original_id);
+
+        assert_eq!(reaction_target_id(&edit), original_id);
+    }
+
+    #[test]
+    fn ordinary_event_reactions_target_the_event_itself() {
+        let event = EventBuilder::new(Kind::Custom(9), "mention")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+
+        assert_eq!(reaction_target_id(&event), event.id.to_hex());
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -715,25 +715,40 @@ impl EventQueue {
     ///
     /// Also clears any `retry_after` throttle for the channel.
     ///
-    /// Returns the event IDs of dropped events so the caller can clean up
-    /// any reactions (👀) that were added at queue-push time.
+    /// Returns the visible event IDs that own lifecycle reactions for every
+    /// dropped event so the caller can clean up any 👀 added at queue-push time.
     pub fn drain_channel(&mut self, channel_id: Uuid) -> Vec<String> {
-        let ids = self
-            .queues
-            .remove(&channel_id)
-            .map(|q| q.into_iter().map(|e| e.event.id.to_hex()).collect())
-            .unwrap_or_default();
+        let mut ids: HashSet<String> = HashSet::new();
+        if let Some(events) = self.queues.remove(&channel_id) {
+            ids.extend(
+                events
+                    .into_iter()
+                    .map(|event| reaction_target_id(&event.event)),
+            );
+        }
+        if let Some(events) = self.cancelled_batches.remove(&channel_id) {
+            ids.extend(
+                events
+                    .into_iter()
+                    .map(|event| reaction_target_id(&event.event)),
+            );
+        }
+        if let Some(events) = self.withheld_native_steer.remove(&channel_id) {
+            ids.extend(
+                events
+                    .into_iter()
+                    .map(|event| reaction_target_id(&event.event)),
+            );
+        }
         self.retry_after.remove(&channel_id);
         self.retry_counts.remove(&channel_id);
-        self.cancelled_batches.remove(&channel_id);
         self.cancel_reasons.remove(&channel_id);
-        self.withheld_native_steer.remove(&channel_id);
         // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
         // will expire (auto-cleaning the channel). Removing deadlines without
         // removing in_flight_channels would disable auto-expiry and leave a
         // wedged task permanently blocking the channel.
-        ids
+        ids.into_iter().collect()
     }
 
     /// Whether a prompt is currently in-flight for the given channel.
@@ -4040,6 +4055,33 @@ mod tests {
         let drained = q.drain_channel(ch);
         assert_eq!(drained.len(), 2);
         assert_eq!(pending_count(&q), 0);
+    }
+
+    #[test]
+    fn test_drain_channel_returns_visible_edit_targets_including_withheld() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let queued_target = "77".repeat(32);
+        let withheld_target = "88".repeat(32);
+
+        let queued = QueuedEvent {
+            channel_id: ch,
+            event: edit_event(&queued_target),
+            received_at: Instant::now(),
+            prompt_tag: "test".into(),
+        };
+        let withheld = QueuedEvent {
+            channel_id: ch,
+            event: edit_event(&withheld_target),
+            received_at: Instant::now(),
+            prompt_tag: "test".into(),
+        };
+        q.push(queued);
+        q.withheld_native_steer.insert(ch, vec![withheld]);
+
+        let drained: HashSet<String> = q.drain_channel(ch).into_iter().collect();
+        assert_eq!(drained, HashSet::from([queued_target, withheld_target]));
+        assert!(q.withheld_native_steer.is_empty());
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -884,6 +884,23 @@ pub struct ThreadTags {
 /// NOTE: Only handles NIP-10 marker-based format (preferred). The deprecated
 /// positional format (no markers, `["e", id, relay_url]`) is not supported —
 /// Buzz always generates marker-based tags (see relay messages.rs:762-783).
+/// Return the original message id targeted by a kind:40003 edit event.
+///
+/// Edit events deliberately use a bare two-element `e` tag; this is not the
+/// deprecated positional NIP-10 thread format and must not be accepted by
+/// [`parse_thread_tags`] for other event kinds.
+pub fn edit_target_id(event: &Event) -> Option<String> {
+    (event.kind.as_u16() == 40003)
+        .then(|| {
+            event.tags.iter().find_map(|tag| {
+                let parts = tag.as_slice();
+                (parts.len() == 2 && parts.first().map(String::as_str) == Some("e"))
+                    .then(|| parts[1].clone())
+            })
+        })
+        .flatten()
+}
+
 pub fn parse_thread_tags(event: &Event) -> ThreadTags {
     let mut root = None;
     let mut reply = None;
@@ -1444,6 +1461,13 @@ fn format_conversation_context(
     s
 }
 
+/// Original-message routing recovered for a kind:40003 edit event.
+#[derive(Debug, Clone)]
+pub struct ResolvedEdit {
+    pub target_event_id: String,
+    pub target_thread_tags: ThreadTags,
+}
+
 /// Arguments for [`format_prompt`] beyond the required [`FlushBatch`].
 #[derive(Default)]
 pub struct FormatPromptArgs<'a> {
@@ -1456,6 +1480,10 @@ pub struct FormatPromptArgs<'a> {
     /// live session had already received. Trigger-only context does not set it.
     pub conversation_context_had_delivered_events: bool,
     pub profile_lookup: Option<&'a PromptProfileLookup>,
+    /// Routing derived by resolving a kind:40003 edit target. When present,
+    /// prompt scope and reply instructions use the original message rather
+    /// than the invisible edit auxiliary event.
+    pub resolved_edit: Option<&'a ResolvedEdit>,
     /// When true, base_prompt and system_prompt are delivered via the system
     /// role (session/new) and omitted from the user message. When false
     /// (legacy agents), they are injected as `[Base]` and `[System]` sections.
@@ -1577,7 +1605,17 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
             return Vec::new();
         }
     };
-    let thread_tags = parse_thread_tags(&last_event.event);
+    let edit_target = edit_target_id(&last_event.event);
+    let resolved_edit = args.resolved_edit.filter(|_| edit_target.is_some());
+    // An edit's own bare `e` tag is not a thread tag. Route via the original
+    // message when it was fetched, or its target id as the safe fallback.
+    let thread_tags = resolved_edit
+        .map(|edit| edit.target_thread_tags.clone())
+        .unwrap_or_else(|| parse_thread_tags(&last_event.event));
+    let routing_event_id = resolved_edit
+        .map(|edit| edit.target_event_id.clone())
+        .or(edit_target.clone())
+        .unwrap_or_else(|| last_event.event.id.to_hex());
     let is_dm = args
         .channel_info
         .map(|ci| ci.channel_type == "dm")
@@ -1616,12 +1654,12 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         thread_tags
             .root_event_id
             .is_some()
-            .then(|| last_event.event.id.to_hex())
+            .then(|| routing_event_id.to_string())
     } else {
         resolve_reply_anchor(
             &sender_pubkey,
             &thread_tags,
-            &last_event.event.id.to_hex(),
+            &routing_event_id,
             args.profile_lookup,
         )
     };
@@ -1634,6 +1672,16 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         args.conversation_context_had_delivered_events,
         reply_anchor.as_deref(),
     ));
+    if let Some(edit) = resolved_edit {
+        sections.push(format!(
+            "[Edit routing]\nTrigger is a kind:40003 edit event; original message ID: {}",
+            edit.target_event_id
+        ));
+    } else if let Some(target_id) = edit_target {
+        sections.push(format!(
+            "[Edit routing]\nTrigger is a kind:40003 edit event; original message ID: {target_id} (original event fetch failed; using target as reply anchor)"
+        ));
+    }
 
     // 3. Conversation context (thread or DM).
     if let Some(ctx) = args.conversation_context {
@@ -5114,6 +5162,78 @@ mod tests {
             q.in_flight_channels.contains(&ch),
             "ch must still be in-flight after has_flushable_work finds ch2 work"
         );
+    }
+
+    fn edit_event(target: &str) -> Event {
+        let keys = Keys::generate();
+        EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .tags([nostr::Tag::parse(["e", target]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    fn one_event_batch(event: Event) -> FlushBatch {
+        FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        }
+    }
+
+    #[test]
+    fn edit_of_top_level_anchors_original_message_in_rendered_prompt() {
+        let original_id = "11".repeat(32);
+        let edit = edit_event(&original_id);
+        let prompt = format_prompt(
+            &one_event_batch(edit),
+            &FormatPromptArgs {
+                resolved_edit: Some(&ResolvedEdit {
+                    target_event_id: original_id.clone(),
+                    target_thread_tags: ThreadTags::default(),
+                }),
+                ..Default::default()
+            },
+        )
+        .join("\n");
+        assert!(prompt.contains(&format!("--reply-to {original_id}")));
+        assert!(prompt.contains(&format!("original message ID: {original_id}")));
+    }
+
+    #[test]
+    fn edit_of_threaded_reply_anchors_original_thread_root_in_rendered_prompt() {
+        let original_id = "22".repeat(32);
+        let root_id = "33".repeat(32);
+        let prompt = format_prompt(
+            &one_event_batch(edit_event(&original_id)),
+            &FormatPromptArgs {
+                resolved_edit: Some(&ResolvedEdit {
+                    target_event_id: original_id,
+                    target_thread_tags: ThreadTags {
+                        root_event_id: Some(root_id.clone()),
+                        parent_event_id: Some("44".repeat(32)),
+                        mentioned_pubkeys: vec![],
+                    },
+                }),
+                ..Default::default()
+            },
+        )
+        .join("\n");
+        assert!(prompt.contains(&format!("--reply-to {root_id}")));
+    }
+
+    #[test]
+    fn edit_fetch_failure_anchors_target_never_auxiliary_edit_event() {
+        let original_id = "55".repeat(32);
+        let edit = edit_event(&original_id);
+        let edit_id = edit.id.to_hex();
+        let prompt = format_prompt(&one_event_batch(edit), &FormatPromptArgs::default()).join("\n");
+        assert!(prompt.contains(&format!("--reply-to {original_id}")));
+        assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
     }
 
     // ── F2 case 2.5: steer renewal is monotonic across repeated steers ───────

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -536,15 +536,58 @@ impl EventQueue {
     /// merged prompt is framed correctly. On a double-cancel, the most recent
     /// reason wins.
     ///
-    /// Unlike `requeue_preserve_timestamps`, events are NOT pushed back into
-    /// the generic queue — they are stored separately and merged by
-    /// `flush_next()`. No retry throttle, no backoff.
+    /// Cancelled batches normally remain separate for annotated merge framing.
+    /// If the interrupted work contains an edit, the complete interrupted
+    /// sequence instead returns to the ordinary queue so `flush_next()` can
+    /// preserve chronology and isolate the edit at its routing boundary.
+    /// No retry throttle or backoff is applied.
     pub fn requeue_as_cancelled(&mut self, batch: FlushBatch, reason: CancelReason) {
-        let entry = self.cancelled_batches.entry(batch.channel_id).or_default();
+        let channel_id = batch.channel_id;
+        let mut cancelled = self
+            .cancelled_batches
+            .remove(&channel_id)
+            .unwrap_or_default();
         // Preserve any already-cancelled events from a prior cancel (double-cancel).
-        entry.extend(batch.cancelled_events);
-        entry.extend(batch.events);
-        self.cancel_reasons.insert(batch.channel_id, reason);
+        cancelled.extend(batch.cancelled_events);
+        cancelled.extend(batch.events);
+
+        // Edit routing is defined per independently dispatched prompt. An edit
+        // that remains in `cancelled_events` would be merged with the later
+        // event that caused cancellation, and `format_prompt` would derive
+        // routing only from that later event. Restore the whole interrupted
+        // sequence to the ordinary queue instead; `flush_next`'s chronological
+        // sort and edit boundary then preserve both ordering and edit routing.
+        if cancelled
+            .iter()
+            .any(|event| edit_target_id(&event.event).is_some())
+        {
+            let queue = self.queues.entry(channel_id).or_default();
+            for event in cancelled.into_iter().rev() {
+                queue.push_front(QueuedEvent {
+                    channel_id,
+                    event: event.event,
+                    prompt_tag: event.prompt_tag,
+                    received_at: event.received_at,
+                });
+            }
+            let withheld = self
+                .withheld_native_steer
+                .get(&channel_id)
+                .map_or(0, Vec::len);
+            while queue.len().saturating_add(withheld) > MAX_PENDING_PER_CHANNEL {
+                queue.pop_back();
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "cancelled edit requeue overflow — dropped newest queued event to enforce cap"
+                );
+            }
+            self.cancel_reasons.remove(&channel_id);
+            return;
+        }
+
+        self.cancelled_batches.insert(channel_id, cancelled);
+        self.cancel_reasons.insert(channel_id, reason);
     }
 
     /// Returns `true` if any channel has pending events that are not in-flight
@@ -4130,6 +4173,46 @@ mod tests {
             2,
             "should have 2 cancelled events"
         );
+    }
+
+    #[test]
+    fn cancelled_edit_returns_to_queue_and_keeps_routing_boundary() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let target_id = "ab".repeat(32);
+        let edit = EventBuilder::new(Kind::Custom(40003), "edited request")
+            .tags([nostr::Tag::parse(["e", &target_id]).unwrap()])
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let edit_id = edit.id;
+        q.push(QueuedEvent {
+            channel_id: ch,
+            event: edit,
+            received_at: Instant::now(),
+            prompt_tag: "edit".into(),
+        });
+        let interrupted = q.flush_next().expect("edit should dispatch alone");
+
+        let later = make_queued(ch, "later request");
+        let later_id = later.event.id;
+        q.push(later);
+        q.requeue_as_cancelled(interrupted, CancelReason::Steer);
+        q.mark_complete(ch);
+
+        let restored_edit = q.flush_next().expect("cancelled edit should be restored");
+        assert_eq!(restored_edit.events.len(), 1);
+        assert_eq!(restored_edit.events[0].event.id, edit_id);
+        assert!(restored_edit.cancelled_events.is_empty());
+        assert_eq!(
+            edit_target_id(&restored_edit.events[0].event),
+            Some(target_id)
+        );
+
+        q.mark_complete(ch);
+        let later_batch = q.flush_next().expect("later request should remain queued");
+        assert_eq!(later_batch.events.len(), 1);
+        assert_eq!(later_batch.events[0].event.id, later_id);
+        assert!(later_batch.cancelled_events.is_empty());
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -332,10 +332,34 @@ impl EventQueue {
             }
         };
 
-        // Drain up to MAX_BATCH_EVENTS; leave any remainder in the queue.
+        // Relay replay delivers stored events newest-first (`ORDER BY
+        // created_at DESC`). Establish chronological order before locating an
+        // edit boundary: partitioning the raw replay deque would otherwise
+        // dispatch a newer ordinary event before an older edit. Stable sort
+        // preserves delivery order for same-second events.
         let queue = self.queues.entry(channel_id).or_default();
-        let drain_count = MAX_BATCH_EVENTS.min(queue.len());
-        let mut events: Vec<BatchEvent> = queue
+        queue
+            .make_contiguous()
+            .sort_by_key(|event| event.event.created_at);
+
+        // Drain up to MAX_BATCH_EVENTS, but isolate edit events. Edit routing
+        // is resolved per dispatched prompt, so allowing an edit to share a
+        // batch with a later event would make the later event's reply anchor
+        // hide the edit's original-message anchor.
+        let max_drain = MAX_BATCH_EVENTS.min(queue.len());
+        let drain_count = if queue
+            .front()
+            .is_some_and(|event| edit_target_id(&event.event).is_some())
+        {
+            1
+        } else {
+            queue
+                .iter()
+                .take(max_drain)
+                .position(|event| edit_target_id(&event.event).is_some())
+                .unwrap_or(max_drain)
+        };
+        let events: Vec<BatchEvent> = queue
             .drain(..drain_count)
             .map(|qe| BatchEvent {
                 event: qe.event,
@@ -343,11 +367,6 @@ impl EventQueue {
                 received_at: qe.received_at,
             })
             .collect();
-        // Relay replay delivers stored events newest-first (`ORDER BY
-        // created_at DESC`), but batch consumers — `format_prompt` scope and
-        // reply-anchor selection — require the LAST event to be the newest.
-        // Stable sort: same-second events keep delivery order.
-        events.sort_by_key(|be| be.event.created_at);
 
         // Remove the queue entry if now empty.
         if self.queues.get(&channel_id).is_some_and(|q| q.is_empty()) {

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -894,8 +894,11 @@ pub fn edit_target_id(event: &Event) -> Option<String> {
         .then(|| {
             event.tags.iter().find_map(|tag| {
                 let parts = tag.as_slice();
-                (parts.len() == 2 && parts.first().map(String::as_str) == Some("e"))
-                    .then(|| parts[1].clone())
+                (parts.first().map(String::as_str) == Some("e"))
+                    .then(|| parts.get(1))
+                    .flatten()
+                    .and_then(|target| nostr::EventId::from_hex(target).ok())
+                    .map(|target| target.to_hex())
             })
         })
         .flatten()
@@ -5183,6 +5186,21 @@ mod tests {
             cancelled_events: vec![],
             cancel_reason: None,
         }
+    }
+
+    #[test]
+    fn edit_target_skips_malformed_e_tags_and_selects_first_valid_id() {
+        let valid_target = "ab".repeat(32);
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .tags([
+                nostr::Tag::parse(["e", "not-an-event-id"]).unwrap(),
+                nostr::Tag::parse(["e", &valid_target]).unwrap(),
+            ])
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        assert_eq!(edit_target_id(&event), Some(valid_target));
     }
 
     #[test]

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -1065,7 +1065,7 @@ mod tests {
     fn setup_edit(target: &str) -> nostr::Event {
         let keys = nostr::Keys::generate();
         nostr::EventBuilder::new(
-            nostr::Kind::Custom(KIND_STREAM_MESSAGE_EDIT as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_EDIT as u16),
             "edited",
         )
         .tags([nostr::Tag::parse(["e", target]).unwrap()])

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -464,6 +464,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         if let Err(e) = publish_setup_nudge(
             &publisher,
             &config.keys,
+            &rest_client,
             buzz_event.channel_id,
             &buzz_event.event,
             &payload,
@@ -588,6 +589,48 @@ async fn handle_setup_membership(
     }
 }
 
+/// Fetch and verify the original event targeted by a kind:40003 edit.
+async fn fetch_edit_original(
+    target_event_id: &str,
+    rest_client: &crate::relay::RestClient,
+) -> Option<nostr::Event> {
+    use std::time::Duration;
+
+    let target_id = nostr::EventId::from_hex(target_event_id).ok()?;
+    let filter = nostr::Filter::new().id(target_id).limit(1);
+    let response = match tokio::time::timeout(
+        Duration::from_millis(2_000),
+        rest_client.query(&[filter]),
+    )
+    .await
+    {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            tracing::warn!(
+                target_event_id,
+                "setup-mode: edit original fetch failed: {error}"
+            );
+            return None;
+        }
+        Err(_) => return None,
+    };
+    let raw = response.as_array()?.first()?;
+    match serde_json::from_value::<nostr::Event>(raw.clone()) {
+        Ok(event) if event.id == target_id && event.verify().is_ok() => Some(event),
+        _ => None,
+    }
+}
+
+/// Construct the flat thread reference used by a setup nudge.
+fn setup_nudge_thread_ref(target_event_id: &str) -> Result<buzz_sdk::ThreadRef> {
+    let target_id = nostr::EventId::from_hex(target_event_id)
+        .map_err(|e| anyhow::anyhow!("invalid nudge anchor event id: {e}"))?;
+    Ok(buzz_sdk::ThreadRef {
+        root_event_id: target_id,
+        parent_event_id: target_id,
+    })
+}
+
 /// Build and publish a setup nudge reply to the triggering event.
 ///
 /// Threading: flat reply to the thread root if one exists; otherwise reply
@@ -595,30 +638,31 @@ async fn handle_setup_membership(
 async fn publish_setup_nudge(
     publisher: &RelayEventPublisher,
     keys: &nostr::Keys,
+    rest_client: &crate::relay::RestClient,
     channel_id: Uuid,
     triggering_event: &nostr::Event,
     payload: &SetupPayload,
 ) -> Result<()> {
-    use buzz_sdk::ThreadRef;
-
-    // Parse NIP-10 thread tags to determine reply target.
-    let thread_tags = crate::queue::parse_thread_tags(triggering_event);
-
-    let thread_ref = if let Some(root_str) = &thread_tags.root_event_id {
-        // Threaded event: reply flat to the root.
-        let root_id = nostr::EventId::from_hex(root_str)
-            .map_err(|e| anyhow::anyhow!("invalid root event id: {e}"))?;
-        Some(ThreadRef {
-            root_event_id: root_id,
-            parent_event_id: root_id,
-        })
-    } else {
-        // Top-level event: reply to the triggering event.
-        Some(ThreadRef {
-            root_event_id: triggering_event.id,
-            parent_event_id: triggering_event.id,
-        })
+    let edit_target = crate::queue::edit_target_id(triggering_event);
+    let target_event_id = match edit_target.as_deref() {
+        Some(target) => match fetch_edit_original(target, rest_client).await {
+            Some(original) => {
+                let thread_tags = crate::queue::parse_thread_tags(&original);
+                thread_tags
+                    .root_event_id
+                    .unwrap_or_else(|| target.to_string())
+            }
+            None => {
+                tracing::warn!(edit_event_id = %triggering_event.id, target_event_id = target,
+                    "setup-mode: original edit target unavailable; using target as nudge anchor");
+                target.to_string()
+            }
+        },
+        None => crate::queue::parse_thread_tags(triggering_event)
+            .root_event_id
+            .unwrap_or_else(|| triggering_event.id.to_hex()),
     };
+    let thread_ref = Some(setup_nudge_thread_ref(&target_event_id)?);
 
     let body = payload.nudge_body();
     let author_hex = triggering_event.pubkey.to_hex();
@@ -992,6 +1036,14 @@ mod tests {
     // (a) non-allowlisted author → no nudge, (b) same event-id → exactly one
     // nudge. They use the extracted `should_nudge_for_event` helper, which is
     // the exact code the live loop calls.
+
+    #[test]
+    fn setup_nudge_edit_fallback_anchors_edit_target_not_edit_event() {
+        let target = "66".repeat(32);
+        let thread_ref = setup_nudge_thread_ref(&target).unwrap();
+        assert_eq!(thread_ref.root_event_id.to_hex(), target);
+        assert_eq!(thread_ref.parent_event_id.to_hex(), target);
+    }
 
     fn fake_event_id(byte: u8) -> EventId {
         EventId::from_byte_array([byte; 32])

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -631,6 +631,46 @@ fn setup_nudge_thread_ref(target_event_id: &str) -> Result<buzz_sdk::ThreadRef> 
     })
 }
 
+/// Resolve the flat reply anchor for a setup-mode nudge. This is the exact
+/// routing seam used by [`publish_setup_nudge`]; `original` is `None` only
+/// when the bounded relay fetch for a kind:40003 edit failed.
+fn setup_nudge_anchor(triggering_event: &nostr::Event, original: Option<&nostr::Event>) -> String {
+    match crate::queue::edit_target_id(triggering_event) {
+        Some(target) => original
+            .and_then(|event| crate::queue::parse_thread_tags(event).root_event_id)
+            .unwrap_or(target),
+        None => crate::queue::parse_thread_tags(triggering_event)
+            .root_event_id
+            .unwrap_or_else(|| triggering_event.id.to_hex()),
+    }
+}
+
+/// Build the signed setup nudge event at the supplied resolved anchor.
+/// Kept separate so the production path and output tests share event building.
+fn build_setup_nudge_event(
+    keys: &nostr::Keys,
+    channel_id: Uuid,
+    triggering_event: &nostr::Event,
+    payload: &SetupPayload,
+    anchor_event_id: &str,
+) -> Result<nostr::Event> {
+    let thread_ref = Some(setup_nudge_thread_ref(anchor_event_id)?);
+    let body = payload.nudge_body();
+    let author_hex = triggering_event.pubkey.to_hex();
+    let event_builder = buzz_sdk::build_message(
+        channel_id,
+        &body,
+        thread_ref.as_ref(),
+        &[&author_hex],
+        false,
+        &[],
+    )
+    .map_err(|e| anyhow::anyhow!("failed to build setup nudge: {e}"))?;
+    event_builder
+        .sign_with_keys(keys)
+        .map_err(|e| anyhow::anyhow!("failed to sign setup nudge: {e}"))
+}
+
 /// Build and publish a setup nudge reply to the triggering event.
 ///
 /// Threading: flat reply to the thread root if one exists; otherwise reply
@@ -643,49 +683,26 @@ async fn publish_setup_nudge(
     triggering_event: &nostr::Event,
     payload: &SetupPayload,
 ) -> Result<()> {
-    let edit_target = crate::queue::edit_target_id(triggering_event);
-    let target_event_id = match edit_target.as_deref() {
-        Some(target) => match fetch_edit_original(target, rest_client).await {
-            Some(original) => {
-                let thread_tags = crate::queue::parse_thread_tags(&original);
-                thread_tags
-                    .root_event_id
-                    .unwrap_or_else(|| target.to_string())
-            }
-            None => {
-                tracing::warn!(edit_event_id = %triggering_event.id, target_event_id = target,
-                    "setup-mode: original edit target unavailable; using target as nudge anchor");
-                target.to_string()
-            }
-        },
-        None => crate::queue::parse_thread_tags(triggering_event)
-            .root_event_id
-            .unwrap_or_else(|| triggering_event.id.to_hex()),
+    let original = match crate::queue::edit_target_id(triggering_event) {
+        Some(target) => fetch_edit_original(&target, rest_client).await,
+        None => None,
     };
-    let thread_ref = Some(setup_nudge_thread_ref(&target_event_id)?);
-
-    let body = payload.nudge_body();
-    let author_hex = triggering_event.pubkey.to_hex();
-
-    let event_builder = buzz_sdk::build_message(
+    let anchor_event_id = setup_nudge_anchor(triggering_event, original.as_ref());
+    if crate::queue::edit_target_id(triggering_event).is_some() && original.is_none() {
+        tracing::warn!(edit_event_id = %triggering_event.id, anchor_event_id,
+            "setup-mode: original edit target unavailable; using target as nudge anchor");
+    }
+    let signed = build_setup_nudge_event(
+        keys,
         channel_id,
-        &body,
-        thread_ref.as_ref(),
-        &[&author_hex], // p-tag the asker
-        false,
-        &[],
-    )
-    .map_err(|e| anyhow::anyhow!("failed to build setup nudge: {e}"))?;
-
-    let signed = event_builder
-        .sign_with_keys(keys)
-        .map_err(|e| anyhow::anyhow!("failed to sign setup nudge: {e}"))?;
-
+        triggering_event,
+        payload,
+        &anchor_event_id,
+    )?;
     publisher
         .publish_event(signed)
         .await
         .map_err(|e| anyhow::anyhow!("failed to publish setup nudge: {e}"))?;
-
     Ok(())
 }
 
@@ -1037,12 +1054,85 @@ mod tests {
     // nudge. They use the extracted `should_nudge_for_event` helper, which is
     // the exact code the live loop calls.
 
+    fn setup_test_payload() -> SetupPayload {
+        SetupPayload {
+            agent_name: "Fizz".into(),
+            agent_pubkey: "agent".into(),
+            requirements: vec![],
+        }
+    }
+
+    fn setup_edit(target: &str) -> nostr::Event {
+        let keys = nostr::Keys::generate();
+        nostr::EventBuilder::new(
+            nostr::Kind::Custom(KIND_STREAM_MESSAGE_EDIT as u16),
+            "edited",
+        )
+        .tags([nostr::Tag::parse(["e", target]).unwrap()])
+        .sign_with_keys(&keys)
+        .unwrap()
+    }
+
+    fn setup_original_threaded(root: &str) -> nostr::Event {
+        let keys = nostr::Keys::generate();
+        nostr::EventBuilder::new(nostr::Kind::Custom(KIND_STREAM_MESSAGE as u16), "original")
+            .tags([nostr::Tag::parse(["e", root, "", "reply"]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    fn nudge_e_tags(event: &nostr::Event) -> Vec<Vec<String>> {
+        event
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .filter(|tag| tag[0] == "e")
+            .collect()
+    }
+
     #[test]
-    fn setup_nudge_edit_fallback_anchors_edit_target_not_edit_event() {
-        let target = "66".repeat(32);
-        let thread_ref = setup_nudge_thread_ref(&target).unwrap();
-        assert_eq!(thread_ref.root_event_id.to_hex(), target);
-        assert_eq!(thread_ref.parent_event_id.to_hex(), target);
+    fn setup_nudge_edit_threaded_original_builds_at_original_root() {
+        let original_id = "66".repeat(32);
+        let root_id = "77".repeat(32);
+        let edit = setup_edit(&original_id);
+        let original = setup_original_threaded(&root_id);
+        let anchor = setup_nudge_anchor(&edit, Some(&original));
+        let nudge = build_setup_nudge_event(
+            &nostr::Keys::generate(),
+            Uuid::new_v4(),
+            &edit,
+            &setup_test_payload(),
+            &anchor,
+        )
+        .unwrap();
+        assert_eq!(anchor, root_id);
+        assert_eq!(
+            nudge_e_tags(&nudge),
+            vec![vec!["e".into(), root_id, "".into(), "reply".into()]]
+        );
+    }
+
+    #[test]
+    fn setup_nudge_edit_fetch_failure_builds_at_target_never_edit_event() {
+        let target_id = "88".repeat(32);
+        let edit = setup_edit(&target_id);
+        let edit_id = edit.id.to_hex();
+        let anchor = setup_nudge_anchor(&edit, None);
+        let nudge = build_setup_nudge_event(
+            &nostr::Keys::generate(),
+            Uuid::new_v4(),
+            &edit,
+            &setup_test_payload(),
+            &anchor,
+        )
+        .unwrap();
+        assert_eq!(anchor, target_id);
+        let e_tags = nudge_e_tags(&nudge);
+        assert_eq!(
+            e_tags,
+            vec![vec!["e".into(), target_id, "".into(), "reply".into()]]
+        );
+        assert_ne!(e_tags[0][1], edit_id);
     }
 
     fn fake_event_id(byte: u8) -> EventId {


### PR DESCRIPTION
🤖
## Summary
Message edits are auxiliary events, but replies, reactions, setup nudges, and queued delivery must remain anchored to the original visible message. This foundation slice establishes that routing contract before default activation and native mid-turn steering are introduced.

- Resolves an edit's original message and thread root before dispatch.
- Keeps edit-triggered reactions and replies attached to the visible original event, including cancellation and setup-mode paths.
- Replays queued events chronologically, then isolates edit delivery at its routing boundary so an edit cannot inherit another event's reply target.
- Falls back to the edit's target ID when the original cannot be fetched within the bounded lookup.

### Stack position
**1 of 3 — foundation**, based on `main`.

Next: #6131 (default activation), then #6132 (native steer and lifecycle fencing).

### Related issue
None found.

### Acceptance gates
- [x] ACP unit and lifecycle tests pass locally: `cargo test -p buzz-acp --all-targets` (787 unit tests and 9 lifecycle tests)
- [x] ACP compilation passes locally: `cargo check -p buzz-acp`
- [ ] Required CI checks pass on foundation head `0a70cb739bc029d972166781389bb944e7695e0f`
- [ ] Bottom-up stack review is complete
