### PR TITLE
fix(desktop): close stdin on CLI login probes so they cannot hang readiness

### DIFF
--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
@@ -60,6 +60,12 @@ pub(crate) fn login_probe(
 ) -> ProbeOutcome {
     let mut command = std::process::Command::new(binary_path);
     command.args(&probe_args[1..]);
+    // Close stdin explicitly. `output()` pipes stdout/stderr but leaves stdin
+    // inherited, and a GUI-launched desktop has no console — CLIs that sniff
+    // stdin for piped input (Claude Code does) then block on it forever. A
+    // hung probe is worse than a failed one: readiness never resolves, the
+    // agent stays NotReady, and creation/spawn flows wedge behind it.
+    command.stdin(std::process::Stdio::null());
     if let Some(path) = augmented_path {
         command.env("PATH", path);
     }


### PR DESCRIPTION
## Problem

`login_probe` (`desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs`) spawns the harness auth probe — `claude auth status` / `codex login status` — via `Command::output()`. That pipes stdout/stderr but leaves **stdin inherited**. A GUI-launched desktop has no console, and CLIs that sniff stdin for piped input (Claude Code does) block on it indefinitely.

Measured on Windows 11:

| Spawn | Result |
|---|---|
| `claude auth status` as spawned by the desktop | child alive **420s**, never exits, desktop respawns it and the new one hangs too |
| same command with stdin closed (`</dev/null`) | exits in **~1s** with valid logged-in JSON |

## Why it matters more than it looks

`agent_readiness` gates on this probe, so the hang is load-bearing:

- **Agent creation wedges**: the create dialog sits on "Saving…" indefinitely (killing the hung probe child unblocks the save immediately, which is how this was isolated).
- **Fresh Claude Code agents can never become ready**: readiness never resolves → permanent `NotReady` → the runtime never reaches its relay subscribe → mentions to a newly created agent are silently dropped. Existing agents that passed readiness before the hang keep working, which makes this look like agent-specific corruption rather than what it is.

A hung probe is strictly worse than a failed one: failure yields a `CliLogin` requirement the UI can surface, while a hang wedges every flow queued behind it.

## Fix

Spawn the probe with `stdin(Stdio::null())`. One call site; the login/auth CLIs never legitimately need interactive stdin for a `status` check.

## Verification

- `cargo check --lib` on the desktop crate: clean (warning count unchanged from `main`).
- Behavior delta measured directly on Windows 11 as above; with stdin closed the probe completes and returns the JSON the classifier expects.

Related but separate: #5379 (model-probe timeout), #5393 (MCP credential channel for empty `mcp_command`). This PR is deliberately single-purpose.

Commit is DCO signed-off.