### PR TITLE
docs(relay): drop stale fix-pending notes from the tenant.rs RED gate comments

### DIFF
--- a/crates/buzz-relay/src/tenant.rs
+++ b/crates/buzz-relay/src/tenant.rs
@@ -263,21 +263,12 @@ mod tests {
         /// RED gate. Configures a resolver with an `""→CommunityId` mapping
         /// (the schema permits it; no CHECK against empty host exists), then
         /// asks `bind_community` to bind an empty raw_host as a request with
-        /// a missing/invalid Host header would. Today this returns
-        /// `Ok(TenantContext{community=X})` — the fence collapses to the
-        /// misconfigured row. The fix: short-circuit in `bind_community` so
-        /// that `normalize_host(raw_host).is_empty()` returns
-        /// `Err(BindError::UnmappedHost)` before any resolver lookup.
+        /// a missing/invalid Host header would.
         ///
         /// Generic-rejection note: we reuse `UnmappedHost` (not a new
         /// `EmptyHost` variant) so the door's response is byte-identical to
         /// any other unmapped host — an unauthenticated caller cannot probe
         /// whether the deployment has an empty-host row.
-        ///
-        /// Delete this `#[ignore]` when the fix lands; verified RED with
-        /// `cargo test -p buzz-relay --include-ignored
-        ///   tenant::tests::redteam_attack2::empty_raw_host_fails_closed_even_if_db_has_empty_host_row`
-
         #[tokio::test]
         async fn empty_raw_host_fails_closed_even_if_db_has_empty_host_row() {
             // Simulate operator misconfig / buggy migration: an empty-host row
@@ -301,9 +292,6 @@ mod tests {
         /// RED gate. Same property, whitespace-only host: `normalize_host`
         /// trims to empty (`buzz-core::tenant::normalize_host_empty_stays_empty`),
         /// so this is the same fence collapse via a different raw input.
-        ///
-        /// Delete `#[ignore]` when the fix lands.
-
         #[tokio::test]
         async fn whitespace_only_raw_host_fails_closed_even_if_db_has_empty_host_row() {
             let r = resolver_with("", 0xdeadbeef);


### PR DESCRIPTION
## What changed

Remove the fix-pending notes from the two `redteam_attack2` doc comments in `crates/buzz-relay/src/tenant.rs`: the pre-fix return value, the prescribed fix, and the two instructions to delete an `#[ignore]`.

## Why

`bind_community` short-circuits when the normalized host is empty and returns `BindError::UnmappedHost` before any resolver lookup. The comments still describe that guard as outstanding work, stating that binding an empty `raw_host` currently succeeds onto a misconfigured empty-host row, prescribing the short-circuit as the fix, and telling the reader to delete an `#[ignore]` that neither test carries. The first also points at `cargo test --include-ignored`, which selects nothing here.

Read at face value the module reports the host-binding fence as broken, which is the kind of claim someone auditing tenant isolation acts on.

## Impact

Documentation only. The comments now match the behaviour the tests cover.

## Validation

- `cargo test -p buzz-relay --lib tenant::` reports 10 passed, 0 failed, 0 ignored
- `cargo clippy -p buzz-relay --lib --all-targets` reports no warnings
- `cargo fmt --all -- --check` is clean
- Run against rustc 1.95.0 via Hermit, matching `rust-toolchain.toml`
