### PR TITLE
feat(acp): add --ttl to bound total harness lifetime

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -113,7 +113,17 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
+| `BUZZ_ACP_TTL` | no | `0` | Total process lifetime in seconds; `0` = disabled. On expiry the harness shuts down gracefully, then force-exits after a 30s grace period. Must be `0` or ≥60. |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
+
+**Bounding a harness vs. bounding a turn:** `BUZZ_ACP_IDLE_TIMEOUT` and
+`BUZZ_ACP_MAX_TURN_DURATION` bound a single *turn*, and
+`BUZZ_ACP_EXIT_AFTER_INACTIVITY` bounds time since the last dispatch — but a
+heartbeat *is* a dispatch, so enabling `BUZZ_ACP_HEARTBEAT_INTERVAL` keeps
+resetting the inactivity clock. Use `BUZZ_ACP_TTL` for ephemeral or scripted
+harnesses that must not outlive the job that spawned them: a backgrounded
+harness reparents to init when its parent exits, so ending the session that
+launched it does not stop it.
 
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -35,6 +35,22 @@ pub(crate) const DEFAULT_MAX_TURN_DURATION_SECS: u64 = 7200;
 /// deadline (`max_turn_duration + IN_FLIGHT_DEADLINE_BUFFER_SECS`).
 pub(crate) const MAX_TURN_DURATION_CEILING_SECS: u64 = 604_800;
 
+/// Smallest meaningful process TTL. Below this the harness would routinely be
+/// killed mid-turn, which presents as a flaky agent rather than as the
+/// misconfiguration it is.
+pub(crate) const MIN_TTL_SECS: u64 = 60;
+
+/// Reject a TTL that is non-zero but too short to complete useful work.
+/// 0 disables the TTL entirely (the default — unchanged legacy behaviour).
+pub(crate) fn validate_ttl(secs: u64) -> Result<(), ConfigError> {
+    if secs > 0 && secs < MIN_TTL_SECS {
+        return Err(ConfigError::ConfigFile(format!(
+            "ttl must be 0 (disabled) or ≥{MIN_TTL_SECS} seconds"
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("failed to parse nostr keys: {0}")]
@@ -302,6 +318,20 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_TURN_LIVENESS_SECS", default_value_t = 10)]
     pub turn_liveness_secs: u64,
 
+    /// Total process lifetime in seconds. After this much wall-clock time the
+    /// harness shuts down gracefully, exactly as if it had received SIGTERM or
+    /// an owner `!shutdown`. 0 = disabled (run forever).
+    ///
+    /// This is a *process* lifetime, not a turn timeout. `--idle-timeout`
+    /// bounds a single silent turn and `--max-turn-duration` bounds one turn's
+    /// wall-clock; neither can stop a harness that keeps getting work. A
+    /// self-prompting `--heartbeat-interval` generates that work forever, so an
+    /// ephemeral harness nobody is talking to still bills a model call every
+    /// heartbeat until something kills it. Set a TTL on any short-lived or
+    /// scripted harness so it cannot outlive the job that spawned it.
+    #[arg(long, env = "BUZZ_ACP_TTL", default_value_t = 0)]
+    pub ttl: u64,
+
     /// Heartbeat prompt text. Conflicts with --heartbeat-prompt-file.
     #[arg(
         long,
@@ -508,6 +538,12 @@ pub struct Config {
     /// `heartbeat_interval_secs` (agent self-prompting) — this is the desktop
     /// crash-backstop signal.
     pub turn_liveness_secs: u64,
+    /// Total process lifetime in seconds. 0 = disabled (run forever).
+    ///
+    /// Bounds the whole harness, not a turn: on expiry the run loop takes the
+    /// normal graceful-shutdown path. Set this on ephemeral/scripted harnesses
+    /// so they cannot outlive the job that spawned them.
+    pub ttl_secs: u64,
     pub heartbeat_prompt: Option<String>,
     pub system_prompt: Option<String>,
     /// Team-owned instructions layered separately from the agent system prompt.
@@ -862,6 +898,8 @@ impl Config {
             ));
         }
 
+        validate_ttl(args.ttl)?;
+
         if args.turn_liveness_secs > 0 && args.turn_liveness_secs < 5 {
             return Err(ConfigError::ConfigFile(
                 "turn liveness interval must be 0 (disabled) or ≥5 seconds".into(),
@@ -1071,6 +1109,7 @@ impl Config {
             agents: args.agents,
             heartbeat_interval_secs: heartbeat_interval,
             turn_liveness_secs,
+            ttl_secs: args.ttl,
             heartbeat_prompt,
             system_prompt,
             team_instructions: args
@@ -1477,6 +1516,7 @@ mod tests {
             has_generated_codex_config: false,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
+            ttl_secs: 0,
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,
@@ -2190,6 +2230,32 @@ channels = "ALL"
             "120",
         ]);
         assert_eq!(configured.exit_after_inactivity, 120);
+    }
+
+    #[test]
+    fn ttl_defaults_disabled_and_accepts_cli_value() {
+        let key = "0".repeat(64);
+        let default = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert_eq!(default.ttl, 0, "TTL must stay opt-in");
+
+        let configured = CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--ttl", "3600"]);
+        assert_eq!(configured.ttl, 3600);
+    }
+
+    #[test]
+    fn ttl_zero_is_allowed_and_means_disabled() {
+        assert!(validate_ttl(0).is_ok());
+    }
+
+    #[test]
+    fn ttl_at_minimum_is_allowed() {
+        assert!(validate_ttl(MIN_TTL_SECS).is_ok());
+    }
+
+    #[test]
+    fn ttl_below_minimum_is_rejected() {
+        let err = validate_ttl(MIN_TTL_SECS - 1).unwrap_err();
+        assert!(err.to_string().contains("ttl must be 0"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -66,6 +66,13 @@ const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
 /// human interaction, so it must not share the short probe timeout.
 const AUTHENTICATE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
+/// Grace period between the TTL's graceful shutdown signal and a forced exit.
+///
+/// Long enough for in-flight prompts to drain on the normal shutdown path,
+/// short enough that a harness stuck somewhere that never observes the signal
+/// (for example the initial relay-connect retry loop) still terminates.
+const TTL_SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
+
 /// Publish a kind:20001 presence update event via the WebSocket connection.
 ///
 /// Ephemeral kinds (20000-29999) are rejected by the HTTP bridge, so presence
@@ -1604,6 +1611,28 @@ async fn tokio_main() -> Result<()> {
     let mut pool_ready = !config.lazy_pool;
     let mut pool_lifecycle: PoolLifecycle<AgentPool> = PoolLifecycle::listening();
 
+    // TTL deadline, fixed here — BEFORE the relay connect, which retries with
+    // backoff and can block for minutes. Both TTL stages key off this one
+    // absolute instant so the forced exit can never precede the graceful signal
+    // no matter where startup happens to be when the deadline lands.
+    let ttl_deadline = (config.ttl_secs > 0)
+        .then(|| tokio::time::Instant::now() + Duration::from_secs(config.ttl_secs));
+
+    // Hard backstop, armed before anything can block. The graceful path needs
+    // the main loop to be running and watching the shutdown channel; until then
+    // the signal lands with nobody listening. Without this, a harness stuck in
+    // the initial relay-connect retry loop ignores its TTL entirely.
+    if let Some(deadline) = ttl_deadline {
+        tokio::spawn(async move {
+            tokio::time::sleep_until(deadline + TTL_SHUTDOWN_GRACE).await;
+            tracing::warn!(
+                grace_secs = TTL_SHUTDOWN_GRACE.as_secs(),
+                "TTL shutdown did not complete within the grace period — exiting"
+            );
+            std::process::exit(0);
+        });
+    }
+
     // Capture a startup watermark BEFORE connecting to the relay. This timestamp
     // is used for membership notification replay (via startup_watermark) and as
     // the initial subscribe_since for channels discovered at startup. The Subscribe
@@ -1942,6 +1971,26 @@ async fn tokio_main() -> Result<()> {
             use tokio::signal::unix::{signal, SignalKind};
             let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
             sigterm.recv().await;
+            let _ = tx.send(());
+        });
+    }
+
+    // TTL: a wall-clock cap on the whole process, not on a turn.
+    //
+    // Fires the same graceful shutdown as SIGTERM, so in-flight prompts drain
+    // normally. Without this, an ephemeral harness outlives whatever spawned it
+    // — and if it also self-prompts (`--heartbeat-interval`), it keeps issuing
+    // billable model calls with nobody on the other end. Backgrounded harnesses
+    // reparent to init, so "the session ended" does not stop them; only an
+    // explicit signal or this timer does.
+    // Graceful stage of the TTL: drain in-flight prompts the same way SIGTERM
+    // does. The forced-exit stage was already armed before the relay connect.
+    if let Some(deadline) = ttl_deadline {
+        let tx = shutdown_tx.clone();
+        let ttl_secs = config.ttl_secs;
+        tokio::spawn(async move {
+            tokio::time::sleep_until(deadline).await;
+            tracing::info!(ttl_secs, "TTL reached — shutting down");
             let _ = tx.send(());
         });
     }
@@ -6248,6 +6297,7 @@ mod build_mcp_servers_tests {
             has_generated_codex_config: false,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
+            ttl_secs: 0,
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,
@@ -6470,6 +6520,7 @@ mod error_outcome_emission_tests {
             has_generated_codex_config: false,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
+            ttl_secs: 0,
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,


### PR DESCRIPTION
## Summary

Adds `--ttl` / `BUZZ_ACP_TTL`: a wall-clock cap on the whole `buzz-acp` process. Default `0` (disabled), so existing behaviour is unchanged.

Every existing bound is scoped to a turn — `--idle-timeout` bounds one silent turn, `--max-turn-duration` bounds one turn's wall clock. `--exit-after-inactivity` looks like it covers the process, but `last_activity` is reset on every dispatch (`dispatch_pending`) and a heartbeat *is* a dispatch, so `--heartbeat-interval` continuously resets the clock meant to stop an unattended harness.

The result is a harness with no terminating condition. Scripts typically background `buzz-acp`, so when the parent exits the process reparents to init — ending the session that launched it does not stop it. It keeps waking on its heartbeat and issuing model calls against a billed provider with nobody reading the output. Nothing errors; the turns succeed. The only external symptom is spend.

**How it's implemented.** Two stages off one absolute deadline fixed *before* the relay connect:

1. at the deadline — fire the existing graceful shutdown, so in-flight prompts drain exactly as they do for SIGTERM;
2. 30s later — force the exit.

The second stage is not belt-and-braces. The graceful signal is a `watch` channel observed only by the main run loop, and `HarnessRelay::connect` retries with backoff well before that loop starts, so a TTL armed after the connect is silently ignored by a harness stuck in startup. My first version did exactly that: it sailed past its deadline and was still alive at 131s on a 60s TTL, with unit tests green. Deriving both stages from one absolute instant also guarantees the forced exit can never precede the graceful signal when startup is slow.

Values below 60s are rejected — they would routinely kill the harness mid-turn and present as a flaky agent rather than a misconfiguration.

### Related issue

#5636 — opened alongside this PR with the problem statement and alternatives considered.

Searched open PRs and issues for duplicates: none found. The few open items touching ACP timeouts are turn-scoped and unrelated to process lifetime.

### Testing

`just ci` passes locally. `cargo test -p buzz-acp --lib` — 740 passed. Four new unit tests cover the default, CLI/env plumbing, and minimum-value validation.

Manual verification, against a stub relay (WebSocket + NIP-42 AUTH + `POST /query`), since the interesting behaviour is timing that unit tests cannot observe:

| Scenario | Expected | Result |
|---|---|---|
| Healthy relay, main loop running | graceful exit at TTL | exits at **60s** — `TTL reached — shutting down` → `waiting for in-flight prompts` |
| Stuck in initial relay-connect retry | forced exit after grace | exits at **92s** (60s TTL + 30s grace) |
| Same, with the forced stage removed | — | **still running at 131s** (the failure this design exists to prevent) |

To reproduce the first case: run `buzz-acp` with `BUZZ_ACP_TTL=60` against any reachable relay and confirm it exits on its own at 60s.

No UI changes.

*Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/*

