### PR TITLE
Allow opt-in community-member agent DMs

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -136,6 +136,7 @@ Controls which authors' events the harness forwards to the agent. Events from di
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|
 | `--respond-to` | `BUZZ_ACP_RESPOND_TO` | `owner-only` | Author gate mode: `owner-only`, `allowlist`, `anyone`, `nobody`. |
+| `--allow-external-dms` | `BUZZ_ACP_ALLOW_EXTERNAL_DMS` | `false` | Apply `respond-to` inside DMs, allowing non-owner DM participants when the selected mode admits them. |
 | `--respond-to-allowlist` | `BUZZ_ACP_RESPOND_TO_ALLOWLIST` | — | Comma-separated 64-char hex pubkeys (required when mode is `allowlist`). Owner is always implicitly included. |
 
 **Modes:**
@@ -146,6 +147,10 @@ Controls which authors' events the harness forwards to the agent. Events from di
 | `allowlist` | Forward events from the listed pubkeys plus the owner. |
 | `anyone` | Forward all events (no author filtering). |
 | `nobody` | Drop all inbound events. Agent only acts on heartbeat prompts. |
+
+DMs remain owner/sibling-only by default. Set `BUZZ_ACP_ALLOW_EXTERNAL_DMS=true`
+to apply the selected mode inside DMs; for example, combining it with `anyone`
+lets any community member who shares a DM with the agent prompt it.
 
 The gate applies to **all** inbound events — @mentions, DMs, thread replies, and any event delivered by the relay. Owner control commands are checked **before** the gate, so the owner can still manage the harness regardless of mode:
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -453,6 +453,11 @@ pub struct CliArgs {
     )]
     pub respond_to: RespondTo,
 
+    /// Allow the configured inbound author gate to apply inside direct messages.
+    /// By default DMs remain restricted to the owner and verified sibling agents.
+    #[arg(long, env = "BUZZ_ACP_ALLOW_EXTERNAL_DMS", default_value_t = false)]
+    pub allow_external_dms: bool,
+
     /// Comma-separated 64-char hex pubkeys for allowlist mode.
     /// Owner pubkey is always implicitly included.
     #[arg(long, env = "BUZZ_ACP_RESPOND_TO_ALLOWLIST", value_delimiter = ',')]
@@ -540,6 +545,8 @@ pub struct Config {
     pub permission_mode: PermissionMode,
     /// Inbound author gate mode.
     pub respond_to: RespondTo,
+    /// Whether non-owner authors admitted by `respond_to` may prompt the agent in DMs.
+    pub allow_external_dms: bool,
     /// Validated allowlist of pubkey hex strings (used when respond_to == Allowlist).
     pub respond_to_allowlist: HashSet<String>,
     /// Allowed `respond_to` modes. Empty = all modes allowed.
@@ -1100,6 +1107,7 @@ impl Config {
                 .and_then(sanitize_session_title),
             permission_mode: args.permission_mode,
             respond_to: args.respond_to,
+            allow_external_dms: args.allow_external_dms,
             respond_to_allowlist,
             allowed_respond_to,
             persona_env_vars,
@@ -1131,7 +1139,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {} allow_external_dms={}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1153,6 +1161,7 @@ impl Config {
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
             respond_to_detail,
+            self.allow_external_dms,
             allowed_respond_to_detail,
         )
     }
@@ -1243,6 +1252,18 @@ pub fn resolve_channel_filters(
     discovered_channels: &[Uuid],
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
+    resolve_channel_filters_with_dms(config, discovered_channels, rules, &HashSet::new())
+}
+
+/// Resolve startup filters while allowing explicitly enabled DMs to bypass a
+/// shared-channel pin. This keeps agents out of unrelated shared channels while
+/// still letting newly joined DM participants reach them.
+pub fn resolve_channel_filters_with_dms(
+    config: &Config,
+    discovered_channels: &[Uuid],
+    rules: &[SubscriptionRule],
+    dm_channels: &HashSet<Uuid>,
+) -> HashMap<Uuid, ChannelFilter> {
     use buzz_core::kind::{
         KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
@@ -1252,6 +1273,14 @@ pub fn resolve_channel_filters(
             .iter()
             .filter_map(|s| s.parse::<Uuid>().ok())
             .filter(|id| discovered_channels.contains(id))
+            .chain(
+                discovered_channels
+                    .iter()
+                    .filter(|id| config.allow_external_dms && dm_channels.contains(id))
+                    .copied(),
+            )
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect()
     } else {
         discovered_channels.to_vec()
@@ -1333,17 +1362,18 @@ pub fn resolve_channel_filters(
 
 /// Resolve the subscription filter for a single dynamically-discovered channel.
 ///
-/// In Mentions/All mode, `channels_override` (--channels) is enforced — the agent
-/// won't subscribe to channels outside the operator's allowlist. In Config mode,
+/// In Mentions/All mode, `channels_override` (`--channels`) is enforced unless
+/// this is a DM and external DM access is explicitly enabled. In Config mode,
 /// `--channels` is ignored (per CLI contract) and rule-matching determines scope.
 ///
 /// Returns `None` when the channel is outside the agent's configured scope:
-/// - Mentions/All: channel not in `channels_override` (if set)
+/// - Mentions/All: channel not in `channels_override` (unless it is an opted-in DM)
 /// - Config: no subscription rules match the channel
 pub fn resolve_dynamic_channel_filter(
     config: &Config,
     channel_id: Uuid,
     rules: &[crate::filter::SubscriptionRule],
+    is_dm: bool,
 ) -> Option<ChannelFilter> {
     use buzz_core::kind::{
         KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
@@ -1358,7 +1388,7 @@ pub fn resolve_dynamic_channel_filter(
             let allowed = overrides
                 .iter()
                 .any(|s| s.parse::<Uuid>().ok() == Some(channel_id));
-            if !allowed {
+            if !allowed && !(config.allow_external_dms && is_dm) {
                 return None;
             }
         }
@@ -1471,6 +1501,7 @@ mod tests {
             session_title: None,
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,
+            allow_external_dms: false,
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: Vec::new(),
             persona_env_vars: vec![],
@@ -1813,6 +1844,35 @@ mod tests {
         assert!(result.contains_key(&ch_a));
         assert!(!result.contains_key(&ch_b));
         assert!(!result.contains_key(&ch_unknown));
+    }
+
+    #[test]
+    fn test_external_dm_opt_in_bypasses_shared_channel_override() {
+        let mut config = test_config(SubscribeMode::All);
+        config.allow_external_dms = true;
+        let pinned = Uuid::new_v4();
+        let dm = Uuid::new_v4();
+        let unrelated_shared = Uuid::new_v4();
+        config.channels_override = Some(vec![pinned.to_string()]);
+
+        let discovered = vec![pinned, dm, unrelated_shared];
+        let dm_channels = HashSet::from([dm]);
+        let result = resolve_channel_filters_with_dms(&config, &discovered, &[], &dm_channels);
+
+        assert!(result.contains_key(&pinned));
+        assert!(result.contains_key(&dm));
+        assert!(!result.contains_key(&unrelated_shared));
+    }
+
+    #[test]
+    fn test_dynamic_external_dm_bypasses_shared_channel_override() {
+        let mut config = test_config(SubscribeMode::All);
+        config.allow_external_dms = true;
+        config.channels_override = Some(vec![Uuid::new_v4().to_string()]);
+        let new_dm = Uuid::new_v4();
+
+        assert!(resolve_dynamic_channel_filter(&config, new_dm, &[], true).is_some());
+        assert!(resolve_dynamic_channel_filter(&config, new_dm, &[], false).is_none());
     }
 
     #[test]
@@ -2204,6 +2264,16 @@ channels = "ALL"
         let args = CliArgs::try_parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool=true"]);
         assert!(args.is_err(), "bool flags do not take an explicit value");
         assert!(CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool"]).lazy_pool);
+    }
+
+    #[test]
+    fn external_dms_require_explicit_opt_in() {
+        let key = "0".repeat(64);
+        assert!(!CliArgs::parse_from(["buzz-acp", "--private-key", &key]).allow_external_dms);
+        assert!(
+            CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--allow-external-dms",])
+                .allow_external_dms
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -227,20 +227,21 @@ async fn is_owner_or_sibling(
 /// message looks like a mention and would fire a turn. Combined with
 /// agent-initiated DMs (the agent can be asked to DM a third party), that
 /// turns `anyone`/`allowlist` modes into transitive access grants: whoever
-/// lands in a DM with the agent can prompt it. To close that hole, when
-/// `is_dm` is true only the owner and cryptographically verified same-owner
-/// siblings may fire a turn — the explicit allowlist and `anyone` mode do
-/// NOT apply inside DMs. `Nobody` still drops everything. Callers must
-/// resolve `is_dm` fail-closed: unknown channel type ⇒ treat as DM.
+/// lands in a DM with the agent can prompt it. By default, when `is_dm` is
+/// true only the owner and cryptographically verified same-owner siblings may
+/// fire a turn. Operators can explicitly set `allow_external_dms` to apply the
+/// normal `respond_to` gate inside DMs. Callers must resolve `is_dm`
+/// fail-closed: unknown channel type ⇒ treat as DM.
 async fn author_allowed(
     respond_to: &RespondTo,
     allowlist: &HashSet<String>,
     author: &str,
     is_dm: bool,
+    allow_external_dms: bool,
     owner_cache: &OwnerCache,
     rest_client: &relay::RestClient,
 ) -> bool {
-    if is_dm {
+    if is_dm && !allow_external_dms {
         return match respond_to {
             RespondTo::Nobody => false,
             _ => is_owner_or_sibling(author, owner_cache, rest_client).await,
@@ -1717,6 +1718,10 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("discovered {} channel(s)", channel_info_map.len());
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
+    let dm_channel_ids: HashSet<Uuid> = channel_info_map
+        .iter()
+        .filter_map(|(id, info)| (info.channel_type == "dm").then_some(*id))
+        .collect();
 
     let rules: Vec<SubscriptionRule> = match config.subscribe_mode {
         SubscribeMode::Mentions => {
@@ -1755,7 +1760,8 @@ async fn tokio_main() -> Result<()> {
         }
     };
 
-    let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let channel_filters =
+        config::resolve_channel_filters_with_dms(&config, &channel_ids, &rules, &dm_channel_ids);
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -2269,15 +2275,18 @@ async fn tokio_main() -> Result<()> {
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
-                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
-                                        tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
-                                        if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
-                                            tracing::warn!("failed to subscribe to new channel {ch}: {e}");
-                                        } else {
-                                            subscribed_channel_ids.insert(ch);
-                                        }
                                     } else {
-                                        tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        let is_dm = is_dm_channel(ch, &ctx.channel_info).await;
+                                        if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules, is_dm) {
+                                            tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
+                                            if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
+                                                tracing::warn!("failed to subscribe to new channel {ch}: {e}");
+                                            } else {
+                                                subscribed_channel_ids.insert(ch);
+                                            }
+                                        } else {
+                                            tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        }
                                     }
                                 } else {
                                     subscribed_channel_ids.remove(&ch);
@@ -2457,6 +2466,7 @@ async fn tokio_main() -> Result<()> {
                                     &config.respond_to_allowlist,
                                     &author,
                                     is_dm,
+                                    config.allow_external_dms,
                                     &owner_cache,
                                     &ctx.rest_client,
                                 )
@@ -4829,6 +4839,7 @@ mod author_gate_tests {
                 &allowlist,
                 SIBLING,
                 false,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4846,6 +4857,7 @@ mod author_gate_tests {
                 &RespondTo::Allowlist,
                 &allowlist,
                 EXTERNAL,
+                false,
                 false,
                 &cache,
                 &dummy_rest_client()
@@ -4865,6 +4877,7 @@ mod author_gate_tests {
                 &allowlist,
                 STRANGER,
                 false,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4882,6 +4895,7 @@ mod author_gate_tests {
                 &RespondTo::Allowlist,
                 &allowlist,
                 OWNER,
+                false,
                 false,
                 &cache,
                 &dummy_rest_client()
@@ -4904,6 +4918,7 @@ mod author_gate_tests {
                 &HashSet::new(),
                 STRANGER,
                 false,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4921,6 +4936,7 @@ mod author_gate_tests {
                     &RespondTo::OwnerOnly,
                     &HashSet::new(),
                     who,
+                    false,
                     false,
                     &cache,
                     &dummy_rest_client()
@@ -4948,6 +4964,7 @@ mod author_gate_tests {
                 &allowlist,
                 EXTERNAL,
                 true,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4965,6 +4982,7 @@ mod author_gate_tests {
                 &HashSet::new(),
                 STRANGER,
                 true,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4988,6 +5006,7 @@ mod author_gate_tests {
                         &HashSet::new(),
                         who,
                         true,
+                        false,
                         &cache,
                         &dummy_rest_client()
                     )
@@ -5007,11 +5026,30 @@ mod author_gate_tests {
                 &HashSet::new(),
                 OWNER,
                 true,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
             .await,
             "respond_to=nobody must drop everything, DMs included"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dm_opt_in_applies_anyone_gate() {
+        let cache = cache_with_sibling();
+        assert!(
+            author_allowed(
+                &RespondTo::Anyone,
+                &HashSet::new(),
+                STRANGER,
+                true,
+                true,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "an external DM participant must be admitted when the operator explicitly opts in"
         );
     }
 
@@ -5147,6 +5185,7 @@ mod author_gate_tests {
                 &allowlist,
                 EXTERNAL,
                 is_dm,
+                false,
                 &owner_cache,
                 &dummy_rest_client(),
             )
@@ -6245,6 +6284,7 @@ mod build_mcp_servers_tests {
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
+            allow_external_dms: false,
             respond_to_allowlist: std::collections::HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
@@ -6467,6 +6507,7 @@ mod error_outcome_emission_tests {
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
+            allow_external_dms: false,
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -359,12 +359,21 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
     );
 
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
+    let dm_channel_ids: std::collections::HashSet<Uuid> = channel_info_map
+        .iter()
+        .filter_map(|(id, info)| (info.channel_type == "dm").then_some(*id))
+        .collect();
 
     // Build subscription rules: mentions only (setup mode must not react to
     // every message in a channel).
     let rules = build_setup_subscription_rules(&config);
 
-    let channel_filters = crate::config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let channel_filters = crate::config::resolve_channel_filters_with_dms(
+        &config,
+        &channel_ids,
+        &rules,
+        &dm_channel_ids,
+    );
 
     if channel_filters.is_empty() {
         tracing::warn!(
@@ -426,8 +435,8 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         }
 
         // Apply the same author gate as normal mode so the nudge only goes
-        // to authors the real agent would have answered. Same DM hardening:
-        // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
+        // to authors the real agent would have answered. DM access remains
+        // owner/sibling-only unless the operator explicitly opted in.
         let author_hex = buzz_event.event.pubkey.to_hex();
         let is_dm = crate::is_dm_channel(buzz_event.channel_id, &channel_info).await;
         let allowed = author_allowed(
@@ -435,6 +444,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             &config.respond_to_allowlist,
             &author_hex,
             is_dm,
+            config.allow_external_dms,
             &owner_cache,
             &rest_client,
         )


### PR DESCRIPTION
## What changed

- adds an explicit `BUZZ_ACP_ALLOW_EXTERNAL_DMS` opt-in while preserving owner-only DMs by default
- applies the configured inbound author gate inside opted-in DMs
- lets opted-in DMs bypass shared-channel pins at startup and when discovered dynamically
- documents the new setting and adds regression coverage

## Why

Hosted community agents may intentionally serve all community members over direct messages. The existing hard-coded DM gate always restricted prompts to the owner and sibling agents, even when `BUZZ_ACP_RESPOND_TO=anyone` was configured.

## Impact

Operators can enable community-member DMs per agent. Agents that do not opt in retain the existing secure behavior.

## Validation

- `cargo fmt --all`
- `cargo test -p buzz-acp --lib` — 665 passed