### PR TITLE
fix(acp): raise model-probe timeout and make it configurable

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -64,11 +64,14 @@ fn is_subcommand(name: &str) -> bool {
 ///
 /// These probes are only "lightweight" once the adapter is running: a cold
 /// probe boots Node plus the vendor app server before `initialize` is answered.
-/// On Windows that routinely lands at 9-12s for both `codex-acp` and
-/// `claude-agent-acp`, so the previous 10s budget failed intermittently and
-/// surfaced as an empty model picker indistinguishable from a broken install.
+/// Measured cold probes on Windows span an order of magnitude across shipped
+/// harnesses: `codex-acp` 9-12s, `claude-agent-acp` 29-31s, `opencode acp` 58s.
+/// The previous 10s budget failed for all but the fastest, surfacing as an
+/// empty model picker indistinguishable from a broken install. The default
+/// must clear the slowest known harness with margin, because a false timeout
+/// is a worse failure than a slow success: it is silent and misdiagnosed.
 /// Override via `BUZZ_ACP_MODELS_TIMEOUT` (whole seconds).
-const DEFAULT_MODELS_TIMEOUT_SECS: u64 = 45;
+const DEFAULT_MODELS_TIMEOUT_SECS: u64 = 120;
 
 /// Parse `BUZZ_ACP_MODELS_TIMEOUT` (whole seconds), falling back to
 /// [`DEFAULT_MODELS_TIMEOUT_SECS`]. A malformed or zero value falls back
@@ -7897,9 +7900,10 @@ mod models_timeout_tests {
 
     #[test]
     fn default_clears_observed_windows_cold_start() {
-        // Cold `codex-acp` / `claude-agent-acp` probes on Windows measured
-        // 9-12s; the previous 10s budget failed intermittently.
-        assert!(DEFAULT_MODELS_TIMEOUT_SECS >= 30);
+        // Slowest measured shipped harness is `opencode acp` at 58s cold on
+        // Windows; the default must clear it with margin so a future edit
+        // cannot silently reintroduce a too-tight budget.
+        assert!(DEFAULT_MODELS_TIMEOUT_SECS >= 90);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -59,8 +59,35 @@ fn is_subcommand(name: &str) -> bool {
     std::env::args().nth(1).map(|a| a == name).unwrap_or(false)
 }
 
-/// Timeout for lightweight helper subcommands (spawn + initialize + model/method probes).
-const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
+/// Default timeout for lightweight helper subcommands (spawn + initialize +
+/// model/method probes).
+///
+/// These probes are only "lightweight" once the adapter is running: a cold
+/// probe boots Node plus the vendor app server before `initialize` is answered.
+/// On Windows that routinely lands at 9-12s for both `codex-acp` and
+/// `claude-agent-acp`, so the previous 10s budget failed intermittently and
+/// surfaced as an empty model picker indistinguishable from a broken install.
+/// Override via `BUZZ_ACP_MODELS_TIMEOUT` (whole seconds).
+const DEFAULT_MODELS_TIMEOUT_SECS: u64 = 45;
+
+/// Parse `BUZZ_ACP_MODELS_TIMEOUT` (whole seconds), falling back to
+/// [`DEFAULT_MODELS_TIMEOUT_SECS`]. A malformed or zero value falls back
+/// rather than failing the probe: an unusable override must not be a harder
+/// failure than no override.
+fn models_timeout_from_env(raw: Option<&str>) -> Duration {
+    let secs = raw
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(DEFAULT_MODELS_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Timeout for lightweight helper subcommands. See [`DEFAULT_MODELS_TIMEOUT_SECS`].
+fn models_timeout() -> Duration {
+    models_timeout_from_env(std::env::var("BUZZ_ACP_MODELS_TIMEOUT").ok().as_deref())
+}
 
 /// Timeout for `buzz-acp authenticate`. Browser-based vendor auth can require
 /// human interaction, so it must not share the short probe timeout.
@@ -4275,7 +4302,8 @@ async fn run_auth_methods(args: AuthMethodsArgs) -> Result<()> {
         }
     };
 
-    let init_result = match tokio::time::timeout(MODELS_TIMEOUT, client.initialize()).await {
+    let models_timeout = models_timeout();
+    let init_result = match tokio::time::timeout(models_timeout, client.initialize()).await {
         Ok(Ok(result)) => result,
         Ok(Err(e)) => {
             client.shutdown().await;
@@ -4284,7 +4312,7 @@ async fn run_auth_methods(args: AuthMethodsArgs) -> Result<()> {
         }
         Err(_) => {
             client.shutdown().await;
-            eprintln!("error: agent timed out ({MODELS_TIMEOUT:?})");
+            eprintln!("error: agent timed out ({models_timeout:?})");
             std::process::exit(1);
         }
     };
@@ -4323,7 +4351,8 @@ async fn run_authenticate(args: AuthenticateArgs) -> Result<()> {
         }
     };
 
-    let init_result = match tokio::time::timeout(MODELS_TIMEOUT, client.initialize()).await {
+    let models_timeout = models_timeout();
+    let init_result = match tokio::time::timeout(models_timeout, client.initialize()).await {
         Ok(Ok(result)) => result,
         Ok(Err(e)) => {
             client.shutdown().await;
@@ -4332,7 +4361,7 @@ async fn run_authenticate(args: AuthenticateArgs) -> Result<()> {
         }
         Err(_) => {
             client.shutdown().await;
-            eprintln!("error: agent initialize timed out ({MODELS_TIMEOUT:?})");
+            eprintln!("error: agent initialize timed out ({models_timeout:?})");
             std::process::exit(1);
         }
     };
@@ -4394,7 +4423,8 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
 
     // Initialize + session/new under a timeout. Client is owned above,
     // so shutdown() runs on all paths (success, error, timeout).
-    let protocol_result = tokio::time::timeout(MODELS_TIMEOUT, async {
+    let models_timeout = models_timeout();
+    let protocol_result = tokio::time::timeout(models_timeout, async {
         let init = client.initialize().await?;
         let session = client.session_new_full(&cwd, vec![], None, None).await?;
         Ok::<_, acp::AcpError>((init, session))
@@ -4410,7 +4440,7 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
         }
         Err(_) => {
             client.shutdown().await;
-            eprintln!("error: agent timed out ({MODELS_TIMEOUT:?})");
+            eprintln!("error: agent timed out ({models_timeout:?})");
             std::process::exit(1);
         }
     };
@@ -7849,5 +7879,43 @@ mod observer_payload_trim_tests {
         assert!(leaf.starts_with('…'));
         assert!(leaf.ends_with('…'));
         assert!(leaf.contains("[elided"));
+    }
+}
+
+#[cfg(test)]
+mod models_timeout_tests {
+    use super::{models_timeout_from_env, DEFAULT_MODELS_TIMEOUT_SECS};
+    use std::time::Duration;
+
+    #[test]
+    fn defaults_when_unset_or_blank() {
+        let expected = Duration::from_secs(DEFAULT_MODELS_TIMEOUT_SECS);
+        assert_eq!(models_timeout_from_env(None), expected);
+        assert_eq!(models_timeout_from_env(Some("")), expected);
+        assert_eq!(models_timeout_from_env(Some("   ")), expected);
+    }
+
+    #[test]
+    fn default_clears_observed_windows_cold_start() {
+        // Cold `codex-acp` / `claude-agent-acp` probes on Windows measured
+        // 9-12s; the previous 10s budget failed intermittently.
+        assert!(DEFAULT_MODELS_TIMEOUT_SECS >= 30);
+    }
+
+    #[test]
+    fn parses_whole_seconds() {
+        assert_eq!(models_timeout_from_env(Some("20")), Duration::from_secs(20));
+        assert_eq!(
+            models_timeout_from_env(Some("  90  ")),
+            Duration::from_secs(90)
+        );
+    }
+
+    #[test]
+    fn unusable_values_fall_back_instead_of_failing_the_probe() {
+        let expected = Duration::from_secs(DEFAULT_MODELS_TIMEOUT_SECS);
+        for raw in ["0", "-5", "abc", "12.5", "9999999999999999999999"] {
+            assert_eq!(models_timeout_from_env(Some(raw)), expected, "raw={raw}");
+        }
     }
 }


### PR DESCRIPTION
Closes #2261.

## Problem

`MODELS_TIMEOUT` (`crates/buzz-acp/src/lib.rs`) was a hardcoded `Duration::from_secs(10)`. That covers a warm adapter, but a cold probe boots Node plus the vendor app server before answering `initialize`, and on Windows that routinely exceeds it.

Measured cold probes of `buzz-acp models --json` on Windows 11, timing the real binary:

| Adapter | Cold probe | vs 10s budget |
|---|---|---|
| `codex-acp` 1.1.7 | 9-12s | oscillates across the line |
| `codex-acp` 1.1.14 | 11-12s | consistently over |
| `claude-agent-acp` 0.66.0 | 29-31s | consistently over, by 3x |

Claude Code never fits. Codex fits only when the OS file cache happens to be warm, which is why this reads as intermittent.

The failure mode is bad: an empty model picker or a spinner that never resolves, indistinguishable from a broken install. And it is unrecoverable by the user, because the constant is reachable from neither config nor env, unlike `BUZZ_ACP_IDLE_TIMEOUT` and `BUZZ_ACP_TURN_TIMEOUT`.

## Change

- Default 10s → **45s**, clearing the slowest measured adapter with margin. This is recommendation 1 in #2261 ("raise to 30-45s").
- Add **`BUZZ_ACP_MODELS_TIMEOUT`** (whole seconds), following the existing `BUZZ_ACP_IDLE_TIMEOUT` convention, so a slower machine or a future adapter can be tuned without a rebuild.
- A malformed, zero, or negative override falls back to the default rather than failing the probe: an unusable override must never be a harder failure than no override.

Scope is deliberately narrow — one constant becomes a function, three call sites bind it locally so the timeout reported in the error message is always the one actually applied. I did not touch the UX items in #2261 (retry affordance, caching successful catalogs); those are separate and worth doing, but this is the part that makes discovery work at all.

## Verification

Windows 11, toolchain 1.95.0, release binary built from this branch:

- `codex-acp`: full catalog returned in **14s and 19s** (8735 bytes) — both fatal under the old budget.
- `claude-agent-acp`: returned in **29s and 31s** (1269 bytes) — previously always timed out.
- `BUZZ_ACP_MODELS_TIMEOUT=2` still fails fast at 2s with `error: agent timed out (2s)`, confirming the override is applied and the message reflects the effective value.
- `cargo test -p buzz-acp --lib models_timeout` — 4 new unit tests pass (default when unset/blank, whole-second parsing, unusable-value fallback, and a guard that the default stays ≥30s so a future edit cannot silently reintroduce a too-tight budget).
- `cargo fmt -p buzz-acp -- --check` clean.

Commit is DCO signed-off.