### PR TITLE
feat(projects): read public GitHub remotes in the project Code tab

### DIFF
--- a/desktop/src-tauri/src/commands/project_git.rs
+++ b/desktop/src-tauri/src/commands/project_git.rs
@@ -1,6 +1,6 @@
 use super::project_git_exec::{
-    build_git_auth_config, clean_branch, clean_target_ref, run_git, validate_workspace_clone_url,
-    GitAuthConfig,
+    build_git_auth_config, clean_branch, clean_target_ref, run_git, validate_local_clone_url,
+    validate_workspace_clone_url, GitAuthConfig,
 };
 use super::project_git_file_content::{checkout_project_repo, read_preview_content};
 use super::project_git_push::push_project_local_repository_blocking;
@@ -626,7 +626,12 @@ pub async fn get_project_repo_snapshot(
     target_commit: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoSnapshotInfo, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
+    // Public GitHub is a first-class *read* remote. Buzz-hosted git still
+    // has to live on this workspace's relay.
+    validate_local_clone_url(&clone_url)?;
+    if !clone_url.to_ascii_lowercase().contains("://github.com/") {
+        validate_workspace_clone_url(&clone_url, &state)?;
+    }
     let auth = build_git_auth_config(&state)?;
     let branch = clean_branch(default_branch);
     let base_branch = clean_branch(base_branch);

--- a/desktop/src/features/projects/lib/projectGitDataState.test.mjs
+++ b/desktop/src/features/projects/lib/projectGitDataState.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { projectGitDataState } from "./projectGitDataState.ts";
+
+test("github remotes with a snapshot are available, not blocked", () => {
+  assert.equal(
+    projectGitDataState({
+      error: null,
+      fileCount: 3,
+      hasSnapshot: true,
+      loading: false,
+    }),
+    "available",
+  );
+});
+
+test("loading wins over a missing snapshot", () => {
+  assert.equal(
+    projectGitDataState({
+      error: null,
+      fileCount: 0,
+      hasSnapshot: false,
+      loading: true,
+    }),
+    "checking",
+  );
+});
+
+test("empty trees stay empty", () => {
+  assert.equal(
+    projectGitDataState({
+      error: null,
+      fileCount: 0,
+      hasSnapshot: true,
+      loading: false,
+    }),
+    "empty",
+  );
+});
+
+test("errors and missing snapshots stay unavailable", () => {
+  assert.equal(
+    projectGitDataState({
+      error: new Error("401"),
+      fileCount: 0,
+      hasSnapshot: false,
+      loading: false,
+    }),
+    "unavailable",
+  );
+});

--- a/desktop/src/features/projects/lib/projectGitDataState.ts
+++ b/desktop/src/features/projects/lib/projectGitDataState.ts
@@ -1,0 +1,29 @@
+export type ProjectGitDataState =
+  | "checking"
+  | "available"
+  | "empty"
+  | "unavailable";
+
+/**
+ * Whether the Code tab can show a tree/README for the selected source.
+ *
+ * GitHub remotes are first-class for *reading* (public clone). They used to
+ * force `unavailable` so the UI asked people to "clone locally" even when
+ * Buzz can snapshot the same URL. Local checkout is still the edit surface.
+ */
+export function projectGitDataState({
+  error,
+  fileCount,
+  hasSnapshot,
+  loading,
+}: {
+  error: unknown;
+  fileCount: number;
+  hasSnapshot: boolean;
+  loading: boolean;
+}): ProjectGitDataState {
+  if (loading) return "checking";
+  if (error || !hasSnapshot) return "unavailable";
+  if (fileCount === 0) return "empty";
+  return "available";
+}

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -219,7 +219,10 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
     activeBranch,
     activeRepoPullRequest,
     activeTag,
-    isBuzzHost: repoRemote.host.kind === "buzz",
+    isBuzzHost:
+      repoRemote.host.kind === "buzz" ||
+      (repoRemote.host.kind === "external" &&
+        repoRemote.host.host === "github.com"),
     repository,
     reposDir: activeCommunity?.reposDir,
     repoSource,

--- a/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
@@ -42,10 +42,8 @@ import { ProjectCommitDetailPanel } from "./ProjectCommitDetailPanel";
 import { ActivityPanel, ContributorsPanel } from "./ProjectDetailFeedPanels";
 import { ProjectIssuesPanel } from "./ProjectIssuesPanel";
 import type { OpenMergeRecoveryTerminal } from "./MergePullRequestButton";
-import {
-  type GitDataState,
-  ProjectOverviewPanel,
-} from "./ProjectOverviewPanel";
+import { projectGitDataState } from "@/features/projects/lib/projectGitDataState";
+import { ProjectOverviewPanel } from "./ProjectOverviewPanel";
 import { PullRequestsPanel } from "./ProjectPullRequestsPanel";
 import { ProjectTabsList } from "./ProjectWorkspaceTabList";
 import { ProjectPullRequestFilesChangedPanel } from "./ProjectPullRequestFilesChangedPanel";
@@ -214,13 +212,12 @@ export function WorkspaceTabs({
     repoSource === "remote" && repoHost.kind === "external"
       ? repoHost.host
       : undefined;
-  const gitDataState: GitDataState = displayedSnapshot
-    ? files.length === 0
-      ? "empty"
-      : "available"
-    : displayedSnapshotLoading
-      ? "checking"
-      : "unavailable";
+  const gitDataState = projectGitDataState({
+    error: displayedSnapshotError,
+    fileCount: files.length,
+    hasSnapshot: Boolean(displayedSnapshot),
+    loading: displayedSnapshotLoading,
+  });
   const unavailableReason =
     gitDataState === "unavailable" && !externalHost
       ? repoSource === "remote"
@@ -591,8 +588,8 @@ export function WorkspaceTabs({
                 profiles={profiles}
                 snapshot={displayedSnapshot}
                 unavailableMessage={
-                  externalHost
-                    ? `Not mirrored on Buzz. Repository files are hosted on ${externalHost}.`
+                  gitDataState === "unavailable" && externalHost
+                    ? `Could not read ${externalHost} yet. Clone locally to browse offline, or retry if the remote is public.`
                     : undefined
                 }
               />


### PR DESCRIPTION
## Summary

Public `github.com` clone URLs are a first-class **read** remote for a project's Files, README, and commits. Desktop no longer treats an external GitHub host as "repository not found on the Buzz relay."

This is the usual setup for people who only have a Desktop client and a company-hosted community they cannot operate: the project announcement already points at GitHub; they should be able to browse that tree without SSH to the host or a relay-side git mirror.

Local checkout stays the edit surface. This PR does not add GitHub PR rows, publish/copy, or a two-way mirror.

### Related issue
Fixes #5726 (`Not showing clone/web host as the remote even when present`).

Follow-ups (not in this PR):
- GitHub open-PR rows in the project PRs tab
- Optional one-way publish/copy of a local tree onto the relay
- Local-first project create

### Testing
- Desktop JS: `projectGitDataState` — GitHub remotes are `available` when a snapshot loads; missing/error snapshots stay `unavailable`
- Desktop unit suite on this worktree: 4962 passed, 0 failed
- Manual: project with a public `github.com` clone URL → Code tab Remote shows Files / README / commits instead of "Repository not initialized"
- Manual: non-GitHub / Buzz-hosted clone URLs still require this workspace's relay (`validate_workspace_clone_url`)
- No UI screenshot in this body yet; I can add a Files-tab capture with `scripts/post-screenshots.sh` if wanted