### PR TITLE
fix: reject empty stream messages at CLI, SDK, and relay ingest

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -581,6 +581,19 @@ pub async fn cmd_send_message(
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
     validate_content_size(&p.content)?;
+    // Fail fast on empty text with nothing attached. The classic producer of
+    // this state is a stdin pipe that delivered zero bytes (`--content -`
+    // after the upstream command died or the heredoc was mangled) — before
+    // this guard, "" sailed through every gate and published a blank message
+    // the author believed was real content.
+    if p.content.trim().is_empty() && p.files.is_empty() {
+        return Err(CliError::Usage(
+            "refusing to send an empty message: content is empty or \
+             whitespace-only and no --files are attached (if you piped \
+             content via '--content -', the pipe delivered zero bytes)"
+                .into(),
+        ));
+    }
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
     }

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -2726,6 +2726,17 @@ async fn ingest_event_inner(
         .filter(|t| t.kind().to_string() == "imeta")
         .map(|t| t.as_slice().iter().map(|s| s.to_string()).collect())
         .collect();
+    // A stream message must carry text or media. Empty content used to be
+    // accepted here, so a client whose input pipeline lost its payload
+    // published a blank message that read as success to its author. Edits
+    // (kind 40003) are unaffected — clearing an edit to empty is the
+    // deletion gesture and flows through a different kind.
+    if kind_u32 == KIND_STREAM_MESSAGE && event.content.trim().is_empty() && imeta_tags.is_empty()
+    {
+        return Err(IngestError::Rejected(
+            "invalid: empty message content (no text and no media)".into(),
+        ));
+    }
     if !imeta_tags.is_empty() {
         crate::api::validate_imeta_tags(&imeta_tags, &tenant_media_base)
             .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -230,6 +230,14 @@ pub fn build_message(
     media_tags: &[Vec<String>],
 ) -> Result<EventBuilder, SdkError> {
     check_content(content, 64 * 1024)?;
+    // An empty (or whitespace-only) message with no media renders as a blank
+    // bubble and, worse, lets upstream failures pass silently: a producer
+    // whose stdin pipe delivered zero bytes used to publish "" without any
+    // gate complaining, so the author believed the message was posted.
+    // Media-only messages (imeta tags, no text) remain legal.
+    if content.trim().is_empty() && media_tags.is_empty() {
+        return Err(SdkError::EmptyContent);
+    }
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     if let Some(tr) = thread_ref {
         thread_tags(tr, &mut tags)?;
@@ -2206,6 +2214,28 @@ pub fn build_delete_addressable(
 mod tests {
     use super::*;
     use nostr::{EventId, Keys};
+
+    #[test]
+    fn build_message_rejects_empty_content_without_media() {
+        let err = build_message(Uuid::new_v4(), "", None, &[], false, &[]).unwrap_err();
+        assert!(matches!(err, SdkError::EmptyContent));
+    }
+
+    #[test]
+    fn build_message_rejects_whitespace_only_content_without_media() {
+        let err = build_message(Uuid::new_v4(), " \n\t ", None, &[], false, &[]).unwrap_err();
+        assert!(matches!(err, SdkError::EmptyContent));
+    }
+
+    #[test]
+    fn build_message_allows_media_only_message() {
+        let media = vec![vec![
+            "imeta".to_string(),
+            "url https://example.com/x.png".to_string(),
+            "m image/png".to_string(),
+        ]];
+        assert!(build_message(Uuid::new_v4(), "", None, &[], false, &media).is_ok());
+    }
 
     fn keys() -> Keys {
         Keys::generate()

--- a/crates/buzz-sdk/src/lib.rs
+++ b/crates/buzz-sdk/src/lib.rs
@@ -94,6 +94,9 @@ pub enum SdkError {
         /// Actual byte count.
         got: usize,
     },
+    /// Message content is empty (or whitespace-only) with no media attached.
+    #[error("refusing to build a message with empty content and no media")]
+    EmptyContent,
     /// A tag could not be constructed.
     #[error("invalid tag: {0}")]
     InvalidTag(String),


### PR DESCRIPTION
## What

A production agent's channel post was published with **empty content**: its oversized turn output was rejected by the 64 KiB cap, the retry piped content via stdin, the pipe delivered zero bytes, and `""` passed every gate — CLI validation, SDK builder, and relay ingest all accept empty content for kind 9. The author (an automated agent) believed the message was posted; the recipients saw a blank bubble. Silent content loss.

## Fix — three layers, innermost out

- **buzz-cli** `cmd_send_message`: fail fast with a usage error that names the stdin-pipe case when content is empty/whitespace-only and no `--files` are attached.
- **buzz-sdk** `build_message`: new `SdkError::EmptyContent` unless media tags are present — every kind-9 producer inherits the guard.
- **buzz-relay** ingest: reject kind 9 with empty content and no `imeta` tags, covering non-CLI clients.

## Deliberately unaffected

- **Media-only messages** (imeta tags, no text) remain legal at every layer.
- **Message edits (kind 40003)**: clearing an edit to empty is the deletion gesture (#3813) and flows through a different kind — untouched.
- `mem set <slug> ''` and other non-kind-9 empty-content uses — untouched (the guards are kind-9-scoped).

## Tests

Three new SDK unit tests (empty rejected, whitespace-only rejected, media-only allowed); `cargo test -p buzz-sdk` green (187), `buzz-cli` + `buzz-relay` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)