### PR TITLE
fix(observer): align NIP-44 plaintext limit

### DIFF
--- a/crates/buzz-core/src/observer.rs
+++ b/crates/buzz-core/src/observer.rs
@@ -21,8 +21,8 @@ pub const OBSERVER_FRAME_CONTROL: &str = "control";
 pub const NIP44_MIN_CONTENT_LEN: usize = 132;
 /// Maximum NIP-44 v2 ciphertext length.
 pub const NIP44_MAX_CONTENT_LEN: usize = 87_472;
-/// Maximum observer plaintext JSON size accepted by helpers.
-pub const OBSERVER_MAX_PLAINTEXT_LEN: usize = 65_535;
+/// Maximum observer plaintext JSON size accepted by the NIP-44 v2 codec.
+pub const OBSERVER_MAX_PLAINTEXT_LEN: usize = 65_536 - 128;
 
 /// Errors returned by observer payload encryption/decryption helpers.
 #[derive(Debug, Error)]
@@ -115,6 +115,12 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Kind, Tag};
 
+    const NIP44_V2_MAX_PLAINTEXT_LEN: usize = 65_536 - 128;
+
+    fn json_string_with_serialized_len(len: usize) -> String {
+        "x".repeat(len - 2)
+    }
+
     #[test]
     fn observer_payload_round_trips_with_nip44() {
         let sender = Keys::generate();
@@ -155,5 +161,33 @@ mod tests {
             decrypt_observer_payload::<serde_json::Value>(&recipient, &event),
             Err(ObserverPayloadError::InvalidCiphertextLength(_))
         ));
+    }
+
+    #[test]
+    fn observer_payload_accepts_largest_nip44_plaintext() {
+        let sender = Keys::generate();
+        let recipient = Keys::generate();
+        let payload = json_string_with_serialized_len(NIP44_V2_MAX_PLAINTEXT_LEN);
+
+        encrypt_observer_payload(&sender, &recipient.public_key(), &payload)
+            .expect("encrypt maximum-size NIP-44 plaintext");
+    }
+
+    #[test]
+    fn observer_payload_rejects_plaintext_above_nip44_limit_before_encrypting() {
+        let sender = Keys::generate();
+        let recipient = Keys::generate();
+        let payload = json_string_with_serialized_len(NIP44_V2_MAX_PLAINTEXT_LEN + 1);
+
+        let error = encrypt_observer_payload(&sender, &recipient.public_key(), &payload)
+            .expect_err("reject plaintext above the NIP-44 limit");
+
+        match error {
+            ObserverPayloadError::PlaintextTooLarge { max, got } => {
+                assert_eq!(max, NIP44_V2_MAX_PLAINTEXT_LEN);
+                assert_eq!(got, NIP44_V2_MAX_PLAINTEXT_LEN + 1);
+            }
+            other => panic!("expected PlaintextTooLarge, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Align the observer plaintext budget with the NIP-44 v2 codec's actual 65,408-byte maximum.
- Add boundary regression coverage for the largest accepted payload and the first rejected payload.

The observer helper previously allowed JSON plaintext up to 65,535 bytes. The pinned NIP-44 implementation rejects anything above 65,408 bytes, so payloads in that 127-byte gap passed Buzz's preflight and then failed during encryption with `Nip44(V2(MessageTooLong))`. This caused oversized observer frames to be dropped instead of being trimmed or rejected by the shared Buzz budget.

With this change, callers using `OBSERVER_MAX_PLAINTEXT_LEN` trim and batch against the same limit enforced by encryption, and oversized payloads return the actionable `PlaintextTooLarge` error before entering NIP-44.

### Related issue

None found after searching open issues and PRs for the observer/NIP-44 limit mismatch.

### Testing

Test-first reproduction on the unmodified implementation:

- `cargo test -p buzz-core observer_payload_rejects_plaintext_above_nip44_limit_before_encrypting -- --nocapture`
- Failed as expected with `expected PlaintextTooLarge, got Nip44(V2(MessageTooLong))`.

Passing after the fix:

- `cargo test -p buzz-core observer::tests` — 4 passed
- `cargo test -p buzz-acp observer_publish_queue_tests` — 15 passed
- `cargo test -p buzz-acp observer_payload_trim_tests` — 8 passed
- Repository formatting, clippy, desktop/web/mobile static checks
- Remaining Rust unit suites — 7 passed
- Desktop unit tests and production frontend build
- Desktop Tauri compile check
- Web production build
- Mobile tests — 1,261 passed

`just ci` was attempted. On this machine, `buzz-voice` and `desktop-tauri-test` cannot link because Apple Clang 12 is older than the bundled Sherpa/ONNX macOS 13.4 objects (missing libc++/CoreAudio symbols). The same environment-only linker failure reproduces directly in `cargo test -p buzz-voice --no-run`; no voice or Tauri source is changed by this PR.