### PR TITLE
feat(desktop): optional Dock hiding when closing to the menu bar

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -909,6 +909,8 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             tray_menu::clear_tray_agent_activity,
             #[cfg(target_os = "macos")]
+            tray_menu::set_hide_dock_icon_on_close,
+            #[cfg(target_os = "macos")]
             tray_menu::requeue_tray_actions,
             #[cfg(target_os = "macos")]
             tray_menu::take_tray_actions,
@@ -940,6 +942,7 @@ pub fn run() {
                     eprintln!("buzz-desktop: failed to hide main window: {error}");
                 }
             }
+            tray_menu::hide_dock_icon_after_close(app_handle);
         }
         RunEvent::WindowEvent {
             label,

--- a/desktop/src-tauri/src/tray_menu.rs
+++ b/desktop/src-tauri/src/tray_menu.rs
@@ -9,7 +9,10 @@
 pub(crate) mod mouse_nav;
 
 use std::{
-    sync::{Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex, OnceLock,
+    },
     time::{Duration, Instant},
 };
 
@@ -220,7 +223,65 @@ pub enum TrayAction {
     },
 }
 
+/// Whether closing the main window should also drop Buzz out of the Dock.
+///
+/// The webview owns this preference and republishes it on every launch, so the
+/// backend only needs the current value rather than its own persistence.
+#[cfg(target_os = "macos")]
+static HIDE_DOCK_ICON_ON_CLOSE: AtomicBool = AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn set_hide_dock_icon_on_close(enabled: bool) {
+    HIDE_DOCK_ICON_ON_CLOSE.store(enabled, Ordering::Relaxed);
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn hides_dock_icon_on_close() -> bool {
+    HIDE_DOCK_ICON_ON_CLOSE.load(Ordering::Relaxed)
+}
+
+/// Drops Buzz out of the Dock and the app switcher once its window is closed.
+///
+/// Opt-in through the Appearance setting. It is skipped while any other window
+/// is still on screen: an app with no Dock icon and a visible window cannot be
+/// brought back to the front by clicking it.
+#[cfg(target_os = "macos")]
+pub(crate) fn hide_dock_icon_after_close<R: Runtime>(app: &AppHandle<R>) {
+    if !hides_dock_icon_on_close() {
+        return;
+    }
+
+    let another_window_is_visible = app
+        .webview_windows()
+        .iter()
+        .any(|(label, window)| label != "main" && window.is_visible().unwrap_or(false));
+    if another_window_is_visible {
+        return;
+    }
+
+    if let Err(error) = app.set_dock_visibility(false) {
+        eprintln!("buzz-desktop: failed to hide the Dock icon: {error}");
+    }
+}
+
+/// Puts Buzz back in the Dock and the app switcher.
+///
+/// Restoring runs unconditionally: a user who turns the preference off while
+/// Buzz is hidden still expects the next open to behave like a regular app.
+#[cfg(target_os = "macos")]
+pub(crate) fn restore_dock_icon<R: Runtime>(app: &AppHandle<R>) {
+    if let Err(error) = app.set_dock_visibility(true) {
+        eprintln!("buzz-desktop: failed to restore the Dock icon: {error}");
+    }
+}
+
 pub(crate) fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+    // The Dock icon has to come back before the window is focused, otherwise
+    // macOS refuses to bring an accessory app to the front.
+    #[cfg(target_os = "macos")]
+    restore_dock_icon(app);
+
     let Some(window) = app.get_webview_window("main") else {
         return;
     };

--- a/desktop/src/features/settings/ui/AppearanceSettingsControls.tsx
+++ b/desktop/src/features/settings/ui/AppearanceSettingsControls.tsx
@@ -9,10 +9,15 @@ import { useCommunities } from "@/features/communities/useCommunities";
 import { AvatarFramingSlider } from "@/features/profile/ui/AnimatedAvatarControls";
 import { contrastColorForBackground } from "@/features/profile/ui/ProfileAvatarEditor.utils";
 import {
+  setHideDockIconOnClose,
+  useHideDockIconOnClose,
+} from "@/shared/lib/dockIconPreference";
+import {
   setLinkPreviewStyle,
   useLinkPreviewStyle,
   type LinkPreviewStyle,
 } from "@/shared/lib/linkPreviewStylePreference";
+import { isMacPlatform } from "@/shared/lib/platform";
 import {
   ACCENT_COLORS,
   DEFAULT_GLASS_OPACITY,
@@ -137,6 +142,42 @@ export function LinkPreviewStyleSetting() {
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+    </SettingsOptionRow>
+  );
+}
+
+/**
+ * macOS keeps a Dock icon for every regular app, so closing Buzz to the menu
+ * bar still leaves it in the Dock and in the ⌘-Tab switcher. This row lets a
+ * user opt into a true menu-bar-only app while Buzz is closed.
+ */
+export function HideDockIconSetting() {
+  const hideDockIcon = useHideDockIconOnClose();
+
+  if (!isMacPlatform()) {
+    return null;
+  }
+
+  return (
+    <SettingsOptionRow data-testid="hide-dock-icon-row">
+      <div className="min-w-0">
+        <label className="text-sm font-medium" htmlFor="hide-dock-icon-switch">
+          Hide from the Dock when closed
+        </label>
+        <p
+          className="text-sm font-normal text-muted-foreground/70"
+          data-settings-subcopy
+        >
+          Closing the window leaves Buzz in the menu bar only. Reopen it from
+          the menu bar item to bring the Dock icon back.
+        </p>
+      </div>
+      <Switch
+        checked={hideDockIcon}
+        data-testid="hide-dock-icon-toggle"
+        id="hide-dock-icon-switch"
+        onCheckedChange={setHideDockIconOnClose}
+      />
     </SettingsOptionRow>
   );
 }

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -56,6 +56,7 @@ import { appearanceCommunityLabel } from "../lib/appearanceScopeCopy";
 import {
   AccentPickerContent,
   GlassBackgroundSetting,
+  HideDockIconSetting,
   LinkPreviewStyleSetting,
   ProminentActiveTabSetting,
   ThreadLayoutSetting,
@@ -806,6 +807,7 @@ function ThemeSettingsCard() {
         >
           <LinkPreviewStyleSetting />
           <ThreadLayoutSetting />
+          <HideDockIconSetting />
         </SettingsOptionGroup>
       </div>
     </section>

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -17,6 +17,7 @@ import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
 import { PoofBurstProvider } from "@/shared/ui/PoofBurstProvider";
 import { Toaster } from "@/shared/ui/sonner";
 import { TooltipProvider } from "@/shared/ui/tooltip";
+import { syncHideDockIconOnClose } from "@/shared/lib/dockIconPreference";
 import { recoverLocalStorageQuotaOnStartup } from "@/shared/lib/localStorageQuota";
 import { startLocalStorageSweep } from "@/shared/lib/localStorageSweep";
 
@@ -125,6 +126,7 @@ async function bootstrap() {
   recoverLocalStorageQuotaOnStartup();
   startLocalStorageSweep();
   await installE2eBridgeIfConfigured();
+  syncHideDockIconOnClose();
   await migrateLegacyCommunityStorageBeforeRender();
   renderApp();
 }

--- a/desktop/src/shared/lib/dockIconPreference.test.mjs
+++ b/desktop/src/shared/lib/dockIconPreference.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const values = new Map();
+globalThis.localStorage = {
+  getItem: (key) => values.get(key) ?? null,
+  setItem: (key, value) => values.set(key, value),
+};
+
+const preference = await import("./dockIconPreference.ts");
+
+test("defaults to keeping the Dock icon", () => {
+  assert.equal(preference.getHideDockIconOnClose(), false);
+  assert.equal(preference.DEFAULT_HIDE_DOCK_ICON_ON_CLOSE, false);
+});
+
+test("persists the selected dock behavior", () => {
+  preference.setHideDockIconOnClose(true);
+  assert.equal(preference.getHideDockIconOnClose(), true);
+  assert.equal(values.get(preference.HIDE_DOCK_ICON_STORAGE_KEY), "true");
+
+  preference.setHideDockIconOnClose(false);
+  assert.equal(preference.getHideDockIconOnClose(), false);
+  assert.equal(values.get(preference.HIDE_DOCK_ICON_STORAGE_KEY), "false");
+});
+
+test("treats any non-true stored value as disabled", () => {
+  for (const stored of ["", "1", "yes", "TRUE", null]) {
+    values.set(preference.HIDE_DOCK_ICON_STORAGE_KEY, stored);
+    assert.equal(
+      globalThis.localStorage.getItem(preference.HIDE_DOCK_ICON_STORAGE_KEY) ===
+        "true",
+      false,
+    );
+  }
+});

--- a/desktop/src/shared/lib/dockIconPreference.ts
+++ b/desktop/src/shared/lib/dockIconPreference.ts
@@ -1,0 +1,77 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import * as React from "react";
+
+/**
+ * macOS-only preference. When enabled, closing the main window drops Buzz to a
+ * menu-bar-only app: the Dock icon and the ⌘-Tab entry go away until Buzz is
+ * reopened from its tray menu.
+ *
+ * The webview owns persistence, so the backend is told the current value at
+ * startup and on every change; the close handler in Rust reads it from there.
+ */
+export const HIDE_DOCK_ICON_STORAGE_KEY = "buzz.appearance.hideDockIconOnClose";
+export const DEFAULT_HIDE_DOCK_ICON_ON_CLOSE = false;
+
+const listeners = new Set<() => void>();
+let hideDockIconOnClose = readStoredHideDockIconOnClose();
+
+function readStoredHideDockIconOnClose(): boolean {
+  try {
+    return (
+      globalThis.localStorage?.getItem(HIDE_DOCK_ICON_STORAGE_KEY) === "true"
+    );
+  } catch {
+    return DEFAULT_HIDE_DOCK_ICON_ON_CLOSE;
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getHideDockIconOnClose(): boolean {
+  return hideDockIconOnClose;
+}
+
+export function setHideDockIconOnClose(enabled: boolean): void {
+  hideDockIconOnClose = enabled;
+  try {
+    globalThis.localStorage?.setItem(
+      HIDE_DOCK_ICON_STORAGE_KEY,
+      String(enabled),
+    );
+  } catch {
+    // Persistence is best-effort; the in-memory preference still applies.
+  }
+  publishHideDockIconOnClose(enabled);
+  for (const listener of listeners) listener();
+}
+
+function publishHideDockIconOnClose(enabled: boolean): void {
+  if (!isTauri()) {
+    return;
+  }
+
+  void invoke("set_hide_dock_icon_on_close", { enabled }).catch(
+    (error: unknown) => {
+      console.error("failed to publish dock icon preference", error);
+    },
+  );
+}
+
+/**
+ * Hands the stored preference to the backend during startup. Without this the
+ * backend would fall back to its default until the user toggles the setting.
+ */
+export function syncHideDockIconOnClose(): void {
+  publishHideDockIconOnClose(hideDockIconOnClose);
+}
+
+export function useHideDockIconOnClose(): boolean {
+  return React.useSyncExternalStore(
+    subscribe,
+    getHideDockIconOnClose,
+    () => DEFAULT_HIDE_DOCK_ICON_ON_CLOSE,
+  );
+}


### PR DESCRIPTION
## Summary

Closing the Buzz window on macOS already keeps the process alive and hides the window to the menu bar (`lib.rs`, `CloseRequested` → `prevent_close()` + `hide()`). The Dock icon and the ⌘-Tab entry stay behind, though, so a closed Buzz still occupies both. For those of us who leave Buzz running all day for agent work, that is the one thing that stops it from behaving like the background app it already is.

This finishes that behaviour behind an opt-in preference: while the main window is closed, Buzz leaves the Dock and the app switcher and lives in the menu bar only. Reopening from the tray brings the icon back.

Defaults to off, so nothing changes for anyone who does not turn it on.

```
Settings → Appearance → Preferences
  [ ] Hide from the Dock when closed        (macOS only)
```

Implementation notes:

* `tray_menu::hide_dock_icon_after_close()` runs at the end of the existing macOS `CloseRequested` arm. `tray_menu::restore_dock_icon()` runs at the top of `show_main_window()`, before `set_focus()`, because macOS will not bring an accessory app to the front otherwise.
* Restoring is unconditional. Someone who switches the preference off while Buzz is hidden still expects the next open to behave like a regular app.
* The Dock is left alone while another window (a huddle window, say) is still visible. An app with no Dock icon and a visible window cannot be raised by clicking it.
* Uses `AppHandle::set_dock_visibility` rather than `LSUIElement`. `LSUIElement` would make Buzz menu-bar-only permanently, including at launch, which is a different product decision and not what this asks for.
* Persistence lives in the webview, matching the existing `linkPreviewStylePreference` and `threadViewModePreference` modules. The value is republished to the backend at startup and on every change.

### Related issue

No exact match. The closest is #4024, which asks for the opposite default: a preference to **quit** on close, because that reporter's window switcher hides Buzz once its window is hidden. Both requests are reasonable and they point in opposite directions, which is why this ships as a preference instead of a behaviour change.

### Testing

`cargo check` (buzz-desktop), `pnpm typecheck`, `pnpm check` (biome plus the three ratchet scripts) and a new unit test for the preference module, all green at 42d8622.

Runtime behaviour was measured with `lsappinfo` rather than screenshotted, on macOS 15 / Apple silicon:

```
$ lsappinfo info -only ApplicationType <pid>
before   "ApplicationType"="Foreground"     # Dock icon present
after    "ApplicationType"="UIElement"      # Dock icon gone, process alive
```

The instrument was validated first against a known pair on the same machine: shipping `Buzz` reports `Foreground`, its `Buzz Networking` helper reports `UIElement`. So the field tracks Dock presence, not focus.

What is **not** covered: a real ⌘W. The machine that ran this has no Accessibility grant (no synthetic keystrokes) and no Screen Recording grant (no screenshots), so the close had to be reached another way. `WebviewWindow::close()` returns `Ok` without entering the `CloseRequested` arm, so it is not a stand-in for a user close. What is verified is that the call the arm makes does flip the Dock state, and that the arm reaches that call unconditionally, with no early return between `prevent_close()` and the new line. Five seconds of ⌘W on a machine with a display closes that gap and I would welcome a reviewer doing it.

One trap worth writing down for anyone building this repo locally. The keychain service name in `secret_store.rs` is a constant and does not key off the bundle identifier, so a locally built binary asks macOS for permission to read the shipping app's keychain item. On a machine with nobody at the screen that dialog never gets answered and `tauri::app::setup` hangs inside `resolve_persisted_identity`, silently, with no log and no timeout. `BUZZ_DEV_KEYRING_SERVICE=buzz-desktop-dev.<scope>` avoids it. That cost a couple of hours before the `sample` output made it obvious.
