### PR TITLE
refactor(relay): backend seams prep for local mode (PR 0/12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "buzz-auth",
  "buzz-core",
  "chrono",
+ "dashmap",
  "deadpool-redis",
  "futures-util",
  "nostr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-db-backend-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "trybuild",
+]
+
+[[package]]
 name = "buzz-dev-mcp"
 version = "0.1.0"
 dependencies = [
@@ -3258,6 +3268,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -9489,6 +9505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9499,6 +9521,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -10177,6 +10208,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/buzz-conformance",
     "crates/buzz-push-gateway",
     "crates/buzz-db",
+    "crates/buzz-db-backend-macro",
     "crates/buzz-pubsub",
     "crates/buzz-auth",
     "crates/buzz-search",

--- a/crates/buzz-db-backend-macro/Cargo.toml
+++ b/crates/buzz-db-backend-macro/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "buzz-db-backend-macro"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+trybuild = "1"

--- a/crates/buzz-db-backend-macro/src/lib.rs
+++ b/crates/buzz-db-backend-macro/src/lib.rs
@@ -1,0 +1,104 @@
+//! Compile-time enforcement for explicit SQLite decisions on public `Db` methods.
+//!
+//! The impl-level attribute inspects only public associated methods. Private and
+//! `pub(crate)` plumbing is intentionally outside this policy boundary.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, Attribute, ImplItem, ItemImpl, LitStr, Visibility};
+
+#[proc_macro_attribute]
+pub fn enforce_sqlite_backend_declarations(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as ItemImpl);
+    let mut errors = Vec::new();
+    let mut inventory = Vec::new();
+
+    for impl_item in &mut item.items {
+        let ImplItem::Fn(method) = impl_item else {
+            continue;
+        };
+        if !matches!(method.vis, Visibility::Public(_)) {
+            continue;
+        }
+
+        let mut markers = Vec::new();
+        let mut retained = Vec::new();
+        for attr in method.attrs.drain(..) {
+            if attr.path().is_ident("sqlite_backend") {
+                markers.push(attr);
+            } else {
+                retained.push(attr);
+            }
+        }
+        method.attrs = retained;
+
+        let name = method.sig.ident.to_string();
+        match markers.as_slice() {
+            [] => errors.push(syn::Error::new(
+                method.sig.ident.span(),
+                format!("public Db method `{name}` is missing #[sqlite_backend(...)]"),
+            )),
+            [marker] => match parse_marker(marker) {
+                Ok(reason) => inventory.push((name, reason)),
+                Err(error) => errors.push(error),
+            },
+            _ => errors.push(syn::Error::new(
+                method.sig.ident.span(),
+                format!("public Db method `{name}` has duplicate #[sqlite_backend] markers"),
+            )),
+        }
+    }
+
+    inventory.sort_by(|a, b| a.0.cmp(&b.0));
+    let names = inventory
+        .iter()
+        .map(|(name, _)| LitStr::new(name, proc_macro2::Span::call_site()));
+    let reasons = inventory.iter().map(|(_, reason)| match reason {
+        Some(reason) => quote! { Some(#reason) },
+        None => quote! { None },
+    });
+    let errors = errors.into_iter().map(|e| e.to_compile_error());
+
+    quote! {
+        #(#errors)*
+        #item
+        #[doc(hidden)]
+        pub const SQLITE_BACKEND_INVENTORY: &[(&str, Option<&str>)] = &[#((#names, #reasons)),*];
+    }
+    .into()
+}
+
+fn parse_marker(attr: &Attribute) -> syn::Result<Option<LitStr>> {
+    let mut result = None;
+    attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("implemented") {
+            if result.is_some() {
+                return Err(meta.error("duplicate backend decision"));
+            }
+            result = Some(None);
+            return Ok(());
+        }
+        if meta.path.is_ident("unsupported") {
+            if result.is_some() {
+                return Err(meta.error("duplicate backend decision"));
+            }
+            let value = meta.value()?.parse::<LitStr>()?;
+            if value.value().trim().is_empty() {
+                return Err(syn::Error::new(
+                    value.span(),
+                    "unsupported reason must not be empty",
+                ));
+            }
+            result = Some(Some(value));
+            return Ok(());
+        }
+        Err(meta.error("expected `implemented` or `unsupported = \"reason\"`"))
+    })?;
+    result.ok_or_else(|| {
+        syn::Error::new(
+            attr.span(),
+            "backend decision must be `implemented` or `unsupported = \"reason\"`",
+        )
+    })
+}

--- a/crates/buzz-db-backend-macro/tests/compile.rs
+++ b/crates/buzz-db-backend-macro/tests/compile.rs
@@ -1,0 +1,9 @@
+#[test]
+fn ui() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/missing_marker.rs");
+    tests.compile_fail("tests/ui/duplicate_marker.rs");
+    tests.compile_fail("tests/ui/empty_reason.rs");
+    tests.compile_fail("tests/ui/malformed_marker.rs");
+    tests.pass("tests/ui/valid_markers.rs");
+}

--- a/crates/buzz-db-backend-macro/tests/ui/duplicate_marker.rs
+++ b/crates/buzz-db-backend-macro/tests/ui/duplicate_marker.rs
@@ -1,0 +1,9 @@
+use buzz_db_backend_macro::enforce_sqlite_backend_declarations;
+struct Db;
+#[enforce_sqlite_backend_declarations]
+impl Db {
+    #[sqlite_backend(implemented)]
+    #[sqlite_backend(implemented)]
+    pub fn duplicated(&self) {}
+}
+fn main() {}

--- a/crates/buzz-db-backend-macro/tests/ui/duplicate_marker.stderr
+++ b/crates/buzz-db-backend-macro/tests/ui/duplicate_marker.stderr
@@ -1,0 +1,5 @@
+error: public Db method `duplicated` has duplicate #[sqlite_backend] markers
+ --> tests/ui/duplicate_marker.rs:7:12
+  |
+7 |     pub fn duplicated(&self) {}
+  |            ^^^^^^^^^^

--- a/crates/buzz-db-backend-macro/tests/ui/empty_reason.rs
+++ b/crates/buzz-db-backend-macro/tests/ui/empty_reason.rs
@@ -1,0 +1,8 @@
+use buzz_db_backend_macro::enforce_sqlite_backend_declarations;
+struct Db;
+#[enforce_sqlite_backend_declarations]
+impl Db {
+    #[sqlite_backend(unsupported = "  ")]
+    pub fn empty(&self) {}
+}
+fn main() {}

--- a/crates/buzz-db-backend-macro/tests/ui/empty_reason.stderr
+++ b/crates/buzz-db-backend-macro/tests/ui/empty_reason.stderr
@@ -1,0 +1,5 @@
+error: unsupported reason must not be empty
+ --> tests/ui/empty_reason.rs:5:36
+  |
+5 |     #[sqlite_backend(unsupported = "  ")]
+  |                                    ^^^^

--- a/crates/buzz-db-backend-macro/tests/ui/malformed_marker.rs
+++ b/crates/buzz-db-backend-macro/tests/ui/malformed_marker.rs
@@ -1,0 +1,8 @@
+use buzz_db_backend_macro::enforce_sqlite_backend_declarations;
+struct Db;
+#[enforce_sqlite_backend_declarations]
+impl Db {
+    #[sqlite_backend(sometimes)]
+    pub fn malformed(&self) {}
+}
+fn main() {}

--- a/crates/buzz-db-backend-macro/tests/ui/malformed_marker.stderr
+++ b/crates/buzz-db-backend-macro/tests/ui/malformed_marker.stderr
@@ -1,0 +1,5 @@
+error: expected `implemented` or `unsupported = "reason"`
+ --> tests/ui/malformed_marker.rs:5:22
+  |
+5 |     #[sqlite_backend(sometimes)]
+  |                      ^^^^^^^^^

--- a/crates/buzz-db-backend-macro/tests/ui/missing_marker.rs
+++ b/crates/buzz-db-backend-macro/tests/ui/missing_marker.rs
@@ -1,0 +1,10 @@
+use buzz_db_backend_macro::enforce_sqlite_backend_declarations;
+
+struct Db;
+
+#[enforce_sqlite_backend_declarations]
+impl Db {
+    pub fn omitted(&self) {}
+}
+
+fn main() {}

--- a/crates/buzz-db-backend-macro/tests/ui/missing_marker.stderr
+++ b/crates/buzz-db-backend-macro/tests/ui/missing_marker.stderr
@@ -1,0 +1,5 @@
+error: public Db method `omitted` is missing #[sqlite_backend(...)]
+ --> tests/ui/missing_marker.rs:7:12
+  |
+7 |     pub fn omitted(&self) {}
+  |            ^^^^^^^

--- a/crates/buzz-db-backend-macro/tests/ui/valid_markers.rs
+++ b/crates/buzz-db-backend-macro/tests/ui/valid_markers.rs
@@ -1,0 +1,18 @@
+use buzz_db_backend_macro::enforce_sqlite_backend_declarations;
+
+struct Db;
+
+#[enforce_sqlite_backend_declarations]
+impl Db {
+    #[sqlite_backend(implemented)]
+    #[allow(dead_code)]
+    pub fn implemented(&self) {}
+
+    /// Deliberately unsupported operation.
+    #[sqlite_backend(unsupported = "requires postgres-only advisory locks")]
+    pub async fn unsupported(&self) {}
+
+    fn private(&self) {}
+}
+
+fn main() {}

--- a/crates/buzz-media/src/storage.rs
+++ b/crates/buzz-media/src/storage.rs
@@ -442,14 +442,21 @@ impl MediaStorage {
                 .await
                 .map_err(|e| MediaError::StorageError(e.to_string()))?
                 .map_err(Self::fs_error)?;
-                let start = continuation_token
-                    .and_then(|token| {
-                        files
-                            .iter()
-                            .position(|(key, _)| key == &token)
-                            .map(|n| n + 1)
-                    })
-                    .unwrap_or(0);
+                if max_keys == 0 {
+                    return Err(MediaError::StorageError(
+                        "list page size must be nonzero".to_owned(),
+                    ));
+                }
+                let start = match continuation_token {
+                    Some(token) => files
+                        .iter()
+                        .position(|(key, _)| key == &token)
+                        .map(|n| n + 1)
+                        .ok_or_else(|| {
+                            MediaError::StorageError("unknown list continuation token".to_owned())
+                        })?,
+                    None => 0,
+                };
                 let remaining = files.split_off(start);
                 let is_truncated = remaining.len() > max_keys;
                 let objects: Vec<_> = remaining.into_iter().take(max_keys).collect();
@@ -593,6 +600,29 @@ mod tests {
         assert!(page.is_truncated);
         storage.delete(&key).await.unwrap();
         assert!(!storage.head(&key).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn filesystem_listing_rejects_zero_page_size_and_unknown_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = MediaStorage::filesystem(dir.path());
+        let key = format!("{}.bin", "b".repeat(64));
+        storage
+            .put(&key, b"x", "application/octet-stream")
+            .await
+            .unwrap();
+        assert!(storage
+            .list_page(None, 0)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("nonzero"));
+        assert!(storage
+            .list_page(Some("missing".to_owned()), 1)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("unknown list continuation token"));
     }
 
     #[test]

--- a/crates/buzz-media/src/storage.rs
+++ b/crates/buzz-media/src/storage.rs
@@ -17,6 +17,14 @@ pub type ByteStream = Pin<Box<dyn futures_core::Stream<Item = Result<Bytes, Medi
 
 /// S3-compatible object storage client.
 pub struct MediaStorage {
+    backend: MediaBackend,
+}
+
+enum MediaBackend {
+    S3(S3MediaStorage),
+}
+
+struct S3MediaStorage {
     bucket: Box<Bucket>,
 }
 
@@ -66,7 +74,15 @@ impl MediaStorage {
             S3AddressingStyle::Path => bucket.with_path_style(),
             S3AddressingStyle::Virtual => bucket,
         };
-        Ok(Self { bucket })
+        Ok(Self {
+            backend: MediaBackend::S3(S3MediaStorage { bucket }),
+        })
+    }
+
+    fn s3(&self) -> &S3MediaStorage {
+        match &self.backend {
+            MediaBackend::S3(storage) => storage,
+        }
     }
 
     /// Store an object from a byte slice.
@@ -74,7 +90,8 @@ impl MediaStorage {
     /// Used for images, sidecars, and thumbnails. For large video files use
     /// [`put_file`] to avoid loading the entire blob into RAM.
     pub async fn put(&self, key: &str, bytes: &[u8], content_type: &str) -> Result<(), MediaError> {
-        self.bucket
+        self.s3()
+            .bucket
             .put_object_with_content_type(key, bytes, content_type)
             .await?;
         Ok(())
@@ -98,7 +115,8 @@ impl MediaStorage {
             .map_err(|e| MediaError::Io(e.to_string()))?;
         let mut reader = tokio::io::BufReader::with_capacity(BUF, file);
 
-        self.bucket
+        self.s3()
+            .bucket
             .put_object_stream_with_content_type(&mut reader, key, content_type)
             .await?;
         Ok(())
@@ -106,7 +124,7 @@ impl MediaStorage {
 
     /// Retrieve an object's bytes.
     pub async fn get(&self, key: &str) -> Result<Vec<u8>, MediaError> {
-        match self.bucket.get_object(key).await {
+        match self.s3().bucket.get_object(key).await {
             Ok(response) => Ok(response.to_vec()),
             Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Err(MediaError::NotFound),
             Err(e) => Err(MediaError::StorageError(e.to_string())),
@@ -119,7 +137,12 @@ impl MediaStorage {
     /// is transferred from S3 — the full object is never loaded into RAM.
     /// Intended for HTTP 206 range responses on large video blobs.
     pub async fn get_range(&self, key: &str, start: u64, end: u64) -> Result<Vec<u8>, MediaError> {
-        match self.bucket.get_object_range(key, start, Some(end)).await {
+        match self
+            .s3()
+            .bucket
+            .get_object_range(key, start, Some(end))
+            .await
+        {
             Ok(response) => Ok(response.to_vec()),
             Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Err(MediaError::NotFound),
             Err(e) => Err(MediaError::StorageError(e.to_string())),
@@ -133,6 +156,7 @@ impl MediaStorage {
     /// blobs (video) directly into HTTP responses via `Body::from_stream()`.
     pub async fn get_stream(&self, key: &str) -> Result<ByteStream, MediaError> {
         let response = self
+            .s3()
             .bucket
             .get_object_stream(key)
             .await
@@ -150,7 +174,7 @@ impl MediaStorage {
 
     /// Check if an object exists. Returns false on 404.
     pub async fn head(&self, key: &str) -> Result<bool, MediaError> {
-        match self.bucket.head_object(key).await {
+        match self.s3().bucket.head_object(key).await {
             Ok(_) => Ok(true),
             Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Ok(false),
             Err(e) => Err(MediaError::StorageError(e.to_string())),
@@ -159,7 +183,8 @@ impl MediaStorage {
 
     /// Delete an object. Returns an error on failure — callers decide whether to propagate.
     pub async fn delete(&self, key: &str) -> Result<(), MediaError> {
-        self.bucket
+        self.s3()
+            .bucket
             .delete_object(key)
             .await
             .map_err(|e| MediaError::StorageError(e.to_string()))?;
@@ -168,7 +193,7 @@ impl MediaStorage {
 
     /// HEAD with metadata — returns Content-Length (size).
     pub async fn head_with_metadata(&self, key: &str) -> Result<Option<BlobHeadMeta>, MediaError> {
-        match self.bucket.head_object(key).await {
+        match self.s3().bucket.head_object(key).await {
             Ok((result, _)) => Ok(Some(BlobHeadMeta {
                 size: result.content_length.unwrap_or(0) as u64,
             })),
@@ -199,7 +224,7 @@ impl MediaStorage {
         sha256: &str,
     ) -> Result<BlobMeta, MediaError> {
         let key = Self::ctx_sidecar_key(ctx, sha256);
-        let resp = self.bucket.get_object(&key).await?;
+        let resp = self.s3().bucket.get_object(&key).await?;
         let meta: BlobMeta = serde_json::from_slice(&resp.to_vec())?;
         Ok(meta)
     }
@@ -248,6 +273,7 @@ impl MediaStorage {
         max_keys: usize,
     ) -> Result<crate::bucket_index::Page, MediaError> {
         let (result, _status) = self
+            .s3()
             .bucket
             .list_page(
                 String::new(),
@@ -307,8 +333,8 @@ mod tests {
     fn static_keys_build_client_with_configured_region() {
         let storage = MediaStorage::new(&storage_config("buzz_dev", "buzz_dev_secret"))
             .expect("static creds should build a client");
-        match storage.bucket.region {
-            Region::Custom { ref region, .. } => assert_eq!(region, "us-west-2"),
+        match &storage.s3().bucket.region {
+            Region::Custom { region, .. } => assert_eq!(region, "us-west-2"),
             other => panic!("expected Custom region, got {other:?}"),
         }
     }
@@ -317,15 +343,15 @@ mod tests {
     fn client_constructor_applies_both_addressing_styles() {
         let path = MediaStorage::new(&storage_config("buzz_dev", "buzz_dev_secret"))
             .expect("path-style client");
-        assert!(path.bucket.is_path_style());
-        assert_eq!(path.bucket.url(), "http://localhost:9000/buzz-media");
+        assert!(path.s3().bucket.is_path_style());
+        assert_eq!(path.s3().bucket.url(), "http://localhost:9000/buzz-media");
 
         let mut virtual_config = storage_config("buzz_dev", "buzz_dev_secret");
         virtual_config.s3_addressing_style = S3AddressingStyle::Virtual;
         let virtual_hosted = MediaStorage::new(&virtual_config).expect("virtual-hosted client");
-        assert!(virtual_hosted.bucket.is_subdomain_style());
+        assert!(virtual_hosted.s3().bucket.is_subdomain_style());
         assert_eq!(
-            virtual_hosted.bucket.url(),
+            virtual_hosted.s3().bucket.url(),
             "http://buzz-media.localhost:9000"
         );
     }

--- a/crates/buzz-media/src/storage.rs
+++ b/crates/buzz-media/src/storage.rs
@@ -1,6 +1,6 @@
 //! S3/MinIO storage client.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 
 use buzz_core::tenant::{CommunityId, TenantContext};
@@ -12,6 +12,7 @@ use futures_util::StreamExt;
 use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
 
 /// A stream of byte chunks from S3, usable with `axum::body::Body::from_stream()`.
@@ -102,23 +103,62 @@ impl MediaStorage {
     }
 
     fn filesystem_path(storage: &FilesystemMediaStorage, key: &str) -> Result<PathBuf, MediaError> {
+        let key_path = Path::new(key);
         if key.is_empty()
-            || key.starts_with('/')
+            || key.contains('\\')
             || key
                 .split('/')
                 .any(|part| part.is_empty() || part == "." || part == "..")
+            || key_path
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
         {
             return Err(MediaError::StorageError(
                 "invalid media storage key".to_owned(),
             ));
         }
-        let filename = key.rsplit('/').next().expect("validated non-empty key");
+        let filename = key_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| MediaError::StorageError("invalid media storage key".to_owned()))?;
         let sha = filename.split('.').next().unwrap_or_default();
         if sha.len() >= 4 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-            Ok(storage.root.join(&sha[..2]).join(&sha[2..4]).join(key))
+            Ok(storage.root.join(&sha[..2]).join(&sha[2..4]).join(key_path))
         } else {
-            Ok(storage.root.join("_aux").join(key))
+            Ok(storage.root.join("_aux").join(key_path))
         }
+    }
+
+    async fn atomic_filesystem_write(path: &Path, bytes: &[u8]) -> Result<(), MediaError> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| MediaError::StorageError("media path has no parent".to_owned()))?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(Self::fs_error)?;
+        let temp = tempfile::NamedTempFile::new_in(parent).map_err(Self::fs_error)?;
+        tokio::fs::write(temp.path(), bytes)
+            .await
+            .map_err(Self::fs_error)?;
+        temp.persist(path)
+            .map_err(|error| Self::fs_error(error.error))?;
+        Ok(())
+    }
+
+    async fn atomic_filesystem_copy(source: &Path, target: &Path) -> Result<(), MediaError> {
+        let parent = target
+            .parent()
+            .ok_or_else(|| MediaError::StorageError("media path has no parent".to_owned()))?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(Self::fs_error)?;
+        let temp = tempfile::NamedTempFile::new_in(parent).map_err(Self::fs_error)?;
+        tokio::fs::copy(source, temp.path())
+            .await
+            .map_err(Self::fs_error)?;
+        temp.persist(target)
+            .map_err(|error| Self::fs_error(error.error))?;
+        Ok(())
     }
 
     fn fs_error(error: std::io::Error) -> MediaError {
@@ -141,12 +181,7 @@ impl MediaStorage {
             }
             MediaBackend::Filesystem(storage) => {
                 let path = Self::filesystem_path(storage, key)?;
-                if let Some(parent) = path.parent() {
-                    tokio::fs::create_dir_all(parent)
-                        .await
-                        .map_err(Self::fs_error)?;
-                }
-                tokio::fs::write(path, bytes).await.map_err(Self::fs_error)
+                Self::atomic_filesystem_write(&path, bytes).await
             }
         }
     }
@@ -173,15 +208,7 @@ impl MediaStorage {
             }
             MediaBackend::Filesystem(storage) => {
                 let target = Self::filesystem_path(storage, key)?;
-                if let Some(parent) = target.parent() {
-                    tokio::fs::create_dir_all(parent)
-                        .await
-                        .map_err(Self::fs_error)?;
-                }
-                tokio::fs::copy(path, target)
-                    .await
-                    .map(|_| ())
-                    .map_err(Self::fs_error)
+                Self::atomic_filesystem_copy(path, &target).await
             }
         }
     }
@@ -213,17 +240,25 @@ impl MediaStorage {
                 }
             }
             MediaBackend::Filesystem(storage) => {
-                let bytes = tokio::fs::read(Self::filesystem_path(storage, key)?)
-                    .await
-                    .map_err(Self::fs_error)?;
-                let start = usize::try_from(start)
-                    .map_err(|_| MediaError::StorageError("range start overflow".to_owned()))?;
-                let end = usize::try_from(end)
-                    .map_err(|_| MediaError::StorageError("range end overflow".to_owned()))?;
-                if start > end || end >= bytes.len() {
+                let path = Self::filesystem_path(storage, key)?;
+                let mut file = tokio::fs::File::open(path).await.map_err(Self::fs_error)?;
+                let length = end
+                    .checked_sub(start)
+                    .and_then(|length| length.checked_add(1))
+                    .ok_or_else(|| MediaError::StorageError("invalid media range".to_owned()))?;
+                let size = file.metadata().await.map_err(Self::fs_error)?.len();
+                if start >= size || end >= size {
                     return Err(MediaError::StorageError("invalid media range".to_owned()));
                 }
-                Ok(bytes[start..=end].to_vec())
+                file.seek(std::io::SeekFrom::Start(start))
+                    .await
+                    .map_err(Self::fs_error)?;
+                let mut bytes = Vec::with_capacity(usize::try_from(length).unwrap_or(0));
+                file.take(length)
+                    .read_to_end(&mut bytes)
+                    .await
+                    .map_err(Self::fs_error)?;
+                Ok(bytes)
             }
         }
     }
@@ -552,6 +587,31 @@ mod tests {
             err.to_string().contains("must be configured together"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn filesystem_keys_reject_traversal_and_windows_separators() {
+        let storage = MediaStorage::filesystem(tempfile::tempdir().unwrap().path());
+        let filesystem = match &storage.backend {
+            MediaBackend::Filesystem(storage) => storage,
+            MediaBackend::S3(_) => unreachable!(),
+        };
+        for key in [
+            "",
+            "/absolute",
+            "nested//key",
+            "nested/./key",
+            "nested/../key",
+            r"nested\\key",
+            r"..\\outside",
+            r"C:\\outside",
+            r"\\\\server\\share",
+        ] {
+            assert!(
+                MediaStorage::filesystem_path(filesystem, key).is_err(),
+                "{key}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/buzz-media/src/storage.rs
+++ b/crates/buzz-media/src/storage.rs
@@ -1,6 +1,6 @@
 //! S3/MinIO storage client.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
 use buzz_core::tenant::{CommunityId, TenantContext};
@@ -8,9 +8,11 @@ use buzz_core::tenant::{CommunityId, TenantContext};
 use crate::config::{MediaConfig, S3AddressingStyle};
 use crate::error::MediaError;
 use bytes::Bytes;
+use futures_util::StreamExt;
 use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
+use tokio_util::io::ReaderStream;
 
 /// A stream of byte chunks from S3, usable with `axum::body::Body::from_stream()`.
 pub type ByteStream = Pin<Box<dyn futures_core::Stream<Item = Result<Bytes, MediaError>> + Send>>;
@@ -22,6 +24,11 @@ pub struct MediaStorage {
 
 enum MediaBackend {
     S3(S3MediaStorage),
+    Filesystem(FilesystemMediaStorage),
+}
+
+struct FilesystemMediaStorage {
+    root: PathBuf,
 }
 
 struct S3MediaStorage {
@@ -79,126 +86,232 @@ impl MediaStorage {
         })
     }
 
+    /// Creates a filesystem-backed content-addressed media store rooted at `root`.
+    pub fn filesystem(root: impl Into<PathBuf>) -> Self {
+        Self {
+            backend: MediaBackend::Filesystem(FilesystemMediaStorage { root: root.into() }),
+        }
+    }
+
+    #[cfg(test)]
     fn s3(&self) -> &S3MediaStorage {
         match &self.backend {
             MediaBackend::S3(storage) => storage,
+            MediaBackend::Filesystem(_) => panic!("filesystem media storage has no S3 client"),
+        }
+    }
+
+    fn filesystem_path(storage: &FilesystemMediaStorage, key: &str) -> Result<PathBuf, MediaError> {
+        if key.is_empty()
+            || key.starts_with('/')
+            || key
+                .split('/')
+                .any(|part| part.is_empty() || part == "." || part == "..")
+        {
+            return Err(MediaError::StorageError(
+                "invalid media storage key".to_owned(),
+            ));
+        }
+        let filename = key.rsplit('/').next().expect("validated non-empty key");
+        let sha = filename.split('.').next().unwrap_or_default();
+        if sha.len() >= 4 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            Ok(storage.root.join(&sha[..2]).join(&sha[2..4]).join(key))
+        } else {
+            Ok(storage.root.join("_aux").join(key))
+        }
+    }
+
+    fn fs_error(error: std::io::Error) -> MediaError {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            MediaError::NotFound
+        } else {
+            MediaError::Io(error.to_string())
         }
     }
 
     /// Store an object from a byte slice.
-    ///
-    /// Used for images, sidecars, and thumbnails. For large video files use
-    /// [`put_file`] to avoid loading the entire blob into RAM.
     pub async fn put(&self, key: &str, bytes: &[u8], content_type: &str) -> Result<(), MediaError> {
-        self.s3()
-            .bucket
-            .put_object_with_content_type(key, bytes, content_type)
-            .await?;
-        Ok(())
+        match &self.backend {
+            MediaBackend::S3(storage) => {
+                storage
+                    .bucket
+                    .put_object_with_content_type(key, bytes, content_type)
+                    .await?;
+                Ok(())
+            }
+            MediaBackend::Filesystem(storage) => {
+                let path = Self::filesystem_path(storage, key)?;
+                if let Some(parent) = path.parent() {
+                    tokio::fs::create_dir_all(parent)
+                        .await
+                        .map_err(Self::fs_error)?;
+                }
+                tokio::fs::write(path, bytes).await.map_err(Self::fs_error)
+            }
+        }
     }
 
-    /// Stream a file from disk into S3 without loading it into RAM.
-    ///
-    /// Uses rust-s3's `put_object_stream_with_content_type` which reads from
-    /// the file incrementally via an 8 MiB `BufReader`. The full file is never
-    /// held in memory simultaneously. Intended for video blobs (up to 500 MB).
+    /// Stream a file from disk into storage without loading it into RAM.
     pub async fn put_file(
         &self,
         key: &str,
         path: &Path,
         content_type: &str,
     ) -> Result<(), MediaError> {
-        const BUF: usize = 8 * 1024 * 1024; // 8 MiB read buffer
-
-        let file = tokio::fs::File::open(path)
-            .await
-            .map_err(|e| MediaError::Io(e.to_string()))?;
-        let mut reader = tokio::io::BufReader::with_capacity(BUF, file);
-
-        self.s3()
-            .bucket
-            .put_object_stream_with_content_type(&mut reader, key, content_type)
-            .await?;
-        Ok(())
+        match &self.backend {
+            MediaBackend::S3(storage) => {
+                const BUF: usize = 8 * 1024 * 1024;
+                let file = tokio::fs::File::open(path)
+                    .await
+                    .map_err(|e| MediaError::Io(e.to_string()))?;
+                let mut reader = tokio::io::BufReader::with_capacity(BUF, file);
+                storage
+                    .bucket
+                    .put_object_stream_with_content_type(&mut reader, key, content_type)
+                    .await?;
+                Ok(())
+            }
+            MediaBackend::Filesystem(storage) => {
+                let target = Self::filesystem_path(storage, key)?;
+                if let Some(parent) = target.parent() {
+                    tokio::fs::create_dir_all(parent)
+                        .await
+                        .map_err(Self::fs_error)?;
+                }
+                tokio::fs::copy(path, target)
+                    .await
+                    .map(|_| ())
+                    .map_err(Self::fs_error)
+            }
+        }
     }
 
     /// Retrieve an object's bytes.
     pub async fn get(&self, key: &str) -> Result<Vec<u8>, MediaError> {
-        match self.s3().bucket.get_object(key).await {
-            Ok(response) => Ok(response.to_vec()),
-            Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Err(MediaError::NotFound),
-            Err(e) => Err(MediaError::StorageError(e.to_string())),
+        match &self.backend {
+            MediaBackend::S3(storage) => match storage.bucket.get_object(key).await {
+                Ok(response) => Ok(response.to_vec()),
+                Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Err(MediaError::NotFound),
+                Err(e) => Err(MediaError::StorageError(e.to_string())),
+            },
+            MediaBackend::Filesystem(storage) => {
+                tokio::fs::read(Self::filesystem_path(storage, key)?)
+                    .await
+                    .map_err(Self::fs_error)
+            }
         }
     }
 
-    /// Retrieve a byte range from an object via S3-native `Range` GET.
-    ///
-    /// `start` and `end` are inclusive byte offsets. Only the requested slice
-    /// is transferred from S3 — the full object is never loaded into RAM.
-    /// Intended for HTTP 206 range responses on large video blobs.
+    /// Retrieve an inclusive byte range from an object.
     pub async fn get_range(&self, key: &str, start: u64, end: u64) -> Result<Vec<u8>, MediaError> {
-        match self
-            .s3()
-            .bucket
-            .get_object_range(key, start, Some(end))
-            .await
-        {
-            Ok(response) => Ok(response.to_vec()),
-            Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Err(MediaError::NotFound),
-            Err(e) => Err(MediaError::StorageError(e.to_string())),
+        match &self.backend {
+            MediaBackend::S3(storage) => {
+                match storage.bucket.get_object_range(key, start, Some(end)).await {
+                    Ok(response) => Ok(response.to_vec()),
+                    Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Err(MediaError::NotFound),
+                    Err(e) => Err(MediaError::StorageError(e.to_string())),
+                }
+            }
+            MediaBackend::Filesystem(storage) => {
+                let bytes = tokio::fs::read(Self::filesystem_path(storage, key)?)
+                    .await
+                    .map_err(Self::fs_error)?;
+                let start = usize::try_from(start)
+                    .map_err(|_| MediaError::StorageError("range start overflow".to_owned()))?;
+                let end = usize::try_from(end)
+                    .map_err(|_| MediaError::StorageError("range end overflow".to_owned()))?;
+                if start > end || end >= bytes.len() {
+                    return Err(MediaError::StorageError("invalid media range".to_owned()));
+                }
+                Ok(bytes[start..=end].to_vec())
+            }
         }
     }
 
-    /// Stream an object's bytes from S3 without loading into RAM.
-    ///
-    /// Returns a pinned stream of `Result<Bytes, MediaError>` chunks.
-    /// The full object is never buffered — intended for streaming large
-    /// blobs (video) directly into HTTP responses via `Body::from_stream()`.
+    /// Stream an object's bytes without buffering its full content.
     pub async fn get_stream(&self, key: &str) -> Result<ByteStream, MediaError> {
-        let response = self
-            .s3()
-            .bucket
-            .get_object_stream(key)
-            .await
-            .map_err(|e| MediaError::StorageError(e.to_string()))?;
-
-        if response.status_code == 404 {
-            return Err(MediaError::NotFound);
+        match &self.backend {
+            MediaBackend::S3(storage) => {
+                let response = storage
+                    .bucket
+                    .get_object_stream(key)
+                    .await
+                    .map_err(|e| MediaError::StorageError(e.to_string()))?;
+                if response.status_code == 404 {
+                    return Err(MediaError::NotFound);
+                }
+                Ok(Box::pin(futures_util::StreamExt::map(
+                    response.bytes,
+                    |chunk| chunk.map_err(|e| MediaError::StorageError(e.to_string())),
+                )))
+            }
+            MediaBackend::Filesystem(storage) => {
+                let file = tokio::fs::File::open(Self::filesystem_path(storage, key)?)
+                    .await
+                    .map_err(Self::fs_error)?;
+                Ok(Box::pin(
+                    ReaderStream::new(file).map(|chunk| chunk.map_err(Self::fs_error)),
+                ))
+            }
         }
-
-        let stream = futures_util::StreamExt::map(response.bytes, |chunk| {
-            chunk.map_err(|e| MediaError::StorageError(e.to_string()))
-        });
-        Ok(Box::pin(stream))
     }
 
-    /// Check if an object exists. Returns false on 404.
+    /// Check if an object exists. Returns false on absence.
     pub async fn head(&self, key: &str) -> Result<bool, MediaError> {
-        match self.s3().bucket.head_object(key).await {
-            Ok(_) => Ok(true),
-            Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Ok(false),
-            Err(e) => Err(MediaError::StorageError(e.to_string())),
+        match &self.backend {
+            MediaBackend::S3(storage) => match storage.bucket.head_object(key).await {
+                Ok(_) => Ok(true),
+                Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Ok(false),
+                Err(e) => Err(MediaError::StorageError(e.to_string())),
+            },
+            MediaBackend::Filesystem(storage) => {
+                match tokio::fs::metadata(Self::filesystem_path(storage, key)?).await {
+                    Ok(_) => Ok(true),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+                    Err(error) => Err(Self::fs_error(error)),
+                }
+            }
         }
     }
 
-    /// Delete an object. Returns an error on failure — callers decide whether to propagate.
+    /// Delete an object.
     pub async fn delete(&self, key: &str) -> Result<(), MediaError> {
-        self.s3()
-            .bucket
-            .delete_object(key)
-            .await
-            .map_err(|e| MediaError::StorageError(e.to_string()))?;
-        Ok(())
+        match &self.backend {
+            MediaBackend::S3(storage) => {
+                storage
+                    .bucket
+                    .delete_object(key)
+                    .await
+                    .map_err(|e| MediaError::StorageError(e.to_string()))?;
+                Ok(())
+            }
+            MediaBackend::Filesystem(storage) => {
+                tokio::fs::remove_file(Self::filesystem_path(storage, key)?)
+                    .await
+                    .map_err(Self::fs_error)
+            }
+        }
     }
 
     /// HEAD with metadata — returns Content-Length (size).
     pub async fn head_with_metadata(&self, key: &str) -> Result<Option<BlobHeadMeta>, MediaError> {
-        match self.s3().bucket.head_object(key).await {
-            Ok((result, _)) => Ok(Some(BlobHeadMeta {
-                size: result.content_length.unwrap_or(0) as u64,
-            })),
-            Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Ok(None),
-            Err(e) => Err(MediaError::StorageError(e.to_string())),
+        match &self.backend {
+            MediaBackend::S3(storage) => match storage.bucket.head_object(key).await {
+                Ok((result, _)) => Ok(Some(BlobHeadMeta {
+                    size: result.content_length.unwrap_or(0) as u64,
+                })),
+                Err(s3::error::S3Error::HttpFailWithBody(404, _)) => Ok(None),
+                Err(e) => Err(MediaError::StorageError(e.to_string())),
+            },
+            MediaBackend::Filesystem(storage) => {
+                match tokio::fs::metadata(Self::filesystem_path(storage, key)?).await {
+                    Ok(metadata) => Ok(Some(BlobHeadMeta {
+                        size: metadata.len(),
+                    })),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                    Err(error) => Err(Self::fs_error(error)),
+                }
+            }
         }
     }
 
@@ -224,8 +337,8 @@ impl MediaStorage {
         sha256: &str,
     ) -> Result<BlobMeta, MediaError> {
         let key = Self::ctx_sidecar_key(ctx, sha256);
-        let resp = self.s3().bucket.get_object(&key).await?;
-        let meta: BlobMeta = serde_json::from_slice(&resp.to_vec())?;
+        let bytes = self.get(&key).await?;
+        let meta: BlobMeta = serde_json::from_slice(&bytes)?;
         Ok(meta)
     }
 
@@ -259,39 +372,96 @@ impl MediaStorage {
             .map(|m| m.mime_type)
     }
 
-    /// One page of a full-bucket listing, for the storage sweep. Wraps
-    /// rust-s3's manual `list_page` (NOT the auto-paginating `list`, which
-    /// has no cap) and converts the result into the storage-agnostic
-    /// [`crate::bucket_index::Page`] shape the pure fold consumes.
-    ///
-    /// `max_keys` bounds one HTTP response, not the sweep's total object
-    /// cap — the caller (`fold_bucket_listing`) enforces the cumulative cap
-    /// across pages.
+    /// One page of a full-bucket listing.
     pub async fn list_page(
         &self,
         continuation_token: Option<String>,
         max_keys: usize,
     ) -> Result<crate::bucket_index::Page, MediaError> {
-        let (result, _status) = self
-            .s3()
-            .bucket
-            .list_page(
-                String::new(),
-                None,
-                continuation_token,
-                None,
-                Some(max_keys),
-            )
-            .await?;
-        Ok(crate::bucket_index::Page {
-            objects: result
-                .contents
-                .into_iter()
-                .map(|obj| (obj.key, obj.size))
-                .collect(),
-            next_continuation_token: result.next_continuation_token,
-            is_truncated: result.is_truncated,
-        })
+        match &self.backend {
+            MediaBackend::S3(storage) => {
+                let (result, _) = storage
+                    .bucket
+                    .list_page(
+                        String::new(),
+                        None,
+                        continuation_token,
+                        None,
+                        Some(max_keys),
+                    )
+                    .await?;
+                Ok(crate::bucket_index::Page {
+                    objects: result
+                        .contents
+                        .into_iter()
+                        .map(|obj| (obj.key, obj.size))
+                        .collect(),
+                    next_continuation_token: result.next_continuation_token,
+                    is_truncated: result.is_truncated,
+                })
+            }
+            MediaBackend::Filesystem(storage) => {
+                let root = storage.root.clone();
+                let mut files = tokio::task::spawn_blocking(move || {
+                    fn walk(
+                        root: &Path,
+                        base: &Path,
+                        out: &mut Vec<(String, u64)>,
+                    ) -> std::io::Result<()> {
+                        for entry in std::fs::read_dir(root)? {
+                            let entry = entry?;
+                            let path = entry.path();
+                            if path.is_dir() {
+                                walk(&path, base, out)?;
+                            } else {
+                                let key = path
+                                    .strip_prefix(base)
+                                    .unwrap()
+                                    .to_string_lossy()
+                                    .replace('\\', "/");
+                                if let Some(key) = key.strip_prefix("_aux/") {
+                                    out.push((key.to_owned(), entry.metadata()?.len()));
+                                } else if let Some((_, _, key)) =
+                                    key.split_once('/').and_then(|(a, rest)| {
+                                        rest.split_once('/').map(|(b, c)| (a, b, c))
+                                    })
+                                {
+                                    out.push((key.to_owned(), entry.metadata()?.len()));
+                                }
+                            }
+                        }
+                        Ok(())
+                    }
+                    let mut out = Vec::new();
+                    if root.exists() {
+                        walk(&root, &root, &mut out)?;
+                    }
+                    out.sort_by(|a, b| a.0.cmp(&b.0));
+                    Ok::<_, std::io::Error>(out)
+                })
+                .await
+                .map_err(|e| MediaError::StorageError(e.to_string()))?
+                .map_err(Self::fs_error)?;
+                let start = continuation_token
+                    .and_then(|token| {
+                        files
+                            .iter()
+                            .position(|(key, _)| key == &token)
+                            .map(|n| n + 1)
+                    })
+                    .unwrap_or(0);
+                let remaining = files.split_off(start);
+                let is_truncated = remaining.len() > max_keys;
+                let objects: Vec<_> = remaining.into_iter().take(max_keys).collect();
+                let next_continuation_token = is_truncated
+                    .then(|| objects.last().expect("nonempty truncated page").0.clone());
+                Ok(crate::bucket_index::Page {
+                    objects,
+                    next_continuation_token,
+                    is_truncated,
+                })
+            }
+        }
     }
 }
 
@@ -375,6 +545,54 @@ mod tests {
             err.to_string().contains("must be configured together"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn filesystem_backend_roundtrips_cas_sidecars_ranges_and_pages() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = MediaStorage::filesystem(dir.path());
+        let sha = "a".repeat(64);
+        let key = format!("{sha}.bin");
+        storage
+            .put(&key, b"hello", "application/octet-stream")
+            .await
+            .unwrap();
+        assert_eq!(storage.get(&key).await.unwrap(), b"hello");
+        assert_eq!(storage.get_range(&key, 1, 3).await.unwrap(), b"ell");
+        assert_eq!(
+            storage
+                .head_with_metadata(&key)
+                .await
+                .unwrap()
+                .unwrap()
+                .size,
+            5
+        );
+        assert!(dir.path().join("aa").join("aa").join(&key).exists());
+
+        let a = tenant(1);
+        let b = tenant(2);
+        storage
+            .put_sidecar(
+                &a,
+                &sha,
+                &BlobMeta {
+                    mime_type: "text/plain".to_owned(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            storage.read_sidecar_mime(&a, &key).await.as_deref(),
+            Some("text/plain")
+        );
+        assert_eq!(storage.read_sidecar_mime(&b, &key).await, None);
+        let page = storage.list_page(None, 1).await.unwrap();
+        assert_eq!(page.objects.len(), 1);
+        assert!(page.is_truncated);
+        storage.delete(&key).await.unwrap();
+        assert!(!storage.head(&key).await.unwrap());
     }
 
     #[test]

--- a/crates/buzz-pubsub/Cargo.toml
+++ b/crates/buzz-pubsub/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+dashmap = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 nostr = { workspace = true }

--- a/crates/buzz-pubsub/src/lib.rs
+++ b/crates/buzz-pubsub/src/lib.rs
@@ -46,7 +46,7 @@ pub use error::PubSubError;
 use std::collections::HashMap;
 use std::future::pending;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use buzz_core::TenantContext;
 use dashmap::DashMap;
@@ -131,8 +131,20 @@ impl PubSubManager {
 
     /// Creates an in-process backend for a single relay process.
     pub fn in_process() -> Self {
+        Self::in_process_with_presence_ttl(Duration::from_secs(presence::PRESENCE_TTL_SECS))
+    }
+
+    #[cfg(test)]
+    fn in_process_with_presence_ttl(presence_ttl: Duration) -> Self {
         Self {
-            backend: PubSubBackend::InProcess(Arc::new(InProcessPubSubManager::new())),
+            backend: PubSubBackend::InProcess(Arc::new(InProcessPubSubManager::new(presence_ttl))),
+        }
+    }
+
+    #[cfg(not(test))]
+    fn in_process_with_presence_ttl(presence_ttl: Duration) -> Self {
+        Self {
+            backend: PubSubBackend::InProcess(Arc::new(InProcessPubSubManager::new(presence_ttl))),
         }
     }
 
@@ -309,20 +321,27 @@ impl PubSubManager {
 /// Process-local pub/sub, presence, and control-plane fan-out for single-node relays.
 struct InProcessPubSubManager {
     topics: DashMap<EventTopicKey, usize>,
-    presence: DashMap<(buzz_core::CommunityId, String), String>,
+    presence: DashMap<(buzz_core::CommunityId, String), PresenceLease>,
+    presence_ttl: Duration,
     broadcast_tx: broadcast::Sender<ChannelEvent>,
     cache_invalidation_tx: broadcast::Sender<ScopedCacheInvalidation>,
     conn_control_tx: broadcast::Sender<ScopedConnControl>,
 }
 
+struct PresenceLease {
+    status: String,
+    expires_at: Instant,
+}
+
 impl InProcessPubSubManager {
-    fn new() -> Self {
+    fn new(presence_ttl: Duration) -> Self {
         let (broadcast_tx, _) = broadcast::channel(4096);
         let (cache_invalidation_tx, _) = broadcast::channel(4096);
         let (conn_control_tx, _) = broadcast::channel(4096);
         Self {
             topics: DashMap::new(),
             presence: DashMap::new(),
+            presence_ttl,
             broadcast_tx,
             cache_invalidation_tx,
             conn_control_tx,
@@ -406,8 +425,13 @@ impl InProcessPubSubManager {
         pubkey: &PublicKey,
         status: &str,
     ) -> Result<(), PubSubError> {
-        self.presence
-            .insert((ctx.community(), pubkey.to_hex()), status.to_owned());
+        self.presence.insert(
+            (ctx.community(), pubkey.to_hex()),
+            PresenceLease {
+                status: status.to_owned(),
+                expires_at: Instant::now() + self.presence_ttl,
+            },
+        );
         Ok(())
     }
     async fn clear_presence(
@@ -423,10 +447,8 @@ impl InProcessPubSubManager {
         ctx: &TenantContext,
         pubkey: &PublicKey,
     ) -> Result<Option<String>, PubSubError> {
-        Ok(self
-            .presence
-            .get(&(ctx.community(), pubkey.to_hex()))
-            .map(|v| v.clone()))
+        let key = (ctx.community(), pubkey.to_hex());
+        Ok(self.active_presence(&key))
     }
     async fn get_presence_bulk(
         &self,
@@ -437,11 +459,20 @@ impl InProcessPubSubManager {
             .iter()
             .filter_map(|p| {
                 let hex = p.to_hex();
-                self.presence
-                    .get(&(ctx.community(), hex.clone()))
-                    .map(|v| (hex, v.clone()))
+                self.active_presence(&(ctx.community(), hex.clone()))
+                    .map(|status| (hex, status))
             })
             .collect())
+    }
+
+    fn active_presence(&self, key: &(buzz_core::CommunityId, String)) -> Option<String> {
+        let lease = self.presence.get(key)?;
+        if lease.expires_at > Instant::now() {
+            return Some(lease.status.clone());
+        }
+        drop(lease);
+        self.presence.remove(key);
+        None
     }
 }
 
@@ -1003,6 +1034,32 @@ mod tests {
         assert_eq!(manager.get_presence(&b, &key).await.unwrap(), None);
         manager.clear_presence(&a, &key).await.unwrap();
         assert_eq!(manager.get_presence(&a, &key).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn in_process_presence_lease_expires_without_disconnect() {
+        let manager = PubSubManager::in_process_with_presence_ttl(Duration::from_millis(5));
+        let tenant = ctx(1, "lease.example");
+        let pubkey = Keys::generate().public_key();
+        manager
+            .set_presence(&tenant, &pubkey, "online")
+            .await
+            .unwrap();
+        assert_eq!(
+            manager
+                .get_presence(&tenant, &pubkey)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("online")
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(manager.get_presence(&tenant, &pubkey).await.unwrap(), None);
+        assert!(manager
+            .get_presence_bulk(&tenant, &[pubkey])
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/crates/buzz-pubsub/src/lib.rs
+++ b/crates/buzz-pubsub/src/lib.rs
@@ -44,10 +44,12 @@ pub mod topic;
 pub use error::PubSubError;
 
 use std::collections::HashMap;
+use std::future::pending;
 use std::sync::Arc;
 use std::time::Duration;
 
 use buzz_core::TenantContext;
+use dashmap::DashMap;
 use nostr::PublicKey;
 use tokio::sync::{broadcast, mpsc, Mutex};
 
@@ -106,6 +108,7 @@ pub struct PubSubManager {
 
 enum PubSubBackend {
     Redis(Arc<RedisPubSubManager>),
+    InProcess(Arc<InProcessPubSubManager>),
 }
 
 impl PubSubManager {
@@ -126,11 +129,19 @@ impl PubSubManager {
         })
     }
 
+    /// Creates an in-process backend for a single relay process.
+    pub fn in_process() -> Self {
+        Self {
+            backend: PubSubBackend::InProcess(Arc::new(InProcessPubSubManager::new())),
+        }
+    }
+
     /// Runs the backend event subscriber. Process-local backends may implement
     /// this as a pending task because publication already reaches local receivers.
     pub async fn run_subscriber(self: Arc<Self>) {
         match &self.backend {
             PubSubBackend::Redis(backend) => Arc::clone(backend).run_subscriber().await,
+            PubSubBackend::InProcess(_) => pending::<()>().await,
         }
     }
 
@@ -142,6 +153,7 @@ impl PubSubManager {
                     .run_cache_invalidation_subscriber()
                     .await
             }
+            PubSubBackend::InProcess(_) => pending::<()>().await,
         }
     }
 
@@ -151,6 +163,7 @@ impl PubSubManager {
             PubSubBackend::Redis(backend) => {
                 Arc::clone(backend).run_conn_control_subscriber().await
             }
+            PubSubBackend::InProcess(_) => pending::<()>().await,
         }
     }
 
@@ -158,6 +171,7 @@ impl PubSubManager {
     pub fn subscribe_local(&self) -> broadcast::Receiver<ChannelEvent> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.subscribe_local(),
+            PubSubBackend::InProcess(backend) => backend.subscribe_local(),
         }
     }
 
@@ -165,6 +179,7 @@ impl PubSubManager {
     pub async fn retain_topic(&self, ctx: &TenantContext, topic: EventTopic) {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.retain_topic(ctx, topic).await,
+            PubSubBackend::InProcess(backend) => backend.retain_topic(ctx, topic).await,
         }
     }
 
@@ -172,6 +187,7 @@ impl PubSubManager {
     pub async fn release_topic(&self, ctx: &TenantContext, topic: EventTopic) {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.release_topic(ctx, topic).await,
+            PubSubBackend::InProcess(backend) => backend.release_topic(ctx, topic).await,
         }
     }
 
@@ -179,6 +195,7 @@ impl PubSubManager {
     pub async fn topic_refcount(&self, ctx: &TenantContext, topic: EventTopic) -> usize {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.topic_refcount(ctx, topic).await,
+            PubSubBackend::InProcess(backend) => backend.topic_refcount(ctx, topic).await,
         }
     }
 
@@ -186,6 +203,7 @@ impl PubSubManager {
     pub fn subscribe_cache_invalidations(&self) -> broadcast::Receiver<ScopedCacheInvalidation> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.subscribe_cache_invalidations(),
+            PubSubBackend::InProcess(backend) => backend.subscribe_cache_invalidations(),
         }
     }
 
@@ -193,6 +211,7 @@ impl PubSubManager {
     pub fn subscribe_conn_control(&self) -> broadcast::Receiver<ScopedConnControl> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.subscribe_conn_control(),
+            PubSubBackend::InProcess(backend) => backend.subscribe_conn_control(),
         }
     }
 
@@ -206,6 +225,9 @@ impl PubSubManager {
             PubSubBackend::Redis(backend) => {
                 backend.publish_cache_invalidation(ctx, invalidation).await
             }
+            PubSubBackend::InProcess(backend) => {
+                backend.publish_cache_invalidation(ctx, invalidation).await
+            }
         }
     }
 
@@ -217,6 +239,7 @@ impl PubSubManager {
     ) -> Result<i64, PubSubError> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.publish_conn_control(ctx, command).await,
+            PubSubBackend::InProcess(backend) => backend.publish_conn_control(ctx, command).await,
         }
     }
 
@@ -229,6 +252,7 @@ impl PubSubManager {
     ) -> Result<i64, PubSubError> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.publish_event(ctx, topic, event).await,
+            PubSubBackend::InProcess(backend) => backend.publish_event(ctx, topic, event).await,
         }
     }
 
@@ -241,6 +265,7 @@ impl PubSubManager {
     ) -> Result<(), PubSubError> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.set_presence(ctx, pubkey, status).await,
+            PubSubBackend::InProcess(backend) => backend.set_presence(ctx, pubkey, status).await,
         }
     }
 
@@ -252,6 +277,7 @@ impl PubSubManager {
     ) -> Result<(), PubSubError> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.clear_presence(ctx, pubkey).await,
+            PubSubBackend::InProcess(backend) => backend.clear_presence(ctx, pubkey).await,
         }
     }
 
@@ -263,6 +289,7 @@ impl PubSubManager {
     ) -> Result<Option<String>, PubSubError> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.get_presence(ctx, pubkey).await,
+            PubSubBackend::InProcess(backend) => backend.get_presence(ctx, pubkey).await,
         }
     }
 
@@ -274,7 +301,147 @@ impl PubSubManager {
     ) -> Result<HashMap<String, String>, PubSubError> {
         match &self.backend {
             PubSubBackend::Redis(backend) => backend.get_presence_bulk(ctx, pubkeys).await,
+            PubSubBackend::InProcess(backend) => backend.get_presence_bulk(ctx, pubkeys).await,
         }
+    }
+}
+
+/// Process-local pub/sub, presence, and control-plane fan-out for single-node relays.
+struct InProcessPubSubManager {
+    topics: DashMap<EventTopicKey, usize>,
+    presence: DashMap<(buzz_core::CommunityId, String), String>,
+    broadcast_tx: broadcast::Sender<ChannelEvent>,
+    cache_invalidation_tx: broadcast::Sender<ScopedCacheInvalidation>,
+    conn_control_tx: broadcast::Sender<ScopedConnControl>,
+}
+
+impl InProcessPubSubManager {
+    fn new() -> Self {
+        let (broadcast_tx, _) = broadcast::channel(4096);
+        let (cache_invalidation_tx, _) = broadcast::channel(4096);
+        let (conn_control_tx, _) = broadcast::channel(4096);
+        Self {
+            topics: DashMap::new(),
+            presence: DashMap::new(),
+            broadcast_tx,
+            cache_invalidation_tx,
+            conn_control_tx,
+        }
+    }
+    fn subscribe_local(&self) -> broadcast::Receiver<ChannelEvent> {
+        self.broadcast_tx.subscribe()
+    }
+    async fn retain_topic(&self, ctx: &TenantContext, topic: EventTopic) {
+        self.topics
+            .entry(EventTopicKey::from_context(ctx, topic))
+            .and_modify(|n| *n += 1)
+            .or_insert(1);
+    }
+    async fn release_topic(&self, ctx: &TenantContext, topic: EventTopic) {
+        let key = EventTopicKey::from_context(ctx, topic);
+        if let Some(mut entry) = self.topics.get_mut(&key) {
+            *entry -= 1;
+            if *entry == 0 {
+                drop(entry);
+                self.topics.remove(&key);
+            }
+        }
+    }
+    async fn topic_refcount(&self, ctx: &TenantContext, topic: EventTopic) -> usize {
+        self.topics
+            .get(&EventTopicKey::from_context(ctx, topic))
+            .map(|n| *n)
+            .unwrap_or(0)
+    }
+    fn subscribe_cache_invalidations(&self) -> broadcast::Receiver<ScopedCacheInvalidation> {
+        self.cache_invalidation_tx.subscribe()
+    }
+    fn subscribe_conn_control(&self) -> broadcast::Receiver<ScopedConnControl> {
+        self.conn_control_tx.subscribe()
+    }
+    async fn publish_cache_invalidation(
+        &self,
+        ctx: &TenantContext,
+        invalidation: &CacheInvalidation,
+    ) -> Result<i64, PubSubError> {
+        Ok(self
+            .cache_invalidation_tx
+            .send(ScopedCacheInvalidation {
+                community_id: ctx.community(),
+                invalidation: invalidation.clone(),
+            })
+            .unwrap_or(0) as i64)
+    }
+    async fn publish_conn_control(
+        &self,
+        ctx: &TenantContext,
+        command: &ConnControl,
+    ) -> Result<i64, PubSubError> {
+        Ok(self
+            .conn_control_tx
+            .send(ScopedConnControl {
+                community_id: ctx.community(),
+                command: command.clone(),
+            })
+            .unwrap_or(0) as i64)
+    }
+    async fn publish_event(
+        &self,
+        ctx: &TenantContext,
+        topic: EventTopic,
+        event: &nostr::Event,
+    ) -> Result<i64, PubSubError> {
+        Ok(self
+            .broadcast_tx
+            .send(ChannelEvent {
+                community_id: ctx.community(),
+                topic,
+                event: event.clone(),
+            })
+            .unwrap_or(0) as i64)
+    }
+    async fn set_presence(
+        &self,
+        ctx: &TenantContext,
+        pubkey: &PublicKey,
+        status: &str,
+    ) -> Result<(), PubSubError> {
+        self.presence
+            .insert((ctx.community(), pubkey.to_hex()), status.to_owned());
+        Ok(())
+    }
+    async fn clear_presence(
+        &self,
+        ctx: &TenantContext,
+        pubkey: &PublicKey,
+    ) -> Result<(), PubSubError> {
+        self.presence.remove(&(ctx.community(), pubkey.to_hex()));
+        Ok(())
+    }
+    async fn get_presence(
+        &self,
+        ctx: &TenantContext,
+        pubkey: &PublicKey,
+    ) -> Result<Option<String>, PubSubError> {
+        Ok(self
+            .presence
+            .get(&(ctx.community(), pubkey.to_hex()))
+            .map(|v| v.clone()))
+    }
+    async fn get_presence_bulk(
+        &self,
+        ctx: &TenantContext,
+        pubkeys: &[PublicKey],
+    ) -> Result<HashMap<String, String>, PubSubError> {
+        Ok(pubkeys
+            .iter()
+            .filter_map(|p| {
+                let hex = p.to_hex();
+                self.presence
+                    .get(&(ctx.community(), hex.clone()))
+                    .map(|v| (hex, v.clone()))
+            })
+            .collect())
     }
 }
 
@@ -790,6 +957,52 @@ mod tests {
 
         manager.release_topic(&ctx, topic).await;
         assert_eq!(manager.topic_refcount(&ctx, topic).await, 0);
+    }
+
+    #[tokio::test]
+    async fn in_process_fanout_presence_and_control_are_community_scoped() {
+        let manager = PubSubManager::in_process();
+        let a = ctx(1, "a.example");
+        let b = ctx(2, "b.example");
+        let topic = EventTopic::Global;
+        manager.retain_topic(&a, topic).await;
+        manager.retain_topic(&a, topic).await;
+        assert_eq!(manager.topic_refcount(&a, topic).await, 2);
+        manager.release_topic(&a, topic).await;
+        assert_eq!(manager.topic_refcount(&a, topic).await, 1);
+
+        let mut events = manager.subscribe_local();
+        let mut invalidations = manager.subscribe_cache_invalidations();
+        let mut controls = manager.subscribe_conn_control();
+        let event = EventBuilder::new(Kind::TextNote, "local")
+            .tags([])
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        assert_eq!(manager.publish_event(&a, topic, &event).await.unwrap(), 1);
+        assert_eq!(events.recv().await.unwrap().community_id, a.community());
+        manager
+            .publish_cache_invalidation(&a, &CacheInvalidation::AccessibleAll)
+            .await
+            .unwrap();
+        assert_eq!(
+            invalidations.recv().await.unwrap().community_id,
+            a.community()
+        );
+        manager
+            .publish_conn_control(&b, &ConnControl::DisconnectCommunity)
+            .await
+            .unwrap();
+        assert_eq!(controls.recv().await.unwrap().community_id, b.community());
+
+        let key = Keys::generate().public_key();
+        manager.set_presence(&a, &key, "online").await.unwrap();
+        assert_eq!(
+            manager.get_presence(&a, &key).await.unwrap().as_deref(),
+            Some("online")
+        );
+        assert_eq!(manager.get_presence(&b, &key).await.unwrap(), None);
+        manager.clear_presence(&a, &key).await.unwrap();
+        assert_eq!(manager.get_presence(&a, &key).await.unwrap(), None);
     }
 
     #[test]

--- a/crates/buzz-pubsub/src/lib.rs
+++ b/crates/buzz-pubsub/src/lib.rs
@@ -96,8 +96,190 @@ impl PubSubConfig {
     }
 }
 
-/// Central pub/sub manager for a Buzz relay instance.
+/// Backend-neutral pub/sub handle selected once at relay startup.
+///
+/// Request handlers use this stable surface; backend selection never occurs in
+/// the event, presence, or subscription paths.
 pub struct PubSubManager {
+    backend: PubSubBackend,
+}
+
+enum PubSubBackend {
+    Redis(Arc<RedisPubSubManager>),
+}
+
+impl PubSubManager {
+    /// Creates the production Redis pub/sub backend.
+    pub async fn new(redis_url: &str, pool: deadpool_redis::Pool) -> Result<Self, PubSubError> {
+        Self::with_config(PubSubConfig::new(redis_url), pool).await
+    }
+
+    /// Creates the production Redis backend with explicit configuration.
+    pub async fn with_config(
+        config: PubSubConfig,
+        pool: deadpool_redis::Pool,
+    ) -> Result<Self, PubSubError> {
+        Ok(Self {
+            backend: PubSubBackend::Redis(Arc::new(
+                RedisPubSubManager::with_config(config, pool).await?,
+            )),
+        })
+    }
+
+    /// Runs the backend event subscriber. Process-local backends may implement
+    /// this as a pending task because publication already reaches local receivers.
+    pub async fn run_subscriber(self: Arc<Self>) {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => Arc::clone(backend).run_subscriber().await,
+        }
+    }
+
+    /// Runs the backend cache-invalidation subscriber.
+    pub async fn run_cache_invalidation_subscriber(self: Arc<Self>) {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => {
+                Arc::clone(backend)
+                    .run_cache_invalidation_subscriber()
+                    .await
+            }
+        }
+    }
+
+    /// Runs the backend connection-control subscriber.
+    pub async fn run_conn_control_subscriber(self: Arc<Self>) {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => {
+                Arc::clone(backend).run_conn_control_subscriber().await
+            }
+        }
+    }
+
+    /// Returns a receiver for locally visible channel events.
+    pub fn subscribe_local(&self) -> broadcast::Receiver<ChannelEvent> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.subscribe_local(),
+        }
+    }
+
+    /// Retains interest in a scoped event topic.
+    pub async fn retain_topic(&self, ctx: &TenantContext, topic: EventTopic) {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.retain_topic(ctx, topic).await,
+        }
+    }
+
+    /// Releases interest in a scoped event topic.
+    pub async fn release_topic(&self, ctx: &TenantContext, topic: EventTopic) {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.release_topic(ctx, topic).await,
+        }
+    }
+
+    /// Returns the current topic retain count.
+    pub async fn topic_refcount(&self, ctx: &TenantContext, topic: EventTopic) -> usize {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.topic_refcount(ctx, topic).await,
+        }
+    }
+
+    /// Returns a receiver for cache invalidations.
+    pub fn subscribe_cache_invalidations(&self) -> broadcast::Receiver<ScopedCacheInvalidation> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.subscribe_cache_invalidations(),
+        }
+    }
+
+    /// Returns a receiver for connection-control commands.
+    pub fn subscribe_conn_control(&self) -> broadcast::Receiver<ScopedConnControl> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.subscribe_conn_control(),
+        }
+    }
+
+    /// Publishes a cache invalidation.
+    pub async fn publish_cache_invalidation(
+        &self,
+        ctx: &TenantContext,
+        invalidation: &CacheInvalidation,
+    ) -> Result<i64, PubSubError> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => {
+                backend.publish_cache_invalidation(ctx, invalidation).await
+            }
+        }
+    }
+
+    /// Publishes a connection-control command.
+    pub async fn publish_conn_control(
+        &self,
+        ctx: &TenantContext,
+        command: &ConnControl,
+    ) -> Result<i64, PubSubError> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.publish_conn_control(ctx, command).await,
+        }
+    }
+
+    /// Publishes an event to the selected backend.
+    pub async fn publish_event(
+        &self,
+        ctx: &TenantContext,
+        topic: EventTopic,
+        event: &nostr::Event,
+    ) -> Result<i64, PubSubError> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.publish_event(ctx, topic, event).await,
+        }
+    }
+
+    /// Sets presence for a principal.
+    pub async fn set_presence(
+        &self,
+        ctx: &TenantContext,
+        pubkey: &PublicKey,
+        status: &str,
+    ) -> Result<(), PubSubError> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.set_presence(ctx, pubkey, status).await,
+        }
+    }
+
+    /// Clears presence for a principal.
+    pub async fn clear_presence(
+        &self,
+        ctx: &TenantContext,
+        pubkey: &PublicKey,
+    ) -> Result<(), PubSubError> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.clear_presence(ctx, pubkey).await,
+        }
+    }
+
+    /// Gets presence for one principal.
+    pub async fn get_presence(
+        &self,
+        ctx: &TenantContext,
+        pubkey: &PublicKey,
+    ) -> Result<Option<String>, PubSubError> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.get_presence(ctx, pubkey).await,
+        }
+    }
+
+    /// Gets presence for multiple principals.
+    pub async fn get_presence_bulk(
+        &self,
+        ctx: &TenantContext,
+        pubkeys: &[PublicKey],
+    ) -> Result<HashMap<String, String>, PubSubError> {
+        match &self.backend {
+            PubSubBackend::Redis(backend) => backend.get_presence_bulk(ctx, pubkeys).await,
+        }
+    }
+}
+
+/// Redis implementation behind [`PubSubManager`].
+struct RedisPubSubManager {
     pool: deadpool_redis::Pool,
     /// Redis URL used by the reconnect loop to re-establish pub/sub connections.
     redis_url: String,
@@ -112,12 +294,7 @@ pub struct PubSubManager {
     conn_control_tx: broadcast::Sender<ScopedConnControl>,
 }
 
-impl PubSubManager {
-    /// Creates a new `PubSubManager` connected to the given Redis URL.
-    pub async fn new(redis_url: &str, pool: deadpool_redis::Pool) -> Result<Self, PubSubError> {
-        Self::with_config(PubSubConfig::new(redis_url), pool).await
-    }
-
+impl RedisPubSubManager {
     /// Creates a new `PubSubManager` using explicit pub/sub configuration.
     pub async fn with_config(
         config: PubSubConfig,

--- a/crates/buzz-pubsub/src/rate_limiter.rs
+++ b/crates/buzz-pubsub/src/rate_limiter.rs
@@ -78,6 +78,60 @@ async fn run_rate_limit(
     }
 }
 
+/// Backend-neutral admission limiter selected once at relay startup.
+pub enum AdmissionRateLimiter {
+    /// Production Redis fixed-window counters.
+    Redis(RedisRateLimiter),
+    /// Process-local profile policy until bounded in-memory counters are installed.
+    ///
+    /// This is explicit rather than a fallback: callers must select it at startup.
+    Permissive,
+}
+
+impl AdmissionRateLimiter {
+    /// Creates the production Redis limiter.
+    pub fn redis(pool: deadpool_redis::Pool) -> Self {
+        Self::Redis(RedisRateLimiter::new(pool))
+    }
+
+    /// Creates the explicit permissive policy for a process-local relay.
+    pub fn permissive() -> Self {
+        Self::Permissive
+    }
+}
+
+impl RateLimiter for AdmissionRateLimiter {
+    async fn check_and_increment(
+        &self,
+        ctx: &TenantContext,
+        pubkey: &PublicKey,
+        limit_type: LimitType,
+        window_secs: u64,
+        limit: u64,
+    ) -> Result<RateLimitResult, AuthError> {
+        match self {
+            Self::Redis(limiter) => {
+                limiter
+                    .check_and_increment(ctx, pubkey, limit_type, window_secs, limit)
+                    .await
+            }
+            Self::Permissive => Ok(RateLimitResult::allowed(1, limit, window_secs)),
+        }
+    }
+
+    async fn check_ip_connection(
+        &self,
+        ip: &IpAddr,
+        window_secs: u64,
+        limit: u64,
+    ) -> Result<RateLimitResult, AuthError> {
+        match self {
+            Self::Redis(limiter) => limiter.check_ip_connection(ip, window_secs, limit).await,
+            Self::Permissive => Ok(RateLimitResult::allowed(1, limit, window_secs)),
+        }
+    }
+}
+
 /// Redis-backed rate limiter using fixed-window counters.
 ///
 /// Pubkey keys are community-scoped via `&TenantContext`:
@@ -117,5 +171,38 @@ impl RateLimiter for RedisRateLimiter {
     ) -> Result<RateLimitResult, AuthError> {
         let key = buzz_auth::rate_limit::ip_rate_limit_key(ip);
         run_rate_limit(&self.pool, &key, window_secs, limit).await
+    }
+}
+
+#[cfg(test)]
+mod admission_backend_tests {
+    use super::*;
+    use buzz_core::CommunityId;
+    use nostr::Keys;
+    use std::net::{IpAddr, Ipv4Addr};
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn permissive_backend_allows_principal_and_ip_without_redis() {
+        let limiter = AdmissionRateLimiter::permissive();
+        let tenant =
+            TenantContext::resolved(CommunityId::from_uuid(Uuid::from_u128(1)), "local.invalid");
+        let principal = limiter
+            .check_and_increment(
+                &tenant,
+                &Keys::generate().public_key(),
+                LimitType::Messages,
+                60,
+                10,
+            )
+            .await
+            .expect("permissive principal policy");
+        let ip = limiter
+            .check_ip_connection(&IpAddr::V4(Ipv4Addr::LOCALHOST), 60, 10)
+            .await
+            .expect("permissive IP policy");
+
+        assert!(principal.allowed);
+        assert!(ip.allowed);
     }
 }

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -50,9 +50,41 @@ pub struct JoinPolicyConfig {
 /// WebSocket close-frame delivery after the final delayed cancellation.
 pub const MAX_DRAIN_JITTER_MS: u64 = 20_000;
 
+/// Relay runtime profile. The default preserves the production service graph;
+/// `single-node` selects only process-local or filesystem-backed services.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayProfile {
+    /// Postgres, Redis, S3, and Postgres FTS.
+    Production,
+    /// One-process local relay with no external service dependencies.
+    SingleNode,
+}
+
+impl RelayProfile {
+    /// Whether this profile must avoid every external service connection.
+    pub fn is_single_node(self) -> bool {
+        matches!(self, Self::SingleNode)
+    }
+
+    fn from_env() -> Result<Self, ConfigError> {
+        match std::env::var("BUZZ_PROFILE") {
+            Err(_) => Ok(Self::Production),
+            Ok(value) if value.trim().is_empty() || value.eq_ignore_ascii_case("production") => {
+                Ok(Self::Production)
+            }
+            Ok(value) if value.eq_ignore_ascii_case("single-node") => Ok(Self::SingleNode),
+            Ok(value) => Err(ConfigError::InvalidValue(format!(
+                "BUZZ_PROFILE must be 'production' or 'single-node', got {value:?}"
+            ))),
+        }
+    }
+}
+
 /// Relay runtime configuration, loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct Config {
+    /// Service topology selected by `BUZZ_PROFILE`.
+    pub profile: RelayProfile,
     /// Address the relay HTTP/WebSocket server binds to.
     pub bind_addr: SocketAddr,
     /// Postgres database connection URL.
@@ -459,6 +491,7 @@ fn inert_env_vars<'a>(names: &[&'a str], lookup: impl Fn(&str) -> Option<String>
 impl Config {
     /// Loads configuration from environment variables, falling back to development defaults.
     pub fn from_env() -> Result<Self, ConfigError> {
+        let profile = RelayProfile::from_env()?;
         let bind_addr_raw =
             std::env::var("BUZZ_BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:3000".to_string());
         let bind_addr = parse_bind_addr(&bind_addr_raw)?;
@@ -987,6 +1020,7 @@ impl Config {
         }
 
         Ok(Self {
+            profile,
             bind_addr,
             database_url,
             read_database_url,

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -153,6 +153,15 @@ async fn main() -> anyhow::Result<()> {
         "Config loaded"
     );
 
+    // Phase 1 constructor fence: never fall through to production's eager
+    // Postgres/Redis/S3 graph for a single-node profile. The local backend
+    // constructor replaces this explicit denial as its implementations land.
+    if config.profile.is_single_node() {
+        return Err(anyhow::anyhow!(
+            "BUZZ_PROFILE=single-node local backend bundle is not installed yet"
+        ));
+    }
+
     let usage_interval_secs = usage_metrics_interval_secs();
     let usage_idle_timeout_secs = usage_metrics_idle_timeout_secs(usage_interval_secs);
     relay_metrics::install(config.metrics_port, usage_idle_timeout_secs);
@@ -468,7 +477,10 @@ async fn main() -> anyhow::Result<()> {
     // operator who asked for the mesh gets it or gets told why not.
     if let Some(handle) = buzz_relay::mesh_boot::boot_mesh(
         &state.config,
-        state.redis_pool.clone(),
+        state
+            .redis_pool
+            .clone()
+            .expect("production profile has Redis"),
         &state.relay_keypair,
         Arc::clone(&state.shutting_down),
     )
@@ -1013,11 +1025,13 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
 
-                let rs = pool_state.redis_pool.status();
-                metrics::gauge!("buzz_redis_pool_available").set(rs.available as f64);
-                metrics::gauge!("buzz_redis_pool_size").set(rs.size as f64);
-                metrics::gauge!("buzz_redis_pool_max").set(rs.max_size as f64);
-                metrics::gauge!("buzz_redis_pool_waiting").set(rs.waiting as f64);
+                if let Some(redis_pool) = &pool_state.redis_pool {
+                    let rs = redis_pool.status();
+                    metrics::gauge!("buzz_redis_pool_available").set(rs.available as f64);
+                    metrics::gauge!("buzz_redis_pool_size").set(rs.size as f64);
+                    metrics::gauge!("buzz_redis_pool_max").set(rs.max_size as f64);
+                    metrics::gauge!("buzz_redis_pool_waiting").set(rs.waiting as f64);
+                }
             }
         });
     }

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -46,9 +46,12 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .layer(RequestBodyLimitLayer::new(media_body_limit))
         .with_state(state.clone());
 
-    let git_router = api::git::git_router(state.clone());
-
-    let git_policy_router = api::git::git_policy_router(state.clone());
+    // Git is deliberately unavailable in the single-node profile: its only
+    // durable backend is S3. Do not build its routes (or internal hook policy
+    // endpoint) until a local GitStore exists.
+    let git_enabled = !state.config.profile.is_single_node();
+    let git_router = git_enabled.then(|| api::git::git_router(state.clone()));
+    let git_policy_router = git_enabled.then(|| api::git::git_policy_router(state.clone()));
 
     let admin_enabled = state.config.admin.is_some();
     let admin_web_dir = state
@@ -133,10 +136,13 @@ pub fn build_router(state: Arc<AppState>) -> Router {
 
     // Merge — each sub-router carries its own body limit.
     // Metrics → Trace → CORS applied once over the combined router.
-    let mut merged = api_router
-        .merge(media_router)
-        .merge(git_router)
-        .merge(git_policy_router);
+    let mut merged = api_router.merge(media_router);
+    if let Some(git_router) = git_router {
+        merged = merged.merge(git_router);
+    }
+    if let Some(git_policy_router) = git_policy_router {
+        merged = merged.merge(git_policy_router);
+    }
     if let Some(admin_router) = admin_router {
         merged = merged.merge(admin_router);
     }

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -377,8 +377,11 @@ async fn readiness_handler(State(state): State<Arc<AppState>>) -> impl IntoRespo
 
     let check = async {
         let (pg_ok, redis_ok) = tokio::join!(state.db.ping(), async {
-            state.redis_pool.get().await.is_ok()
-        },);
+            match &state.redis_pool {
+                Some(pool) => pool.get().await.is_ok(),
+                None => true,
+            }
+        });
         (pg_ok, redis_ok)
     };
 

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -24,7 +24,7 @@ use buzz_db::Db;
 use buzz_media::MediaStorage;
 use buzz_pubsub::cache_invalidation::CacheInvalidation;
 use buzz_pubsub::conn_control::ConnControl;
-use buzz_pubsub::rate_limiter::RedisRateLimiter;
+use buzz_pubsub::rate_limiter::AdmissionRateLimiter;
 use buzz_pubsub::{PubSubManager, RedisNip98ReplayGuard};
 use buzz_search::SearchService;
 use buzz_workflow::WorkflowEngine;
@@ -575,6 +575,29 @@ impl Default for ConnectionManager {
     }
 }
 
+/// Runtime backends injected at the application-state boundary.
+///
+/// Production construction remains in `main.rs`; the single-node profile supplies
+/// alternate implementations without adding backend checks to request handlers.
+pub struct AppBackends {
+    /// Database backend.
+    pub db: Db,
+    /// Redis health/command pool; absent for process-local profiles.
+    pub redis_pool: Option<deadpool_redis::Pool>,
+    /// Event and control-plane pub/sub.
+    pub pubsub: Arc<PubSubManager>,
+    /// Full-text search backend.
+    pub search: SearchService,
+    /// Media blob backend.
+    pub media_storage: MediaStorage,
+    /// Git object backend.
+    pub git_store: crate::api::git::store::GitStore,
+    /// NIP-98 replay fence.
+    pub nip98_replay: Arc<dyn Nip98ReplayGuard>,
+    /// Admission rate limiter.
+    pub admission_rate_limiter: Arc<AdmissionRateLimiter>,
+}
+
 /// Shared application state, cloned cheaply via inner `Arc` fields.
 #[derive(Clone)]
 pub struct AppState {
@@ -582,8 +605,8 @@ pub struct AppState {
     pub config: Arc<Config>,
     /// Database connection pool.
     pub db: Db,
-    /// Redis pool for readiness health checks.
-    pub redis_pool: deadpool_redis::Pool,
+    /// Redis pool for readiness health checks; absent in single-node mode.
+    pub redis_pool: Option<deadpool_redis::Pool>,
     /// Audit event service, absent when audit logging is disabled.
     pub audit: Option<Arc<AuditService>>,
     /// Pub/sub manager for broadcasting events to subscribers.
@@ -673,7 +696,7 @@ pub struct AppState {
     /// cross-pod routing.
     pub nip98_replay: Arc<dyn Nip98ReplayGuard>,
     /// Shared Redis-backed admission limits for ordinary HTTP and WebSocket work.
-    pub admission_rate_limiter: Arc<RedisRateLimiter>,
+    pub admission_rate_limiter: Arc<AdmissionRateLimiter>,
 
     /// Per-agent sliding-window rate limiter for observer frames (kind 24200).
     /// Key: (community_id, agent pubkey bytes). Value: (count, window_start).
@@ -738,6 +761,57 @@ impl AppState {
         relay_keypair: nostr::Keys,
         media_storage: MediaStorage,
     ) -> (Self, AuditShutdownHandle) {
+        let git_store = crate::api::git::store::GitStore::new(
+            &config.media.s3_endpoint,
+            &config.media.s3_access_key,
+            &config.media.s3_secret_key,
+            &config.media.s3_bucket,
+            &config.media.s3_region,
+            config.media.s3_addressing_style,
+        )
+        .expect("media storage was already constructed with this S3 config");
+        let nip98_replay: Arc<dyn Nip98ReplayGuard> =
+            Arc::new(RedisNip98ReplayGuard::new(redis_pool.clone()));
+        let admission_rate_limiter = Arc::new(AdmissionRateLimiter::redis(redis_pool.clone()));
+        Self::new_with_backends(
+            config,
+            AppBackends {
+                db,
+                redis_pool: Some(redis_pool),
+                pubsub,
+                search,
+                media_storage,
+                git_store,
+                nip98_replay,
+                admission_rate_limiter,
+            },
+            audit,
+            auth,
+            workflow_engine,
+            relay_keypair,
+        )
+    }
+
+    /// Constructs state from an explicit backend bundle.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_backends(
+        config: Config,
+        backends: AppBackends,
+        audit: impl Into<Option<AuditService>>,
+        auth: AuthService,
+        workflow_engine: Arc<WorkflowEngine>,
+        relay_keypair: nostr::Keys,
+    ) -> (Self, AuditShutdownHandle) {
+        let AppBackends {
+            db,
+            redis_pool,
+            pubsub,
+            search,
+            media_storage,
+            git_store,
+            nip98_replay,
+            admission_rate_limiter,
+        } = backends;
         let max_connections = config.max_connections;
         let max_concurrent_handlers = config.max_concurrent_handlers;
         let search_arc = Arc::new(search);
@@ -783,15 +857,6 @@ impl AppState {
 
         let git_max_concurrent_ops = config.git_max_concurrent_ops;
         let media_max_concurrent_uploads = config.media_max_concurrent_uploads;
-        let git_store = crate::api::git::store::GitStore::new(
-            &config.media.s3_endpoint,
-            &config.media.s3_access_key,
-            &config.media.s3_secret_key,
-            &config.media.s3_bucket,
-            &config.media.s3_region,
-            config.media.s3_addressing_style,
-        )
-        .expect("media storage was already constructed with this S3 config");
         let git_pack_cache = Arc::new(
             crate::api::git::pack_cache::GitPackCache::new(
                 &config.git_pack_cache_path,
@@ -800,9 +865,6 @@ impl AppState {
             )
             .expect("git pack cache path must be available"),
         );
-        let nip98_replay: Arc<dyn Nip98ReplayGuard> =
-            Arc::new(RedisNip98ReplayGuard::new(redis_pool.clone()));
-        let admission_rate_limiter = Arc::new(RedisRateLimiter::new(redis_pool.clone()));
         let audit_enabled = audit_arc.is_some();
         let state = Self {
             config: Arc::new(config),

--- a/crates/buzz-search/src/error.rs
+++ b/crates/buzz-search/src/error.rs
@@ -3,6 +3,9 @@ use thiserror::Error;
 /// Errors produced by the FTS service.
 #[derive(Debug, Error)]
 pub enum SearchError {
+    /// Search is intentionally unavailable in the selected runtime profile.
+    #[error("search unsupported by runtime profile")]
+    Unsupported,
     /// A database error from sqlx.
     #[error("database error: {0}")]
     Db(#[from] sqlx::Error),

--- a/crates/buzz-search/src/lib.rs
+++ b/crates/buzz-search/src/lib.rs
@@ -32,23 +32,39 @@ pub use query::{search, ChannelScope, SearchHit, SearchMode, SearchQuery, Search
 
 use sqlx::PgPool;
 
-/// Thin handle around a `PgPool` for community-scoped FTS.
-///
-/// Holds nothing the pool itself doesn't already own. The whole purpose of
-/// this type is a stable injection point for the relay's `AppState`.
+/// Search backend selected at startup.
+#[derive(Debug, Clone)]
+enum SearchBackend {
+    Postgres(PgPool),
+    Unsupported,
+}
+
+/// Stable search-service injection point.
 #[derive(Debug, Clone)]
 pub struct SearchService {
-    pool: PgPool,
+    backend: SearchBackend,
 }
 
 impl SearchService {
     /// Build a search service over an existing Postgres pool.
     pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+        Self {
+            backend: SearchBackend::Postgres(pool),
+        }
+    }
+
+    /// Build a backend that explicitly reports search as unsupported.
+    pub fn unsupported() -> Self {
+        Self {
+            backend: SearchBackend::Unsupported,
+        }
     }
 
     /// Execute a community-scoped FTS query.
     pub async fn search(&self, query: &SearchQuery) -> Result<SearchResult, SearchError> {
-        query::search(&self.pool, query).await
+        match &self.backend {
+            SearchBackend::Postgres(pool) => query::search(pool, query).await,
+            SearchBackend::Unsupported => Err(SearchError::Unsupported),
+        }
     }
 }


### PR DESCRIPTION
## PR 0 of 12 — Backend seams prep (local-mode graduation stack)

First PR of the local-mode graduation train (source branch `wip-experiment-local-mode` @ `b3f365faf`, re-cut as a 12-PR stack; plan in the `buzz-experiment-local-mode` channel canvas).

### What this PR does

Mechanical seams-prep refactor with **zero hosted-path behavior change**:

- **`buzz-db-backend-macro` crate** (new, standalone): compile-time enforcement that every public `Db` method carries an explicit `#[sqlite_backend(...)]` decision marker, with trybuild compile-pass/fail coverage. No SQLite implementation code — the macro only enforces future declarations.
- **Relay pubsub/media/presence/config seams**: `RelayProfile` config enum (`BUZZ_PROFILE`, defaults to `production`; `single-node` fails fast at boot — constructor fence, no local backend installed yet), `AppState::new_with_backends` injection point, `redis_pool` becomes `Option` (always `Some` on the production path), pubsub/media/search backend selection moved behind startup-selected wrappers.
- **Filesystem media backend hardening** (pulled forward from the source branch per review): component-aware cross-platform key rejection (traversal, `\\`, drive/UNC paths), atomic same-directory temp-file writes/copies, seek + bounded `take` range reads, regression coverage for the traversal/Windows-separator boundary.

Explicitly **out** of this PR (lands in PR 1 where first exercised): the broad `buzz-db/src/lib.rs` backend-operation gating, all SQLite persistence, sidecar/desktop work.

### Size

24 files, +1,414/−154 = 1,568 changed lines (stack budget: ≤2k after the PR 1 tracer).

### Evidence

- `cargo test -p buzz-media` — 111 passed / 1 ignored (MinIO, infra-dependent)
- `cargo test -p buzz-db-backend-macro` — green (incl. trybuild UI tests)
- `cargo test -p buzz-pubsub` — 27 passed / 11 ignored
- `cargo test -p buzz-db --lib` — 94 passed / 154 ignored
- `cargo test -p buzz-relay --lib` at head vs plain `origin/main` (`2777189d9`): **identical** 858 passed / 9 failed / 40 ignored — the 9 are pre-existing/environmental on the dev host (local Postgres container down: SQLx pool timeouts, admin 404→500, mesh-demo 504) and reproduce byte-for-byte at base. CI's real-database run is the authoritative gate.
- Full pre-push hook suite green (rust-tests, desktop check/typecheck/test/tauri, mobile-test).

### Review

Blocking review by Larry: initial 6/10 (filesystem media boundary needed the source branch's hardening family), fix round closed it, final **10/10** at exactly this head — no remaining blockers or suggestions.

Builder: Brother Darryl. Verification: Wakko (independent test reruns at exact head `8f29ecb`).
