### PR TITLE
fix(acp): safely route verified direct replies

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -1,6 +1,6 @@
 # buzz-acp
 
-ACP harness that connects AI agents to Buzz. The harness listens for @mentions on the relay, prompts your agent, and the agent replies using the Buzz CLI.
+ACP harness that connects AI agents to Buzz. The harness listens for @mentions and direct replies to the agent on the relay, prompts your agent, and the agent replies using the Buzz CLI.
 
 ```
 Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
@@ -62,7 +62,7 @@ export GOOSE_MODE=auto
 buzz-acp
 ```
 
-That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent, goose receives the message and can reply using the Buzz CLI that the harness configures automatically.
+That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent or directly replies to one of its messages, goose receives the message and can reply using the Buzz CLI that the harness configures automatically. Direct messages continue to route through their participant `p` tags.
 
 ## Running with Codex
 
@@ -266,7 +266,7 @@ Forum event kinds:
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
-3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
+3. **Event loop** — Listens for the bounded channel-message kinds. It accepts explicit @mentions and verifies direct-reply parent events before accepting an unmentioned reply; unrelated unmentioned chatter is dropped. Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
 5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1363,7 +1363,11 @@ pub fn resolve_channel_filters(
                     KIND_STREAM_REMINDER,
                 ]
             });
-            let require_mention = !config.no_mention_filter;
+            // Mentions mode also accepts direct thread replies whose parent was
+            // authored by this agent. NIP-01 cannot express "#p OR reply to one
+            // of my events" in a single filter, so receive the bounded message
+            // kinds and enforce the mention/reply union in the application gate.
+            let require_mention = false;
             for ch in &target_channels {
                 result.insert(
                     *ch,
@@ -1388,7 +1392,6 @@ pub fn resolve_channel_filters(
         SubscribeMode::Config => {
             for ch in discovered_channels {
                 let mut merged_kinds: Option<Vec<u32>> = Some(vec![]);
-                let mut require_mention = true;
                 let mut has_rule = false;
 
                 for rule in rules {
@@ -1405,9 +1408,6 @@ pub fn resolve_channel_filters(
                             }
                         }
                     }
-                    if !rule.require_mention {
-                        require_mention = false;
-                    }
                 }
 
                 if has_rule {
@@ -1415,7 +1415,10 @@ pub fn resolve_channel_filters(
                         *ch,
                         ChannelFilter {
                             kinds: merged_kinds,
-                            require_mention,
+                            // Config-mode rules may admit verified direct replies
+                            // without a p-tag. Receive configured kinds and enforce
+                            // each rule's mention predicate in the application gate.
+                            require_mention: false,
                         },
                     );
                 }
@@ -1468,7 +1471,9 @@ pub fn resolve_dynamic_channel_filter(
                     KIND_STREAM_REMINDER,
                 ]
             })),
-            require_mention: !config.no_mention_filter,
+            // See resolve_channel_filters(): direct-reply routing requires the
+            // application gate to see unmentioned reply candidates.
+            require_mention: false,
         }),
         SubscribeMode::All => Some(ChannelFilter {
             kinds: config.kinds_override.clone(),
@@ -1479,7 +1484,6 @@ pub fn resolve_dynamic_channel_filter(
             // evaluate ALL rules against this specific channel (including
             // channel-specific rules, not just ChannelScope::All).
             let mut merged_kinds: Option<Vec<u32>> = Some(vec![]);
-            let mut require_mention = true;
             let mut has_rule = false;
 
             for rule in rules {
@@ -1496,9 +1500,6 @@ pub fn resolve_dynamic_channel_filter(
                         }
                     }
                 }
-                if !rule.require_mention {
-                    require_mention = false;
-                }
             }
 
             if !has_rule {
@@ -1509,7 +1510,9 @@ pub fn resolve_dynamic_channel_filter(
 
             Some(ChannelFilter {
                 kinds: merged_kinds,
-                require_mention,
+                // Keep dynamic subscriptions equivalent to startup: direct
+                // replies must reach the application-level rule matcher.
+                require_mention: false,
             })
         }
     }
@@ -1612,7 +1615,10 @@ mod tests {
         assert_eq!(result.len(), 2);
         for ch in &channels {
             let f = result.get(ch).expect("channel should be present");
-            assert!(f.require_mention, "mentions mode requires mention");
+            assert!(
+                !f.require_mention,
+                "mentions mode must receive thread replies so the application gate can admit only replies to this agent"
+            );
             let kinds = f.kinds.as_ref().expect("should have kinds");
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
             assert!(kinds.contains(&buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED));
@@ -2001,6 +2007,34 @@ mod tests {
 
         let result = resolve_channel_filters(&config, &[ch], &rules);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_config_mode_all_mention_rules_receive_direct_reply_candidates() {
+        let config = test_config(SubscribeMode::Config);
+        let ch = Uuid::new_v4();
+        let rules = vec![make_rule(
+            "mention-or-reply",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+        )];
+
+        let startup = resolve_channel_filters(&config, &[ch], &rules);
+        let startup_filter = startup.get(&ch).expect("channel should be subscribed");
+        assert_eq!(startup_filter.kinds.as_deref(), Some([9].as_slice()));
+        assert!(
+            !startup_filter.require_mention,
+            "relay subscription must deliver unmentioned direct replies"
+        );
+
+        let dynamic = resolve_dynamic_channel_filter(&config, ch, &rules)
+            .expect("dynamic channel should be subscribed");
+        assert_eq!(dynamic.kinds.as_deref(), Some([9].as_slice()));
+        assert!(
+            !dynamic.require_mention,
+            "dynamic subscription must match startup reply delivery"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -155,6 +155,13 @@ pub struct MatchedRule {
     pub prompt_tag: String,
 }
 
+#[derive(Debug, Clone)]
+pub enum MatchOutcome {
+    Matched(MatchedRule),
+    NoMatch,
+    FailedClosed,
+}
+
 /// Maximum expression length accepted by `evaluate_filter`.
 ///
 /// Bounds worst-case O(2^n) evaluation paths. The spawn_blocking thread cannot
@@ -371,6 +378,55 @@ pub async fn match_event(
     rules: &[SubscriptionRule],
     agent_pubkey_hex: &str,
 ) -> Option<MatchedRule> {
+    match match_event_outcome(event, channel_id, rules, agent_pubkey_hex).await {
+        MatchOutcome::Matched(matched) => Some(matched),
+        MatchOutcome::NoMatch | MatchOutcome::FailedClosed => None,
+    }
+}
+
+pub async fn match_event_outcome(
+    event: &nostr::Event,
+    channel_id: uuid::Uuid,
+    rules: &[SubscriptionRule],
+    agent_pubkey_hex: &str,
+) -> MatchOutcome {
+    match_event_with_mention_policy(event, channel_id, rules, agent_pubkey_hex, false).await
+}
+
+/// Match an event whose direct-reply parent has already been cryptographically
+/// verified as this agent's event in the same channel.
+///
+/// This waives only `require_mention`; channel, kind, custom-filter ordering,
+/// timeout accounting, and fail-closed behavior are identical to [`match_event`].
+#[cfg(test)]
+pub async fn match_verified_reply(
+    event: &nostr::Event,
+    channel_id: uuid::Uuid,
+    rules: &[SubscriptionRule],
+    agent_pubkey_hex: &str,
+) -> Option<MatchedRule> {
+    match match_verified_reply_outcome(event, channel_id, rules, agent_pubkey_hex).await {
+        MatchOutcome::Matched(matched) => Some(matched),
+        MatchOutcome::NoMatch | MatchOutcome::FailedClosed => None,
+    }
+}
+
+pub async fn match_verified_reply_outcome(
+    event: &nostr::Event,
+    channel_id: uuid::Uuid,
+    rules: &[SubscriptionRule],
+    agent_pubkey_hex: &str,
+) -> MatchOutcome {
+    match_event_with_mention_policy(event, channel_id, rules, agent_pubkey_hex, true).await
+}
+
+async fn match_event_with_mention_policy(
+    event: &nostr::Event,
+    channel_id: uuid::Uuid,
+    rules: &[SubscriptionRule],
+    agent_pubkey_hex: &str,
+    verified_reply: bool,
+) -> MatchOutcome {
     let filter_ctx = FilterContext::from_event(event, channel_id);
 
     for (index, rule) in rules.iter().enumerate() {
@@ -387,7 +443,7 @@ pub async fn match_event(
         // 3. Mention check — look for a `p` tag whose first element equals
         //    agent_pubkey_hex. Uses tag.as_slice() for stable, library-independent
         //    access — avoids relying on the Display impl of tag kind.
-        if rule.require_mention {
+        if rule.require_mention && !verified_reply {
             let mentioned = event.tags.iter().any(|tag| {
                 let s = tag.as_slice();
                 s.first().map(|k| k.as_str()) == Some("p")
@@ -411,7 +467,7 @@ pub async fn match_event(
                      failing closed (no match for any rule)"
                 );
                 // Fail-closed: disabled rule → no match for this event.
-                return None;
+                return MatchOutcome::FailedClosed;
             }
 
             match evaluate_filter(expr, &filter_ctx, rule.compiled_filter.clone()).await {
@@ -432,7 +488,7 @@ pub async fn match_event(
                         "filter expression timed out; failing closed (no match for any rule)"
                     );
                     // Fail-closed: timeout → no match, not next rule.
-                    return None;
+                    return MatchOutcome::FailedClosed;
                 }
                 Err(e) => {
                     warn!(
@@ -442,7 +498,7 @@ pub async fn match_event(
                         "filter expression error; failing closed (no match for any rule)"
                     );
                     // Fail-closed: any error → no match, not next rule.
-                    return None;
+                    return MatchOutcome::FailedClosed;
                 }
             }
         }
@@ -450,13 +506,13 @@ pub async fn match_event(
         // All checks passed — this rule wins.
         let prompt_tag = rule.prompt_tag.clone().unwrap_or_else(|| rule.name.clone());
 
-        return Some(MatchedRule {
+        return MatchOutcome::Matched(MatchedRule {
             rule_index: index,
             prompt_tag,
         });
     }
 
-    None
+    MatchOutcome::NoMatch
 }
 
 #[cfg(test)]
@@ -607,35 +663,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_match_event_kind_filter() {
-        let event = make_event(9, "hello");
-        let channel_id = any_channel();
-
-        let rules = vec![
-            make_rule(
-                "wrong-kind",
-                ChannelScope::All("all".into()),
-                vec![1],
-                false,
-                None,
-                None,
-            ),
-            make_rule(
-                "right-kind",
-                ChannelScope::All("all".into()),
-                vec![9],
-                false,
-                None,
-                Some("matched"),
-            ),
-        ];
-
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
-        assert_eq!(matched.rule_index, 1);
-        assert_eq!(matched.prompt_tag, "matched");
-    }
-
-    #[tokio::test]
     async fn test_match_event_require_mention() {
         let agent_pubkey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
@@ -661,6 +688,94 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(matched.prompt_tag, "mentioned");
+    }
+
+    #[tokio::test]
+    async fn verified_reply_waives_only_mention_requirement() {
+        let channel_id = any_channel();
+        let other_channel = any_channel();
+        let event = make_event(9, "follow-up");
+        let author_filter = format!(r#"author == "{}""#, event.pubkey.to_hex());
+        let rules = vec![make_rule(
+            "shared-replies",
+            ChannelScope::List(vec![channel_id.to_string()]),
+            vec![9],
+            true,
+            Some(&author_filter),
+            Some("@reply"),
+        )];
+
+        assert!(match_event(&event, channel_id, &rules, "agent")
+            .await
+            .is_none());
+        let matched = match_verified_reply(&event, channel_id, &rules, "agent")
+            .await
+            .expect("verified reply should waive only the mention predicate");
+        assert_eq!(matched.prompt_tag, "@reply");
+        assert!(match_verified_reply(&event, other_channel, &rules, "agent")
+            .await
+            .is_none());
+
+        let wrong_kind = make_event(1, "follow-up");
+        assert!(
+            match_verified_reply(&wrong_kind, channel_id, &rules, "agent")
+                .await
+                .is_none()
+        );
+
+        let rejecting_rules = vec![make_rule(
+            "rejecting-filter",
+            ChannelScope::List(vec![channel_id.to_string()]),
+            vec![9],
+            true,
+            Some("false"),
+            None,
+        )];
+        assert!(
+            match_verified_reply(&event, channel_id, &rejecting_rules, "agent")
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn verified_reply_rule_failure_cannot_fall_through_to_open_rule() {
+        let channel_id = any_channel();
+        let event = make_event(9, "follow-up");
+        let strict = make_rule(
+            "strict-disabled",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+            Some("true"),
+            Some("strict"),
+        );
+        strict
+            .consecutive_timeouts
+            .store(MAX_CONSECUTIVE_TIMEOUTS, Ordering::Relaxed);
+        let rules = vec![
+            strict,
+            make_rule(
+                "later-open",
+                ChannelScope::All("all".into()),
+                vec![9],
+                false,
+                None,
+                Some("open"),
+            ),
+        ];
+
+        assert_eq!(
+            match_event(&event, channel_id, &rules, "agent")
+                .await
+                .expect("ordinary matcher skips the unmentioned strict rule")
+                .prompt_tag,
+            "open"
+        );
+        assert!(matches!(
+            match_verified_reply_outcome(&event, channel_id, &rules, "agent").await,
+            MatchOutcome::FailedClosed
+        ));
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -46,7 +46,7 @@ use pool::{
 use pool_lifecycle::PoolLifecycle;
 use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
 use relay::{HarnessRelay, RelayEventPublisher};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, watch, Semaphore};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
@@ -341,6 +341,8 @@ mod inbound_author_gate {
     };
     use std::collections::HashSet;
 
+    #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) struct InboundAuthorGateDecision {
         pub(crate) effective_author: String,
         pub(crate) allowed: bool,
@@ -354,12 +356,91 @@ mod inbound_author_gate {
     /// loops therefore have to consume the gate's verdict before they can use
     /// or publish the event; replacing the call with a raw signer or a local
     /// `allowed = true` no longer type-checks.
+    #[derive(Debug)]
     pub(crate) struct AuthorizedListenerEvent {
         buzz_event: relay::BuzzEvent,
         effective_author: String,
     }
 
+    /// Trusted workflow attribution resolved, but author policy not yet run.
+    /// This typed state lets reply candidates move profile lookup off-loop
+    /// without accidentally reauthorizing the raw relay signer.
+    pub(crate) struct AttributedListenerEvent {
+        buzz_event: relay::BuzzEvent,
+        effective_author: String,
+    }
+
+    impl AttributedListenerEvent {
+        pub(crate) fn buzz_event(&self) -> &relay::BuzzEvent {
+            &self.buzz_event
+        }
+
+        #[cfg(test)]
+        pub(crate) fn for_test(buzz_event: relay::BuzzEvent, effective_author: String) -> Self {
+            Self {
+                buzz_event,
+                effective_author,
+            }
+        }
+
+        pub(crate) async fn authorize(
+            self,
+            respond_to: &RespondTo,
+            allowlist: &HashSet<String>,
+            owner_cache: &OwnerCache,
+            channel_info: &pool::ChannelInfoResolver,
+            rest_client: &relay::RestClient,
+        ) -> Option<AuthorizedListenerEvent> {
+            let is_dm = is_dm_channel(self.buzz_event.channel_id, channel_info).await;
+            let allowed = author_allowed(
+                respond_to,
+                allowlist,
+                &self.effective_author,
+                is_dm,
+                owner_cache,
+                rest_client,
+            )
+            .await;
+            if !allowed {
+                tracing::debug!(
+                    channel_id = %self.buzz_event.channel_id,
+                    raw_author = %self.buzz_event.event.pubkey.to_hex(),
+                    effective_author = %self.effective_author,
+                    mode = %respond_to,
+                    is_dm,
+                    "inbound author gate — dropping event"
+                );
+                return None;
+            }
+            Some(AuthorizedListenerEvent {
+                buzz_event: self.buzz_event,
+                effective_author: self.effective_author,
+            })
+        }
+    }
+
+    #[cfg(test)]
+    impl From<relay::BuzzEvent> for AttributedListenerEvent {
+        fn from(buzz_event: relay::BuzzEvent) -> Self {
+            let effective_author = buzz_event.event.pubkey.to_hex();
+            Self::for_test(buzz_event, effective_author)
+        }
+    }
+
     impl AuthorizedListenerEvent {
+        #[cfg(test)]
+        pub(crate) fn buzz_event(&self) -> &relay::BuzzEvent {
+            &self.buzz_event
+        }
+
+        #[cfg(test)]
+        pub(crate) fn for_test(buzz_event: relay::BuzzEvent, effective_author: String) -> Self {
+            Self {
+                buzz_event,
+                effective_author,
+            }
+        }
+
         pub(crate) fn into_parts(self) -> (relay::BuzzEvent, String) {
             (self.buzz_event, self.effective_author)
         }
@@ -369,7 +450,7 @@ mod inbound_author_gate {
     ///
     /// This stays private to the gate module so neither listener can bypass
     /// workflow attribution by calling the raw-signer policy directly.
-    async fn author_allowed(
+    pub(super) async fn author_allowed(
         respond_to: &RespondTo,
         allowlist: &HashSet<String>,
         author: &str,
@@ -462,6 +543,7 @@ mod inbound_author_gate {
         /// Both production listeners call this exact boundary. Identity refresh
         /// cannot be omitted independently of authorization; the raw-author
         /// policy and relay identity are private to this module.
+        #[cfg(test)]
         pub(crate) async fn evaluate_listener_event(
             &mut self,
             buzz_event: &relay::BuzzEvent,
@@ -494,6 +576,7 @@ mod inbound_author_gate {
             .await
         }
 
+        #[cfg(test)]
         async fn evaluate_with_channel_trust(
             &self,
             event: &nostr::Event,
@@ -521,6 +604,30 @@ mod inbound_author_gate {
             }
         }
 
+        pub(crate) async fn attribute_listener_event(
+            &mut self,
+            buzz_event: relay::BuzzEvent,
+            rest_client: &relay::RestClient,
+        ) -> AttributedListenerEvent {
+            if refresh_needed(self.refreshed_generation, buzz_event.connection_generation) {
+                let (relay_self, completed) =
+                    refresh_relay_self(rest_client, self.relay_self.take(), "listener").await;
+                self.relay_self = relay_self;
+                if completed {
+                    self.refreshed_generation = Some(buzz_event.connection_generation);
+                }
+            }
+            let effective_author = effective_prompt_author(
+                &buzz_event.event,
+                self.relay_self.as_deref(),
+                &self.agent_pubkey_hex,
+            );
+            AttributedListenerEvent {
+                buzz_event,
+                effective_author,
+            }
+        }
+
         pub(crate) async fn authorize_listener_event(
             &mut self,
             buzz_event: relay::BuzzEvent,
@@ -530,31 +637,16 @@ mod inbound_author_gate {
             channel_info: &pool::ChannelInfoResolver,
             rest_client: &relay::RestClient,
         ) -> Option<AuthorizedListenerEvent> {
-            let decision = self
-                .evaluate_listener_event(
-                    &buzz_event,
+            self.attribute_listener_event(buzz_event, rest_client)
+                .await
+                .authorize(
                     respond_to,
                     allowlist,
                     owner_cache,
                     channel_info,
                     rest_client,
                 )
-                .await;
-            if !decision.allowed {
-                tracing::debug!(
-                    channel_id = %buzz_event.channel_id,
-                    raw_author = %buzz_event.event.pubkey.to_hex(),
-                    effective_author = %decision.effective_author,
-                    mode = %respond_to,
-                    is_dm = decision.is_dm,
-                    "inbound author gate — dropping event"
-                );
-                return None;
-            }
-            Some(AuthorizedListenerEvent {
-                buzz_event,
-                effective_author: decision.effective_author,
-            })
+                .await
         }
 
         #[cfg(test)]
@@ -580,7 +672,7 @@ mod inbound_author_gate {
     }
 }
 
-use inbound_author_gate::{AuthorizedListenerEvent, InboundAuthorGate};
+use inbound_author_gate::{AttributedListenerEvent, AuthorizedListenerEvent, InboundAuthorGate};
 
 struct AuthorizedNormalListenerEvent(AuthorizedListenerEvent);
 
@@ -591,24 +683,8 @@ struct NormalListenerIngress {
 }
 
 impl AuthorizedNormalListenerEvent {
-    async fn match_subscription(
-        self,
-        rules: &[SubscriptionRule],
-        agent_pubkey_hex: &str,
-    ) -> Option<NormalListenerIngress> {
-        let (buzz_event, effective_author) = self.0.into_parts();
-        let matched = filter::match_event(
-            &buzz_event.event,
-            buzz_event.channel_id,
-            rules,
-            agent_pubkey_hex,
-        )
-        .await?;
-        Some(NormalListenerIngress {
-            buzz_event,
-            effective_author,
-            prompt_tag: matched.prompt_tag,
-        })
+    fn into_parts(self) -> (relay::BuzzEvent, String) {
+        self.0.into_parts()
     }
 }
 
@@ -781,6 +857,319 @@ pub(crate) async fn is_dm_channel(
             true
         }
     }
+}
+
+const RECENT_REPLY_PARENT_CAPACITY: usize = 4096;
+const MAX_PENDING_REPLY_LOOKUPS: usize = 8;
+const MAX_PENDING_EVENT_VERIFICATIONS: usize = 8;
+const MAX_RELAY_EVENTS_BEFORE_VALIDATED_REPLY: usize = 32;
+
+#[derive(Debug)]
+struct ValidatedReply {
+    event: AuthorizedListenerEvent,
+    subscription_generation: Uuid,
+    parent_verified: bool,
+}
+
+fn take_ready_validated_reply_after_budget(
+    relay_events_since_validated_reply: usize,
+    validated_reply_rx: &mut mpsc::Receiver<ValidatedReply>,
+) -> Option<ValidatedReply> {
+    if relay_events_since_validated_reply < MAX_RELAY_EVENTS_BEFORE_VALIDATED_REPLY {
+        return None;
+    }
+    validated_reply_rx.try_recv().ok()
+}
+
+fn validated_reply_generation_is_current(
+    channel_id: Uuid,
+    validated_generation: Option<Uuid>,
+    subscribed_channel_ids: &HashSet<Uuid>,
+    subscription_generations: &HashMap<Uuid, Uuid>,
+) -> bool {
+    subscribed_channel_ids.contains(&channel_id)
+        && validated_generation == subscription_generations.get(&channel_id).copied()
+}
+
+fn classified_ordinary_fallback_is_terminal(
+    validated_generation: Option<Uuid>,
+    parent_verified: bool,
+) -> bool {
+    validated_generation.is_some() && !parent_verified
+}
+
+fn reply_candidate_requires_classification(
+    verified_candidate: Option<&filter::MatchedRule>,
+    ordinary_match: Option<&filter::MatchedRule>,
+    parent_known_other: bool,
+    already_classified: bool,
+) -> bool {
+    if parent_known_other || already_classified {
+        return false;
+    }
+    match (verified_candidate, ordinary_match) {
+        (Some(verified), Some(ordinary)) => verified.rule_index < ordinary.rule_index,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+/// Bounded metadata cache for events already observed on the relay stream.
+///
+/// In mentions mode the relay subscription is intentionally broad enough to
+/// receive direct replies. Remembering recent signed parents lets the hot path
+/// reject replies to other authors without an HTTP query. Cache misses still
+/// use the authoritative REST fallback so replies to pre-restart events work.
+#[derive(Default)]
+struct RecentReplyParents {
+    order: VecDeque<String>,
+    entries: HashMap<String, Uuid>,
+}
+
+impl RecentReplyParents {
+    fn insert_verified(&mut self, event_id: String, channel_id: Uuid) {
+        if self.entries.contains_key(&event_id) {
+            return;
+        }
+        while self.entries.len() >= RECENT_REPLY_PARENT_CAPACITY {
+            if let Some(expired) = self.order.pop_front() {
+                self.entries.remove(&expired);
+            }
+        }
+        self.order.push_back(event_id.clone());
+        self.entries.insert(event_id, channel_id);
+    }
+
+    /// `None` means the parent has not been observed and needs REST fallback.
+    fn is_agent_parent(&self, parent_event_id: &str, channel_id: Uuid) -> Option<bool> {
+        self.entries
+            .get(parent_event_id)
+            .map(|parent_channel| *parent_channel == channel_id)
+    }
+}
+
+async fn verify_event_bounded(event: nostr::Event, permits: Arc<Semaphore>) -> bool {
+    let Ok(permit) = permits.try_acquire_owned() else {
+        return false;
+    };
+    tokio::task::spawn_blocking(move || {
+        // Keep the permit in the blocking closure. If an async timeout drops
+        // the JoinHandle, the still-running CPU work remains bounded.
+        let _permit = permit;
+        buzz_core::verify_event(&event).is_ok()
+    })
+    .await
+    .unwrap_or(false)
+}
+
+fn schedule_recent_parent_observation(
+    event: &nostr::Event,
+    channel_id: Uuid,
+    agent_pubkey_hex: &str,
+    cache: Arc<std::sync::Mutex<RecentReplyParents>>,
+    verification_permits: Arc<Semaphore>,
+) {
+    // Broad mentions-mode subscriptions receive ordinary human chatter.
+    // Reject non-agent authors and wrong-channel events before spawning work.
+    if event.pubkey.to_hex() != agent_pubkey_hex || !event_has_channel_tag(event, channel_id) {
+        return;
+    }
+    let Ok(permit) = verification_permits.try_acquire_owned() else {
+        return;
+    };
+    let event = event.clone();
+    tokio::spawn(async move {
+        let event_id = event.id.to_hex();
+        let verified = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            buzz_core::verify_event(&event).is_ok()
+        })
+        .await
+        .unwrap_or(false);
+        if verified {
+            if let Ok(mut cache) = cache.lock() {
+                cache.insert_verified(event_id, channel_id);
+            }
+        }
+    });
+}
+
+fn event_has_channel_tag(event: &nostr::Event, channel_id: Uuid) -> bool {
+    let channel_hex = channel_id.to_string();
+    event.tags.iter().any(|tag| {
+        let parts = tag.as_slice();
+        parts.first().map(String::as_str) == Some("h")
+            && parts.get(1).map(String::as_str) == Some(channel_hex.as_str())
+    })
+}
+
+fn direct_reply_parent_id(event: &nostr::Event) -> Option<String> {
+    let parent_hex = queue::parse_thread_tags(event).parent_event_id?;
+    nostr::EventId::from_hex(&parent_hex).ok()?;
+    Some(parent_hex)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ParentLookupOutcome {
+    Agent,
+    NotAgent,
+    FailedClosed,
+}
+
+/// Classify whether the referenced parent was authored by this agent in the
+/// same channel. Lookup failure is distinct from an authoritative non-agent
+/// result so callers cannot widen routing after a timeout or transport error.
+async fn lookup_direct_reply_parent(
+    parent_hex: &str,
+    channel_id: Uuid,
+    agent_pubkey_hex: &str,
+    rest_client: &relay::RestClient,
+    verification_permits: Arc<Semaphore>,
+) -> ParentLookupOutcome {
+    let Ok(parent_id) = nostr::EventId::from_hex(parent_hex) else {
+        return ParentLookupOutcome::NotAgent;
+    };
+    let filter = nostr::Filter::new().id(parent_id);
+    let response = match tokio::time::timeout(Duration::from_secs(2), rest_client.query(&[filter]))
+        .await
+    {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            tracing::debug!(parent_event_id = %parent_hex, "reply parent lookup failed: {error}");
+            return ParentLookupOutcome::FailedClosed;
+        }
+        Err(_) => {
+            tracing::debug!(parent_event_id = %parent_hex, "reply parent lookup timed out");
+            return ParentLookupOutcome::FailedClosed;
+        }
+    };
+    let Some(values) = response.as_array() else {
+        return ParentLookupOutcome::FailedClosed;
+    };
+
+    for value in values {
+        let Ok(parent) = serde_json::from_value::<nostr::Event>(value.clone()) else {
+            continue;
+        };
+        if parent.id != parent_id
+            || parent.pubkey.to_hex() != agent_pubkey_hex
+            || !event_has_channel_tag(&parent, channel_id)
+        {
+            continue;
+        }
+        return if verify_event_bounded(parent, verification_permits).await {
+            ParentLookupOutcome::Agent
+        } else {
+            ParentLookupOutcome::NotAgent
+        };
+    }
+    ParentLookupOutcome::NotAgent
+}
+
+struct ReplyValidationContext {
+    agent_pubkey_hex: String,
+    rest_client: relay::RestClient,
+    channel_info: pool::ChannelInfoResolver,
+    respond_to: RespondTo,
+    allowlist: HashSet<String>,
+    owner_cache: Arc<OwnerCache>,
+    permits: Arc<Semaphore>,
+    verification_permits: Arc<Semaphore>,
+    validated_tx: mpsc::Sender<ValidatedReply>,
+}
+
+#[cfg(test)]
+fn reply_validation_needs_sibling_cache(
+    respond_to: &RespondTo,
+    allowlist: &HashSet<String>,
+    author: &str,
+    is_dm: bool,
+) -> bool {
+    if is_dm {
+        return !matches!(respond_to, RespondTo::Nobody);
+    }
+    match respond_to {
+        RespondTo::OwnerOnly => true,
+        RespondTo::Allowlist => !allowlist.contains(author),
+        RespondTo::Anyone | RespondTo::Nobody => false,
+    }
+}
+
+fn schedule_direct_reply_validation(
+    attributed_event: impl Into<AttributedListenerEvent>,
+    parent_hex: String,
+    parent_verified_from_cache: bool,
+    subscription_generation: Uuid,
+    context: ReplyValidationContext,
+) -> bool {
+    let attributed_event = attributed_event.into();
+    let Ok(permit) = context.permits.try_acquire_owned() else {
+        return false;
+    };
+    tokio::spawn(async move {
+        let _permit = permit;
+        let channel_id = attributed_event.buzz_event().channel_id;
+        let validation = async {
+            if !verify_event_bounded(
+                attributed_event.buzz_event().event.clone(),
+                context.verification_permits.clone(),
+            )
+            .await
+                || !event_has_channel_tag(&attributed_event.buzz_event().event, channel_id)
+            {
+                return None;
+            }
+            let parent_outcome = if parent_verified_from_cache {
+                ParentLookupOutcome::Agent
+            } else {
+                lookup_direct_reply_parent(
+                    &parent_hex,
+                    channel_id,
+                    &context.agent_pubkey_hex,
+                    &context.rest_client,
+                    context.verification_permits.clone(),
+                )
+                .await
+            };
+            if parent_outcome == ParentLookupOutcome::FailedClosed {
+                return None;
+            }
+            let authorized_event = attributed_event
+                .authorize(
+                    &context.respond_to,
+                    &context.allowlist,
+                    &context.owner_cache,
+                    &context.channel_info,
+                    &context.rest_client,
+                )
+                .await?;
+            Some((
+                authorized_event,
+                parent_outcome == ParentLookupOutcome::Agent,
+            ))
+        };
+        match tokio::time::timeout(Duration::from_secs(2), validation).await {
+            Ok(Some((event, parent_verified))) => {
+                let _ = context
+                    .validated_tx
+                    .send(ValidatedReply {
+                        event,
+                        subscription_generation,
+                        parent_verified,
+                    })
+                    .await;
+            }
+            Ok(None) => {}
+            Err(_) => {
+                tracing::debug!(
+                    channel_id = %channel_id,
+                    parent_event_id = %parent_hex,
+                    "reply validation timed out"
+                );
+            }
+        }
+    });
+    true
 }
 
 /// Query an author's kind:0 profile and check if their NIP-OA auth tag
@@ -2622,7 +3011,7 @@ async fn tokio_main() -> Result<()> {
             _ => {} // anyone/nobody don't depend on owner
         }
     }
-    let owner_cache = OwnerCache::new(startup_owner.clone());
+    let owner_cache = Arc::new(OwnerCache::new(startup_owner.clone()));
 
     let mut relay_observer_control_rx = None;
     let mut relay_observer_publisher_task = None;
@@ -2978,6 +3367,18 @@ async fn tokio_main() -> Result<()> {
         Wake(u32, Result<AgentPool, String>),
     }
 
+    let recent_reply_parents = Arc::new(std::sync::Mutex::new(RecentReplyParents::default()));
+    let (validated_reply_tx, mut validated_reply_rx) =
+        mpsc::channel::<ValidatedReply>(MAX_PENDING_REPLY_LOOKUPS);
+    let reply_lookup_permits = Arc::new(Semaphore::new(MAX_PENDING_REPLY_LOOKUPS));
+    let event_verification_permits = Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS));
+    let mut subscription_generations: HashMap<Uuid, Uuid> = subscribed_channel_ids
+        .iter()
+        .copied()
+        .map(|channel_id| (channel_id, Uuid::new_v4()))
+        .collect();
+    let mut relay_events_since_validated_reply = 0usize;
+
     loop {
         // Whether buffered work is waiting on a lazy pool. Also gates the
         // retry-deadline sleep arm below: a `Failed` lifecycle keeps its
@@ -3201,10 +3602,46 @@ async fn tokio_main() -> Result<()> {
                     None
                 }
                 // Remaining branches don't touch pool — evaluated when pool is idle.
-                buzz_event = relay.next_event() => {
+                inbound = async {
+                    // Keep relay events (including membership revocations) ahead of
+                    // completed validations within a bounded window, then force one
+                    // ready validation so sustained chatter cannot starve replies.
+                    if let Some(validated) = take_ready_validated_reply_after_budget(
+                        relay_events_since_validated_reply,
+                        &mut validated_reply_rx,
+                    ) {
+                        let (event, effective_author) = validated.event.into_parts();
+                        return Some((
+                            event,
+                            validated.parent_verified,
+                            Some(validated.subscription_generation),
+                            Some(effective_author),
+                        ));
+                    }
+                    tokio::select! {
+                        biased;
+                        // Prioritize relay ordering only within the bounded window.
+                        event = relay.next_event() => event.map(|event| (event, false, None, None)),
+                        event = validated_reply_rx.recv() => event.map(|validated| {
+                            let (event, effective_author) = validated.event.into_parts();
+                            (
+                                event,
+                                validated.parent_verified,
+                                Some(validated.subscription_generation),
+                                Some(effective_author),
+                            )
+                        }),
+                    }
+                } => {
                     let _ = result_rx; // end split borrow before relay handling
-                    match buzz_event {
-                        Some(buzz_event) => {
+                    match inbound {
+                        Some((buzz_event, direct_reply_verified, validated_generation, preauthorized_author)) => {
+                            if validated_generation.is_some() {
+                                relay_events_since_validated_reply = 0;
+                            } else {
+                                relay_events_since_validated_reply =
+                                    relay_events_since_validated_reply.saturating_add(1);
+                            }
                             let kind_u32 = buzz_event.event.kind.as_u16() as u32;
 
                             if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION
@@ -3258,6 +3695,7 @@ async fn tokio_main() -> Result<()> {
                                     }
                                 }
                                 membership_newest_ts.insert(ch, ts);
+                                subscription_generations.insert(ch, Uuid::new_v4());
 
                                 if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION {
                                     // Clear removal tracking so sessions are not
@@ -3324,6 +3762,29 @@ async fn tokio_main() -> Result<()> {
                                 }
                                 continue;
                             }
+
+                            if validated_generation.is_some()
+                                && !validated_reply_generation_is_current(
+                                    buzz_event.channel_id,
+                                    validated_generation,
+                                    &subscribed_channel_ids,
+                                    &subscription_generations,
+                                )
+                            {
+                                tracing::debug!(
+                                    channel_id = %buzz_event.channel_id,
+                                    "dropping validated reply from an inactive subscription generation"
+                                );
+                                continue;
+                            }
+
+                            schedule_recent_parent_observation(
+                                &buzz_event.event,
+                                buzz_event.channel_id,
+                                &pubkey_hex,
+                                recent_reply_parents.clone(),
+                                event_verification_permits.clone(),
+                            );
 
                             if config.ignore_self && buzz_event.event.pubkey.to_hex() == pubkey_hex {
                                 tracing::debug!(channel_id = %buzz_event.channel_id, "dropping self-authored event");
@@ -3464,37 +3925,231 @@ async fn tokio_main() -> Result<()> {
                                 // Not from owner — fall through to normal prompt handling.
                             }
 
-                            // Coarse security policy: drop events from disallowed
-                            // authors before they reach subscription rules or the
-                            // agent. Must be AFTER !shutdown (owner can always
-                            // shut down regardless of gate mode).
-                            //
-                            // Both OwnerOnly and Allowlist accept events from
-                            // "siblings" — pubkeys whose agent_owner_pubkey
-                            // matches this agent's owner (e.g. other bots
-                            // launched by the same human). Allowlist adds the
-                            // explicit pubkey list on top, for external people;
-                            // it never revokes same-owner team bots.
-                            let Some(authorized_event) = authorize_normal_listener_event(
-                                &mut author_gate_ctx,
-                                buzz_event,
-                                &config.respond_to,
-                                &config.respond_to_allowlist,
-                                &owner_cache,
-                                &ctx.channel_info,
-                                &ctx.rest_client,
-                            )
-                            .await
-                            else {
-                                continue;
-                            };
-                            let Some(ingress) =
-                                AuthorizedNormalListenerEvent(authorized_event)
-                                    .match_subscription(&rules, &pubkey_hex)
+                            // Classify cheap routing candidacy before any author/profile
+                            // lookup. Broad mention subscriptions therefore discard ordinary
+                            // unmentioned chatter without stalling the relay loop, while reply
+                            // candidates move signature, parent, channel, and typed effective-
+                            // author authorization into the bounded background classifier.
+                            let parent_hex = direct_reply_parent_id(&buzz_event.event);
+                            let mut needs_reply_classification = false;
+                            let matched = if config.subscribe_mode == SubscribeMode::Config
+                                && direct_reply_verified
+                            {
+                                match filter::match_verified_reply_outcome(
+                                    &buzz_event.event,
+                                    buzz_event.channel_id,
+                                    &rules,
+                                    &pubkey_hex,
+                                )
+                                .await
+                                {
+                                    filter::MatchOutcome::Matched(matched) => Some(matched),
+                                    filter::MatchOutcome::NoMatch => None,
+                                    filter::MatchOutcome::FailedClosed => {
+                                        tracing::debug!(
+                                            channel_id = %buzz_event.channel_id,
+                                            "verified reply rule evaluation failed closed"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            } else if config.subscribe_mode == SubscribeMode::Config
+                                && validated_generation.is_none()
+                                && parent_hex.is_some()
+                            {
+                                // Evaluate the mention-waived view first. If it finds an
+                                // earlier rule, a later ordinary-only failure cannot preempt
+                                // that candidate; parent classification decides which ordered
+                                // view is authoritative.
+                                let verified_candidate =
+                                    match filter::match_verified_reply_outcome(
+                                        &buzz_event.event,
+                                        buzz_event.channel_id,
+                                        &rules,
+                                        &pubkey_hex,
+                                    )
                                     .await
-                            else {
-                                tracing::debug!("authorized event matched no rule — dropping");
-                                continue;
+                                    {
+                                        filter::MatchOutcome::Matched(matched) => Some(matched),
+                                        filter::MatchOutcome::NoMatch => None,
+                                        filter::MatchOutcome::FailedClosed => {
+                                            tracing::debug!(
+                                                channel_id = %buzz_event.channel_id,
+                                                "verified reply candidate rule evaluation failed closed"
+                                            );
+                                            continue;
+                                        }
+                                    };
+                                let (ordinary_match, ordinary_failed_closed) =
+                                    match filter::match_event_outcome(
+                                        &buzz_event.event,
+                                        buzz_event.channel_id,
+                                        &rules,
+                                        &pubkey_hex,
+                                    )
+                                    .await
+                                    {
+                                        filter::MatchOutcome::Matched(matched) => {
+                                            (Some(matched), false)
+                                        }
+                                        filter::MatchOutcome::NoMatch => (None, false),
+                                        filter::MatchOutcome::FailedClosed => (None, true),
+                                    };
+                                let parent_status = parent_hex.as_deref().and_then(|parent| {
+                                    recent_reply_parents.lock().ok().and_then(|cache| {
+                                        cache.is_agent_parent(parent, buzz_event.channel_id)
+                                    })
+                                });
+                                if reply_candidate_requires_classification(
+                                    verified_candidate.as_ref(),
+                                    ordinary_match.as_ref(),
+                                    parent_status == Some(false),
+                                    false,
+                                ) || (verified_candidate.is_some()
+                                    && ordinary_failed_closed
+                                    && parent_status != Some(false))
+                                {
+                                    // Even a verified-parent cache hit must traverse child
+                                    // signature verification and typed reauthorization.
+                                    needs_reply_classification = true;
+                                    None
+                                } else if ordinary_failed_closed {
+                                    tracing::debug!(
+                                        channel_id = %buzz_event.channel_id,
+                                        "ordinary rule evaluation failed closed"
+                                    );
+                                    continue;
+                                } else {
+                                    ordinary_match
+                                }
+                            } else {
+                                match filter::match_event_outcome(
+                                    &buzz_event.event,
+                                    buzz_event.channel_id,
+                                    &rules,
+                                    &pubkey_hex,
+                                )
+                                .await
+                                {
+                                    filter::MatchOutcome::Matched(matched) => Some(matched),
+                                    filter::MatchOutcome::NoMatch => None,
+                                    filter::MatchOutcome::FailedClosed => {
+                                        tracing::debug!(
+                                            channel_id = %buzz_event.channel_id,
+                                            "ordinary rule evaluation failed closed"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            };
+
+                            let prompt_tag = match matched {
+                                Some(matched) => matched.prompt_tag,
+                                None
+                                    if classified_ordinary_fallback_is_terminal(
+                                        validated_generation,
+                                        direct_reply_verified,
+                                    ) =>
+                                {
+                                    tracing::debug!(
+                                        channel_id = %buzz_event.channel_id,
+                                        "classified ordinary fallback matched no rule — dropping"
+                                    );
+                                    continue;
+                                }
+                                None if direct_reply_verified => {
+                                    if config.subscribe_mode == SubscribeMode::Config {
+                                        tracing::debug!(
+                                            channel_id = %buzz_event.channel_id,
+                                            "verified reply matched no configured rule — dropping"
+                                        );
+                                        continue;
+                                    }
+                                    "@reply".to_string()
+                                }
+                                None if needs_reply_classification
+                                    || (config.subscribe_mode != SubscribeMode::Config
+                                        && validated_generation.is_none()
+                                        && parent_hex.is_some()) =>
+                                {
+                                    let Some(parent_hex) = parent_hex else {
+                                        continue;
+                                    };
+                                    let parent_verified_from_cache = recent_reply_parents
+                                        .lock()
+                                        .ok()
+                                        .and_then(|cache| {
+                                            cache.is_agent_parent(
+                                                &parent_hex,
+                                                buzz_event.channel_id,
+                                            )
+                                        })
+                                        == Some(true);
+                                    let Some(subscription_generation) = subscription_generations
+                                        .get(&buzz_event.channel_id)
+                                        .copied()
+                                    else {
+                                        tracing::debug!(
+                                            channel_id = %buzz_event.channel_id,
+                                            "reply candidate has no active subscription generation"
+                                        );
+                                        continue;
+                                    };
+                                    let attributed_event = author_gate_ctx
+                                        .attribute_listener_event(buzz_event, &ctx.rest_client)
+                                        .await;
+                                    if !schedule_direct_reply_validation(
+                                        attributed_event,
+                                        parent_hex,
+                                        parent_verified_from_cache,
+                                        subscription_generation,
+                                        ReplyValidationContext {
+                                            agent_pubkey_hex: pubkey_hex.clone(),
+                                            rest_client: ctx.rest_client.clone(),
+                                            channel_info: ctx.channel_info.clone(),
+                                            respond_to: config.respond_to.clone(),
+                                            allowlist: config.respond_to_allowlist.clone(),
+                                            owner_cache: owner_cache.clone(),
+                                            permits: reply_lookup_permits.clone(),
+                                            verification_permits: event_verification_permits.clone(),
+                                            validated_tx: validated_reply_tx.clone(),
+                                        },
+                                    ) {
+                                        tracing::debug!(
+                                            channel_id = %subscription_generation,
+                                            "reply classifier at capacity — dropping candidate"
+                                        );
+                                    }
+                                    continue;
+                                }
+                                None => {
+                                    tracing::debug!("authorized event matched no rule — dropping");
+                                    continue;
+                                }
+                            };
+                            let (buzz_event, effective_author) =
+                                if let Some(effective_author) = preauthorized_author {
+                                    (buzz_event, effective_author)
+                                } else {
+                                    let Some(authorized_event) = authorize_normal_listener_event(
+                                        &mut author_gate_ctx,
+                                        buzz_event,
+                                        &config.respond_to,
+                                        &config.respond_to_allowlist,
+                                        &owner_cache,
+                                        &ctx.channel_info,
+                                        &ctx.rest_client,
+                                    )
+                                    .await
+                                    else {
+                                        continue;
+                                    };
+                                    AuthorizedNormalListenerEvent(authorized_event).into_parts()
+                                };
+                            let ingress = NormalListenerIngress {
+                                buzz_event,
+                                effective_author,
+                                prompt_tag,
                             };
                             // Derive the session scope once, at admission, from
                             // the operator policy, DM status, and NIP-10 thread
@@ -7839,6 +8494,1044 @@ mod author_gate_tests {
             is_dm_channel(Uuid::new_v4(), &resolver(HashMap::new())).await,
             "an unresolvable channel type must be treated as a DM"
         );
+    }
+}
+
+#[cfg(test)]
+mod reply_routing_tests {
+    use super::*;
+    use nostr::{EventBuilder, Kind, Tag};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn channel_message(
+        keys: &nostr::Keys,
+        channel_id: Uuid,
+        content: &str,
+        reply_to: Option<nostr::EventId>,
+    ) -> nostr::Event {
+        let mut tags = vec![Tag::parse(["h", &channel_id.to_string()]).unwrap()];
+        if let Some(parent) = reply_to {
+            tags.push(Tag::parse(["e", &parent.to_hex(), "", "reply"]).unwrap());
+        }
+        EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), content)
+            .tags(tags)
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    async fn rest_client_returning_after(
+        events: serde_json::Value,
+        delay: Duration,
+    ) -> (relay::RestClient, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test HTTP server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let body = events.to_string();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept query");
+            let mut request = vec![0; 8192];
+            let _ = socket.read(&mut request).await;
+            tokio::time::sleep(delay).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        (
+            relay::RestClient {
+                http: reqwest::Client::new(),
+                base_url,
+                keys: nostr::Keys::generate(),
+                auth_tag_json: None,
+            },
+            server,
+        )
+    }
+
+    async fn rest_client_returning(
+        events: serde_json::Value,
+    ) -> (relay::RestClient, tokio::task::JoinHandle<()>) {
+        rest_client_returning_after(events, Duration::ZERO).await
+    }
+
+    async fn rest_client_failing_with_status(
+        status: u16,
+    ) -> (relay::RestClient, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test HTTP server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept query");
+            let mut request = vec![0; 8192];
+            let _ = socket.read(&mut request).await;
+            let response = format!(
+                "HTTP/1.1 {status} Test Failure\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        (
+            relay::RestClient {
+                http: reqwest::Client::new(),
+                base_url,
+                keys: nostr::Keys::generate(),
+                auth_tag_json: None,
+            },
+            server,
+        )
+    }
+
+    fn dummy_rest_client() -> relay::RestClient {
+        relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:0".into(),
+            keys: nostr::Keys::generate(),
+            auth_tag_json: None,
+        }
+    }
+
+    fn authorized(event: relay::BuzzEvent) -> AuthorizedListenerEvent {
+        let effective_author = event.event.pubkey.to_hex();
+        AuthorizedListenerEvent::for_test(event, effective_author)
+    }
+
+    #[tokio::test]
+    async fn ready_validation_is_forced_after_bounded_relay_window() {
+        let keys = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let event = relay::BuzzEvent {
+            channel_id,
+            event: channel_message(&keys, channel_id, "reply", None),
+            connection_generation: 0,
+        };
+        let generation = Uuid::new_v4();
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send(ValidatedReply {
+            event: authorized(event),
+            subscription_generation: generation,
+            parent_verified: true,
+        })
+        .await
+        .unwrap();
+
+        assert!(take_ready_validated_reply_after_budget(
+            MAX_RELAY_EVENTS_BEFORE_VALIDATED_REPLY - 1,
+            &mut rx,
+        )
+        .is_none());
+        let selected = take_ready_validated_reply_after_budget(
+            MAX_RELAY_EVENTS_BEFORE_VALIDATED_REPLY,
+            &mut rx,
+        )
+        .expect("ready validation must be forced at the relay-drain bound");
+        assert_eq!(selected.subscription_generation, generation);
+    }
+
+    #[test]
+    fn sibling_cache_warming_is_only_required_by_author_policy() {
+        let author = "aa".repeat(32);
+        let allowlist = HashSet::from([author.clone()]);
+        assert!(!reply_validation_needs_sibling_cache(
+            &RespondTo::Anyone,
+            &HashSet::new(),
+            &author,
+            false,
+        ));
+        assert!(!reply_validation_needs_sibling_cache(
+            &RespondTo::Allowlist,
+            &allowlist,
+            &author,
+            false,
+        ));
+        assert!(reply_validation_needs_sibling_cache(
+            &RespondTo::OwnerOnly,
+            &HashSet::new(),
+            &author,
+            false,
+        ));
+        assert!(reply_validation_needs_sibling_cache(
+            &RespondTo::Anyone,
+            &HashSet::new(),
+            &author,
+            true,
+        ));
+        assert!(!reply_validation_needs_sibling_cache(
+            &RespondTo::Nobody,
+            &HashSet::new(),
+            &author,
+            true,
+        ));
+    }
+
+    #[tokio::test]
+    async fn direct_reply_to_agent_is_routable_without_mention() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let (rest, server) = rest_client_returning(serde_json::json!([parent])).await;
+
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        assert_eq!(
+            lookup_direct_reply_parent(
+                &parent_hex,
+                channel_id,
+                &agent.public_key().to_hex(),
+                &rest,
+                Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+            )
+            .await,
+            ParentLookupOutcome::Agent
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reply_to_another_author_is_not_routable() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&human, channel_id, "human message", None);
+        let reply = channel_message(&human, channel_id, "human follow-up", Some(parent.id));
+        let (rest, server) = rest_client_returning(serde_json::json!([parent])).await;
+
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        assert_eq!(
+            lookup_direct_reply_parent(
+                &parent_hex,
+                channel_id,
+                &agent.public_key().to_hex(),
+                &rest,
+                Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+            )
+            .await,
+            ParentLookupOutcome::NotAgent
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rest_fallback_rejects_returned_event_id_mismatch() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let requested_parent = channel_message(&agent, channel_id, "requested", None);
+        let returned_parent = channel_message(&agent, channel_id, "different", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(requested_parent.id));
+        let (rest, server) = rest_client_returning(serde_json::json!([returned_parent])).await;
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+
+        assert_eq!(
+            lookup_direct_reply_parent(
+                &parent_hex,
+                channel_id,
+                &agent.public_key().to_hex(),
+                &rest,
+                Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+            )
+            .await,
+            ParentLookupOutcome::NotAgent
+        );
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn recent_parent_cache_short_circuits_by_author_and_channel() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let agent_parent = channel_message(&agent, channel_id, "agent", None);
+        let human_parent = channel_message(&human, channel_id, "human", None);
+        let mut cache = RecentReplyParents::default();
+
+        cache.insert_verified(agent_parent.id.to_hex(), channel_id);
+
+        assert_eq!(
+            cache.is_agent_parent(&agent_parent.id.to_hex(), channel_id),
+            Some(true)
+        );
+        assert_eq!(
+            cache.is_agent_parent(&human_parent.id.to_hex(), channel_id),
+            None
+        );
+        assert_eq!(
+            cache.is_agent_parent(&agent_parent.id.to_hex(), other_channel),
+            Some(false)
+        );
+    }
+
+    #[tokio::test]
+    async fn recent_parent_observation_verifies_off_loop_and_ignores_other_authors() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let agent_parent = channel_message(&agent, channel_id, "agent", None);
+        let human_parent = channel_message(&human, channel_id, "human", None);
+        let cache = Arc::new(std::sync::Mutex::new(RecentReplyParents::default()));
+        let verification_permits = Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS));
+
+        schedule_recent_parent_observation(
+            &human_parent,
+            channel_id,
+            &agent.public_key().to_hex(),
+            cache.clone(),
+            verification_permits.clone(),
+        );
+        schedule_recent_parent_observation(
+            &agent_parent,
+            channel_id,
+            &agent.public_key().to_hex(),
+            cache.clone(),
+            verification_permits,
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if cache
+                    .lock()
+                    .unwrap()
+                    .entries
+                    .contains_key(&agent_parent.id.to_hex())
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("agent parent verification should complete");
+        let cache = cache.lock().unwrap();
+        assert!(!cache.entries.contains_key(&human_parent.id.to_hex()));
+    }
+
+    #[test]
+    fn recent_parent_cache_capacity_evicts_oldest_entry() {
+        let channel_id = Uuid::new_v4();
+        let mut cache = RecentReplyParents::default();
+        for index in 0..RECENT_REPLY_PARENT_CAPACITY {
+            let id = format!("cached-{index}");
+            cache.order.push_back(id.clone());
+            cache.entries.insert(id, channel_id);
+        }
+        let agent = nostr::Keys::generate();
+        let newest = channel_message(&agent, channel_id, "newest", None);
+
+        cache.insert_verified(newest.id.to_hex(), channel_id);
+
+        assert_eq!(cache.entries.len(), RECENT_REPLY_PARENT_CAPACITY);
+        assert!(!cache.entries.contains_key("cached-0"));
+        assert!(cache.entries.contains_key(&newest.id.to_hex()));
+    }
+
+    #[tokio::test]
+    async fn bounded_verification_rejects_invalid_signature() {
+        let agent = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent", None);
+        let mut value = serde_json::to_value(&parent).unwrap();
+        value["content"] = serde_json::json!("tampered");
+        let tampered = serde_json::from_value::<nostr::Event>(value).unwrap();
+        assert!(
+            !verify_event_bounded(
+                tampered,
+                Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_verification_capacity_exhaustion_fails_closed() {
+        let event = channel_message(&nostr::Keys::generate(), Uuid::new_v4(), "event", None);
+        assert!(!verify_event_bounded(event, Arc::new(Semaphore::new(0))).await);
+    }
+
+    #[test]
+    fn earlier_verified_rule_defers_first_arrival_but_not_fallback() {
+        let verified = filter::MatchedRule {
+            rule_index: 0,
+            prompt_tag: "strict".to_string(),
+        };
+        let ordinary = filter::MatchedRule {
+            rule_index: 1,
+            prompt_tag: "open".to_string(),
+        };
+
+        assert!(reply_candidate_requires_classification(
+            Some(&verified),
+            Some(&ordinary),
+            false,
+            false,
+        ));
+        assert!(!reply_candidate_requires_classification(
+            Some(&verified),
+            Some(&ordinary),
+            false,
+            true,
+        ));
+        assert!(!reply_candidate_requires_classification(
+            Some(&verified),
+            Some(&ordinary),
+            true,
+            false,
+        ));
+        let generation = Some(Uuid::new_v4());
+        assert!(classified_ordinary_fallback_is_terminal(generation, false));
+        assert!(!classified_ordinary_fallback_is_terminal(None, false));
+        assert!(!classified_ordinary_fallback_is_terminal(generation, true));
+    }
+
+    #[test]
+    fn stale_subscription_generation_is_rejected_after_readd() {
+        let channel_id = Uuid::new_v4();
+        let old_generation = Uuid::new_v4();
+        let new_generation = Uuid::new_v4();
+        let subscribed = HashSet::from([channel_id]);
+        let generations = HashMap::from([(channel_id, new_generation)]);
+
+        assert!(!validated_reply_generation_is_current(
+            channel_id,
+            Some(old_generation),
+            &subscribed,
+            &generations,
+        ));
+        assert!(validated_reply_generation_is_current(
+            channel_id,
+            Some(new_generation),
+            &subscribed,
+            &generations,
+        ));
+    }
+
+    #[tokio::test]
+    async fn rest_fallback_rejects_cross_channel_parent() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let parent = channel_message(&agent, other_channel, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let (rest, server) = rest_client_returning(serde_json::json!([parent])).await;
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+
+        assert_eq!(
+            lookup_direct_reply_parent(
+                &parent_hex,
+                channel_id,
+                &agent.public_key().to_hex(),
+                &rest,
+                Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+            )
+            .await,
+            ParentLookupOutcome::NotAgent
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rest_fallback_rejects_invalid_signature() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let mut value = serde_json::to_value(&parent).unwrap();
+        value["content"] = serde_json::json!("tampered");
+        let (rest, server) = rest_client_returning(serde_json::json!([value])).await;
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+
+        assert_eq!(
+            lookup_direct_reply_parent(
+                &parent_hex,
+                channel_id,
+                &agent.public_key().to_hex(),
+                &rest,
+                Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+            )
+            .await,
+            ParentLookupOutcome::NotAgent
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cached_parent_routes_without_rest() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let rest = dummy_rest_client();
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+        let subscription_generation = Uuid::new_v4();
+
+        assert!(schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: reply.clone(),
+                connection_generation: 0,
+            },
+            parent_hex,
+            true,
+            subscription_generation,
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS,)),
+                validated_tx: tx,
+            },
+        ));
+        let validated = tokio::time::timeout(Duration::from_millis(200), rx.recv())
+            .await
+            .expect("cache-hit validation must not wait on REST")
+            .expect("cache-hit reply should be accepted");
+        assert_eq!(validated.event.buzz_event().event.id, reply.id);
+        assert_eq!(validated.subscription_generation, subscription_generation);
+        assert!(validated.parent_verified);
+    }
+
+    #[tokio::test]
+    async fn non_agent_parent_returns_one_ordinary_fallback_classification() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let missing_parent = nostr::EventId::all_zeros();
+        let reply = channel_message(&human, channel_id, "open-rule reply", Some(missing_parent));
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let (rest, server) = rest_client_returning(serde_json::json!([])).await;
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+        let generation = Uuid::new_v4();
+
+        assert!(schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: reply.clone(),
+                connection_generation: 0,
+            },
+            parent_hex,
+            false,
+            generation,
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS,)),
+                validated_tx: tx,
+            },
+        ));
+        let classified = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("classification should complete")
+            .expect("valid child should return an ordinary fallback");
+        assert_eq!(classified.event.buzz_event().event.id, reply.id);
+        assert_eq!(classified.subscription_generation, generation);
+        assert!(!classified.parent_verified);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn parent_lookup_error_fails_closed_without_ordinary_fallback() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let reply = channel_message(
+            &human,
+            channel_id,
+            "open-rule reply",
+            Some(nostr::EventId::all_zeros()),
+        );
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let (rest, server) = rest_client_failing_with_status(500).await;
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: reply,
+                connection_generation: 0,
+            },
+            parent_hex,
+            false,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+                validated_tx: tx,
+            },
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .expect("lookup error classification should terminate")
+                .is_none(),
+            "lookup error must not emit an ordinary fallback"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn parent_lookup_timeout_fails_closed_without_ordinary_fallback() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let reply = channel_message(
+            &human,
+            channel_id,
+            "open-rule reply",
+            Some(nostr::EventId::all_zeros()),
+        );
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let (rest, server) =
+            rest_client_returning_after(serde_json::json!([]), Duration::from_secs(3)).await;
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: reply,
+                connection_generation: 0,
+            },
+            parent_hex,
+            false,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+                validated_tx: tx,
+            },
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(3), rx.recv())
+                .await
+                .expect("lookup timeout classification should terminate")
+                .is_none(),
+            "lookup timeout must not emit an ordinary fallback"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn trusted_workflow_effective_author_is_used_for_reauthorization() {
+        let agent = nostr::Keys::generate();
+        let relay_signer = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(
+            &relay_signer,
+            channel_id,
+            "workflow follow-up",
+            Some(parent.id),
+        );
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let rest = dummy_rest_client();
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+        let buzz_event = relay::BuzzEvent {
+            channel_id,
+            event: reply,
+            connection_generation: 0,
+        };
+        let attributed = AttributedListenerEvent::for_test(buzz_event, owner.public_key().to_hex());
+
+        assert!(schedule_direct_reply_validation(
+            attributed,
+            parent_hex,
+            true,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::OwnerOnly,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(Some(owner.public_key().to_hex()))),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+                validated_tx: tx,
+            },
+        ));
+        let validated = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("typed workflow reauthorization should finish")
+            .expect("effective workflow owner should be authorized");
+        assert_eq!(
+            validated.event.into_parts().1,
+            owner.public_key().to_hex(),
+            "classifier must preserve the effective workflow author"
+        );
+    }
+
+    #[tokio::test]
+    async fn anyone_policy_does_not_wait_for_unneeded_profile_lookup() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let (rest, server) =
+            rest_client_returning_after(serde_json::json!([]), Duration::from_secs(1)).await;
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: reply,
+                connection_generation: 0,
+            },
+            parent_hex,
+            true,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS)),
+                validated_tx: tx,
+            },
+        ));
+        assert!(tokio::time::timeout(Duration::from_millis(200), rx.recv())
+            .await
+            .expect("Anyone validation must not await an irrelevant profile query")
+            .is_some());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn cached_parent_tampered_child_signature_fails_closed() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let mut value = serde_json::to_value(reply).unwrap();
+        value["content"] = serde_json::json!("tampered");
+        let tampered = serde_json::from_value::<nostr::Event>(value).unwrap();
+        let rest = dummy_rest_client();
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: tampered,
+                connection_generation: 0,
+            },
+            parent_hex,
+            true,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS,)),
+                validated_tx: tx,
+            },
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .expect("signature validation should finish")
+                .is_none(),
+            "invalid reply signature must fail closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn reply_validation_capacity_exhaustion_drops_fail_closed() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let rest = dummy_rest_client();
+        let channel_info = pool::ChannelInfoResolver::new(HashMap::new(), rest.clone());
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(!schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: reply,
+                connection_generation: 0,
+            },
+            parent_hex,
+            false,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits: Arc::new(Semaphore::new(0)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS,)),
+                validated_tx: tx,
+            },
+        ));
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn slow_author_lookup_does_not_block_a_following_explicit_mention() {
+        let agent = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let (rest, server) =
+            rest_client_returning_after(serde_json::json!([]), Duration::from_millis(250)).await;
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(schedule_direct_reply_validation(
+            relay::BuzzEvent {
+                channel_id,
+                event: reply,
+                connection_generation: 0,
+            },
+            parent_hex,
+            true,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::OwnerOnly,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(Some(owner.public_key().to_hex()))),
+                permits: Arc::new(Semaphore::new(1)),
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS,)),
+                validated_tx: tx,
+            },
+        ));
+
+        let (mention_tx, mut mention_rx) = mpsc::channel(1);
+        mention_tx.send("@agent follow-up").await.unwrap();
+        tokio::select! {
+            mention = mention_rx.recv() => {
+                assert_eq!(mention, Some("@agent follow-up"));
+            }
+            validated = rx.recv() => {
+                panic!("slow author validation completed before explicit mention: {validated:?}");
+            }
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .expect("author validation should finish")
+                .is_none(),
+            "unverified author must fail closed"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn slow_rest_fallback_does_not_block_a_following_explicit_mention() {
+        let agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let parent = channel_message(&agent, channel_id, "agent answer", None);
+        let reply = channel_message(&human, channel_id, "follow-up", Some(parent.id));
+        let parent_hex = direct_reply_parent_id(&reply).unwrap();
+        let (rest, server) =
+            rest_client_returning_after(serde_json::json!([parent]), Duration::from_millis(250))
+                .await;
+        let (tx, mut rx) = mpsc::channel(1);
+        let permits = Arc::new(Semaphore::new(1));
+        let buzz_event = relay::BuzzEvent {
+            channel_id,
+            event: reply,
+            connection_generation: 0,
+        };
+
+        let channel_info = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        let started = std::time::Instant::now();
+        assert!(schedule_direct_reply_validation(
+            buzz_event.clone(),
+            parent_hex,
+            false,
+            Uuid::new_v4(),
+            ReplyValidationContext {
+                agent_pubkey_hex: agent.public_key().to_hex(),
+                rest_client: rest,
+                channel_info,
+                respond_to: RespondTo::Anyone,
+                allowlist: HashSet::new(),
+                owner_cache: Arc::new(OwnerCache::new(None)),
+                permits,
+                verification_permits: Arc::new(Semaphore::new(MAX_PENDING_EVENT_VERIFICATIONS,)),
+                validated_tx: tx,
+            },
+        ));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "scheduling must not await the REST fallback"
+        );
+
+        // Model the main loop receiving a subsequent explicit mention while
+        // the cache-miss validation is still waiting on REST. The mention-side
+        // event is immediately available and must win before validation.
+        let (mention_tx, mut mention_rx) = mpsc::channel(1);
+        mention_tx.send("@agent follow-up").await.unwrap();
+        tokio::select! {
+            mention = mention_rx.recv() => {
+                assert_eq!(mention, Some("@agent follow-up"));
+            }
+            validated = rx.recv() => {
+                panic!("slow parent validation completed before explicit mention: {validated:?}");
+            }
+        }
+
+        let validated = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("validation should finish")
+            .expect("validated event should be returned");
+        assert_eq!(validated.event.buzz_event().event.id, buzz_event.event.id);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn top_level_unmentioned_message_is_not_routable() {
+        let human = nostr::Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let message = channel_message(&human, channel_id, "ordinary chatter", None);
+        assert!(direct_reply_parent_id(&message).is_none());
     }
 }
 


### PR DESCRIPTION
## Summary
- deliver bounded unmentioned reply candidates in both mentions and config subscription modes
- accept a direct reply only after verifying the child signature and its signed immediate parent, agent authorship, and same-channel binding
- preserve ordered config rules while waiving only the mention predicate for a verified reply
- retain owner/sibling DM authorization and drop unrelated unmentioned shared-channel traffic

## Safety and liveness
- re-authorize the effective listener/workflow author after bounded background classification
- distinguish `Matched`, `NoMatch`, and `FailedClosed` so filter failures cannot widen into later rules
- fail closed on malformed events and parent lookup failure/timeout; non-agent parents receive at most one ordinary fallback classification
- cap the recent-parent cache at 4,096, parent lookups and signature verifications at 8 each, and deadlines at two seconds
- service validated replies after at most 32 relay events and reject stale subscription generations

## Tests
- `cargo test -p buzz-acp`: 932 unit + 9 lifecycle tests passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The production backport remains separately pinned to the deployed relay source; this PR targets current upstream `main`.