### PR TITLE
fix(desktop): treat CLAUDE_CODE_OAUTH_TOKEN as claude auth evidence

### DIFF
--- a/desktop/src-tauri/src/commands/agent_config_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_config_tests.rs
@@ -61,6 +61,7 @@ fn goose_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_token_env_vars: &[],
     }
 }
 

--- a/desktop/src-tauri/src/commands/agent_config_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_config_tests.rs
@@ -60,7 +60,7 @@ fn goose_runtime() -> &'static KnownAcpRuntime {
         max_rounds_env_var: None,
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe_args: None, auth_token_env_vars: &[],
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -60,6 +60,7 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_token_env_vars: &[],
     }
 }
 
@@ -649,6 +650,7 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_token_env_vars: &[],
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -59,7 +59,7 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         max_rounds_env_var: None,
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe_args: None, auth_token_env_vars: &[],
     }
 }
 
@@ -651,7 +651,7 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
         max_rounds_env_var: Some("BUZZ_AGENT_MAX_ROUNDS"),
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe_args: None, auth_token_env_vars: &[],
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -110,6 +110,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_token_env_vars: &[],
     },
     KnownAcpRuntime {
         id: "claude",
@@ -143,6 +144,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &[],
         login_hint: Some("Run the Claude CLI to complete authentication."),
         auth_probe_args: Some(&["claude", "auth", "status"]),
+        auth_token_env_vars: &["CLAUDE_CODE_OAUTH_TOKEN"],
     },
     KnownAcpRuntime {
         id: "codex",
@@ -177,6 +179,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+        auth_token_env_vars: &[],
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -210,6 +213,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_token_env_vars: &[],
     },
 ];
 
@@ -999,6 +1003,21 @@ pub(crate) fn is_npm_global_install(cmd: &str) -> bool {
         || t.starts_with("npm uninstall -g ")
 }
 
+/// True when any of `env_vars` is set to a non-whitespace value.
+///
+/// A set token is evidence about the runtime Buzz will actually spawn, whereas
+/// `auth_probe_args` reports on a sibling CLI that may resolve credentials from
+/// somewhere else entirely. When they disagree, the token wins: it is read by
+/// the process that has to do the work.
+pub(crate) fn auth_token_env_var_present(
+    env_vars: &[&str],
+    lookup: impl Fn(&str) -> Option<String>,
+) -> bool {
+    env_vars
+        .iter()
+        .any(|name| lookup(name).is_some_and(|value| !value.trim().is_empty()))
+}
+
 /// Run a CLI auth probe with a 10-second process-level timeout.
 ///
 /// Spawns the probe CLI as a child process. Stdout and stderr are drained on
@@ -1445,6 +1464,20 @@ pub fn discover_acp_runtimes_from(
         .map(discover_acp_runtime_phase1)
         .collect();
 
+    // Phase 1.5: a token in the environment is proof about the runtime we
+    // actually spawn, unlike the sibling CLI `auth_probe_args` interrogates.
+    // Settle those first so they short-circuit the probe and its 10s timeout.
+    for partial in &mut partials {
+        if partial.entry.availability == AcpAvailabilityStatus::Available
+            && auth_token_env_var_present(partial.runtime.auth_token_env_vars, |name| {
+                std::env::var(name).ok()
+            })
+        {
+            partial.entry.auth_status = AuthStatus::LoggedIn;
+            partial.entry.login_hint = None;
+        }
+    }
+
     // Phase 2: run auth probes in parallel for entries that need them.
     // Spawn one thread per probeable entry; total cost = max(probe latency).
     let probe_handles: Vec<(usize, std::thread::JoinHandle<AuthStatus>)> = partials
@@ -1452,6 +1485,10 @@ pub fn discover_acp_runtimes_from(
         .enumerate()
         .filter_map(|(idx, partial)| {
             if partial.entry.availability != AcpAvailabilityStatus::Available {
+                return None;
+            }
+            // Already settled by a token in Phase 1.5 -- do not spend a probe.
+            if partial.entry.auth_status == AuthStatus::LoggedIn {
                 return None;
             }
             let probe_args = partial.runtime.auth_probe_args?;

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -9,6 +9,7 @@ use crate::managed_agents::{
     HarnessSource,
 };
 mod auth_status_cache;
+mod auth_token;
 mod bounded_command;
 mod login_shell;
 mod presets;
@@ -27,7 +28,6 @@ pub(crate) use presets::{
 };
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use runtime_metadata::KnownAcpRuntime;
-
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
@@ -117,7 +117,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_rounds_env_var: None,
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe_args: None, auth_token_env_vars: &[],
     },
     KnownAcpRuntime {
         id: "claude",
@@ -150,7 +150,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_rounds_env_var: None,
         required_normalized_fields: &[],
         login_hint: Some("Run the Claude CLI to complete authentication."),
-        auth_probe_args: Some(&["claude", "auth", "status"]),
+        auth_probe_args: Some(&["claude", "auth", "status"]), auth_token_env_vars: &["CLAUDE_CODE_OAUTH_TOKEN"],
     },
     KnownAcpRuntime {
         id: "codex",
@@ -184,7 +184,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &[],
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
-        auth_probe_args: Some(&["codex", "login", "status"]),
+        auth_probe_args: Some(&["codex", "login", "status"]), auth_token_env_vars: &[],
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -217,7 +217,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_rounds_env_var: Some("BUZZ_AGENT_MAX_ROUNDS"),
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe_args: None, auth_token_env_vars: &[],
     },
 ];
 

--- a/desktop/src-tauri/src/managed_agents/discovery/auth_status_cache.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/auth_status_cache.rs
@@ -54,12 +54,19 @@ pub(crate) fn len() -> usize {
 pub(super) fn resolve_auth_statuses(partials: &mut [super::PartialEntry], force: bool) {
     use crate::managed_agents::AcpAvailabilityStatus;
 
+    // Token evidence describes the spawned runtime; settle it before any probe.
+    super::auth_token::apply_token_auth_evidence(partials);
+
     if force {
         let probe_handles: Vec<(usize, std::thread::JoinHandle<AuthStatus>)> = partials
             .iter()
             .enumerate()
             .filter_map(|(idx, partial)| {
                 if partial.entry.availability != AcpAvailabilityStatus::Available {
+                    return None;
+                }
+                // Already settled by a token — do not spend a probe.
+                if partial.entry.auth_status == AuthStatus::LoggedIn {
                     return None;
                 }
                 let probe_args = partial.runtime.auth_probe_args?;
@@ -85,6 +92,7 @@ pub(super) fn resolve_auth_statuses(partials: &mut [super::PartialEntry], force:
         for partial in partials.iter_mut() {
             if partial.entry.availability != AcpAvailabilityStatus::Available
                 || partial.runtime.auth_probe_args.is_none()
+                || partial.entry.auth_status == AuthStatus::LoggedIn
             {
                 continue;
             }

--- a/desktop/src-tauri/src/managed_agents/discovery/auth_token.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/auth_token.rs
@@ -1,0 +1,115 @@
+//! Token-in-environment auth evidence for ACP runtimes.
+//!
+//! Some runtimes (notably `claude`) spawn an adapter that honours an OAuth
+//! token env var the sibling CLI probe cannot see. When that token is set, it
+//! is evidence about the process that will actually authenticate, so it wins
+//! over the probe and short-circuits it.
+
+use crate::managed_agents::{AcpAvailabilityStatus, AuthStatus};
+
+use super::PartialEntry;
+
+/// True when any declared env var is present and non-empty after trim.
+pub(crate) fn auth_token_env_var_present(
+    env_vars: &[&str],
+    lookup: impl Fn(&str) -> Option<String>,
+) -> bool {
+    env_vars
+        .iter()
+        .any(|name| lookup(name).is_some_and(|value| !value.trim().is_empty()))
+}
+
+/// Mark available runtimes with a set auth token as logged in before probing.
+pub(super) fn apply_token_auth_evidence(partials: &mut [PartialEntry]) {
+    for partial in partials {
+        if partial.entry.availability == AcpAvailabilityStatus::Available
+            && auth_token_env_var_present(partial.runtime.auth_token_env_vars, |name| {
+                std::env::var(name).ok()
+            })
+        {
+            partial.entry.auth_status = AuthStatus::LoggedIn;
+            partial.entry.login_hint = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::auth_token_env_var_present;
+    use super::super::KNOWN_ACP_RUNTIMES;
+
+    fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + 'static {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |name: &str| {
+            owned
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+        }
+    }
+
+    #[test]
+    fn a_set_token_counts_as_auth_evidence() {
+        assert!(auth_token_env_var_present(
+            &["CLAUDE_CODE_OAUTH_TOKEN"],
+            env_from(&[("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-abc")]),
+        ));
+    }
+
+    #[test]
+    fn an_unset_token_is_not_evidence() {
+        assert!(!auth_token_env_var_present(
+            &["CLAUDE_CODE_OAUTH_TOKEN"],
+            env_from(&[]),
+        ));
+    }
+
+    #[test]
+    fn an_empty_or_whitespace_token_is_not_evidence() {
+        for value in ["", "   ", "\t\n"] {
+            assert!(
+                !auth_token_env_var_present(
+                    &["CLAUDE_CODE_OAUTH_TOKEN"],
+                    env_from(&[("CLAUDE_CODE_OAUTH_TOKEN", value)]),
+                ),
+                "{value:?} must not count"
+            );
+        }
+    }
+
+    #[test]
+    fn a_runtime_declaring_no_token_vars_is_never_short_circuited() {
+        assert!(!auth_token_env_var_present(
+            &[],
+            env_from(&[("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-abc")]),
+        ));
+    }
+
+    #[test]
+    fn any_one_of_several_declared_vars_is_enough() {
+        assert!(auth_token_env_var_present(
+            &["FIRST_TOKEN", "SECOND_TOKEN"],
+            env_from(&[("SECOND_TOKEN", "value")]),
+        ));
+    }
+
+    #[test]
+    fn claude_declares_the_adapter_token_and_other_runtimes_do_not() {
+        let claude = KNOWN_ACP_RUNTIMES
+            .iter()
+            .find(|runtime| runtime.id == "claude")
+            .expect("claude runtime");
+        assert_eq!(claude.auth_token_env_vars, &["CLAUDE_CODE_OAUTH_TOKEN"]);
+
+        for runtime in KNOWN_ACP_RUNTIMES.iter().filter(|r| r.id != "claude") {
+            assert!(
+                runtime.auth_token_env_vars.is_empty(),
+                "{} must not claim token evidence without a documented reason",
+                runtime.id
+            );
+        }
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -64,6 +64,9 @@ pub(crate) struct KnownAcpRuntime {
     /// CLI args for probing authentication status. `args[0]` is the binary name;
     /// the remainder are the subcommand. `None` for runtimes with no login step.
     pub auth_probe_args: Option<&'static [&'static str]>,
+    /// Env vars that, when set non-empty, prove the *spawned* runtime can auth.
+    /// Checked before `auth_probe_args` so a sibling CLI cannot false-negative.
+    pub auth_token_env_vars: &'static [&'static str],
 }
 
 impl KnownAcpRuntime {

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -64,6 +64,16 @@ pub(crate) struct KnownAcpRuntime {
     /// CLI args for probing authentication status. `args[0]` is the binary name;
     /// the remainder are the subcommand. `None` for runtimes with no login step.
     pub auth_probe_args: Option<&'static [&'static str]>,
+    /// Environment variables that, when set to a non-empty value, are
+    /// themselves proof the runtime can authenticate.
+    ///
+    /// `auth_probe_args` runs a *sibling* CLI. For `claude` that is the Claude
+    /// Code CLI, while the runtime Buzz actually spawns is `claude-agent-acp`,
+    /// which resolves credentials differently -- it also honours
+    /// `CLAUDE_CODE_OAUTH_TOKEN`, which the CLI probe cannot see. A token set
+    /// here means the spawned runtime authenticates no matter what the sibling
+    /// CLI reports, so it is checked first and short-circuits the probe.
+    pub auth_token_env_vars: &'static [&'static str],
 }
 
 impl KnownAcpRuntime {

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use super::overrides::{divergent_agent_command_override, update_time_agent_command_override};
 use super::{
-    apply_agent_command_update, classify_runtime, codex_adapter_availability,
-    codex_adapter_is_outdated, create_time_agent_command_override, default_agent_command,
-    effective_agent_command, find_nvm_default_bin, find_via_login_shell,
+    apply_agent_command_update, auth_token_env_var_present, classify_runtime,
+    codex_adapter_availability, codex_adapter_is_outdated, create_time_agent_command_override,
+    default_agent_command, effective_agent_command, find_nvm_default_bin, find_via_login_shell,
     is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
     parse_semver_tag, probe_codex_acp_version, record_agent_command, refresh_login_shell_path,
     try_record_agent_command, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
@@ -1836,4 +1836,93 @@ fn discovery_publish_path_drops_mid_flight_delete() {
         lookup_loaded_harness_by_id("mid-flight-delete").is_none(),
         "discovery's publish must not resurrect a harness deleted mid-discovery"
     );
+}
+
+// ── Auth-token evidence ──────────────────────────────────────────────────────
+//
+// `auth_probe_args` runs a sibling CLI. For `claude` that is the Claude Code
+// CLI, while the runtime Buzz spawns is `claude-agent-acp`, which also honours
+// `CLAUDE_CODE_OAUTH_TOKEN` -- invisible to the probe. A machine was observed
+// where the CLI reported logged out while the adapter completed a turn
+// successfully, purely because that token was set.
+
+fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + 'static {
+    let owned: Vec<(String, String)> = pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    move |name: &str| {
+        owned
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.clone())
+    }
+}
+
+#[test]
+fn a_set_token_counts_as_auth_evidence() {
+    assert!(auth_token_env_var_present(
+        &["CLAUDE_CODE_OAUTH_TOKEN"],
+        env_from(&[("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-abc")]),
+    ));
+}
+
+#[test]
+fn an_unset_token_is_not_evidence() {
+    assert!(!auth_token_env_var_present(
+        &["CLAUDE_CODE_OAUTH_TOKEN"],
+        env_from(&[]),
+    ));
+}
+
+#[test]
+fn an_empty_or_whitespace_token_is_not_evidence() {
+    // An exported-but-empty variable is the shape a half-finished shell profile
+    // leaves behind; treating it as proof would reintroduce the false positive
+    // this check exists to avoid.
+    for value in ["", "   ", "\t\n"] {
+        assert!(
+            !auth_token_env_var_present(
+                &["CLAUDE_CODE_OAUTH_TOKEN"],
+                env_from(&[("CLAUDE_CODE_OAUTH_TOKEN", value)]),
+            ),
+            "{value:?} must not count"
+        );
+    }
+}
+
+#[test]
+fn a_runtime_declaring_no_token_vars_is_never_short_circuited() {
+    assert!(!auth_token_env_var_present(
+        &[],
+        env_from(&[("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-abc")]),
+    ));
+}
+
+#[test]
+fn any_one_of_several_declared_vars_is_enough() {
+    assert!(auth_token_env_var_present(
+        &["FIRST_TOKEN", "SECOND_TOKEN"],
+        env_from(&[("SECOND_TOKEN", "value")]),
+    ));
+}
+
+#[test]
+fn claude_declares_the_adapter_token_and_other_runtimes_do_not() {
+    let claude = super::KNOWN_ACP_RUNTIMES
+        .iter()
+        .find(|runtime| runtime.id == "claude")
+        .expect("claude runtime");
+    assert_eq!(claude.auth_token_env_vars, &["CLAUDE_CODE_OAUTH_TOKEN"]);
+
+    for runtime in super::KNOWN_ACP_RUNTIMES
+        .iter()
+        .filter(|r| r.id != "claude")
+    {
+        assert!(
+            runtime.auth_token_env_vars.is_empty(),
+            "{} must not claim token evidence without a documented reason",
+            runtime.id
+        );
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -1055,6 +1055,7 @@ mod tests {
             required_normalized_fields: &[],
             login_hint: None,
             auth_probe_args: None,
+            auth_token_env_vars: &[],
         }
     }
 
@@ -1247,6 +1248,7 @@ mod tests {
             required_normalized_fields: &[],
             login_hint: None,
             auth_probe_args: None,
+            auth_token_env_vars: &[],
         }
     }
 

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -1054,7 +1054,7 @@ mod tests {
             max_rounds_env_var: None,
             required_normalized_fields: &[],
             login_hint: None,
-            auth_probe_args: None,
+            auth_probe_args: None, auth_token_env_vars: &[],
         }
     }
 
@@ -1246,7 +1246,7 @@ mod tests {
             max_rounds_env_var: None,
             required_normalized_fields: &[],
             login_hint: None,
-            auth_probe_args: None,
+            auth_probe_args: None, auth_token_env_vars: &[],
         }
     }
 


### PR DESCRIPTION
Refs #5460 — this fixes the **false-negative** direction only. See "Scope".

## What happens

The `claude` runtime's auth badge comes from `auth_probe_args: Some(&["claude", "auth", "status"])`,
which runs the Claude Code CLI and reads *its* credential store. The runtime Buzz
actually spawns is `claude-agent-acp`, which resolves credentials differently — it
also honours `CLAUDE_CODE_OAUTH_TOKEN`, and the probe has no way to see that.

So the badge reports on a sibling process, not on the one that has to do the
work, and the two disagree. The issue documents both directions observed on one
machine on one day. The direction this PR addresses: `~/.claude/.credentials.json`
is an empty husk, `claude auth status` exits 1 with `{"loggedIn": false}`, and the
adapter nonetheless completes a turn with `stopReason: end_turn` — because
`CLAUDE_CODE_OAUTH_TOKEN` was set via `claude setup-token`. The UI shows the
runtime as unauthenticated while it works.

## Fix

`KnownAcpRuntime` gains `auth_token_env_vars`, declared alongside the existing
`auth_probe_args`. For `claude` it is `["CLAUDE_CODE_OAUTH_TOKEN"]`; every other
runtime declares `&[]`.

A new Phase 1.5 in `discover_acp_runtimes_from` settles any available entry whose
declared token is set before the probe phase runs. Two consequences, both wanted:

1. Token evidence **wins** over the sibling CLI, because it describes the process
   that will actually authenticate.
2. That entry skips the probe entirely, so it also skips that probe's 10-second
   timeout.

An exported-but-empty (or whitespace-only) variable does not count — that is the
shape a half-finished shell profile leaves behind, and honouring it would
manufacture the very false positive this check exists to avoid.

Keeping it declarative rather than special-casing `claude` inside the probe
follows the existing shape of that table (`model_env_var`, `thinking_env_var`,
`max_tokens_env_var`, …), so the next runtime with the same split is a one-line
addition.

## Evidence

6 new tests in `discovery/tests.rs`, against a pure
`auth_token_env_var_present(env_vars, lookup)` seam so no real environment is
touched:

- a set token counts as evidence
- an unset token does not
- empty and whitespace-only values do not
- a runtime declaring no token vars is never short-circuited, even with the
  variable set
- any one of several declared vars is enough
- `claude` declares the adapter token and **no other runtime claims token
  evidence** — this one guards against a future copy-paste quietly granting a
  runtime a free pass

Ran:

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` — **2432 passed,
  0 failed, 14 ignored** (2426 on `main` + 6)
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets` — no
  warnings, no errors
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check` — clean

Not run locally: the real credential scenario. I do not have the reporter's
Windows machine or a Claude Code install in the split state they describe, so the
behaviour is verified at the decision function, not against a live adapter.

## Scope

The issue calls the **false positive** the damaging direction — the CLI reporting
logged in while the adapter fails every turn — and that is deliberately not
addressed here. Fixing it properly means the reporter's primary suggestion:
driving the adapter's own `initialize` (and probably `session/new`) over stdio and
treating a successful handshake as authenticated. That replaces the probe
mechanism rather than extending it, needs its own timeout and failure-mode
handling, and should be its own diff.

This PR is the reporter's explicitly-named "cheaper partial improvement". It
makes a working runtime stop reading as broken; it does not yet make a broken one
stop reading as working.
