### PR TITLE
fix(projects): deliver issue mentions to managed agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "buzz-cli",
  "buzz-core",
  "buzz-persona",
  "buzz-sdk",
+ "buzz-test-client",
  "chrono",
  "clap",
  "evalexpr",

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -79,3 +79,5 @@ nix = { version = "0.31", default-features = false, features = ["signal"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 httparse = "1"
+buzz-test-client = { path = "../buzz-test-client" }
+buzz-cli = { path = "../buzz-cli" }

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -24,7 +24,7 @@ The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ
 | `buzz social` | `publish`, `notes` |
 | `buzz repos` | `create`, `get`, `list` |
 | `buzz projects` | `create`, `get`, `list`, `add-repo`, `add-channel` |
-| `buzz issues` | `create`, `get`, `list`, `status`, `assign` |
+| `buzz issues` | `assign`, `comment`, `create`, `get`, `list`, `status`, `unassign` |
 | `buzz pr` | `open`, `update`, `get`, `list`, `status` |
 | `buzz upload` | `file` |
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -875,6 +875,46 @@ pub struct ThreadTags {
     pub mentioned_pubkeys: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepoThreadRef {
+    root_event_id: String,
+    repo_owner: String,
+    repo_id: String,
+}
+
+fn is_hex64(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn parse_repo_thread_ref(event: &Event) -> Option<RepoThreadRef> {
+    if event.kind.as_u16() != 9 {
+        return None;
+    }
+    let root_event_id = event.tags.iter().find_map(|tag| {
+        let parts = tag.as_slice();
+        (parts.len() >= 4 && parts[0] == "e" && parts[3] == "root" && is_hex64(&parts[1]))
+            .then(|| parts[1].clone())
+    })?;
+    let (repo_owner, repo_id) = event.tags.iter().find_map(|tag| {
+        let parts = tag.as_slice();
+        if parts.len() < 2 || parts[0] != "a" {
+            return None;
+        }
+        let mut coordinate = parts[1].splitn(3, ':');
+        let kind = coordinate.next()?;
+        let owner = coordinate.next()?;
+        let id = coordinate.next()?;
+        (kind == "30617" && is_hex64(owner) && !id.is_empty())
+            .then(|| (owner.to_string(), id.to_string()))
+    })?;
+
+    Some(RepoThreadRef {
+        root_event_id,
+        repo_owner,
+        repo_id,
+    })
+}
+
 /// Parse NIP-10 thread tags from a Nostr event.
 ///
 /// Marker parsing and the (root, reply) → (root, parent) collapse are delegated
@@ -1196,6 +1236,16 @@ fn append_reply_instruction(s: &mut String, event_id: &str) {
     ));
 }
 
+fn append_repo_comment_instruction(s: &mut String, channel_id: Uuid, repo: &RepoThreadRef) {
+    s.push_str(&format!(
+        "\nIMPORTANT: This is a Project issue comment. For an ordinary reply, \
+         run `buzz issues comment --channel {channel_id} --issue {} --repo-owner {} \
+         --repo-id {} --content \"...\"`. Do NOT use `buzz messages send --reply-to` \
+         for this turn because it would omit the repository attachment.",
+        repo.root_event_id, repo.repo_owner, repo.repo_id
+    ));
+}
+
 /// Append a new-thread reply instruction for a human-facing top-level mention.
 ///
 /// The triggering mention has no thread tags, so the agent's reply becomes the
@@ -1354,14 +1404,26 @@ fn append_project_home(s: &mut String, channel_info: Option<&PromptChannelInfo>,
 /// replies; in the channel branch a `Some` anchor means a human-facing
 /// top-level mention whose reply should open a new thread rooted at the
 /// triggering event.
-fn format_context_hints(
+struct ContextHintArgs<'a> {
     channel_id: Uuid,
-    channel_info: Option<&PromptChannelInfo>,
-    thread_tags: &ThreadTags,
+    channel_info: Option<&'a PromptChannelInfo>,
+    thread_tags: &'a ThreadTags,
+    repo_thread: Option<&'a RepoThreadRef>,
     is_dm: bool,
     conversation_context_status: ConversationContextStatus,
-    reply_anchor: Option<&str>,
-) -> String {
+    reply_anchor: Option<&'a str>,
+}
+
+fn format_context_hints(args: ContextHintArgs<'_>) -> String {
+    let ContextHintArgs {
+        channel_id,
+        channel_info,
+        thread_tags,
+        repo_thread,
+        is_dm,
+        conversation_context_status,
+        reply_anchor,
+    } = args;
     let channel_display = match channel_info {
         Some(ci) => format!("{} (#{channel_id})", ci.name),
         None => channel_id.to_string(),
@@ -1415,6 +1477,16 @@ fn format_context_hints(
                 append_reply_instruction(&mut s, event_id);
             }
         }
+        crate::prompt_framing::semantic_section("context", &s)
+    } else if let Some(repo) = repo_thread {
+        let mut s = format!(
+            "Scope: project-comment\n\
+             Channel: {channel_display}\n\
+             Project root: {}\n\
+             Repository: 30617:{}:{}",
+            repo.root_event_id, repo.repo_owner, repo.repo_id
+        );
+        append_repo_comment_instruction(&mut s, channel_id, repo);
         crate::prompt_framing::semantic_section("context", &s)
     } else if let Some(ref root) = thread_tags.root_event_id {
         let ctx_hint = if complete_conversation_context {
@@ -1734,6 +1806,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         }
     };
     let thread_tags = parse_thread_tags(&last_event.event);
+    let repo_thread = parse_repo_thread_ref(&last_event.event);
     let is_dm = args
         .channel_info
         .map(|ci| ci.channel_type == "dm")
@@ -1781,18 +1854,19 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
             args.profile_lookup,
         )
     };
-    sections.push(format_context_hints(
-        batch.channel_id,
-        args.channel_info,
-        &thread_tags,
+    sections.push(format_context_hints(ContextHintArgs {
+        channel_id: batch.channel_id,
+        channel_info: args.channel_info,
+        thread_tags: &thread_tags,
+        repo_thread: repo_thread.as_ref(),
         is_dm,
-        conversation_context_status(
+        conversation_context_status: conversation_context_status(
             batch,
             args.conversation_context,
             args.conversation_context_had_delivered_events,
         ),
-        reply_anchor.as_deref(),
-    ));
+        reply_anchor: reply_anchor.as_deref(),
+    }));
 
     // 3. Conversation context (thread or DM).
     if let Some(ctx) = args.conversation_context {
@@ -1946,8 +2020,35 @@ pub(crate) fn native_steer_framing() -> (&'static str, &'static str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostr::{EventBuilder, Keys, Kind, Timestamp};
+    use crate::acp::AcpClient;
+    use crate::config::PermissionMode;
+    use crate::pool::{
+        ChannelDeliveryState, ChannelInfoResolver, OwnedAgent, PromptContext, PromptOutcome,
+        SessionState,
+    };
+    use crate::relay::{ChannelInfo, RestClient};
+    use buzz_sdk::{build_git_issue, build_git_issue_comment, GitIssueMeta, GitRepoCoord};
+    use buzz_test_client::BuzzTestClient;
+    use nostr::{Alphabet, EventBuilder, Filter, Keys, Kind, SingleLetterTag, Tag, Timestamp};
+    use std::sync::Arc;
     use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    fn relay_url() -> String {
+        std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+    }
+
+    async fn query_relay(client: &mut BuzzTestClient, filter: Filter) -> Vec<Event> {
+        let subscription_id = format!("project-agent-{}", Uuid::new_v4());
+        client
+            .subscribe(&subscription_id, vec![filter])
+            .await
+            .expect("subscribe");
+        client
+            .collect_until_eose(&subscription_id, Duration::from_secs(5))
+            .await
+            .expect("collect events")
+    }
 
     /// Build a test event with the given content and kind.
     fn make_event(content: &str) -> Event {
@@ -5878,5 +5979,316 @@ mod tests {
             !prompt.contains("Description:"),
             "unresolved metadata must not render a Description field; got: {prompt}"
         );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn authorized_project_issue_mention_round_trips_through_acp_contract() {
+        let owner = Keys::generate();
+        let agent = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let repo_id = format!("agent-delivery-{}", &Uuid::new_v4().to_string()[..8]);
+        let repo = GitRepoCoord {
+            owner: owner.public_key().to_hex(),
+            id: repo_id.clone(),
+        };
+        let repo_address = format!("30617:{}:{repo_id}", repo.owner);
+
+        let mut owner_client = BuzzTestClient::connect(&relay_url(), &owner)
+            .await
+            .expect("connect owner");
+        let create_channel = EventBuilder::new(Kind::Custom(9007), "")
+            .tags([
+                Tag::parse(["h", &channel_id.to_string()]).unwrap(),
+                Tag::parse(["name", "Project agent delivery"]).unwrap(),
+                Tag::parse(["channel_type", "forum"]).unwrap(),
+                Tag::parse(["visibility", "private"]).unwrap(),
+            ])
+            .sign_with_keys(&owner)
+            .unwrap();
+        assert!(
+            owner_client
+                .send_event(create_channel)
+                .await
+                .expect("create channel")
+                .accepted
+        );
+
+        let add_agent = EventBuilder::new(Kind::Custom(9000), "")
+            .tags([
+                Tag::parse(["h", &channel_id.to_string()]).unwrap(),
+                Tag::parse(["p", &agent.public_key().to_hex()]).unwrap(),
+                Tag::parse(["role", "bot"]).unwrap(),
+            ])
+            .sign_with_keys(&owner)
+            .unwrap();
+        assert!(
+            owner_client
+                .send_event(add_agent)
+                .await
+                .expect("add agent")
+                .accepted
+        );
+
+        let announcement = EventBuilder::new(Kind::Custom(30617), "")
+            .tags([
+                Tag::parse(["d", &repo_id]).unwrap(),
+                Tag::parse(["name", &repo_id]).unwrap(),
+                Tag::parse(["h", &channel_id.to_string()]).unwrap(),
+            ])
+            .sign_with_keys(&owner)
+            .unwrap();
+        assert!(
+            owner_client
+                .send_event(announcement)
+                .await
+                .expect("announce repository")
+                .accepted
+        );
+
+        let issue = build_git_issue(
+            &repo,
+            "Agent delivery regression",
+            "Investigate the failing Project workflow.",
+            &GitIssueMeta::default(),
+        )
+        .unwrap()
+        .sign_with_keys(&owner)
+        .unwrap();
+        assert!(
+            owner_client
+                .send_event(issue.clone())
+                .await
+                .expect("publish issue")
+                .accepted
+        );
+
+        let trigger = build_git_issue_comment(
+            channel_id,
+            &issue.id.to_hex(),
+            &repo,
+            "@agent please investigate",
+            &[&agent.public_key().to_hex()],
+        )
+        .unwrap()
+        .sign_with_keys(&owner)
+        .unwrap();
+        assert!(
+            owner_client
+                .send_event(trigger.clone())
+                .await
+                .expect("publish agent mention")
+                .accepted
+        );
+
+        let mut agent_client = BuzzTestClient::connect(&relay_url(), &agent)
+            .await
+            .expect("connect agent");
+        let delivered = query_relay(
+            &mut agent_client,
+            Filter::new()
+                .kind(Kind::Custom(9))
+                .custom_tags(
+                    SingleLetterTag::lowercase(Alphabet::H),
+                    [channel_id.to_string()],
+                )
+                .custom_tags(
+                    SingleLetterTag::lowercase(Alphabet::P),
+                    [agent.public_key().to_hex()],
+                ),
+        )
+        .await;
+        assert_eq!(delivered.len(), 1, "ACP must receive exactly one trigger");
+
+        let capture = std::env::temp_dir().join(format!(
+            "buzz-acp-project-delivery-{}.ndjson",
+            Uuid::new_v4()
+        ));
+        let quoted_capture = capture.to_string_lossy().replace('\'', "'\\''");
+        let script = format!(
+            r#"count=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> '{quoted_capture}'
+  printf '%s\n' "{{\"jsonrpc\":\"2.0\",\"id\":$count,\"result\":{{\"stopReason\":\"end_turn\"}}}}"
+  count=$((count + 1))
+done"#
+        );
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+            .await
+            .expect("spawn deterministic ACP agent");
+        let mut state = SessionState::default();
+        state.sessions.insert(channel_id, "project-session".into());
+        state
+            .deliveries
+            .insert(channel_id, ChannelDeliveryState::default());
+        let owned_agent = OwnedAgent {
+            index: 0,
+            acp,
+            state,
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            desired_model_request_id: None,
+            desired_model_pending_ack: false,
+            startup_effort: None,
+            agent_name: "project-test-agent".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        };
+        let relay_http_url = relay_url()
+            .replacen("ws://", "http://", 1)
+            .replacen("wss://", "https://", 1);
+        let rest_client = RestClient {
+            http: reqwest::Client::new(),
+            base_url: relay_http_url.clone(),
+            keys: agent.clone(),
+            auth_tag_json: None,
+        };
+        let context = Arc::new(PromptContext {
+            mcp_servers: vec![],
+            initial_message: None,
+            idle_timeout: Duration::from_secs(10),
+            max_turn_duration: Duration::from_secs(30),
+            turn_liveness_interval: Duration::ZERO,
+            dedup_mode: DedupMode::Queue,
+            system_prompt: None,
+            session_title: None,
+            team_instructions: None,
+            heartbeat_prompt: None,
+            base_prompt: None,
+            cwd: ".".into(),
+            rest_client: rest_client.clone(),
+            channel_info: ChannelInfoResolver::new(
+                HashMap::from([(
+                    channel_id,
+                    ChannelInfo {
+                        name: "Project agent delivery".into(),
+                        channel_type: "forum".into(),
+                        description: None,
+                    },
+                )]),
+                rest_client,
+            ),
+            context_message_limit: 12,
+            max_turns_per_session: 0,
+            permission_mode: PermissionMode::Default,
+            agent_keys: agent.clone(),
+            agent_owner_pubkey: Some(owner.public_key()),
+            memory_enabled: false,
+            harness_name: "test-agent".into(),
+            relay_url: relay_url(),
+        });
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        assert!(queue.push(QueuedEvent {
+            channel_id,
+            event: delivered[0].clone(),
+            received_at: Instant::now(),
+            prompt_tag: "@mention".into(),
+        }));
+        let batch = queue.flush_next().expect("flush one ACP turn");
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        crate::pool::run_prompt_task(
+            owned_agent,
+            Some(batch),
+            None,
+            context,
+            result_tx,
+            None,
+            Uuid::new_v4().to_string(),
+        )
+        .await;
+        let mut result = result_rx.recv().await.expect("ACP prompt result");
+        assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
+        result.agent.acp.shutdown().await;
+
+        let captured = std::fs::read_to_string(&capture).expect("read ACP capture");
+        let prompt_requests = captured
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .filter(|request| request["method"] == "session/prompt")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            prompt_requests.len(),
+            1,
+            "mention must produce exactly one ACP turn"
+        );
+        let prompt = prompt_requests[0]["params"]["prompt"]
+            .as_array()
+            .expect("ACP prompt blocks")
+            .iter()
+            .filter_map(|block| block["text"].as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        assert!(prompt.contains("Investigate the failing Project workflow."));
+        assert!(prompt.contains(&format!("Repository: {repo_address}")));
+        assert!(prompt.contains(&format!(
+            "buzz issues comment --channel {channel_id} --issue {}",
+            issue.id.to_hex()
+        )));
+
+        let ordinary_comment =
+            EventBuilder::new(Kind::TextNote, "Human follow-up before the agent reply.")
+                .tags([
+                    Tag::parse(["e", &issue.id.to_hex(), "", "root"]).unwrap(),
+                    Tag::parse(["a", &repo_address]).unwrap(),
+                ])
+                .custom_created_at(Timestamp::from(trigger.created_at.as_secs() + 1))
+                .sign_with_keys(&owner)
+                .unwrap();
+        assert!(
+            owner_client
+                .send_event(ordinary_comment.clone())
+                .await
+                .expect("publish ordinary Project comment")
+                .accepted
+        );
+
+        let exit_code = buzz_cli::run_from_args([
+            "buzz".to_string(),
+            "--relay".into(),
+            relay_http_url,
+            "--private-key".into(),
+            agent.secret_key().to_bech32().unwrap(),
+            "issues".into(),
+            "comment".into(),
+            "--channel".into(),
+            channel_id.to_string(),
+            "--issue".into(),
+            issue.id.to_hex(),
+            "--repo-owner".into(),
+            repo.owner.clone(),
+            "--repo-id".into(),
+            repo.id.clone(),
+            "--content".into(),
+            "Agent reply attached to the issue.".into(),
+            "--to".into(),
+            owner.public_key().to_hex(),
+        ])
+        .await;
+        assert_eq!(exit_code, 0, "agent-facing CLI publication must succeed");
+
+        let replies = query_relay(
+            &mut owner_client,
+            Filter::new()
+                .kind(Kind::Custom(9))
+                .author(agent.public_key())
+                .custom_tags(SingleLetterTag::lowercase(Alphabet::E), [issue.id.to_hex()])
+                .custom_tags(SingleLetterTag::lowercase(Alphabet::A), [repo_address]),
+        )
+        .await;
+        assert_eq!(
+            replies.len(),
+            1,
+            "issue must contain exactly one agent reply"
+        );
+        assert_eq!(replies[0].content, "Agent reply attached to the issue.");
+        assert!(
+            replies[0].created_at > ordinary_comment.created_at,
+            "agent reply must sort after both ordinary and agent Project comments"
+        );
+
+        let _ = std::fs::remove_file(capture);
+        agent_client.disconnect().await.expect("disconnect agent");
+        owner_client.disconnect().await.expect("disconnect owner");
     }
 }

--- a/crates/buzz-cli/src/commands/issues.rs
+++ b/crates/buzz-cli/src/commands/issues.rs
@@ -4,7 +4,7 @@ use crate::client::BuzzClient;
 use crate::commands::with_git_provenance;
 use crate::commands::GIT_ORIGIN_CHANNEL_ENV;
 use crate::error::CliError;
-use crate::validate::{read_or_stdin, sdk_err, validate_hex64, validate_repo_id};
+use crate::validate::{parse_uuid, read_or_stdin, sdk_err, validate_hex64, validate_repo_id};
 use buzz_sdk::{GitIssueMeta, GitRepoCoord, GitStatusMeta};
 use nostr::Timestamp;
 use serde::Deserialize;
@@ -228,7 +228,6 @@ impl IssueAssignmentOperation {
         }
     }
 }
-
 pub async fn cmd_create_issue(
     client: &BuzzClient,
     repo_owner: &str,
@@ -488,6 +487,67 @@ pub async fn cmd_get_issue(client: &BuzzClient, event: &str) -> Result<(), CliEr
     Ok(())
 }
 
+/// Publish a channel-scoped Project issue comment with monotonic ordering.
+pub async fn cmd_comment_issue(
+    client: &BuzzClient,
+    channel: &str,
+    issue: &str,
+    repo_owner: &str,
+    repo_id: &str,
+    content: &str,
+    recipients: &[String],
+) -> Result<(), CliError> {
+    validate_hex64(issue)?;
+    validate_hex64(repo_owner)?;
+    validate_repo_id(repo_id)?;
+    let channel = parse_uuid(channel)?;
+    let content = read_or_stdin(content)?;
+    let recipient_refs = recipients
+        .iter()
+        .map(|recipient| {
+            validate_hex64(recipient)?;
+            Ok(recipient.as_str())
+        })
+        .collect::<Result<Vec<_>, CliError>>()?;
+    let repo = GitRepoCoord {
+        owner: repo_owner.to_string(),
+        id: repo_id.to_string(),
+    };
+    let repo_address = format!("30617:{repo_owner}:{repo_id}");
+    let prior_comments_raw = client
+        .query(&serde_json::json!({
+            "kinds": [1, 9],
+            "#e": [issue],
+            "#a": [repo_address],
+            "limit": 500
+        }))
+        .await?;
+    let prior_comments: serde_json::Value = serde_json::from_str(&prior_comments_raw)
+        .map_err(|error| CliError::Other(format!("failed to parse issue comments: {error}")))?;
+    let newest_comment = prior_comments
+        .as_array()
+        .ok_or_else(|| CliError::Other("relay returned an invalid issue comment list".into()))?
+        .iter()
+        .filter_map(|event| event.get("created_at")?.as_u64())
+        .max();
+    let now = Timestamp::now().as_secs();
+    let created_at = match newest_comment {
+        Some(timestamp) => Timestamp::from(now.max(timestamp.checked_add(1).ok_or_else(|| {
+            CliError::Other("issue comment timestamp cannot be advanced".into())
+        })?)),
+        None => Timestamp::from(now),
+    };
+    let builder = with_git_provenance(
+        buzz_sdk::build_git_issue_comment(channel, issue, &repo, &content, &recipient_refs)
+            .map_err(sdk_err)?
+            .custom_created_at(created_at),
+    )?;
+    let event = client.sign_event(builder)?;
+    let response = client.submit_event(event).await?;
+    println!("{response}");
+    Ok(())
+}
+
 pub async fn cmd_list_issues(
     client: &BuzzClient,
     repo_owner: &str,
@@ -611,6 +671,25 @@ pub async fn dispatch(cmd: crate::IssuesCmd, client: &BuzzClient) -> Result<(), 
             cmd_create_issue(client, &repo_owner, &repo_id, &title, &content, &label, &to).await
         }
         IssuesCmd::Get { event } => cmd_get_issue(client, &event).await,
+        IssuesCmd::Comment {
+            channel,
+            issue,
+            repo_owner,
+            repo_id,
+            content,
+            to,
+        } => {
+            cmd_comment_issue(
+                client,
+                &channel,
+                &issue,
+                &repo_owner,
+                &repo_id,
+                &content,
+                &to,
+            )
+            .await
+        }
         IssuesCmd::List {
             repo_owner,
             repo_id,

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -1687,6 +1687,27 @@ pub enum IssuesCmd {
         #[arg(long)]
         event: String,
     },
+    /// Post a channel-scoped comment attached to an issue
+    Comment {
+        /// Repository discussion channel UUID
+        #[arg(long)]
+        channel: String,
+        /// Issue event id (64-char hex)
+        #[arg(long)]
+        issue: String,
+        /// Repo owner pubkey (64-char hex)
+        #[arg(long)]
+        repo_owner: String,
+        /// Repo identifier (d-tag)
+        #[arg(long)]
+        repo_id: String,
+        /// Comment body, markdown. Use '-' to read from stdin.
+        #[arg(long)]
+        content: String,
+        /// Additional recipient pubkey(s). Can be specified multiple times.
+        #[arg(long = "to")]
+        to: Vec<String>,
+    },
     /// List issues for a repo
     List {
         /// Repo owner pubkey (64-char hex)
@@ -2409,7 +2430,7 @@ mod tests {
         );
         assert_eq!(
             names(&cmd, "issues"),
-            vec!["assign", "create", "get", "list", "status", "unassign"]
+            vec!["assign", "comment", "create", "get", "list", "status", "unassign"]
         );
         assert_eq!(names(&cmd, "media"), vec!["get"]);
         assert_eq!(names(&cmd, "upload"), vec!["file"]);
@@ -2438,7 +2459,7 @@ mod tests {
             ("dms", 4),
             ("emoji", 5),
             ("feed", 1),
-            ("issues", 6),
+            ("issues", 7),
             ("media", 1),
             ("messages", 8),
             ("pack", 2),

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -1246,6 +1246,29 @@ fn build_git_issue_assignee_operation(
     Ok(EventBuilder::new(Kind::Custom(1), content).tags(tags))
 }
 
+/// Build a channel-scoped comment attached to a git issue.
+pub fn build_git_issue_comment(
+    channel_id: Uuid,
+    issue_id: &str,
+    repo: &GitRepoCoord,
+    content: &str,
+    recipients: &[&str],
+) -> Result<EventBuilder, SdkError> {
+    check_content(content, 64 * 1024)?;
+    let issue_id = check_hex_exact(issue_id, 64, "issue_id")?;
+    let a_value = repo.to_a_tag_value()?;
+    let mut tags = vec![
+        tag(&["h", &channel_id.to_string()])?,
+        tag(&["e", &issue_id, "", "root"])?,
+        tag(&["a", &a_value])?,
+    ];
+    mention_tags(recipients, &mut tags)?;
+
+    Ok(EventBuilder::new(Kind::Custom(9), content)
+        .tags(tags)
+        .allow_self_tagging())
+}
+
 /// Status to apply to a patch or issue root (kind:1630/1631/1632/1633, NIP-34).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GitStatus {

--- a/desktop/src/features/projects/hooks.ts
+++ b/desktop/src/features/projects/hooks.ts
@@ -23,6 +23,7 @@ import {
   KIND_GIT_STATUS_MERGED,
   KIND_GIT_STATUS_OPEN,
   KIND_REPO_STATE,
+  KIND_STREAM_MESSAGE,
   KIND_TEXT_NOTE,
 } from "@/shared/constants/kinds";
 import type {
@@ -42,10 +43,7 @@ import {
   mergeEventsById,
 } from "./assignmentOperationFetch";
 import type { ProjectIssue } from "./projectIssues.mjs";
-import {
-  nextProjectIssueCommentCreatedAt,
-  projectIssueEventsToIssues,
-} from "./projectIssues.mjs";
+import { projectIssueEventsToIssues } from "./projectIssues.mjs";
 import type {
   ProjectPullRequest,
   ProjectPullRequestCommentAnchor,
@@ -73,6 +71,7 @@ import {
   fetchProjectEventsExhaustively,
 } from "./projectEnumeration";
 import { projectMatchesRouteId } from "./projectRoutes";
+import { createProjectIssueComment } from "./projectIssueCommentPublish";
 
 export { projectsQueryKey };
 
@@ -260,7 +259,7 @@ async function fetchProjectIssues(
         limit: 500,
       }),
       relayClient.fetchEvents({
-        kinds: [KIND_TEXT_NOTE],
+        kinds: [KIND_TEXT_NOTE, KIND_STREAM_MESSAGE],
         "#a": [project.repoAddress],
         limit: 500,
       }),
@@ -402,56 +401,6 @@ async function createProjectPullRequestComment({
     event,
     "Timed out posting review comment.",
     "Failed to post review comment.",
-  );
-}
-
-async function createProjectIssueComment({
-  content,
-  mediaTags,
-  mentionPubkeys = [],
-  issue,
-  project,
-}: {
-  content: string;
-  mediaTags?: string[][];
-  mentionPubkeys?: string[];
-  issue: ProjectIssue;
-  project: Repository;
-}): Promise<void> {
-  const body = content.trim();
-  if (!body) {
-    throw new Error("Comment cannot be empty.");
-  }
-
-  const recipients = new Set([
-    project.owner.toLowerCase(),
-    issue.author.toLowerCase(),
-    ...issue.recipients.map((recipient) => recipient.toLowerCase()),
-    ...mentionPubkeys.map((pubkey) => pubkey.toLowerCase()),
-  ]);
-  const tags = [
-    ["e", issue.id, "", "root"],
-    ["a", project.repoAddress],
-    ...[...recipients].map((recipient) => ["p", recipient]),
-    ...(mediaTags ?? []),
-  ];
-  const identity = await getIdentity();
-
-  const event = await signRelayEvent({
-    kind: KIND_TEXT_NOTE,
-    content: body,
-    createdAt: nextProjectIssueCommentCreatedAt(
-      issue,
-      Math.floor(Date.now() / 1_000),
-      identity.pubkey,
-    ),
-    tags,
-  });
-
-  await relayClient.publishEvent(
-    event,
-    "Timed out posting task comment.",
-    "Failed to post task comment.",
   );
 }
 
@@ -870,11 +819,13 @@ export function useCreateProjectIssueCommentMutation(
 
   return useMutation({
     mutationFn: ({
+      agentMentionPubkeys,
       content,
       mediaTags,
       mentionPubkeys,
       issue,
     }: {
+      agentMentionPubkeys?: string[];
       content: string;
       mediaTags?: string[][];
       mentionPubkeys?: string[];
@@ -882,6 +833,7 @@ export function useCreateProjectIssueCommentMutation(
     }) => {
       if (!project) throw new Error("No project selected.");
       return createProjectIssueComment({
+        agentMentionPubkeys,
         content,
         mediaTags,
         mentionPubkeys,

--- a/desktop/src/features/projects/projectIssueCommentPublish.ts
+++ b/desktop/src/features/projects/projectIssueCommentPublish.ts
@@ -1,0 +1,106 @@
+import { relayClient } from "@/shared/api/relayClient";
+import { getChannelMembers, signRelayEvent } from "@/shared/api/tauri";
+import { getIdentity } from "@/shared/api/tauriIdentity";
+import { KIND_STREAM_MESSAGE, KIND_TEXT_NOTE } from "@/shared/constants/kinds";
+
+import type { ProjectIssue } from "./projectIssues.mjs";
+import { nextProjectIssueCommentCreatedAt } from "./projectIssues.mjs";
+import type { Repository } from "./projectModels";
+
+export async function createProjectIssueComment({
+  agentMentionPubkeys = [],
+  content,
+  mediaTags,
+  mentionPubkeys = [],
+  issue,
+  project,
+}: {
+  agentMentionPubkeys?: string[];
+  content: string;
+  mediaTags?: string[][];
+  mentionPubkeys?: string[];
+  issue: ProjectIssue;
+  project: Repository;
+}): Promise<void> {
+  const body = content.trim();
+  if (!body) throw new Error("Comment cannot be empty.");
+
+  const identity = await getIdentity();
+  let kind = KIND_TEXT_NOTE;
+  let channelTags: string[][] = [];
+  const authorizedAgentPubkeys = new Set<string>();
+  if (agentMentionPubkeys.length > 0) {
+    if (!project.channelId) {
+      throw new Error(
+        "Agent mentions require this repository to be bound to a discussion channel.",
+      );
+    }
+    const channelMembers = await getChannelMembers(project.channelId);
+    const memberPubkeys = new Set(
+      channelMembers.map((member) => member.pubkey.toLowerCase()),
+    );
+    for (const member of channelMembers) {
+      if (member.role === "bot" || member.isAgent) {
+        authorizedAgentPubkeys.add(member.pubkey.toLowerCase());
+      }
+    }
+    if (!memberPubkeys.has(identity.pubkey.toLowerCase())) {
+      throw new Error(
+        "Only repository channel members can address agents from an issue.",
+      );
+    }
+    if (
+      agentMentionPubkeys.some(
+        (pubkey) => !memberPubkeys.has(pubkey.toLowerCase()),
+      )
+    ) {
+      throw new Error(
+        "Addressed agents must be members of the repository channel.",
+      );
+    }
+    kind = KIND_STREAM_MESSAGE;
+    channelTags = [["h", project.channelId]];
+  }
+
+  const recipients = new Set([
+    project.owner.toLowerCase(),
+    issue.author.toLowerCase(),
+    ...issue.recipients.map((recipient) => recipient.toLowerCase()),
+    ...mentionPubkeys.map((pubkey) => pubkey.toLowerCase()),
+  ]);
+  if (kind === KIND_STREAM_MESSAGE) {
+    const addressedAgents = new Set(
+      agentMentionPubkeys.map((pubkey) => pubkey.toLowerCase()),
+    );
+    for (const recipient of recipients) {
+      if (
+        authorizedAgentPubkeys.has(recipient) &&
+        !addressedAgents.has(recipient)
+      ) {
+        recipients.delete(recipient);
+      }
+    }
+  }
+  const event = await signRelayEvent({
+    kind,
+    content: body,
+    createdAt: nextProjectIssueCommentCreatedAt(
+      issue,
+      Math.floor(Date.now() / 1_000),
+      identity.pubkey,
+    ),
+    tags: [
+      ...channelTags,
+      ["e", issue.id, "", "root"],
+      ["a", project.repoAddress],
+      ...[...recipients].map((recipient) => ["p", recipient]),
+      ...(mediaTags ?? []),
+    ],
+  });
+
+  await relayClient.publishEvent(
+    event,
+    "Timed out posting issue comment.",
+    "Failed to post issue comment.",
+  );
+}

--- a/desktop/src/features/projects/projectWorkItems.ts
+++ b/desktop/src/features/projects/projectWorkItems.ts
@@ -12,6 +12,7 @@ import {
   KIND_GIT_STATUS_DRAFT,
   KIND_GIT_STATUS_MERGED,
   KIND_GIT_STATUS_OPEN,
+  KIND_STREAM_MESSAGE,
   KIND_TEXT_NOTE,
 } from "@/shared/constants/kinds";
 import {
@@ -112,7 +113,7 @@ export async function fetchProjectsWorkItems<TProject extends ProjectReference>(
         limit: 2_000,
       }),
       fetchEvents({
-        kinds: [KIND_TEXT_NOTE],
+        kinds: [KIND_TEXT_NOTE, KIND_STREAM_MESSAGE],
         "#a": repoAddresses,
         limit: 2_000,
       }),

--- a/desktop/src/features/projects/ui/ProjectIssuesPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectIssuesPanel.tsx
@@ -15,6 +15,10 @@ import { toast } from "sonner";
 import { useIsManagedAgent } from "@/features/agent-memory/hooks";
 import { ForumComposer } from "@/features/forum/ui/ForumComposer";
 import {
+  useManagedAgentsQuery,
+  useRelayAgentsQuery,
+} from "@/features/agents/hooks";
+import {
   type ProjectIssue,
   type Repository as Project,
   useCreateProjectIssueCommentMutation,
@@ -281,9 +285,26 @@ export function ProjectIssueDetail({
   project: Project;
 }) {
   const commentMutation = useCreateProjectIssueCommentMutation(project);
+  const managedAgentsQuery = useManagedAgentsQuery();
+  const relayAgentsQuery = useRelayAgentsQuery();
   const members = React.useMemo(
     () => issueMembers(project, issue, profiles),
     [issue, profiles, project],
+  );
+  const agentPubkeys = React.useMemo(
+    () =>
+      new Set([
+        ...(managedAgentsQuery.data ?? []).map((agent) =>
+          normalizePubkey(agent.pubkey),
+        ),
+        ...(relayAgentsQuery.data ?? []).map((agent) =>
+          normalizePubkey(agent.pubkey),
+        ),
+        ...Object.entries(profiles ?? {}).flatMap(([pubkey, profile]) =>
+          profile.isAgent ? [normalizePubkey(pubkey)] : [],
+        ),
+      ]),
+    [managedAgentsQuery.data, profiles, relayAgentsQuery.data],
   );
   const handleCommentSubmit = React.useCallback(
     async (
@@ -293,6 +314,9 @@ export function ProjectIssueDetail({
     ) => {
       try {
         await commentMutation.mutateAsync({
+          agentMentionPubkeys: mentionPubkeys.filter((pubkey) =>
+            agentPubkeys.has(normalizePubkey(pubkey)),
+          ),
           content,
           issue,
           mediaTags,
@@ -306,7 +330,7 @@ export function ProjectIssueDetail({
         throw error;
       }
     },
-    [commentMutation, issue],
+    [agentPubkeys, commentMutation, issue],
   );
   const identityQuery = useIdentityQuery();
   const status = issueStatusVisual(issue.status);
@@ -406,6 +430,8 @@ export function ProjectIssueDetail({
         data-testid="project-issue-comment-composer"
       >
         <ForumComposer
+          channelId={project.channelId}
+          channelType="forum"
           className="border border-border/60 bg-background/45"
           disabled={commentMutation.isPending}
           isSending={commentMutation.isPending}


### PR DESCRIPTION
Fixes #2462.

Controlling Linear issue: [BAC-109](https://linear.app/scale-lean/issue/BAC-109/refresh-and-verify-selected-buzz-and-hermes-upstream-contributions)

## Summary

- Publish a Project issue comment as a channel-scoped kind 9 event when it mentions an authorized managed agent.
- Give buzz-acp the originating issue and repository context.
- Add `buzz issues comment` so the agent reply preserves the issue `e`, repository `a`, and channel `h` tags.
- Preserve pull-request review decisions and monotonic Project comment ordering across legacy kind 1 and agent-addressed kind 9 comments.
- Add one core relay-backed regression for the complete delivery contract.

This supersedes only the #2462 portion of #2498. It preserves that PR's correct kind 9 plus channel `h` direction, while leaving its unrelated mesh-demo and Builderlab changes separate. Thank you to @Chessing234 for the original investigation and implementation direction.

The response now gets back to where it once belonged: the originating Project issue.

## Authorization model

- Delivery fails closed unless the repository is bound to a Buzz channel.
- The relay authorizes the comment author against that channel.
- The mentioned agent must be an authorized channel member.
- buzz-acp retains its channel-scoped subscription.
- This does not add a global p-tag subscription or turn arbitrary mentions into agent tasks.

## Verification

Rebased onto current main at `c363ce13c`. The conflict resolution preserves the current semantic prompt framing and Projects CLI guidance together with the issue and repository context added by this PR.

- `cargo check -p buzz-acp -p buzz-cli --tests`: passed.
- `pnpm -C desktop typecheck`: passed.
- `cargo test -p buzz-cli issues --lib`: 5 passed, 0 failed.
- `just ci`: passed on commit `cf3e44a0c856c071482ce1bc725e973b5fbd30a1`, including all required Rust, Desktop, Web, Mobile, format, lint, build, and security-script checks.
- `cargo test -p buzz-acp authorized_project_issue_mention_round_trips_through_acp_contract -- --ignored --nocapture`: the current live rerun remains environment-blocked because no local relay is available. The same focused regression passed before the earlier rebase. A fresh live run is still required before treating the end-to-end verifier as current.

The focused regression publishes an authorized Project mention, drives it through the production EventQueue, observes exactly one ACP `session/prompt` with issue and repository context, publishes the response through the real CLI dispatch, and verifies one reply attached with the original `h`, `e`, and `a` tags after a later legacy kind 1 comment.

## Compatibility and privacy

- Ordinary plaintext Project comments remain compatible.
- Existing pull-request review decision tags and ordering remain intact.
- Current Projects assignment events remain compatible after the rebase.
- No credentials, local files, or environment values are included in events.
- No scheduler, file scan, upload path, or new global subscription is introduced.
