### PR TITLE
fix(desktop): ship a bundle that parses on WebKit without lookbehind (Intel/macOS 12)

### DIFF
--- a/desktop/src/features/messages/lib/mentionHighlightExtension.ts
+++ b/desktop/src/features/messages/lib/mentionHighlightExtension.ts
@@ -106,10 +106,7 @@ export function buildHighlightPatterns(
       n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
     );
     patterns.push(
-      new RegExp(
-        `(?:^|(?<=[\\s(]))@(${escapedNames.join("|")})(?=\\W|$)`,
-        "gi",
-      ),
+      new RegExp(`(^|[\\s(])@(${escapedNames.join("|")})(?=\\W|$)`, "gi"),
     );
   }
 
@@ -121,10 +118,7 @@ export function buildHighlightPatterns(
       n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
     );
     patterns.push(
-      new RegExp(
-        `(?:^|(?<=\\s))#(${escapedChannels.join("|")})(?=\\W|$)`,
-        "gi",
-      ),
+      new RegExp(`(^|\\s)#(${escapedChannels.join("|")})(?=\\W|$)`, "gi"),
     );
   }
 
@@ -145,7 +139,15 @@ export function findHighlightMatches(
     pattern.lastIndex = 0;
     let m: RegExpExecArray | null = pattern.exec(text);
     while (m !== null) {
-      results.push({ from: m.index, to: m.index + m[0].length, match: m[0] });
+      // Group 1 is the boundary prefix (empty at start-of-text). It replaces
+      // the previous lookbehind, which macOS 12's WebKit cannot parse
+      // (see block/buzz#3295); skip it so offsets point at the @/# sigil.
+      const prefixLen = m[1] ? m[1].length : 0;
+      results.push({
+        from: m.index + prefixLen,
+        to: m.index + m[0].length,
+        match: m[0].slice(prefixLen),
+      });
       m = pattern.exec(text);
     }
   }

--- a/desktop/src/features/settings/ui/KeyboardShortcutsCard.tsx
+++ b/desktop/src/features/settings/ui/KeyboardShortcutsCard.tsx
@@ -6,11 +6,34 @@ import {
 import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 
+// Split a key-combo string on "+" separators. A "+" is a separator unless it
+// directly follows another "+" (so "⌘++" keeps "+" as a key) or only
+// whitespace remains after it (so a trailing "+" stays attached). Mirrors the
+// previous /(?<!\+)\+(?!\s*$)/ split without lookbehind/lookahead.
+function splitKeyCombo(keys: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  for (let i = 0; i < keys.length; i++) {
+    const ch = keys[i];
+    const isSeparator =
+      ch === "+" && keys[i - 1] !== "+" && keys.slice(i + 1).trim() !== "";
+    if (isSeparator) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
 function KeyCombo({ shortcut }: { shortcut: KeyboardShortcut }) {
   const keys = getPlatformKeys(shortcut);
-  // Split on "+" but keep "+" as a standalone key (e.g. for zoom-in "⌘+")
-  const parts = keys
-    .split(/(?<!\+)\+(?!\s*$)/)
+  // Split on "+" but keep "+" as a standalone key (e.g. for zoom-in "⌘+").
+  // Implemented without RegExp lookbehind so the bundle parses on macOS 12's
+  // system WebKit (Safari 16.4 feature). See block/buzz#3295.
+  const parts = splitKeyCombo(keys)
     .map((p) => p.trim())
     .filter(Boolean);
 

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -28,6 +28,13 @@ export default defineConfig(async () => ({
     },
   },
 
+  // Target Safari 15 so the bundle parses on macOS 12's system WebKit (613),
+  // which lacks Safari 16.4 syntax (e.g. RegExp lookbehind in literals,
+  // class static blocks). See https://github.com/block/buzz/issues/3295
+  build: {
+    target: ["es2020", "safari15"],
+  },
+
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
   // 1. prevent Vite from obscuring rust errors

--- a/patches/mdast-util-gfm-autolink-literal@2.0.1.patch
+++ b/patches/mdast-util-gfm-autolink-literal@2.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/index.js b/lib/index.js
+index c5ca771c24dd914e342f791716a822431ee32b3a..7fcfaf8441a81d42cceb059c7f48925373e794d3 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -132,7 +132,7 @@ function transformGfmAutolinkLiterals(tree) {
+     tree,
+     [
+       [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
+-      [/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]
++      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]
+     ],
+     {ignore: ['link', 'linkReference']}
+   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
 
 patchedDependencies:
   isomorphic-git: e9b414a60d4cf1d8aa18f7a779483984e821989967c235662566e94ef0238d3f
+  mdast-util-gfm-autolink-literal@2.0.1: b6c92ec682456ca4b035718f71ee2b4a77d00da4c08cbc5e235e99eaabd96c45
   virtua@0.49.3: 30a7a92b94800ec37be8d36546ea98c04a05dcd0637f9fac27a06f016ba2eff4
 
 importers:
@@ -6036,7 +6037,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-autolink-literal@2.0.1:
+  mdast-util-gfm-autolink-literal@2.0.1(patch_hash=b6c92ec682456ca4b035718f71ee2b4a77d00da4c08cbc5e235e99eaabd96c45):
     dependencies:
       '@types/mdast': 4.0.4
       ccount: 2.0.1
@@ -6084,7 +6085,7 @@ snapshots:
   mdast-util-gfm@3.1.0:
     dependencies:
       mdast-util-from-markdown: 2.0.3
-      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-autolink-literal: 2.0.1(patch_hash=b6c92ec682456ca4b035718f71ee2b4a77d00da4c08cbc5e235e99eaabd96c45)
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,4 +20,5 @@ overrides:
   linkify-it: "^5.0.2"
 patchedDependencies:
   isomorphic-git: patches/isomorphic-git.patch
+  mdast-util-gfm-autolink-literal@2.0.1: patches/mdast-util-gfm-autolink-literal@2.0.1.patch
   virtua@0.49.3: patches/virtua@0.49.3.patch


### PR DESCRIPTION
## Summary

Buzz Desktop renders a blank window on Macs whose system WebKit predates Safari 16.4: the shipped bundle contains RegExp lookbehind patterns, and older WebKit fails at *parse* time, so the frontend never renders. This matches the symptom in #3295, and matters because the project ships and promotes Intel DMGs (#748 added the x86_64 release target; #2090 steers Safari users to the right DMG) while the app declares minimum macOS 10.15.

Four changes make the bundle lookbehind-free:

1. `desktop/vite.config.ts` — build target `["es2020", "safari15"]`, so the toolchain lowers syntax for pre-16.4 WebKit.
2. `mentionHighlightExtension.ts` — rewrite the two mention/channel patterns using a boundary capture group instead of lookbehind, with a prefix-length offset fix in `findHighlightMatches`.
3. `KeyboardShortcutsCard.tsx` — replace the lookbehind/lookahead key-combo split with a small `splitKeyCombo` helper (same behavior).
4. `patches/mdast-util-gfm-autolink-literal@2.0.1.patch` — the dependency ships pre-bundled code with a lookbehind in the email-autolink pattern; patched via the existing `patches/` convention, since a build target cannot rewrite it.

Because the failure is at parse time, one pattern anywhere blanks the whole app — that is why both the build target and the source/dependency rewrites are needed.

Trade-offs, stated honestly: (a) the `safari15` target affects all platforms, not only macOS 12; (b) the dependency patch slightly changes email-autolink edge behavior everywhere, relying on the package's boundary guard instead of the lookbehind — the ideal fix is upstream in micromark, this is the interim.

Heads-up: #4701 (open) introduces a new negative lookbehind in the bare-URL pattern; the same portability concern applies there.

### Related issue

Relates to #3295 — same blank-render symptom; note the original report is arm64/Safari 17.6, which may be a separate cause. This PR fixes the lookbehind parse failure affecting pre-16.4 WebKit. Before opening I searched existing PRs/issues for "macOS 12", "Intel", "lookbehind" — closest existing PR: none found.

### Testing

- `grep -rln -E '\(\?<[=!]'` over the built `Buzz.app` Resources: clean.
- `just desktop-test`: 4,604 tests pass. `just desktop-tauri-test`: pass.
- Built with `just desktop-release-build x86_64-apple-darwin` on current main (post-0.5.9).
- Smoke-tested the resulting DMG on macOS 12 Intel hardware (MacBook Air): window renders, login persists, channels and history load, mentions highlight, URLs linkify. Same patches previously ran in daily self-hosted use on a 0.5.8 base (Air + iMac).
- **Not tested:** Apple Silicon regression, macOS 13+.