### PR TITLE
fix(desktop): skip community view transition on Linux WebKitGTK to avoid UI-process segfault

### DIFF
--- a/desktop/src/app/communityViewTransition.test.mjs
+++ b/desktop/src/app/communityViewTransition.test.mjs
@@ -3,23 +3,51 @@ import test, { afterEach, mock } from "node:test";
 
 import {
   completeCommunityViewTransition,
-  isLinuxWebKitGtk,
   replaceCommunityDestinationRoute,
   runCommunityViewTransition,
+  shouldSkipCommunityViewTransition,
 } from "./communityViewTransition.ts";
 
 const originalDocument = globalThis.document;
 const originalWindow = globalThis.window;
+const originalNavigator = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "navigator",
+);
+
+const WEBKITGTK_UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+const MAC_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15";
 
 afterEach(() => {
   globalThis.document = originalDocument;
   globalThis.window = originalWindow;
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, "navigator", originalNavigator);
+  } else {
+    delete globalThis.navigator;
+  }
   mock.restoreAll();
 });
+
+// `undefined` removes navigator entirely, so `typeof navigator === "undefined"`.
+// afterEach puts the real one back.
+function setNavigator(value) {
+  if (value === undefined) {
+    delete globalThis.navigator;
+    return;
+  }
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value });
+}
 
 function installBrowser(startViewTransition) {
   globalThis.window = { clearTimeout, setTimeout };
   globalThis.document = { startViewTransition };
+  // node reports navigator.platform as "Linux x86_64", which is exactly what
+  // the crash guard skips the transition for. Default these tests to a
+  // platform that keeps the animation path; the linux cases set their own.
+  setNavigator({ platform: "MacIntel", userAgent: MAC_UA });
 }
 
 function transitionFor(callback) {
@@ -34,52 +62,46 @@ test("replaceCommunityDestinationRoute uses router history and encodes the chann
   assert.deepEqual(replacements, ["/channels/channel%2Fwith%20spaces"]);
 });
 
-const WEBKITGTK_UA =
-  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+test("the transition is skipped on linux and kept everywhere else", () => {
+  setNavigator({ platform: "Linux x86_64", userAgent: WEBKITGTK_UA });
+  assert.equal(shouldSkipCommunityViewTransition(), true);
 
-test("isLinuxWebKitGtk matches WebKitGTK and nothing else", () => {
-  assert.equal(isLinuxWebKitGtk(WEBKITGTK_UA), true);
-  assert.equal(
-    isLinuxWebKitGtk(
+  // Chromium on Linux is skipped too. The guard fails closed on purpose: it
+  // cannot tell a WebKitGTK webview from a Linux browser without sniffing the
+  // user agent, and losing an animation costs less than a segfault.
+  setNavigator({
+    platform: "Linux x86_64",
+    userAgent:
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
-    ),
-    false,
-  );
-  assert.equal(
-    isLinuxWebKitGtk(
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
-    ),
-    false,
-  );
-  assert.equal(isLinuxWebKitGtk(""), false);
+  });
+  assert.equal(shouldSkipCommunityViewTransition(), true);
+
+  setNavigator({ platform: "MacIntel", userAgent: MAC_UA });
+  assert.equal(shouldSkipCommunityViewTransition(), false);
+
+  // Android reports a Linux platform but is not a WebKitGTK desktop webview.
+  setNavigator({
+    platform: "Linux armv8l",
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36",
+  });
+  assert.equal(shouldSkipCommunityViewTransition(), false);
+
+  setNavigator(undefined);
+  assert.equal(shouldSkipCommunityViewTransition(), false);
 });
 
-test("linux webkitgtk runs the update without starting a transition", async () => {
+test("linux runs the update without starting a transition", async () => {
   const startViewTransition = mock.fn((callback) => transitionFor(callback));
   installBrowser(startViewTransition);
-  const navigatorDescriptor = Object.getOwnPropertyDescriptor(
-    globalThis,
-    "navigator",
-  );
-  Object.defineProperty(globalThis, "navigator", {
-    configurable: true,
-    value: { userAgent: WEBKITGTK_UA },
-  });
+  setNavigator({ platform: "Linux x86_64", userAgent: WEBKITGTK_UA });
 
-  try {
-    let updated = false;
-    await runCommunityViewTransition(async () => {
-      updated = true;
-    });
-    assert.equal(updated, true);
-    assert.equal(startViewTransition.mock.callCount(), 0);
-  } finally {
-    if (navigatorDescriptor) {
-      Object.defineProperty(globalThis, "navigator", navigatorDescriptor);
-    } else {
-      delete globalThis.navigator;
-    }
-  }
+  let updated = false;
+  await runCommunityViewTransition(async () => {
+    updated = true;
+  });
+  assert.equal(updated, true);
+  assert.equal(startViewTransition.mock.callCount(), 0);
 });
 
 test("unsupported browsers execute the update and contain rejection", async () => {

--- a/desktop/src/app/communityViewTransition.test.mjs
+++ b/desktop/src/app/communityViewTransition.test.mjs
@@ -3,6 +3,7 @@ import test, { afterEach, mock } from "node:test";
 
 import {
   completeCommunityViewTransition,
+  isLinuxWebKitGtk,
   replaceCommunityDestinationRoute,
   runCommunityViewTransition,
 } from "./communityViewTransition.ts";
@@ -31,6 +32,54 @@ test("replaceCommunityDestinationRoute uses router history and encodes the chann
     replace: (href) => replacements.push(href),
   });
   assert.deepEqual(replacements, ["/channels/channel%2Fwith%20spaces"]);
+});
+
+const WEBKITGTK_UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+test("isLinuxWebKitGtk matches WebKitGTK and nothing else", () => {
+  assert.equal(isLinuxWebKitGtk(WEBKITGTK_UA), true);
+  assert.equal(
+    isLinuxWebKitGtk(
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+    ),
+    false,
+  );
+  assert.equal(
+    isLinuxWebKitGtk(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+    ),
+    false,
+  );
+  assert.equal(isLinuxWebKitGtk(""), false);
+});
+
+test("linux webkitgtk runs the update without starting a transition", async () => {
+  const startViewTransition = mock.fn((callback) => transitionFor(callback));
+  installBrowser(startViewTransition);
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "navigator",
+  );
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { userAgent: WEBKITGTK_UA },
+  });
+
+  try {
+    let updated = false;
+    await runCommunityViewTransition(async () => {
+      updated = true;
+    });
+    assert.equal(updated, true);
+    assert.equal(startViewTransition.mock.callCount(), 0);
+  } finally {
+    if (navigatorDescriptor) {
+      Object.defineProperty(globalThis, "navigator", navigatorDescriptor);
+    } else {
+      delete globalThis.navigator;
+    }
+  }
 });
 
 test("unsupported browsers execute the update and contain rejection", async () => {

--- a/desktop/src/app/communityViewTransition.ts
+++ b/desktop/src/app/communityViewTransition.ts
@@ -13,11 +13,31 @@ export function replaceCommunityDestinationRoute(
   history.replace(`/channels/${encodeURIComponent(channelId)}`);
 }
 
+// WebKitGTK (the engine under every Linux Tauri webview) crashes the UI
+// process when a view transition is the first thing to demand accelerated
+// compositing on a machine whose accelerated backing store could not be
+// created (X11 sessions, dmabuf transport disabled or unavailable): the
+// missing-store guard is a debug ASSERT that release builds compile out, so
+// document.startViewTransition() segfaults instead of animating. Reproduced
+// 100% outside Buzz on WebKitGTK 2.52 regardless of the dmabuf env vars —
+// see #3488, #4142. Skip the animation there and take the same plain-update
+// path as browsers without the API. Chromium-based browsers on Linux are
+// excluded so dev-server sessions keep the transition.
+export function isLinuxWebKitGtk(
+  userAgent = globalThis.navigator?.userAgent ?? "",
+): boolean {
+  return (
+    userAgent.includes("Linux") &&
+    userAgent.includes("AppleWebKit") &&
+    !userAgent.includes("Chrome")
+  );
+}
+
 export async function runCommunityViewTransition(
   update: () => Promise<void> | void,
   options: { timeoutMs?: number } = {},
 ): Promise<void> {
-  if (!document.startViewTransition) {
+  if (!document.startViewTransition || isLinuxWebKitGtk()) {
     try {
       await update();
     } catch (error) {

--- a/desktop/src/app/communityViewTransition.ts
+++ b/desktop/src/app/communityViewTransition.ts
@@ -1,3 +1,5 @@
+import { isLinuxPlatform } from "@/shared/lib/platform";
+
 const COMMUNITY_TRANSITION_TIMEOUT_MS = 5_000;
 
 let finishPendingTransition: (() => void) | null = null;
@@ -20,24 +22,24 @@ export function replaceCommunityDestinationRoute(
 // missing-store guard is a debug ASSERT that release builds compile out, so
 // document.startViewTransition() segfaults instead of animating. Reproduced
 // 100% outside Buzz on WebKitGTK 2.52 regardless of the dmabuf env vars —
-// see #3488, #4142. Skip the animation there and take the same plain-update
-// path as browsers without the API. Chromium-based browsers on Linux are
-// excluded so dev-server sessions keep the transition.
-export function isLinuxWebKitGtk(
-  userAgent = globalThis.navigator?.userAgent ?? "",
-): boolean {
-  return (
-    userAgent.includes("Linux") &&
-    userAgent.includes("AppleWebKit") &&
-    !userAgent.includes("Chrome")
-  );
+// see #3488, #4142, and https://bugs.webkit.org/show_bug.cgi?id=321683.
+//
+// Keyed on the platform alone, deliberately: this guards a UI-process
+// segfault, so it has to fail closed. Narrowing it to WebKitGTK would mean
+// sniffing the user agent for the engine, and a UA test that quietly stops
+// matching re-enables the crash with nothing pointing back at this line. On
+// Tauri, Linux means WebKitGTK anyway, so the cost of over-matching is only a
+// missing cross-fade in a Linux browser session — a crash is not a tradeoff
+// worth taking for an animation.
+export function shouldSkipCommunityViewTransition(): boolean {
+  return isLinuxPlatform();
 }
 
 export async function runCommunityViewTransition(
   update: () => Promise<void> | void,
   options: { timeoutMs?: number } = {},
 ): Promise<void> {
-  if (!document.startViewTransition || isLinuxWebKitGtk()) {
+  if (!document.startViewTransition || shouldSkipCommunityViewTransition()) {
     try {
       await update();
     } catch (error) {


### PR DESCRIPTION
## Summary

Switching communities crashes the Buzz UI process on many Linux machines,
100% of the time (#3488, #4142). The root cause is a WebKitGTK 2.52 bug:
when a view transition is the first thing to demand accelerated
compositing and the accelerated backing store could not be created, the
UI process dereferences a null `AcceleratedBackingStore`. The guard for
that case is a debug `ASSERT`, which release builds compile out — so
users get a bare `SIGSEGV` instead of an assertion.

This PR detects Linux WebKitGTK by user agent in
`runCommunityViewTransition` and takes the **existing**
no-`startViewTransition` fallback path. The community switch still
happens — instantly, without the cross-fade — until a fixed WebKitGTK
ships. Two tests added, no other behavior touched.

### Why the FORCE_SHM heuristic doesn't cover this

`webkit_rendering.rs` (the #3654 fix) sets
`WEBKIT_DMABUF_RENDERER_FORCE_SHM=1` on NVIDIA/AppImage. That does not
prevent this crash. We wrote a ~100-line repro **outside Buzz** — plain
GTK + `WebKitWebView` whose page just calls `document.startViewTransition()`
in a loop — and ran it with a scrubbed environment (`env -i`), one
variable at a time, on Ubuntu 24.04 / GNOME-X11 / NVIDIA / WebKitGTK
2.52.3:

| Environment | Result |
|---|---|
| no WebKit vars at all | SIGSEGV, `segfault at 48`, offset `fd69b2` |
| `WEBKIT_DMABUF_RENDERER_FORCE_SHM=1` (what Buzz ships) | SIGSEGV, identical |
| `WEBKIT_DISABLE_DMABUF_RENDERER=1` (legacy) | SIGSEGV, identical |
| `ViewTransitions` WebKit feature disabled | clean — Buzz's own fallback path works |

`segfault at 48` is `m_surfaceID` at offset `0x48` read through a null
`this`, matching the symbolized analysis by @shawnyeager in #3488 exactly.
The null store is the **default** state on this X11 box — no env var
needed to get there — so no rendering env tweak can fix it. The only
app-side mitigation is not entering the view-transition compositing path.

### Why a UA check instead of `isLinuxPlatform()`

#4276 proposes the same guard via `shared/lib/platform.ts`'s
`isLinuxPlatform()`, which reads `navigator.platform`. Node ≥ 21 defines
`navigator.platform === "Linux x86_64"` under plain Node on Linux, so
that guard also fires inside the unit-test runner: the three existing
`communityViewTransition` transition-path tests then take the fallback
branch and fail on any Linux dev box or CI runner (they pass on macOS,
which hides it locally).

The UA check here (`Linux` + `AppleWebKit` − `Chrome`) targets WebKitGTK
specifically — Node's UA (`Node.js/24`) and Chromium dev-server sessions
on Linux keep the real transition path, and the suite stays green.

### Related issue

Fixes #3488. Fixes #4142.

Searched for duplicates — the closest existing PR is **#4276** (same call
site, motivated by the #3931 `updateCallbackDone` hang on community
removal). It bundles unrelated agent-UI changes and trips the unit-test
issue above. Maintainers should feel free to take whichever they prefer;
the goal is just to stop the Linux crashes. This guard very likely also
resolves #3931, since it skips the same API on the same platform — but we
only verified the segfault, not the hang, so it isn't claimed here.

Also related: #3654 (the env-var mechanism this bypasses).

### Testing

- `pnpm test` (desktop): **4763 pass / 0 fail**, including 2 new tests —
  a UA detection matrix, and "Linux WebKitGTK runs the update without
  calling `startViewTransition`".
- `pnpm typecheck` clean; `pnpm check` clean.
- On an affected machine: stock Buzz crashed on **every** community
  switch. Running the same build with the `ViewTransitions` WebKit
  feature disabled — which routes through the identical fallback branch
  this PR selects — community switching has been 100% stable since.
- The standalone C repro crashes reliably without the transition path
  skipped and runs clean with it skipped; source and full matrix
  available if useful for CI or for the upstream report.

No screenshots: the visible change on Linux is the *absence* of the
cross-fade (an instant switch), and the "before" state is the app
disappearing. Happy to attach a screen recording of both if a maintainer
wants it.

### Upstream

Filed against WebKitGTK with the minimal repro attached and a proposed
`ASSERT` → runtime-null-check patch for the three unguarded call sites in
`WebKitWebViewBase.cpp`:
**https://bugs.webkit.org/show_bug.cgi?id=321683**

### Revert condition

Once Buzz's minimum WebKitGTK carries that upstream fix, this guard can be
removed.
