### PR TITLE
feat: complete community Magic Board across desktop and mobile

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         "**/exact-key-profile.spec.ts",
         "**/key-import-reveal.spec.ts",
         "**/navigation.spec.ts",
+        "**/magic-board.spec.ts",
         "**/channels.spec.ts",
         "**/channel-shared-header-backdrop.spec.ts",
         "**/auxiliary-pane-close-visibility.spec.ts",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         "**/identity-key-help.spec.ts",
         "**/key-import-reveal.spec.ts",
         "**/navigation.spec.ts",
+        "**/magic-board.spec.ts",
         "**/channels.spec.ts",
         "**/channel-shared-header-backdrop.spec.ts",
         "**/channel-composer-overflow.spec.ts",

--- a/desktop/src-tauri/src/commands/canvas.rs
+++ b/desktop/src-tauri/src/commands/canvas.rs
@@ -46,10 +46,25 @@ pub async fn get_canvas(
 pub async fn set_canvas(
     channel_id: String,
     content: String,
+    enforce_revision: Option<bool>,
+    expected_event_id: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<serde_json::Value, String> {
     let uuid = uuid::Uuid::parse_str(&channel_id)
         .map_err(|_| format!("invalid channel UUID: {channel_id}"))?;
+    if enforce_revision.unwrap_or(false) {
+        let events = query_relay(
+            &state,
+            &[serde_json::json!({
+                "kinds": [40100],
+                "#h": [channel_id],
+                "limit": 1
+            })],
+        )
+        .await?;
+        let current_event_id = events.first().map(|event| event.id.to_hex());
+        ensure_canvas_revision(expected_event_id.as_deref(), current_event_id.as_deref())?;
+    }
     let builder = events::build_set_canvas(uuid, &content)?;
     let result = submit_event(builder, &state).await?;
 
@@ -57,4 +72,29 @@ pub async fn set_canvas(
         "ok": true,
         "event_id": result.event_id,
     }))
+}
+
+fn ensure_canvas_revision(expected: Option<&str>, current: Option<&str>) -> Result<(), String> {
+    if expected == current {
+        return Ok(());
+    }
+    Err("Canvas revision conflict: the board changed before this save.".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_canvas_revision;
+
+    #[test]
+    fn canvas_revision_accepts_matching_existing_or_empty_state() {
+        assert!(ensure_canvas_revision(Some("abc"), Some("abc")).is_ok());
+        assert!(ensure_canvas_revision(None, None).is_ok());
+    }
+
+    #[test]
+    fn canvas_revision_rejects_stale_or_unexpected_state() {
+        assert!(ensure_canvas_revision(Some("old"), Some("new")).is_err());
+        assert!(ensure_canvas_revision(None, Some("new")).is_err());
+        assert!(ensure_canvas_revision(Some("old"), None).is_err());
+    }
 }

--- a/desktop/src/app/routes/ChannelRouteScreen.tsx
+++ b/desktop/src/app/routes/ChannelRouteScreen.tsx
@@ -4,9 +4,15 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { SearchHighlightNavigation } from "@/app/navigation/searchHighlightNavigation";
 import { getCachedSearchHitEvent } from "@/app/navigation/searchHitEventCache";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
-import { useChannelsQuery } from "@/features/channels/hooks";
+import { useCanvasQuery, useChannelsQuery } from "@/features/channels/hooks";
 import { useOpenChannelDirectoryQuery } from "@/features/channels/openChannelDirectory";
+import {
+  type ChannelViewMode,
+  resolveChannelViewMode,
+} from "@/features/channels/lib/canvasBoard";
+import { ChannelBoardScreen } from "@/features/channels/ui/ChannelBoardScreen";
 import { ChannelScreen } from "@/features/channels/ui/ChannelScreen";
+import { ChannelViewModeProvider } from "@/features/channels/ui/ChannelViewModeContext";
 import { HuddleStartingView } from "@/features/huddle/components/HuddleStartingView";
 import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
 import {
@@ -34,6 +40,7 @@ type ChannelRouteScreenProps = {
   autoSendDraftKey: string | null;
   channelId: string;
   searchHighlight: SearchHighlightNavigation | null | undefined;
+  hasStreamRouteIntent: boolean;
   selectedPostId: string | null;
   targetMessageId: string | null;
   targetReplyId: string | null;
@@ -115,6 +122,7 @@ export function ChannelRouteScreen({
   autoSendDraftKey,
   channelId,
   searchHighlight,
+  hasStreamRouteIntent,
   selectedPostId,
   targetMessageId,
   targetReplyId,
@@ -159,6 +167,41 @@ export function ChannelRouteScreen({
   );
   const projectHome =
     enumeratedProjectHome ?? projectHomeLookupQuery.data ?? null;
+  const canvasQuery = useCanvasQuery(
+    activeChannel?.id ?? null,
+    activeChannel !== null && activeChannel.channelType !== "dm",
+  );
+  const [viewSelection, setViewSelection] = React.useState<{
+    channelId: string;
+    mode: ChannelViewMode;
+  } | null>(null);
+  const hasRouteTarget = Boolean(
+    hasStreamRouteIntent ||
+      searchHighlight ||
+      selectedPostId ||
+      targetMessageId ||
+      targetReplyId ||
+      targetThreadRootId,
+  );
+  const explicitView =
+    viewSelection?.channelId === channelId ? viewSelection.mode : null;
+  const channelView = resolveChannelViewMode({
+    channelName: activeChannel?.name ?? null,
+    channelType: activeChannel?.channelType ?? null,
+    explicitView,
+    hasCanvas: Boolean(canvasQuery.data?.content?.trim()),
+    hasRouteTarget,
+  });
+  const handleViewModeChange = React.useCallback(
+    (mode: ChannelViewMode) => setViewSelection({ channelId, mode }),
+    [channelId],
+  );
+
+  React.useEffect(() => {
+    if (hasRouteTarget) {
+      setViewSelection({ channelId, mode: "stream" });
+    }
+  }, [channelId, hasRouteTarget]);
   const [targetMessageEvents, setTargetMessageEvents] = React.useState<
     RelayEvent[]
   >(() => {
@@ -309,23 +352,41 @@ export function ChannelRouteScreen({
   }
 
   return (
-    <ChannelScreen
-      activeChannel={activeChannel}
-      autoSendDraftKey={autoSendDraftKey}
-      currentIdentity={identityQuery.data}
-      currentProfile={profileQuery.data}
-      onCloseForumPost={() => {
-        void closeForumPost(channelId);
+    <ChannelViewModeProvider
+      value={{
+        boardAvailable: channelView.boardAvailable && !hasRouteTarget,
+        mode: channelView.mode,
+        onModeChange: handleViewModeChange,
       }}
-      onSelectForumPost={(postId) => {
-        void goForumPost(channelId, postId);
-      }}
-      selectedForumPostId={selectedPostId}
-      targetForumReplyId={targetReplyId}
-      targetMessageEvents={targetMessageEvents}
-      targetMessageId={targetMessageId}
-      targetSearchMessageId={activeSearchHighlight?.messageId}
-      targetSearchQuery={activeSearchHighlight?.query}
-    />
+    >
+      {channelView.mode === "board" && activeChannel ? (
+        <ChannelBoardScreen
+          canvas={canvasQuery.data}
+          canvasError={canvasQuery.error}
+          canvasLoading={canvasQuery.isLoading}
+          channel={activeChannel}
+          currentPubkey={identityQuery.data?.pubkey}
+        />
+      ) : (
+        <ChannelScreen
+          activeChannel={activeChannel}
+          autoSendDraftKey={autoSendDraftKey}
+          currentIdentity={identityQuery.data}
+          currentProfile={profileQuery.data}
+          onCloseForumPost={() => {
+            void closeForumPost(channelId);
+          }}
+          onSelectForumPost={(postId) => {
+            void goForumPost(channelId, postId);
+          }}
+          selectedForumPostId={selectedPostId}
+          targetForumReplyId={targetReplyId}
+          targetMessageEvents={targetMessageEvents}
+          targetMessageId={targetMessageId}
+          targetSearchMessageId={activeSearchHighlight?.messageId}
+          targetSearchQuery={activeSearchHighlight?.query}
+        />
+      )}
+    </ChannelViewModeProvider>
   );
 }

--- a/desktop/src/app/routes/ChannelRouteScreen.tsx
+++ b/desktop/src/app/routes/ChannelRouteScreen.tsx
@@ -4,11 +4,17 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { SearchHighlightNavigation } from "@/app/navigation/searchHighlightNavigation";
 import { getCachedSearchHitEvent } from "@/app/navigation/searchHitEventCache";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
-import { useCanvasQuery, useChannelsQuery } from "@/features/channels/hooks";
+import {
+  useCanvasQuery,
+  useCanvasSubscription,
+  useChannelsQuery,
+} from "@/features/channels/hooks";
 import { useOpenChannelDirectoryQuery } from "@/features/channels/openChannelDirectory";
 import {
   type ChannelViewMode,
+  readStoredChannelViewMode,
   resolveChannelViewMode,
+  writeStoredChannelViewMode,
 } from "@/features/channels/lib/canvasBoard";
 import { ChannelBoardScreen } from "@/features/channels/ui/ChannelBoardScreen";
 import { ChannelScreen } from "@/features/channels/ui/ChannelScreen";
@@ -171,6 +177,10 @@ export function ChannelRouteScreen({
     activeChannel?.id ?? null,
     activeChannel !== null && activeChannel.channelType !== "dm",
   );
+  useCanvasSubscription(
+    activeChannel?.id ?? null,
+    activeChannel !== null && activeChannel.channelType !== "dm",
+  );
   const [viewSelection, setViewSelection] = React.useState<{
     channelId: string;
     mode: ChannelViewMode;
@@ -184,7 +194,9 @@ export function ChannelRouteScreen({
       targetThreadRootId,
   );
   const explicitView =
-    viewSelection?.channelId === channelId ? viewSelection.mode : null;
+    viewSelection?.channelId === channelId
+      ? viewSelection.mode
+      : readStoredChannelViewMode(channelId);
   const channelView = resolveChannelViewMode({
     channelName: activeChannel?.name ?? null,
     channelType: activeChannel?.channelType ?? null,
@@ -193,15 +205,12 @@ export function ChannelRouteScreen({
     hasRouteTarget,
   });
   const handleViewModeChange = React.useCallback(
-    (mode: ChannelViewMode) => setViewSelection({ channelId, mode }),
+    (mode: ChannelViewMode) => {
+      setViewSelection({ channelId, mode });
+      writeStoredChannelViewMode(channelId, mode);
+    },
     [channelId],
   );
-
-  React.useEffect(() => {
-    if (hasRouteTarget) {
-      setViewSelection({ channelId, mode: "stream" });
-    }
-  }, [channelId, hasRouteTarget]);
   const [targetMessageEvents, setTargetMessageEvents] = React.useState<
     RelayEvent[]
   >(() => {

--- a/desktop/src/app/routes/ChannelRouteScreen.tsx
+++ b/desktop/src/app/routes/ChannelRouteScreen.tsx
@@ -2,8 +2,14 @@ import * as React from "react";
 
 import { getCachedSearchHitEvent } from "@/app/navigation/searchHitEventCache";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
-import { useChannelsQuery } from "@/features/channels/hooks";
+import { useCanvasQuery, useChannelsQuery } from "@/features/channels/hooks";
+import {
+  type ChannelViewMode,
+  resolveChannelViewMode,
+} from "@/features/channels/lib/canvasBoard";
+import { ChannelBoardScreen } from "@/features/channels/ui/ChannelBoardScreen";
 import { ChannelScreen } from "@/features/channels/ui/ChannelScreen";
+import { ChannelViewModeProvider } from "@/features/channels/ui/ChannelViewModeContext";
 import { HuddleStartingView } from "@/features/huddle/components/HuddleStartingView";
 import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
 import {
@@ -19,6 +25,7 @@ import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 type ChannelRouteScreenProps = {
   autoSendDraftKey: string | null;
   channelId: string;
+  hasStreamRouteIntent: boolean;
   selectedPostId: string | null;
   targetMessageId: string | null;
   targetReplyId: string | null;
@@ -99,6 +106,7 @@ async function fetchRouteTargetEvents(
 export function ChannelRouteScreen({
   autoSendDraftKey,
   channelId,
+  hasStreamRouteIntent,
   selectedPostId,
   targetMessageId,
   targetReplyId,
@@ -112,6 +120,39 @@ export function ChannelRouteScreen({
   const channels = channelsQuery.data ?? [];
   const activeChannel =
     channels.find((channel) => channel.id === channelId) ?? null;
+  const canvasQuery = useCanvasQuery(
+    activeChannel?.id ?? null,
+    activeChannel !== null && activeChannel.channelType !== "dm",
+  );
+  const [viewSelection, setViewSelection] = React.useState<{
+    channelId: string;
+    mode: ChannelViewMode;
+  } | null>(null);
+  const hasRouteTarget = Boolean(
+    hasStreamRouteIntent ||
+      selectedPostId ||
+      targetMessageId ||
+      targetThreadRootId,
+  );
+  const explicitView =
+    viewSelection?.channelId === channelId ? viewSelection.mode : null;
+  const channelView = resolveChannelViewMode({
+    channelName: activeChannel?.name ?? null,
+    channelType: activeChannel?.channelType ?? null,
+    explicitView,
+    hasCanvas: Boolean(canvasQuery.data?.content?.trim()),
+    hasRouteTarget,
+  });
+  const handleViewModeChange = React.useCallback(
+    (mode: ChannelViewMode) => setViewSelection({ channelId, mode }),
+    [channelId],
+  );
+
+  React.useEffect(() => {
+    if (hasRouteTarget) {
+      setViewSelection({ channelId, mode: "stream" });
+    }
+  }, [channelId, hasRouteTarget]);
   const [targetMessageEvents, setTargetMessageEvents] = React.useState<
     RelayEvent[]
   >(() => {
@@ -201,21 +242,39 @@ export function ChannelRouteScreen({
   }
 
   return (
-    <ChannelScreen
-      activeChannel={activeChannel}
-      autoSendDraftKey={autoSendDraftKey}
-      currentIdentity={identityQuery.data}
-      currentProfile={profileQuery.data}
-      onCloseForumPost={() => {
-        void closeForumPost(channelId);
+    <ChannelViewModeProvider
+      value={{
+        boardAvailable: channelView.boardAvailable && !hasRouteTarget,
+        mode: channelView.mode,
+        onModeChange: handleViewModeChange,
       }}
-      onSelectForumPost={(postId) => {
-        void goForumPost(channelId, postId);
-      }}
-      selectedForumPostId={selectedPostId}
-      targetForumReplyId={targetReplyId}
-      targetMessageEvents={targetMessageEvents}
-      targetMessageId={targetMessageId}
-    />
+    >
+      {channelView.mode === "board" && activeChannel ? (
+        <ChannelBoardScreen
+          canvas={canvasQuery.data}
+          canvasError={canvasQuery.error}
+          canvasLoading={canvasQuery.isLoading}
+          channel={activeChannel}
+          currentPubkey={identityQuery.data?.pubkey}
+        />
+      ) : (
+        <ChannelScreen
+          activeChannel={activeChannel}
+          autoSendDraftKey={autoSendDraftKey}
+          currentIdentity={identityQuery.data}
+          currentProfile={profileQuery.data}
+          onCloseForumPost={() => {
+            void closeForumPost(channelId);
+          }}
+          onSelectForumPost={(postId) => {
+            void goForumPost(channelId, postId);
+          }}
+          selectedForumPostId={selectedPostId}
+          targetForumReplyId={targetReplyId}
+          targetMessageEvents={targetMessageEvents}
+          targetMessageId={targetMessageId}
+        />
+      )}
+    </ChannelViewModeProvider>
   );
 }

--- a/desktop/src/app/routes/channels.$channelId.posts.$postId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.posts.$postId.tsx
@@ -46,6 +46,7 @@ function ForumPostRouteComponent() {
         autoSendDraftKey={null}
         channelId={channelId}
         searchHighlight={searchHighlight}
+        hasStreamRouteIntent={false}
         selectedPostId={postId}
         targetMessageId={null}
         targetReplyId={search.replyId ?? null}

--- a/desktop/src/app/routes/channels.$channelId.posts.$postId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.posts.$postId.tsx
@@ -41,6 +41,7 @@ function ForumPostRouteComponent() {
       <ChannelRouteScreen
         autoSendDraftKey={null}
         channelId={channelId}
+        hasStreamRouteIntent={false}
         selectedPostId={postId}
         targetMessageId={null}
         targetReplyId={search.replyId ?? null}

--- a/desktop/src/app/routes/channels.$channelId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.tsx
@@ -80,6 +80,9 @@ function ChannelRouteComponent() {
         autoSendDraftKey={search.autoSend ?? null}
         channelId={channelId}
         searchHighlight={searchHighlight}
+        hasStreamRouteIntent={Boolean(
+          search.autoSend || search.agentSession || search.profile,
+        )}
         selectedPostId={null}
         targetMessageId={search.messageId ?? null}
         targetReplyId={null}

--- a/desktop/src/app/routes/channels.$channelId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.tsx
@@ -74,6 +74,9 @@ function ChannelRouteComponent() {
       <ChannelRouteScreen
         autoSendDraftKey={search.autoSend ?? null}
         channelId={channelId}
+        hasStreamRouteIntent={Boolean(
+          search.autoSend || search.agentSession || search.profile,
+        )}
         selectedPostId={null}
         targetMessageId={search.messageId ?? null}
         targetReplyId={null}

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -27,11 +27,14 @@ import {
   unarchiveChannel,
   updateChannel,
 } from "@/shared/api/tauri";
+import { relayClient } from "@/shared/api/relayClient";
 import type {
   AddChannelMembersInput,
+  CanvasResponse,
   Channel,
   ChannelDetail,
   CreateChannelInput,
+  RelayEvent,
   SetChannelPurposeInput,
   SetChannelTopicInput,
   UpdateChannelInput,
@@ -976,15 +979,94 @@ export function useCanvasQuery(channelId: string | null, enabled = true) {
   });
 }
 
+export function useCanvasSubscription(
+  channelId: string | null,
+  enabled = true,
+) {
+  const queryClient = useQueryClient();
+
+  React.useEffect(() => {
+    if (!enabled || !channelId) {
+      return;
+    }
+    let isDisposed = false;
+    let cleanup: (() => void) | undefined;
+    const applyCanvasEvent = (event: RelayEvent) => {
+      queryClient.setQueryData<CanvasResponse>(
+        ["channel-canvas", channelId],
+        (current) => {
+          if (current?.updatedAt && current.updatedAt > event.created_at) {
+            return current;
+          }
+          return {
+            author: event.pubkey,
+            content: event.content,
+            eventId: event.id,
+            updatedAt: event.created_at,
+          };
+        },
+      );
+    };
+    void relayClient
+      .subscribeLive(
+        {
+          "#h": [channelId],
+          kinds: [40100],
+          limit: 0,
+        },
+        applyCanvasEvent,
+      )
+      .then((dispose) => {
+        if (isDisposed) {
+          dispose();
+          return;
+        }
+        cleanup = dispose;
+      })
+      .catch((error) => {
+        console.error(
+          "Failed to subscribe to channel canvas",
+          channelId,
+          error,
+        );
+      });
+    const disposeReconnect = relayClient.subscribeToReconnects(() => {
+      void queryClient.invalidateQueries({
+        queryKey: ["channel-canvas", channelId],
+      });
+    });
+    return () => {
+      isDisposed = true;
+      cleanup?.();
+      disposeReconnect();
+    };
+  }, [channelId, enabled, queryClient]);
+}
+
 export function useSetCanvasMutation(channelId: string | null) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (content: string) => {
+    mutationFn: (
+      input:
+        | string
+        | {
+            content: string;
+            enforceRevision?: boolean;
+            expectedEventId?: string | null;
+          },
+    ) => {
       if (!channelId) {
         return Promise.reject(new Error("No channel selected"));
       }
-      return setCanvas({ channelId, content });
+      return setCanvas({
+        channelId,
+        content: typeof input === "string" ? input : input.content,
+        enforceRevision:
+          typeof input === "string" ? false : input.enforceRevision,
+        expectedEventId:
+          typeof input === "string" ? undefined : input.expectedEventId,
+      });
     },
     onSuccess: () => {
       if (channelId) {

--- a/desktop/src/features/channels/lib/canvasBoard.test.mjs
+++ b/desktop/src/features/channels/lib/canvasBoard.test.mjs
@@ -2,9 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  appendCanvasBoardCard,
   classifyCanvasBoardCard,
   parseCanvasBoard,
+  reorderCanvasBoardCard,
   resolveChannelViewMode,
+  updateCanvasBoardCard,
+  validateCanvasBoardCardDraft,
 } from "./canvasBoard.ts";
 
 test("parseCanvasBoard turns level-two sections into durable cards", () => {
@@ -97,6 +101,150 @@ test("parseCanvasBoard falls back to one overview card", () => {
 test("classifyCanvasBoardCard keeps stewardship language visible", () => {
   assert.equal(classifyCanvasBoardCard("People and stewards"), "people");
   assert.equal(classifyCanvasBoardCard("Source and story boundary"), "note");
+});
+
+test("appendCanvasBoardCard preserves the board preamble and adds one card", () => {
+  const content = `# Dispatch
+
+Shared introduction.
+
+## Start here
+
+Read the welcome.
+`;
+
+  const updated = appendCanvasBoardCard(content, {
+    body: "Bring one seed.",
+    title: "Next action",
+  });
+  const board = parseCanvasBoard(updated);
+
+  assert.equal(board.title, "Dispatch");
+  assert.equal(board.introduction, "Shared introduction.");
+  assert.deepEqual(
+    board.cards.map(({ body, title }) => ({ body, title })),
+    [
+      { body: "Read the welcome.", title: "Start here" },
+      { body: "Bring one seed.", title: "Next action" },
+    ],
+  );
+});
+
+test("updateCanvasBoardCard edits only the selected source section", () => {
+  const content = `# Dispatch
+
+## Start here
+
+Old instructions.
+
+## Finished example
+
+Keep this intact.
+`;
+
+  const updated = updateCanvasBoardCard(content, "start-here-1", {
+    body: "New **Markdown** instructions.",
+    title: "Start here now",
+  });
+  assert.ok(updated);
+
+  const board = parseCanvasBoard(updated);
+  assert.deepEqual(
+    board.cards.map(({ body, title }) => ({ body, title })),
+    [
+      {
+        body: "New **Markdown** instructions.",
+        title: "Start here now",
+      },
+      { body: "Keep this intact.", title: "Finished example" },
+    ],
+  );
+});
+
+test("updateCanvasBoardCard turns a fallback overview into a durable section", () => {
+  const updated = updateCanvasBoardCard(
+    "# A small room\n\nEverything useful lives here.\n",
+    "overview-1",
+    {
+      body: "The overview is now editable from the Board.",
+      title: "Start here",
+    },
+  );
+  assert.ok(updated);
+
+  const board = parseCanvasBoard(updated);
+  assert.equal(board.title, "A small room");
+  assert.equal(board.introduction, "");
+  assert.deepEqual(
+    board.cards.map(({ body, title }) => ({ body, title })),
+    [
+      {
+        body: "The overview is now editable from the Board.",
+        title: "Start here",
+      },
+    ],
+  );
+});
+
+test("reorderCanvasBoardCard moves raw fenced sections without losing content", () => {
+  const content = `# Dispatch
+
+## Notes
+
+\`\`\`\`md
+\`\`\`md
+## Not a card
+\`\`\`
+\`\`\`\`
+
+## Next action
+
+Ship the proof.
+
+## Finished example
+
+Keep this too.
+`;
+
+  const updated = reorderCanvasBoardCard(
+    content,
+    "finished-example-3",
+    "notes-1",
+  );
+  assert.ok(updated);
+
+  const board = parseCanvasBoard(updated);
+  assert.deepEqual(
+    board.cards.map(({ title }) => title),
+    ["Finished example", "Notes", "Next action"],
+  );
+  assert.match(board.cards[1].body, /## Not a card/u);
+  assert.match(board.cards[2].body, /Ship the proof/u);
+});
+
+test("canvas card draft validation rejects nested level-two card headings", () => {
+  assert.equal(
+    validateCanvasBoardCardDraft({ body: "Body", title: "" }),
+    "Add a card title.",
+  );
+  assert.equal(
+    validateCanvasBoardCardDraft({ body: "Body", title: "x".repeat(121) }),
+    "Keep the card title to 120 characters or fewer.",
+  );
+  assert.equal(
+    validateCanvasBoardCardDraft({
+      body: "## Accidental second card",
+      title: "First card",
+    }),
+    "Use level-three headings inside a card. Level-two headings create separate cards.",
+  );
+  assert.equal(
+    validateCanvasBoardCardDraft({
+      body: "```md\n## Safe example\n```",
+      title: "Code sample",
+    }),
+    null,
+  );
 });
 
 test("resolveChannelViewMode makes Dispatch board-first without hiding targets", () => {

--- a/desktop/src/features/channels/lib/canvasBoard.test.mjs
+++ b/desktop/src/features/channels/lib/canvasBoard.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyCanvasBoardCard,
+  parseCanvasBoard,
+  resolveChannelViewMode,
+} from "./canvasBoard.ts";
+
+test("parseCanvasBoard turns level-two sections into durable cards", () => {
+  const board = parseCanvasBoard(`# Dispatch — Open Studio 001
+
+Bring one seed and leave with one artifact.
+
+## This week at Sweet Works
+
+Open Studio 001 is active.
+
+## Start here
+
+1. Read the welcome.
+2. Open a Workshop thread.
+
+## Finished example
+
+[Open the magic mirror](https://example.com)
+`);
+
+  assert.equal(board.title, "Dispatch — Open Studio 001");
+  assert.equal(
+    board.introduction,
+    "Bring one seed and leave with one artifact.",
+  );
+  assert.deepEqual(
+    board.cards.map(({ kind, title }) => ({ kind, title })),
+    [
+      { kind: "now", title: "This week at Sweet Works" },
+      { kind: "welcome", title: "Start here" },
+      { kind: "artifact", title: "Finished example" },
+    ],
+  );
+});
+
+test("parseCanvasBoard leaves headings inside fences in card bodies", () => {
+  const board = parseCanvasBoard(`## Notes
+
+\`\`\`md
+## Not a card
+\`\`\`
+
+## Next action
+
+Ship the proof.
+`);
+
+  assert.equal(board.cards.length, 2);
+  assert.match(board.cards[0].body, /## Not a card/u);
+  assert.equal(board.cards[1].kind, "invitation");
+});
+
+test("parseCanvasBoard does not close a longer fence with a shorter example fence", () => {
+  const board = parseCanvasBoard(`## Notes
+
+\`\`\`\`md
+\`\`\`md
+## Not a card
+\`\`\`
+\`\`\`\`
+
+## Next action
+
+Ship the proof.
+`);
+
+  assert.equal(board.cards.length, 2);
+  assert.match(board.cards[0].body, /## Not a card/u);
+  assert.equal(board.cards[1].title, "Next action");
+});
+
+test("parseCanvasBoard falls back to one overview card", () => {
+  const board = parseCanvasBoard(
+    "# A small room\n\nEverything useful lives here.",
+  );
+
+  assert.equal(board.title, "A small room");
+  assert.equal(board.introduction, "");
+  assert.deepEqual(board.cards, [
+    {
+      body: "Everything useful lives here.",
+      id: "overview-1",
+      kind: "welcome",
+      title: "Overview",
+    },
+  ]);
+});
+
+test("classifyCanvasBoardCard keeps stewardship language visible", () => {
+  assert.equal(classifyCanvasBoardCard("People and stewards"), "people");
+  assert.equal(classifyCanvasBoardCard("Source and story boundary"), "note");
+});
+
+test("resolveChannelViewMode makes Dispatch board-first without hiding targets", () => {
+  assert.deepEqual(
+    resolveChannelViewMode({
+      channelName: "Dispatch",
+      channelType: "stream",
+      explicitView: null,
+      hasCanvas: true,
+      hasRouteTarget: false,
+    }),
+    { boardAvailable: true, mode: "board" },
+  );
+
+  assert.deepEqual(
+    resolveChannelViewMode({
+      channelName: "Dispatch",
+      channelType: "stream",
+      explicitView: "board",
+      hasCanvas: true,
+      hasRouteTarget: true,
+    }),
+    { boardAvailable: true, mode: "stream" },
+  );
+
+  assert.deepEqual(
+    resolveChannelViewMode({
+      channelName: "The Workshop",
+      channelType: "stream",
+      explicitView: null,
+      hasCanvas: true,
+      hasRouteTarget: false,
+    }),
+    { boardAvailable: true, mode: "stream" },
+  );
+});

--- a/desktop/src/features/channels/lib/canvasBoard.test.mjs
+++ b/desktop/src/features/channels/lib/canvasBoard.test.mjs
@@ -3,11 +3,15 @@ import test from "node:test";
 
 import {
   appendCanvasBoardCard,
+  buildCanvasBoardCardConversationOpener,
+  canvasBoardCardConversationMarker,
   classifyCanvasBoardCard,
+  classifyCanvasBoardCardType,
   parseCanvasBoard,
   reorderCanvasBoardCard,
   resolveChannelViewMode,
   updateCanvasBoardCard,
+  updateCanvasBoardCardMetadata,
   validateCanvasBoardCardDraft,
 } from "./canvasBoard.ts";
 
@@ -88,19 +92,43 @@ test("parseCanvasBoard falls back to one overview card", () => {
 
   assert.equal(board.title, "A small room");
   assert.equal(board.introduction, "");
-  assert.deepEqual(board.cards, [
-    {
-      body: "Everything useful lives here.",
-      id: "overview-1",
-      kind: "welcome",
-      title: "Overview",
-    },
-  ]);
+  assert.deepEqual(
+    board.cards.map(({ body, id, kind, status, threadId, title, type }) => ({
+      body,
+      id,
+      kind,
+      status,
+      threadId,
+      title,
+      type,
+    })),
+    [
+      {
+        body: "Everything useful lives here.",
+        id: "overview-1",
+        kind: "welcome",
+        status: "backlog",
+        threadId: null,
+        title: "Overview",
+        type: "note",
+      },
+    ],
+  );
 });
 
 test("classifyCanvasBoardCard keeps stewardship language visible", () => {
   assert.equal(classifyCanvasBoardCard("People and stewards"), "people");
   assert.equal(classifyCanvasBoardCard("Source and story boundary"), "note");
+});
+
+test("classifyCanvasBoardCardType recognizes native workflow cards", () => {
+  assert.equal(
+    classifyCanvasBoardCardType("Decision: use one source"),
+    "decision",
+  );
+  assert.equal(classifyCanvasBoardCardType("Ora Mirror project"), "project");
+  assert.equal(classifyCanvasBoardCardType("Agent: Fizz"), "agent");
+  assert.equal(classifyCanvasBoardCardType("A plain thought"), "note");
 });
 
 test("appendCanvasBoardCard preserves the board preamble and adds one card", () => {
@@ -114,8 +142,12 @@ Read the welcome.
 `;
 
   const updated = appendCanvasBoardCard(content, {
+    author: "a".repeat(64),
     body: "Bring one seed.",
+    id: "fresh-card-id",
+    status: "doing",
     title: "Next action",
+    type: "task",
   });
   const board = parseCanvasBoard(updated);
 
@@ -128,6 +160,11 @@ Read the welcome.
       { body: "Bring one seed.", title: "Next action" },
     ],
   );
+  assert.match(updated, /<!-- buzz-board-card /u);
+  assert.equal(board.cards[1].id, "fresh-card-id");
+  assert.equal(board.cards[1].type, "task");
+  assert.equal(board.cards[1].status, "doing");
+  assert.equal(board.cards[1].author, "a".repeat(64));
 });
 
 test("updateCanvasBoardCard edits only the selected source section", () => {
@@ -220,6 +257,64 @@ Keep this too.
   );
   assert.match(board.cards[1].body, /## Not a card/u);
   assert.match(board.cards[2].body, /Ship the proof/u);
+});
+
+test("card metadata gives cards durable identity, workflow state, and a thread", () => {
+  const threadId = "b".repeat(64);
+  const content = `# Dispatch
+
+## Ship the proof
+<!-- buzz-board-card {"id":"card-123","type":"task","status":"doing","thread":"${threadId}","author":"author-pubkey"} -->
+
+Keep the visible body clean.
+`;
+
+  const [card] = parseCanvasBoard(content).cards;
+  assert.equal(card.id, "card-123");
+  assert.equal(card.type, "task");
+  assert.equal(card.status, "doing");
+  assert.equal(card.threadId, threadId);
+  assert.equal(card.author, "author-pubkey");
+  assert.equal(card.body, "Keep the visible body clean.");
+  assert.equal(card.hasExplicitMetadata, true);
+});
+
+test("metadata updates preserve the human Markdown and materialize legacy cards", () => {
+  const threadId = "c".repeat(64);
+  const content = `# Dispatch
+
+## Next action
+
+Ship the proof.
+`;
+  const updated = updateCanvasBoardCardMetadata(content, "next-action-1", {
+    status: "done",
+    threadId,
+    type: "decision",
+  });
+  assert.ok(updated);
+
+  const [card] = parseCanvasBoard(updated).cards;
+  assert.equal(card.id, "next-action-1");
+  assert.equal(card.type, "decision");
+  assert.equal(card.status, "done");
+  assert.equal(card.threadId, threadId);
+  assert.equal(card.body, "Ship the proof.");
+  assert.match(updated, /<!-- buzz-board-card /u);
+});
+
+test("card conversations use a deterministic marker and readable opener", () => {
+  const [card] = parseCanvasBoard(
+    "## Decide next step\n\nChoose the small loop.\n",
+  ).cards;
+  assert.equal(
+    canvasBoardCardConversationMarker(card.id),
+    "magic-board-card:decide-next-step-1",
+  );
+  assert.equal(
+    buildCanvasBoardCardConversationOpener(card, "Dispatch"),
+    "## Decide next step\n\nChoose the small loop.\n\n_Conversation attached to the Dispatch board._",
+  );
 });
 
 test("canvas card draft validation rejects nested level-two card headings", () => {

--- a/desktop/src/features/channels/lib/canvasBoard.ts
+++ b/desktop/src/features/channels/lib/canvasBoard.ts
@@ -22,12 +22,30 @@ export type CanvasBoard = {
   title: string | null;
 };
 
+export type CanvasBoardCardDraft = {
+  body: string;
+  title: string;
+};
+
 export type ChannelViewMode = "board" | "stream";
 
 const H1_PATTERN = /^#\s+(.+?)\s*#*\s*$/u;
 const H2_PATTERN = /^##\s+(.+?)\s*#*\s*$/u;
 const FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})/u;
 const FENCE_CLOSE_PATTERN = /^ {0,3}(`{3,}|~{3,})[ \t]*$/u;
+
+type CanvasBoardSourceSection = {
+  bodyLines: string[];
+  headingLine: string;
+  title: string;
+};
+
+type CanvasBoardSource = {
+  introductionLines: string[];
+  preambleLines: string[];
+  sections: CanvasBoardSourceSection[];
+  title: string | null;
+};
 
 function cardId(title: string, index: number): string {
   const slug = title
@@ -60,15 +78,12 @@ export function classifyCanvasBoardCard(title: string): CanvasBoardCardKind {
   return "note";
 }
 
-/**
- * Converts a shared Markdown canvas into a title/introduction plus `##` cards.
- * Headings inside fenced code blocks remain body content.
- */
-export function parseCanvasBoard(content: string): CanvasBoard {
+function parseCanvasBoardSource(content: string): CanvasBoardSource {
   const introductionLines: string[] = [];
-  const sections: Array<{ title: string; bodyLines: string[] }> = [];
+  const preambleLines: string[] = [];
+  const sections: CanvasBoardSourceSection[] = [];
   let title: string | null = null;
-  let activeSection: { title: string; bodyLines: string[] } | null = null;
+  let activeSection: CanvasBoardSourceSection | null = null;
   let activeFence: { character: "`" | "~"; length: number } | null = null;
 
   for (const line of content.replace(/\r\n?/gu, "\n").split("\n")) {
@@ -98,6 +113,7 @@ export function parseCanvasBoard(content: string): CanvasBoard {
       const h1Match = line.match(H1_PATTERN);
       if (h1Match && title === null) {
         title = h1Match[1].trim();
+        preambleLines.push(line);
         continue;
       }
     }
@@ -105,7 +121,11 @@ export function parseCanvasBoard(content: string): CanvasBoard {
     if (!isFenceBoundary) {
       const h2Match = line.match(H2_PATTERN);
       if (h2Match) {
-        activeSection = { title: h2Match[1].trim(), bodyLines: [] };
+        activeSection = {
+          bodyLines: [],
+          headingLine: line,
+          title: h2Match[1].trim(),
+        };
         sections.push(activeSection);
         continue;
       }
@@ -114,17 +134,45 @@ export function parseCanvasBoard(content: string): CanvasBoard {
     if (activeSection) {
       activeSection.bodyLines.push(line);
     } else {
+      preambleLines.push(line);
       introductionLines.push(line);
     }
   }
 
-  const introduction = introductionLines.join("\n").trim();
-  const cards = sections.map((section, index) => ({
+  return { introductionLines, preambleLines, sections, title };
+}
+
+function serializeCanvasBoardSource(source: CanvasBoardSource): string {
+  const blocks = [
+    source.preambleLines.join("\n").trim(),
+    ...source.sections.map((section) => {
+      const body = section.bodyLines.join("\n").trim();
+      return body ? `${section.headingLine}\n\n${body}` : section.headingLine;
+    }),
+  ].filter((block) => block.length > 0);
+
+  return blocks.length > 0 ? `${blocks.join("\n\n")}\n` : "";
+}
+
+function canvasBoardCardsFromSource(
+  source: CanvasBoardSource,
+): CanvasBoardCard[] {
+  return source.sections.map((section, index) => ({
     body: section.bodyLines.join("\n").trim(),
     id: cardId(section.title, index),
     kind: classifyCanvasBoardCard(section.title),
     title: section.title,
   }));
+}
+
+/**
+ * Converts a shared Markdown canvas into a title/introduction plus `##` cards.
+ * Headings inside fenced code blocks remain body content.
+ */
+export function parseCanvasBoard(content: string): CanvasBoard {
+  const source = parseCanvasBoardSource(content);
+  const introduction = source.introductionLines.join("\n").trim();
+  const cards = canvasBoardCardsFromSource(source);
 
   if (cards.length === 0 && introduction.length > 0) {
     cards.push({
@@ -137,9 +185,102 @@ export function parseCanvasBoard(content: string): CanvasBoard {
 
   return {
     cards,
-    introduction: sections.length > 0 ? introduction : "",
-    title,
+    introduction: source.sections.length > 0 ? introduction : "",
+    title: source.title,
   };
+}
+
+export function validateCanvasBoardCardDraft(
+  draft: CanvasBoardCardDraft,
+): string | null {
+  const title = draft.title.trim();
+  if (!title) {
+    return "Add a card title.";
+  }
+  if (/\r|\n/u.test(title)) {
+    return "Keep the card title on one line.";
+  }
+  if (title.length > 120) {
+    return "Keep the card title to 120 characters or fewer.";
+  }
+
+  const preview = parseCanvasBoard(`## ${title}\n\n${draft.body}`);
+  if (preview.cards.length !== 1) {
+    return "Use level-three headings inside a card. Level-two headings create separate cards.";
+  }
+
+  return null;
+}
+
+export function appendCanvasBoardCard(
+  content: string,
+  draft: CanvasBoardCardDraft,
+): string {
+  const source = parseCanvasBoardSource(content);
+  source.sections.push({
+    bodyLines: draft.body.trim().split("\n"),
+    headingLine: `## ${draft.title.trim()}`,
+    title: draft.title.trim(),
+  });
+  return serializeCanvasBoardSource(source);
+}
+
+export function updateCanvasBoardCard(
+  content: string,
+  cardIdToUpdate: string,
+  draft: CanvasBoardCardDraft,
+): string | null {
+  const source = parseCanvasBoardSource(content);
+  if (
+    source.sections.length === 0 &&
+    cardIdToUpdate === "overview-1" &&
+    source.introductionLines.join("\n").trim().length > 0
+  ) {
+    source.preambleLines = source.preambleLines.filter((line) =>
+      H1_PATTERN.test(line),
+    );
+    source.introductionLines = [];
+    source.sections.push({
+      bodyLines: draft.body.trim().split("\n"),
+      headingLine: `## ${draft.title.trim()}`,
+      title: draft.title.trim(),
+    });
+    return serializeCanvasBoardSource(source);
+  }
+
+  const cards = canvasBoardCardsFromSource(source);
+  const sectionIndex = cards.findIndex((card) => card.id === cardIdToUpdate);
+  const section = source.sections[sectionIndex];
+  if (!section) {
+    return null;
+  }
+
+  section.bodyLines = draft.body.trim().split("\n");
+  section.headingLine = `## ${draft.title.trim()}`;
+  section.title = draft.title.trim();
+  return serializeCanvasBoardSource(source);
+}
+
+export function reorderCanvasBoardCard(
+  content: string,
+  activeCardId: string,
+  overCardId: string,
+): string | null {
+  if (activeCardId === overCardId) {
+    return content;
+  }
+
+  const source = parseCanvasBoardSource(content);
+  const cards = canvasBoardCardsFromSource(source);
+  const activeIndex = cards.findIndex((card) => card.id === activeCardId);
+  const overIndex = cards.findIndex((card) => card.id === overCardId);
+  if (activeIndex === -1 || overIndex === -1) {
+    return null;
+  }
+
+  const [movedSection] = source.sections.splice(activeIndex, 1);
+  source.sections.splice(overIndex, 0, movedSection);
+  return serializeCanvasBoardSource(source);
 }
 
 export function resolveChannelViewMode(input: {

--- a/desktop/src/features/channels/lib/canvasBoard.ts
+++ b/desktop/src/features/channels/lib/canvasBoard.ts
@@ -1,5 +1,6 @@
 import type { ChannelType } from "@/shared/api/types";
 import { channelNamesMatch } from "@/features/channels/lib/canonicalChannelName";
+import { getStorageItem, setStorageItem } from "@/shared/lib/safeStorage";
 
 export type CanvasBoardCardKind =
   | "artifact"
@@ -9,11 +10,28 @@ export type CanvasBoardCardKind =
   | "people"
   | "welcome";
 
+export type CanvasBoardCardType =
+  | "agent"
+  | "artifact"
+  | "conversation"
+  | "decision"
+  | "note"
+  | "person"
+  | "project"
+  | "task";
+
+export type CanvasBoardCardStatus = "backlog" | "doing" | "done";
+
 export type CanvasBoardCard = {
+  author: string | null;
   body: string;
+  hasExplicitMetadata: boolean;
   id: string;
   kind: CanvasBoardCardKind;
+  status: CanvasBoardCardStatus;
+  threadId: string | null;
   title: string;
+  type: CanvasBoardCardType;
 };
 
 export type CanvasBoard = {
@@ -23,16 +41,57 @@ export type CanvasBoard = {
 };
 
 export type CanvasBoardCardDraft = {
+  author?: string | null;
   body: string;
+  id?: string;
+  status?: CanvasBoardCardStatus;
+  threadId?: string | null;
   title: string;
+  type?: CanvasBoardCardType;
 };
 
 export type ChannelViewMode = "board" | "stream";
+
+const CHANNEL_VIEW_MODE_STORAGE_PREFIX = "buzz.channelViewMode.v1";
 
 const H1_PATTERN = /^#\s+(.+?)\s*#*\s*$/u;
 const H2_PATTERN = /^##\s+(.+?)\s*#*\s*$/u;
 const FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})/u;
 const FENCE_CLOSE_PATTERN = /^ {0,3}(`{3,}|~{3,})[ \t]*$/u;
+const CARD_METADATA_PATTERN =
+  /^\s*<!--\s*buzz-board-card\s+(\{.*\})\s*-->\s*$/u;
+const CARD_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/u;
+const EVENT_ID_PATTERN = /^[0-9a-f]{64}$/u;
+
+const CARD_TYPES = new Set<CanvasBoardCardType>([
+  "agent",
+  "artifact",
+  "conversation",
+  "decision",
+  "note",
+  "person",
+  "project",
+  "task",
+]);
+const CARD_STATUSES = new Set<CanvasBoardCardStatus>([
+  "backlog",
+  "doing",
+  "done",
+]);
+
+type CanvasBoardCardMetadata = {
+  author: string | null;
+  id: string | null;
+  status: CanvasBoardCardStatus | null;
+  threadId: string | null;
+  type: CanvasBoardCardType | null;
+};
+
+type ParsedCanvasBoardSection = {
+  body: string;
+  hasExplicitMetadata: boolean;
+  metadata: CanvasBoardCardMetadata;
+};
 
 type CanvasBoardSourceSection = {
   bodyLines: string[];
@@ -53,6 +112,113 @@ function cardId(title: string, index: number): string {
     .replace(/[^a-z0-9]+/gu, "-")
     .replace(/^-|-$/gu, "");
   return `${slug || "card"}-${index + 1}`;
+}
+
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function parseCardMetadataLine(line: string): CanvasBoardCardMetadata | null {
+  const match = line.match(CARD_METADATA_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(match[1]);
+    if (!isStringRecord(parsed)) {
+      return null;
+    }
+    const id = optionalString(parsed.id);
+    const type = optionalString(parsed.type);
+    const status = optionalString(parsed.status);
+    const threadId = optionalString(parsed.thread);
+    const author = optionalString(parsed.author);
+    return {
+      author,
+      id: id && CARD_ID_PATTERN.test(id) ? id : null,
+      status:
+        status && CARD_STATUSES.has(status as CanvasBoardCardStatus)
+          ? (status as CanvasBoardCardStatus)
+          : null,
+      threadId:
+        threadId && EVENT_ID_PATTERN.test(threadId.toLowerCase())
+          ? threadId.toLowerCase()
+          : null,
+      type:
+        type && CARD_TYPES.has(type as CanvasBoardCardType)
+          ? (type as CanvasBoardCardType)
+          : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseCanvasBoardSection(
+  section: CanvasBoardSourceSection,
+): ParsedCanvasBoardSection {
+  const bodyLines = [...section.bodyLines];
+  const metadataLineIndex = bodyLines.findIndex(
+    (line) => line.trim().length > 0,
+  );
+  if (metadataLineIndex === -1) {
+    return {
+      body: "",
+      hasExplicitMetadata: false,
+      metadata: {
+        author: null,
+        id: null,
+        status: null,
+        threadId: null,
+        type: null,
+      },
+    };
+  }
+
+  const metadata = parseCardMetadataLine(bodyLines[metadataLineIndex]);
+  if (!metadata) {
+    return {
+      body: bodyLines.join("\n").trim(),
+      hasExplicitMetadata: false,
+      metadata: {
+        author: null,
+        id: null,
+        status: null,
+        threadId: null,
+        type: null,
+      },
+    };
+  }
+
+  bodyLines.splice(metadataLineIndex, 1);
+  return {
+    body: bodyLines.join("\n").trim(),
+    hasExplicitMetadata: true,
+    metadata,
+  };
+}
+
+function serializeCardMetadata(metadata: {
+  author?: string | null;
+  id: string;
+  status: CanvasBoardCardStatus;
+  threadId?: string | null;
+  type: CanvasBoardCardType;
+}): string {
+  return `<!-- buzz-board-card ${JSON.stringify({
+    id: metadata.id,
+    type: metadata.type,
+    status: metadata.status,
+    ...(metadata.threadId ? { thread: metadata.threadId } : {}),
+    ...(metadata.author ? { author: metadata.author } : {}),
+  })} -->`;
 }
 
 export function classifyCanvasBoardCard(title: string): CanvasBoardCardKind {
@@ -76,6 +242,42 @@ export function classifyCanvasBoardCard(title: string): CanvasBoardCardKind {
     return "welcome";
   }
   return "note";
+}
+
+export function classifyCanvasBoardCardType(
+  title: string,
+): CanvasBoardCardType {
+  const normalizedTitle = title.toLowerCase();
+  if (/\b(agent|bot|berd)\b/u.test(normalizedTitle)) return "agent";
+  if (/\b(person|people|member|steward|contributor)\b/u.test(normalizedTitle)) {
+    return "person";
+  }
+  if (/\b(decision|decide|approved|verdict)\b/u.test(normalizedTitle)) {
+    return "decision";
+  }
+  if (/\b(conversation|discussion|thread|work room)\b/u.test(normalizedTitle)) {
+    return "conversation";
+  }
+  if (/\b(project|initiative|program|campaign)\b/u.test(normalizedTitle)) {
+    return "project";
+  }
+  if (/\b(finished|made|shipped|artifact|showcase)\b/u.test(normalizedTitle)) {
+    return "artifact";
+  }
+  if (
+    /\b(task|todo|to-do|help|join|next|action|now|today|week|current|active)\b/u.test(
+      normalizedTitle,
+    )
+  ) {
+    return "task";
+  }
+  return "note";
+}
+
+function inferredCardStatus(kind: CanvasBoardCardKind): CanvasBoardCardStatus {
+  if (kind === "artifact") return "done";
+  if (kind === "now") return "doing";
+  return "backlog";
 }
 
 function parseCanvasBoardSource(content: string): CanvasBoardSource {
@@ -157,12 +359,23 @@ function serializeCanvasBoardSource(source: CanvasBoardSource): string {
 function canvasBoardCardsFromSource(
   source: CanvasBoardSource,
 ): CanvasBoardCard[] {
-  return source.sections.map((section, index) => ({
-    body: section.bodyLines.join("\n").trim(),
-    id: cardId(section.title, index),
-    kind: classifyCanvasBoardCard(section.title),
-    title: section.title,
-  }));
+  return source.sections.map((section, index) => {
+    const parsedSection = parseCanvasBoardSection(section);
+    const kind = classifyCanvasBoardCard(section.title);
+    return {
+      author: parsedSection.metadata.author,
+      body: parsedSection.body,
+      hasExplicitMetadata: parsedSection.hasExplicitMetadata,
+      id: parsedSection.metadata.id ?? cardId(section.title, index),
+      kind,
+      status: parsedSection.metadata.status ?? inferredCardStatus(kind),
+      threadId: parsedSection.metadata.threadId,
+      title: section.title,
+      type:
+        parsedSection.metadata.type ??
+        classifyCanvasBoardCardType(section.title),
+    };
+  });
 }
 
 /**
@@ -176,10 +389,15 @@ export function parseCanvasBoard(content: string): CanvasBoard {
 
   if (cards.length === 0 && introduction.length > 0) {
     cards.push({
+      author: null,
       body: introduction,
+      hasExplicitMetadata: false,
       id: "overview-1",
       kind: "welcome",
+      status: "backlog",
+      threadId: null,
       title: "Overview",
+      type: "note",
     });
   }
 
@@ -217,8 +435,21 @@ export function appendCanvasBoardCard(
   draft: CanvasBoardCardDraft,
 ): string {
   const source = parseCanvasBoardSource(content);
+  const type = draft.type ?? classifyCanvasBoardCardType(draft.title);
+  const status = draft.status ?? "backlog";
+  const id = draft.id ?? cardId(draft.title, source.sections.length);
   source.sections.push({
-    bodyLines: draft.body.trim().split("\n"),
+    bodyLines: [
+      serializeCardMetadata({
+        author: draft.author,
+        id,
+        status,
+        threadId: draft.threadId,
+        type,
+      }),
+      "",
+      ...draft.body.trim().split("\n"),
+    ],
     headingLine: `## ${draft.title.trim()}`,
     title: draft.title.trim(),
   });
@@ -241,7 +472,17 @@ export function updateCanvasBoardCard(
     );
     source.introductionLines = [];
     source.sections.push({
-      bodyLines: draft.body.trim().split("\n"),
+      bodyLines: [
+        serializeCardMetadata({
+          author: draft.author,
+          id: draft.id ?? cardId(draft.title, 0),
+          status: draft.status ?? "backlog",
+          threadId: draft.threadId,
+          type: draft.type ?? classifyCanvasBoardCardType(draft.title),
+        }),
+        "",
+        ...draft.body.trim().split("\n"),
+      ],
       headingLine: `## ${draft.title.trim()}`,
       title: draft.title.trim(),
     });
@@ -255,10 +496,73 @@ export function updateCanvasBoardCard(
     return null;
   }
 
-  section.bodyLines = draft.body.trim().split("\n");
+  const currentCard = cards[sectionIndex];
+  section.bodyLines = [
+    serializeCardMetadata({
+      author: draft.author ?? currentCard.author,
+      id: draft.id ?? currentCard.id,
+      status: draft.status ?? currentCard.status,
+      threadId:
+        draft.threadId === undefined ? currentCard.threadId : draft.threadId,
+      type: draft.type ?? currentCard.type,
+    }),
+    "",
+    ...draft.body.trim().split("\n"),
+  ];
   section.headingLine = `## ${draft.title.trim()}`;
   section.title = draft.title.trim();
   return serializeCanvasBoardSource(source);
+}
+
+export function updateCanvasBoardCardMetadata(
+  content: string,
+  cardIdToUpdate: string,
+  patch: Partial<{
+    author: string | null;
+    status: CanvasBoardCardStatus;
+    threadId: string | null;
+    type: CanvasBoardCardType;
+  }>,
+): string | null {
+  const source = parseCanvasBoardSource(content);
+  const cards = canvasBoardCardsFromSource(source);
+  const sectionIndex = cards.findIndex((card) => card.id === cardIdToUpdate);
+  const section = source.sections[sectionIndex];
+  const card = cards[sectionIndex];
+  if (!section || !card) {
+    return null;
+  }
+
+  section.bodyLines = [
+    serializeCardMetadata({
+      author: patch.author === undefined ? card.author : patch.author,
+      id: card.id,
+      status: patch.status ?? card.status,
+      threadId: patch.threadId === undefined ? card.threadId : patch.threadId,
+      type: patch.type ?? card.type,
+    }),
+    "",
+    ...card.body.split("\n"),
+  ];
+  return serializeCanvasBoardSource(source);
+}
+
+export function canvasBoardCardConversationMarker(cardId: string): string {
+  return `magic-board-card:${cardId}`;
+}
+
+export function buildCanvasBoardCardConversationOpener(
+  card: CanvasBoardCard,
+  channelName: string,
+): string {
+  const body = card.body.trim();
+  return [
+    `## ${card.title}`,
+    body,
+    `_Conversation attached to the ${channelName} board._`,
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n\n");
 }
 
 export function reorderCanvasBoardCard(
@@ -306,4 +610,22 @@ export function resolveChannelViewMode(input: {
     boardAvailable,
     mode: input.explicitView ?? (isDispatch ? "board" : "stream"),
   };
+}
+
+export function channelViewModeStorageKey(channelId: string): string {
+  return `${CHANNEL_VIEW_MODE_STORAGE_PREFIX}:${channelId}`;
+}
+
+export function readStoredChannelViewMode(
+  channelId: string,
+): ChannelViewMode | null {
+  const value = getStorageItem(channelViewModeStorageKey(channelId));
+  return value === "board" || value === "stream" ? value : null;
+}
+
+export function writeStoredChannelViewMode(
+  channelId: string,
+  mode: ChannelViewMode,
+): boolean {
+  return setStorageItem(channelViewModeStorageKey(channelId), mode);
 }

--- a/desktop/src/features/channels/lib/canvasBoard.ts
+++ b/desktop/src/features/channels/lib/canvasBoard.ts
@@ -1,0 +1,168 @@
+import type { ChannelType } from "@/shared/api/types";
+import { channelNamesMatch } from "@/features/channels/lib/canonicalChannelName";
+
+export type CanvasBoardCardKind =
+  | "artifact"
+  | "invitation"
+  | "note"
+  | "now"
+  | "people"
+  | "welcome";
+
+export type CanvasBoardCard = {
+  body: string;
+  id: string;
+  kind: CanvasBoardCardKind;
+  title: string;
+};
+
+export type CanvasBoard = {
+  cards: CanvasBoardCard[];
+  introduction: string;
+  title: string | null;
+};
+
+export type ChannelViewMode = "board" | "stream";
+
+const H1_PATTERN = /^#\s+(.+?)\s*#*\s*$/u;
+const H2_PATTERN = /^##\s+(.+?)\s*#*\s*$/u;
+const FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})/u;
+const FENCE_CLOSE_PATTERN = /^ {0,3}(`{3,}|~{3,})[ \t]*$/u;
+
+function cardId(title: string, index: number): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-|-$/gu, "");
+  return `${slug || "card"}-${index + 1}`;
+}
+
+export function classifyCanvasBoardCard(title: string): CanvasBoardCardKind {
+  const normalizedTitle = title.toLowerCase();
+
+  if (/\b(finished|made|shipped|artifact|showcase)\b/u.test(normalizedTitle)) {
+    return "artifact";
+  }
+  if (
+    /\b(help|join|invitation|next|action|participate)\b/u.test(normalizedTitle)
+  ) {
+    return "invitation";
+  }
+  if (/\b(people|member|agent|steward|contributor)\b/u.test(normalizedTitle)) {
+    return "people";
+  }
+  if (/\b(now|today|week|current|happening|active)\b/u.test(normalizedTitle)) {
+    return "now";
+  }
+  if (/\b(welcome|start|about|orientation)\b/u.test(normalizedTitle)) {
+    return "welcome";
+  }
+  return "note";
+}
+
+/**
+ * Converts a shared Markdown canvas into a title/introduction plus `##` cards.
+ * Headings inside fenced code blocks remain body content.
+ */
+export function parseCanvasBoard(content: string): CanvasBoard {
+  const introductionLines: string[] = [];
+  const sections: Array<{ title: string; bodyLines: string[] }> = [];
+  let title: string | null = null;
+  let activeSection: { title: string; bodyLines: string[] } | null = null;
+  let activeFence: { character: "`" | "~"; length: number } | null = null;
+
+  for (const line of content.replace(/\r\n?/gu, "\n").split("\n")) {
+    const wasInsideFence = activeFence !== null;
+    if (activeFence) {
+      const closingFenceMatch = line.match(FENCE_CLOSE_PATTERN);
+      if (
+        closingFenceMatch &&
+        closingFenceMatch[1][0] === activeFence.character &&
+        closingFenceMatch[1].length >= activeFence.length
+      ) {
+        activeFence = null;
+      }
+    } else {
+      const openingFenceMatch = line.match(FENCE_OPEN_PATTERN);
+      if (openingFenceMatch) {
+        activeFence = {
+          character: openingFenceMatch[1][0] as "`" | "~",
+          length: openingFenceMatch[1].length,
+        };
+      }
+    }
+
+    const isFenceBoundary = wasInsideFence || activeFence !== null;
+
+    if (!isFenceBoundary && !activeSection) {
+      const h1Match = line.match(H1_PATTERN);
+      if (h1Match && title === null) {
+        title = h1Match[1].trim();
+        continue;
+      }
+    }
+
+    if (!isFenceBoundary) {
+      const h2Match = line.match(H2_PATTERN);
+      if (h2Match) {
+        activeSection = { title: h2Match[1].trim(), bodyLines: [] };
+        sections.push(activeSection);
+        continue;
+      }
+    }
+
+    if (activeSection) {
+      activeSection.bodyLines.push(line);
+    } else {
+      introductionLines.push(line);
+    }
+  }
+
+  const introduction = introductionLines.join("\n").trim();
+  const cards = sections.map((section, index) => ({
+    body: section.bodyLines.join("\n").trim(),
+    id: cardId(section.title, index),
+    kind: classifyCanvasBoardCard(section.title),
+    title: section.title,
+  }));
+
+  if (cards.length === 0 && introduction.length > 0) {
+    cards.push({
+      body: introduction,
+      id: "overview-1",
+      kind: "welcome",
+      title: "Overview",
+    });
+  }
+
+  return {
+    cards,
+    introduction: sections.length > 0 ? introduction : "",
+    title,
+  };
+}
+
+export function resolveChannelViewMode(input: {
+  channelName: string | null;
+  channelType: ChannelType | null;
+  explicitView: ChannelViewMode | null;
+  hasCanvas: boolean;
+  hasRouteTarget: boolean;
+}): { boardAvailable: boolean; mode: ChannelViewMode } {
+  const isDispatch =
+    input.channelName !== null &&
+    channelNamesMatch(input.channelName, "Dispatch");
+  const boardAvailable =
+    input.channelType !== null &&
+    input.channelType !== "dm" &&
+    (input.hasCanvas || isDispatch);
+
+  if (input.hasRouteTarget || !boardAvailable) {
+    return { boardAvailable, mode: "stream" };
+  }
+
+  return {
+    boardAvailable,
+    mode: input.explicitView ?? (isDispatch ? "board" : "stream"),
+  };
+}

--- a/desktop/src/features/channels/ui/ChannelBoard.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoard.tsx
@@ -1,9 +1,28 @@
 import {
+  closestCenter,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import {
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  SortableContext,
+  useSortable,
+} from "@dnd-kit/sortable";
+import {
   Boxes,
   Compass,
+  GripVertical,
   HandHeart,
   MessageSquareText,
   PackageCheck,
+  Pencil,
+  Plus,
   Settings2,
   Sparkles,
   StickyNote,
@@ -52,14 +71,20 @@ const CARD_ICONS = {
 } satisfies Record<CanvasBoardCardKind, typeof StickyNote>;
 
 type ChannelBoardProps = {
+  actionErrorMessage?: string;
   agentCount: number;
   author: string | null;
+  canEdit: boolean;
   channelName: string;
   content: string | null;
   errorMessage?: string;
   isLoading: boolean;
+  isSaving: boolean;
   memberCount: number;
+  onCreateCard: () => void;
+  onEditCard: (card: CanvasBoardCard) => void;
   onManageBoard: () => void;
+  onMoveCard: (activeCardId: string, overCardId: string) => void;
   onOpenMembers: () => void;
   onOpenStream: () => void;
   updatedAt: number | null;
@@ -77,34 +102,114 @@ function formatCanvasUpdatedAt(updatedAt: number | null): string | null {
 
 function BoardCard({
   card,
+  canEdit,
   channelNames,
+  isSaving,
+  onEdit,
 }: {
   card: CanvasBoardCard;
+  canEdit: boolean;
   channelNames: string[];
+  isSaving: boolean;
+  onEdit: () => void;
 }) {
+  const Icon = CARD_ICONS[card.kind];
+  const dragDisabled = !canEdit || isSaving;
+  const {
+    attributes,
+    isDragging,
+    isOver,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+  } = useSortable({
+    id: card.id,
+    disabled: dragDisabled,
+  });
+
+  return (
+    <div
+      className={cn(
+        "mb-4 break-inside-avoid rounded-xl transition-shadow",
+        isDragging && "opacity-35",
+        isOver && !isDragging && "ring-2 ring-primary/50 ring-offset-2",
+      )}
+      data-board-kind={card.kind}
+      data-testid={`magic-board-card-${card.id}`}
+      ref={setNodeRef}
+    >
+      <Card
+        className={cn(
+          "overflow-hidden shadow-sm transition-shadow duration-200 hover:shadow-md",
+          CARD_STYLES[card.kind],
+        )}
+      >
+        <CardHeader className="gap-3 p-5 pb-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2 pt-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              <Icon className="h-3.5 w-3.5" />
+              {CARD_LABELS[card.kind]}
+            </div>
+            {canEdit ? (
+              <div className="flex shrink-0 items-center gap-1">
+                <Button
+                  aria-label={`Move ${card.title}`}
+                  className="touch-none cursor-grab text-muted-foreground active:cursor-grabbing"
+                  data-testid={`magic-board-drag-${card.id}`}
+                  disabled={isSaving}
+                  ref={setActivatorNodeRef}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                  {...attributes}
+                  {...listeners}
+                >
+                  <GripVertical />
+                </Button>
+                <Button
+                  aria-label={`Edit ${card.title}`}
+                  data-testid={`magic-board-edit-${card.id}`}
+                  disabled={isSaving}
+                  onClick={onEdit}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Pencil />
+                </Button>
+              </div>
+            ) : null}
+          </div>
+          <CardTitle className="text-lg leading-6">{card.title}</CardTitle>
+        </CardHeader>
+        {card.body ? (
+          <CardContent className="p-5 pt-0 text-sm">
+            <Markdown channelNames={channelNames} content={card.body} />
+          </CardContent>
+        ) : null}
+      </Card>
+    </div>
+  );
+}
+
+function BoardCardDragOverlay({ card }: { card: CanvasBoardCard }) {
   const Icon = CARD_ICONS[card.kind];
 
   return (
     <Card
       className={cn(
-        "mb-4 break-inside-avoid overflow-hidden shadow-sm transition-shadow duration-200 hover:shadow-md",
+        "w-72 overflow-hidden shadow-xl ring-1 ring-primary/30",
         CARD_STYLES[card.kind],
       )}
-      data-board-kind={card.kind}
-      data-testid={`magic-board-card-${card.id}`}
+      data-testid="magic-board-drag-overlay"
     >
-      <CardHeader className="gap-3 p-5 pb-3">
+      <CardHeader className="gap-2 p-4">
         <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
           <Icon className="h-3.5 w-3.5" />
           {CARD_LABELS[card.kind]}
         </div>
-        <CardTitle className="text-lg leading-6">{card.title}</CardTitle>
+        <CardTitle className="text-base leading-5">{card.title}</CardTitle>
       </CardHeader>
-      {card.body ? (
-        <CardContent className="p-5 pt-0 text-sm">
-          <Markdown channelNames={channelNames} content={card.body} />
-        </CardContent>
-      ) : null}
     </Card>
   );
 }
@@ -171,14 +276,20 @@ function LiveBoardCards({
 }
 
 export function ChannelBoard({
+  actionErrorMessage,
   agentCount,
   author,
+  canEdit,
   channelName,
   content,
   errorMessage,
   isLoading,
+  isSaving,
   memberCount,
+  onCreateCard,
+  onEditCard,
   onManageBoard,
+  onMoveCard,
   onOpenMembers,
   onOpenStream,
   updatedAt,
@@ -193,6 +304,28 @@ export function ChannelBoard({
   );
   const board = React.useMemo(() => parseCanvasBoard(content ?? ""), [content]);
   const updatedLabel = formatCanvasUpdatedAt(updatedAt);
+  const [activeCardId, setActiveCardId] = React.useState<string | null>(null);
+  const activeCard = activeCardId
+    ? (board.cards.find((card) => card.id === activeCardId) ?? null)
+    : null;
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveCardId(String(event.active.id));
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveCardId(null);
+    if (!event.over || event.active.id === event.over.id) {
+      return;
+    }
+    onMoveCard(String(event.active.id), String(event.over.id));
+  }
 
   return (
     <div
@@ -245,6 +378,18 @@ export function ChannelBoard({
               </div>
             </div>
             <div className="flex shrink-0 flex-wrap gap-2">
+              {canEdit ? (
+                <Button
+                  data-testid="magic-board-create-card"
+                  disabled={isSaving}
+                  onClick={onCreateCard}
+                  size="sm"
+                  type="button"
+                >
+                  <Plus className="h-4 w-4" />
+                  New card
+                </Button>
+              ) : null}
               <Button onClick={onOpenStream} size="sm" type="button">
                 <MessageSquareText className="h-4 w-4" />
                 Open stream
@@ -261,6 +406,15 @@ export function ChannelBoard({
             </div>
           </div>
         </section>
+
+        {actionErrorMessage ? (
+          <p
+            className="mb-4 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+            data-testid="magic-board-action-error"
+          >
+            {actionErrorMessage}
+          </p>
+        ) : null}
 
         {isLoading ? (
           <div className="rounded-xl border border-border/60 bg-background/60 px-5 py-8 text-sm text-muted-foreground">
@@ -292,24 +446,43 @@ export function ChannelBoard({
             </Button>
           </div>
         ) : (
-          <div
-            className="columns-1 gap-4 md:columns-2 xl:columns-3"
-            data-testid="magic-board-grid"
+          <DndContext
+            collisionDetection={closestCenter}
+            onDragCancel={() => setActiveCardId(null)}
+            onDragEnd={handleDragEnd}
+            onDragStart={handleDragStart}
+            sensors={sensors}
           >
-            {board.cards.map((card) => (
-              <BoardCard
-                card={card}
-                channelNames={channelNames}
-                key={card.id}
-              />
-            ))}
-            <LiveBoardCards
-              agentCount={agentCount}
-              memberCount={memberCount}
-              onOpenMembers={onOpenMembers}
-              onOpenStream={onOpenStream}
-            />
-          </div>
+            <SortableContext
+              items={board.cards.map((card) => card.id)}
+              strategy={rectSortingStrategy}
+            >
+              <div
+                className="columns-1 gap-4 md:columns-2 xl:columns-3"
+                data-testid="magic-board-grid"
+              >
+                {board.cards.map((card) => (
+                  <BoardCard
+                    canEdit={canEdit}
+                    card={card}
+                    channelNames={channelNames}
+                    isSaving={isSaving}
+                    key={card.id}
+                    onEdit={() => onEditCard(card)}
+                  />
+                ))}
+                <LiveBoardCards
+                  agentCount={agentCount}
+                  memberCount={memberCount}
+                  onOpenMembers={onOpenMembers}
+                  onOpenStream={onOpenStream}
+                />
+              </div>
+            </SortableContext>
+            <DragOverlay dropAnimation={null}>
+              {activeCard ? <BoardCardDragOverlay card={activeCard} /> : null}
+            </DragOverlay>
+          </DndContext>
         )}
       </div>
     </div>

--- a/desktop/src/features/channels/ui/ChannelBoard.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoard.tsx
@@ -87,7 +87,7 @@ function BoardCard({
   return (
     <Card
       className={cn(
-        "mb-4 break-inside-avoid overflow-hidden shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md",
+        "mb-4 break-inside-avoid overflow-hidden shadow-sm transition-shadow duration-200 hover:shadow-md",
         CARD_STYLES[card.kind],
       )}
       data-board-kind={card.kind}

--- a/desktop/src/features/channels/ui/ChannelBoard.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoard.tsx
@@ -3,11 +3,17 @@ import {
   DndContext,
   DragOverlay,
   KeyboardSensor,
+  pointerWithin,
   PointerSensor,
+  useDroppable,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import type {
+  CollisionDetection,
+  DragEndEvent,
+  DragStartEvent,
+} from "@dnd-kit/core";
 import {
   rectSortingStrategy,
   sortableKeyboardCoordinates,
@@ -15,24 +21,33 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import {
+  Bot,
   Boxes,
-  Compass,
+  CheckCircle2,
+  CircleDot,
+  Columns3,
+  FileCheck2,
+  FolderKanban,
+  Gavel,
   GripVertical,
-  HandHeart,
+  LayoutGrid,
+  ListTodo,
+  MessageCircle,
   MessageSquareText,
-  PackageCheck,
   Pencil,
   Plus,
   Settings2,
   Sparkles,
   StickyNote,
+  UserRound,
   Users,
 } from "lucide-react";
 import * as React from "react";
 
 import {
   type CanvasBoardCard,
-  type CanvasBoardCardKind,
+  type CanvasBoardCardStatus,
+  type CanvasBoardCardType,
   parseCanvasBoard,
 } from "@/features/channels/lib/canvasBoard";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
@@ -43,32 +58,59 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Markdown } from "@/shared/ui/markdown";
 import { PubKey } from "@/shared/ui/PubKey";
 
-const CARD_STYLES: Record<CanvasBoardCardKind, string> = {
+const CARD_TYPE_STYLES: Record<CanvasBoardCardType, string> = {
+  agent: "border-fuchsia-500/25 bg-fuchsia-500/8",
   artifact: "border-emerald-500/25 bg-emerald-500/8",
-  invitation: "border-rose-500/25 bg-rose-500/8",
+  conversation: "border-blue-500/25 bg-blue-500/8",
+  decision: "border-orange-500/25 bg-orange-500/8",
   note: "border-violet-500/20 bg-violet-500/7",
-  now: "border-amber-500/30 bg-amber-500/10",
-  people: "border-sky-500/25 bg-sky-500/8",
-  welcome: "border-cyan-500/25 bg-cyan-500/8",
+  person: "border-sky-500/25 bg-sky-500/8",
+  project: "border-cyan-500/25 bg-cyan-500/8",
+  task: "border-amber-500/30 bg-amber-500/10",
 };
 
-const CARD_LABELS: Record<CanvasBoardCardKind, string> = {
-  artifact: "Made here",
-  invitation: "Open invitation",
-  note: "Shared note",
-  now: "Happening now",
-  people: "People",
-  welcome: "Start here",
+const CARD_TYPE_LABELS: Record<CanvasBoardCardType, string> = {
+  agent: "Agent",
+  artifact: "Artifact",
+  conversation: "Conversation",
+  decision: "Decision",
+  note: "Note",
+  person: "Person",
+  project: "Project",
+  task: "Task",
 };
 
-const CARD_ICONS = {
-  artifact: PackageCheck,
-  invitation: HandHeart,
+const CARD_TYPE_ICONS = {
+  agent: Bot,
+  artifact: FileCheck2,
+  conversation: MessageCircle,
+  decision: Gavel,
   note: StickyNote,
-  now: Sparkles,
-  people: Users,
-  welcome: Compass,
-} satisfies Record<CanvasBoardCardKind, typeof StickyNote>;
+  person: UserRound,
+  project: FolderKanban,
+  task: ListTodo,
+} satisfies Record<CanvasBoardCardType, typeof StickyNote>;
+
+const STATUS_LABELS: Record<CanvasBoardCardStatus, string> = {
+  backlog: "Backlog",
+  doing: "Doing",
+  done: "Done",
+};
+
+const STATUS_ICONS = {
+  backlog: CircleDot,
+  doing: Sparkles,
+  done: CheckCircle2,
+} satisfies Record<CanvasBoardCardStatus, typeof CircleDot>;
+
+const KANBAN_STATUSES: CanvasBoardCardStatus[] = ["backlog", "doing", "done"];
+
+const boardCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+  return pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args);
+};
+
+type CanvasBoardLayout = "cards" | "kanban";
 
 type ChannelBoardProps = {
   actionErrorMessage?: string;
@@ -82,11 +124,17 @@ type ChannelBoardProps = {
   isSaving: boolean;
   memberCount: number;
   onCreateCard: () => void;
+  onChangeCardStatus: (
+    card: CanvasBoardCard,
+    status: CanvasBoardCardStatus,
+  ) => void;
   onEditCard: (card: CanvasBoardCard) => void;
   onManageBoard: () => void;
   onMoveCard: (activeCardId: string, overCardId: string) => void;
   onOpenMembers: () => void;
+  onOpenCardConversation: (card: CanvasBoardCard) => void;
   onOpenStream: () => void;
+  pendingConversationCardId?: string | null;
   updatedAt: number | null;
 };
 
@@ -104,16 +152,21 @@ function BoardCard({
   card,
   canEdit,
   channelNames,
+  isConversationPending,
   isSaving,
   onEdit,
+  onOpenConversation,
 }: {
   card: CanvasBoardCard;
   canEdit: boolean;
   channelNames: string[];
+  isConversationPending: boolean;
   isSaving: boolean;
   onEdit: () => void;
+  onOpenConversation: () => void;
 }) {
-  const Icon = CARD_ICONS[card.kind];
+  const Icon = CARD_TYPE_ICONS[card.type];
+  const StatusIcon = STATUS_ICONS[card.status];
   const dragDisabled = !canEdit || isSaving;
   const {
     attributes,
@@ -135,20 +188,22 @@ function BoardCard({
         isOver && !isDragging && "ring-2 ring-primary/50 ring-offset-2",
       )}
       data-board-kind={card.kind}
+      data-board-status={card.status}
+      data-board-type={card.type}
       data-testid={`magic-board-card-${card.id}`}
       ref={setNodeRef}
     >
       <Card
         className={cn(
           "overflow-hidden shadow-sm transition-shadow duration-200 hover:shadow-md",
-          CARD_STYLES[card.kind],
+          CARD_TYPE_STYLES[card.type],
         )}
       >
         <CardHeader className="gap-3 p-5 pb-3">
           <div className="flex items-start justify-between gap-3">
             <div className="flex items-center gap-2 pt-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
               <Icon className="h-3.5 w-3.5" />
-              {CARD_LABELS[card.kind]}
+              {CARD_TYPE_LABELS[card.type]}
             </div>
             {canEdit ? (
               <div className="flex shrink-0 items-center gap-1">
@@ -187,30 +242,126 @@ function BoardCard({
             <Markdown channelNames={channelNames} content={card.body} />
           </CardContent>
         ) : null}
+        <CardContent className="flex flex-wrap items-center justify-between gap-2 border-t border-border/40 p-4 text-xs text-muted-foreground">
+          <span className="inline-flex flex-wrap items-center gap-1.5">
+            <StatusIcon className="h-3.5 w-3.5" />
+            {STATUS_LABELS[card.status]}
+            {card.author ? (
+              <React.Fragment>
+                <span aria-hidden>·</span>
+                <span className="inline-flex items-center gap-1">
+                  by <PubKey pubkey={card.author} />
+                </span>
+              </React.Fragment>
+            ) : null}
+          </span>
+          {card.threadId || canEdit ? (
+            <Button
+              data-testid={`magic-board-conversation-${card.id}`}
+              disabled={isSaving || isConversationPending}
+              onClick={onOpenConversation}
+              size="xs"
+              type="button"
+              variant={card.threadId ? "secondary" : "outline"}
+            >
+              <MessageCircle className="h-3.5 w-3.5" />
+              {isConversationPending
+                ? "Linking…"
+                : card.threadId
+                  ? "Open thread"
+                  : "Start thread"}
+            </Button>
+          ) : null}
+        </CardContent>
       </Card>
     </div>
   );
 }
 
 function BoardCardDragOverlay({ card }: { card: CanvasBoardCard }) {
-  const Icon = CARD_ICONS[card.kind];
+  const Icon = CARD_TYPE_ICONS[card.type];
 
   return (
     <Card
       className={cn(
         "w-72 overflow-hidden shadow-xl ring-1 ring-primary/30",
-        CARD_STYLES[card.kind],
+        CARD_TYPE_STYLES[card.type],
       )}
       data-testid="magic-board-drag-overlay"
     >
       <CardHeader className="gap-2 p-4">
         <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
           <Icon className="h-3.5 w-3.5" />
-          {CARD_LABELS[card.kind]}
+          {CARD_TYPE_LABELS[card.type]}
         </div>
         <CardTitle className="text-base leading-5">{card.title}</CardTitle>
       </CardHeader>
     </Card>
+  );
+}
+
+function KanbanColumn({
+  cards,
+  canEdit,
+  channelNames,
+  isSaving,
+  onEditCard,
+  onOpenCardConversation,
+  pendingConversationCardId,
+  status,
+}: {
+  cards: CanvasBoardCard[];
+  canEdit: boolean;
+  channelNames: string[];
+  isSaving: boolean;
+  onEditCard: (card: CanvasBoardCard) => void;
+  onOpenCardConversation: (card: CanvasBoardCard) => void;
+  pendingConversationCardId?: string | null;
+  status: CanvasBoardCardStatus;
+}) {
+  const { isOver, setNodeRef } = useDroppable({ id: `status:${status}` });
+  const StatusIcon = STATUS_ICONS[status];
+
+  return (
+    <section
+      className={cn(
+        "min-h-48 rounded-2xl border border-border/60 bg-background/55 p-3 transition-colors",
+        isOver && "border-primary/50 bg-primary/5",
+      )}
+      data-testid={`magic-board-kanban-${status}`}
+      ref={setNodeRef}
+    >
+      <header className="mb-3 flex items-center justify-between gap-2 px-1">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <StatusIcon className="h-4 w-4 text-muted-foreground" />
+          {STATUS_LABELS[status]}
+        </div>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+          {cards.length}
+        </span>
+      </header>
+      <SortableContext items={cards.map((card) => card.id)}>
+        <div className="space-y-3">
+          {cards.map((card) => (
+            <BoardCard
+              canEdit={canEdit}
+              card={card}
+              channelNames={channelNames}
+              isConversationPending={pendingConversationCardId === card.id}
+              isSaving={isSaving}
+              key={card.id}
+              onEdit={() => onEditCard(card)}
+              onOpenConversation={() => onOpenCardConversation(card)}
+            />
+          ))}
+          {cards.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-border/70 px-3 py-8 text-center text-xs text-muted-foreground">
+              {canEdit ? "Drop a card here" : "No cards"}
+            </div>
+          ) : null}
+        </div>
+      </SortableContext>
+    </section>
   );
 }
 
@@ -286,12 +437,15 @@ export function ChannelBoard({
   isLoading,
   isSaving,
   memberCount,
+  onChangeCardStatus,
   onCreateCard,
   onEditCard,
   onManageBoard,
   onMoveCard,
+  onOpenCardConversation,
   onOpenMembers,
   onOpenStream,
+  pendingConversationCardId,
   updatedAt,
 }: ChannelBoardProps) {
   const { channels } = useChannelNavigation();
@@ -305,6 +459,7 @@ export function ChannelBoard({
   const board = React.useMemo(() => parseCanvasBoard(content ?? ""), [content]);
   const updatedLabel = formatCanvasUpdatedAt(updatedAt);
   const [activeCardId, setActiveCardId] = React.useState<string | null>(null);
+  const [layout, setLayout] = React.useState<CanvasBoardLayout>("cards");
   const activeCard = activeCardId
     ? (board.cards.find((card) => card.id === activeCardId) ?? null)
     : null;
@@ -324,7 +479,27 @@ export function ChannelBoard({
     if (!event.over || event.active.id === event.over.id) {
       return;
     }
-    onMoveCard(String(event.active.id), String(event.over.id));
+    const activeCard = board.cards.find(
+      (card) => card.id === String(event.active.id),
+    );
+    const overId = String(event.over.id);
+    const overCard = board.cards.find((card) => card.id === overId);
+    const targetStatus = overId.startsWith("status:")
+      ? (overId.slice("status:".length) as CanvasBoardCardStatus)
+      : overCard?.status;
+
+    if (
+      layout === "kanban" &&
+      activeCard &&
+      targetStatus &&
+      targetStatus !== activeCard.status
+    ) {
+      onChangeCardStatus(activeCard, targetStatus);
+      return;
+    }
+    if (overCard) {
+      onMoveCard(activeCard?.id ?? String(event.active.id), overCard.id);
+    }
   }
 
   return (
@@ -376,8 +551,40 @@ export function ChannelBoard({
                   </React.Fragment>
                 ) : null}
               </div>
+              <p className="text-xs text-muted-foreground">
+                Stewards curate the shared layout; every member can join linked
+                card threads.
+              </p>
             </div>
             <div className="flex shrink-0 flex-wrap gap-2">
+              <fieldset
+                aria-label="Board layout"
+                className="inline-flex rounded-lg border border-border bg-muted/40 p-0.5"
+                data-testid="magic-board-layout"
+              >
+                <Button
+                  aria-pressed={layout === "cards"}
+                  data-testid="magic-board-layout-cards"
+                  onClick={() => setLayout("cards")}
+                  size="sm"
+                  type="button"
+                  variant={layout === "cards" ? "secondary" : "ghost"}
+                >
+                  <LayoutGrid className="h-4 w-4" />
+                  Cards
+                </Button>
+                <Button
+                  aria-pressed={layout === "kanban"}
+                  data-testid="magic-board-layout-kanban"
+                  onClick={() => setLayout("kanban")}
+                  size="sm"
+                  type="button"
+                  variant={layout === "kanban" ? "secondary" : "ghost"}
+                >
+                  <Columns3 className="h-4 w-4" />
+                  Kanban
+                </Button>
+              </fieldset>
               {canEdit ? (
                 <Button
                   data-testid="magic-board-create-card"
@@ -447,38 +654,63 @@ export function ChannelBoard({
           </div>
         ) : (
           <DndContext
-            collisionDetection={closestCenter}
+            collisionDetection={boardCollisionDetection}
             onDragCancel={() => setActiveCardId(null)}
             onDragEnd={handleDragEnd}
             onDragStart={handleDragStart}
             sensors={sensors}
           >
-            <SortableContext
-              items={board.cards.map((card) => card.id)}
-              strategy={rectSortingStrategy}
-            >
-              <div
-                className="columns-1 gap-4 md:columns-2 xl:columns-3"
-                data-testid="magic-board-grid"
+            {layout === "cards" ? (
+              <SortableContext
+                items={board.cards.map((card) => card.id)}
+                strategy={rectSortingStrategy}
               >
-                {board.cards.map((card) => (
-                  <BoardCard
+                <div
+                  className="columns-1 gap-4 md:columns-2 xl:columns-3"
+                  data-testid="magic-board-grid"
+                >
+                  {board.cards.map((card) => (
+                    <BoardCard
+                      canEdit={canEdit}
+                      card={card}
+                      channelNames={channelNames}
+                      isConversationPending={
+                        pendingConversationCardId === card.id
+                      }
+                      isSaving={isSaving}
+                      key={card.id}
+                      onEdit={() => onEditCard(card)}
+                      onOpenConversation={() => onOpenCardConversation(card)}
+                    />
+                  ))}
+                  <LiveBoardCards
+                    agentCount={agentCount}
+                    memberCount={memberCount}
+                    onOpenMembers={onOpenMembers}
+                    onOpenStream={onOpenStream}
+                  />
+                </div>
+              </SortableContext>
+            ) : (
+              <div
+                className="grid gap-4 lg:grid-cols-3"
+                data-testid="magic-board-kanban"
+              >
+                {KANBAN_STATUSES.map((status) => (
+                  <KanbanColumn
                     canEdit={canEdit}
-                    card={card}
+                    cards={board.cards.filter((card) => card.status === status)}
                     channelNames={channelNames}
                     isSaving={isSaving}
-                    key={card.id}
-                    onEdit={() => onEditCard(card)}
+                    key={status}
+                    onEditCard={onEditCard}
+                    onOpenCardConversation={onOpenCardConversation}
+                    pendingConversationCardId={pendingConversationCardId}
+                    status={status}
                   />
                 ))}
-                <LiveBoardCards
-                  agentCount={agentCount}
-                  memberCount={memberCount}
-                  onOpenMembers={onOpenMembers}
-                  onOpenStream={onOpenStream}
-                />
               </div>
-            </SortableContext>
+            )}
             <DragOverlay dropAnimation={null}>
               {activeCard ? <BoardCardDragOverlay card={activeCard} /> : null}
             </DragOverlay>

--- a/desktop/src/features/channels/ui/ChannelBoard.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoard.tsx
@@ -1,0 +1,317 @@
+import {
+  Boxes,
+  Compass,
+  HandHeart,
+  MessageSquareText,
+  PackageCheck,
+  Settings2,
+  Sparkles,
+  StickyNote,
+  Users,
+} from "lucide-react";
+import * as React from "react";
+
+import {
+  type CanvasBoardCard,
+  type CanvasBoardCardKind,
+  parseCanvasBoard,
+} from "@/features/channels/lib/canvasBoard";
+import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
+import { cn } from "@/shared/lib/cn";
+import { channelChrome } from "@/shared/layout/chromeLayout";
+import { Button } from "@/shared/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
+import { Markdown } from "@/shared/ui/markdown";
+import { PubKey } from "@/shared/ui/PubKey";
+
+const CARD_STYLES: Record<CanvasBoardCardKind, string> = {
+  artifact: "border-emerald-500/25 bg-emerald-500/8",
+  invitation: "border-rose-500/25 bg-rose-500/8",
+  note: "border-violet-500/20 bg-violet-500/7",
+  now: "border-amber-500/30 bg-amber-500/10",
+  people: "border-sky-500/25 bg-sky-500/8",
+  welcome: "border-cyan-500/25 bg-cyan-500/8",
+};
+
+const CARD_LABELS: Record<CanvasBoardCardKind, string> = {
+  artifact: "Made here",
+  invitation: "Open invitation",
+  note: "Shared note",
+  now: "Happening now",
+  people: "People",
+  welcome: "Start here",
+};
+
+const CARD_ICONS = {
+  artifact: PackageCheck,
+  invitation: HandHeart,
+  note: StickyNote,
+  now: Sparkles,
+  people: Users,
+  welcome: Compass,
+} satisfies Record<CanvasBoardCardKind, typeof StickyNote>;
+
+type ChannelBoardProps = {
+  agentCount: number;
+  author: string | null;
+  channelName: string;
+  content: string | null;
+  errorMessage?: string;
+  isLoading: boolean;
+  memberCount: number;
+  onManageBoard: () => void;
+  onOpenMembers: () => void;
+  onOpenStream: () => void;
+  updatedAt: number | null;
+};
+
+function formatCanvasUpdatedAt(updatedAt: number | null): string | null {
+  if (updatedAt === null) {
+    return null;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(updatedAt * 1_000));
+}
+
+function BoardCard({
+  card,
+  channelNames,
+}: {
+  card: CanvasBoardCard;
+  channelNames: string[];
+}) {
+  const Icon = CARD_ICONS[card.kind];
+
+  return (
+    <Card
+      className={cn(
+        "mb-4 break-inside-avoid overflow-hidden shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md",
+        CARD_STYLES[card.kind],
+      )}
+      data-board-kind={card.kind}
+      data-testid={`magic-board-card-${card.id}`}
+    >
+      <CardHeader className="gap-3 p-5 pb-3">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          <Icon className="h-3.5 w-3.5" />
+          {CARD_LABELS[card.kind]}
+        </div>
+        <CardTitle className="text-lg leading-6">{card.title}</CardTitle>
+      </CardHeader>
+      {card.body ? (
+        <CardContent className="p-5 pt-0 text-sm">
+          <Markdown channelNames={channelNames} content={card.body} />
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+function LiveBoardCards({
+  agentCount,
+  memberCount,
+  onOpenMembers,
+  onOpenStream,
+}: {
+  agentCount: number;
+  memberCount: number;
+  onOpenMembers: () => void;
+  onOpenStream: () => void;
+}) {
+  return (
+    <React.Fragment>
+      <Card className="mb-4 break-inside-avoid border-sky-500/25 bg-sky-500/8 shadow-sm">
+        <CardHeader className="gap-3 p-5 pb-3">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            <Users className="h-3.5 w-3.5" />
+            Live from Buzz
+          </div>
+          <CardTitle className="text-lg leading-6">People & agents</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 p-5 pt-0 text-sm">
+          <p className="text-muted-foreground">
+            {memberCount === 1 ? "1 member" : `${memberCount} members`} ·{" "}
+            {agentCount === 1 ? "1 agent" : `${agentCount} agents`} tending this
+            room.
+          </p>
+          <Button
+            onClick={onOpenMembers}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <Users className="h-4 w-4" />
+            View people
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-4 break-inside-avoid border-border/70 bg-card/70 shadow-sm">
+        <CardHeader className="gap-3 p-5 pb-3">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            <MessageSquareText className="h-3.5 w-3.5" />
+            Contained conversation
+          </div>
+          <CardTitle className="text-lg leading-6">Open the room</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 p-5 pt-0 text-sm">
+          <p className="text-muted-foreground">
+            Continue into the channel stream without losing this shared board.
+          </p>
+          <Button onClick={onOpenStream} size="sm" type="button">
+            <MessageSquareText className="h-4 w-4" />
+            Open conversation
+          </Button>
+        </CardContent>
+      </Card>
+    </React.Fragment>
+  );
+}
+
+export function ChannelBoard({
+  agentCount,
+  author,
+  channelName,
+  content,
+  errorMessage,
+  isLoading,
+  memberCount,
+  onManageBoard,
+  onOpenMembers,
+  onOpenStream,
+  updatedAt,
+}: ChannelBoardProps) {
+  const { channels } = useChannelNavigation();
+  const channelNames = React.useMemo(
+    () =>
+      channels
+        .filter((channel) => channel.channelType !== "dm")
+        .map((channel) => channel.name),
+    [channels],
+  );
+  const board = React.useMemo(() => parseCanvasBoard(content ?? ""), [content]);
+  const updatedLabel = formatCanvasUpdatedAt(updatedAt);
+
+  return (
+    <div
+      className={cn(
+        "min-h-0 flex-1 overflow-y-auto bg-[radial-gradient(circle_at_top_left,hsl(var(--muted)/0.45),transparent_38%)]",
+        channelChrome.contentPadding,
+      )}
+      data-testid="channel-magic-board"
+    >
+      <div className="mx-auto w-full max-w-7xl px-5 pb-10 pt-6 sm:px-7 lg:px-10">
+        <section className="mb-6 rounded-2xl border border-border/60 bg-background/75 p-5 shadow-sm backdrop-blur-sm sm:p-7">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+            <div className="max-w-3xl space-y-3">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                <Boxes className="h-4 w-4" />
+                Shared community board
+              </div>
+              <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+                {board.title ?? channelName}
+              </h2>
+              {board.introduction ? (
+                <div className="text-sm text-muted-foreground sm:text-base">
+                  <Markdown
+                    channelNames={channelNames}
+                    content={board.introduction}
+                  />
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  See what matters now, where to join, and what this community
+                  has made.
+                </p>
+              )}
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                <span>Snapshot of this channel’s shared canvas</span>
+                {author ? (
+                  <React.Fragment>
+                    <span aria-hidden>·</span>
+                    <span className="inline-flex items-center gap-1">
+                      by <PubKey pubkey={author} />
+                    </span>
+                  </React.Fragment>
+                ) : null}
+                {updatedLabel ? (
+                  <React.Fragment>
+                    <span aria-hidden>·</span>
+                    <span>Updated {updatedLabel}</span>
+                  </React.Fragment>
+                ) : null}
+              </div>
+            </div>
+            <div className="flex shrink-0 flex-wrap gap-2">
+              <Button onClick={onOpenStream} size="sm" type="button">
+                <MessageSquareText className="h-4 w-4" />
+                Open stream
+              </Button>
+              <Button
+                onClick={onManageBoard}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <Settings2 className="h-4 w-4" />
+                Board settings
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {isLoading ? (
+          <div className="rounded-xl border border-border/60 bg-background/60 px-5 py-8 text-sm text-muted-foreground">
+            Loading community board…
+          </div>
+        ) : errorMessage ? (
+          <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-5 py-4 text-sm text-destructive">
+            {errorMessage}
+          </div>
+        ) : board.cards.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border bg-background/60 px-5 py-10 text-center">
+            <StickyNote className="mx-auto mb-3 h-7 w-7 text-muted-foreground" />
+            <h3 className="text-base font-semibold">
+              This board is ready for its first note.
+            </h3>
+            <p className="mx-auto mt-1 max-w-lg text-sm text-muted-foreground">
+              Add Markdown sections to the channel canvas. Each level-two
+              heading becomes a shared module here.
+            </p>
+            <Button
+              className="mt-4"
+              onClick={onManageBoard}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <Settings2 className="h-4 w-4" />
+              Open board settings
+            </Button>
+          </div>
+        ) : (
+          <div
+            className="columns-1 gap-4 md:columns-2 xl:columns-3"
+            data-testid="magic-board-grid"
+          >
+            {board.cards.map((card) => (
+              <BoardCard
+                card={card}
+                channelNames={channelNames}
+                key={card.id}
+              />
+            ))}
+            <LiveBoardCards
+              agentCount={agentCount}
+              memberCount={memberCount}
+              onOpenMembers={onOpenMembers}
+              onOpenStream={onOpenStream}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelBoardCardEditorDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoardCardEditorDialog.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+
+import {
+  type CanvasBoardCard,
+  type CanvasBoardCardDraft,
+  validateCanvasBoardCardDraft,
+} from "@/features/channels/lib/canvasBoard";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+import { Textarea } from "@/shared/ui/textarea";
+
+type ChannelBoardCardEditorDialogProps = {
+  card: CanvasBoardCard | null;
+  errorMessage: string | null;
+  isSaving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (draft: CanvasBoardCardDraft) => Promise<void>;
+  open: boolean;
+};
+
+export function ChannelBoardCardEditorDialog({
+  card,
+  errorMessage,
+  isSaving,
+  onOpenChange,
+  onSave,
+  open,
+}: ChannelBoardCardEditorDialogProps) {
+  const titleId = React.useId();
+  const bodyId = React.useId();
+  const [title, setTitle] = React.useState("");
+  const [body, setBody] = React.useState("");
+  const draft = React.useMemo(() => ({ body, title }), [body, title]);
+  const validationError = validateCanvasBoardCardDraft(draft);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setTitle(card?.title ?? "");
+    setBody(card?.body ?? "");
+  }, [card?.body, card?.title, open]);
+
+  async function handleSave(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (validationError || isSaving) {
+      return;
+    }
+
+    try {
+      await onSave({ body: body.trim(), title: title.trim() });
+    } catch {
+      // The mutation error stays visible in the dialog for a safe retry.
+    }
+  }
+
+  const isEditing = card !== null;
+
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!isSaving) {
+          onOpenChange(nextOpen);
+        }
+      }}
+      open={open}
+    >
+      <DialogContent
+        className="max-h-[calc(100vh-2rem)] max-w-xl overflow-y-auto"
+        data-testid="magic-board-card-editor"
+      >
+        <DialogHeader>
+          <DialogTitle>{isEditing ? "Edit card" : "Create card"}</DialogTitle>
+          <DialogDescription>
+            Cards are shared Markdown sections. Use level-three headings inside
+            the body; level-two headings start separate cards.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={handleSave}>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor={titleId}>
+              Title
+            </label>
+            <Input
+              autoFocus
+              data-testid="magic-board-card-title"
+              disabled={isSaving}
+              id={titleId}
+              maxLength={120}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="What should people notice?"
+              value={title}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor={bodyId}>
+              Body
+            </label>
+            <Textarea
+              className="min-h-56 font-mono text-sm"
+              data-testid="magic-board-card-body"
+              disabled={isSaving}
+              id={bodyId}
+              onChange={(event) => setBody(event.target.value)}
+              placeholder="Write the card in Markdown..."
+              value={body}
+            />
+          </div>
+
+          {validationError || errorMessage ? (
+            <p
+              className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              data-testid="magic-board-card-error"
+            >
+              {validationError ?? errorMessage}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              disabled={isSaving}
+              onClick={() => onOpenChange(false)}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              data-testid="magic-board-card-save"
+              disabled={Boolean(validationError) || isSaving}
+              type="submit"
+            >
+              {isSaving ? "Saving..." : isEditing ? "Save card" : "Create card"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelBoardCardEditorDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoardCardEditorDialog.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 import {
   type CanvasBoardCard,
   type CanvasBoardCardDraft,
+  type CanvasBoardCardStatus,
+  type CanvasBoardCardType,
   validateCanvasBoardCardDraft,
 } from "@/features/channels/lib/canvasBoard";
 import { Button } from "@/shared/ui/button";
@@ -26,6 +28,32 @@ type ChannelBoardCardEditorDialogProps = {
   open: boolean;
 };
 
+const CARD_TYPE_OPTIONS: Array<{
+  label: string;
+  value: CanvasBoardCardType;
+}> = [
+  { label: "Note", value: "note" },
+  { label: "Task", value: "task" },
+  { label: "Decision", value: "decision" },
+  { label: "Conversation", value: "conversation" },
+  { label: "Project", value: "project" },
+  { label: "Artifact", value: "artifact" },
+  { label: "Person", value: "person" },
+  { label: "Agent", value: "agent" },
+];
+
+const CARD_STATUS_OPTIONS: Array<{
+  label: string;
+  value: CanvasBoardCardStatus;
+}> = [
+  { label: "Backlog", value: "backlog" },
+  { label: "Doing", value: "doing" },
+  { label: "Done", value: "done" },
+];
+
+const SELECT_CLASS_NAME =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
 export function ChannelBoardCardEditorDialog({
   card,
   errorMessage,
@@ -38,7 +66,12 @@ export function ChannelBoardCardEditorDialog({
   const bodyId = React.useId();
   const [title, setTitle] = React.useState("");
   const [body, setBody] = React.useState("");
-  const draft = React.useMemo(() => ({ body, title }), [body, title]);
+  const [type, setType] = React.useState<CanvasBoardCardType>("note");
+  const [status, setStatus] = React.useState<CanvasBoardCardStatus>("backlog");
+  const draft = React.useMemo(
+    () => ({ body, status, title, type }),
+    [body, status, title, type],
+  );
   const validationError = validateCanvasBoardCardDraft(draft);
 
   React.useEffect(() => {
@@ -47,7 +80,9 @@ export function ChannelBoardCardEditorDialog({
     }
     setTitle(card?.title ?? "");
     setBody(card?.body ?? "");
-  }, [card?.body, card?.title, open]);
+    setType(card?.type ?? "note");
+    setStatus(card?.status ?? "backlog");
+  }, [card?.body, card?.status, card?.title, card?.type, open]);
 
   async function handleSave(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -56,7 +91,12 @@ export function ChannelBoardCardEditorDialog({
     }
 
     try {
-      await onSave({ body: body.trim(), title: title.trim() });
+      await onSave({
+        body: body.trim(),
+        status,
+        title: title.trim(),
+        type,
+      });
     } catch {
       // The mutation error stays visible in the dialog for a safe retry.
     }
@@ -100,6 +140,58 @@ export function ChannelBoardCardEditorDialog({
               placeholder="What should people notice?"
               value={title}
             />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium"
+                htmlFor={`${titleId}-type`}
+              >
+                Type
+              </label>
+              <select
+                className={SELECT_CLASS_NAME}
+                data-testid="magic-board-card-type"
+                disabled={isSaving}
+                id={`${titleId}-type`}
+                onChange={(event) =>
+                  setType(event.target.value as CanvasBoardCardType)
+                }
+                value={type}
+              >
+                {CARD_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium"
+                htmlFor={`${titleId}-status`}
+              >
+                Status
+              </label>
+              <select
+                className={SELECT_CLASS_NAME}
+                data-testid="magic-board-card-status"
+                disabled={isSaving}
+                id={`${titleId}-status`}
+                onChange={(event) =>
+                  setStatus(event.target.value as CanvasBoardCardStatus)
+                }
+                value={status}
+              >
+                {CARD_STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
 
           <div className="space-y-2">

--- a/desktop/src/features/channels/ui/ChannelBoardScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoardScreen.tsx
@@ -9,11 +9,16 @@ import {
 } from "@/features/channels/hooks";
 import {
   appendCanvasBoardCard,
+  buildCanvasBoardCardConversationOpener,
+  canvasBoardCardConversationMarker,
   type CanvasBoardCard,
   type CanvasBoardCardDraft,
+  type CanvasBoardCardStatus,
   reorderCanvasBoardCard,
   updateCanvasBoardCard,
+  updateCanvasBoardCardMetadata,
 } from "@/features/channels/lib/canvasBoard";
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
 import { ChannelBoard } from "@/features/channels/ui/ChannelBoard";
 import { ChannelBoardCardEditorDialog } from "@/features/channels/ui/ChannelBoardCardEditorDialog";
@@ -24,6 +29,8 @@ import { MembersSidebar } from "@/features/channels/ui/MembersSidebar";
 import { useChannelViewMode } from "@/features/channels/ui/ChannelViewModeContext";
 import { useCommunities } from "@/features/communities/useCommunities";
 import type { CanvasResponse, Channel } from "@/shared/api/types";
+import { relayClient } from "@/shared/api/relayClient";
+import { KIND_STREAM_MESSAGE } from "@/shared/constants/kinds";
 import {
   isRelayUnreachableError,
   RELAY_UNREACHABLE_SHORT,
@@ -51,6 +58,7 @@ export function ChannelBoardScreen({
   currentPubkey,
 }: ChannelBoardScreenProps) {
   const { activeCommunity } = useCommunities();
+  const { goChannel } = useAppNavigation();
   const queryClient = useQueryClient();
   const channelViewMode = useChannelViewMode();
   const membersQuery = useChannelMembersQuery(channel.id);
@@ -70,6 +78,8 @@ export function ChannelBoardScreen({
   const [actionErrorMessage, setActionErrorMessage] = React.useState<
     string | null
   >(null);
+  const [pendingConversationCardId, setPendingConversationCardId] =
+    React.useState<string | null>(null);
   const {
     activeChannelEphemeralDisplay,
     activeChannelTitle,
@@ -102,6 +112,8 @@ export function ChannelBoardScreen({
     channel.archivedAt === null &&
     channel.channelType !== "dm";
   const sourceContent = canvas?.content ?? "";
+  const sourceContentRef = React.useRef(sourceContent);
+  sourceContentRef.current = sourceContent;
   const isBoardSaving = setCanvasMutation.isPending;
 
   function openCreateCard() {
@@ -125,10 +137,20 @@ export function ChannelBoardScreen({
     queryClient.setQueryData<CanvasResponse>(canvasQueryKey, {
       author: currentPubkey ?? previousCanvas?.author ?? null,
       content: nextContent,
+      eventId: previousCanvas?.eventId ?? canvas?.eventId ?? null,
       updatedAt: Math.floor(Date.now() / 1_000),
     });
     try {
-      await setCanvasMutation.mutateAsync(nextContent);
+      const result = await setCanvasMutation.mutateAsync({
+        content: nextContent,
+        enforceRevision: true,
+        expectedEventId: previousCanvas?.eventId ?? canvas?.eventId ?? null,
+      });
+      queryClient.setQueryData<CanvasResponse>(canvasQueryKey, (current) =>
+        current?.content === nextContent
+          ? { ...current, eventId: result.eventId }
+          : current,
+      );
       toast.success(successMessage);
     } catch (error) {
       queryClient.setQueryData<CanvasResponse | undefined>(
@@ -156,7 +178,11 @@ export function ChannelBoardScreen({
 
     const nextContent = cardEditor.card
       ? updateCanvasBoardCard(sourceContent, cardEditor.card.id, draft)
-      : appendCanvasBoardCard(sourceContent, draft);
+      : appendCanvasBoardCard(sourceContent, {
+          ...draft,
+          author: currentPubkey ?? null,
+          id: crypto.randomUUID(),
+        });
     if (nextContent === null) {
       const message =
         "This card is no longer on the board. Reopen it and try again.";
@@ -185,6 +211,92 @@ export function ChannelBoardScreen({
       await persistCanvasContent(nextContent, "Card order saved");
     } catch {
       // The board restores the relay-backed order and shows the error inline.
+    }
+  }
+
+  async function handleChangeCardStatus(
+    card: CanvasBoardCard,
+    status: CanvasBoardCardStatus,
+  ) {
+    if (status === card.status) {
+      return;
+    }
+    const nextContent = updateCanvasBoardCardMetadata(sourceContent, card.id, {
+      status,
+    });
+    if (nextContent === null) {
+      setActionErrorMessage(
+        "This card is no longer on the board. Refresh and try again.",
+      );
+      return;
+    }
+    try {
+      await persistCanvasContent(nextContent, `Card moved to ${status}`);
+    } catch {
+      // The optimistic update rolls back and the board keeps the relay state.
+    }
+  }
+
+  function openLinkedConversation(threadId: string) {
+    channelViewMode.onModeChange("stream");
+    void goChannel(channel.id, {
+      messageId: threadId,
+      threadRootId: threadId,
+    });
+  }
+
+  async function handleOpenCardConversation(card: CanvasBoardCard) {
+    if (card.threadId) {
+      openLinkedConversation(card.threadId);
+      return;
+    }
+    if (!canEditBoard || pendingConversationCardId) {
+      return;
+    }
+
+    setActionErrorMessage(null);
+    setPendingConversationCardId(card.id);
+    try {
+      const marker = canvasBoardCardConversationMarker(card.id);
+      const existing = await relayClient.fetchFirstEvent({
+        "#client": [marker],
+        "#h": [channel.id],
+        kinds: [KIND_STREAM_MESSAGE],
+        limit: 1,
+      });
+      const thread =
+        existing ??
+        (await relayClient.sendMessage(
+          channel.id,
+          buildCanvasBoardCardConversationOpener(card, channel.name),
+          [],
+          [["client", marker]],
+        ));
+      const latestContent = sourceContentRef.current;
+      const nextContent = updateCanvasBoardCardMetadata(
+        latestContent,
+        card.id,
+        {
+          author: card.author ?? currentPubkey ?? null,
+          threadId: thread.id,
+          type: card.type === "note" ? "conversation" : card.type,
+        },
+      );
+      if (nextContent === null) {
+        throw new Error(
+          "The conversation was created, but the card changed before it could be linked. Try again to recover the existing thread.",
+        );
+      }
+      await persistCanvasContent(nextContent, "Card conversation linked");
+      openLinkedConversation(thread.id);
+    } catch (error) {
+      setActionErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Couldn’t open the card conversation.",
+      );
+    } finally {
+      setPendingConversationCardId(null);
     }
   }
 
@@ -217,14 +329,21 @@ export function ChannelBoardScreen({
           isLoading={canvasLoading}
           isSaving={isBoardSaving}
           memberCount={members.length || channel.memberCount}
+          onChangeCardStatus={(card, status) => {
+            void handleChangeCardStatus(card, status);
+          }}
           onCreateCard={openCreateCard}
           onEditCard={openEditCard}
           onManageBoard={() => setIsChannelManagementOpen(true)}
           onMoveCard={(activeCardId, overCardId) => {
             void handleMoveCard(activeCardId, overCardId);
           }}
+          onOpenCardConversation={(card) => {
+            void handleOpenCardConversation(card);
+          }}
           onOpenMembers={() => setIsMembersSidebarOpen(true)}
           onOpenStream={() => channelViewMode.onModeChange("stream")}
+          pendingConversationCardId={pendingConversationCardId}
           updatedAt={canvas?.updatedAt ?? null}
         />
       </div>

--- a/desktop/src/features/channels/ui/ChannelBoardScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoardScreen.tsx
@@ -1,12 +1,24 @@
 import * as React from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import {
   useChannelMembersQuery,
   useJoinChannelMutation,
+  useSetCanvasMutation,
 } from "@/features/channels/hooks";
+import {
+  appendCanvasBoardCard,
+  type CanvasBoardCard,
+  type CanvasBoardCardDraft,
+  reorderCanvasBoardCard,
+  updateCanvasBoardCard,
+} from "@/features/channels/lib/canvasBoard";
 import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
 import { ChannelBoard } from "@/features/channels/ui/ChannelBoard";
+import { ChannelBoardCardEditorDialog } from "@/features/channels/ui/ChannelBoardCardEditorDialog";
 import { ChannelManagementSheet } from "@/features/channels/ui/ChannelManagementSheet";
+import { useChannelModerationCapabilities } from "@/features/channels/ui/ChannelManagementModerationActions";
 import { ChannelScreenHeader } from "@/features/channels/ui/ChannelScreenHeader";
 import { MembersSidebar } from "@/features/channels/ui/MembersSidebar";
 import { useChannelViewMode } from "@/features/channels/ui/ChannelViewModeContext";
@@ -16,6 +28,7 @@ import {
   isRelayUnreachableError,
   RELAY_UNREACHABLE_SHORT,
 } from "@/shared/lib/relayError";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 
 type ChannelBoardScreenProps = {
   canvas: CanvasResponse | undefined;
@@ -23,6 +36,11 @@ type ChannelBoardScreenProps = {
   canvasLoading: boolean;
   channel: Channel;
   currentPubkey?: string;
+};
+
+type CardEditorState = {
+  baseContent: string;
+  card: CanvasBoardCard | null;
 };
 
 export function ChannelBoardScreen({
@@ -33,9 +51,11 @@ export function ChannelBoardScreen({
   currentPubkey,
 }: ChannelBoardScreenProps) {
   const { activeCommunity } = useCommunities();
+  const queryClient = useQueryClient();
   const channelViewMode = useChannelViewMode();
   const membersQuery = useChannelMembersQuery(channel.id);
   const joinChannelMutation = useJoinChannelMutation(channel.id);
+  const setCanvasMutation = useSetCanvasMutation(channel.id);
   const members = membersQuery.data ?? [];
   const agentCount = members.filter(
     (member) => member.isAgent || member.role === "bot",
@@ -44,6 +64,12 @@ export function ChannelBoardScreen({
   const [isChannelManagementOpen, setIsChannelManagementOpen] =
     React.useState(false);
   const [isAddBotOpen, setIsAddBotOpen] = React.useState(false);
+  const [cardEditor, setCardEditor] = React.useState<CardEditorState | null>(
+    null,
+  );
+  const [actionErrorMessage, setActionErrorMessage] = React.useState<
+    string | null
+  >(null);
   const {
     activeChannelEphemeralDisplay,
     activeChannelTitle,
@@ -57,6 +83,110 @@ export function ChannelBoardScreen({
         ? RELAY_UNREACHABLE_SHORT
         : canvasError.message
       : undefined;
+  const { canManageChannel } = useChannelModerationCapabilities(
+    membersQuery.data,
+    currentPubkey,
+    true,
+  );
+  const normalizedCurrentPubkey = currentPubkey
+    ? normalizePubkey(currentPubkey)
+    : null;
+  const selfMember = members.find(
+    (member) =>
+      normalizedCurrentPubkey !== null &&
+      normalizePubkey(member.pubkey) === normalizedCurrentPubkey,
+  );
+  const canEditBoard =
+    canManageChannel &&
+    selfMember !== undefined &&
+    channel.archivedAt === null &&
+    channel.channelType !== "dm";
+  const sourceContent = canvas?.content ?? "";
+  const isBoardSaving = setCanvasMutation.isPending;
+
+  function openCreateCard() {
+    setActionErrorMessage(null);
+    setCardEditor({ baseContent: sourceContent, card: null });
+  }
+
+  function openEditCard(card: CanvasBoardCard) {
+    setActionErrorMessage(null);
+    setCardEditor({ baseContent: sourceContent, card });
+  }
+
+  async function persistCanvasContent(
+    nextContent: string,
+    successMessage: string,
+  ) {
+    setActionErrorMessage(null);
+    const canvasQueryKey = ["channel-canvas", channel.id] as const;
+    const previousCanvas =
+      queryClient.getQueryData<CanvasResponse>(canvasQueryKey);
+    queryClient.setQueryData<CanvasResponse>(canvasQueryKey, {
+      author: currentPubkey ?? previousCanvas?.author ?? null,
+      content: nextContent,
+      updatedAt: Math.floor(Date.now() / 1_000),
+    });
+    try {
+      await setCanvasMutation.mutateAsync(nextContent);
+      toast.success(successMessage);
+    } catch (error) {
+      queryClient.setQueryData<CanvasResponse | undefined>(
+        canvasQueryKey,
+        (current) =>
+          current?.content === nextContent ? previousCanvas : current,
+      );
+      const message =
+        error instanceof Error ? error.message : "Couldn’t save the board.";
+      setActionErrorMessage(message);
+      throw error;
+    }
+  }
+
+  async function handleSaveCard(draft: CanvasBoardCardDraft) {
+    if (!cardEditor) {
+      return;
+    }
+    if (sourceContent !== cardEditor.baseContent) {
+      const message =
+        "This board changed while the card was open. Close and reopen the card before saving.";
+      setActionErrorMessage(message);
+      throw new Error(message);
+    }
+
+    const nextContent = cardEditor.card
+      ? updateCanvasBoardCard(sourceContent, cardEditor.card.id, draft)
+      : appendCanvasBoardCard(sourceContent, draft);
+    if (nextContent === null) {
+      const message =
+        "This card is no longer on the board. Reopen it and try again.";
+      setActionErrorMessage(message);
+      throw new Error(message);
+    }
+
+    await persistCanvasContent(
+      nextContent,
+      cardEditor.card ? "Card updated" : "Card created",
+    );
+    setCardEditor(null);
+  }
+
+  async function handleMoveCard(activeCardId: string, overCardId: string) {
+    const nextContent = reorderCanvasBoardCard(
+      sourceContent,
+      activeCardId,
+      overCardId,
+    );
+    if (nextContent === null || nextContent === sourceContent) {
+      return;
+    }
+
+    try {
+      await persistCanvasContent(nextContent, "Card order saved");
+    } catch {
+      // The board restores the relay-backed order and shows the error inline.
+    }
+  }
 
   return (
     <React.Fragment>
@@ -77,19 +207,41 @@ export function ChannelBoardScreen({
           onToggleMembers={() => setIsMembersSidebarOpen((open) => !open)}
         />
         <ChannelBoard
+          actionErrorMessage={actionErrorMessage ?? undefined}
           agentCount={agentCount}
           author={canvas?.author ?? null}
+          canEdit={canEditBoard}
           channelName={activeChannelTitle}
-          content={canvas?.content ?? null}
+          content={sourceContent}
           errorMessage={canvasErrorMessage}
           isLoading={canvasLoading}
+          isSaving={isBoardSaving}
           memberCount={members.length || channel.memberCount}
+          onCreateCard={openCreateCard}
+          onEditCard={openEditCard}
           onManageBoard={() => setIsChannelManagementOpen(true)}
+          onMoveCard={(activeCardId, overCardId) => {
+            void handleMoveCard(activeCardId, overCardId);
+          }}
           onOpenMembers={() => setIsMembersSidebarOpen(true)}
           onOpenStream={() => channelViewMode.onModeChange("stream")}
           updatedAt={canvas?.updatedAt ?? null}
         />
       </div>
+
+      <ChannelBoardCardEditorDialog
+        card={cardEditor?.card ?? null}
+        errorMessage={actionErrorMessage}
+        isSaving={isBoardSaving}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCardEditor(null);
+            setActionErrorMessage(null);
+          }
+        }}
+        onSave={handleSaveCard}
+        open={cardEditor !== null}
+      />
 
       <ChannelManagementSheet
         channel={channel}

--- a/desktop/src/features/channels/ui/ChannelBoardScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelBoardScreen.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+
+import {
+  useChannelMembersQuery,
+  useJoinChannelMutation,
+} from "@/features/channels/hooks";
+import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
+import { ChannelBoard } from "@/features/channels/ui/ChannelBoard";
+import { ChannelManagementSheet } from "@/features/channels/ui/ChannelManagementSheet";
+import { ChannelScreenHeader } from "@/features/channels/ui/ChannelScreenHeader";
+import { MembersSidebar } from "@/features/channels/ui/MembersSidebar";
+import { useChannelViewMode } from "@/features/channels/ui/ChannelViewModeContext";
+import { useCommunities } from "@/features/communities/useCommunities";
+import type { CanvasResponse, Channel } from "@/shared/api/types";
+import {
+  isRelayUnreachableError,
+  RELAY_UNREACHABLE_SHORT,
+} from "@/shared/lib/relayError";
+
+type ChannelBoardScreenProps = {
+  canvas: CanvasResponse | undefined;
+  canvasError: unknown;
+  canvasLoading: boolean;
+  channel: Channel;
+  currentPubkey?: string;
+};
+
+export function ChannelBoardScreen({
+  canvas,
+  canvasError,
+  canvasLoading,
+  channel,
+  currentPubkey,
+}: ChannelBoardScreenProps) {
+  const { activeCommunity } = useCommunities();
+  const channelViewMode = useChannelViewMode();
+  const membersQuery = useChannelMembersQuery(channel.id);
+  const joinChannelMutation = useJoinChannelMutation(channel.id);
+  const members = membersQuery.data ?? [];
+  const agentCount = members.filter(
+    (member) => member.isAgent || member.role === "bot",
+  ).length;
+  const [isMembersSidebarOpen, setIsMembersSidebarOpen] = React.useState(false);
+  const [isChannelManagementOpen, setIsChannelManagementOpen] =
+    React.useState(false);
+  const [isAddBotOpen, setIsAddBotOpen] = React.useState(false);
+  const {
+    activeChannelEphemeralDisplay,
+    activeChannelTitle,
+    activeDmAvatarUrl,
+    activeDmHeaderParticipants,
+    activeDmPresenceStatus,
+  } = useActiveChannelHeader(channel, currentPubkey);
+  const canvasErrorMessage =
+    canvasError instanceof Error
+      ? isRelayUnreachableError(canvasError)
+        ? RELAY_UNREACHABLE_SHORT
+        : canvasError.message
+      : undefined;
+
+  return (
+    <React.Fragment>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <ChannelScreenHeader
+          activeChannel={channel}
+          activeChannelEphemeralDisplay={activeChannelEphemeralDisplay}
+          activeChannelTitle={activeChannelTitle}
+          activeDmAvatarUrl={activeDmAvatarUrl}
+          activeDmHeaderParticipants={activeDmHeaderParticipants}
+          activeDmPresenceStatus={activeDmPresenceStatus}
+          currentPubkey={currentPubkey}
+          isAddBotOpen={isAddBotOpen}
+          isJoining={joinChannelMutation.isPending}
+          onAddBotOpenChange={setIsAddBotOpen}
+          onJoinChannel={joinChannelMutation.mutateAsync}
+          onManageChannel={() => setIsChannelManagementOpen(true)}
+          onToggleMembers={() => setIsMembersSidebarOpen((open) => !open)}
+        />
+        <ChannelBoard
+          agentCount={agentCount}
+          author={canvas?.author ?? null}
+          channelName={activeChannelTitle}
+          content={canvas?.content ?? null}
+          errorMessage={canvasErrorMessage}
+          isLoading={canvasLoading}
+          memberCount={members.length || channel.memberCount}
+          onManageBoard={() => setIsChannelManagementOpen(true)}
+          onOpenMembers={() => setIsMembersSidebarOpen(true)}
+          onOpenStream={() => channelViewMode.onModeChange("stream")}
+          updatedAt={canvas?.updatedAt ?? null}
+        />
+      </div>
+
+      <ChannelManagementSheet
+        channel={channel}
+        currentPubkey={currentPubkey}
+        onOpenChange={setIsChannelManagementOpen}
+        open={isChannelManagementOpen}
+      />
+      <MembersSidebar
+        channel={channel}
+        currentPubkey={currentPubkey}
+        onOpenChange={setIsMembersSidebarOpen}
+        open={isMembersSidebarOpen}
+        relayUrl={activeCommunity?.relayUrl}
+      />
+    </React.Fragment>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelCanvas.tsx
+++ b/desktop/src/features/channels/ui/ChannelCanvas.tsx
@@ -34,24 +34,48 @@ export function ChannelCanvas({
   );
   const [isEditing, setIsEditing] = React.useState(false);
   const [draft, setDraft] = React.useState("");
+  const [editingBaseContent, setEditingBaseContent] = React.useState("");
+  const [editingRevision, setEditingRevision] = React.useState<string | null>(
+    null,
+  );
+  const [localError, setLocalError] = React.useState<string | null>(null);
 
   const canvasContent = canvasQuery.data?.content ?? null;
+  const mutationErrorMessage =
+    setCanvasMutation.error instanceof Error
+      ? setCanvasMutation.error.message
+      : null;
   // Defer the single large Markdown parse so opening the canvas commits the
   // surrounding chrome immediately and the heavy render reconciles after.
   const deferredCanvasContent = React.useDeferredValue(canvasContent);
 
   function handleStartEditing() {
     setDraft(canvasContent ?? "");
+    setEditingBaseContent(canvasContent ?? "");
+    setEditingRevision(canvasQuery.data?.eventId ?? null);
+    setLocalError(null);
     setIsEditing(true);
   }
 
   function handleCancelEditing() {
     setIsEditing(false);
     setDraft("");
+    setLocalError(null);
   }
 
   async function handleSave() {
-    await setCanvasMutation.mutateAsync(draft);
+    if ((canvasContent ?? "") !== editingBaseContent) {
+      setLocalError(
+        "This canvas changed while the editor was open. Cancel and reopen it before saving.",
+      );
+      return;
+    }
+    setLocalError(null);
+    await setCanvasMutation.mutateAsync({
+      content: draft,
+      enforceRevision: true,
+      expectedEventId: editingRevision,
+    });
     setIsEditing(false);
   }
 
@@ -108,9 +132,9 @@ export function ChannelCanvas({
             Cancel
           </Button>
         </div>
-        {setCanvasMutation.error instanceof Error ? (
+        {localError || mutationErrorMessage ? (
           <p className="text-sm text-destructive">
-            {setCanvasMutation.error.message}
+            {localError ?? mutationErrorMessage}
           </p>
         ) : null}
       </div>

--- a/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
@@ -9,6 +9,7 @@ import { getDmParticipantPreview } from "@/features/channels/lib/dmParticipantDi
 import { ChannelGlyph } from "@/features/channels/ui/ChannelGlyph";
 import { ChannelHeaderStatusBadge } from "@/features/channels/ui/ChannelHeaderStatusBadge";
 import { ChannelMembersBar } from "@/features/channels/ui/ChannelMembersBar";
+import { ChannelViewModeToggle } from "@/features/channels/ui/ChannelViewModeContext";
 import {
   DEFAULT_HOVER_PROFILE_STATUS_GEOMETRY,
   ProfileAvatarWithStatus,
@@ -19,6 +20,7 @@ import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { UserNameIndicators } from "@/features/user-status/ui/UserNameIndicators";
 import { Button } from "@/shared/ui/button";
 import type { Channel, PresenceStatus } from "@/shared/api/types";
+import { useIsMobile } from "@/shared/hooks/use-mobile";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
   toggleTerminalPanel,
@@ -72,6 +74,8 @@ export function ChannelScreenHeader({
   onManageChannel,
   onToggleMembers,
 }: ChannelScreenHeaderProps) {
+  const isMobile = useIsMobile();
+  const resolvedActionsVariant = isMobile ? "compact" : actionsVariant;
   const isGroupDm =
     activeChannel?.channelType === "dm" &&
     activeDmHeaderParticipants.length > 1;
@@ -90,6 +94,7 @@ export function ChannelScreenHeader({
         terminalPanel.mode === "closed" ? "Open Buzz Term" : "Hide Buzz Term"
       }
       onClick={toggleTerminalPanel}
+      className="hidden sm:inline-flex"
       size="icon"
       title="Buzz Term (⌘J)"
       type="button"
@@ -121,15 +126,16 @@ export function ChannelScreenHeader({
         onAddBotOpenChange={onAddBotOpenChange}
         onManageChannel={onManageChannel}
         onToggleMembers={onToggleMembers}
-        variant={actionsVariant}
+        variant={resolvedActionsVariant}
       />
     )
   ) : (
     headerEndActions
   );
   const actions =
-    terminalButton || channelActions ? (
+    activeChannel || terminalButton || channelActions ? (
       <div className="flex items-center gap-1">
+        {activeChannel ? <ChannelViewModeToggle /> : null}
         {terminalButton}
         {channelActions}
       </div>

--- a/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
@@ -8,6 +8,7 @@ import { getChannelDescription } from "@/features/channels/lib/channelDescriptio
 import { getDmParticipantPreview } from "@/features/channels/lib/dmParticipantDisplay";
 import { ChannelHeaderStatusBadge } from "@/features/channels/ui/ChannelHeaderStatusBadge";
 import { ChannelMembersBar } from "@/features/channels/ui/ChannelMembersBar";
+import { ChannelViewModeToggle } from "@/features/channels/ui/ChannelViewModeContext";
 import {
   DEFAULT_HOVER_PROFILE_STATUS_GEOMETRY,
   ProfileAvatarWithStatus,
@@ -16,6 +17,7 @@ import {
 import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { Button } from "@/shared/ui/button";
 import type { Channel, PresenceStatus } from "@/shared/api/types";
+import { useIsMobile } from "@/shared/hooks/use-mobile";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
   toggleTerminalPanel,
@@ -67,6 +69,8 @@ export function ChannelScreenHeader({
   onManageChannel,
   onToggleMembers,
 }: ChannelScreenHeaderProps) {
+  const isMobile = useIsMobile();
+  const resolvedActionsVariant = isMobile ? "compact" : actionsVariant;
   const isGroupDm =
     activeChannel?.channelType === "dm" &&
     activeDmHeaderParticipants.length > 1;
@@ -85,6 +89,7 @@ export function ChannelScreenHeader({
         terminalPanel.mode === "closed" ? "Open Buzz Term" : "Hide Buzz Term"
       }
       onClick={toggleTerminalPanel}
+      className="hidden sm:inline-flex"
       size="icon"
       title="Buzz Term (⌘J)"
       type="button"
@@ -112,12 +117,13 @@ export function ChannelScreenHeader({
         onAddBotOpenChange={onAddBotOpenChange}
         onManageChannel={onManageChannel}
         onToggleMembers={onToggleMembers}
-        variant={actionsVariant}
+        variant={resolvedActionsVariant}
       />
     )
   ) : null;
   const actions = activeChannel ? (
     <div className="flex items-center gap-1">
+      <ChannelViewModeToggle />
       {terminalButton}
       {channelActions}
     </div>

--- a/desktop/src/features/channels/ui/ChannelViewModeContext.tsx
+++ b/desktop/src/features/channels/ui/ChannelViewModeContext.tsx
@@ -1,0 +1,79 @@
+import { LayoutDashboard, MessageSquareText } from "lucide-react";
+import * as React from "react";
+
+import type { ChannelViewMode } from "@/features/channels/lib/canvasBoard";
+import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+
+type ChannelViewModeContextValue = {
+  boardAvailable: boolean;
+  mode: ChannelViewMode;
+  onModeChange: (mode: ChannelViewMode) => void;
+};
+
+const ChannelViewModeContext = React.createContext<
+  ChannelViewModeContextValue | undefined
+>(undefined);
+
+export function ChannelViewModeProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: ChannelViewModeContextValue;
+}) {
+  return (
+    <ChannelViewModeContext.Provider value={value}>
+      {children}
+    </ChannelViewModeContext.Provider>
+  );
+}
+
+export function ChannelViewModeToggle() {
+  const context = React.useContext(ChannelViewModeContext);
+
+  if (!context?.boardAvailable) {
+    return null;
+  }
+
+  return (
+    <Tabs
+      onValueChange={(value) => context.onModeChange(value as ChannelViewMode)}
+      value={context.mode}
+    >
+      <TabsList
+        aria-label="Channel view"
+        className="h-8 gap-0.5 rounded-lg p-0.5"
+        data-testid="channel-view-mode"
+      >
+        <TabsTrigger
+          aria-label="Board view"
+          className="h-7 gap-1.5 px-2 text-xs"
+          data-testid="channel-view-board"
+          value="board"
+        >
+          <LayoutDashboard className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">Board</span>
+        </TabsTrigger>
+        <TabsTrigger
+          aria-label="Stream view"
+          className="h-7 gap-1.5 px-2 text-xs"
+          data-testid="channel-view-stream"
+          value="stream"
+        >
+          <MessageSquareText className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">Stream</span>
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}
+
+export function useChannelViewMode(): ChannelViewModeContextValue {
+  const context = React.useContext(ChannelViewModeContext);
+  if (!context) {
+    throw new Error(
+      "useChannelViewMode must be used inside ChannelViewModeProvider",
+    );
+  }
+  return context;
+}

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -235,6 +235,7 @@ type RawListRelayMembersResponse = {
 
 type RawCanvasResponse = {
   content: string | null;
+  event_id: string | null;
   updated_at: number | null;
   author: string | null;
 };
@@ -406,6 +407,7 @@ export async function getCanvas(channelId: string): Promise<CanvasResponse> {
   });
   return {
     content: response.content,
+    eventId: response.event_id ?? null,
     // Normalize absent keys to null: ensureWelcomeCanvas treats null as
     // "no canvas yet", and `undefined !== null` would make every fresh
     // channel look already-seeded.
@@ -420,6 +422,8 @@ export async function setCanvas(
   const response = await invokeTauri<RawSetCanvasResult>("set_canvas", {
     channelId: input.channelId,
     content: input.content,
+    enforceRevision: input.enforceRevision ?? false,
+    expectedEventId: input.expectedEventId ?? null,
   });
   return {
     ok: response.ok,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -70,6 +70,7 @@ export type SetChannelPurposeInput = {
 };
 
 export type CanvasResponse = {
+  eventId: string | null;
   content: string | null;
   updatedAt: number | null;
   author: string | null;
@@ -78,6 +79,8 @@ export type CanvasResponse = {
 export type SetCanvasInput = {
   channelId: string;
   content: string;
+  enforceRevision?: boolean;
+  expectedEventId?: string | null;
 };
 
 export type SetCanvasResult = {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -370,6 +370,11 @@ type E2eConfig = {
     /** Number of seeded rows in the deep-history fixture. Defaults to 600. */
     deepHistoryMessageCount?: number;
     feedReadError?: string;
+    canvas?: {
+      author?: string | null;
+      content: string | null;
+      updatedAt?: number | null;
+    };
     canvasReadError?: string;
     /** Delay (ms) for `apply_workspace` so e2e tests can observe the
      *  community-switch gate. 0/undefined = instant. */
@@ -1508,6 +1513,7 @@ declare global {
       channelId: string;
       channelType?: "stream" | "forum" | "dm";
       description?: string;
+      name?: string;
       removeMemberPubkey?: string;
     }) => void;
     /**
@@ -11573,6 +11579,7 @@ export function maybeInstallE2eTauriMocks() {
     channelId,
     channelType,
     description,
+    name,
     removeMemberPubkey,
   }) => {
     const channel = mockChannels.find((ch) => ch.id === channelId);
@@ -11582,6 +11589,9 @@ export function maybeInstallE2eTauriMocks() {
     }
     if (description !== undefined) {
       channel.description = description;
+    }
+    if (name !== undefined) {
+      channel.name = name;
     }
     if (removeMemberPubkey !== undefined) {
       channel.members = channel.members.filter(
@@ -14659,15 +14669,29 @@ export function maybeInstallE2eTauriMocks() {
         // The spec only verifies UI state, not the submitted request shape;
         // returning null mirrors the Rust submit_event success path.
         return null;
-      case "set_canvas":
+      case "set_canvas": {
+        const input = payload as { content: string };
+        if (activeConfig) {
+          activeConfig.mock ??= {};
+          activeConfig.mock.canvas = {
+            author: identity?.pubkey ?? null,
+            content: input.content,
+            updatedAt: Math.floor(Date.now() / 1_000),
+          };
+        }
         return { ok: true, event_id: mockEventId() };
+      }
       case "get_canvas": {
         const canvasReadError = activeConfig?.mock?.canvasReadError;
         if (canvasReadError) {
           throw new Error(canvasReadError);
         }
-        // Return the no-canvas success shape — content null means no canvas set.
-        return { content: null, updated_at: null, author: null };
+        const canvas = activeConfig?.mock?.canvas;
+        return {
+          content: canvas?.content ?? null,
+          updated_at: canvas?.updatedAt ?? null,
+          author: canvas?.author ?? null,
+        };
       }
       // ── Local-save archive ──────────────────────────────────────────────
       // These stubs drive the LocalArchiveSettingsCard in screenshot / UI tests

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -373,6 +373,7 @@ type E2eConfig = {
     canvas?: {
       author?: string | null;
       content: string | null;
+      eventId?: string | null;
       updatedAt?: number | null;
     };
     canvasReadError?: string;
@@ -14670,16 +14671,28 @@ export function maybeInstallE2eTauriMocks() {
         // returning null mirrors the Rust submit_event success path.
         return null;
       case "set_canvas": {
-        const input = payload as { content: string };
+        const input = payload as {
+          content: string;
+          enforceRevision?: boolean;
+          expectedEventId?: string | null;
+        };
+        const currentEventId = activeConfig?.mock?.canvas?.eventId ?? null;
+        if (input.enforceRevision && input.expectedEventId !== currentEventId) {
+          throw new Error(
+            "Canvas revision conflict: the board changed before this save.",
+          );
+        }
+        const eventId = mockEventId();
         if (activeConfig) {
           activeConfig.mock ??= {};
           activeConfig.mock.canvas = {
             author: identity?.pubkey ?? null,
             content: input.content,
+            eventId,
             updatedAt: Math.floor(Date.now() / 1_000),
           };
         }
-        return { ok: true, event_id: mockEventId() };
+        return { ok: true, event_id: eventId };
       }
       case "get_canvas": {
         const canvasReadError = activeConfig?.mock?.canvasReadError;
@@ -14689,6 +14702,7 @@ export function maybeInstallE2eTauriMocks() {
         const canvas = activeConfig?.mock?.canvas;
         return {
           content: canvas?.content ?? null,
+          event_id: canvas?.eventId ?? null,
           updated_at: canvas?.updatedAt ?? null,
           author: canvas?.author ?? null,
         };

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -312,6 +312,11 @@ type E2eConfig = {
     /** Number of seeded rows in the deep-history fixture. Defaults to 600. */
     deepHistoryMessageCount?: number;
     feedReadError?: string;
+    canvas?: {
+      author?: string | null;
+      content: string | null;
+      updatedAt?: number | null;
+    };
     canvasReadError?: string;
     /** Delay (ms) for `apply_workspace` so e2e tests can observe the
      *  community-switch gate. 0/undefined = instant. */
@@ -1331,6 +1336,7 @@ declare global {
     __BUZZ_E2E_MUTATE_CHANNEL__?: (opts: {
       channelId: string;
       channelType?: "stream" | "forum" | "dm";
+      name?: string;
       removeMemberPubkey?: string;
     }) => void;
     /**
@@ -10198,12 +10204,16 @@ export function maybeInstallE2eTauriMocks() {
   window.__BUZZ_E2E_MUTATE_CHANNEL__ = ({
     channelId,
     channelType,
+    name,
     removeMemberPubkey,
   }) => {
     const channel = mockChannels.find((ch) => ch.id === channelId);
     if (!channel) return;
     if (channelType !== undefined) {
       channel.channel_type = channelType;
+    }
+    if (name !== undefined) {
+      channel.name = name;
     }
     if (removeMemberPubkey !== undefined) {
       channel.members = channel.members.filter(
@@ -12914,15 +12924,29 @@ export function maybeInstallE2eTauriMocks() {
         // The spec only verifies UI state, not the submitted request shape;
         // returning null mirrors the Rust submit_event success path.
         return null;
-      case "set_canvas":
+      case "set_canvas": {
+        const input = payload as { content: string };
+        if (activeConfig) {
+          activeConfig.mock ??= {};
+          activeConfig.mock.canvas = {
+            author: identity?.pubkey ?? null,
+            content: input.content,
+            updatedAt: Math.floor(Date.now() / 1_000),
+          };
+        }
         return { ok: true, event_id: mockEventId() };
+      }
       case "get_canvas": {
         const canvasReadError = activeConfig?.mock?.canvasReadError;
         if (canvasReadError) {
           throw new Error(canvasReadError);
         }
-        // Return the no-canvas success shape — content null means no canvas set.
-        return { content: null, updated_at: null, author: null };
+        const canvas = activeConfig?.mock?.canvas;
+        return {
+          content: canvas?.content ?? null,
+          updated_at: canvas?.updatedAt ?? null,
+          author: canvas?.author ?? null,
+        };
       }
       // ── Local-save archive ──────────────────────────────────────────────
       // These stubs drive the LocalArchiveSettingsCard in screenshot / UI tests

--- a/desktop/tests/e2e/magic-board.spec.ts
+++ b/desktop/tests/e2e/magic-board.spec.ts
@@ -1,0 +1,185 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const DISPATCH_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const DISPATCH_CANVAS = `# Dispatch — Open Studio 001
+
+Bring one seed. Leave with one small, shareable artifact.
+
+## This week at Sweet Works
+
+**Open Studio 001: One Seed, One Artifact** is active now.
+
+## Start here
+
+1. Read the welcome.
+2. Open a Workshop thread.
+3. Name one finish line.
+
+## Help wanted
+
+Use 👋 for “I can help,” then name what you can offer.
+
+## Finished example
+
+**Ora #5821 — The Smallest Edge of Day** completed the full loop.
+
+## Next pilot action
+
+Invite the first 12–20 participants after the example is accessible.
+`;
+
+async function openDispatchRoute(page: Page, search = "") {
+  await page.goto("/");
+  await expect(page.getByTestId("home-inbox")).toBeVisible();
+  await page.evaluate(
+    async ({ channelId, search }) => {
+      window.__BUZZ_E2E_MUTATE_CHANNEL__?.({
+        channelId,
+        name: "Dispatch",
+      });
+      await window.__BUZZ_E2E_INVALIDATE_CHANNELS__?.();
+      window.location.hash = `#/channels/${channelId}${search}`;
+    },
+    { channelId: DISPATCH_CHANNEL_ID, search },
+  );
+}
+
+async function openDispatchBoard(page: Page) {
+  await openDispatchRoute(page);
+  await expect(page.getByTestId("channel-magic-board")).toBeVisible();
+}
+
+async function captureBoard(page: Page, testInfo: TestInfo, name: string) {
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: testInfo.outputPath(`${name}.png`),
+    fullPage: true,
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page, {
+    canvas: {
+      author: TEST_IDENTITIES.tyler.pubkey,
+      content: DISPATCH_CANVAS,
+      updatedAt: 1_786_336_800,
+    },
+    managedAgents: [
+      {
+        channelIds: [DISPATCH_CHANNEL_ID],
+        channelNames: ["Dispatch"],
+        name: "Charlie",
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        status: "running",
+      },
+    ],
+  });
+});
+
+test("Dispatch opens as a board and keeps the stream one click away", async ({
+  page,
+}, testInfo) => {
+  await openDispatchBoard(page);
+
+  await expect(page.getByTestId("channel-view-board")).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+  await expect(
+    page.getByRole("heading", { name: "Dispatch — Open Studio 001" }),
+  ).toBeVisible();
+  await expect(page.getByText("This week at Sweet Works")).toBeVisible();
+  await expect(page.getByTestId("magic-board-card-start-here-2")).toBeVisible();
+  await expect(
+    page.getByTestId("magic-board-card-help-wanted-3"),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Finished example", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("5 members · 3 agents tending this room."),
+  ).toBeVisible();
+
+  await captureBoard(page, testInfo, "magic-board-desktop");
+
+  await page.getByTestId("channel-view-stream").click();
+  await expect(page.getByTestId("channel-magic-board")).toBeHidden();
+  await expect(page.getByText("Welcome to #general")).toBeVisible();
+
+  await page.getByTestId("channel-view-board").click();
+  await expect(page.getByTestId("channel-magic-board")).toBeVisible();
+});
+
+test("Dispatch board stacks cleanly at a narrow viewport", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openDispatchBoard(page);
+
+  const title = page.getByTestId("chat-title");
+  await expect(title).toHaveText("Dispatch");
+  await expect
+    .poll(() =>
+      title.evaluate((element) => element.clientWidth >= element.scrollWidth),
+    )
+    .toBe(true);
+
+  const grid = page.getByTestId("magic-board-grid");
+  await expect(grid).toBeVisible();
+  const firstCard = page.getByTestId(
+    "magic-board-card-this-week-at-sweet-works-1",
+  );
+  const secondCard = page.getByTestId("magic-board-card-start-here-2");
+  const [firstBox, secondBox] = await Promise.all([
+    firstCard.boundingBox(),
+    secondCard.boundingBox(),
+  ]);
+  expect(firstBox).not.toBeNull();
+  expect(secondBox).not.toBeNull();
+  expect(secondBox?.y ?? 0).toBeGreaterThan(
+    (firstBox?.y ?? 0) + (firstBox?.height ?? 0),
+  );
+
+  await captureBoard(page, testInfo, "magic-board-narrow");
+});
+
+test("a Dispatch message deep link opens the stream instead of hiding its target", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  await page.evaluate(async (channelId) => {
+    window.__BUZZ_E2E_MUTATE_CHANNEL__?.({
+      channelId,
+      name: "Dispatch",
+    });
+    await window.__BUZZ_E2E_INVALIDATE_CHANNELS__?.();
+    window.location.hash = `#/channels/${channelId}?messageId=mock-general-welcome`;
+  }, DISPATCH_CHANNEL_ID);
+
+  await expect(page.getByText("Welcome to #general")).toBeVisible();
+  await expect(page.getByTestId("channel-magic-board")).toBeHidden();
+  await expect(page.getByTestId("channel-view-mode")).toBeHidden();
+});
+
+test("Dispatch Stream-owned route intents are never masked by the board", async ({
+  page,
+}) => {
+  await openDispatchRoute(page, "?autoSend=channel%3Adispatch-draft");
+  await expect(page.getByText("Welcome to #general")).toBeVisible();
+  await expect(page.getByTestId("channel-magic-board")).toBeHidden();
+
+  await openDispatchRoute(page, `?profile=${TEST_IDENTITIES.bob.pubkey}`);
+  await expect(page.getByTestId("user-profile-panel")).toBeVisible();
+  await expect(page.getByTestId("channel-magic-board")).toBeHidden();
+
+  await openDispatchRoute(
+    page,
+    `?agentSession=${TEST_IDENTITIES.charlie.pubkey}`,
+  );
+  await expect(page.getByTestId("agent-session-thread-panel")).toBeVisible();
+  await expect(page.getByTestId("channel-magic-board")).toBeHidden();
+});

--- a/desktop/tests/e2e/magic-board.spec.ts
+++ b/desktop/tests/e2e/magic-board.spec.ts
@@ -65,6 +65,7 @@ test.beforeEach(async ({ page }) => {
     canvas: {
       author: TEST_IDENTITIES.tyler.pubkey,
       content: DISPATCH_CANVAS,
+      eventId: "c".repeat(64),
       updatedAt: 1_786_336_800,
     },
     managedAgents: [
@@ -121,7 +122,17 @@ test("Dispatch opens as a board and keeps the stream one click away", async ({
   await expect(page.getByTestId("channel-magic-board")).toBeHidden();
   await expect(page.getByText("Welcome to #general")).toBeVisible();
 
+  await openDispatchRoute(page);
+  await expect(page.getByTestId("channel-magic-board")).toBeHidden();
+  await expect(page.getByTestId("channel-view-stream")).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+
   await page.getByTestId("channel-view-board").click();
+  await expect(page.getByTestId("channel-magic-board")).toBeVisible();
+
+  await openDispatchRoute(page);
   await expect(page.getByTestId("channel-magic-board")).toBeVisible();
 });
 
@@ -179,32 +190,40 @@ test("a steward can create, edit, and drag a card into a durable order", async (
   await page
     .getByTestId("magic-board-card-body")
     .fill("A **new** shared card written from the Board.");
+  await page.getByTestId("magic-board-card-type").selectOption("task");
+  await page.getByTestId("magic-board-card-status").selectOption("doing");
   await page.getByTestId("magic-board-card-save").click();
 
-  const createdCard = page.getByTestId("magic-board-card-fresh-signal-6");
+  const createdCard = page
+    .locator("[data-testid^='magic-board-card-']")
+    .filter({ hasText: "Fresh signal" });
   await expect(createdCard).toContainText("Fresh signal");
   await expect(createdCard).toContainText(
     "A new shared card written from the Board.",
   );
+  await expect(createdCard).toHaveAttribute("data-board-type", "task");
+  await expect(createdCard).toHaveAttribute("data-board-status", "doing");
+  const createdTestId = await createdCard.getAttribute("data-testid");
+  expect(createdTestId).toMatch(/^magic-board-card-/u);
+  const createdId = createdTestId?.replace("magic-board-card-", "");
+  if (!createdId) {
+    throw new Error("Created card did not expose its durable id.");
+  }
 
-  await page.getByTestId("magic-board-edit-fresh-signal-6").click();
+  await page.getByTestId(`magic-board-edit-${createdId}`).click();
   await page.getByTestId("magic-board-card-title").fill("Fresh signal updated");
   await page
     .getByTestId("magic-board-card-body")
     .fill("Edited **in place** without opening raw canvas settings.");
   await page.getByTestId("magic-board-card-save").click();
 
-  const updatedCard = page.getByTestId(
-    "magic-board-card-fresh-signal-updated-6",
-  );
+  const updatedCard = page.getByTestId(`magic-board-card-${createdId}`);
   await expect(updatedCard).toContainText("Fresh signal updated");
   await expect(updatedCard).toContainText(
     "Edited in place without opening raw canvas settings.",
   );
 
-  const dragHandle = page.getByTestId(
-    "magic-board-drag-fresh-signal-updated-6",
-  );
+  const dragHandle = page.getByTestId(`magic-board-drag-${createdId}`);
   await expect(dragHandle).toBeEnabled();
   const firstCard = page.getByTestId(
     "magic-board-card-this-week-at-sweet-works-1",
@@ -243,7 +262,7 @@ test("a steward can create, edit, and drag a card into a durable order", async (
         ),
     )
     .toEqual([
-      "magic-board-card-fresh-signal-updated-1",
+      `magic-board-card-${createdId}`,
       "magic-board-card-this-week-at-sweet-works-2",
       "magic-board-card-start-here-3",
       "magic-board-card-help-wanted-4",
@@ -274,9 +293,123 @@ test("a steward can create, edit, and drag a card into a durable order", async (
 
   await page.getByTestId("channel-view-stream").click();
   await page.getByTestId("channel-view-board").click();
-  await expect(
-    page.getByTestId("magic-board-card-fresh-signal-updated-1"),
-  ).toBeVisible();
+  await expect(page.getByTestId(`magic-board-card-${createdId}`)).toBeVisible();
+});
+
+test("Kanban moves a card between workflow states and persists metadata", async ({
+  page,
+}) => {
+  await openDispatchBoard(page);
+  await page.getByTestId("magic-board-layout-kanban").click();
+
+  const dragHandle = page.getByTestId(
+    "magic-board-drag-this-week-at-sweet-works-1",
+  );
+  const doneCard = page.getByTestId("magic-board-card-finished-example-4");
+  const [dragBox, targetBox] = await Promise.all([
+    dragHandle.boundingBox(),
+    doneCard.boundingBox(),
+  ]);
+  expect(dragBox).not.toBeNull();
+  expect(targetBox).not.toBeNull();
+  if (!dragBox || !targetBox) {
+    throw new Error("Kanban drag geometry is unavailable.");
+  }
+
+  await dragHandle.hover();
+  await page.mouse.down();
+  await page.mouse.move(
+    dragBox.x + dragBox.width / 2,
+    dragBox.y + dragBox.height / 2 + 8,
+    { steps: 8 },
+  );
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 20 },
+  );
+  await page.mouse.up();
+
+  const movedCard = page.getByTestId(
+    "magic-board-card-this-week-at-sweet-works-1",
+  );
+  await expect(movedCard).toHaveAttribute("data-board-status", "done");
+  const storedCanvas = await page.evaluate(async (channelId) => {
+    const invoke = (
+      window as Window & {
+        __TAURI_INTERNALS__?: {
+          invoke: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error("Tauri invoke bridge is unavailable.");
+    return invoke("get_canvas", { channelId }) as Promise<{ content: string }>;
+  }, DISPATCH_CHANNEL_ID);
+  expect(storedCanvas.content).toContain('"status":"done"');
+});
+
+test("a card creates one linked work-room thread and opens it", async ({
+  page,
+}) => {
+  await openDispatchBoard(page);
+
+  await page.getByTestId("magic-board-conversation-start-here-2").click();
+  await expect(page.getByTestId("channel-magic-board")).toBeHidden();
+  await expect(page.getByTestId("message-thread-panel")).toBeVisible();
+  await expect(page).toHaveURL(/[?&]thread=[0-9a-f]{64}/u);
+
+  const storedCanvas = await page.evaluate(async (channelId) => {
+    const invoke = (
+      window as Window & {
+        __TAURI_INTERNALS__?: {
+          invoke: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error("Tauri invoke bridge is unavailable.");
+    return invoke("get_canvas", { channelId }) as Promise<{ content: string }>;
+  }, DISPATCH_CHANNEL_ID);
+  expect(storedCanvas.content).toMatch(
+    /"id":"start-here-2".*"thread":"[0-9a-f]{64}"/u,
+  );
+});
+
+test("a live canvas change blocks a stale card editor save", async ({
+  page,
+}) => {
+  await openDispatchBoard(page);
+  await page.getByTestId("magic-board-edit-start-here-2").click();
+  await page.getByTestId("magic-board-card-title").fill("Stale local edit");
+
+  await page.evaluate(
+    ({ content, pubkey }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "Dispatch",
+        content,
+        createdAt: Math.floor(Date.now() / 1_000) + 10,
+        id: "d".repeat(64),
+        kind: 40100,
+        pubkey,
+      });
+    },
+    {
+      content: `${DISPATCH_CANVAS}\n## Remote update\n\nA teammate arrived first.\n`,
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+    },
+  );
+  await expect(page.getByTestId("magic-board-card-editor")).toBeVisible();
+  await page.getByTestId("magic-board-card-save").click();
+
+  await expect(page.getByTestId("magic-board-card-error")).toContainText(
+    "This board changed while the card was open",
+  );
+  await expect(page.getByTestId("magic-board-card-editor")).toBeVisible();
 });
 
 test("board mutation controls stay hidden from non-stewards", async ({

--- a/desktop/tests/e2e/magic-board.spec.ts
+++ b/desktop/tests/e2e/magic-board.spec.ts
@@ -103,6 +103,18 @@ test("Dispatch opens as a board and keeps the stream one click away", async ({
     page.getByText("5 members · 3 agents tending this room."),
   ).toBeVisible();
 
+  const authoredCards = page.locator("[data-testid^='magic-board-card-']");
+  await expect(authoredCards).toHaveCount(5);
+  for (const card of await authoredCards.all()) {
+    await card.hover();
+    await expect(card).toBeVisible();
+    await expect
+      .poll(() =>
+        card.evaluate((element) => getComputedStyle(element).transform),
+      )
+      .toBe("none");
+  }
+
   await captureBoard(page, testInfo, "magic-board-desktop");
 
   await page.getByTestId("channel-view-stream").click();

--- a/desktop/tests/e2e/magic-board.spec.ts
+++ b/desktop/tests/e2e/magic-board.spec.ts
@@ -156,6 +156,163 @@ test("Dispatch board stacks cleanly at a narrow viewport", async ({
   );
 
   await captureBoard(page, testInfo, "magic-board-narrow");
+
+  await page.getByTestId("magic-board-create-card").click();
+  const editor = page.getByTestId("magic-board-card-editor");
+  await expect(editor).toBeVisible();
+  const editorBox = await editor.boundingBox();
+  expect(editorBox).not.toBeNull();
+  expect(editorBox?.width ?? 391).toBeLessThanOrEqual(358);
+  await expect(page.getByTestId("magic-board-card-save")).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(editor).toBeHidden();
+});
+
+test("a steward can create, edit, and drag a card into a durable order", async ({
+  page,
+}) => {
+  await openDispatchBoard(page);
+
+  await page.getByTestId("magic-board-create-card").click();
+  await expect(page.getByTestId("magic-board-card-editor")).toBeVisible();
+  await page.getByTestId("magic-board-card-title").fill("Fresh signal");
+  await page
+    .getByTestId("magic-board-card-body")
+    .fill("A **new** shared card written from the Board.");
+  await page.getByTestId("magic-board-card-save").click();
+
+  const createdCard = page.getByTestId("magic-board-card-fresh-signal-6");
+  await expect(createdCard).toContainText("Fresh signal");
+  await expect(createdCard).toContainText(
+    "A new shared card written from the Board.",
+  );
+
+  await page.getByTestId("magic-board-edit-fresh-signal-6").click();
+  await page.getByTestId("magic-board-card-title").fill("Fresh signal updated");
+  await page
+    .getByTestId("magic-board-card-body")
+    .fill("Edited **in place** without opening raw canvas settings.");
+  await page.getByTestId("magic-board-card-save").click();
+
+  const updatedCard = page.getByTestId(
+    "magic-board-card-fresh-signal-updated-6",
+  );
+  await expect(updatedCard).toContainText("Fresh signal updated");
+  await expect(updatedCard).toContainText(
+    "Edited in place without opening raw canvas settings.",
+  );
+
+  const dragHandle = page.getByTestId(
+    "magic-board-drag-fresh-signal-updated-6",
+  );
+  await expect(dragHandle).toBeEnabled();
+  const firstCard = page.getByTestId(
+    "magic-board-card-this-week-at-sweet-works-1",
+  );
+  const [dragBox, targetBox] = await Promise.all([
+    dragHandle.boundingBox(),
+    firstCard.boundingBox(),
+  ]);
+  expect(dragBox).not.toBeNull();
+  expect(targetBox).not.toBeNull();
+  if (!dragBox || !targetBox) {
+    throw new Error("Board drag geometry is unavailable.");
+  }
+
+  await dragHandle.hover();
+  await page.mouse.down();
+  await page.mouse.move(
+    dragBox.x + dragBox.width / 2,
+    dragBox.y + dragBox.height / 2 - 8,
+    { steps: 8 },
+  );
+  await expect(page.getByTestId("magic-board-drag-overlay")).toBeVisible();
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 20 },
+  );
+  await page.mouse.up();
+
+  await expect
+    .poll(() =>
+      page
+        .locator("[data-board-kind]")
+        .evaluateAll((cards) =>
+          cards.map((card) => card.getAttribute("data-testid")),
+        ),
+    )
+    .toEqual([
+      "magic-board-card-fresh-signal-updated-1",
+      "magic-board-card-this-week-at-sweet-works-2",
+      "magic-board-card-start-here-3",
+      "magic-board-card-help-wanted-4",
+      "magic-board-card-finished-example-5",
+      "magic-board-card-next-pilot-action-6",
+    ]);
+
+  const storedCanvas = await page.evaluate(async (channelId) => {
+    const tauriWindow = window as Window & {
+      __TAURI_INTERNALS__?: {
+        invoke: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+      };
+    };
+    const invoke = tauriWindow.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) {
+      throw new Error("Tauri invoke bridge is unavailable.");
+    }
+    return invoke("get_canvas", { channelId }) as Promise<{
+      content: string;
+    }>;
+  }, DISPATCH_CHANNEL_ID);
+  expect(storedCanvas.content.indexOf("## Fresh signal updated")).toBeLessThan(
+    storedCanvas.content.indexOf("## This week at Sweet Works"),
+  );
+
+  await page.getByTestId("channel-view-stream").click();
+  await page.getByTestId("channel-view-board").click();
+  await expect(
+    page.getByTestId("magic-board-card-fresh-signal-updated-1"),
+  ).toBeVisible();
+});
+
+test("board mutation controls stay hidden from non-stewards", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByTestId("home-inbox")).toBeVisible();
+  await page.evaluate(async (channelId) => {
+    const tauriWindow = window as Window & {
+      __TAURI_INTERNALS__?: {
+        invoke: (command: string) => Promise<unknown>;
+      };
+    };
+    const identity = (await tauriWindow.__TAURI_INTERNALS__?.invoke(
+      "get_identity",
+    )) as { pubkey: string } | undefined;
+    if (!identity) {
+      throw new Error("Mock identity is unavailable.");
+    }
+    window.__BUZZ_E2E_MUTATE_CHANNEL__?.({
+      channelId,
+      name: "Dispatch",
+      removeMemberPubkey: identity.pubkey,
+    });
+    await window.__BUZZ_E2E_INVALIDATE_CHANNELS__?.();
+    window.location.hash = `#/channels/${channelId}`;
+  }, DISPATCH_CHANNEL_ID);
+
+  await expect(page.getByTestId("channel-magic-board")).toBeVisible();
+  await expect(page.getByTestId("magic-board-create-card")).toHaveCount(0);
+  await expect(page.locator("[data-testid^='magic-board-edit-']")).toHaveCount(
+    0,
+  );
+  await expect(page.locator("[data-testid^='magic-board-drag-']")).toHaveCount(
+    0,
+  );
 });
 
 test("a Dispatch message deep link opens the stream instead of hiding its target", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -290,6 +290,7 @@ type MockBridgeOptions = {
   canvas?: {
     author?: string | null;
     content: string | null;
+    eventId?: string | null;
     updatedAt?: number | null;
   };
   canvasReadError?: string;

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -287,6 +287,11 @@ type MockBridgeOptions = {
   /** Number of seeded rows in the deep-history fixture. Defaults to 600. */
   deepHistoryMessageCount?: number;
   feedReadError?: string;
+  canvas?: {
+    author?: string | null;
+    content: string | null;
+    updatedAt?: number | null;
+  };
   canvasReadError?: string;
   /** Delay (ms) for `apply_workspace`; see e2eBridge mock config. */
   applyCommunityDelayMs?: number;

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -270,6 +270,11 @@ type MockBridgeOptions = {
   /** Number of seeded rows in the deep-history fixture. Defaults to 600. */
   deepHistoryMessageCount?: number;
   feedReadError?: string;
+  canvas?: {
+    author?: string | null;
+    content: string | null;
+    updatedAt?: number | null;
+  };
   canvasReadError?: string;
   /** Delay (ms) for `apply_workspace`; see e2eBridge mock config. */
   applyCommunityDelayMs?: number;

--- a/mobile/lib/features/channels/canvas_board.dart
+++ b/mobile/lib/features/channels/canvas_board.dart
@@ -1,0 +1,290 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+enum CanvasBoardCardType {
+  agent,
+  artifact,
+  conversation,
+  decision,
+  note,
+  person,
+  project,
+  task,
+}
+
+enum CanvasBoardCardStatus { backlog, doing, done }
+
+enum ChannelCanvasView { board, stream }
+
+@immutable
+class CanvasBoardCard {
+  final String id;
+  final String title;
+  final String body;
+  final CanvasBoardCardType type;
+  final CanvasBoardCardStatus status;
+  final String? threadId;
+  final String? authorPubkey;
+
+  const CanvasBoardCard({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.type,
+    required this.status,
+    this.threadId,
+    this.authorPubkey,
+  });
+}
+
+@immutable
+class CanvasBoard {
+  final String? title;
+  final String introduction;
+  final List<CanvasBoardCard> cards;
+
+  const CanvasBoard({
+    required this.title,
+    required this.introduction,
+    required this.cards,
+  });
+}
+
+const channelCanvasViewPreferencePrefix = 'buzz.channelViewMode.v1';
+
+String channelCanvasViewPreferenceKey(String channelId) =>
+    '$channelCanvasViewPreferencePrefix.$channelId';
+
+bool channelHasCanvasBoard({
+  required String channelName,
+  required bool isDm,
+  required String? content,
+}) {
+  if (isDm) return false;
+  final canonicalName = channelName.replaceFirst(RegExp(r'^[#\s]+'), '').trim();
+  return content?.trim().isNotEmpty == true ||
+      canonicalName.toLowerCase() == 'dispatch';
+}
+
+ChannelCanvasView initialChannelCanvasView({
+  required String channelName,
+  required String? storedValue,
+}) {
+  if (storedValue == ChannelCanvasView.board.name) {
+    return ChannelCanvasView.board;
+  }
+  if (storedValue == ChannelCanvasView.stream.name) {
+    return ChannelCanvasView.stream;
+  }
+  final canonicalName = channelName.replaceFirst(RegExp(r'^[#\s]+'), '').trim();
+  return canonicalName.toLowerCase() == 'dispatch'
+      ? ChannelCanvasView.board
+      : ChannelCanvasView.stream;
+}
+
+final _h1Pattern = RegExp(r'^#\s+(.+?)\s*#*\s*$');
+final _h2Pattern = RegExp(r'^##\s+(.+?)\s*#*\s*$');
+final _fenceOpenPattern = RegExp(r'^ {0,3}(`{3,}|~{3,})');
+final _fenceClosePattern = RegExp(r'^ {0,3}(`{3,}|~{3,})[ \t]*$');
+final _metadataPattern = RegExp(
+  r'^\s*<!--\s*buzz-board-card\s+(\{.*\})\s*-->\s*$',
+);
+final _cardIdPattern = RegExp(r'^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$');
+final _eventIdPattern = RegExp(r'^[0-9a-f]{64}$');
+
+class _SourceSection {
+  final String title;
+  final List<String> bodyLines;
+
+  _SourceSection(this.title) : bodyLines = [];
+}
+
+String _derivedCardId(String title, int index) {
+  final slug = title
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+      .replaceAll(RegExp(r'^-|-$'), '');
+  return '${slug.isEmpty ? 'card' : slug}-${index + 1}';
+}
+
+CanvasBoardCardType _inferCardType(String title) {
+  final normalized = title.toLowerCase();
+  if (RegExp(r'\b(agent|bot|berd)\b').hasMatch(normalized)) {
+    return CanvasBoardCardType.agent;
+  }
+  if (RegExp(
+    r'\b(person|people|member|steward|contributor)\b',
+  ).hasMatch(normalized)) {
+    return CanvasBoardCardType.person;
+  }
+  if (RegExp(r'\b(decision|decide|approved|verdict)\b').hasMatch(normalized)) {
+    return CanvasBoardCardType.decision;
+  }
+  if (RegExp(
+    r'\b(conversation|discussion|thread|work room)\b',
+  ).hasMatch(normalized)) {
+    return CanvasBoardCardType.conversation;
+  }
+  if (RegExp(
+    r'\b(project|initiative|program|campaign)\b',
+  ).hasMatch(normalized)) {
+    return CanvasBoardCardType.project;
+  }
+  if (RegExp(
+    r'\b(finished|made|shipped|artifact|showcase)\b',
+  ).hasMatch(normalized)) {
+    return CanvasBoardCardType.artifact;
+  }
+  if (RegExp(
+    r'\b(task|todo|to-do|help|join|next|action|now|today|week|current|active)\b',
+  ).hasMatch(normalized)) {
+    return CanvasBoardCardType.task;
+  }
+  return CanvasBoardCardType.note;
+}
+
+CanvasBoardCardStatus _inferCardStatus(String title) {
+  final normalized = title.toLowerCase();
+  if (RegExp(
+    r'\b(finished|made|shipped|artifact|showcase)\b',
+  ).hasMatch(normalized)) {
+    return CanvasBoardCardStatus.done;
+  }
+  if (RegExp(
+    r'\b(now|today|week|current|happening|active)\b',
+  ).hasMatch(normalized)) {
+    return CanvasBoardCardStatus.doing;
+  }
+  return CanvasBoardCardStatus.backlog;
+}
+
+T? _enumByName<T extends Enum>(Iterable<T> values, Object? name) {
+  if (name is! String) return null;
+  for (final value in values) {
+    if (value.name == name) return value;
+  }
+  return null;
+}
+
+Map<String, Object?>? _metadataFromFirstMeaningfulLine(List<String> lines) {
+  final index = lines.indexWhere((line) => line.trim().isNotEmpty);
+  if (index == -1) return null;
+  final match = _metadataPattern.firstMatch(lines[index]);
+  if (match == null) return null;
+  try {
+    final decoded = jsonDecode(match.group(1)!);
+    if (decoded is! Map<String, dynamic>) return null;
+    lines.removeAt(index);
+    return decoded;
+  } catch (_) {
+    return null;
+  }
+}
+
+String? _validString(Object? value, RegExp pattern) {
+  if (value is! String) return null;
+  final normalized = value.trim();
+  return pattern.hasMatch(normalized) ? normalized : null;
+}
+
+/// Parses the same Markdown-backed card contract used by desktop Magic Board.
+CanvasBoard parseCanvasBoard(String content) {
+  final normalized = content.replaceAll(RegExp(r'\r\n?'), '\n');
+  final introductionLines = <String>[];
+  final sections = <_SourceSection>[];
+  String? title;
+  _SourceSection? activeSection;
+  String? fenceCharacter;
+  var fenceLength = 0;
+
+  for (final line in normalized.split('\n')) {
+    final wasInsideFence = fenceCharacter != null;
+    if (fenceCharacter != null) {
+      final closing = _fenceClosePattern.firstMatch(line)?.group(1);
+      if (closing != null &&
+          closing.startsWith(fenceCharacter) &&
+          closing.length >= fenceLength) {
+        fenceCharacter = null;
+        fenceLength = 0;
+      }
+    } else {
+      final opening = _fenceOpenPattern.firstMatch(line)?.group(1);
+      if (opening != null) {
+        fenceCharacter = opening[0];
+        fenceLength = opening.length;
+      }
+    }
+    final isFenceBoundary = wasInsideFence || fenceCharacter != null;
+
+    if (!isFenceBoundary && activeSection == null) {
+      final match = _h1Pattern.firstMatch(line);
+      if (match != null && title == null) {
+        title = match.group(1)!.trim();
+        continue;
+      }
+    }
+    if (!isFenceBoundary) {
+      final match = _h2Pattern.firstMatch(line);
+      if (match != null) {
+        activeSection = _SourceSection(match.group(1)!.trim());
+        sections.add(activeSection);
+        continue;
+      }
+    }
+    if (activeSection == null) {
+      introductionLines.add(line);
+    } else {
+      activeSection.bodyLines.add(line);
+    }
+  }
+
+  final introduction = introductionLines.join('\n').trim();
+  final cards = <CanvasBoardCard>[
+    for (final (index, section) in sections.indexed)
+      (() {
+        final bodyLines = [...section.bodyLines];
+        final metadata = _metadataFromFirstMeaningfulLine(bodyLines);
+        final id = _validString(metadata?['id'], _cardIdPattern);
+        final rawThreadId = metadata?['thread'];
+        final threadId = _validString(
+          rawThreadId is String ? rawThreadId.toLowerCase() : null,
+          _eventIdPattern,
+        );
+        final author = metadata?['author'];
+        return CanvasBoardCard(
+          id: id ?? _derivedCardId(section.title, index),
+          title: section.title,
+          body: bodyLines.join('\n').trim(),
+          type:
+              _enumByName(CanvasBoardCardType.values, metadata?['type']) ??
+              _inferCardType(section.title),
+          status:
+              _enumByName(CanvasBoardCardStatus.values, metadata?['status']) ??
+              _inferCardStatus(section.title),
+          threadId: threadId,
+          authorPubkey: author is String && author.trim().isNotEmpty
+              ? author.trim()
+              : null,
+        );
+      })(),
+  ];
+
+  if (cards.isEmpty && introduction.isNotEmpty) {
+    cards.add(
+      CanvasBoardCard(
+        id: 'overview-1',
+        title: 'Overview',
+        body: introduction,
+        type: CanvasBoardCardType.note,
+        status: CanvasBoardCardStatus.backlog,
+      ),
+    );
+  }
+
+  return CanvasBoard(
+    title: title,
+    introduction: sections.isEmpty ? '' : introduction,
+    cards: cards,
+  );
+}

--- a/mobile/lib/features/channels/channel_canvas_board.dart
+++ b/mobile/lib/features/channels/channel_canvas_board.dart
@@ -1,0 +1,335 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../shared/theme/theme.dart';
+import '../../shared/widgets/buzz_loading_indicator.dart';
+import 'canvas_board.dart';
+
+class ChannelCanvasBoard extends HookWidget {
+  final String channelName;
+  final String? content;
+  final String? errorMessage;
+  final bool isLoading;
+  final double topPadding;
+  final Future<void> Function(String threadId) onOpenThread;
+
+  const ChannelCanvasBoard({
+    super.key,
+    required this.channelName,
+    required this.content,
+    required this.errorMessage,
+    required this.isLoading,
+    required this.topPadding,
+    required this.onOpenThread,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final board = useMemoized(() => parseCanvasBoard(content ?? ''), [content]);
+    final layout = useState(_BoardLayout.cards);
+
+    return CustomScrollView(
+      key: const ValueKey('channel-canvas-board'),
+      slivers: [
+        SliverPadding(
+          padding: EdgeInsets.fromLTRB(
+            Grid.gutter,
+            topPadding + Grid.xs,
+            Grid.gutter,
+            Grid.xl,
+          ),
+          sliver: SliverList.list(
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          board.title ?? channelName,
+                          style: context.textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        if (board.introduction.isNotEmpty) ...[
+                          const SizedBox(height: Grid.xxs),
+                          GptMarkdown(
+                            board.introduction,
+                            style: context.textTheme.bodyMedium?.copyWith(
+                              color: context.colors.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: Grid.xxs),
+                  SegmentedButton<_BoardLayout>(
+                    key: const ValueKey('channel-canvas-board-layout'),
+                    segments: const [
+                      ButtonSegment(
+                        value: _BoardLayout.cards,
+                        icon: Icon(LucideIcons.layoutGrid, size: 17),
+                        tooltip: 'Cards',
+                      ),
+                      ButtonSegment(
+                        value: _BoardLayout.kanban,
+                        icon: Icon(LucideIcons.columns3, size: 17),
+                        tooltip: 'Kanban',
+                      ),
+                    ],
+                    selected: {layout.value},
+                    showSelectedIcon: false,
+                    onSelectionChanged: (selection) =>
+                        layout.value = selection.first,
+                  ),
+                ],
+              ),
+              const SizedBox(height: Grid.xs),
+              if (isLoading)
+                const Padding(
+                  padding: EdgeInsets.all(Grid.sm),
+                  child: Center(
+                    child: BuzzLoadingIndicator(
+                      size: 40,
+                      semanticLabel: 'Loading channel board',
+                    ),
+                  ),
+                )
+              else if (errorMessage case final error?)
+                Container(
+                  padding: const EdgeInsets.all(Grid.xs),
+                  decoration: BoxDecoration(
+                    color: context.colors.errorContainer,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Text(
+                    error,
+                    style: context.textTheme.bodyMedium?.copyWith(
+                      color: context.colors.onErrorContainer,
+                    ),
+                  ),
+                )
+              else if (board.cards.isEmpty)
+                _EmptyBoard(channelName: channelName)
+              else if (layout.value == _BoardLayout.cards)
+                for (final card in board.cards) ...[
+                  _CanvasCard(card: card, onOpenThread: onOpenThread),
+                  const SizedBox(height: Grid.xxs),
+                ]
+              else
+                for (final status in CanvasBoardCardStatus.values) ...[
+                  _KanbanColumn(
+                    status: status,
+                    cards: board.cards
+                        .where((card) => card.status == status)
+                        .toList(),
+                    onOpenThread: onOpenThread,
+                  ),
+                  const SizedBox(height: Grid.xs),
+                ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+enum _BoardLayout { cards, kanban }
+
+class _EmptyBoard extends StatelessWidget {
+  final String channelName;
+
+  const _EmptyBoard({required this.channelName});
+
+  @override
+  Widget build(BuildContext context) => Container(
+    padding: const EdgeInsets.all(Grid.sm),
+    decoration: BoxDecoration(
+      border: Border.all(color: context.colors.outlineVariant),
+      borderRadius: BorderRadius.circular(16),
+    ),
+    child: Column(
+      children: [
+        Icon(LucideIcons.stickyNote, color: context.colors.onSurfaceVariant),
+        const SizedBox(height: Grid.xxs),
+        Text(
+          '$channelName is ready for its first board card.',
+          textAlign: TextAlign.center,
+          style: context.textTheme.bodyMedium,
+        ),
+      ],
+    ),
+  );
+}
+
+class _KanbanColumn extends StatelessWidget {
+  final CanvasBoardCardStatus status;
+  final List<CanvasBoardCard> cards;
+  final Future<void> Function(String threadId) onOpenThread;
+
+  const _KanbanColumn({
+    required this.status,
+    required this.cards,
+    required this.onOpenThread,
+  });
+
+  @override
+  Widget build(BuildContext context) => Container(
+    key: ValueKey('channel-canvas-kanban-${status.name}'),
+    padding: const EdgeInsets.all(Grid.xxs),
+    decoration: BoxDecoration(
+      color: context.colors.surfaceContainerHighest.withValues(alpha: 0.35),
+      borderRadius: BorderRadius.circular(16),
+      border: Border.all(color: context.colors.outlineVariant),
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(Grid.half),
+          child: Row(
+            children: [
+              Icon(_statusIcon(status), size: 17),
+              const SizedBox(width: Grid.half),
+              Text(
+                _statusLabel(status),
+                style: context.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const Spacer(),
+              Text('${cards.length}'),
+            ],
+          ),
+        ),
+        if (cards.isEmpty)
+          Padding(
+            padding: const EdgeInsets.all(Grid.xs),
+            child: Text(
+              'No cards',
+              textAlign: TextAlign.center,
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          )
+        else
+          for (final card in cards) ...[
+            _CanvasCard(card: card, onOpenThread: onOpenThread),
+            const SizedBox(height: Grid.xxs),
+          ],
+      ],
+    ),
+  );
+}
+
+class _CanvasCard extends StatelessWidget {
+  final CanvasBoardCard card;
+  final Future<void> Function(String threadId) onOpenThread;
+
+  const _CanvasCard({required this.card, required this.onOpenThread});
+
+  @override
+  Widget build(BuildContext context) => Card(
+    key: ValueKey('channel-canvas-card-${card.id}'),
+    clipBehavior: Clip.antiAlias,
+    child: Padding(
+      padding: const EdgeInsets.all(Grid.xs),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(_typeIcon(card.type), size: 16),
+              const SizedBox(width: Grid.half),
+              Text(
+                _typeLabel(card.type).toUpperCase(),
+                style: context.textTheme.labelSmall?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.1,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: Grid.xxs),
+          Text(
+            card.title,
+            style: context.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          if (card.body.isNotEmpty) ...[
+            const SizedBox(height: Grid.xxs),
+            GptMarkdown(card.body, style: context.textTheme.bodyMedium),
+          ],
+          const SizedBox(height: Grid.xxs),
+          Row(
+            children: [
+              Icon(
+                _statusIcon(card.status),
+                size: 15,
+                color: context.colors.onSurfaceVariant,
+              ),
+              const SizedBox(width: Grid.half),
+              Text(
+                _statusLabel(card.status),
+                style: context.textTheme.labelMedium?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                ),
+              ),
+              const Spacer(),
+              if (card.threadId case final threadId?)
+                TextButton.icon(
+                  key: ValueKey('channel-canvas-thread-${card.id}'),
+                  onPressed: () => onOpenThread(threadId),
+                  icon: const Icon(LucideIcons.messageCircle, size: 16),
+                  label: const Text('Open thread'),
+                ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+String _typeLabel(CanvasBoardCardType type) => switch (type) {
+  CanvasBoardCardType.agent => 'Agent',
+  CanvasBoardCardType.artifact => 'Artifact',
+  CanvasBoardCardType.conversation => 'Conversation',
+  CanvasBoardCardType.decision => 'Decision',
+  CanvasBoardCardType.note => 'Note',
+  CanvasBoardCardType.person => 'Person',
+  CanvasBoardCardType.project => 'Project',
+  CanvasBoardCardType.task => 'Task',
+};
+
+String _statusLabel(CanvasBoardCardStatus status) => switch (status) {
+  CanvasBoardCardStatus.backlog => 'Backlog',
+  CanvasBoardCardStatus.doing => 'Doing',
+  CanvasBoardCardStatus.done => 'Done',
+};
+
+IconData _typeIcon(CanvasBoardCardType type) => switch (type) {
+  CanvasBoardCardType.agent => LucideIcons.bot,
+  CanvasBoardCardType.artifact => LucideIcons.fileCheck2,
+  CanvasBoardCardType.conversation => LucideIcons.messageCircle,
+  CanvasBoardCardType.decision => LucideIcons.gavel,
+  CanvasBoardCardType.note => LucideIcons.stickyNote,
+  CanvasBoardCardType.person => LucideIcons.userRound,
+  CanvasBoardCardType.project => LucideIcons.folderKanban,
+  CanvasBoardCardType.task => LucideIcons.listTodo,
+};
+
+IconData _statusIcon(CanvasBoardCardStatus status) => switch (status) {
+  CanvasBoardCardStatus.backlog => LucideIcons.circleDot,
+  CanvasBoardCardStatus.doing => LucideIcons.sparkles,
+  CanvasBoardCardStatus.done => LucideIcons.circleCheck,
+};

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -38,6 +38,8 @@ import '../forum/forum_posts_view.dart';
 import 'android_ime_lift.dart';
 import 'channel.dart';
 import 'channel_actions_sheet.dart';
+import 'canvas_board.dart';
+import 'channel_canvas_board.dart';
 import 'channel_link_navigation.dart';
 import 'agent_activity/working_bots_provider.dart';
 import 'channel_management_provider.dart';
@@ -271,6 +273,7 @@ class ChannelDetailPage extends HookConsumerWidget {
     final restoreComposerFocus = useRef<VoidCallback?>(null);
     final sendMessage = ref.read(sendMessageProvider);
     final detailsAsync = ref.watch(channelDetailsProvider(channel.id));
+    final canvasAsync = ref.watch(channelCanvasProvider(channel.id));
     final channelsAsync = ref.watch(channelsProvider);
     final messagesState = ref.watch(channelMessagesProvider(channel.id));
     final huddleLifecycle =
@@ -349,6 +352,25 @@ class ChannelDetailPage extends HookConsumerWidget {
         channel;
     final resolvedChannel =
         detailsAsync.whenData(baseChannel.mergeDetails).value ?? baseChannel;
+    final canvas = canvasAsync.asData?.value;
+    final selectedCanvasView = useState(
+      initialChannelCanvasView(
+        channelName: resolvedChannel.name,
+        storedValue: ref
+            .read(savedPrefsProvider)
+            .getString(channelCanvasViewPreferenceKey(channel.id)),
+      ),
+    );
+    final boardAvailable = channelHasCanvasBoard(
+      channelName: resolvedChannel.name,
+      isDm: resolvedChannel.isDm,
+      content: canvas?.content,
+    );
+    final showsBoard =
+        boardAvailable &&
+        initialMessageId == null &&
+        initialThreadRootId == null &&
+        selectedCanvasView.value == ChannelCanvasView.board;
     final participantCount = resolvedChannel.participantPubkeys
         .map((pubkey) => pubkey.trim().toLowerCase())
         .where((pubkey) => pubkey.isNotEmpty)
@@ -531,6 +553,38 @@ class ChannelDetailPage extends HookConsumerWidget {
       return session.registerVisibleChannel(channel.id);
     }, [channel.id]);
 
+    useEffect(() {
+      if (sessionStatus != SessionStatus.connected || !boardAvailable) {
+        return null;
+      }
+      var disposed = false;
+      void Function()? unsubscribe;
+      Future.microtask(() async {
+        try {
+          final cleanup = await ref
+              .read(relaySessionProvider.notifier)
+              .subscribe(NostrFilters.canvas(channel.id), (_) {
+                if (!disposed) {
+                  ref.invalidate(channelCanvasProvider(channel.id));
+                }
+              });
+          if (disposed) {
+            cleanup();
+          } else {
+            unsubscribe = cleanup;
+          }
+        } catch (error) {
+          if (!disposed) {
+            debugPrint('[CanvasBoard] live subscription failed: $error');
+          }
+        }
+      });
+      return () {
+        disposed = true;
+        unsubscribe?.call();
+      };
+    }, [boardAvailable, channel.id, sessionStatus]);
+
     useEffect(
       () {
         if (channel.isForum) return null;
@@ -567,6 +621,52 @@ class ChannelDetailPage extends HookConsumerWidget {
             .clearObservedUnreadCoveredByRead(channel.id, readTimestamp);
       });
     }, [channel.id, readState.isReady, readTimestamp]);
+
+    Future<void> openCanvasThread(String threadId) async {
+      final notifier = ref.read(channelMessagesProvider(channel.id).notifier);
+      try {
+        await _loadDeepLinkEvents(ref, channel.id, {threadId});
+        final events =
+            ref.read(channelMessagesProvider(channel.id)).value ??
+            const <NostrEvent>[];
+        final messages = formatTimeline(events, currentPubkey: currentPubkey);
+        final threadHead = messages
+            .where((message) => message.id == threadId)
+            .firstOrNull;
+        if (threadHead == null) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Couldn’t load this card thread.')),
+            );
+          }
+          return;
+        }
+        if (!context.mounted) return;
+        await Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => ThreadDetailPage(
+              threadHead: threadHead,
+              allMessages: messages,
+              channelId: channel.id,
+              currentPubkey: currentPubkey,
+              isMember: resolvedChannel.isMember,
+              isArchived: resolvedChannel.isArchived,
+            ),
+          ),
+        );
+      } finally {
+        notifier.releaseDeepLinkEvents({threadId});
+      }
+    }
+
+    void selectCanvasView(ChannelCanvasView view) {
+      selectedCanvasView.value = view;
+      unawaited(
+        ref
+            .read(savedPrefsProvider)
+            .setString(channelCanvasViewPreferenceKey(channel.id), view.name),
+      );
+    }
 
     return FrostedScaffold(
       resizeToAvoidBottomInset:
@@ -653,6 +753,33 @@ class ChannelDetailPage extends HookConsumerWidget {
                 ),
               ]
             : [
+                if (boardAvailable)
+                  PopupMenuButton<ChannelCanvasView>(
+                    key: const ValueKey('channel-view-mode-menu'),
+                    tooltip: 'View mode',
+                    initialValue: showsBoard
+                        ? ChannelCanvasView.board
+                        : ChannelCanvasView.stream,
+                    onSelected: selectCanvasView,
+                    itemBuilder: (_) => [
+                      CheckedPopupMenuItem(
+                        value: ChannelCanvasView.board,
+                        checked: showsBoard,
+                        child: const Text('Board'),
+                      ),
+                      CheckedPopupMenuItem(
+                        value: ChannelCanvasView.stream,
+                        checked: !showsBoard,
+                        child: const Text('Stream'),
+                      ),
+                    ],
+                    icon: Icon(
+                      showsBoard
+                          ? LucideIcons.layoutGrid
+                          : LucideIcons.messageSquareText,
+                      size: 21,
+                    ),
+                  ),
                 if (showsComposer)
                   _HuddleButton(
                     channel: resolvedChannel,
@@ -669,7 +796,21 @@ class ChannelDetailPage extends HookConsumerWidget {
           Column(
             children: [
               Expanded(
-                child: resolvedChannel.isForum
+                child: showsBoard
+                    ? ChannelCanvasBoard(
+                        channelName: resolvedChannel.name,
+                        content: canvas?.content,
+                        errorMessage: canvasAsync.hasError
+                            ? 'Couldn’t load the channel board.'
+                            : null,
+                        isLoading: canvasAsync.isLoading,
+                        topPadding: frostedAppBarHeight(
+                          context,
+                          titleContentHeight: appBarTitleContentHeight,
+                        ),
+                        onOpenThread: openCanvasThread,
+                      )
+                    : resolvedChannel.isForum
                     ? Stack(
                         fit: StackFit.expand,
                         children: [
@@ -777,7 +918,8 @@ class ChannelDetailPage extends HookConsumerWidget {
                         ),
                       ),
               ),
-              if (!resolvedChannel.isForum &&
+              if (!showsBoard &&
+                  !resolvedChannel.isForum &&
                   (!resolvedChannel.isMember ||
                       resolvedChannel.isArchived)) ...[
                 AnimatedSize(
@@ -795,7 +937,7 @@ class ChannelDetailPage extends HookConsumerWidget {
               ],
             ],
           ),
-          if (showsComposer)
+          if (showsComposer && !showsBoard)
             AndroidImeLift(
               child: Align(
                 alignment: Alignment.bottomCenter,

--- a/mobile/lib/features/channels/channel_management_actions.dart
+++ b/mobile/lib/features/channels/channel_management_actions.dart
@@ -212,8 +212,22 @@ class ChannelActions {
   Future<void> setCanvas({
     required String channelId,
     required String content,
+    bool enforceRevision = false,
+    String? expectedEventId,
   }) async {
     _ensureCommunityValid();
+    if (enforceRevision) {
+      final events = await _session.fetchHistory(
+        NostrFilters.canvas(channelId),
+      );
+      final currentEventId = events.isEmpty ? null : events.first.id;
+      if (currentEventId != expectedEventId) {
+        throw StateError(
+          'Canvas revision conflict: the board changed before this save.',
+        );
+      }
+      _ensureCommunityValid();
+    }
     await _signedEventRelay.submit(
       kind: 40100,
       content: content,

--- a/mobile/lib/features/channels/channel_management_provider.dart
+++ b/mobile/lib/features/channels/channel_management_provider.dart
@@ -142,11 +142,13 @@ class ChannelCanvas {
   final String? content;
   final DateTime? updatedAt;
   final String? authorPubkey;
+  final String? eventId;
 
   const ChannelCanvas({
     required this.content,
     required this.updatedAt,
     required this.authorPubkey,
+    this.eventId,
   });
 }
 
@@ -589,6 +591,7 @@ final channelCanvasProvider = FutureProvider.family<ChannelCanvas, String>((
       content: null,
       updatedAt: null,
       authorPubkey: null,
+      eventId: null,
     );
   }
   final event = events.first;
@@ -599,6 +602,7 @@ final channelCanvasProvider = FutureProvider.family<ChannelCanvas, String>((
       isUtc: true,
     ),
     authorPubkey: event.pubkey,
+    eventId: event.id,
   );
 });
 

--- a/mobile/lib/features/channels/manage_channel_sheet.dart
+++ b/mobile/lib/features/channels/manage_channel_sheet.dart
@@ -30,6 +30,7 @@ class ManageChannelSheet extends HookConsumerWidget {
     useListenable(descriptionController);
     final canvasController = useTextEditingController();
     final isEditingCanvas = useState(false);
+    final editingCanvasEventId = useState<String?>(null);
     final isSavingCanvas = useState(false);
     final isSavingDetails = useState(false);
     final actionError = useState<String?>(null);
@@ -54,7 +55,8 @@ class ManageChannelSheet extends HookConsumerWidget {
         canonicalName.isNotEmpty &&
         (nameDirty || descriptionDirty) &&
         !isSavingDetails.value;
-    final canEditCanvas = channel.isMember && !channel.isArchived;
+    final canEditCanvas =
+        canEditDetails && channel.isMember && !channel.isArchived;
 
     Future<void> saveDetails() async {
       if (!canSaveDetails) return;
@@ -91,8 +93,13 @@ class ManageChannelSheet extends HookConsumerWidget {
             .setCanvas(
               channelId: channel.id,
               content: canvasController.text.trim(),
+              enforceRevision: true,
+              expectedEventId: editingCanvasEventId.value,
             );
-        if (context.mounted) isEditingCanvas.value = false;
+        if (context.mounted) {
+          isEditingCanvas.value = false;
+          editingCanvasEventId.value = null;
+        }
       } catch (error) {
         actionError.value = error.toString();
       } finally {
@@ -176,6 +183,7 @@ class ManageChannelSheet extends HookConsumerWidget {
                                   ? null
                                   : () {
                                       isEditingCanvas.value = false;
+                                      editingCanvasEventId.value = null;
                                       canvasController.text =
                                           canvas.content ?? '';
                                     },
@@ -214,7 +222,10 @@ class ManageChannelSheet extends HookConsumerWidget {
                         alignment: Alignment.centerRight,
                         child: FilledButton.tonal(
                           onPressed: canEditCanvas
-                              ? () => isEditingCanvas.value = true
+                              ? () {
+                                  editingCanvasEventId.value = canvas.eventId;
+                                  isEditingCanvas.value = true;
+                                }
                               : null,
                           child: Text(
                             canvas.content?.trim().isNotEmpty == true

--- a/mobile/test/features/channels/canvas_board_test.dart
+++ b/mobile/test/features/channels/canvas_board_test.dart
@@ -1,0 +1,65 @@
+import 'package:buzz/features/channels/canvas_board.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('parses durable card metadata and hides it from the body', () {
+    final threadId = 'b' * 64;
+    final board = parseCanvasBoard(
+      '# Dispatch\n\nA shared work surface.\n\n'
+      '## Decide the next move\n\n'
+      '<!-- buzz-board-card {"id":"decision-1","type":"decision","status":"doing","thread":"$threadId","author":"alice"} -->\n\n'
+      'Choose the smallest complete loop.',
+    );
+
+    expect(board.title, 'Dispatch');
+    expect(board.introduction, 'A shared work surface.');
+    expect(board.cards, hasLength(1));
+    final card = board.cards.single;
+    expect(card.id, 'decision-1');
+    expect(card.type, CanvasBoardCardType.decision);
+    expect(card.status, CanvasBoardCardStatus.doing);
+    expect(card.threadId, threadId);
+    expect(card.authorPubkey, 'alice');
+    expect(card.body, 'Choose the smallest complete loop.');
+  });
+
+  test('leaves headings inside fenced Markdown in the card body', () {
+    final board = parseCanvasBoard(
+      '## Notes\n\n```md\n## Not a card\n```\n\n## Next action\n\nShip it.',
+    );
+
+    expect(board.cards, hasLength(2));
+    expect(board.cards.first.body, contains('## Not a card'));
+    expect(board.cards.last.type, CanvasBoardCardType.task);
+  });
+
+  test('keeps Dispatch board-first and excludes DMs', () {
+    expect(
+      channelHasCanvasBoard(
+        channelName: '#Dispatch',
+        isDm: false,
+        content: null,
+      ),
+      isTrue,
+    );
+    expect(
+      channelHasCanvasBoard(
+        channelName: 'Dispatch',
+        isDm: true,
+        content: '# Hidden',
+      ),
+      isFalse,
+    );
+    expect(
+      initialChannelCanvasView(channelName: 'Dispatch', storedValue: null),
+      ChannelCanvasView.board,
+    );
+    expect(
+      initialChannelCanvasView(
+        channelName: 'Dispatch',
+        storedValue: ChannelCanvasView.stream.name,
+      ),
+      ChannelCanvasView.stream,
+    );
+  });
+}

--- a/mobile/test/features/channels/channel_actions_sheet_test.dart
+++ b/mobile/test/features/channels/channel_actions_sheet_test.dart
@@ -433,53 +433,54 @@ void main() {
     expect(tester.widget<FilledButton>(editCanvas).onPressed, isNull);
   });
 
-  testWidgets('regular members can move channels but cannot edit metadata', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      _modalApp(
-        channel: _channel(),
-        loadMembers: () async => [
-          ChannelMember(
-            pubkey: _currentPubkey,
-            role: 'member',
-            joinedAt: DateTime(2025),
-          ),
-        ],
-        createChannelActions: (ref) => _FakeChannelActions(ref),
-      ),
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Open actions'));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'regular members can move channels but cannot edit metadata or canvas',
+    (tester) async {
+      await tester.pumpWidget(
+        _modalApp(
+          channel: _channel(),
+          loadMembers: () async => [
+            ChannelMember(
+              pubkey: _currentPubkey,
+              role: 'member',
+              joinedAt: DateTime(2025),
+            ),
+          ],
+          createChannelActions: (ref) => _FakeChannelActions(ref),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open actions'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Move to section…'), findsOneWidget);
-    await tester.tap(find.text('Manage channel'));
-    await tester.pumpAndSettle();
+      expect(find.text('Move to section…'), findsOneWidget);
+      await tester.tap(find.text('Manage channel'));
+      await tester.pumpAndSettle();
 
-    final nameField = find.byKey(const ValueKey('manage-channel-name'));
-    final descriptionField = find.byKey(
-      const ValueKey('manage-channel-description'),
-    );
-    expect(tester.widget<TextField>(nameField).enabled, isFalse);
-    expect(tester.widget<TextField>(descriptionField).enabled, isFalse);
-    expect(
-      tester
-          .widget<FilledButton>(
-            find.byKey(const ValueKey('manage-channel-save-details')),
-          )
-          .onPressed,
-      isNull,
-    );
-    expect(
-      tester
-          .widget<FilledButton>(
-            find.widgetWithText(FilledButton, 'Create canvas'),
-          )
-          .onPressed,
-      isNotNull,
-    );
-  });
+      final nameField = find.byKey(const ValueKey('manage-channel-name'));
+      final descriptionField = find.byKey(
+        const ValueKey('manage-channel-description'),
+      );
+      expect(tester.widget<TextField>(nameField).enabled, isFalse);
+      expect(tester.widget<TextField>(descriptionField).enabled, isFalse);
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.byKey(const ValueKey('manage-channel-save-details')),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.widgetWithText(FilledButton, 'Create canvas'),
+            )
+            .onPressed,
+        isNull,
+      );
+    },
+  );
 
   testWidgets('DM omits quick actions, then shows mute and copy rows', (
     tester,

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -16,6 +16,7 @@ import 'package:nostr/nostr.dart' as nostr;
 import 'package:pointycastle/digests/sha256.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/canvas_board.dart';
 import 'package:buzz/features/channels/channel_detail_page.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/channel_messages_provider.dart';
@@ -13951,6 +13952,99 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+  });
+
+  group('mobile canvas board', () {
+    testWidgets('Dispatch defaults to Board and persists an explicit view', (
+      tester,
+    ) async {
+      final dispatch = _testChannel.copyWith(name: 'Dispatch');
+      await tester.pumpWidget(
+        _buildTestable(
+          channel: dispatch,
+          messages: const [],
+          canvasContent: '# Dispatch\n\n## Start here\n\nBring one seed.',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('channel-canvas-board')),
+        findsOneWidget,
+      );
+      await tester.tap(find.byKey(const ValueKey('channel-view-mode-menu')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.ancestor(
+          of: find.text('Stream'),
+          matching: find.byType(CheckedPopupMenuItem<ChannelCanvasView>),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('channel-canvas-board')), findsNothing);
+      expect(
+        _testPrefs.getString(channelCanvasViewPreferenceKey(_channelId)),
+        ChannelCanvasView.stream.name,
+      );
+    });
+
+    testWidgets('a routed message intent temporarily forces Stream', (
+      tester,
+    ) async {
+      await _testPrefs.setString(
+        channelCanvasViewPreferenceKey(_channelId),
+        ChannelCanvasView.board.name,
+      );
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          canvasContent: '# General\n\n## Start here\n\nBring one seed.',
+          initialMessageId: 'missing-message',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('channel-canvas-board')), findsNothing);
+      expect(
+        _testPrefs.getString(channelCanvasViewPreferenceKey(_channelId)),
+        ChannelCanvasView.board.name,
+      );
+    });
+
+    testWidgets('a linked card opens the native thread page', (tester) async {
+      final threadId = 'a' * 64;
+      final root = _textMsg(
+        id: threadId,
+        pubkey: 'alice',
+        content: 'Card work room',
+      );
+      await _testPrefs.setString(
+        channelCanvasViewPreferenceKey(_channelId),
+        ChannelCanvasView.board.name,
+      );
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [root],
+          canvasContent:
+              '# General\n\n## Talk here\n\n'
+              '<!-- buzz-board-card {"id":"talk","type":"conversation","status":"doing","thread":"$threadId"} -->\n\n'
+              'Keep this decision together.',
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+          },
+          threadReplies: {threadId: const []},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey('channel-canvas-thread-talk')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ThreadDetailPage), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- complete the Markdown-backed Magic Board card lifecycle on desktop
- add durable card metadata for type, status, author, and attached Buzz thread
- add Cards and Kanban layouts with persisted drag ordering and status changes
- add per-card Buzz work rooms that create once, recover by deterministic marker, and reopen as native threads
- add live canvas refresh, stale-revision guards, and steward-only layout editing
- persist each channel's Board/Stream preference while preserving Stream for routed message intents
- add read-only Cards/Kanban rendering and linked native-thread navigation on mobile

## Product behavior

### Cards and Kanban

- Existing level-two Markdown sections remain valid cards with inferred type and status.
- New or edited cards store durable metadata in a hidden `buzz-board-card` HTML comment.
- Supported native types are task, note, conversation, project, artifact, person, agent, and decision.
- Supported workflow states are Backlog, Doing, and Done.
- Stewards can create, edit, reorder, and move cards between Kanban columns; the shared Markdown canvas remains the source of truth.

### Card work rooms

- `Start thread` creates an ordinary top-level Buzz conversation and links its event ID into the card metadata.
- A deterministic client marker lets a retry recover the existing conversation instead of creating a duplicate.
- `Open thread` routes directly into the linked native thread on desktop and mobile.

### Collaboration and navigation

- Desktop subscribes to live kind-40100 canvas updates for non-DM channels.
- Board and raw-canvas editors keep the event ID they opened from and reject a stale save before publishing.
- Mobile uses the same revision check in its management flow.
- Revision checks are optimistic conflict guards; the relay does not currently provide an atomic compare-and-swap primitive.
- Only channel stewards can mutate canvas layout. Other members remain read-only on the Board and can participate in linked card threads.
- Board/Stream preference is stored per channel. Dispatch remains Board-first; other eligible channels remain Stream-first until selected.
- Message, post, thread, forum, draft, profile, and agent-session route intents temporarily force Stream without overwriting the saved preference.

### Mobile parity

- Eligible channels expose a Board/Stream selector.
- Mobile parses the same hidden metadata contract and renders Cards or Backlog/Doing/Done columns.
- Linked card conversations open in the native thread page.
- The composer and stream-only controls stay out of the way while Board is active.

## Compatibility

- no new event kinds or data migration
- legacy canvas Markdown continues to render through type/status inference
- the metadata comment remains valid, human-readable Markdown source
- DMs remain Stream-only

## Validation

- `bin/just ci` passed across formatting, linting, Rust, desktop, web, mobile analysis, builds, and full test suites
- full Flutter suite: 2,078 passed, 0 failed
- focused mobile Board/channel matrix: 238 passed, 0 failed
- focused Magic Board Playwright matrix: 9 passed, 0 failed
- canvas model tests: 15 passed, 0 failed
- Rust canvas revision tests: 2 passed, 0 failed
- desktop and 390 px narrow-layout visual QA passed
- `git diff --check` clean; no new Rust `unwrap` or `expect`

Verified head: `a89ea281b4679871d95435419cb8c11a326f699c`
