### PR TITLE
fix(acp): give MCP-less harnesses a sibling buzz-dev-mcp so replies can publish

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -648,6 +648,46 @@ fn validate_allowlist(entries: &[String]) -> Result<HashSet<String>, ConfigError
 /// `DedupMode::Queue`: `DedupMode::Drop` discards events during the cancel drain
 /// window, which would produce incomplete merged prompts. `Queue` handling
 /// imposes no constraint.
+/// Fall back to a `buzz-dev-mcp` binary installed NEXT TO the running
+/// `buzz-acp` executable when no MCP command was configured.
+///
+/// Without an MCP server the agent has no keyed channel back to the relay:
+/// `BUZZ_PRIVATE_KEY` / `BUZZ_RELAY_URL` are injected only into the MCP
+/// server's environment at `session/new` (see `build_mcp_servers`), so a
+/// harness spawned with an empty `mcp_command` — which Desktop currently does
+/// for Claude Code, whose `KnownAcpRuntime.mcp_command` is `None` — can run a
+/// full turn and then have no way to publish its reply.
+///
+/// The fallback is deliberately NOT an env/config knob: the sibling path is
+/// derived from the trusted install directory of the running executable, so it
+/// adds no user-controllable code-execution surface (the reason
+/// `BUZZ_ACP_MCP_COMMAND` is a Desktop-reserved key). When no sibling exists
+/// (e.g. under `cargo test`), the command is left empty and behaviour is
+/// unchanged.
+fn resolve_mcp_command_with_sibling_fallback(configured: String) -> String {
+    if !configured.is_empty() {
+        return configured;
+    }
+    let sibling = std::env::current_exe().ok().and_then(|exe| {
+        let candidate = exe.with_file_name(if cfg!(windows) {
+            "buzz-dev-mcp.exe"
+        } else {
+            "buzz-dev-mcp"
+        });
+        candidate.is_file().then(|| candidate.display().to_string())
+    });
+    match sibling {
+        Some(path) => {
+            tracing::info!(
+                mcp_command = %path,
+                "mcp_command empty; using sibling buzz-dev-mcp fallback"
+            );
+            path
+        }
+        None => configured,
+    }
+}
+
 fn validate_multiple_event_handling(
     handling: MultipleEventHandling,
     dedup: DedupMode,
@@ -1059,7 +1099,7 @@ impl Config {
             relay_url: args.relay_url,
             agent_command,
             agent_args,
-            mcp_command: args.mcp_command,
+            mcp_command: resolve_mcp_command_with_sibling_fallback(args.mcp_command),
             idle_timeout_secs,
             max_turn_duration_secs,
             agents: args.agents,
@@ -1430,6 +1470,24 @@ mod tests {
     use super::*;
     use crate::filter::{ChannelScope, SubscriptionRule};
     use clap::{Parser, ValueEnum};
+
+    #[test]
+    fn sibling_fallback_keeps_a_configured_command() {
+        // A non-empty command is authoritative and must never be overridden.
+        assert_eq!(
+            resolve_mcp_command_with_sibling_fallback("explicit-mcp".to_string()),
+            "explicit-mcp"
+        );
+    }
+
+    #[test]
+    fn sibling_fallback_is_absent_when_no_sibling_binary_exists() {
+        // No `buzz-dev-mcp` sits beside the test executable, so an empty
+        // command stays empty rather than pointing at a nonexistent path. The
+        // populated path is exercised in the packaged desktop layout and
+        // verified there via the `mcp_command empty; using sibling` log line.
+        assert_eq!(resolve_mcp_command_with_sibling_fallback(String::new()), "");
+    }
 
     /// Build a minimal Config for testing without CLI parsing.
     fn test_config(mode: SubscribeMode) -> Config {


### PR DESCRIPTION
## Problem

**Claude Code agents go silent after a turn; Codex agents reply normally.**

An agent's reply reaches the relay only through the MCP server. `BUZZ_PRIVATE_KEY` and `BUZZ_RELAY_URL` are injected **exclusively** into the MCP server's environment when it is registered at `session/new` (`build_mcp_servers`, `crates/buzz-acp/src/lib.rs`). A harness spawned with an **empty `mcp_command`** therefore has no keyed channel back to the relay: it can run a full turn — think, call tools — and then have no authenticated way to publish the result.

Desktop spawns Claude Code exactly this way. In the `KnownAcpRuntime` catalog (`desktop/src-tauri/src/managed_agents/discovery.rs`):

- `codex` → `mcp_command: Some("buzz-dev-mcp")`
- `claude` → `mcp_command: None`

So every Claude Code agent launches with an empty `mcp_command` and cannot publish. Reproduced on Windows 11: two Claude Code agents (opus[1m], sonnet) stayed mute after mentions while a Codex agent (gpt-5.6-sol) in the same channel replied. Their runtime lines differ in exactly one field — `mcp_cmd=` empty vs `mcp_cmd=…\buzz-dev-mcp.exe`.

## Change

When `mcp_command` is empty, fall back to a `buzz-dev-mcp` binary sitting **next to the running `buzz-acp` executable**.

The path is derived from `std::env::current_exe()` — the trusted install directory — never from user input. That is deliberate: it adds no user-controllable code-execution surface, which is why this is **not** an env/config knob (`BUZZ_ACP_MCP_COMMAND` is a Desktop-reserved key precisely to prevent a config from pointing the agent at an arbitrary binary). When no sibling exists (`cargo test`, unusual layouts), the command stays empty and behaviour is unchanged.

This is a one-function, ~10-line change plus two tests. It fixes the packaged desktop case (buzz-acp and buzz-dev-mcp ship in the same directory) without requiring the Desktop catalog to grow an `mcp_command` for every current and future harness.

## Alternative considered

Adding `mcp_command: Some("buzz-dev-mcp")` to the `claude` catalog entry would fix Claude specifically, but any future MCP-less harness would hit the same silent failure. Defaulting at the buzz-acp layer covers them all, and the runtime is the layer that actually knows its own install directory.

## Verification

Windows 11, release binary from this branch installed into the packaged desktop layout:

- Both Claude Code agents now boot with `mcp_cmd=…\buzz-dev-mcp.exe` and log `mcp_command empty; using sibling buzz-dev-mcp fallback`, where before they booted with an empty `mcp_cmd`.
- `cargo test -p buzz-acp --lib` — two new tests pass (configured command is preserved; empty stays empty when no sibling is present).
- `cargo fmt -p buzz-acp -- --check` clean.

Commit is DCO signed-off. Independent of my other open PR #5379 (probe timeout) — this branches from `main` and touches a different code path.