### PR TITLE
feat: add native desktop review harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 __pycache__/
 *.pyc
 
+# Swift native-review build output
+tools/native-review/swift/.build/
+
 # lefthook-generated hook scripts (machine-specific)
 .hooks/
 

--- a/Justfile
+++ b/Justfile
@@ -999,3 +999,11 @@ benchmark *ARGS:
 # Stop the benchmark Docker stack (state and channels are kept)
 benchmark-down:
     docker compose --project-name buzz-benchmark down
+
+# Validate macOS native-review tooling and report required OS permissions.
+native-review-doctor:
+    ./tools/native-review/bin/review-native doctor
+
+# Run one declarative journey against the isolated local desktop fixture.
+native-review-desktop JOURNEY="tools/native-review/desktop/tooltip-fresh-dwell.yaml":
+    ./tools/native-review/bin/review-native run "{{JOURNEY}}"

--- a/Justfile
+++ b/Justfile
@@ -1004,6 +1004,11 @@ benchmark-down:
 native-review-doctor:
     ./tools/native-review/bin/review-native doctor
 
+# Run locked Python contracts plus deterministic Swift driver tests.
+native-review-test:
+    uv run --project tools/native-review --locked python -m unittest discover -s tools/native-review/tests -p 'test_*.py'
+    swift test --package-path tools/native-review/swift
+
 # Run one declarative journey against the isolated local desktop fixture.
 native-review-desktop JOURNEY="tools/native-review/desktop/tooltip-fresh-dwell.yaml":
     ./tools/native-review/bin/review-native run "{{JOURNEY}}"

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -22,6 +22,7 @@ import { recoverLocalStorageQuotaOnStartup } from "@/shared/lib/localStorageQuot
 import { startLocalStorageSweep } from "@/shared/lib/localStorageSweep";
 import { initializeConversationDensityPreference } from "@/shared/lib/conversationDensityPreference";
 import { initializeFontSizePreference } from "@/shared/lib/fontSizePreference";
+import { installNativeReviewSemanticProbe } from "@/testing/nativeReviewSemanticProbe";
 
 type E2eWindow = Window & {
   __BUZZ_E2E__?: unknown;
@@ -31,6 +32,66 @@ const E2E_DEFAULT_PUBKEY = "deadbeef".repeat(8);
 const E2E_COMMUNITY_ID = "e2e-default-community";
 const ONBOARDING_COMPLETION_STORAGE_KEY_PREFIX = "buzz-onboarding-complete.v1:";
 const DEV_STATE_RESET_PARAM = "resetDevState";
+const NATIVE_REVIEW_PARAM = "nativeReview";
+
+function configureNativeReviewFixtureFromUrl() {
+  const buildEnabled = import.meta.env.VITE_NATIVE_REVIEW === "1";
+  if (!import.meta.env.DEV && !buildEnabled) return;
+  const url = new URL(window.location.href);
+  const enabled =
+    url.searchParams.get(NATIVE_REVIEW_PARAM) === "1" || buildEnabled;
+  if (!enabled) return;
+
+  const relayUrl =
+    url.searchParams.get("reviewRelay") ??
+    import.meta.env.VITE_NATIVE_REVIEW_RELAY;
+  const pubkey =
+    url.searchParams.get("reviewPubkey") ??
+    import.meta.env.VITE_NATIVE_REVIEW_PUBKEY;
+  let relay: URL;
+  try {
+    relay = new URL(relayUrl ?? "");
+  } catch {
+    throw new Error(
+      "native review bootstrap requires a loopback relay and 64-character hex pubkey",
+    );
+  }
+  if (
+    !["ws:", "http:"].includes(relay.protocol) ||
+    !["localhost", "127.0.0.1", "[::1]"].includes(relay.hostname) ||
+    !relay.port ||
+    relay.pathname !== "/" ||
+    relay.username ||
+    relay.password ||
+    relay.search ||
+    relay.hash ||
+    !/^[a-f0-9]{64}$/.test(pubkey ?? "")
+  ) {
+    throw new Error(
+      "native review bootstrap requires a loopback relay and 64-character hex pubkey",
+    );
+  }
+  const communityId = "native-review-local";
+  const community = {
+    addedAt: new Date().toISOString(),
+    id: communityId,
+    name: "Native Review",
+    pubkey,
+    relayUrl,
+  };
+  window.localStorage.setItem("buzz-communities", JSON.stringify([community]));
+  window.localStorage.setItem("buzz-active-community-id", communityId);
+  window.localStorage.setItem(
+    `buzz-machine-onboarding-complete.v2:${pubkey}`,
+    "true",
+  );
+  window.localStorage.setItem(`buzz-onboarding-complete.v1:${pubkey}`, "true");
+  window.localStorage.setItem(
+    `buzz-community-onboarding-complete.v1:${encodeURIComponent(relayUrl)}:${pubkey}`,
+    "true",
+  );
+  installNativeReviewSemanticProbe();
+}
 
 function resetDevWebviewStateFromUrl() {
   if (!import.meta.env.DEV) {
@@ -124,6 +185,7 @@ async function installE2eBridgeIfConfigured() {
 
 async function bootstrap() {
   resetDevWebviewStateFromUrl();
+  configureNativeReviewFixtureFromUrl();
   configureDevE2eBridgeFromUrl();
   recoverLocalStorageQuotaOnStartup();
   initializeConversationDensityPreference();

--- a/desktop/src/testing/nativeReviewSemanticProbe.ts
+++ b/desktop/src/testing/nativeReviewSemanticProbe.ts
@@ -1,0 +1,133 @@
+type SemanticNode = {
+  id?: string;
+  role?: string;
+  name?: string;
+  enabled: boolean;
+  focused: boolean;
+  frame: { x: number; y: number; width: number; height: number };
+  viewport: { width: number; height: number };
+};
+
+const IMPLICIT_ROLES: Partial<Record<string, string>> = {
+  A: "link",
+  BUTTON: "button",
+  INPUT: "text-field",
+  TEXTAREA: "text-area",
+};
+
+function accessibleName(element: HTMLElement): string | undefined {
+  const labelledBy = element.getAttribute("aria-labelledby");
+  const labelledText = labelledBy
+    ?.split(/\s+/)
+    .map((id) => document.getElementById(id)?.textContent?.trim())
+    .filter(Boolean)
+    .join(" ");
+  return (
+    element.getAttribute("aria-label")?.trim() ||
+    labelledText ||
+    element.getAttribute("title")?.trim() ||
+    (element.getAttribute("role") === "tooltip"
+      ? element.textContent?.trim()
+      : undefined) ||
+    undefined
+  );
+}
+
+function snapshot(): SemanticNode[] {
+  const nodes: SemanticNode[] = [];
+  for (const candidate of document.querySelectorAll<HTMLElement>(
+    "[data-testid], [role], button, textarea, input, a[href]",
+  )) {
+    const rect = candidate.getBoundingClientRect();
+    const style = window.getComputedStyle(candidate);
+    if (
+      rect.width <= 0 ||
+      rect.height <= 0 ||
+      style.display === "none" ||
+      style.visibility === "hidden"
+    ) {
+      continue;
+    }
+    const id = candidate.dataset.testid;
+    const role =
+      candidate.getAttribute("role") ?? IMPLICIT_ROLES[candidate.tagName];
+    const name = accessibleName(candidate);
+    if (!id && !role && !name) continue;
+    nodes.push({
+      ...(id ? { id } : {}),
+      ...(role ? { role } : {}),
+      ...(name ? { name } : {}),
+      enabled:
+        !candidate.hasAttribute("disabled") &&
+        candidate.getAttribute("aria-disabled") !== "true",
+      focused: candidate === document.activeElement,
+      frame: {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      },
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      },
+    });
+  }
+  return nodes;
+}
+
+const MAX_PAYLOAD_BYTES = 1024 * 1024;
+
+function validProbeUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "http:" &&
+      url.hostname === "127.0.0.1" &&
+      /^\/snapshot\/[a-f0-9]{64}$/.test(url.pathname) &&
+      !url.username &&
+      !url.password &&
+      !url.search &&
+      !url.hash
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function installNativeReviewSemanticProbe(): void {
+  const probeUrl = import.meta.env.VITE_NATIVE_REVIEW_PROBE_URL;
+  if (!validProbeUrl(probeUrl)) {
+    throw new Error(
+      "native review semantic probe requires an authenticated loopback URL",
+    );
+  }
+  let scheduled = false;
+  const publish = () => {
+    scheduled = false;
+    const payload = JSON.stringify(snapshot());
+    if (new Blob([payload]).size > MAX_PAYLOAD_BYTES) {
+      console.error("native review semantic probe snapshot exceeds size limit");
+      return;
+    }
+    if (!navigator.sendBeacon(probeUrl, payload)) {
+      console.error("native review semantic probe beacon was rejected");
+    }
+  };
+  const schedule = () => {
+    if (scheduled) return;
+    scheduled = true;
+    window.requestAnimationFrame(publish);
+  };
+  new MutationObserver(schedule).observe(document.documentElement, {
+    attributes: true,
+    childList: true,
+    subtree: true,
+  });
+  window.addEventListener("focusin", schedule);
+  window.addEventListener("focusout", schedule);
+  window.addEventListener("resize", schedule);
+  window.addEventListener("scroll", schedule, true);
+  schedule();
+}

--- a/scripts/setup-desktop-test-data.sh
+++ b/scripts/setup-desktop-test-data.sh
@@ -15,6 +15,11 @@ BOB_PUBKEY="bb22a5299220cad76ffd46190ccbeede8ab5dc260faa28b6e5a2cb31b9aff260"
 CHARLIE_PUBKEY="554cef57437abac34522ac2c9f0490d685b72c80478cf9f7ed6f9570ee8624ea"
 TYLER_PUBKEY="e5ebc6cdb579be112e336cc319b5989b4bb6af11786ea90dbe52b5f08d741b34"
 AGENT_PUBKEY="db0b028cd36f4d3e36c8300cce87252c1f7fc9495ffecc53f393fcac341ffd36"
+REVIEW_PUBKEY="${BUZZ_REVIEW_PUBKEY:-}"
+if [[ -n "$REVIEW_PUBKEY" && ! "$REVIEW_PUBKEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
+  echo "BUZZ_REVIEW_PUBKEY must be exactly 64 hexadecimal characters." >&2
+  exit 1
+fi
 
 if command -v psql >/dev/null 2>&1; then
   run_psql() { PGPASSWORD="$DB_PASS" psql -h"$DB_HOST" -p"$DB_PORT" -U"$DB_USER" -d"$DB_NAME" -qtA "$@"; }
@@ -128,5 +133,16 @@ VALUES
 ON CONFLICT DO NOTHING
 ;
 "
+
+if [[ -n "$REVIEW_PUBKEY" ]]; then
+  run_sql "
+INSERT INTO channel_members
+  (community_id, channel_id, pubkey, role, invited_by)
+VALUES
+  ('${COMMUNITY_ID}', '${UUID_GENERAL}', decode('${REVIEW_PUBKEY}','hex'), 'member', decode('${SYSTEM_PUBKEY}','hex'))
+ON CONFLICT DO NOTHING
+;
+"
+fi
 
 echo "Desktop e2e data ready."

--- a/scripts/setup-desktop-test-data.sh
+++ b/scripts/setup-desktop-test-data.sh
@@ -16,8 +16,15 @@ CHARLIE_PUBKEY="554cef57437abac34522ac2c9f0490d685b72c80478cf9f7ed6f9570ee8624ea
 TYLER_PUBKEY="e5ebc6cdb579be112e336cc319b5989b4bb6af11786ea90dbe52b5f08d741b34"
 AGENT_PUBKEY="db0b028cd36f4d3e36c8300cce87252c1f7fc9495ffecc53f393fcac341ffd36"
 REVIEW_PUBKEY="${BUZZ_REVIEW_PUBKEY:-}"
-if [[ -n "$REVIEW_PUBKEY" && ! "$REVIEW_PUBKEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
-  echo "BUZZ_REVIEW_PUBKEY must be exactly 64 hexadecimal characters." >&2
+REVIEW_CLEANUP_PUBKEY="${BUZZ_REVIEW_CLEANUP_PUBKEY:-}"
+for value in "$REVIEW_PUBKEY" "$REVIEW_CLEANUP_PUBKEY"; do
+  if [[ -n "$value" && ! "$value" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "Review pubkeys must be exactly 64 lowercase hexadecimal characters." >&2
+    exit 1
+  fi
+done
+if [[ -n "$REVIEW_PUBKEY" && -n "$REVIEW_CLEANUP_PUBKEY" ]]; then
+  echo "Fixture setup and review-principal cleanup are mutually exclusive." >&2
   exit 1
 fi
 
@@ -78,6 +85,17 @@ LIMIT 1
 if [[ ! "${COMMUNITY_ID}" =~ ^[0-9a-fA-F-]{36}$ ]]; then
   echo "Could not resolve community id for host ${COMMUNITY_HOST}." >&2
   exit 1
+fi
+
+if [[ -n "$REVIEW_CLEANUP_PUBKEY" ]]; then
+  run_sql "
+DELETE FROM channel_members
+WHERE community_id = '${COMMUNITY_ID}'
+  AND pubkey = decode('${REVIEW_CLEANUP_PUBKEY}','hex')
+;
+"
+  echo "Desktop e2e review principal removed."
+  exit 0
 fi
 
 UUID_GENERAL=$(uuid5_hex "buzz.channel.general")

--- a/tools/native-review/README.md
+++ b/tools/native-review/README.md
@@ -12,7 +12,8 @@ exact-SHA run receipt. It is a targeted review lane, not a replacement for
   service, HOME, WebKit/app-data state, and artifact directory.
 - The launcher environment is allowlisted before the ephemeral key is added;
   inherited tokens and production keys never enter the reviewed process.
-- Production bundle IDs, keyring services, and remote relays fail closed.
+- Production bundle IDs, keyring services, remote relays, and cleanup opt-outs fail closed.
+- Global pointer and keyboard input is emitted only while the spawned review app is frontmost.
 - This protects reviewer state from accidents. It is **not** containment for
   hostile code; use a dedicated macOS user or disposable VM for untrusted PRs.
 
@@ -21,7 +22,7 @@ exact-SHA run receipt. It is a targeted review lane, not a replacement for
 ```bash
 just native-review-doctor
 just native-review-desktop tools/native-review/desktop/tooltip-fresh-dwell.yaml
-python3 -m unittest discover -s tools/native-review/tests -p 'test_*.py'
+just native-review-test
 ```
 
 The desktop command expects the isolated `buzz-harness` relay on port 3030

--- a/tools/native-review/README.md
+++ b/tools/native-review/README.md
@@ -1,0 +1,43 @@
+# Buzz native review harness
+
+This macOS-only MVP drives the real Tauri/WKWebView app with Accessibility and
+CGEvent, captures its window with Core Graphics and AVFoundation, and writes an
+exact-SHA run receipt. It is a targeted review lane, not a replacement for
+`just ci` or Playwright.
+
+## Safety contract
+
+- Only loopback `ws://`/`http://` relays are accepted.
+- Every run gets an ephemeral Nostr key, run-specific dev bundle ID, keyring
+  service, HOME, WebKit/app-data state, and artifact directory.
+- The launcher environment is allowlisted before the ephemeral key is added;
+  inherited tokens and production keys never enter the reviewed process.
+- Production bundle IDs, keyring services, and remote relays fail closed.
+- This protects reviewer state from accidents. It is **not** containment for
+  hostile code; use a dedicated macOS user or disposable VM for untrusted PRs.
+
+## Commands
+
+```bash
+just native-review-doctor
+just native-review-desktop tools/native-review/desktop/tooltip-fresh-dwell.yaml
+python3 -m unittest discover -s tools/native-review/tests -p 'test_*.py'
+```
+
+The desktop command expects the isolated `buzz-harness` relay on port 3030
+(`scripts/start-isolated-test-relay.sh`). Doctor reports Accessibility and
+Screen Recording separately and the run refuses to proceed unless both are
+already granted to the invoking terminal/agent.
+
+Runs are written under
+`test-results/native-review/<sha>/<flow>/<run-id>/`. A failed locator,
+postcondition, recording, evidence capture, or cleanup produces a failed partial
+receipt. `tests/fixtures/broken-tooltip.yaml` is the deliberate fail-loud
+mutation.
+
+## MVP limits
+
+Only macOS desktop, the local review-channel fixture, role/name/identifier AX
+locators, click/hover/key/wait actions, window screenshots/video, and step AX
+snapshots are implemented. iOS Simulator and repeated base/head performance
+comparison remain later phases.

--- a/tools/native-review/bin/review-native
+++ b/tools/native-review/bin/review-native
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# The repository pins Rust/Node tooling through Hermit; native review must build
+# with the same toolchain as the artifact it records.
+source "$REPO_ROOT/bin/activate-hermit"
+exec uv run --project "$SCRIPT_DIR" --locked python "$SCRIPT_DIR/review_native.py" "$@"

--- a/tools/native-review/desktop/tooltip-fresh-dwell.yaml
+++ b/tools/native-review/desktop/tooltip-fresh-dwell.yaml
@@ -1,0 +1,61 @@
+schema_version: 1
+flow: tooltip_fresh_dwell
+platforms: [macos]
+fixture: local_review_channel
+record:
+  video: window
+  screenshots: false
+  accessibility: false
+steps:
+  - name: activate_buzz
+    act: {type: activate}
+    expect:
+      exists: {role: window}
+    timeout_ms: 15000
+  - name: await_interactive_app
+    act: {type: wait, duration_ms: 100}
+    expect:
+      not_exists: {id: app-loading-gate}
+    timeout_ms: 60000
+  - name: reach_seeded_channel
+    locate:
+      - {id: channel-welcome-everyone}
+      - {role: button, name: welcome-everyone}
+    act: {type: click}
+    expect:
+      exists: {id: message-insert-mention}
+    timeout_ms: 15000
+  - name: settle_pointer_before_fresh_dwell
+    locate:
+      - {id: message-composer}
+      - {role: text-area, name: Message}
+    act: {type: move_pointer, duration_ms: 80}
+    expect:
+      not_exists: {role: tooltip, name: "Mention someone"}
+  - name: clear_tooltip_skip_delay
+    act: {type: wait, duration_ms: 800}
+    expect:
+      not_exists: {role: tooltip, name: "Mention someone"}
+  - name: transit_over_mention
+    locate:
+      - {id: message-insert-mention}
+      - {role: button, name: "Mention someone"}
+    act: {type: move_pointer}
+    expect: {enabled: true}
+  - name: complete_dwell
+    act: {type: wait, duration_ms: 550}
+    expect:
+      exists: {role: tooltip, name: "Mention someone"}
+    timeout_ms: 1000
+    measure: tooltip_open_latency
+  - name: leave_trigger
+    locate:
+      - {id: message-composer}
+      - {role: text-area, name: Message}
+    act: {type: move_pointer, duration_ms: 80}
+    expect:
+      not_exists: {role: tooltip, name: "Mention someone"}
+    timeout_ms: 1000
+cleanup:
+  terminate_app: true
+  remove_state: true

--- a/tools/native-review/desktop/tooltip-fresh-dwell.yaml
+++ b/tools/native-review/desktop/tooltip-fresh-dwell.yaml
@@ -41,12 +41,15 @@ steps:
       - {id: message-insert-mention}
       - {role: button, name: "Mention someone"}
     act: {type: move_pointer}
-    expect: {enabled: true}
+    expect:
+      not_exists: {role: tooltip, name: "Mention someone"}
+    measure_start: tooltip_open_latency
   - name: complete_dwell
-    act: {type: wait, duration_ms: 550}
+    act: {type: wait, duration_ms: 0}
     expect:
       exists: {role: tooltip, name: "Mention someone"}
-    timeout_ms: 1000
+    expect_not_before_ms: 400
+    timeout_ms: 250
     measure: tooltip_open_latency
   - name: leave_trigger
     locate:

--- a/tools/native-review/pyproject.toml
+++ b/tools/native-review/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "buzz-native-review"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["PyYAML==6.0.2"]

--- a/tools/native-review/review_native.py
+++ b/tools/native-review/review_native.py
@@ -246,7 +246,7 @@ def scrubbed_environment(*, include_home: bool = False) -> dict[str, str]:
     return env
 
 
-def fixture_environment(isolation: dict[str, str], review_pubkey: str) -> dict[str, str]:
+def fixture_environment(isolation: dict[str, str], review_pubkey: str, *, cleanup: bool = False) -> dict[str, str]:
     """Return fixed local fixture coordinates without inheriting host credentials."""
     if not re.fullmatch(r"[a-f0-9]{64}", review_pubkey):
         raise HarnessError("fixture seeding requires a 64-character lowercase hex pubkey")
@@ -256,7 +256,7 @@ def fixture_environment(isolation: dict[str, str], review_pubkey: str) -> dict[s
         raise HarnessError("fixture seeding requires the isolated relay at loopback port 3030")
     return {
         **scrubbed_environment(include_home=True),
-        "BUZZ_REVIEW_PUBKEY": review_pubkey,
+        "BUZZ_REVIEW_CLEANUP_PUBKEY" if cleanup else "BUZZ_REVIEW_PUBKEY": review_pubkey,
         "BUZZ_COMMUNITY_HOST": f"{parsed.hostname}:{port}",
         "BUZZ_DB_HOST": "localhost",
         "BUZZ_DB_PORT": "5471",
@@ -367,14 +367,20 @@ def prepare_fixture(run_dir: pathlib.Path, isolation: dict[str, str]) -> dict[st
     fixture = {
         "kind": "local_review_channel", "identity_pubkey": public_match.group(1),
         "secret_path": str(secret_path), "relay_url": isolation["relay_url"],
-        "seed": "scripts/setup-desktop-test-data.sh", "cleanup_scope": "run-local app state and keyring only",
+        "seed": "scripts/setup-desktop-test-data.sh", "cleanup_scope": "run-local app, keyring, and fixture principal",
     }
     try:
         run([str(ROOT / "scripts/setup-desktop-test-data.sh")],
             env=fixture_environment(isolation, fixture["identity_pubkey"]), capture=False)
-    except Exception:
+    except Exception as seed_exc:
+        cleanup_errors = []
+        try:
+            run([str(ROOT / "scripts/setup-desktop-test-data.sh")],
+                env=fixture_environment(isolation, fixture["identity_pubkey"], cleanup=True), capture=False)
+        except Exception as cleanup_exc:
+            cleanup_errors.append(f"; review principal cleanup also failed: {cleanup_exc}")
         secret_path.unlink(missing_ok=True)
-        raise
+        raise HarnessError(f"fixture seed failed: {seed_exc}{''.join(cleanup_errors)}") from seed_exc
     (run_dir / "manifest" / "fixture.json").write_text(json.dumps({k: v for k, v in fixture.items() if k != "secret_path"}, indent=2))
     return fixture
 
@@ -549,6 +555,12 @@ def wait_expectation_not_before(driver: Driver, expectation: dict[str, Any], sta
         time.sleep(0.025)
 
 
+def valid_measurement(marker_ns: int | None, observation_ns: int | None) -> float | None:
+    if marker_ns is None or observation_ns is None:
+        return None
+    return (observation_ns - marker_ns) / 1_000_000
+
+
 def capture_step(driver: Driver, run_dir: pathlib.Path, slug: str, record: dict[str, Any]) -> dict[str, str]:
     artifacts: dict[str, str] = {}
     if record["screenshots"]:
@@ -574,6 +586,11 @@ def cleanup_review_state(run_dir: pathlib.Path, isolation: dict[str, str],
     except Exception as exc:
         errors.append(f"desktop state reset failed: {exc}")
     if fixture:
+        try:
+            run([str(ROOT / "scripts/setup-desktop-test-data.sh")],
+                env=fixture_environment(isolation, fixture["identity_pubkey"], cleanup=True), capture=False)
+        except Exception as exc:
+            errors.append(f"review principal database cleanup failed: {exc}")
         try:
             pathlib.Path(fixture["secret_path"]).unlink(missing_ok=True)
         except Exception as exc:
@@ -684,9 +701,8 @@ def run_journey(path: pathlib.Path, relay_url: str, output_root: pathlib.Path) -
                 step_receipt["finished_monotonic_ns"] = time.monotonic_ns()
                 step_receipt["duration_ms"] = (step_receipt["finished_monotonic_ns"] - step_start) / 1_000_000
                 if metric := step.get("measure"):
-                    marker = measurement_starts.get(metric)
-                    if marker is not None:
-                        value = ((observation_ns or step_receipt["finished_monotonic_ns"]) - marker) / 1_000_000
+                    value = valid_measurement(measurement_starts.get(metric), observation_ns)
+                    if value is not None:
                         step_receipt["measurement"] = metric
                         receipt["measurements"][metric] = {"value": value, "unit": "ms"}
                 step_receipt["artifacts"] = capture_step(driver, run_dir, slug, journey["record"])

--- a/tools/native-review/review_native.py
+++ b/tools/native-review/review_native.py
@@ -1,0 +1,670 @@
+#!/usr/bin/env python3
+"""Exact-SHA-bound native review orchestrator for Buzz Desktop."""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import hashlib
+import http.server
+import json
+import os
+import pathlib
+import re
+import secrets
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - environment preflight
+    raise SystemExit("PyYAML is required (activate the repository Hermit environment)") from exc
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL_ROOT = pathlib.Path(__file__).resolve().parent
+PRODUCTION_BUNDLE_IDS = {"xyz.block.buzz.app", "xyz.block.sprout.app"}
+PRODUCTION_KEYRINGS = {"buzz-desktop", "sprout-desktop"}
+SECRET_NAME = re.compile(r"(AUTH|TOKEN|SECRET|PASSWORD|PRIVATE_KEY|COOKIE)", re.I)
+ALLOWED_TOP = {"schema_version", "flow", "platforms", "fixture", "record", "steps", "cleanup"}
+ALLOWED_STEP = {"name", "locate", "act", "expect", "expect_for", "timeout_ms", "measure"}
+ACTION_FIELDS = {
+    "activate": ({"type"}, {"type"}),
+    "click": ({"type"}, {"type"}),
+    "move_pointer": ({"type"}, {"type", "duration_ms"}),
+    "press": ({"type", "key"}, {"type", "key"}),
+    "wait": ({"type", "duration_ms"}, {"type", "duration_ms"}),
+}
+SUPPORTED_KEYS = {"tab", "return", "enter", "escape", "space"}
+METRIC_NAME = re.compile(r"[a-z][a-z0-9_]{0,63}")
+MAX_PROBE_BYTES = 1024 * 1024
+
+
+def bounded_integer(value: Any, minimum: int, maximum: int) -> bool:
+    return type(value) is int and minimum <= value <= maximum
+
+
+class HarnessError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: pathlib.Path = ROOT, env: dict[str, str] | None = None,
+        check: bool = True, capture: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd,
+                          env=scrubbed_environment(include_home=True) if env is None else env,
+                          check=check, text=True,
+                          stdout=subprocess.PIPE if capture else None,
+                          stderr=subprocess.PIPE if capture else None)
+
+
+def git(*args: str) -> str:
+    return run(["git", *args]).stdout.strip()
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def validate_locator(locator: Any, where: str) -> None:
+    if not isinstance(locator, dict) or not locator or set(locator) - {"id", "role", "name"}:
+        raise HarnessError(f"{where}: locator must contain only id, role, and/or name")
+    if not all(isinstance(value, str) and value for value in locator.values()):
+        raise HarnessError(f"{where}: locator values must be non-empty strings")
+
+
+def validate_expectation(expectation: Any, where: str) -> None:
+    allowed = {"exists", "not_exists", "focused", "enabled"}
+    if (
+        not isinstance(expectation, dict)
+        or len(expectation) != 1
+        or set(expectation) - allowed
+    ):
+        raise HarnessError(f"{where}: expectation must contain exactly one supported condition")
+    for key in ("exists", "not_exists"):
+        if key in expectation:
+            validate_locator(expectation[key], f"{where}.{key}")
+    focused = expectation.get("focused")
+    if focused is not None and not isinstance(focused, bool):
+        validate_locator(focused, f"{where}.focused")
+    if "enabled" in expectation and not isinstance(expectation["enabled"], bool):
+        raise HarnessError(f"{where}.enabled must be boolean")
+
+
+def load_journey(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        journey = yaml.safe_load(path.read_text())
+    except (OSError, yaml.YAMLError) as exc:
+        raise HarnessError(f"cannot read journey {path}: {exc}") from exc
+    if not isinstance(journey, dict) or set(journey) != ALLOWED_TOP:
+        raise HarnessError(f"journey must contain exactly {sorted(ALLOWED_TOP)}")
+    if journey["schema_version"] != 1 or journey["platforms"] != ["macos"]:
+        raise HarnessError("only schema_version 1 and platforms: [macos] are supported")
+    if journey["fixture"] != "local_review_channel":
+        raise HarnessError("desktop MVP permits only fixture: local_review_channel")
+    if not isinstance(journey["flow"], str) or not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", journey["flow"]):
+        raise HarnessError("flow must be a lowercase filesystem-safe identifier")
+    record = journey["record"]
+    if not isinstance(record, dict) or set(record) != {"video", "screenshots", "accessibility"}:
+        raise HarnessError("record requires exactly video, screenshots, accessibility")
+    if record["video"] not in ("window", "off") or not all(isinstance(record[k], bool) for k in ("screenshots", "accessibility")):
+        raise HarnessError("invalid record policy")
+    steps = journey["steps"]
+    if not isinstance(steps, list) or not steps:
+        raise HarnessError("journey requires at least one step")
+    seen_metrics: set[str] = set()
+    for index, step in enumerate(steps):
+        where = f"steps[{index}]"
+        if not isinstance(step, dict) or set(step) - ALLOWED_STEP or not {"name", "act", "expect"} <= set(step):
+            raise HarnessError(f"{where}: requires name/act/expect and contains an unsupported field")
+        if not isinstance(step["name"], str) or not step["name"]:
+            raise HarnessError(f"{where}.name must be non-empty")
+        locators = step.get("locate")
+        if locators is not None:
+            if not isinstance(locators, list) or not locators:
+                raise HarnessError(f"{where}.locate must be a non-empty list")
+            for locator in locators:
+                validate_locator(locator, f"{where}.locate")
+        action = step["act"]
+        action_type = action.get("type") if isinstance(action, dict) else None
+        required_fields, allowed_fields = ACTION_FIELDS[action_type] if action_type in ACTION_FIELDS else (set(), set())
+        if action_type not in ACTION_FIELDS or not required_fields <= set(action) <= allowed_fields:
+            raise HarnessError(f"{where}.act has unsupported type or fields")
+        if action_type in {"click", "move_pointer"} and locators is None:
+            raise HarnessError(f"{where}: {action_type} requires locate")
+        if action_type == "press" and action["key"] not in SUPPORTED_KEYS:
+            raise HarnessError(f"{where}: press key is unsupported")
+        if "duration_ms" in action and not bounded_integer(action["duration_ms"], 0, 30000):
+            raise HarnessError(f"{where}.act.duration_ms must be 0..30000")
+        validate_expectation(step["expect"], f"{where}.expect")
+        if "expect_for" in step:
+            sustained = step["expect_for"]
+            if not isinstance(sustained, dict) or set(sustained) != {"duration_ms", "condition"}:
+                raise HarnessError(f"{where}.expect_for requires duration_ms and condition")
+            if not bounded_integer(sustained["duration_ms"], 1, 30000):
+                raise HarnessError(f"{where}.expect_for.duration_ms must be 1..30000")
+            validate_expectation(sustained["condition"], f"{where}.expect_for.condition")
+        timeout = step.get("timeout_ms", 5000)
+        if not bounded_integer(timeout, 1, 60000):
+            raise HarnessError(f"{where}.timeout_ms must be 1..60000")
+        metric = step.get("measure")
+        if metric is not None:
+            if not isinstance(metric, str) or not METRIC_NAME.fullmatch(metric):
+                raise HarnessError(f"{where}.measure must be a lowercase metric identifier")
+            if metric in seen_metrics:
+                raise HarnessError(f"{where}.measure duplicates {metric}")
+            seen_metrics.add(metric)
+    cleanup = journey["cleanup"]
+    if not isinstance(cleanup, dict) or set(cleanup) != {"terminate_app", "remove_state"} or not all(isinstance(v, bool) for v in cleanup.values()):
+        raise HarnessError("cleanup requires boolean terminate_app and remove_state")
+    return journey
+
+
+def isolation_manifest(run_id: str, relay_url: str) -> dict[str, str]:
+    parsed = urllib.parse.urlparse(relay_url)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise HarnessError(f"refusing malformed review relay: {relay_url}") from exc
+    if (
+        parsed.scheme not in {"ws", "http"}
+        or parsed.hostname not in {"localhost", "127.0.0.1", "::1"}
+        or port is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise HarnessError(f"refusing non-loopback or malformed review relay: {relay_url}")
+    slug = re.sub(r"[^a-z0-9-]", "-", run_id.lower())
+    bundle_id = f"xyz.block.buzz.app.dev.native-review.{slug}"
+    keyring = f"buzz-desktop-dev.native-review.{slug}"
+    if bundle_id in PRODUCTION_BUNDLE_IDS or not bundle_id.startswith("xyz.block.buzz.app.dev.native-review."):
+        raise HarnessError(f"refusing unsafe bundle identifier: {bundle_id}")
+    if keyring in PRODUCTION_KEYRINGS or not keyring.startswith("buzz-desktop-dev.native-review."):
+        raise HarnessError(f"refusing unsafe keyring service: {keyring}")
+    return {"bundle_id": bundle_id, "keyring_service": keyring, "relay_url": relay_url}
+
+
+def provenance() -> dict[str, Any]:
+    head = git("rev-parse", "HEAD")
+    status = git("status", "--porcelain=v1", "--untracked-files=all")
+    diff = run(["git", "diff", "--binary", "HEAD"]).stdout
+    untracked_hashes = []
+    for line in status.splitlines():
+        if line.startswith("?? "):
+            path = ROOT / line[3:]
+            if path.is_file():
+                untracked_hashes.append((line[3:], sha256(path)))
+    dirty_payload = json.dumps({"diff": diff, "untracked": untracked_hashes}, sort_keys=True).encode()
+    return {
+        "head_sha": head,
+        "dirty": bool(status),
+        "dirty_state_sha256": hashlib.sha256(dirty_payload).hexdigest() if status else None,
+        "status": status.splitlines(),
+    }
+
+
+def scrubbed_environment(*, include_home: bool = False) -> dict[str, str]:
+    keep = {"PATH", "TMPDIR", "LANG", "LC_ALL", "SHELL", "USER", "LOGNAME", "TERM", "__CF_USER_TEXT_ENCODING"}
+    env = {key: value for key, value in os.environ.items() if key in keep and not SECRET_NAME.search(key)}
+    env["HOME"] = os.environ.get("HOME", "") if include_home else ""  # isolated per run unless tooling needs host caches
+    return env
+
+
+def fixture_environment(isolation: dict[str, str], review_pubkey: str) -> dict[str, str]:
+    """Return fixed local fixture coordinates without inheriting host credentials."""
+    if not re.fullmatch(r"[a-f0-9]{64}", review_pubkey):
+        raise HarnessError("fixture seeding requires a 64-character lowercase hex pubkey")
+    parsed = urllib.parse.urlparse(isolation["relay_url"])
+    port = parsed.port
+    if port != 3030:
+        raise HarnessError("fixture seeding requires the isolated relay at loopback port 3030")
+    return {
+        **scrubbed_environment(include_home=True),
+        "BUZZ_REVIEW_PUBKEY": review_pubkey,
+        "BUZZ_COMMUNITY_HOST": f"{parsed.hostname}:{port}",
+        "BUZZ_DB_HOST": "localhost",
+        "BUZZ_DB_PORT": "5471",
+        "BUZZ_DB_USER": "buzz",
+        "BUZZ_DB_PASS": "buzz_dev",
+        "BUZZ_DB_NAME": "buzz",
+        "BUZZ_DB_DOCKER_CONTAINER": "buzz-harness-postgres-1",
+    }
+
+
+def driver_binary() -> pathlib.Path:
+    override = os.environ.get("BUZZ_NATIVE_REVIEW_DRIVER")
+    if override:
+        return pathlib.Path(override).resolve()
+    return TOOL_ROOT / "swift" / ".build" / "release" / "buzz-native-driver"
+
+
+def build_driver() -> pathlib.Path:
+    binary = driver_binary()
+    if os.environ.get("BUZZ_NATIVE_REVIEW_DRIVER"):
+        if not binary.is_file():
+            raise HarnessError(f"configured driver does not exist: {binary}")
+        return binary
+    run(["swift", "build", "-c", "release", "--package-path", str(TOOL_ROOT / "swift")],
+        env=scrubbed_environment(include_home=True), capture=False)
+    if not binary.is_file():
+        raise HarnessError(f"Swift build succeeded without driver binary: {binary}")
+    return binary
+
+
+class Driver:
+    def __init__(self, binary: pathlib.Path, pid: int, semantic_snapshot: pathlib.Path):
+        self.process = subprocess.Popen([str(binary), "serve", "--pid", str(pid),
+                                         "--semantic-snapshot", str(semantic_snapshot)], stdin=subprocess.PIPE,
+                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                        env=scrubbed_environment(include_home=True), text=True, bufsize=1)
+
+    def request(self, command: str, **payload: Any) -> dict[str, Any]:
+        assert self.process.stdin and self.process.stdout
+        self.process.stdin.write(json.dumps({"command": command, **payload}) + "\n")
+        self.process.stdin.flush()
+        timeout_seconds = 45 if command in {"record_start", "record_stop"} else 15
+        ready, _, _ = select.select([self.process.stdout], [], [], timeout_seconds)
+        if not ready:
+            self.process.kill()
+            self.process.wait(timeout=5)
+            stderr = self.process.stderr.read() if self.process.stderr else ""
+            detail = f"; driver stderr:\n{stderr.strip()}" if stderr.strip() else ""
+            raise HarnessError(f"native driver timed out during {command}{detail}")
+        line = self.process.stdout.readline()
+        if not line:
+            stderr = self.process.stderr.read() if self.process.stderr else ""
+            raise HarnessError(f"native driver exited during {command}: {stderr.strip()}")
+        response = json.loads(line)
+        if not response.get("ok"):
+            raise HarnessError(str(response.get("error", f"driver {command} failed")))
+        return response
+
+    def close(self) -> None:
+        if self.process.poll() is None:
+            try:
+                self.request("shutdown")
+            except Exception:
+                self.process.terminate()
+        for stream in (self.process.stdin, self.process.stdout, self.process.stderr):
+            if stream:
+                stream.close()
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+
+
+def doctor(require_permissions: bool = False) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    checks.append({"name": "platform", "ok": sys.platform == "darwin", "detail": sys.platform})
+    for command in ("swift", "xcrun", "git"):
+        path = shutil.which(command)
+        checks.append({"name": command, "ok": path is not None, "detail": path or "not found"})
+    checks.append({"name": "repository", "ok": (ROOT / "desktop/src-tauri/tauri.conf.json").is_file(), "detail": str(ROOT)})
+    try:
+        binary = build_driver() if all(c["ok"] for c in checks[:4]) else driver_binary()
+        result = run([str(binary), "doctor"], check=False)
+        native = json.loads(result.stdout) if result.stdout else {"ok": False, "error": result.stderr.strip()}
+        checks.extend(native.get("checks", []))
+    except (HarnessError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        checks.append({"name": "native-driver", "ok": False, "detail": str(exc)})
+    hard_names = {"platform", "swift", "xcrun", "git", "repository", "native-driver-build"}
+    failed = [c for c in checks if not c.get("ok") and (require_permissions or c.get("name") in hard_names)]
+    result = {"ok": not failed, "checks": checks}
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def prepare_fixture(run_dir: pathlib.Path, isolation: dict[str, str]) -> dict[str, Any]:
+    admin = ROOT / "target" / "debug" / "buzz-admin"
+    if not admin.is_file():
+        run(["cargo", "build", "-p", "buzz-admin"], env=scrubbed_environment(include_home=True), capture=False)
+    generated = run([str(admin), "generate-key"], env=scrubbed_environment(include_home=True)).stdout
+    secret_match = re.search(r"Secret key:\s+(\S+)", generated)
+    public_match = re.search(r"Public key:\s+(\S+)", generated)
+    if not secret_match or not public_match:
+        raise HarnessError("buzz-admin generate-key returned an unrecognized response")
+    secret_path = run_dir / "state" / "identity.key"
+    secret_path.parent.mkdir(parents=True, exist_ok=True)
+    secret_path.write_text(secret_match.group(1) + "\n")
+    secret_path.chmod(0o600)
+    fixture = {
+        "kind": "local_review_channel", "identity_pubkey": public_match.group(1),
+        "secret_path": str(secret_path), "relay_url": isolation["relay_url"],
+        "seed": "scripts/setup-desktop-test-data.sh", "cleanup_scope": "run-local app state and keyring only",
+    }
+    try:
+        run([str(ROOT / "scripts/setup-desktop-test-data.sh")],
+            env=fixture_environment(isolation, fixture["identity_pubkey"]), capture=False)
+    except Exception:
+        secret_path.unlink(missing_ok=True)
+        raise
+    (run_dir / "manifest" / "fixture.json").write_text(json.dumps({k: v for k, v in fixture.items() if k != "secret_path"}, indent=2))
+    return fixture
+
+
+def semantic_probe_server(path: pathlib.Path) -> tuple[http.server.ThreadingHTTPServer, str]:
+    token = secrets.token_hex(32)
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            if self.path != f"/snapshot/{token}":
+                self.send_error(404)
+                return
+            try:
+                length = int(self.headers.get("Content-Length", ""))
+            except ValueError:
+                self.send_error(400)
+                return
+            if not 0 < length <= MAX_PROBE_BYTES:
+                self.send_error(413)
+                return
+            payload = self.rfile.read(length)
+            if len(payload) != length:
+                self.send_error(400)
+                return
+            try:
+                value = json.loads(payload)
+                if not isinstance(value, list):
+                    raise ValueError("snapshot must be an array")
+                temporary = path.with_suffix(".json.tmp")
+                temporary.write_text(json.dumps(value))
+                temporary.replace(path)
+                self.send_response(204)
+            except (ValueError, json.JSONDecodeError, OSError):
+                self.send_response(400)
+            self.end_headers()
+
+        def log_message(self, _format: str, *_args: Any) -> None:
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server.daemon_threads = True
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, f"http://127.0.0.1:{server.server_port}/snapshot/{token}"
+
+
+def build_and_launch(run_dir: pathlib.Path, isolation: dict[str, str], fixture: dict[str, Any],
+                     probe_url: str) -> tuple[subprocess.Popen[str], pathlib.Path, int]:
+    # Build with the repository toolchain but no inherited credentials. Launch
+    # the resulting executable separately so only the app receives isolated HOME.
+    dev_url = (
+        "http://localhost:1420?nativeReview=1"
+        f"&reviewRelay={urllib.parse.quote(isolation['relay_url'], safe='')}"
+        f"&reviewPubkey={urllib.parse.quote(fixture['identity_pubkey'], safe='')}"
+    )
+    config = json.dumps({
+        "build": {"devUrl": dev_url},
+        "identifier": isolation["bundle_id"], "productName": "Buzz Native Review",
+        "bundle": {"externalBin": []},
+    }, separators=(",", ":"))
+    build_env = scrubbed_environment(include_home=True)
+    build_env["VITE_NATIVE_REVIEW"] = "1"
+    build_env["VITE_NATIVE_REVIEW_RELAY"] = isolation["relay_url"]
+    build_env["VITE_NATIVE_REVIEW_PUBKEY"] = fixture["identity_pubkey"]
+    build_env["VITE_NATIVE_REVIEW_PROBE_URL"] = probe_url
+    run(["pnpm", "exec", "tauri", "build", "--debug", "--bundles", "app", "--config", config],
+        cwd=ROOT / "desktop", env=build_env, capture=False)
+    app_binary = (ROOT / "desktop" / "src-tauri" / "target" / "debug" / "bundle" / "macos" /
+                  "Buzz Native Review.app" / "Contents" / "MacOS" / "buzz-desktop")
+    if not app_binary.is_file():
+        raise HarnessError(f"Tauri build succeeded without app binary: {app_binary}")
+
+    env = scrubbed_environment()
+    env["HOME"] = str(run_dir / "home")
+    pathlib.Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+    env.update({
+        "BUZZ_PRIVATE_KEY": pathlib.Path(fixture["secret_path"]).read_text().strip(),
+        "BUZZ_RELAY_URL": isolation["relay_url"], "BUZZ_DEV_KEYRING_SERVICE": isolation["keyring_service"],
+        "BUZZ_NATIVE_REVIEW": "1", "BUZZ_NATIVE_REVIEW_CHANNEL": "general",
+    })
+    log = (run_dir / "logs" / "app.log").open("w")
+    process = subprocess.Popen([str(app_binary)], cwd=ROOT, env=env, stdout=log,
+                               stderr=subprocess.STDOUT, text=True)
+    log.close()
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise HarnessError(f"Tauri exited during launch; see {run_dir / 'logs/app.log'}")
+        if run(["ps", "-p", str(process.pid), "-o", "comm="], check=False).stdout.rstrip().endswith("/buzz-desktop"):
+            return process, app_binary, process.pid
+        time.sleep(0.25)
+    process.terminate()
+    raise HarnessError("timed out waiting for native Buzz process")
+
+
+def wait_for_visible_window(driver: Driver, process: subprocess.Popen[str], timeout_seconds: float = 30) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_status: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise HarnessError("Tauri exited while waiting for its initial window")
+        last_status = driver.request("window_status")
+        if last_status.get("visible"):
+            return last_status
+        time.sleep(0.1)
+    detail = last_status.get("detail") if last_status else "driver returned no status"
+    raise HarnessError(f"timed out after {timeout_seconds:g}s waiting for visible native window: {detail}")
+
+
+def locate_required(driver: Driver, locators: list[dict[str, str]], timeout_ms: int) -> dict[str, Any]:
+    """Wait for a semantic target to materialize, then return the locator used."""
+    deadline = time.monotonic() + timeout_ms / 1000
+    while True:
+        found = driver.request("locate", locators=locators, required=False).get("element")
+        if found is not None:
+            return found
+        if time.monotonic() >= deadline:
+            raise HarnessError(f"no accessibility element matched ordered locators within {timeout_ms}ms")
+        time.sleep(0.025)
+
+
+def expectation_holds(driver: Driver, expectation: dict[str, Any]) -> bool:
+    if "exists" in expectation:
+        return driver.request("locate", locators=[expectation["exists"]], required=False).get("element") is not None
+    if "not_exists" in expectation:
+        return driver.request("locate", locators=[expectation["not_exists"]], required=False).get("element") is None
+    if "focused" in expectation and isinstance(expectation["focused"], dict):
+        found = driver.request("locate", locators=[expectation["focused"]], required=False).get("element")
+        return bool(found and found.get("focused"))
+    if "focused" in expectation:
+        return bool(driver.request("focused").get("focused")) == expectation["focused"]
+    if "enabled" in expectation:
+        return bool(driver.request("selected").get("element", {}).get("enabled")) == expectation["enabled"]
+    return False
+
+
+def wait_expectation(driver: Driver, expectation: dict[str, Any], timeout_ms: int) -> None:
+    deadline = time.monotonic() + timeout_ms / 1000
+    while True:
+        if expectation_holds(driver, expectation):
+            return
+        if time.monotonic() >= deadline:
+            raise HarnessError(f"postcondition not met within {timeout_ms}ms: {expectation}")
+        time.sleep(0.025)
+
+
+def capture_step(driver: Driver, run_dir: pathlib.Path, slug: str, record: dict[str, Any]) -> dict[str, str]:
+    artifacts: dict[str, str] = {}
+    if record["screenshots"]:
+        path = run_dir / "screenshots" / f"{slug}.png"
+        driver.request("screenshot", path=str(path))
+        artifacts["screenshot"] = str(path.relative_to(run_dir))
+    if record["accessibility"]:
+        path = run_dir / "accessibility" / f"{slug}.json"
+        response = driver.request("snapshot")
+        path.write_text(json.dumps({key: value for key, value in response.items() if key != "ok"}, indent=2))
+        artifacts["accessibility"] = str(path.relative_to(run_dir))
+    return artifacts
+
+
+def cleanup_review_state(run_dir: pathlib.Path, isolation: dict[str, str],
+                         fixture: dict[str, Any] | None) -> None:
+    errors = []
+    env = scrubbed_environment()
+    env["HOME"] = str(run_dir / "home")
+    try:
+        run([str(ROOT / "scripts/reset-desktop-standalone-state.sh"),
+             isolation["bundle_id"], isolation["keyring_service"]], env=env)
+    except Exception as exc:
+        errors.append(f"desktop state reset failed: {exc}")
+    if fixture:
+        try:
+            pathlib.Path(fixture["secret_path"]).unlink(missing_ok=True)
+        except Exception as exc:
+            errors.append(f"review identity removal failed: {exc}")
+    if errors:
+        raise HarnessError("; ".join(errors))
+
+
+def run_journey(path: pathlib.Path, relay_url: str, output_root: pathlib.Path) -> pathlib.Path:
+    journey = load_journey(path)
+    run_id = f"{journey['flow']}-{dt.datetime.now().strftime('%Y%m%dT%H%M%S')}-{secrets.token_hex(3)}"
+    isolation = isolation_manifest(run_id, relay_url)
+    run_dir = output_root / git("rev-parse", "--short=12", "HEAD") / journey["flow"] / run_id
+    for child in ("manifest", "logs", "screenshots", "accessibility", "state", "home"):
+        (run_dir / child).mkdir(parents=True, exist_ok=True)
+    (run_dir / "journey.yaml").write_text(path.read_text())
+    prov = provenance()
+    (run_dir / "manifest" / "git.json").write_text(json.dumps(prov, indent=2))
+    (run_dir / "manifest" / "isolation.json").write_text(json.dumps(isolation, indent=2))
+    started = utc_now()
+    receipt: dict[str, Any] = {"schema_version": 1, "run_id": run_id, "flow": journey["flow"], "status": "failed",
+        "started_at": started, "finished_at": started, "failure": None, "provenance": prov, "isolation": isolation,
+        "artifacts": {}, "measurements": {}, "steps": [], "cleanup": {"status": "not_started"}}
+    process: subprocess.Popen[str] | None = None
+    driver: Driver | None = None
+    fixture: dict[str, Any] | None = None
+    probe_server: http.server.ThreadingHTTPServer | None = None
+    try:
+        if not doctor(require_permissions=True)["ok"]:
+            raise HarnessError("doctor failed; grant required permissions and rerun")
+        fixture = prepare_fixture(run_dir, isolation)
+        probe_server, probe_url = semantic_probe_server(run_dir / "state" / "semantic.json")
+        process, app_binary, app_pid = build_and_launch(run_dir, isolation, fixture, probe_url)
+        receipt["provenance"]["artifact_path"] = str(app_binary)
+        receipt["provenance"]["artifact_sha256"] = sha256(app_binary)
+        driver = Driver(build_driver(), app_pid, run_dir / "state" / "semantic.json")
+        receipt["provenance"]["initial_window"] = wait_for_visible_window(driver, process)
+        if journey["record"]["video"] == "window":
+            video = run_dir / "video.mp4"
+            driver.request("record_start", path=str(video))
+            receipt["artifacts"]["video"] = "video.mp4"
+        for index, step in enumerate(journey["steps"]):
+            slug = f"{index + 1:02d}-{re.sub(r'[^a-z0-9-]', '-', step['name'].lower())}"
+            step_start = time.monotonic_ns()
+            selected = None
+            step_receipt: dict[str, Any] = {"name": step["name"], "status": "failed", "started_monotonic_ns": step_start}
+            receipt["steps"].append(step_receipt)
+            try:
+                if step.get("locate"):
+                    selected = locate_required(driver, step["locate"], step.get("timeout_ms", 5000))
+                    step_receipt["locator"] = selected.get("locator")
+                driver.request("act", action=step["act"], element=selected)
+                wait_expectation(driver, step["expect"], step.get("timeout_ms", 5000))
+                if sustained := step.get("expect_for"):
+                    until = time.monotonic() + sustained["duration_ms"] / 1000
+                    while time.monotonic() < until:
+                        if not expectation_holds(driver, sustained["condition"]):
+                            raise HarnessError(f"sustained postcondition failed: {sustained['condition']}")
+                        time.sleep(0.025)
+                step_receipt["status"] = "passed"
+            finally:
+                step_receipt["finished_monotonic_ns"] = time.monotonic_ns()
+                step_receipt["duration_ms"] = (step_receipt["finished_monotonic_ns"] - step_start) / 1_000_000
+                if metric := step.get("measure"):
+                    step_receipt["measurement"] = metric
+                    receipt["measurements"][metric] = {"value": step_receipt["duration_ms"], "unit": "ms"}
+                step_receipt["artifacts"] = capture_step(driver, run_dir, slug, journey["record"])
+        if journey["record"]["video"] == "window":
+            driver.request("record_stop")
+        receipt["status"] = "passed"
+    except Exception as exc:
+        receipt["failure"] = str(exc)
+        if driver:
+            try:
+                receipt["artifacts"]["failure"] = capture_step(driver, run_dir, "failure", {"screenshots": True, "accessibility": True})
+            except Exception as capture_exc:
+                receipt["artifacts"]["capture_failure"] = str(capture_exc)
+            try:
+                driver.request("record_stop")
+            except Exception:
+                pass
+    finally:
+        cleanup_errors = []
+        if probe_server:
+            probe_server.shutdown()
+            probe_server.server_close()
+        if driver:
+            try:
+                driver.close()
+            except Exception as exc:
+                cleanup_errors.append(f"native driver cleanup failed: {exc}")
+        if process and journey["cleanup"]["terminate_app"]:
+            process.terminate()
+            try:
+                process.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                process.kill(); cleanup_errors.append("Tauri launcher required SIGKILL")
+        if journey["cleanup"]["remove_state"]:
+            try:
+                cleanup_review_state(run_dir, isolation, fixture)
+            except Exception as exc:
+                cleanup_errors.append(str(exc))
+        receipt["cleanup"] = {"status": "failed" if cleanup_errors else "passed", "errors": cleanup_errors}
+        if cleanup_errors:
+            receipt["status"] = "failed"
+        receipt["finished_at"] = utc_now()
+        (run_dir / "receipt.json").write_text(json.dumps(receipt, indent=2))
+        report = f"# Native review: {journey['flow']}\n\n**{receipt['status'].upper()}** at `{prov['head_sha']}`.\n\nReceipt: `receipt.json`\n"
+        if receipt["failure"]:
+            report += f"\nFailure: `{receipt['failure']}`\n"
+        (run_dir / "report.md").write_text(report)
+    print(run_dir)
+    if receipt["status"] != "passed":
+        raise HarnessError(receipt["failure"] or "journey or cleanup failed")
+    return run_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    doctor_parser = sub.add_parser("doctor")
+    doctor_parser.add_argument("--require-permissions", action="store_true")
+    validate_parser = sub.add_parser("validate")
+    validate_parser.add_argument("journey", type=pathlib.Path)
+    run_parser = sub.add_parser("run")
+    run_parser.add_argument("journey", type=pathlib.Path)
+    run_parser.add_argument("--relay", default="ws://localhost:3030")
+    run_parser.add_argument("--output", type=pathlib.Path, default=ROOT / "test-results/native-review")
+    args = parser.parse_args()
+    try:
+        if args.command == "doctor":
+            return 0 if doctor(args.require_permissions)["ok"] else 1
+        if args.command == "validate":
+            load_journey(args.journey); print(f"valid: {args.journey}"); return 0
+        run_journey(args.journey, args.relay, args.output); return 0
+    except HarnessError as exc:
+        print(f"native-review: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/native-review/review_native.py
+++ b/tools/native-review/review_native.py
@@ -458,14 +458,19 @@ def build_and_launch(run_dir: pathlib.Path, isolation: dict[str, str], fixture: 
     process = subprocess.Popen([str(app_binary)], cwd=ROOT, env=env, stdout=log,
                                stderr=subprocess.STDOUT, text=True)
     log.close()
-    deadline = time.monotonic() + 60
+    return process, app_binary, process.pid
+
+
+def wait_for_native_process(process: subprocess.Popen[str], run_dir: pathlib.Path,
+                            timeout_seconds: float = 60) -> None:
+    """Confirm the spawned app stays alive and resolves to the expected executable."""
+    deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         if process.poll() is not None:
             raise HarnessError(f"Tauri exited during launch; see {run_dir / 'logs/app.log'}")
         if run(["ps", "-p", str(process.pid), "-o", "comm="], check=False).stdout.rstrip().endswith("/buzz-desktop"):
-            return process, app_binary, process.pid
+            return
         time.sleep(0.25)
-    process.terminate()
     raise HarnessError("timed out waiting for native Buzz process")
 
 
@@ -526,14 +531,18 @@ def wait_expectation_not_before(driver: Driver, expectation: dict[str, Any], sta
     lower_ns = start_ns + lower_bound_ms * 1_000_000
     deadline_ns = lower_ns + timeout_ms * 1_000_000
     while True:
-        now_ns = time.monotonic_ns()
         if expectation_holds(driver, expectation):
-            if now_ns < lower_ns:
+            observed_ns = time.monotonic_ns()
+            if observed_ns < lower_ns:
                 raise HarnessError(
                     f"postcondition occurred before {lower_bound_ms}ms lower bound: {expectation}"
                 )
-            return now_ns
-        if now_ns >= deadline_ns:
+            if observed_ns > deadline_ns:
+                raise HarnessError(
+                    f"postcondition not met within {lower_bound_ms + timeout_ms}ms window: {expectation}"
+                )
+            return observed_ns
+        if time.monotonic_ns() >= deadline_ns:
             raise HarnessError(
                 f"postcondition not met within {lower_bound_ms + timeout_ms}ms window: {expectation}"
             )
@@ -632,6 +641,7 @@ def run_journey(path: pathlib.Path, relay_url: str, output_root: pathlib.Path) -
         fixture = prepare_fixture(run_dir, isolation)
         probe_server, probe_url = semantic_probe_server(run_dir / "state" / "semantic.json")
         process, app_binary, app_pid = build_and_launch(run_dir, isolation, fixture, probe_url)
+        wait_for_native_process(process, run_dir)
         receipt["provenance"]["artifact_path"] = str(app_binary)
         receipt["provenance"]["artifact_sha256"] = sha256(app_binary)
         driver = Driver(build_driver(), app_pid, run_dir / "state" / "semantic.json")

--- a/tools/native-review/review_native.py
+++ b/tools/native-review/review_native.py
@@ -33,7 +33,7 @@ PRODUCTION_BUNDLE_IDS = {"xyz.block.buzz.app", "xyz.block.sprout.app"}
 PRODUCTION_KEYRINGS = {"buzz-desktop", "sprout-desktop"}
 SECRET_NAME = re.compile(r"(AUTH|TOKEN|SECRET|PASSWORD|PRIVATE_KEY|COOKIE)", re.I)
 ALLOWED_TOP = {"schema_version", "flow", "platforms", "fixture", "record", "steps", "cleanup"}
-ALLOWED_STEP = {"name", "locate", "act", "expect", "expect_for", "timeout_ms", "measure"}
+ALLOWED_STEP = {"name", "locate", "act", "expect", "expect_for", "expect_not_before_ms", "timeout_ms", "measure_start", "measure"}
 ACTION_FIELDS = {
     "activate": ({"type"}, {"type"}),
     "click": ({"type"}, {"type"}),
@@ -125,7 +125,8 @@ def load_journey(path: pathlib.Path) -> dict[str, Any]:
     steps = journey["steps"]
     if not isinstance(steps, list) or not steps:
         raise HarnessError("journey requires at least one step")
-    seen_metrics: set[str] = set()
+    started_metrics: set[str] = set()
+    completed_metrics: set[str] = set()
     for index, step in enumerate(steps):
         where = f"steps[{index}]"
         if not isinstance(step, dict) or set(step) - ALLOWED_STEP or not {"name", "act", "expect"} <= set(step):
@@ -160,16 +161,34 @@ def load_journey(path: pathlib.Path) -> dict[str, Any]:
         timeout = step.get("timeout_ms", 5000)
         if not bounded_integer(timeout, 1, 60000):
             raise HarnessError(f"{where}.timeout_ms must be 1..60000")
+        lower_bound = step.get("expect_not_before_ms")
+        if lower_bound is not None and not bounded_integer(lower_bound, 1, 30000):
+            raise HarnessError(f"{where}.expect_not_before_ms must be 1..30000")
+        metric_start = step.get("measure_start")
+        if metric_start is not None:
+            if not isinstance(metric_start, str) or not METRIC_NAME.fullmatch(metric_start):
+                raise HarnessError(f"{where}.measure_start must be a lowercase metric identifier")
+            if metric_start in started_metrics:
+                raise HarnessError(f"{where}.measure_start duplicates {metric_start}")
+            started_metrics.add(metric_start)
         metric = step.get("measure")
+        if lower_bound is not None and metric is None:
+            raise HarnessError(f"{where}.expect_not_before_ms requires measure")
         if metric is not None:
             if not isinstance(metric, str) or not METRIC_NAME.fullmatch(metric):
                 raise HarnessError(f"{where}.measure must be a lowercase metric identifier")
-            if metric in seen_metrics:
+            if metric not in started_metrics:
+                raise HarnessError(f"{where}.measure requires an earlier measure_start for {metric}")
+            if metric in completed_metrics:
                 raise HarnessError(f"{where}.measure duplicates {metric}")
-            seen_metrics.add(metric)
+            completed_metrics.add(metric)
+            if lower_bound is None:
+                raise HarnessError(f"{where}.measure requires expect_not_before_ms")
     cleanup = journey["cleanup"]
-    if not isinstance(cleanup, dict) or set(cleanup) != {"terminate_app", "remove_state"} or not all(isinstance(v, bool) for v in cleanup.values()):
-        raise HarnessError("cleanup requires boolean terminate_app and remove_state")
+    if not isinstance(cleanup, dict) or set(cleanup) != {"terminate_app", "remove_state"}:
+        raise HarnessError("cleanup requires terminate_app and remove_state")
+    if cleanup != {"terminate_app": True, "remove_state": True}:
+        raise HarnessError("cleanup is mandatory: terminate_app and remove_state must both be true")
     return journey
 
 
@@ -501,6 +520,26 @@ def wait_expectation(driver: Driver, expectation: dict[str, Any], timeout_ms: in
         time.sleep(0.025)
 
 
+def wait_expectation_not_before(driver: Driver, expectation: dict[str, Any], start_ns: int,
+                                lower_bound_ms: int, timeout_ms: int) -> int:
+    """Return first observed satisfaction, rejecting early and late transitions."""
+    lower_ns = start_ns + lower_bound_ms * 1_000_000
+    deadline_ns = lower_ns + timeout_ms * 1_000_000
+    while True:
+        now_ns = time.monotonic_ns()
+        if expectation_holds(driver, expectation):
+            if now_ns < lower_ns:
+                raise HarnessError(
+                    f"postcondition occurred before {lower_bound_ms}ms lower bound: {expectation}"
+                )
+            return now_ns
+        if now_ns >= deadline_ns:
+            raise HarnessError(
+                f"postcondition not met within {lower_bound_ms + timeout_ms}ms window: {expectation}"
+            )
+        time.sleep(0.025)
+
+
 def capture_step(driver: Driver, run_dir: pathlib.Path, slug: str, record: dict[str, Any]) -> dict[str, str]:
     artifacts: dict[str, str] = {}
     if record["screenshots"]:
@@ -532,6 +571,40 @@ def cleanup_review_state(run_dir: pathlib.Path, isolation: dict[str, str],
             errors.append(f"review identity removal failed: {exc}")
     if errors:
         raise HarnessError("; ".join(errors))
+
+
+def terminate_process(process: subprocess.Popen[str]) -> tuple[list[str], bool]:
+    """Terminate and reap the app, reporting whether state reset is safe."""
+    errors: list[str] = []
+    process.terminate()
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            errors.append("Tauri launcher did not exit after SIGKILL; isolated state was preserved")
+            return errors, False
+        else:
+            errors.append("Tauri launcher required SIGKILL")
+    return errors, True
+
+
+def cleanup_process_and_state(process: subprocess.Popen[str] | None, run_dir: pathlib.Path,
+                              isolation: dict[str, str], fixture: dict[str, Any] | None) -> list[str]:
+    """Stop the app before resetting state; preserve state if exit is unconfirmed."""
+    errors: list[str] = []
+    exited = True
+    if process:
+        termination_errors, exited = terminate_process(process)
+        errors.extend(termination_errors)
+    if exited:
+        try:
+            cleanup_review_state(run_dir, isolation, fixture)
+        except Exception as exc:
+            errors.append(str(exc))
+    return errors
 
 
 def run_journey(path: pathlib.Path, relay_url: str, output_root: pathlib.Path) -> pathlib.Path:
@@ -567,18 +640,29 @@ def run_journey(path: pathlib.Path, relay_url: str, output_root: pathlib.Path) -
             video = run_dir / "video.mp4"
             driver.request("record_start", path=str(video))
             receipt["artifacts"]["video"] = "video.mp4"
+        measurement_starts: dict[str, int] = {}
         for index, step in enumerate(journey["steps"]):
             slug = f"{index + 1:02d}-{re.sub(r'[^a-z0-9-]', '-', step['name'].lower())}"
             step_start = time.monotonic_ns()
             selected = None
             step_receipt: dict[str, Any] = {"name": step["name"], "status": "failed", "started_monotonic_ns": step_start}
             receipt["steps"].append(step_receipt)
+            observation_ns = None
             try:
                 if step.get("locate"):
                     selected = locate_required(driver, step["locate"], step.get("timeout_ms", 5000))
                     step_receipt["locator"] = selected.get("locator")
                 driver.request("act", action=step["act"], element=selected)
-                wait_expectation(driver, step["expect"], step.get("timeout_ms", 5000))
+                if metric_start := step.get("measure_start"):
+                    measurement_starts[metric_start] = time.monotonic_ns()
+                if lower_bound_ms := step.get("expect_not_before_ms"):
+                    metric = step["measure"]
+                    observation_ns = wait_expectation_not_before(
+                        driver, step["expect"], measurement_starts[metric],
+                        lower_bound_ms, step.get("timeout_ms", 5000),
+                    )
+                else:
+                    wait_expectation(driver, step["expect"], step.get("timeout_ms", 5000))
                 if sustained := step.get("expect_for"):
                     until = time.monotonic() + sustained["duration_ms"] / 1000
                     while time.monotonic() < until:
@@ -590,8 +674,11 @@ def run_journey(path: pathlib.Path, relay_url: str, output_root: pathlib.Path) -
                 step_receipt["finished_monotonic_ns"] = time.monotonic_ns()
                 step_receipt["duration_ms"] = (step_receipt["finished_monotonic_ns"] - step_start) / 1_000_000
                 if metric := step.get("measure"):
-                    step_receipt["measurement"] = metric
-                    receipt["measurements"][metric] = {"value": step_receipt["duration_ms"], "unit": "ms"}
+                    marker = measurement_starts.get(metric)
+                    if marker is not None:
+                        value = ((observation_ns or step_receipt["finished_monotonic_ns"]) - marker) / 1_000_000
+                        step_receipt["measurement"] = metric
+                        receipt["measurements"][metric] = {"value": value, "unit": "ms"}
                 step_receipt["artifacts"] = capture_step(driver, run_dir, slug, journey["record"])
         if journey["record"]["video"] == "window":
             driver.request("record_stop")
@@ -617,17 +704,7 @@ def run_journey(path: pathlib.Path, relay_url: str, output_root: pathlib.Path) -
                 driver.close()
             except Exception as exc:
                 cleanup_errors.append(f"native driver cleanup failed: {exc}")
-        if process and journey["cleanup"]["terminate_app"]:
-            process.terminate()
-            try:
-                process.wait(timeout=15)
-            except subprocess.TimeoutExpired:
-                process.kill(); cleanup_errors.append("Tauri launcher required SIGKILL")
-        if journey["cleanup"]["remove_state"]:
-            try:
-                cleanup_review_state(run_dir, isolation, fixture)
-            except Exception as exc:
-                cleanup_errors.append(str(exc))
+        cleanup_errors.extend(cleanup_process_and_state(process, run_dir, isolation, fixture))
         receipt["cleanup"] = {"status": "failed" if cleanup_errors else "passed", "errors": cleanup_errors}
         if cleanup_errors:
             receipt["status"] = "failed"

--- a/tools/native-review/schemas/journey.schema.json
+++ b/tools/native-review/schemas/journey.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buzz.local/native-review/journey.schema.json",
+  "title": "Buzz native review journey",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "flow", "platforms", "fixture", "record", "steps", "cleanup"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "flow": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$"},
+    "platforms": {"type": "array", "minItems": 1, "items": {"enum": ["macos"]}},
+    "fixture": {"enum": ["local_review_channel"]},
+    "record": {
+      "type": "object", "additionalProperties": false,
+      "required": ["video", "screenshots", "accessibility"],
+      "properties": {
+        "video": {"enum": ["window", "off"]},
+        "screenshots": {"type": "boolean"},
+        "accessibility": {"type": "boolean"}
+      }
+    },
+    "steps": {
+      "type": "array", "minItems": 1,
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["name", "act", "expect"],
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "locate": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/locator"}},
+          "act": {"$ref": "#/$defs/action"},
+          "expect": {"$ref": "#/$defs/expectation"},
+          "expect_for": {
+            "type": "object", "additionalProperties": false,
+            "required": ["duration_ms", "condition"],
+            "properties": {
+              "duration_ms": {"type": "integer", "minimum": 1, "maximum": 30000},
+              "condition": {"$ref": "#/$defs/expectation"}
+            }
+          },
+          "timeout_ms": {"type": "integer", "minimum": 1, "maximum": 60000},
+          "measure": {"type": "string", "pattern": "^[a-z][a-z0-9_]{0,63}$"}
+        }
+      }
+    },
+    "cleanup": {
+      "type": "object", "additionalProperties": false,
+      "required": ["terminate_app", "remove_state"],
+      "properties": {"terminate_app": {"type": "boolean"}, "remove_state": {"type": "boolean"}}
+    }
+  },
+  "$defs": {
+    "locator": {
+      "type": "object", "additionalProperties": false, "minProperties": 1,
+      "properties": {"id": {"type": "string"}, "role": {"type": "string"}, "name": {"type": "string"}}
+    },
+    "action": {
+      "oneOf": [
+        {"type": "object", "additionalProperties": false, "required": ["type"], "properties": {"type": {"const": "activate"}}},
+        {"type": "object", "additionalProperties": false, "required": ["type"], "properties": {"type": {"const": "click"}}},
+        {"type": "object", "additionalProperties": false, "required": ["type"], "properties": {"type": {"const": "move_pointer"}, "duration_ms": {"type": "integer", "minimum": 0, "maximum": 30000}}},
+        {"type": "object", "additionalProperties": false, "required": ["type", "key"], "properties": {"type": {"const": "press"}, "key": {"enum": ["tab", "return", "enter", "escape", "space"]}}},
+        {"type": "object", "additionalProperties": false, "required": ["type", "duration_ms"], "properties": {"type": {"const": "wait"}, "duration_ms": {"type": "integer", "minimum": 0, "maximum": 30000}}}
+      ]
+    },
+    "expectation": {
+      "type": "object", "additionalProperties": false, "minProperties": 1, "maxProperties": 1,
+      "properties": {
+        "exists": {"$ref": "#/$defs/locator"},
+        "not_exists": {"$ref": "#/$defs/locator"},
+        "focused": {"oneOf": [{"type": "boolean"}, {"$ref": "#/$defs/locator"}]},
+        "enabled": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/tools/native-review/schemas/journey.schema.json
+++ b/tools/native-review/schemas/journey.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://buzz.local/native-review/journey.schema.json",
   "title": "Buzz native review journey",
+  "description": "Structural authoring schema. The harness runtime additionally enforces cross-step metric invariants: every measure must reference a unique, earlier measure_start with the same name.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "flow", "platforms", "fixture", "record", "steps", "cleanup"],

--- a/tools/native-review/schemas/journey.schema.json
+++ b/tools/native-review/schemas/journey.schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "schema_version": {"const": 1},
     "flow": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$"},
-    "platforms": {"type": "array", "minItems": 1, "items": {"enum": ["macos"]}},
+    "platforms": {"type": "array", "minItems": 1, "maxItems": 1, "uniqueItems": true, "items": {"enum": ["macos"]}},
     "fixture": {"enum": ["local_review_channel"]},
     "record": {
       "type": "object", "additionalProperties": false,
@@ -24,6 +24,7 @@
       "items": {
         "type": "object", "additionalProperties": false,
         "required": ["name", "act", "expect"],
+        "allOf": [{"if": {"required": ["expect_not_before_ms"]}, "then": {"required": ["measure"]}}],
         "properties": {
           "name": {"type": "string", "minLength": 1},
           "locate": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/locator"}},
@@ -38,6 +39,8 @@
             }
           },
           "timeout_ms": {"type": "integer", "minimum": 1, "maximum": 60000},
+          "measure_start": {"type": "string", "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+          "expect_not_before_ms": {"type": "integer", "minimum": 1, "maximum": 30000},
           "measure": {"type": "string", "pattern": "^[a-z][a-z0-9_]{0,63}$"}
         }
       }
@@ -45,7 +48,7 @@
     "cleanup": {
       "type": "object", "additionalProperties": false,
       "required": ["terminate_app", "remove_state"],
-      "properties": {"terminate_app": {"type": "boolean"}, "remove_state": {"type": "boolean"}}
+      "properties": {"terminate_app": {"const": true}, "remove_state": {"const": true}}
     }
   },
   "$defs": {

--- a/tools/native-review/schemas/receipt.schema.json
+++ b/tools/native-review/schemas/receipt.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buzz.local/native-review/receipt.schema.json",
+  "title": "Buzz native review receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id", "flow", "status", "started_at", "finished_at", "provenance", "isolation", "artifacts", "measurements", "steps", "cleanup"],
+  "properties": {
+    "schema_version": {"const": 1}, "run_id": {"type": "string"}, "flow": {"type": "string"},
+    "status": {"enum": ["passed", "failed"]}, "started_at": {"type": "string"}, "finished_at": {"type": "string"},
+    "failure": {"type": ["string", "null"]},
+    "provenance": {"type": "object"}, "isolation": {"type": "object"}, "artifacts": {"type": "object"},
+    "measurements": {
+      "type": "object",
+      "propertyNames": {"pattern": "^[a-z][a-z0-9_]{0,63}$"},
+      "additionalProperties": {
+        "type": "object", "additionalProperties": false,
+        "required": ["value", "unit"],
+        "properties": {"value": {"type": "number", "minimum": 0}, "unit": {"const": "ms"}}
+      }
+    },
+    "steps": {"type": "array", "items": {"type": "object"}}, "cleanup": {"type": "object"}
+  }
+}

--- a/tools/native-review/swift/Package.swift
+++ b/tools/native-review/swift/Package.swift
@@ -5,5 +5,8 @@ let package = Package(
     name: "BuzzNativeDriver",
     platforms: [.macOS(.v13)],
     products: [.executable(name: "buzz-native-driver", targets: ["BuzzNativeDriver"])],
-    targets: [.executableTarget(name: "BuzzNativeDriver")]
+    targets: [
+        .executableTarget(name: "BuzzNativeDriver"),
+        .testTarget(name: "BuzzNativeDriverTests", dependencies: ["BuzzNativeDriver"]),
+    ]
 )

--- a/tools/native-review/swift/Package.swift
+++ b/tools/native-review/swift/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "BuzzNativeDriver",
+    platforms: [.macOS(.v13)],
+    products: [.executable(name: "buzz-native-driver", targets: ["BuzzNativeDriver"])],
+    targets: [.executableTarget(name: "BuzzNativeDriver")]
+)

--- a/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
+++ b/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
@@ -69,6 +69,18 @@ struct CaptureCadence {
     mutating func advance() { frame += 1 }
 }
 
+@discardableResult
+func captureTick(
+    cadence: inout CaptureCadence,
+    isReady: Bool,
+    append: (CMTime) -> Bool
+) -> Bool {
+    let presentationTime = cadence.presentationTime
+    defer { cadence.advance() }
+    guard isReady else { return true }
+    return append(presentationTime)
+}
+
 func targetIsFrontmost(pid: pid_t, frontmostPID: () -> pid_t? = {
     NSWorkspace.shared.frontmostApplication?.processIdentifier
 }) -> Bool {
@@ -87,6 +99,30 @@ func postGlobalEvent(_ event: CGEvent?, pid: pid_t, frontmostPID: () -> pid_t? =
     NSWorkspace.shared.frontmostApplication?.processIdentifier
 }, post: (CGEvent) -> Void = { $0.post(tap: .cghidEventTap) }) throws {
     try requireTargetIsFrontmost(pid: pid, frontmostPID: frontmostPID)
+    guard let event else { throw DriverError.message("failed to create global input event") }
+    post(event)
+}
+
+func requirePointInTargetWindow(
+    _ point: CGPoint,
+    pid: pid_t,
+    targetBounds: (pid_t) throws -> CGRect = { try windowInfo(pid: $0).1 }
+) throws {
+    guard try targetBounds(pid).contains(point) else {
+        throw DriverError.message("refusing global pointer input outside target pid \(pid) window")
+    }
+}
+
+func postGlobalPointerEvent(
+    _ event: CGEvent?,
+    at point: CGPoint,
+    pid: pid_t,
+    frontmostPID: () -> pid_t? = { NSWorkspace.shared.frontmostApplication?.processIdentifier },
+    targetBounds: (pid_t) throws -> CGRect = { try windowInfo(pid: $0).1 },
+    post: (CGEvent) -> Void = { $0.post(tap: .cghidEventTap) }
+) throws {
+    try requireTargetIsFrontmost(pid: pid, frontmostPID: frontmostPID)
+    try requirePointInTargetWindow(point, pid: pid, targetBounds: targetBounds)
     guard let event else { throw DriverError.message("failed to create global input event") }
     post(event)
 }
@@ -361,23 +397,36 @@ final class WindowRecorder: @unchecked Sendable {
                 try? await Task.sleep(until: target)
                 if Task.isCancelled { break }
                 autoreleasepool {
-                    defer { cadence.advance() }
-                    guard writerInput.isReadyForMoreMediaData,
-                          let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]),
-                          let pool = pixelAdaptor.pixelBufferPool else { return }
+                    guard writerInput.isReadyForMoreMediaData else {
+                        captureTick(cadence: &cadence, isReady: false) { _ in true }
+                        return
+                    }
+                    guard let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]),
+                          let pool = pixelAdaptor.pixelBufferPool else {
+                        captureTick(cadence: &cadence, isReady: false) { _ in true }
+                        return
+                    }
                     var optionalBuffer: CVPixelBuffer?
                     guard CVPixelBufferPoolCreatePixelBuffer(nil, pool, &optionalBuffer) == kCVReturnSuccess,
-                          let buffer = optionalBuffer else { return }
+                          let buffer = optionalBuffer else {
+                        captureTick(cadence: &cadence, isReady: false) { _ in true }
+                        return
+                    }
                     CVPixelBufferLockBaseAddress(buffer, [])
                     defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
                     guard let base = CVPixelBufferGetBaseAddress(buffer),
                           let context = CGContext(data: base, width: width, height: height,
                                                   bitsPerComponent: 8, bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
                                                   space: CGColorSpaceCreateDeviceRGB(),
-                                                  bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else { return }
+                                                  bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else {
+                        captureTick(cadence: &cadence, isReady: false) { _ in true }
+                        return
+                    }
                     context.interpolationQuality = .high
                     context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-                    if !pixelAdaptor.append(buffer, withPresentationTime: cadence.presentationTime) {
+                    if !captureTick(cadence: &cadence, isReady: true, append: { presentationTime in
+                        pixelAdaptor.append(buffer, withPresentationTime: presentationTime)
+                    }) {
                         self.captureError = assetWriter.error ?? DriverError.message("failed to append window video frame")
                     }
                 }
@@ -531,15 +580,15 @@ struct BuzzNativeDriver {
                                 for index in 1...steps {
                                     let fraction = Double(index) / Double(steps)
                                     let next = CGPoint(x: start.x + (point.x - start.x) * fraction, y: start.y + (point.y - start.y) * fraction)
-                                    try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: next, mouseButton: .left), pid: pid)
+                                    try postGlobalPointerEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: next, mouseButton: .left), at: next, pid: pid)
                                     try await Task.sleep(for: .milliseconds(duration / steps))
                                 }
                             } else if type == "move_pointer" {
-                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left), pid: pid)
+                                try postGlobalPointerEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left), at: point, pid: pid)
                             } else if type == "click" {
-                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left), pid: pid)
-                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left), pid: pid)
-                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left), pid: pid)
+                                try postGlobalPointerEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left), at: point, pid: pid)
+                                try postGlobalPointerEvent(CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left), at: point, pid: pid)
+                                try postGlobalPointerEvent(CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left), at: point, pid: pid)
                             } else { throw DriverError.message("unsupported action: \(type)") }
                         }
                         response(["ok": true])

--- a/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
+++ b/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
@@ -61,6 +61,36 @@ enum DriverError: Error, CustomStringConvertible {
     }
 }
 
+struct CaptureCadence {
+    private(set) var frame: Int64 = 0
+
+    var presentationTime: CMTime { CMTime(value: frame, timescale: 15) }
+
+    mutating func advance() { frame += 1 }
+}
+
+func targetIsFrontmost(pid: pid_t, frontmostPID: () -> pid_t? = {
+    NSWorkspace.shared.frontmostApplication?.processIdentifier
+}) -> Bool {
+    frontmostPID() == pid
+}
+
+func requireTargetIsFrontmost(pid: pid_t, frontmostPID: () -> pid_t? = {
+    NSWorkspace.shared.frontmostApplication?.processIdentifier
+}) throws {
+    guard targetIsFrontmost(pid: pid, frontmostPID: frontmostPID) else {
+        throw DriverError.message("refusing global input because target pid \(pid) is not frontmost")
+    }
+}
+
+func postGlobalEvent(_ event: CGEvent?, pid: pid_t, frontmostPID: () -> pid_t? = {
+    NSWorkspace.shared.frontmostApplication?.processIdentifier
+}, post: (CGEvent) -> Void = { $0.post(tap: .cghidEventTap) }) throws {
+    try requireTargetIsFrontmost(pid: pid, frontmostPID: frontmostPID)
+    guard let event else { throw DriverError.message("failed to create global input event") }
+    post(event)
+}
+
 func enableWebViewAccessibility(_ app: AXUIElement) {
     // WebKit does not materialize its remote accessibility tree for ordinary
     // automation clients until manual/enhanced accessibility is requested.
@@ -325,13 +355,13 @@ final class WindowRecorder: @unchecked Sendable {
         captureTask = Task.detached { [weak self] in
             guard let self else { return }
             let start = ContinuousClock.now
-            var frame: Int64 = 0
+            var cadence = CaptureCadence()
             while !Task.isCancelled {
-                let target = start.advanced(by: .milliseconds(Int(frame * 1000 / 15)))
+                let target = start.advanced(by: .milliseconds(Int(cadence.frame * 1000 / 15)))
                 try? await Task.sleep(until: target)
                 if Task.isCancelled { break }
                 autoreleasepool {
-                    defer { frame += 1 }
+                    defer { cadence.advance() }
                     guard writerInput.isReadyForMoreMediaData,
                           let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]),
                           let pool = pixelAdaptor.pixelBufferPool else { return }
@@ -347,8 +377,7 @@ final class WindowRecorder: @unchecked Sendable {
                                                   bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else { return }
                     context.interpolationQuality = .high
                     context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-                    let time = CMTime(value: frame, timescale: 15)
-                    if !pixelAdaptor.append(buffer, withPresentationTime: time) {
+                    if !pixelAdaptor.append(buffer, withPresentationTime: cadence.presentationTime) {
                         self.captureError = assetWriter.error ?? DriverError.message("failed to append window video frame")
                     }
                 }
@@ -461,14 +490,23 @@ struct BuzzNativeDriver {
                         guard let action = request["action"] as? [String: Any], let type = action["type"] as? String else { throw DriverError.message("act requires action.type") }
                         if type == "activate" {
                             guard let running = NSRunningApplication(processIdentifier: pid) else { throw DriverError.message("target app is no longer running") }
-                            running.activate(options: [.activateIgnoringOtherApps])
+                            guard running.activate(options: [.activateIgnoringOtherApps]) else {
+                                throw DriverError.message("target app refused activation")
+                            }
+                            let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+                            while !targetIsFrontmost(pid: pid), ContinuousClock.now < deadline {
+                                try await Task.sleep(for: .milliseconds(25))
+                            }
+                            try requireTargetIsFrontmost(pid: pid)
                         } else if type == "wait" {
                             try await Task.sleep(for: .milliseconds(action["duration_ms"] as? Int ?? 0))
                         } else if type == "press" {
+                            try requireTargetIsFrontmost(pid: pid)
                             let code = try keyCode(action["key"] as? String ?? "")
-                            CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: true)?.post(tap: .cghidEventTap)
-                            CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: false)?.post(tap: .cghidEventTap)
+                            try postGlobalEvent(CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: true), pid: pid)
+                            try postGlobalEvent(CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: false), pid: pid)
                         } else {
+                            try requireTargetIsFrontmost(pid: pid)
                             guard let (_, used) = selected else {
                                 throw DriverError.message("action requires a freshly selected element with current bounds")
                             }
@@ -493,15 +531,15 @@ struct BuzzNativeDriver {
                                 for index in 1...steps {
                                     let fraction = Double(index) / Double(steps)
                                     let next = CGPoint(x: start.x + (point.x - start.x) * fraction, y: start.y + (point.y - start.y) * fraction)
-                                    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: next, mouseButton: .left)?.post(tap: .cghidEventTap)
+                                    try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: next, mouseButton: .left), pid: pid)
                                     try await Task.sleep(for: .milliseconds(duration / steps))
                                 }
                             } else if type == "move_pointer" {
-                                CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left), pid: pid)
                             } else if type == "click" {
-                                CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
-                                CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
-                                CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left), pid: pid)
+                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left), pid: pid)
+                                try postGlobalEvent(CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left), pid: pid)
                             } else { throw DriverError.message("unsupported action: \(type)") }
                         }
                         response(["ok": true])

--- a/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
+++ b/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
@@ -187,6 +187,7 @@ func normalizedRole(_ raw: String?) -> String? {
     if value.hasPrefix("AX") { value.removeFirst(2) }
     switch value.lowercased() {
     case "textarea", "text area": return "text-area"
+    case "webarea", "web area": return "web-area"
     default: return value.lowercased()
     }
 }
@@ -266,29 +267,40 @@ func describe(_ element: AXUIElement, locator: Locator) -> ElementDescription {
                        focused: boolAttribute(element, kAXFocusedAttribute), frame: frameAttribute(element))
 }
 
+func semanticContentBounds(pid: pid_t) -> CGRect? {
+    let app = AXUIElementCreateApplication(pid)
+    enableWebViewAccessibility(app)
+    let webArea = find(accessibilityRoots(app: app, pid: pid), locator: Locator(id: nil, role: "web-area", name: nil))
+    guard let frame = webArea.flatMap(frameAttribute) else { return nil }
+    return CGRect(x: frame.x, y: frame.y, width: frame.width, height: frame.height)
+}
+
+func transformSemanticNode(_ node: SemanticNode, contentBounds: CGRect) -> SemanticNode? {
+    guard node.viewport.width > 0, node.viewport.height > 0,
+          contentBounds.width > 0, contentBounds.height > 0 else { return nil }
+    let xScale = contentBounds.width / node.viewport.width
+    let yScale = contentBounds.height / node.viewport.height
+    return SemanticNode(
+        id: node.id,
+        role: node.role,
+        name: node.name,
+        enabled: node.enabled,
+        focused: node.focused,
+        frame: Rect(
+            x: contentBounds.minX + node.frame.x * xScale,
+            y: contentBounds.minY + node.frame.y * yScale,
+            width: node.frame.width * xScale,
+            height: node.frame.height * yScale
+        ),
+        viewport: node.viewport
+    )
+}
+
 func semanticNodes(path: String, pid: pid_t) -> [SemanticNode] {
     guard let data = FileManager.default.contents(atPath: path),
-          let nodes = try? JSONDecoder().decode([SemanticNode].self, from: data) else { return [] }
-    guard let (_, windowBounds) = try? windowInfo(pid: pid) else { return nodes }
-    return nodes.map { node in
-        guard node.viewport.width > 0, node.viewport.height > 0 else { return node }
-        let xScale = windowBounds.width / node.viewport.width
-        let yScale = windowBounds.height / node.viewport.height
-        return SemanticNode(
-            id: node.id,
-            role: node.role,
-            name: node.name,
-            enabled: node.enabled,
-            focused: node.focused,
-            frame: Rect(
-                x: windowBounds.minX + node.frame.x * xScale,
-                y: windowBounds.minY + node.frame.y * yScale,
-                width: node.frame.width * xScale,
-                height: node.frame.height * yScale
-            ),
-            viewport: node.viewport
-        )
-    }
+          let nodes = try? JSONDecoder().decode([SemanticNode].self, from: data),
+          let contentBounds = semanticContentBounds(pid: pid) else { return [] }
+    return nodes.compactMap { transformSemanticNode($0, contentBounds: contentBounds) }
 }
 
 func matches(_ element: SemanticNode, locator: Locator) -> Bool {
@@ -360,12 +372,42 @@ func captureWindow(pid: pid_t, path: String) throws {
     try bitmap.write(to: destination, options: .atomic)
 }
 
+func recordingHasVideoTrack(_ destination: URL) async -> Bool {
+    do {
+        return try await !AVURLAsset(url: destination).loadTracks(withMediaType: .video).isEmpty
+    } catch {
+        return false
+    }
+}
+
+func validateFinalizedRecording(
+    appendedFrameCount: Int,
+    destination: URL?,
+    hasVideoTrack: (URL) async -> Bool = recordingHasVideoTrack
+) async throws {
+    guard appendedFrameCount > 0 else {
+        throw DriverError.message("window recording contained no frames")
+    }
+    guard let destination else {
+        throw DriverError.message("window recording destination is missing")
+    }
+    let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
+    guard let size = attributes[.size] as? NSNumber, size.int64Value > 0 else {
+        throw DriverError.message("window recording is empty")
+    }
+    guard await hasVideoTrack(destination) else {
+        throw DriverError.message("window recording has no readable video track")
+    }
+}
+
 final class WindowRecorder: @unchecked Sendable {
     private var writer: AVAssetWriter?
     private var input: AVAssetWriterInput?
     private var adaptor: AVAssetWriterInputPixelBufferAdaptor?
     private var captureTask: Task<Void, Never>?
     private var captureError: Error?
+    private var appendedFrameCount = 0
+    private var destination: URL?
 
     private func trace(_ message: String) {
         let timestamp = ISO8601DateFormatter().string(from: Date())
@@ -401,6 +443,8 @@ final class WindowRecorder: @unchecked Sendable {
         guard assetWriter.startWriting() else { throw assetWriter.error ?? DriverError.message("AVAssetWriter failed to start") }
         assetWriter.startSession(atSourceTime: .zero)
         writer = assetWriter; input = writerInput; adaptor = pixelAdaptor
+        self.destination = destination
+        appendedFrameCount = 0
         trace("started CGWindow/AVAssetWriter backend window=\(windowID) size=\(width)x\(height)")
 
         captureTask = Task.detached { [weak self] in
@@ -416,21 +460,35 @@ final class WindowRecorder: @unchecked Sendable {
                         cadence: &cadence,
                         isReady: writerInput.isReadyForMoreMediaData,
                         append: { presentationTime in
-                            guard let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]),
-                                  let pool = pixelAdaptor.pixelBufferPool else { return true }
+                            guard let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]) else {
+                                self.captureError = DriverError.message("failed to capture window video frame")
+                                return false
+                            }
+                            guard let pool = pixelAdaptor.pixelBufferPool else {
+                                self.captureError = DriverError.message("window video pixel buffer pool is unavailable")
+                                return false
+                            }
                             var optionalBuffer: CVPixelBuffer?
                             guard CVPixelBufferPoolCreatePixelBuffer(nil, pool, &optionalBuffer) == kCVReturnSuccess,
-                                  let buffer = optionalBuffer else { return true }
+                                  let buffer = optionalBuffer else {
+                                self.captureError = DriverError.message("failed to allocate window video pixel buffer")
+                                return false
+                            }
                             CVPixelBufferLockBaseAddress(buffer, [])
                             defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
                             guard let base = CVPixelBufferGetBaseAddress(buffer),
                                   let context = CGContext(data: base, width: width, height: height,
                                                           bitsPerComponent: 8, bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
                                                           space: CGColorSpaceCreateDeviceRGB(),
-                                                          bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else { return true }
+                                                          bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else {
+                                self.captureError = DriverError.message("failed to create window video drawing context")
+                                return false
+                            }
                             context.interpolationQuality = .high
                             context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-                            return pixelAdaptor.append(buffer, withPresentationTime: presentationTime)
+                            let appended = pixelAdaptor.append(buffer, withPresentationTime: presentationTime)
+                            if appended { self.appendedFrameCount += 1 }
+                            return appended
                         }
                     ) {
                         self.captureError = assetWriter.error ?? DriverError.message("failed to append window video frame")
@@ -447,7 +505,15 @@ final class WindowRecorder: @unchecked Sendable {
         input?.markAsFinished()
         if let assetWriter = writer { await assetWriter.finishWriting() }
         let error = captureError ?? writer?.error
-        writer = nil; input = nil; adaptor = nil; captureError = nil
+        if error == nil {
+            do {
+                try await validateFinalizedRecording(appendedFrameCount: appendedFrameCount, destination: destination)
+            } catch {
+                self.writer = nil; input = nil; adaptor = nil; captureError = nil; destination = nil; appendedFrameCount = 0
+                throw error
+            }
+        }
+        writer = nil; input = nil; adaptor = nil; captureError = nil; destination = nil; appendedFrameCount = 0
         if let error { throw error }
         trace("finalized recording")
     }

--- a/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
+++ b/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
@@ -103,6 +103,21 @@ func postGlobalEvent(_ event: CGEvent?, pid: pid_t, frontmostPID: () -> pid_t? =
     post(event)
 }
 
+func pointerPath(from start: CGPoint, to target: CGPoint, within bounds: CGRect, steps: Int) -> [CGPoint] {
+    let insetBounds = bounds.insetBy(dx: min(1, bounds.width / 4), dy: min(1, bounds.height / 4))
+    let safeStart = CGPoint(
+        x: min(max(start.x, insetBounds.minX), insetBounds.maxX),
+        y: min(max(start.y, insetBounds.minY), insetBounds.maxY)
+    )
+    return (1...max(steps, 1)).map { index in
+        let fraction = Double(index) / Double(max(steps, 1))
+        return CGPoint(
+            x: safeStart.x + (target.x - safeStart.x) * fraction,
+            y: safeStart.y + (target.y - safeStart.y) * fraction
+        )
+    }
+}
+
 func requirePointInTargetWindow(
     _ point: CGPoint,
     pid: pid_t,
@@ -397,36 +412,27 @@ final class WindowRecorder: @unchecked Sendable {
                 try? await Task.sleep(until: target)
                 if Task.isCancelled { break }
                 autoreleasepool {
-                    guard writerInput.isReadyForMoreMediaData else {
-                        captureTick(cadence: &cadence, isReady: false) { _ in true }
-                        return
-                    }
-                    guard let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]),
-                          let pool = pixelAdaptor.pixelBufferPool else {
-                        captureTick(cadence: &cadence, isReady: false) { _ in true }
-                        return
-                    }
-                    var optionalBuffer: CVPixelBuffer?
-                    guard CVPixelBufferPoolCreatePixelBuffer(nil, pool, &optionalBuffer) == kCVReturnSuccess,
-                          let buffer = optionalBuffer else {
-                        captureTick(cadence: &cadence, isReady: false) { _ in true }
-                        return
-                    }
-                    CVPixelBufferLockBaseAddress(buffer, [])
-                    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
-                    guard let base = CVPixelBufferGetBaseAddress(buffer),
-                          let context = CGContext(data: base, width: width, height: height,
-                                                  bitsPerComponent: 8, bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
-                                                  space: CGColorSpaceCreateDeviceRGB(),
-                                                  bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else {
-                        captureTick(cadence: &cadence, isReady: false) { _ in true }
-                        return
-                    }
-                    context.interpolationQuality = .high
-                    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-                    if !captureTick(cadence: &cadence, isReady: true, append: { presentationTime in
-                        pixelAdaptor.append(buffer, withPresentationTime: presentationTime)
-                    }) {
+                    if !captureTick(
+                        cadence: &cadence,
+                        isReady: writerInput.isReadyForMoreMediaData,
+                        append: { presentationTime in
+                            guard let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]),
+                                  let pool = pixelAdaptor.pixelBufferPool else { return true }
+                            var optionalBuffer: CVPixelBuffer?
+                            guard CVPixelBufferPoolCreatePixelBuffer(nil, pool, &optionalBuffer) == kCVReturnSuccess,
+                                  let buffer = optionalBuffer else { return true }
+                            CVPixelBufferLockBaseAddress(buffer, [])
+                            defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+                            guard let base = CVPixelBufferGetBaseAddress(buffer),
+                                  let context = CGContext(data: base, width: width, height: height,
+                                                          bitsPerComponent: 8, bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+                                                          space: CGColorSpaceCreateDeviceRGB(),
+                                                          bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else { return true }
+                            context.interpolationQuality = .high
+                            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+                            return pixelAdaptor.append(buffer, withPresentationTime: presentationTime)
+                        }
+                    ) {
                         self.captureError = assetWriter.error ?? DriverError.message("failed to append window video frame")
                     }
                 }
@@ -577,9 +583,8 @@ struct BuzzNativeDriver {
                                 let current = NSEvent.mouseLocation
                                 let start = CGPoint(x: current.x, y: NSScreen.screens.first.map { $0.frame.height - current.y } ?? current.y)
                                 let steps = max(duration / 8, 2)
-                                for index in 1...steps {
-                                    let fraction = Double(index) / Double(steps)
-                                    let next = CGPoint(x: start.x + (point.x - start.x) * fraction, y: start.y + (point.y - start.y) * fraction)
+                                let bounds = try windowInfo(pid: pid).1
+                                for next in pointerPath(from: start, to: point, within: bounds, steps: steps) {
                                     try postGlobalPointerEvent(CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: next, mouseButton: .left), at: next, pid: pid)
                                     try await Task.sleep(for: .milliseconds(duration / steps))
                                 }

--- a/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
+++ b/tools/native-review/swift/Sources/BuzzNativeDriver/main.swift
@@ -1,0 +1,543 @@
+import AppKit
+import ApplicationServices
+import AVFoundation
+import CoreGraphics
+import Foundation
+
+struct Locator: Codable {
+    let id: String?
+    let role: String?
+    let name: String?
+}
+
+struct Size: Codable {
+    let width: Double
+    let height: Double
+}
+
+struct SemanticNode: Codable {
+    let id: String?
+    let role: String?
+    let name: String?
+    let enabled: Bool
+    let focused: Bool
+    let frame: Rect
+    let viewport: Size
+}
+
+struct ElementDescription: Codable {
+    let locator: Locator
+    let role: String?
+    let name: String?
+    let identifier: String?
+    let enabled: Bool
+    let focused: Bool
+    let frame: Rect?
+}
+
+struct Rect: Codable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+}
+
+struct AXNode: Codable {
+    let role: String?
+    let name: String?
+    let identifier: String?
+    let value: String?
+    let enabled: Bool?
+    let focused: Bool?
+    let frame: Rect?
+    let children: [AXNode]
+    let truncated: Bool?
+}
+
+enum DriverError: Error, CustomStringConvertible {
+    case message(String)
+    var description: String {
+        switch self { case .message(let value): return value }
+    }
+}
+
+func enableWebViewAccessibility(_ app: AXUIElement) {
+    // WebKit does not materialize its remote accessibility tree for ordinary
+    // automation clients until manual/enhanced accessibility is requested.
+    // VoiceOver does this implicitly; the review harness must not require it.
+    let enabled = kCFBooleanTrue as CFTypeRef
+    for name in ["AXManualAccessibility", "AXEnhancedUserInterface"] {
+        _ = AXUIElementSetAttributeValue(app, name as CFString, enabled)
+    }
+}
+
+func attribute(_ element: AXUIElement, _ name: String) -> AnyObject? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else { return nil }
+    return value
+}
+
+func stringAttribute(_ element: AXUIElement, _ names: [String]) -> String? {
+    for name in names {
+        if let value = attribute(element, name) as? String, !value.isEmpty { return value }
+    }
+    return nil
+}
+
+func boolAttribute(_ element: AXUIElement, _ name: String, default fallback: Bool = false) -> Bool {
+    (attribute(element, name) as? Bool) ?? fallback
+}
+
+func frameAttribute(_ element: AXUIElement) -> Rect? {
+    guard let positionObject = attribute(element, kAXPositionAttribute),
+          let sizeObject = attribute(element, kAXSizeAttribute),
+          CFGetTypeID(positionObject) == AXValueGetTypeID(),
+          CFGetTypeID(sizeObject) == AXValueGetTypeID() else { return nil }
+    let positionValue = positionObject as! AXValue
+    let sizeValue = sizeObject as! AXValue
+    var point = CGPoint.zero
+    var size = CGSize.zero
+    guard AXValueGetValue(positionValue, .cgPoint, &point), AXValueGetValue(sizeValue, .cgSize, &size) else { return nil }
+    return Rect(x: point.x, y: point.y, width: size.width, height: size.height)
+}
+
+func normalizedRole(_ raw: String?) -> String? {
+    guard var value = raw else { return nil }
+    if value.hasPrefix("AX") { value.removeFirst(2) }
+    switch value.lowercased() {
+    case "textarea", "text area": return "text-area"
+    default: return value.lowercased()
+    }
+}
+
+func elementName(_ element: AXUIElement) -> String? {
+    stringAttribute(element, [kAXTitleAttribute, kAXDescriptionAttribute, kAXHelpAttribute, kAXValueAttribute])
+}
+
+func elementIdentifier(_ element: AXUIElement) -> String? {
+    stringAttribute(element, [kAXIdentifierAttribute])
+}
+
+func elementRole(_ element: AXUIElement) -> String? {
+    stringAttribute(element, [kAXRoleAttribute])
+}
+
+func matches(_ element: AXUIElement, locator: Locator) -> Bool {
+    if let id = locator.id, elementIdentifier(element) != id { return false }
+    if let role = locator.role, normalizedRole(elementRole(element)) != normalizedRole(role) { return false }
+    if let name = locator.name, elementName(element) != name { return false }
+    return true
+}
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+    let direct = (attribute(element, kAXChildrenAttribute) as? [AXUIElement]) ?? []
+    let windows = (attribute(element, kAXWindowsAttribute) as? [AXUIElement]) ?? []
+    let singular = [kAXMainWindowAttribute, kAXFocusedWindowAttribute].compactMap {
+        attribute(element, $0) as! AXUIElement?
+    }
+    var seen = Set<CFHashCode>()
+    return (direct + windows + singular).filter { child in
+        guard !CFEqual(child, element) else { return false }
+        return seen.insert(CFHash(child)).inserted
+    }
+}
+
+func accessibilityRoots(app: AXUIElement, pid: pid_t) -> [AXUIElement] {
+    // WKWebView's remote tree is not always attached to AXChildren/AXWindows,
+    // even after manual accessibility is enabled. Hit-testing the visible app
+    // window asks the accessibility server for the element actually painted at
+    // each point and reliably materializes the WebKit subtree without DOM IPC.
+    var roots = [app]
+    guard let (_, bounds) = try? windowInfo(pid: pid) else { return roots }
+    let system = AXUIElementCreateSystemWide()
+    for xFraction in stride(from: 0.05, through: 0.95, by: 0.1) {
+        for yFraction in stride(from: 0.05, through: 0.95, by: 0.1) {
+            var element: AXUIElement?
+            let x = Float(bounds.minX + bounds.width * xFraction)
+            let y = Float(bounds.minY + bounds.height * yFraction)
+            if AXUIElementCopyElementAtPosition(system, x, y, &element) == .success,
+               let element {
+                roots.append(element)
+            }
+        }
+    }
+    var seen = Set<CFHashCode>()
+    return roots.filter { seen.insert(CFHash($0)).inserted }
+}
+
+func find(_ roots: [AXUIElement], locator: Locator, maxNodes: Int = 20_000) -> AXUIElement? {
+    var queue = roots
+    var seen = Set<CFHashCode>()
+    var visited = 0
+    while !queue.isEmpty && visited < maxNodes {
+        let current = queue.removeFirst()
+        guard seen.insert(CFHash(current)).inserted else { continue }
+        visited += 1
+        if matches(current, locator: locator) { return current }
+        queue.append(contentsOf: children(current))
+    }
+    return nil
+}
+
+func describe(_ element: AXUIElement, locator: Locator) -> ElementDescription {
+    ElementDescription(locator: locator, role: normalizedRole(elementRole(element)), name: elementName(element),
+                       identifier: elementIdentifier(element), enabled: boolAttribute(element, kAXEnabledAttribute, default: true),
+                       focused: boolAttribute(element, kAXFocusedAttribute), frame: frameAttribute(element))
+}
+
+func semanticNodes(path: String, pid: pid_t) -> [SemanticNode] {
+    guard let data = FileManager.default.contents(atPath: path),
+          let nodes = try? JSONDecoder().decode([SemanticNode].self, from: data) else { return [] }
+    guard let (_, windowBounds) = try? windowInfo(pid: pid) else { return nodes }
+    return nodes.map { node in
+        guard node.viewport.width > 0, node.viewport.height > 0 else { return node }
+        let xScale = windowBounds.width / node.viewport.width
+        let yScale = windowBounds.height / node.viewport.height
+        return SemanticNode(
+            id: node.id,
+            role: node.role,
+            name: node.name,
+            enabled: node.enabled,
+            focused: node.focused,
+            frame: Rect(
+                x: windowBounds.minX + node.frame.x * xScale,
+                y: windowBounds.minY + node.frame.y * yScale,
+                width: node.frame.width * xScale,
+                height: node.frame.height * yScale
+            ),
+            viewport: node.viewport
+        )
+    }
+}
+
+func matches(_ element: SemanticNode, locator: Locator) -> Bool {
+    if let id = locator.id, element.id != id { return false }
+    if let role = locator.role, normalizedRole(element.role) != normalizedRole(role) { return false }
+    if let name = locator.name, element.name != name { return false }
+    return true
+}
+
+func describe(_ element: SemanticNode, locator: Locator) -> ElementDescription {
+    ElementDescription(locator: locator, role: normalizedRole(element.role), name: element.name,
+                       identifier: element.id, enabled: element.enabled, focused: element.focused,
+                       frame: element.frame)
+}
+
+func snapshot(_ element: AXUIElement, depth: Int = 0, budget: inout Int) -> AXNode {
+    budget -= 1
+    let isTruncated = budget <= 0 || depth >= 80
+    let descendants = isTruncated ? [] : children(element).map { snapshot($0, depth: depth + 1, budget: &budget) }
+    return AXNode(role: normalizedRole(elementRole(element)), name: elementName(element), identifier: elementIdentifier(element),
+                  value: stringAttribute(element, [kAXValueAttribute]), enabled: attribute(element, kAXEnabledAttribute) as? Bool,
+                  focused: attribute(element, kAXFocusedAttribute) as? Bool, frame: frameAttribute(element),
+                  children: descendants, truncated: isTruncated ? true : nil)
+}
+
+func windowInfo(pid: pid_t) throws -> (CGWindowID, CGRect) {
+    guard let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
+        throw DriverError.message("cannot enumerate windows; Screen Recording permission may be missing")
+    }
+    let candidates = windows.compactMap { window -> (CGWindowID, CGRect)? in
+        guard (window[kCGWindowOwnerPID as String] as? Int32) == pid,
+              let number = window[kCGWindowNumber as String] as? CGWindowID,
+              let boundsValue = window[kCGWindowBounds as String],
+              CFGetTypeID(boundsValue as CFTypeRef) == CFDictionaryGetTypeID(),
+              let bounds = CGRect(dictionaryRepresentation: boundsValue as! CFDictionary),
+              bounds.width > 0, bounds.height > 0 else { return nil }
+        return (number, bounds)
+    }
+    if let largest = candidates.max(by: { $0.1.width * $0.1.height < $1.1.width * $1.1.height }) {
+        return largest
+    }
+    throw DriverError.message("no on-screen window found for pid \(pid)")
+}
+
+func windowStatus(pid: pid_t) -> [String: Any] {
+    do {
+        let (windowID, bounds) = try windowInfo(pid: pid)
+        return [
+            "ok": true,
+            "visible": true,
+            "window_id": windowID,
+            "bounds": ["x": bounds.origin.x, "y": bounds.origin.y, "width": bounds.width, "height": bounds.height],
+        ]
+    } catch {
+        return ["ok": true, "visible": false, "detail": String(describing: error)]
+    }
+}
+
+func captureWindow(pid: pid_t, path: String) throws {
+    let (windowID, bounds) = try windowInfo(pid: pid)
+    guard let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]) else {
+        throw DriverError.message("window screenshot failed")
+    }
+    let destination = URL(fileURLWithPath: path)
+    try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+    guard let bitmap = NSBitmapImageRep(cgImage: image).representation(using: .png, properties: [:]) else {
+        throw DriverError.message("PNG encoding failed")
+    }
+    try bitmap.write(to: destination, options: .atomic)
+}
+
+final class WindowRecorder: @unchecked Sendable {
+    private var writer: AVAssetWriter?
+    private var input: AVAssetWriterInput?
+    private var adaptor: AVAssetWriterInputPixelBufferAdaptor?
+    private var captureTask: Task<Void, Never>?
+    private var captureError: Error?
+
+    private func trace(_ message: String) {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        FileHandle.standardError.write(Data("[\(timestamp)] record: \(message)\n".utf8))
+    }
+
+    func start(pid: pid_t, path: String) throws {
+        let (windowID, bounds) = try windowInfo(pid: pid)
+        let width = max(Int(bounds.width) & ~1, 2)
+        let height = max(Int(bounds.height) & ~1, 2)
+        let destination = URL(fileURLWithPath: path)
+        try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: destination)
+
+        let assetWriter = try AVAssetWriter(outputURL: destination, fileType: .mp4)
+        let settings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+        ]
+        let writerInput = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+        writerInput.expectsMediaDataInRealTime = true
+        let attributes: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: width,
+            kCVPixelBufferHeightKey as String: height,
+            kCVPixelBufferCGImageCompatibilityKey as String: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true,
+        ]
+        let pixelAdaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: writerInput, sourcePixelBufferAttributes: attributes)
+        guard assetWriter.canAdd(writerInput) else { throw DriverError.message("AVAssetWriter rejected window video input") }
+        assetWriter.add(writerInput)
+        guard assetWriter.startWriting() else { throw assetWriter.error ?? DriverError.message("AVAssetWriter failed to start") }
+        assetWriter.startSession(atSourceTime: .zero)
+        writer = assetWriter; input = writerInput; adaptor = pixelAdaptor
+        trace("started CGWindow/AVAssetWriter backend window=\(windowID) size=\(width)x\(height)")
+
+        captureTask = Task.detached { [weak self] in
+            guard let self else { return }
+            let start = ContinuousClock.now
+            var frame: Int64 = 0
+            while !Task.isCancelled {
+                let target = start.advanced(by: .milliseconds(Int(frame * 1000 / 15)))
+                try? await Task.sleep(until: target)
+                if Task.isCancelled { break }
+                autoreleasepool {
+                    defer { frame += 1 }
+                    guard writerInput.isReadyForMoreMediaData,
+                          let image = CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, [.boundsIgnoreFraming, .bestResolution]),
+                          let pool = pixelAdaptor.pixelBufferPool else { return }
+                    var optionalBuffer: CVPixelBuffer?
+                    guard CVPixelBufferPoolCreatePixelBuffer(nil, pool, &optionalBuffer) == kCVReturnSuccess,
+                          let buffer = optionalBuffer else { return }
+                    CVPixelBufferLockBaseAddress(buffer, [])
+                    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+                    guard let base = CVPixelBufferGetBaseAddress(buffer),
+                          let context = CGContext(data: base, width: width, height: height,
+                                                  bitsPerComponent: 8, bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+                                                  space: CGColorSpaceCreateDeviceRGB(),
+                                                  bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue) else { return }
+                    context.interpolationQuality = .high
+                    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+                    let time = CMTime(value: frame, timescale: 15)
+                    if !pixelAdaptor.append(buffer, withPresentationTime: time) {
+                        self.captureError = assetWriter.error ?? DriverError.message("failed to append window video frame")
+                    }
+                }
+            }
+        }
+    }
+
+    func stop() async throws {
+        captureTask?.cancel()
+        _ = await captureTask?.result
+        captureTask = nil
+        input?.markAsFinished()
+        if let assetWriter = writer { await assetWriter.finishWriting() }
+        let error = captureError ?? writer?.error
+        writer = nil; input = nil; adaptor = nil; captureError = nil
+        if let error { throw error }
+        trace("finalized recording")
+    }
+}
+
+func jsonObject(_ data: Data) throws -> [String: Any] {
+    guard let value = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw DriverError.message("request must be a JSON object")
+    }
+    return value
+}
+
+func locator(from value: Any) throws -> Locator {
+    let data = try JSONSerialization.data(withJSONObject: value)
+    return try JSONDecoder().decode(Locator.self, from: data)
+}
+
+func response(_ object: [String: Any]) {
+    let data = try! JSONSerialization.data(withJSONObject: object)
+    print(String(data: data, encoding: .utf8)!)
+    fflush(stdout)
+}
+
+func encoded<T: Encodable>(_ value: T) throws -> Any {
+    let data = try JSONEncoder().encode(value)
+    return try JSONSerialization.jsonObject(with: data)
+}
+
+func keyCode(_ key: String) throws -> CGKeyCode {
+    switch key.lowercased() {
+    case "tab": return 48
+    case "return", "enter": return 36
+    case "escape": return 53
+    case "space": return 49
+    default: throw DriverError.message("unsupported key: \(key)")
+    }
+}
+
+@main
+struct BuzzNativeDriver {
+    static func main() async {
+        do {
+            let arguments = Array(CommandLine.arguments.dropFirst())
+            guard let command = arguments.first else { throw DriverError.message("usage: buzz-native-driver doctor | serve --pid PID") }
+            if command == "doctor" {
+                let accessibility = AXIsProcessTrusted()
+                let screen = CGPreflightScreenCaptureAccess()
+                response(["ok": true, "checks": [
+                    ["name": "native-driver-build", "ok": true, "detail": "Swift AX/CGEvent/Core Graphics/AVFoundation driver available"],
+                    ["name": "accessibility-permission", "ok": accessibility, "detail": accessibility ? "granted" : "grant Accessibility to the invoking terminal/agent"],
+                    ["name": "screen-recording-permission", "ok": screen, "detail": screen ? "granted" : "grant Screen Recording to the invoking terminal/agent"],
+                    ["name": "recording-api", "ok": ProcessInfo.processInfo.isOperatingSystemAtLeast(.init(majorVersion: 15, minorVersion: 0, patchVersion: 0)), "detail": ProcessInfo.processInfo.operatingSystemVersionString]
+                ]])
+                return
+            }
+            guard command == "serve", (arguments.count == 3 || arguments.count == 5), arguments[1] == "--pid", let pid = pid_t(arguments[2]) else {
+                throw DriverError.message("usage: buzz-native-driver serve --pid PID [--semantic-snapshot PATH]")
+            }
+            let semanticSnapshotPath: String? = arguments.count == 5 && arguments[3] == "--semantic-snapshot" ? arguments[4] : nil
+            guard AXIsProcessTrusted() else { throw DriverError.message("Accessibility permission is not granted") }
+            let app = AXUIElementCreateApplication(pid)
+            enableWebViewAccessibility(app)
+            var selected: (ElementDescription, Locator)?
+            var recorder: Any?
+            for try await line in FileHandle.standardInput.bytes.lines {
+                do {
+                    let request = try jsonObject(Data(line.utf8))
+                    guard let name = request["command"] as? String else { throw DriverError.message("missing command") }
+                    switch name {
+                    case "locate":
+                        guard let values = request["locators"] as? [Any] else { throw DriverError.message("locate requires locators") }
+                        var found: (ElementDescription, Locator)?
+                        for value in values {
+                            let candidate = try locator(from: value)
+                            if let path = semanticSnapshotPath,
+                               let element = semanticNodes(path: path, pid: pid).first(where: { matches($0, locator: candidate) }) {
+                                found = (describe(element, locator: candidate), candidate)
+                                break
+                            }
+                            let semanticActive = semanticSnapshotPath.map { FileManager.default.fileExists(atPath: $0) } ?? false
+                            if !semanticActive || candidate.role == "window" {
+                                if let element = find(accessibilityRoots(app: app, pid: pid), locator: candidate) {
+                                    found = (describe(element, locator: candidate), candidate)
+                                    break
+                                }
+                            }
+                        }
+                        selected = found
+                        if let (element, _) = found {
+                            response(["ok": true, "element": try encoded(element)])
+                        } else if (request["required"] as? Bool) == true {
+                            throw DriverError.message("no accessibility element matched ordered locators")
+                        } else { response(["ok": true, "element": NSNull()]) }
+                    case "act":
+                        guard let action = request["action"] as? [String: Any], let type = action["type"] as? String else { throw DriverError.message("act requires action.type") }
+                        if type == "activate" {
+                            guard let running = NSRunningApplication(processIdentifier: pid) else { throw DriverError.message("target app is no longer running") }
+                            running.activate(options: [.activateIgnoringOtherApps])
+                        } else if type == "wait" {
+                            try await Task.sleep(for: .milliseconds(action["duration_ms"] as? Int ?? 0))
+                        } else if type == "press" {
+                            let code = try keyCode(action["key"] as? String ?? "")
+                            CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: true)?.post(tap: .cghidEventTap)
+                            CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: false)?.post(tap: .cghidEventTap)
+                        } else {
+                            guard let (_, used) = selected else {
+                                throw DriverError.message("action requires a freshly selected element with current bounds")
+                            }
+                            var fresh: ElementDescription?
+                            if let path = semanticSnapshotPath,
+                               let element = semanticNodes(path: path, pid: pid).first(where: { matches($0, locator: used) }) {
+                                fresh = describe(element, locator: used)
+                            }
+                            if fresh == nil, let element = find(accessibilityRoots(app: app, pid: pid), locator: used) {
+                                fresh = describe(element, locator: used)
+                            }
+                            guard let element = fresh, let frame = element.frame else {
+                                throw DriverError.message("action requires a freshly selected element with current bounds")
+                            }
+                            selected = (element, used)
+                            let point = CGPoint(x: frame.x + frame.width / 2, y: frame.y + frame.height / 2)
+                            let duration = max(action["duration_ms"] as? Int ?? 0, 0)
+                            if type == "move_pointer" && duration > 0 {
+                                let current = NSEvent.mouseLocation
+                                let start = CGPoint(x: current.x, y: NSScreen.screens.first.map { $0.frame.height - current.y } ?? current.y)
+                                let steps = max(duration / 8, 2)
+                                for index in 1...steps {
+                                    let fraction = Double(index) / Double(steps)
+                                    let next = CGPoint(x: start.x + (point.x - start.x) * fraction, y: start.y + (point.y - start.y) * fraction)
+                                    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: next, mouseButton: .left)?.post(tap: .cghidEventTap)
+                                    try await Task.sleep(for: .milliseconds(duration / steps))
+                                }
+                            } else if type == "move_pointer" {
+                                CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+                            } else if type == "click" {
+                                CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+                                CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+                                CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+                            } else { throw DriverError.message("unsupported action: \(type)") }
+                        }
+                        response(["ok": true])
+                    case "window_status":
+                        response(windowStatus(pid: pid))
+                    case "snapshot":
+                        var budget = 20_000
+                        var object: [String: Any] = ["ok": true, "tree": try encoded(snapshot(app, budget: &budget))]
+                        if let path = semanticSnapshotPath {
+                            object["semantic"] = try encoded(semanticNodes(path: path, pid: pid))
+                        }
+                        response(object)
+                    case "screenshot":
+                        guard let path = request["path"] as? String else { throw DriverError.message("screenshot requires path") }
+                        try captureWindow(pid: pid, path: path); response(["ok": true])
+                    case "focused":
+                        response(["ok": true, "focused": selected?.0.focused ?? false])
+                    case "selected":
+                        if let (element, _) = selected { response(["ok": true, "element": try encoded(element)]) }
+                        else { response(["ok": true, "element": NSNull()]) }
+                    case "record_start":
+                        guard let path = request["path"] as? String else { throw DriverError.message("record_start requires path") }
+                        let value = WindowRecorder(); try value.start(pid: pid, path: path); recorder = value; response(["ok": true])
+                    case "record_stop":
+                        if let value = recorder as? WindowRecorder { try await value.stop() }
+                        recorder = nil; response(["ok": true])
+                    case "shutdown": response(["ok": true]); return
+                    default: throw DriverError.message("unknown command: \(name)")
+                    }
+                } catch {
+                    response(["ok": false, "error": String(describing: error)])
+                }
+            }
+        } catch {
+            response(["ok": false, "error": String(describing: error)])
+            exit(1)
+        }
+    }
+}

--- a/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
+++ b/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
@@ -53,6 +53,56 @@ final class BuzzNativeDriverTests: XCTestCase {
     XCTAssertEqual(path.last, target)
   }
 
+  func testWebAreaRoleNormalizationSupportsAXSpelling() {
+    XCTAssertEqual(normalizedRole("AXWebArea"), "web-area")
+    XCTAssertEqual(normalizedRole("web area"), "web-area")
+  }
+
+  func testSemanticCoordinatesMapThroughWebContentFrame() throws {
+    let node = SemanticNode(
+      id: "target", role: "button", name: "Target", enabled: true, focused: false,
+      frame: Rect(x: 400, y: 300, width: 80, height: 40),
+      viewport: Size(width: 800, height: 600)
+    )
+    let transformed = try XCTUnwrap(transformSemanticNode(
+      node, contentBounds: CGRect(x: 100, y: 130, width: 800, height: 600)
+    ))
+    XCTAssertEqual(transformed.frame.x, 500)
+    XCTAssertEqual(transformed.frame.y, 430)
+    XCTAssertEqual(transformed.frame.width, 80)
+    XCTAssertEqual(transformed.frame.height, 40)
+  }
+
+  func testFinalizedRecordingRejectsZeroFramesAndEmptyArtifact() async throws {
+    do {
+      try await validateFinalizedRecording(appendedFrameCount: 0, destination: nil)
+      XCTFail("zero frames must be rejected")
+    } catch {
+      XCTAssertEqual(String(describing: error), "window recording contained no frames")
+    }
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".mp4")
+    FileManager.default.createFile(atPath: url.path, contents: Data())
+    defer { try? FileManager.default.removeItem(at: url) }
+    do {
+      try await validateFinalizedRecording(appendedFrameCount: 1, destination: url)
+      XCTFail("empty artifacts must be rejected")
+    } catch {
+      XCTAssertEqual(String(describing: error), "window recording is empty")
+    }
+    try Data([1]).write(to: url)
+    do {
+      try await validateFinalizedRecording(
+        appendedFrameCount: 1, destination: url, hasVideoTrack: { _ in false }
+      )
+      XCTFail("unreadable artifacts must be rejected")
+    } catch {
+      XCTAssertEqual(String(describing: error), "window recording has no readable video track")
+    }
+    try await validateFinalizedRecording(
+      appendedFrameCount: 1, destination: url, hasVideoTrack: { _ in true }
+    )
+  }
+
   func testRecorderLoopRoutesWriterReadinessThroughCaptureTick() throws {
     let source = try String(contentsOfFile: #filePath
       .replacingOccurrences(of: "/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift",

--- a/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
+++ b/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
@@ -1,0 +1,34 @@
+import AVFoundation
+import XCTest
+
+@testable import BuzzNativeDriver
+
+final class BuzzNativeDriverTests: XCTestCase {
+  func testGlobalInputFenceRejectsAnotherFrontmostProcess() {
+    XCTAssertThrowsError(try requireTargetIsFrontmost(pid: 42, frontmostPID: { 7 }))
+  }
+
+  func testGlobalInputFenceAcceptsTargetProcess() {
+    XCTAssertNoThrow(try requireTargetIsFrontmost(pid: 42, frontmostPID: { 42 }))
+  }
+
+  func testEveryGlobalEventRechecksFrontmostOwnership() throws {
+    var checks = [pid_t(42), pid_t(7)]
+    var posts = 0
+    let event = CGEvent(keyboardEventSource: nil, virtualKey: 48, keyDown: true)
+    try postGlobalEvent(event, pid: 42, frontmostPID: { checks.removeFirst() }) { _ in posts += 1 }
+    XCTAssertEqual(posts, 1)
+    XCTAssertThrowsError(
+      try postGlobalEvent(event, pid: 42, frontmostPID: { checks.removeFirst() }) { _ in posts += 1 }
+    )
+    XCTAssertEqual(posts, 1)
+  }
+
+  func testCaptureCadenceAdvancesAcrossBackpressureSkip() {
+    var cadence = CaptureCadence()
+    XCTAssertEqual(cadence.presentationTime, CMTime(value: 0, timescale: 15))
+    cadence.advance()  // frame skipped because writer was not ready
+    XCTAssertEqual(cadence.frame, 1)
+    XCTAssertEqual(cadence.presentationTime, CMTime(value: 1, timescale: 15))
+  }
+}

--- a/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
+++ b/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
@@ -24,11 +24,40 @@ final class BuzzNativeDriverTests: XCTestCase {
     XCTAssertEqual(posts, 1)
   }
 
-  func testCaptureCadenceAdvancesAcrossBackpressureSkip() {
+  func testPointerInputRequiresTargetWindowBounds() throws {
+    let event = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved,
+                        mouseCursorPosition: CGPoint(x: 25, y: 25), mouseButton: .left)
+    var posts = 0
+    try postGlobalPointerEvent(
+      event, at: CGPoint(x: 25, y: 25), pid: 42,
+      frontmostPID: { 42 }, targetBounds: { _ in CGRect(x: 0, y: 0, width: 50, height: 50) }
+    ) { _ in posts += 1 }
+    XCTAssertEqual(posts, 1)
+    XCTAssertThrowsError(
+      try postGlobalPointerEvent(
+        event, at: CGPoint(x: 75, y: 25), pid: 42,
+        frontmostPID: { 42 }, targetBounds: { _ in CGRect(x: 0, y: 0, width: 50, height: 50) }
+      ) { _ in posts += 1 }
+    )
+    XCTAssertEqual(posts, 1)
+  }
+
+  func testCaptureTickAdvancesAcrossBackpressureSkipThenUsesAdvancedPTS() {
     var cadence = CaptureCadence()
-    XCTAssertEqual(cadence.presentationTime, CMTime(value: 0, timescale: 15))
-    cadence.advance()  // frame skipped because writer was not ready
+    var appended = [CMTime]()
+
+    XCTAssertTrue(captureTick(cadence: &cadence, isReady: false) { time in
+      appended.append(time)
+      return true
+    })
     XCTAssertEqual(cadence.frame, 1)
-    XCTAssertEqual(cadence.presentationTime, CMTime(value: 1, timescale: 15))
+    XCTAssertTrue(appended.isEmpty)
+
+    XCTAssertTrue(captureTick(cadence: &cadence, isReady: true) { time in
+      appended.append(time)
+      return true
+    })
+    XCTAssertEqual(cadence.frame, 2)
+    XCTAssertEqual(appended, [CMTime(value: 1, timescale: 15)])
   }
 }

--- a/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
+++ b/tools/native-review/swift/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift
@@ -42,6 +42,24 @@ final class BuzzNativeDriverTests: XCTestCase {
     XCTAssertEqual(posts, 1)
   }
 
+  func testPointerPathStartsAndStaysInsideWindowWhenGlobalCursorIsOutside() {
+    let bounds = CGRect(x: 100, y: 100, width: 400, height: 300)
+    let target = CGPoint(x: 300, y: 250)
+    let path = pointerPath(
+      from: CGPoint(x: -500, y: -500), to: target, within: bounds, steps: 10
+    )
+    XCTAssertEqual(path.count, 10)
+    XCTAssertTrue(path.allSatisfy(bounds.contains))
+    XCTAssertEqual(path.last, target)
+  }
+
+  func testRecorderLoopRoutesWriterReadinessThroughCaptureTick() throws {
+    let source = try String(contentsOfFile: #filePath
+      .replacingOccurrences(of: "/Tests/BuzzNativeDriverTests/BuzzNativeDriverTests.swift",
+                            with: "/Sources/BuzzNativeDriver/main.swift"))
+    XCTAssertTrue(source.contains("isReady: writerInput.isReadyForMoreMediaData"))
+  }
+
   func testCaptureTickAdvancesAcrossBackpressureSkipThenUsesAdvancedPTS() {
     var cadence = CaptureCadence()
     var appended = [CMTime]()

--- a/tools/native-review/tests/fixtures/broken-tooltip.yaml
+++ b/tools/native-review/tests/fixtures/broken-tooltip.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+flow: broken_tooltip
+platforms: [macos]
+fixture: local_review_channel
+record: {video: "off", screenshots: true, accessibility: true}
+steps:
+  - name: impossible_locator
+    locate: [{id: this-element-must-not-exist}]
+    act: {type: click}
+    expect:
+      exists: {id: still-impossible}
+    timeout_ms: 50
+cleanup: {terminate_app: true, remove_state: true}

--- a/tools/native-review/tests/test_review_native.py
+++ b/tools/native-review/tests/test_review_native.py
@@ -361,10 +361,16 @@ class JourneyTests(unittest.TestCase):
                     driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)
 
     def test_lower_bound_samples_observation_after_driver_query(self):
+        clock = {"now": 640_000_000}
         driver = mock.Mock()
         expectation = {"exists": {"id": "tooltip"}}
-        driver.request.return_value = {"ok": True, "element": {"locator": {"id": "tooltip"}}}
-        with mock.patch.object(review_native.time, "monotonic_ns", return_value=660_000_000):
+
+        def complete_query(*_args, **_kwargs):
+            clock["now"] = 660_000_000
+            return {"ok": True, "element": {"locator": {"id": "tooltip"}}}
+
+        driver.request.side_effect = complete_query
+        with mock.patch.object(review_native.time, "monotonic_ns", side_effect=lambda: clock["now"]):
             with self.assertRaisesRegex(review_native.HarnessError, "not met within 650ms"):
                 review_native.wait_expectation_not_before(
                     driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)

--- a/tools/native-review/tests/test_review_native.py
+++ b/tools/native-review/tests/test_review_native.py
@@ -1,0 +1,250 @@
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from unittest import mock
+
+MODULE_PATH = pathlib.Path(__file__).parents[1] / "review_native.py"
+SPEC = importlib.util.spec_from_file_location("review_native", MODULE_PATH)
+review_native = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(review_native)
+
+
+class JourneyTests(unittest.TestCase):
+    def test_real_journey_validates(self):
+        journey = review_native.load_journey(MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml")
+        self.assertEqual(journey["flow"], "tooltip_fresh_dwell")
+
+    def test_broken_mutation_is_schema_valid(self):
+        journey = review_native.load_journey(MODULE_PATH.parent / "tests/fixtures/broken-tooltip.yaml")
+        self.assertEqual(journey["steps"][0]["timeout_ms"], 50)
+
+    def test_action_without_postcondition_is_rejected(self):
+        source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
+        source = source.replace("    expect:\n      exists: {role: window}\n", "", 1)
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "invalid.yaml"
+            path.write_text(source)
+            with self.assertRaisesRegex(review_native.HarnessError, "requires name/act/expect"):
+                review_native.load_journey(path)
+
+    def test_expectation_with_multiple_conditions_is_rejected(self):
+        source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
+        source = source.replace(
+            "    expect:\n      exists: {role: window}\n",
+            "    expect:\n      exists: {role: window}\n      enabled: true\n",
+            1,
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "invalid.yaml"
+            path.write_text(source)
+            with self.assertRaisesRegex(review_native.HarnessError, "exactly one"):
+                review_native.load_journey(path)
+
+    def test_production_and_remote_targets_are_rejected(self):
+        with self.assertRaisesRegex(review_native.HarnessError, "non-loopback"):
+            review_native.isolation_manifest("run", "wss://buzz.block.builderlab.xyz")
+        safe = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+        self.assertTrue(safe["bundle_id"].startswith("xyz.block.buzz.app.dev.native-review."))
+        self.assertNotIn(safe["bundle_id"], review_native.PRODUCTION_BUNDLE_IDS)
+
+    def test_secret_environment_is_scrubbed(self):
+        sentinels = {
+            "BUZZ_PRIVATE_KEY": "must-not-survive",
+            "SSH_AUTH_SOCK": "/tmp/credential-agent",
+            "GITHUB_TOKEN": "github-secret",
+            "AWS_SECRET_ACCESS_KEY": "cloud-secret",
+        }
+        with mock.patch.dict(review_native.os.environ, sentinels, clear=False):
+            environment = review_native.scrubbed_environment()
+        for name in sentinels:
+            self.assertNotIn(name, environment)
+
+    def test_fixture_environment_is_fixed_local_and_scrubbed(self):
+        sentinels = {"BUZZ_DB_HOST": "production-db", "BUZZ_DB_PASS": "production-secret",
+                     "SSH_AUTH_SOCK": "/tmp/credential-agent"}
+        isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+        with mock.patch.dict(review_native.os.environ, sentinels, clear=False):
+            environment = review_native.fixture_environment(isolation, "a" * 64)
+        self.assertEqual(environment["BUZZ_DB_HOST"], "localhost")
+        self.assertEqual(environment["BUZZ_DB_PORT"], "5471")
+        self.assertEqual(environment["BUZZ_DB_PASS"], "buzz_dev")
+        self.assertNotIn("SSH_AUTH_SOCK", environment)
+        with self.assertRaisesRegex(review_native.HarnessError, "port 3030"):
+            review_native.fixture_environment(
+                review_native.isolation_manifest("run", "ws://127.0.0.1:3001"), "a" * 64)
+
+    def test_fixture_seed_failure_removes_generated_identity(self):
+        generated = mock.Mock(stdout=f"Secret key: {'1' * 64}\nPublic key: {'2' * 64}\n")
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = pathlib.Path(directory)
+            (run_dir / "manifest").mkdir()
+            isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+            with mock.patch.object(review_native, "run", side_effect=[generated, RuntimeError("seed failed")]):
+                with self.assertRaisesRegex(RuntimeError, "seed failed"):
+                    review_native.prepare_fixture(run_dir, isolation)
+            self.assertFalse((run_dir / "state/identity.key").exists())
+
+    def test_run_scrubs_repository_controlled_commands_by_default(self):
+        safe = {"PATH": "/usr/bin", "HOME": "/tmp/home"}
+        with mock.patch.object(review_native, "scrubbed_environment", return_value=safe), \
+             mock.patch.object(review_native.subprocess, "run", return_value=mock.Mock()) as subprocess_run:
+            review_native.run(["/tmp/repository-tool"])
+        self.assertEqual(subprocess_run.call_args.kwargs["env"], safe)
+
+    def test_cleanup_uses_isolated_home_without_host_credentials(self):
+        sentinels = {"BUZZ_PRIVATE_KEY": "secret", "SSH_AUTH_SOCK": "/tmp/agent",
+                     "GITHUB_TOKEN": "secret", "AWS_SECRET_ACCESS_KEY": "secret"}
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = pathlib.Path(directory)
+            isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+            with mock.patch.dict(review_native.os.environ, sentinels, clear=False), \
+                 mock.patch.object(review_native, "run") as run:
+                review_native.cleanup_review_state(run_dir, isolation, None)
+        environment = run.call_args.kwargs["env"]
+        self.assertEqual(environment["HOME"], str(run_dir / "home"))
+        for name in sentinels:
+            self.assertNotIn(name, environment)
+
+    def test_cleanup_removes_identity_when_state_reset_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = pathlib.Path(directory)
+            secret_path = run_dir / "state/identity.key"
+            secret_path.parent.mkdir()
+            secret_path.write_text("review-secret")
+            isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+            fixture = {"secret_path": str(secret_path)}
+            with mock.patch.object(review_native, "run", side_effect=RuntimeError("reset failed")):
+                with self.assertRaisesRegex(
+                        review_native.HarnessError,
+                        "desktop state reset failed: reset failed"):
+                    review_native.cleanup_review_state(run_dir, isolation, fixture)
+            self.assertFalse(secret_path.exists())
+
+    def test_cleanup_aggregates_reset_and_identity_removal_failures(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = pathlib.Path(directory)
+            secret_path = run_dir / "state/identity.key"
+            isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+            fixture = {"secret_path": str(secret_path)}
+            with mock.patch.object(review_native, "run", side_effect=RuntimeError("reset failed")), \
+                 mock.patch.object(pathlib.Path, "unlink", side_effect=OSError("unlink failed")):
+                with self.assertRaisesRegex(
+                        review_native.HarnessError,
+                        "desktop state reset failed: reset failed; "
+                        "review identity removal failed: unlink failed"):
+                    review_native.cleanup_review_state(run_dir, isolation, fixture)
+
+    def test_repository_controlled_subprocesses_receive_scrubbed_environments(self):
+        safe = {"PATH": "/usr/bin", "HOME": "/tmp/home"}
+        with mock.patch.object(review_native, "scrubbed_environment", return_value=safe), \
+             mock.patch.object(review_native.subprocess, "Popen") as popen:
+            review_native.Driver(pathlib.Path("/tmp/driver"), 42, pathlib.Path("/tmp/snapshot"))
+        self.assertEqual(popen.call_args.kwargs["env"], safe)
+
+    def test_visible_window_waits_for_reveal(self):
+        driver = mock.Mock()
+        driver.request.side_effect = [
+            {"ok": True, "visible": False, "detail": "not yet"},
+            {"ok": True, "visible": True, "window_id": 42},
+        ]
+        process = mock.Mock()
+        process.poll.return_value = None
+        with mock.patch.object(review_native.time, "sleep"):
+            status = review_native.wait_for_visible_window(driver, process, timeout_seconds=1)
+        self.assertEqual(status["window_id"], 42)
+        self.assertEqual(driver.request.call_count, 2)
+
+    def test_locate_required_retries_until_target_materializes(self):
+        driver = mock.Mock()
+        driver.request.side_effect = [
+            {"ok": True, "element": None},
+            {"ok": True, "element": {"locator": {"id": "target"}}},
+        ]
+        with mock.patch.object(review_native.time, "sleep"):
+            found = review_native.locate_required(driver, [{"id": "target"}], 1000)
+        self.assertEqual(found["locator"]["id"], "target")
+        self.assertEqual(driver.request.call_count, 2)
+
+    def test_visible_window_fails_if_app_exits(self):
+        driver = mock.Mock()
+        process = mock.Mock()
+        process.poll.return_value = 1
+        with self.assertRaisesRegex(review_native.HarnessError, "exited"):
+            review_native.wait_for_visible_window(driver, process, timeout_seconds=1)
+        driver.request.assert_not_called()
+    def test_strict_action_duration_and_metric_validation(self):
+        source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
+        mutations = [
+            ("act: {type: activate}", "act: {type: activate, key: tab}", "unsupported type or fields"),
+            ("duration_ms: 100}", "duration_ms: true}", "duration_ms must be"),
+            ("measure: tooltip_open_latency", "measure: Invalid Metric", "lowercase metric"),
+            ("measure: tooltip_open_latency", "measure: tooltip_open_latency\n    timeout_ms: true", "timeout_ms"),
+        ]
+        for old, new, error in mutations:
+            with self.subTest(new=new), tempfile.TemporaryDirectory() as directory:
+                path = pathlib.Path(directory) / "invalid.yaml"
+                path.write_text(source.replace(old, new, 1))
+                with self.assertRaisesRegex(review_native.HarnessError, error):
+                    review_native.load_journey(path)
+
+    def test_duplicate_metric_is_rejected(self):
+        source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
+        source = source.replace(
+            "    timeout_ms: 15000\n  - name: settle_pointer_before_fresh_dwell",
+            "    timeout_ms: 15000\n    measure: tooltip_open_latency\n  - name: settle_pointer_before_fresh_dwell",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "invalid.yaml"
+            path.write_text(source)
+            with self.assertRaisesRegex(review_native.HarnessError, "duplicates"):
+                review_native.load_journey(path)
+
+    def test_relay_and_pubkey_validation_fail_closed(self):
+        for relay in (
+            "ws://127.0.0.1",
+            "ws://user@127.0.0.1:3030",
+            "ws://127.0.0.1:3030/path",
+            "ws://127.0.0.1:3030?query",
+            "ws://127.0.0.1:99999",
+        ):
+            with self.subTest(relay=relay), self.assertRaises(review_native.HarnessError):
+                review_native.isolation_manifest("run", relay)
+        isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+        with self.assertRaisesRegex(review_native.HarnessError, "pubkey"):
+            review_native.fixture_environment(isolation, "not-a-pubkey")
+
+    def test_semantic_probe_requires_token_and_caps_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "semantic.json"
+            server, url = review_native.semantic_probe_server(path)
+            try:
+                request = urllib.request.Request(url, data=b"[]", method="POST")
+                with urllib.request.urlopen(request) as response:
+                    self.assertEqual(response.status, 204)
+                self.assertEqual(json.loads(path.read_text()), [])
+                wrong = urllib.request.Request(
+                    url.rsplit("/", 1)[0] + "/" + "0" * 64, data=b"[]", method="POST")
+                with self.assertRaisesRegex(urllib.error.HTTPError, "404"):
+                    urllib.request.urlopen(wrong)
+                oversized = urllib.request.Request(
+                    url, data=b"[]", method="POST",
+                    headers={"Content-Length": str(review_native.MAX_PROBE_BYTES + 1)})
+                with self.assertRaisesRegex(urllib.error.HTTPError, "413"):
+                    urllib.request.urlopen(oversized)
+            finally:
+                server.shutdown()
+                server.server_close()
+
+    def test_measurement_receipt_shape_is_durable(self):
+        duration_ms = 12.5
+        receipt = {"measurements": {"tooltip_open_latency": {"value": duration_ms, "unit": "ms"}}}
+        self.assertEqual(json.loads(json.dumps(receipt))["measurements"]["tooltip_open_latency"]["value"], duration_ms)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/native-review/tests/test_review_native.py
+++ b/tools/native-review/tests/test_review_native.py
@@ -245,6 +245,45 @@ class JourneyTests(unittest.TestCase):
                 server.server_close()
 
 
+    def test_launch_timeout_preserves_process_for_confirmed_cleanup(self):
+        process = mock.Mock(pid=42)
+        process.poll.return_value = None
+        process.wait.side_effect = [review_native.subprocess.TimeoutExpired("app", 15), 0]
+        with tempfile.TemporaryDirectory() as directory, \
+             mock.patch.object(review_native.time, "monotonic", side_effect=[0, 0, 1]), \
+             mock.patch.object(review_native.time, "sleep"), \
+             mock.patch.object(review_native, "run", return_value=mock.Mock(stdout="not-buzz")), \
+             mock.patch.object(review_native, "cleanup_review_state") as reset:
+            with self.assertRaisesRegex(review_native.HarnessError, "timed out"):
+                review_native.wait_for_native_process(process, pathlib.Path(directory), timeout_seconds=0.5)
+            errors = review_native.cleanup_process_and_state(
+                process, pathlib.Path(directory), {}, None)
+        self.assertEqual(errors, ["Tauri launcher required SIGKILL"])
+        self.assertEqual(
+            [call[0] for call in process.method_calls],
+            ["poll", "terminate", "wait", "kill", "wait"],
+        )
+        reset.assert_called_once()
+
+    def test_launch_timeout_preserves_state_when_exit_cannot_be_confirmed(self):
+        process = mock.Mock(pid=42)
+        process.poll.return_value = None
+        process.wait.side_effect = [
+            review_native.subprocess.TimeoutExpired("app", 15),
+            review_native.subprocess.TimeoutExpired("app", 5),
+        ]
+        with tempfile.TemporaryDirectory() as directory, \
+             mock.patch.object(review_native.time, "monotonic", side_effect=[0, 0, 1]), \
+             mock.patch.object(review_native.time, "sleep"), \
+             mock.patch.object(review_native, "run", return_value=mock.Mock(stdout="not-buzz")), \
+             mock.patch.object(review_native, "cleanup_review_state") as reset:
+            with self.assertRaisesRegex(review_native.HarnessError, "timed out"):
+                review_native.wait_for_native_process(process, pathlib.Path(directory), timeout_seconds=0.5)
+            errors = review_native.cleanup_process_and_state(
+                process, pathlib.Path(directory), {}, None)
+        self.assertEqual(errors, ["Tauri launcher did not exit after SIGKILL; isolated state was preserved"])
+        reset.assert_not_called()
+
     def test_forced_termination_is_reaped_before_cleanup(self):
         process = mock.Mock()
         process.wait.side_effect = [review_native.subprocess.TimeoutExpired("app", 15), 0]
@@ -318,6 +357,15 @@ class JourneyTests(unittest.TestCase):
         driver.request.return_value = {"ok": True, "element": None}
         with mock.patch.object(review_native.time, "monotonic_ns", return_value=650_000_000):
             with self.assertRaisesRegex(review_native.HarnessError, "not met"):
+                review_native.wait_expectation_not_before(
+                    driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)
+
+    def test_lower_bound_samples_observation_after_driver_query(self):
+        driver = mock.Mock()
+        expectation = {"exists": {"id": "tooltip"}}
+        driver.request.return_value = {"ok": True, "element": {"locator": {"id": "tooltip"}}}
+        with mock.patch.object(review_native.time, "monotonic_ns", return_value=660_000_000):
+            with self.assertRaisesRegex(review_native.HarnessError, "not met within 650ms"):
                 review_native.wait_expectation_not_before(
                     driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)
 

--- a/tools/native-review/tests/test_review_native.py
+++ b/tools/native-review/tests/test_review_native.py
@@ -78,15 +78,38 @@ class JourneyTests(unittest.TestCase):
             review_native.fixture_environment(
                 review_native.isolation_manifest("run", "ws://127.0.0.1:3001"), "a" * 64)
 
+    def test_fixture_environment_uses_cleanup_mode_without_seed_variable(self):
+        isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+        environment = review_native.fixture_environment(isolation, "a" * 64, cleanup=True)
+        self.assertEqual(environment["BUZZ_REVIEW_CLEANUP_PUBKEY"], "a" * 64)
+        self.assertNotIn("BUZZ_REVIEW_PUBKEY", environment)
+
+    def test_cleanup_attempts_database_principal_and_secret_removal_after_reset_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = pathlib.Path(directory)
+            secret_path = run_dir / "state/identity.key"
+            secret_path.parent.mkdir()
+            secret_path.write_text("review-secret")
+            isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
+            fixture = {"secret_path": str(secret_path), "identity_pubkey": "a" * 64}
+            with mock.patch.object(review_native, "run", side_effect=[RuntimeError("reset failed"), mock.Mock()]) as run:
+                with self.assertRaisesRegex(review_native.HarnessError, "desktop state reset failed"):
+                    review_native.cleanup_review_state(run_dir, isolation, fixture)
+            cleanup_env = run.call_args_list[1].kwargs["env"]
+            self.assertEqual(cleanup_env["BUZZ_REVIEW_CLEANUP_PUBKEY"], "a" * 64)
+            self.assertFalse(secret_path.exists())
+
     def test_fixture_seed_failure_removes_generated_identity(self):
         generated = mock.Mock(stdout=f"Secret key: {'1' * 64}\nPublic key: {'2' * 64}\n")
         with tempfile.TemporaryDirectory() as directory:
             run_dir = pathlib.Path(directory)
             (run_dir / "manifest").mkdir()
             isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
-            with mock.patch.object(review_native, "run", side_effect=[generated, RuntimeError("seed failed")]):
-                with self.assertRaisesRegex(RuntimeError, "seed failed"):
+            with mock.patch.object(review_native, "run", side_effect=[mock.Mock(), generated, RuntimeError("seed failed"), mock.Mock()]) as run:
+                with self.assertRaisesRegex(review_native.HarnessError, "fixture seed failed: seed failed"):
                     review_native.prepare_fixture(run_dir, isolation)
+            self.assertEqual(run.call_count, 4)
+            self.assertEqual(run.call_args_list[3].kwargs["env"]["BUZZ_REVIEW_CLEANUP_PUBKEY"], "2" * 64)
             self.assertFalse((run_dir / "state/identity.key").exists())
 
     def test_run_scrubs_repository_controlled_commands_by_default(self):
@@ -117,8 +140,8 @@ class JourneyTests(unittest.TestCase):
             secret_path.parent.mkdir()
             secret_path.write_text("review-secret")
             isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
-            fixture = {"secret_path": str(secret_path)}
-            with mock.patch.object(review_native, "run", side_effect=RuntimeError("reset failed")):
+            fixture = {"secret_path": str(secret_path), "identity_pubkey": "a" * 64}
+            with mock.patch.object(review_native, "run", side_effect=[RuntimeError("reset failed"), mock.Mock()]):
                 with self.assertRaisesRegex(
                         review_native.HarnessError,
                         "desktop state reset failed: reset failed"):
@@ -130,8 +153,8 @@ class JourneyTests(unittest.TestCase):
             run_dir = pathlib.Path(directory)
             secret_path = run_dir / "state/identity.key"
             isolation = review_native.isolation_manifest("run", "ws://127.0.0.1:3030")
-            fixture = {"secret_path": str(secret_path)}
-            with mock.patch.object(review_native, "run", side_effect=RuntimeError("reset failed")), \
+            fixture = {"secret_path": str(secret_path), "identity_pubkey": "a" * 64}
+            with mock.patch.object(review_native, "run", side_effect=[RuntimeError("reset failed"), mock.Mock()]), \
                  mock.patch.object(pathlib.Path, "unlink", side_effect=OSError("unlink failed")):
                 with self.assertRaisesRegex(
                         review_native.HarnessError,
@@ -383,6 +406,10 @@ class JourneyTests(unittest.TestCase):
             observed = review_native.wait_expectation_not_before(
                 driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)
         self.assertEqual(observed, 500_000_000)
+
+    def test_failed_observation_does_not_produce_measurement(self):
+        self.assertIsNone(review_native.valid_measurement(100_000_000, None))
+        self.assertEqual(review_native.valid_measurement(100_000_000, 350_000_000), 250)
 
     def test_measurement_receipt_shape_is_durable(self):
         duration_ms = 12.5

--- a/tools/native-review/tests/test_review_native.py
+++ b/tools/native-review/tests/test_review_native.py
@@ -195,8 +195,12 @@ class JourneyTests(unittest.TestCase):
     def test_duplicate_metric_is_rejected(self):
         source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
         source = source.replace(
-            "    timeout_ms: 15000\n  - name: settle_pointer_before_fresh_dwell",
-            "    timeout_ms: 15000\n    measure: tooltip_open_latency\n  - name: settle_pointer_before_fresh_dwell",
+            "    measure: tooltip_open_latency\n  - name: leave_trigger",
+            "    measure: tooltip_open_latency\n  - name: duplicate_measurement\n"
+            "    act: {type: wait, duration_ms: 0}\n"
+            "    expect:\n      exists: {role: tooltip, name: \"Mention someone\"}\n"
+            "    expect_not_before_ms: 400\n    measure: tooltip_open_latency\n"
+            "  - name: leave_trigger",
         )
         with tempfile.TemporaryDirectory() as directory:
             path = pathlib.Path(directory) / "invalid.yaml"
@@ -239,6 +243,92 @@ class JourneyTests(unittest.TestCase):
             finally:
                 server.shutdown()
                 server.server_close()
+
+
+    def test_forced_termination_is_reaped_before_cleanup(self):
+        process = mock.Mock()
+        process.wait.side_effect = [review_native.subprocess.TimeoutExpired("app", 15), 0]
+        errors, exited = review_native.terminate_process(process)
+        self.assertTrue(exited)
+        self.assertEqual(errors, ["Tauri launcher required SIGKILL"])
+        self.assertEqual(
+            [call[0] for call in process.method_calls],
+            ["terminate", "wait", "kill", "wait"],
+        )
+
+    def test_unconfirmed_exit_preserves_isolated_state(self):
+        process = mock.Mock()
+        process.wait.side_effect = [
+            review_native.subprocess.TimeoutExpired("app", 15),
+            review_native.subprocess.TimeoutExpired("app", 5),
+        ]
+        with mock.patch.object(review_native, "cleanup_review_state") as cleanup:
+            errors = review_native.cleanup_process_and_state(
+                process, pathlib.Path("/tmp/run"), {}, None)
+        cleanup.assert_not_called()
+        self.assertEqual(
+            errors,
+            ["Tauri launcher did not exit after SIGKILL; isolated state was preserved"],
+        )
+        self.assertEqual(
+            [call[0] for call in process.method_calls],
+            ["terminate", "wait", "kill", "wait"],
+        )
+
+    def test_cleanup_cannot_be_disabled(self):
+        source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
+        source = source.replace("terminate_app: true", "terminate_app: false")
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "invalid.yaml"
+            path.write_text(source)
+            with self.assertRaisesRegex(review_native.HarnessError, "cleanup is mandatory"):
+                review_native.load_journey(path)
+
+    def test_lower_bound_requires_measurement(self):
+        source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
+        source = source.replace("    measure: tooltip_open_latency\n", "", 1)
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "invalid.yaml"
+            path.write_text(source)
+            with self.assertRaisesRegex(review_native.HarnessError, "requires measure"):
+                review_native.load_journey(path)
+
+    def test_measurement_requires_causal_start_and_lower_bound(self):
+        source = (MODULE_PATH.parent / "desktop/tooltip-fresh-dwell.yaml").read_text()
+        mutations = [
+            ("    measure_start: tooltip_open_latency\n", "", "earlier measure_start"),
+            ("    expect_not_before_ms: 400\n", "", "requires expect_not_before_ms"),
+        ]
+        for old, new, error in mutations:
+            with self.subTest(error=error), tempfile.TemporaryDirectory() as directory:
+                path = pathlib.Path(directory) / "invalid.yaml"
+                path.write_text(source.replace(old, new, 1))
+                with self.assertRaisesRegex(review_native.HarnessError, error):
+                    review_native.load_journey(path)
+
+    def test_lower_bound_rejects_early_and_late_postconditions(self):
+        driver = mock.Mock()
+        expectation = {"exists": {"id": "tooltip"}}
+        driver.request.return_value = {"ok": True, "element": {"locator": {"id": "tooltip"}}}
+        with mock.patch.object(review_native.time, "monotonic_ns", return_value=100_000_000):
+            with self.assertRaisesRegex(review_native.HarnessError, "before 400ms"):
+                review_native.wait_expectation_not_before(
+                    driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)
+
+        driver.request.return_value = {"ok": True, "element": None}
+        with mock.patch.object(review_native.time, "monotonic_ns", return_value=650_000_000):
+            with self.assertRaisesRegex(review_native.HarnessError, "not met"):
+                review_native.wait_expectation_not_before(
+                    driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)
+
+    def test_lower_bound_records_first_valid_observation(self):
+        driver = mock.Mock()
+        expectation = {"exists": {"id": "tooltip"}}
+        driver.request.return_value = {"ok": True, "element": {"locator": {"id": "tooltip"}}}
+        with mock.patch.object(review_native.time, "monotonic_ns", return_value=500_000_000):
+            observed = review_native.wait_expectation_not_before(
+                driver, expectation, start_ns=0, lower_bound_ms=400, timeout_ms=250)
+        self.assertEqual(observed, 500_000_000)
 
     def test_measurement_receipt_shape_is_durable(self):
         duration_ms = 12.5

--- a/tools/native-review/uv.lock
+++ b/tools/native-review/uv.lock
@@ -1,0 +1,49 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "buzz-native-review"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = "==6.0.2" }]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/simple" }
+sdist = { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e" }
+wheels = [
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183" },
+    { url = "https://global.block-artifacts.com/artifactory/api/pypi/block-pypi/packages/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563" },
+]


### PR DESCRIPTION
## Summary

- add a declarative macOS native-review journey runner for the real Tauri/WKWebView app
- drive pointer and keyboard input through CGEvent while using a debug-only semantic probe for reliable perception
- record window-only MP4s and write exact-SHA receipts, screenshots, AX diagnostics, and cleanup evidence
- isolate bundle ID, keyring, HOME, app/WebKit state, fixture identity, and relay access; reject non-loopback relays
- add a seeded tooltip-dwell journey and deliberate fail-loud mutation fixture

## Why this is separate from Playwright

This exercises native launch/packaging, WKWebView behavior, macOS input delivery, window capture, timing-sensitive hover behavior, and cleanup boundaries that browser E2E does not establish.

## Validation

At clean HEAD `8b3450af0ef952f5a0b5b8e593f29deb523e5d87`:

- pre-push hooks passed: branch skew, Desktop check/typecheck/test, Rust tests, and Tauri checks
- native harness Python suite: 9/9
- doctor: Accessibility and Screen Recording granted; Swift driver builds
- happy native journey passed three consecutive times with finalized MP4s and cleanup
- deliberate broken locator failed loudly with screenshot and AX diagnostics
- journey schemas and `git diff --check` passed

Representative local receipts:

- `test-results/native-review/8b3450af0ef9/tooltip_fresh_dwell/tooltip_fresh_dwell-20260815T074527-b4904c/receipt.json`
- `test-results/native-review/8b3450af0ef9/broken_tooltip/broken_tooltip-20260815T074613-529821/receipt.json`

## Scope

This is the macOS Desktop MVP. Follow-up stacks will add broader journeys, base/head performance comparison and budgets, iOS Simulator driving/recording, and teammate-grade setup documentation.
