### PR TITLE
fix(dev-mcp): sweep orphaned temp dirs left by killed processes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -429,9 +429,9 @@ test-unit:
         # tests remain excluded and run in their dedicated integration lanes.
         cargo nextest run -p buzz-acp --lib
         # buzz-dev-mcp: the temp-dir orphan sweep (#6025) decides whether to
-        # delete a directory based on process liveness and an inherited file
-        # lock, and both of those are Unix primitives with Windows analogues
-        # rather than shared code. Only the Windows CI job ran this crate's
+        # delete a directory from process-group liveness and a file lock, and
+        # both of those are Unix primitives with Windows analogues rather than
+        # shared code. Only the Windows CI job ran this crate's
         # tests, so the Unix half of that logic — the half that guards a live
         # agent's shim directory — shipped unexecuted. Same reasoning as
         # buzz-backend-kubernetes above: infra-free, and workspace membership

--- a/Justfile
+++ b/Justfile
@@ -341,9 +341,9 @@ test-unit:
         # diverges Rust from the corpus ships green.
         cargo nextest run -p buzz-agent --lib
         # buzz-dev-mcp: the temp-dir orphan sweep (#6025) decides whether to
-        # delete a directory based on process liveness and an inherited file
-        # lock, and both of those are Unix primitives with Windows analogues
-        # rather than shared code. Only the Windows CI job ran this crate's
+        # delete a directory from process-group liveness and a file lock, and
+        # both of those are Unix primitives with Windows analogues rather than
+        # shared code. Only the Windows CI job ran this crate's
         # tests, so the Unix half of that logic — the half that guards a live
         # agent's shim directory — shipped unexecuted. Same reasoning as
         # buzz-backend-kubernetes above: infra-free, and workspace membership

--- a/Justfile
+++ b/Justfile
@@ -428,6 +428,15 @@ test-unit:
         # relay events and agent prompts. They are infra-free; ignored lifecycle
         # tests remain excluded and run in their dedicated integration lanes.
         cargo nextest run -p buzz-acp --lib
+        # buzz-dev-mcp: the temp-dir orphan sweep (#6025) decides whether to
+        # delete a directory based on process liveness and an inherited file
+        # lock, and both of those are Unix primitives with Windows analogues
+        # rather than shared code. Only the Windows CI job ran this crate's
+        # tests, so the Unix half of that logic — the half that guards a live
+        # agent's shim directory — shipped unexecuted. Same reasoning as
+        # buzz-backend-kubernetes above: infra-free, and workspace membership
+        # alone buys clippy, not a single executed test.
+        cargo nextest run -p buzz-dev-mcp
     else
         ./scripts/run-tests.sh unit
     fi

--- a/Justfile
+++ b/Justfile
@@ -340,6 +340,15 @@ test-unit:
         # `cargo test --workspace`; without this step a manifest edit that
         # diverges Rust from the corpus ships green.
         cargo nextest run -p buzz-agent --lib
+        # buzz-dev-mcp: the temp-dir orphan sweep (#6025) decides whether to
+        # delete a directory based on process liveness and an inherited file
+        # lock, and both of those are Unix primitives with Windows analogues
+        # rather than shared code. Only the Windows CI job ran this crate's
+        # tests, so the Unix half of that logic — the half that guards a live
+        # agent's shim directory — shipped unexecuted. Same reasoning as
+        # buzz-backend-kubernetes above: infra-free, and workspace membership
+        # alone buys clippy, not a single executed test.
+        cargo nextest run -p buzz-dev-mcp
     else
         ./scripts/run-tests.sh unit
     fi

--- a/crates/buzz-dev-mcp/Cargo.toml
+++ b/crates/buzz-dev-mcp/Cargo.toml
@@ -40,8 +40,11 @@ base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 buzz-core = { workspace = true }
 
+# "fs" is needed by the temp-dir lease and the hardened marker read in
+# `sweep`: flock's FD_CLOEXEC handling (fcntl/FdFlag) and the O_NOFOLLOW /
+# O_NONBLOCK open flags (OFlag) all live behind it.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal", "process"] }
+nix = { version = "0.31", default-features = false, features = ["fs", "signal", "process"] }
 
 # Windows Job Object APIs for the shell tool's timeout kill path: terminating a
 # job kills the bash child AND every MSYS grandchild it forked, the Windows
@@ -50,4 +53,6 @@ nix = { version = "0.31", default-features = false, features = ["signal", "proce
 # required because CreateJobObjectW takes a SECURITY_ATTRIBUTES parameter;
 # Win32_System_Threading supplies IO_COUNTERS inside the extended-limit struct.
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading"] }
+# Win32_Storage_FileSystem supplies the FILE_SHARE_* flags the temp-dir lease
+# opens with (`sweep::acquire_lease`).
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading"] }

--- a/crates/buzz-dev-mcp/src/lib.rs
+++ b/crates/buzz-dev-mcp/src/lib.rs
@@ -16,6 +16,7 @@ mod rg;
 mod shell;
 mod shim;
 mod str_replace;
+mod sweep;
 mod todo;
 mod tree;
 mod view_image;
@@ -175,6 +176,23 @@ async fn async_main(cmd: String) -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .with_ansi(false)
         .init();
+
+    // Best-effort startup sweep for temp dirs orphaned by a killed
+    // buzz-dev-mcp process (#6025) — see crate::sweep for the design. Run
+    // before creating this process's own dirs so it never considers them.
+    let temp_root = std::env::temp_dir();
+    let sweep_stats = sweep::sweep_stale_dirs(&temp_root);
+    tracing::debug!(
+        ?sweep_stats,
+        dir = %temp_root.display(),
+        "buzz-dev-mcp: startup temp dir sweep complete"
+    );
+    if sweep_stats.removed > 0 {
+        tracing::info!(
+            removed = sweep_stats.removed,
+            "buzz-dev-mcp: startup sweep removed orphaned temp dir(s) left by killed processes (#6025)"
+        );
+    }
 
     let cwd = std::env::current_dir()?;
     let shim = shim::Shim::install()?;

--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -26,6 +26,10 @@ const READ_CHUNK: usize = 16 * 1024;
 pub struct SharedState {
     pub cwd: PathBuf,
     pub shim: Shim,
+    /// Declared before `session_dir`, and it has to stay that way: fields drop
+    /// in declaration order, and on Windows the lease file must be closed
+    /// before `TempDir` can remove the directory holding it.
+    _session_claim: Option<crate::sweep::DirClaim>,
     pub session_dir: TempDir,
     pub bootstrap_instructions: String,
     /// The shell resolved at construction: `Ok((path, display_name))` when a shell
@@ -41,9 +45,9 @@ impl SharedState {
         let session_dir = tempfile::Builder::new()
             .prefix("buzz-dev-mcp-session-")
             .tempdir()?;
-        // Ownership marker for the startup orphan sweep (#6025) — best-effort,
-        // see crate::sweep docs for why a write failure here is non-fatal.
-        crate::sweep::write_owner_marker(session_dir.path());
+        // Ownership claim for the startup orphan sweep (#6025) — best-effort,
+        // see crate::sweep docs for why a failure here is non-fatal.
+        let session_claim = crate::sweep::claim_dir(session_dir.path());
         // Resolve the shell ONCE using the same PATH the spawn will use.
         // Both the bootstrap dialect hint and every run() call read this result,
         // so they can never disagree. A failed resolution is stored as Err and
@@ -57,6 +61,7 @@ impl SharedState {
         Ok(Self {
             cwd,
             shim,
+            _session_claim: session_claim,
             session_dir,
             bootstrap_instructions,
             resolved_shell,
@@ -199,6 +204,15 @@ pub async fn run(
     // child so the Windows job can take the process handle, which only exists
     // after spawn. Held for the whole run; its Drop is the last-resort reaper.
     let mut kill_group = KillGroup::new(&child, pid);
+    if !kill_group.armed() {
+        // Nothing left ties this command's lifetime to ours, and nothing
+        // records that it is using the shim and session dirs. A later startup
+        // sweep would see a dead owner pid and a free lease and delete both
+        // directories out from under it, so give up the right to reclaim them
+        // instead. Costs disk; never costs a live command its binaries.
+        crate::sweep::surrender_claim(state.shim.dir());
+        crate::sweep::surrender_claim(state.session_dir.path());
+    }
 
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
@@ -729,6 +743,19 @@ impl KillGroup {
     fn disarm(&mut self) {
         self.0 = None;
     }
+
+    /// Whether this command's use of the shim/session dirs stays observable
+    /// after a hard kill of this process.
+    ///
+    /// Always true on Unix, for a reason that has nothing to do with the
+    /// process group: the command inherited the directory lease at spawn
+    /// (`sweep::acquire_lease`), so even a fully orphaned command keeps the
+    /// directories claimed until it exits. Windows does not inherit that
+    /// handle and leans on the job object instead, so there the answer can be
+    /// false.
+    fn armed(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(unix)]
@@ -741,6 +768,10 @@ impl Drop for KillGroup {
 #[cfg(windows)]
 struct KillGroup {
     job: windows_sys::Win32::Foundation::HANDLE,
+    /// Whether the job object was actually established: created, configured
+    /// with KILL_ON_JOB_CLOSE, and holding this child. Every Win32 call in
+    /// `new` can fail, and a job that was not established kills nothing.
+    armed: bool,
 }
 
 // SAFETY: `job` is a raw Win32 HANDLE (`*mut c_void`), which is neither `Send`
@@ -773,28 +804,46 @@ impl KillGroup {
         // anonymous job, a zeroed #[repr(C)] info struct sized by size_of, and
         // the live process handle from `child` (valid while it is running).
         // A null job HANDLE on failure makes every later call a harmless no-op.
-        let job = unsafe {
+        let (job, armed) = unsafe {
             let job: HANDLE = CreateJobObjectW(std::ptr::null(), std::ptr::null());
-            if !job.is_null() {
+            if job.is_null() {
+                (job, false)
+            } else {
                 let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = zeroed();
                 // KILL_ON_JOB_CLOSE: when the LAST handle to the job closes,
                 // Windows kills every process still in it. This is both the
                 // explicit-kill mechanism and the Drop-time safety net — and the
                 // reason the job HANDLE must outlive the child (see Drop).
                 info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-                SetInformationJobObject(
+                let configured = SetInformationJobObject(
                     job,
                     JobObjectExtendedLimitInformation,
                     std::ptr::addr_of!(info).cast(),
                     size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-                );
-                if let Some(handle) = child.raw_handle() {
-                    AssignProcessToJobObject(job, handle as HANDLE);
-                }
+                ) != 0;
+                let assigned = match child.raw_handle() {
+                    Some(handle) => AssignProcessToJobObject(job, handle as HANDLE) != 0,
+                    None => false,
+                };
+                (job, configured && assigned)
             }
-            job
         };
-        Self { job }
+        if !armed {
+            // Not fatal for the command itself — the explicit kill path still
+            // terminates bash directly — but this child is no longer
+            // guaranteed to die with us, which is what the caller needs to
+            // know. See the surrender in `run`.
+            tracing::warn!(
+                "buzz-dev-mcp: could not put the shell command in a job object; \
+                 it may outlive a hard kill of this process"
+            );
+        }
+        Self { job, armed }
+    }
+
+    /// See the Unix twin for the contract.
+    fn armed(&self) -> bool {
+        self.armed
     }
 
     fn kill_immediate(&self) {
@@ -857,6 +906,11 @@ impl KillGroup {
     fn kill_immediate(&self) {}
     async fn kill_graceful(&self) {}
     fn disarm(&mut self) {}
+    /// No kill primitive and no lease on this target, so a spawned command's
+    /// use of the temp dirs is never observable. See the Unix twin.
+    fn armed(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Default)]

--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -187,10 +187,17 @@ pub async fn run(
     set_process_group(&mut cmd);
     crate::configure_no_window_async(&mut cmd);
 
+    // Registry slots for the two directories this command can reach: the shim
+    // dir (first on its PATH) and the session dir. Reserved *before* the
+    // spawn, because the window this closes is a live command with nothing on
+    // disk recording that it exists — see `sweep::register_command`.
+    let pending = crate::sweep::register_command(&[state.shim.dir(), state.session_dir.path()]);
+
     let started = Instant::now();
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
+            pending.abandon();
             return Ok(CallToolResult::error(vec![Content::text(format!(
                 "failed to spawn shell: {e}"
             ))]));
@@ -204,15 +211,26 @@ pub async fn run(
     // child so the Windows job can take the process handle, which only exists
     // after spawn. Held for the whole run; its Drop is the last-resort reaper.
     let mut kill_group = KillGroup::new(&child, pid);
-    if !kill_group.armed() {
-        // Nothing left ties this command's lifetime to ours, and nothing
-        // records that it is using the shim and session dirs. A later startup
-        // sweep would see a dead owner pid and a free lease and delete both
-        // directories out from under it, so give up the right to reclaim them
-        // instead. Costs disk; never costs a live command its binaries.
-        crate::sweep::surrender_claim(state.shim.dir());
-        crate::sweep::surrender_claim(state.session_dir.path());
-    }
+    // Bind the reserved slots to this command's lifetime handle: on Unix the
+    // process group, which `set_process_group` made equal to the child's own
+    // pid, and on Windows the pid. Held for the rest of `run`, so the entries
+    // disappear when the command is done and the directories go back to being
+    // reclaimable.
+    let _registered = match pid.filter(|_| kill_group.armed()) {
+        Some(handle) => Some(pending.confirm(handle)),
+        None => {
+            // Nothing left ties this command's lifetime to ours, and nothing
+            // can record that it is using the shim and session dirs. A later
+            // startup sweep would see a dead owner and an empty registry and
+            // delete both directories out from under it, so give up the right
+            // to reclaim them instead. Costs disk; never costs a live command
+            // its binaries.
+            pending.abandon();
+            crate::sweep::surrender_claim(state.shim.dir());
+            crate::sweep::surrender_claim(state.session_dir.path());
+            None
+        }
+    };
 
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
@@ -747,14 +765,13 @@ impl KillGroup {
     /// Whether this command's use of the shim/session dirs stays observable
     /// after a hard kill of this process.
     ///
-    /// Always true on Unix, for a reason that has nothing to do with the
-    /// process group: the command inherited the directory lease at spawn
-    /// (`sweep::acquire_lease`), so even a fully orphaned command keeps the
-    /// directories claimed until it exits. Windows does not inherit that
-    /// handle and leans on the job object instead, so there the answer can be
-    /// false.
+    /// On Unix that is exactly the question "do we know the process group",
+    /// because the group id is what goes into the command registry
+    /// (`sweep::register_command`) and what a later sweep asks about. Without
+    /// it the command is untrackable, and the caller surrenders the claim
+    /// rather than let a sweep guess.
     fn armed(&self) -> bool {
-        true
+        self.0.is_some()
     }
 }
 

--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -210,13 +210,13 @@ pub async fn run(
     // primitive (Unix process group / Windows Job Object). Built from the live
     // child so the Windows job can take the process handle, which only exists
     // after spawn. Held for the whole run; its Drop is the last-resort reaper.
-    let mut kill_group = KillGroup::new(&child, pid);
+    let kill_group = KillGroup::new(&child, pid);
     // Bind the reserved slots to this command's lifetime handle: on Unix the
     // process group, which `set_process_group` made equal to the child's own
-    // pid, and on Windows the pid. Held for the rest of `run`, so the entries
-    // disappear when the command is done and the directories go back to being
-    // reclaimable.
-    let _registered = match pid.filter(|_| kill_group.armed()) {
+    // pid — the same assumption `KillGroup` kills by — and on Windows the pid.
+    // Held for the rest of `run`, so the entries disappear when the command is
+    // done and the directories go back to being reclaimable.
+    let registered = match pid.filter(|_| kill_group.armed()) {
         Some(handle) => Some(pending.confirm(handle)),
         None => {
             // Nothing left ties this command's lifetime to ours, and nothing
@@ -231,6 +231,13 @@ pub async fn run(
             None
         }
     };
+    // One tuple rather than two bindings, because the drop order matters and
+    // is otherwise invisible: tuple fields drop left to right, so the kill
+    // guard fires before the entry naming that process group is removed. Two
+    // separate bindings drop in reverse declaration order, which would take
+    // the directory's last protection away while the group it names is still
+    // up.
+    let (mut kill_group, _registered) = (kill_group, registered);
 
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();

--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -41,6 +41,9 @@ impl SharedState {
         let session_dir = tempfile::Builder::new()
             .prefix("buzz-dev-mcp-session-")
             .tempdir()?;
+        // Ownership marker for the startup orphan sweep (#6025) — best-effort,
+        // see crate::sweep docs for why a write failure here is non-fatal.
+        crate::sweep::write_owner_marker(session_dir.path());
         // Resolve the shell ONCE using the same PATH the spawn will use.
         // Both the bootstrap dialect hint and every run() call read this result,
         // so they can never disagree. A failed resolution is stored as Err and

--- a/crates/buzz-dev-mcp/src/shim.rs
+++ b/crates/buzz-dev-mcp/src/shim.rs
@@ -16,8 +16,13 @@ use zeroize::Zeroize;
 /// the keyfile is written — git helpers read from the keyfile only.
 /// Cleaned up on drop (TempDir) in the common case; if this process is
 /// killed before `Drop` runs, a future buzz-dev-mcp startup's orphan sweep
-/// (`crate::sweep`) removes it once this process's pid is confirmed dead.
+/// (`crate::sweep`) removes it once this process's pid is confirmed dead AND
+/// no command spawned from it still holds the directory lease.
 pub struct Shim {
+    /// Declared before `_dir`, and it has to stay that way: fields drop in
+    /// declaration order, and on Windows the lease file must be closed before
+    /// `TempDir` can remove the directory holding it.
+    _claim: Option<crate::sweep::DirClaim>,
     _dir: TempDir,
     pub path_env: String,
     pub git_env: Vec<(String, String)>,
@@ -27,9 +32,9 @@ impl Shim {
     pub fn install() -> std::io::Result<Self> {
         let dir = tempfile::Builder::new().prefix("buzz-dev-mcp-").tempdir()?;
         set_owner_only(dir.path())?;
-        // Ownership marker for the startup orphan sweep (#6025) — best-effort,
-        // see crate::sweep docs for why a write failure here is non-fatal.
-        crate::sweep::write_owner_marker(dir.path());
+        // Ownership claim for the startup orphan sweep (#6025) — best-effort,
+        // see crate::sweep docs for why a failure here is non-fatal.
+        let claim = crate::sweep::claim_dir(dir.path());
 
         let self_exe = std::env::current_exe()?;
 
@@ -73,10 +78,18 @@ impl Shim {
         }
 
         Ok(Self {
+            _claim: claim,
             _dir: dir,
             path_env,
             git_env,
         })
+    }
+
+    /// Path of the shim directory. Used by the shell tool to surrender the
+    /// ownership claim when a spawned command's lifetime stops being
+    /// observable (see `sweep::surrender_claim`).
+    pub fn dir(&self) -> &Path {
+        self._dir.path()
     }
 }
 

--- a/crates/buzz-dev-mcp/src/shim.rs
+++ b/crates/buzz-dev-mcp/src/shim.rs
@@ -14,7 +14,9 @@ use zeroize::Zeroize;
 /// Shell children receive `path_env`, `git_env`, and `BUZZ_PRIVATE_KEY` (for
 /// the buzz CLI). `NOSTR_PRIVATE_KEY` is removed from the process env after
 /// the keyfile is written — git helpers read from the keyfile only.
-/// Cleaned up on drop (TempDir).
+/// Cleaned up on drop (TempDir) in the common case; if this process is
+/// killed before `Drop` runs, a future buzz-dev-mcp startup's orphan sweep
+/// (`crate::sweep`) removes it once this process's pid is confirmed dead.
 pub struct Shim {
     _dir: TempDir,
     pub path_env: String,
@@ -25,6 +27,9 @@ impl Shim {
     pub fn install() -> std::io::Result<Self> {
         let dir = tempfile::Builder::new().prefix("buzz-dev-mcp-").tempdir()?;
         set_owner_only(dir.path())?;
+        // Ownership marker for the startup orphan sweep (#6025) — best-effort,
+        // see crate::sweep docs for why a write failure here is non-fatal.
+        crate::sweep::write_owner_marker(dir.path());
 
         let self_exe = std::env::current_exe()?;
 

--- a/crates/buzz-dev-mcp/src/sweep.rs
+++ b/crates/buzz-dev-mcp/src/sweep.rs
@@ -1416,7 +1416,9 @@ mod tests {
     #[test]
     fn claiming_a_directory_creates_an_empty_registry() {
         let root = tempdir().expect("tempdir");
-        let dir = root.path().join(format!("{OWNER_PREFIX}test-claim-registry"));
+        let dir = root
+            .path()
+            .join(format!("{OWNER_PREFIX}test-claim-registry"));
         std::fs::create_dir(&dir).expect("mkdir");
 
         let _claim = claim_dir(&dir).expect("claim");

--- a/crates/buzz-dev-mcp/src/sweep.rs
+++ b/crates/buzz-dev-mcp/src/sweep.rs
@@ -122,12 +122,34 @@ fn pid_liveness(pid: u32) -> Liveness {
     }
 }
 
+/// Classify an `OpenProcess` failure into [`Liveness`].
+///
+/// Only `ERROR_INVALID_PARAMETER` — what Windows returns for a pid no
+/// process object exists for — establishes that the owner is gone.
+/// `ERROR_ACCESS_DENIED` means the process is there but not queryable (a
+/// protected process, or one owned by another user). Everything else
+/// (resource exhaustion, transient kernel failures) says nothing either way
+/// about whether the pid exists, and under this module's fail-safe contract
+/// "says nothing" must never authorize a delete, so every code but the one
+/// that positively proves absence maps to `Unknown`.
+///
+/// Split out of `pid_liveness` so the classification is unit-testable
+/// directly, without having to provoke real system errors.
+#[cfg(windows)]
+fn classify_open_process_error(err: u32) -> Liveness {
+    use windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER;
+
+    if err == ERROR_INVALID_PARAMETER {
+        Liveness::Dead
+    } else {
+        Liveness::Unknown
+    }
+}
+
 #[cfg(windows)]
 #[allow(unsafe_code)]
 fn pid_liveness(pid: u32) -> Liveness {
-    use windows_sys::Win32::Foundation::{
-        CloseHandle, GetLastError, ERROR_ACCESS_DENIED, STILL_ACTIVE,
-    };
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, STILL_ACTIVE};
     use windows_sys::Win32::System::Threading::{
         GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
     };
@@ -142,15 +164,7 @@ fn pid_liveness(pid: u32) -> Liveness {
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if handle.is_null() {
-            return if GetLastError() == ERROR_ACCESS_DENIED {
-                // The process exists but this query is denied (e.g. a
-                // protected process) — the safe direction is to assume it's
-                // alive rather than guess it's gone.
-                Liveness::Unknown
-            } else {
-                // Typically ERROR_INVALID_PARAMETER: no such pid.
-                Liveness::Dead
-            };
+            return classify_open_process_error(GetLastError());
         }
         let mut exit_code: u32 = 0;
         let ok = GetExitCodeProcess(handle, &mut exit_code);
@@ -197,6 +211,16 @@ pub(crate) struct SweepStats {
 /// stuck or misconfigured temp directory must never prevent the MCP server
 /// from starting.
 pub(crate) fn sweep_stale_dirs(temp_root: &Path) -> SweepStats {
+    sweep_stale_dirs_with(temp_root, &|dir| std::fs::remove_dir_all(dir))
+}
+
+/// [`sweep_stale_dirs`] with the removal step injected, so tests can drive
+/// the removal-failure branch deterministically on every platform instead of
+/// trying to provoke a real filesystem error.
+fn sweep_stale_dirs_with(
+    temp_root: &Path,
+    remove: &dyn Fn(&Path) -> std::io::Result<()>,
+) -> SweepStats {
     let mut stats = SweepStats::default();
 
     let entries = match std::fs::read_dir(temp_root) {
@@ -247,13 +271,13 @@ pub(crate) fn sweep_stale_dirs(temp_root: &Path) -> SweepStats {
             }
         }
 
-        sweep_one(&entry.path(), &mut stats);
+        sweep_one(&entry.path(), &mut stats, remove);
     }
 
     stats
 }
 
-fn sweep_one(dir: &Path, stats: &mut SweepStats) {
+fn sweep_one(dir: &Path, stats: &mut SweepStats, remove: &dyn Fn(&Path) -> std::io::Result<()>) {
     let Some(marker) = read_owner_marker(dir) else {
         // Legacy rule: a directory with no confirmable owner — either it
         // predates this change, or its marker is corrupt/half-written — is
@@ -273,7 +297,7 @@ fn sweep_one(dir: &Path, stats: &mut SweepStats) {
         return;
     }
 
-    match std::fs::remove_dir_all(dir) {
+    match remove(dir) {
         Ok(()) => {
             stats.removed += 1;
             tracing::info!(
@@ -425,36 +449,77 @@ mod tests {
         assert_eq!(stats.removed, 0, "{stats:?}");
     }
 
-    #[cfg(unix)]
+    /// A directory whose removal fails must be counted as an error and left
+    /// in place, and one failure must not abandon the rest of the sweep.
+    ///
+    /// The remover is injected rather than provoked with real filesystem
+    /// permissions. Stripping permissions from the directory makes its
+    /// *marker* unreadable first, so the sweep skips it as unowned and never
+    /// reaches removal at all; on top of that, chmod has no Windows analogue
+    /// and root bypasses it entirely, so a permission-based version of this
+    /// test would silently cover nothing on three different setups.
     #[test]
-    fn sweep_tolerates_a_permission_denied_entry() {
-        use std::os::unix::fs::PermissionsExt;
-
-        // root bypasses permission checks entirely, so chmod 000 would not
-        // reproduce a permission error under root (e.g. some CI containers)
-        // — skip rather than assert something that can't happen there.
-        if nix::unistd::Uid::effective().is_root() {
-            eprintln!("skipping: running as root, permission checks are bypassed");
-            return;
+    fn removal_failures_are_counted_and_do_not_abort_the_sweep() {
+        let root = tempdir().expect("tempdir");
+        let first = root
+            .path()
+            .join(format!("{OWNER_PREFIX}test-remove-fails-a"));
+        let second = root
+            .path()
+            .join(format!("{OWNER_PREFIX}test-remove-fails-b"));
+        for dir in [&first, &second] {
+            std::fs::create_dir(dir).expect("mkdir");
+            write_marker(dir, dead_pid());
         }
 
-        let root = tempdir().expect("tempdir");
-        let target = root.path().join(format!("{OWNER_PREFIX}test-noperm"));
-        std::fs::create_dir(&target).expect("mkdir");
-        write_marker(&target, dead_pid());
-        // Strip all permissions from the child dir so remove_dir_all on it
-        // fails with a permission error instead of succeeding — the sweep
-        // must record the error and move on rather than propagating it.
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o000))
-            .expect("chmod 000");
+        let stats = sweep_stale_dirs_with(root.path(), &|_dir| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "injected removal failure",
+            ))
+        });
 
-        let stats = sweep_stale_dirs(root.path());
-
-        // Restore permissions so the tempdir guard can clean up afterwards.
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700))
-            .expect("restore perms for cleanup");
-
+        // Two errors, not one: whatever order read_dir hands the entries
+        // back in, the sweep kept going after the first failure.
+        assert_eq!(stats.errors, 2, "{stats:?}");
         assert_eq!(stats.removed, 0, "{stats:?}");
-        assert_eq!(stats.errors, 1, "{stats:?}");
+        assert!(
+            first.exists() && second.exists(),
+            "a dir whose removal failed must be left in place"
+        );
+    }
+
+    /// Only the error code that positively proves a pid has no process
+    /// object may authorize a delete. Anything else is a probe that failed,
+    /// which is not evidence the owner is gone.
+    #[cfg(windows)]
+    #[test]
+    fn only_an_invalid_pid_error_proves_the_owner_is_gone() {
+        use windows_sys::Win32::Foundation::{
+            ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER, ERROR_NOT_ENOUGH_MEMORY,
+            ERROR_NO_SYSTEM_RESOURCES,
+        };
+
+        assert_eq!(
+            classify_open_process_error(ERROR_INVALID_PARAMETER),
+            Liveness::Dead
+        );
+        // Exists, just not queryable by us.
+        assert_eq!(
+            classify_open_process_error(ERROR_ACCESS_DENIED),
+            Liveness::Unknown
+        );
+        // Resource pressure and transient kernel failures say nothing about
+        // whether the pid exists — deleting on these would take out a live
+        // session's binaries.
+        assert_eq!(
+            classify_open_process_error(ERROR_NOT_ENOUGH_MEMORY),
+            Liveness::Unknown
+        );
+        assert_eq!(
+            classify_open_process_error(ERROR_NO_SYSTEM_RESOURCES),
+            Liveness::Unknown
+        );
+        assert_eq!(classify_open_process_error(0), Liveness::Unknown);
     }
 }

--- a/crates/buzz-dev-mcp/src/sweep.rs
+++ b/crates/buzz-dev-mcp/src/sweep.rs
@@ -18,28 +18,50 @@
 //! NOT the mechanism here: a session can legitimately run for days, and
 //! deleting its shim/session dir out from under it would break a live agent
 //! mid-command. Instead every directory this crate creates is *claimed*, and
-//! a claim has two independent parts. Both must say "gone" before anything is
-//! removed:
+//! a claim has three independent parts. All three must say "gone" before
+//! anything is removed:
 //!
 //! 1. **Owner marker** — a file recording the creating process's pid. The
 //!    sweep deletes only when that pid is positively confirmed dead.
-//! 2. **Directory lease** — a lock file the creating process holds open, and
-//!    that every command it spawns inherits. The sweep deletes only when the
-//!    lease is provably unheld.
+//! 2. **Owner lease** — a lock file the creating process holds open for
+//!    exactly as long as it lives, released by the kernel when it dies,
+//!    `SIGKILL` included. It answers the same question the pid does, minus
+//!    the pid's weak spot: pid numbers get recycled, and a stranger's process
+//!    wearing our dead owner's number reads as `Alive` forever. A held lease
+//!    is proof the owner itself is still there.
+//! 3. **Command registry** — a directory holding one file per command the
+//!    owner spawned, created before the spawn and removed when the command is
+//!    reaped. The sweep deletes only when every registered command is
+//!    provably gone.
 //!
-//! The pid alone is not enough, and the reason is the shell tool. On Unix a
-//! spawned command gets its own process group (`shell::set_process_group`), so
-//! a `SIGKILL` of the server leaves the command running — the `Drop` guard
-//! that would have killed its group never runs. That surviving command still
-//! has the shim directory first on `PATH` and can invoke `buzz`/`rg`/`tree`/the
-//! git helpers out of it at any later moment. "Owner pid is dead" says nothing
-//! about that command. The lease does: it is held on the open file
-//! description, so an inherited descriptor keeps it held for exactly as long
-//! as any process that came from this server is alive, and it is released by
-//! the kernel the moment the last of them exits — including on `SIGKILL`,
-//! where no user-space cleanup runs at all.
+//! The owner being dead is not enough, and the reason is the shell tool. On
+//! Unix a spawned command gets its own process group
+//! (`shell::set_process_group`), so a `SIGKILL` of the server leaves the
+//! command running — the `Drop` guard that would have killed its group never
+//! runs. That surviving command still has the shim directory first on `PATH`
+//! and can invoke `buzz`/`rg`/`tree`/the git helpers out of it at any later
+//! moment. "Owner is gone" says nothing about that command. The registry
+//! does, and it is the reason removal is safe at all.
 //!
-//! Windows differs on both halves and is documented at [`acquire_lease`].
+//! ## Why the registry is on disk and not a descriptor
+//!
+//! The obvious cheaper trick is to have the lease descriptor inherited by
+//! every spawned command, so the kernel tracks command lifetime for free.
+//! That was the previous shape of this module and it is not sound. An
+//! inherited descriptor lands in the command's own descriptor table, where
+//! the command owns it: `bash` hands out descriptors 3 upward for its own
+//! redirections, plenty of programs close everything above 2 on startup, and
+//! any of that silently drops the lease while the command runs happily on.
+//! The sweep then sees a free lease and deletes a live command's binaries.
+//!
+//! A registry entry is not reachable from the command at all. Nothing the
+//! command does to its descriptors, its environment or its signal handlers
+//! can retract it. Buzz writes it, Buzz removes it, and if Buzz is killed
+//! before it can remove it the entry stays and the directory survives, which
+//! is the direction this module errs in everywhere else too.
+//!
+//! Windows differs and is documented at [`acquire_lease`] and
+//! [`command_liveness`].
 //!
 //! ## Untrusted input
 //!
@@ -53,9 +75,10 @@
 //! ## Failure direction
 //!
 //! Every uncertain case — marker missing, marker corrupt or not a regular
-//! file, lease held or unreadable, pid alive, pid liveness undeterminable, or
-//! a removal failure — leaves the directory alone and logs. The safe failure
-//! mode is a persisted leak, never a deleted live session.
+//! file, lease held or unreadable, pid alive, pid liveness undeterminable, a
+//! registry that cannot be read or holds an entry whose command cannot be
+//! ruled out, or a removal failure — leaves the directory alone and logs. The
+//! safe failure mode is a persisted leak, never a deleted live session.
 
 use std::path::Path;
 
@@ -68,9 +91,21 @@ pub(crate) const OWNER_PREFIX: &str = "buzz-dev-mcp-";
 /// creates.
 const MARKER_FILE_NAME: &str = ".buzz-dev-mcp-owner";
 
-/// Lease file name. Held open (and locked, on Unix) for as long as the
-/// directory is in use. See [`acquire_lease`].
+/// Lease file name. Held open (and locked, on Unix) by the owning process for
+/// as long as it lives. See [`acquire_lease`].
 const LEASE_FILE_NAME: &str = ".buzz-dev-mcp-lease";
+
+/// Command registry directory name, inside every claimed directory. Holds one
+/// file per command the owner has spawned and not yet reaped. See
+/// [`register_command`].
+const CMDS_DIR_NAME: &str = ".buzz-dev-mcp-cmds";
+
+/// Hard cap on registry entries read in one sweep of one directory. A real
+/// registry holds one entry per concurrently running command, so single
+/// digits. The cap only exists so a hostile directory in a world-writable
+/// temp root cannot turn the startup sweep into an unbounded amount of work;
+/// hitting it means the directory is not something to delete anyway.
+const MAX_REGISTRY_ENTRIES: usize = 4096;
 
 /// Hard cap on the marker read. A real marker is two short `key=value` lines,
 /// around 40 bytes. Anything bigger is not one of ours and is not read.
@@ -88,14 +123,15 @@ pub(crate) struct DirClaim {
     _lease: Lease,
 }
 
-/// Claim `dir`: take the lease first, then write the owner marker.
+/// Claim `dir`: take the lease, create the command registry, then write the
+/// owner marker.
 ///
 /// The order matters and is load-bearing. The sweep treats "no marker" as
 /// "never touch this directory", so writing the marker last means a marked
-/// directory always has a lease behind it. If the lease cannot be taken, the
-/// directory gets no marker at all and is permanently off-limits to the
-/// sweep — a leak, which is the failure direction this module chooses every
-/// time.
+/// directory always has both a lease and a registry behind it. If either
+/// cannot be created, the directory gets no marker at all and is permanently
+/// off-limits to the sweep — a leak, which is the failure direction this
+/// module chooses every time.
 ///
 /// Best-effort: a failure here only affects a *future* startup sweep, never
 /// this session, so it must not fail directory creation.
@@ -112,6 +148,19 @@ pub(crate) fn claim_dir(dir: &Path) -> Option<DirClaim> {
             return None;
         }
     };
+
+    // Before the marker, for the same reason the lease comes first: a marked
+    // directory must never be missing a part of its claim. A registry that
+    // cannot be created means commands cannot be registered, which means the
+    // sweep must never be allowed to reason about this directory at all.
+    if let Err(e) = std::fs::create_dir_all(dir.join(CMDS_DIR_NAME)) {
+        tracing::warn!(
+            error = %e,
+            dir = %dir.display(),
+            "buzz-dev-mcp: could not create the command registry; this directory will never be auto-reclaimed"
+        );
+        return None;
+    }
 
     if let Err(e) = write_owner_marker(dir) {
         tracing::warn!(
@@ -272,6 +321,22 @@ enum Liveness {
     Unknown,
 }
 
+/// Verdict on a directory's command registry, same reasoning as [`Liveness`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandsState {
+    /// The registry exists and every command in it is provably gone.
+    Idle,
+    /// At least one registered command is alive, or cannot be ruled out
+    /// (an entry still being registered, an unparseable name, a liveness
+    /// check that failed). All of these authorize exactly the same action,
+    /// which is none.
+    Busy,
+    /// No registry directory at all: a directory this crate did not claim,
+    /// or claimed with a version that had no registry. Not accountable, so
+    /// not deletable.
+    Missing,
+}
+
 /// Tri-state result of a lease probe, same reasoning as [`Liveness`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LeaseState {
@@ -286,41 +351,44 @@ enum LeaseState {
 
 /// The whole deletion policy, as one pure function.
 ///
-/// Removal needs positive proof on *both* axes: the process that created the
-/// directory is gone, AND nothing that inherited its lease is still running.
-/// Every other combination — including the three `Missing` cases, since
-/// [`claim_dir`] writes the lease before the marker and so a marked directory
-/// without a lease file is a directory whose state we cannot account for —
-/// leaves the directory alone.
-fn may_remove(owner: Liveness, lease: LeaseState) -> bool {
-    matches!(owner, Liveness::Dead) && matches!(lease, LeaseState::Free)
+/// Removal needs positive proof on *all three* axes: the pid that created the
+/// directory is confirmed dead, the owner's lease is confirmed unheld, and
+/// every command the owner registered is confirmed gone. Every other
+/// combination — including each `Missing` case, since [`claim_dir`] writes
+/// the lease and the registry before the marker and so a marked directory
+/// missing either is a directory whose state we cannot account for — leaves
+/// the directory alone.
+fn may_remove(owner: Liveness, lease: LeaseState, commands: CommandsState) -> bool {
+    matches!(owner, Liveness::Dead)
+        && matches!(lease, LeaseState::Free)
+        && matches!(commands, CommandsState::Idle)
 }
 
-/// Take the directory lease.
+/// Take the directory lease: proof that the process which created this
+/// directory is still running.
 ///
-/// **Unix.** The lock is `flock(LOCK_SH)`, and `FD_CLOEXEC` is cleared on the
-/// descriptor so that every command this process spawns inherits it. `flock`
-/// locks belong to the open file description rather than to a process, so an
-/// inherited descriptor holds the same lock: the lease stays held while the
-/// server or *any* command descended from it is alive, and the kernel drops
-/// it when the last of them exits, `SIGKILL` included. That is what makes the
-/// sweep safe against the orphaned-command case in the module docs.
+/// The lease covers the owner and nothing else. Commands the owner spawns are
+/// tracked by the registry ([`register_command`]), not by this descriptor —
+/// see the module docs for why an inherited descriptor cannot do that job.
+/// `FD_CLOEXEC` is therefore left at its default, so this descriptor never
+/// reaches a spawned command in the first place.
+///
+/// **Unix.** The lock is `flock(LOCK_SH)`. It is released when the owner
+/// exits however it exits, `SIGKILL` included, because the kernel closes the
+/// descriptor. The guard's `Drop` also unlocks explicitly on the clean path
+/// (`nix`'s `Flock` issues `LOCK_UN`), which reaches the same state by a
+/// different route.
 ///
 /// **Windows.** The handle is opened denying `FILE_SHARE_DELETE`, so the
 /// directory cannot be removed while the server lives, and the probe below
-/// detects the open handle. It is deliberately *not* marked inheritable:
-/// spawned commands there are held in a Job Object with
-/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (`shell::KillGroup`), so a hard kill
-/// of the server takes the whole command tree with it and no orphan can
-/// outlive the pid check. Inheriting the handle instead would keep a file
-/// open inside the directory during the normal shutdown path, where a
-/// just-terminated child that has not finished exiting would block
-/// `TempDir`'s own cleanup and turn every clean exit into a leak. The one
-/// case where the Job Object cannot be established is handled at the spawn
-/// site, by surrendering the claim (see [`surrender_claim`]).
+/// detects the open handle. Spawned commands there are held in a Job Object
+/// with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (`shell::KillGroup`), so a hard
+/// kill of the server takes the whole command tree with it. The one case
+/// where the Job Object cannot be established is handled at the spawn site,
+/// by surrendering the claim (see [`surrender_claim`]).
 #[cfg(unix)]
 fn acquire_lease(path: &Path) -> std::io::Result<Lease> {
-    use nix::fcntl::{fcntl, FcntlArg, FdFlag, Flock, FlockArg};
+    use nix::fcntl::{Flock, FlockArg};
 
     let file = std::fs::OpenOptions::new()
         .create(true)
@@ -328,10 +396,6 @@ fn acquire_lease(path: &Path) -> std::io::Result<Lease> {
         .write(true)
         .truncate(false)
         .open(path)?;
-    // Must happen before any command is spawned, which is why the claim is
-    // taken at directory-creation time.
-    fcntl(&file, FcntlArg::F_SETFD(FdFlag::empty()))
-        .map_err(|errno| std::io::Error::from_raw_os_error(errno as i32))?;
     Flock::lock(file, FlockArg::LockSharedNonblock)
         .map(|lock| Lease { _lock: lock })
         .map_err(|(_file, errno)| std::io::Error::from_raw_os_error(errno as i32))
@@ -433,6 +497,187 @@ fn probe_lease(path: &Path) -> LeaseState {
     }
 }
 
+/// A registry slot reserved for a command that has not been spawned yet.
+///
+/// Reserved *before* the spawn on purpose. The dangerous window is a command
+/// that is alive with no registry entry naming it, and that window is exactly
+/// "after spawn, before the entry is written". Writing a placeholder first
+/// closes it: the entry is already on disk when the command draws its first
+/// breath, and the sweep treats a placeholder as an unfinished registration
+/// it cannot reason about, so the directory is safe either way.
+///
+/// Dropping one without calling [`PendingCommand::confirm`] or
+/// [`PendingCommand::abandon`] leaves the placeholder behind, which costs the
+/// directory its reclaimability and nothing else.
+pub(crate) struct PendingCommand {
+    paths: Vec<std::path::PathBuf>,
+}
+
+/// A registered, running command. Dropping it deregisters, which is what
+/// makes the directory reclaimable once every command has finished.
+pub(crate) struct CommandLifetime {
+    paths: Vec<std::path::PathBuf>,
+}
+
+/// Reserve a registry slot in each of `dirs` for a command about to be
+/// spawned.
+///
+/// Best-effort per directory: a directory whose registry cannot be written
+/// (never claimed, claimed by an older version, or unwritable) simply gets no
+/// entry. That is not silently unsafe — a directory with no registry reads as
+/// [`CommandsState::Missing`], which never authorizes a delete.
+pub(crate) fn register_command(dirs: &[&Path]) -> PendingCommand {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    // Unique per reservation within this process; combined with the pid it is
+    // unique across every process sharing the temp root.
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let name = format!(
+        "pending-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    );
+
+    let mut paths = Vec::with_capacity(dirs.len());
+    for dir in dirs {
+        let path = dir.join(CMDS_DIR_NAME).join(&name);
+        match std::fs::File::create(&path) {
+            Ok(_) => paths.push(path),
+            Err(e) => tracing::debug!(
+                error = %e,
+                path = %path.display(),
+                "buzz-dev-mcp: could not reserve a command registry slot"
+            ),
+        }
+    }
+    PendingCommand { paths }
+}
+
+impl PendingCommand {
+    /// Bind the reservation to the spawned command's lifetime handle: its
+    /// process group on Unix, its pid on Windows. Renames rather than
+    /// rewrites, so there is no instant where the slot is absent.
+    pub(crate) fn confirm(self, handle: u32) -> CommandLifetime {
+        let mut paths = Vec::with_capacity(self.paths.len());
+        for pending in &self.paths {
+            let Some(parent) = pending.parent() else {
+                continue;
+            };
+            let final_path = parent.join(handle.to_string());
+            match std::fs::rename(pending, &final_path) {
+                Ok(()) => paths.push(final_path),
+                Err(e) => {
+                    // The placeholder is still there and still blocks
+                    // reclamation, so nothing is at risk; the directory just
+                    // stays unreclaimable until a human clears it.
+                    tracing::debug!(
+                        error = %e,
+                        path = %pending.display(),
+                        "buzz-dev-mcp: could not name the command registry slot; leaving the placeholder"
+                    );
+                }
+            }
+        }
+        CommandLifetime { paths }
+    }
+
+    /// Give the reservation back, for a command that never started.
+    pub(crate) fn abandon(self) {
+        for path in &self.paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+impl Drop for CommandLifetime {
+    fn drop(&mut self) {
+        for path in &self.paths {
+            if let Err(e) = std::fs::remove_file(path) {
+                tracing::debug!(
+                    error = %e,
+                    path = %path.display(),
+                    "buzz-dev-mcp: could not deregister a finished command"
+                );
+            }
+        }
+    }
+}
+
+/// Read a directory's command registry.
+///
+/// Like the marker read, this parses state owned by some other process in a
+/// world-writable directory, so every unexpected shape resolves to
+/// [`CommandsState::Busy`] rather than to a delete: an entry name that is not
+/// a number, a registry that is a file or a symlink to somewhere strange, a
+/// liveness check that fails, or more entries than any real session has.
+fn probe_commands(dir: &Path) -> CommandsState {
+    let registry = dir.join(CMDS_DIR_NAME);
+    let entries = match std::fs::read_dir(&registry) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return CommandsState::Missing,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                path = %registry.display(),
+                "buzz-dev-mcp: startup sweep: unreadable command registry; treating the dir as in use"
+            );
+            return CommandsState::Busy;
+        }
+    };
+
+    for (seen, entry) in entries.enumerate() {
+        if seen >= MAX_REGISTRY_ENTRIES {
+            return CommandsState::Busy;
+        }
+        let Ok(entry) = entry else {
+            return CommandsState::Busy;
+        };
+        let name = entry.file_name();
+        let Some(handle) = name.to_str().and_then(|n| n.parse::<u32>().ok()) else {
+            // A placeholder from `register_command`, or something that is not
+            // ours at all. Either way it is not a command that can be ruled
+            // out.
+            return CommandsState::Busy;
+        };
+        if command_liveness(handle) != Liveness::Dead {
+            return CommandsState::Busy;
+        }
+    }
+
+    CommandsState::Idle
+}
+
+/// Is the command behind a registry entry still running?
+///
+/// **Unix.** The handle is a process group id, and the question is asked of
+/// the whole group with `killpg`, not of one pid. A command is a `bash` that
+/// forks freely; the group is what `shell::KillGroup` manages and what
+/// survives a hard kill of the server, so the group is the unit whose life
+/// the directory depends on. `killpg` succeeds while *any* member is alive,
+/// including when the leader has already exited.
+///
+/// **Windows.** The handle is a pid, checked exactly like an owner pid.
+///
+/// A recycled id makes a finished command look alive, which costs a leaked
+/// directory. There is no failure in the other direction: an id that is
+/// provably gone cannot come back.
+#[cfg(unix)]
+fn command_liveness(pgid: u32) -> Liveness {
+    use nix::errno::Errno;
+    use nix::sys::signal::killpg;
+    use nix::unistd::Pid;
+
+    match killpg(Pid::from_raw(pgid as i32), None) {
+        Ok(()) => Liveness::Alive,
+        Err(Errno::ESRCH) => Liveness::Dead,
+        Err(_) => Liveness::Unknown,
+    }
+}
+
+#[cfg(not(unix))]
+fn command_liveness(pid: u32) -> Liveness {
+    pid_liveness(pid)
+}
+
 #[cfg(unix)]
 fn pid_liveness(pid: u32) -> Liveness {
     use nix::errno::Errno;
@@ -528,8 +773,9 @@ pub(crate) struct SweepStats {
 
 /// Startup sweep: scan `temp_root` for entries left behind by a killed
 /// buzz-dev-mcp process (see module docs). Removes an entry ONLY when its
-/// marker names a pid that is positively confirmed dead AND its lease is
-/// provably unheld. Every other case is left alone and logged.
+/// marker names a pid that is positively confirmed dead, its lease is
+/// provably unheld, and every command it registered is provably gone. Every
+/// other case is left alone and logged.
 ///
 /// Best-effort end to end: nothing here returns an error or panics, since a
 /// stuck or hostile temp directory must never prevent the MCP server from
@@ -621,19 +867,22 @@ fn sweep_one(dir: &Path, stats: &mut SweepStats, remove: &dyn Fn(&Path) -> std::
 
     let owner = pid_liveness(marker.pid);
     let lease = probe_lease(&dir.join(LEASE_FILE_NAME));
-    if !may_remove(owner, lease) {
+    let commands = probe_commands(dir);
+    if !may_remove(owner, lease, commands) {
         if owner == Liveness::Dead {
-            // The creating process is gone but something it spawned still
-            // holds the lease: exactly the orphaned-command case the lease
-            // exists for. Logged at info because it is the interesting one —
-            // the directory will be reclaimed on a later startup, once that
+            // The creating process is gone but the directory is still spoken
+            // for, by a surviving command or by a lease that has not been
+            // released: exactly the orphaned-command case this policy exists
+            // for. Logged at info because it is the interesting one — the
+            // directory will be reclaimed on a later startup, once that
             // command finishes.
             stats.skipped_in_use += 1;
             tracing::info!(
                 dir = %dir.display(),
                 pid = marker.pid,
                 ?lease,
-                "buzz-dev-mcp: startup sweep: owner is gone but the temp dir is still leased; leaving it"
+                ?commands,
+                "buzz-dev-mcp: startup sweep: owner is gone but the temp dir is still in use; leaving it"
             );
         } else {
             stats.skipped_alive_or_unknown += 1;
@@ -667,19 +916,29 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    /// Stand in for a directory this crate created: an unheld lease file plus
-    /// a marker naming `pid`. Written by hand rather than via [`claim_dir`]
-    /// because most cases need an owner pid other than this process's.
+    /// Stand in for a directory this crate created and then lost its owner:
+    /// an unheld lease file, an empty command registry, and a marker naming
+    /// `pid`. Written by hand rather than via [`claim_dir`] because most
+    /// cases need an owner pid other than this process's.
     fn claimed_dir(root: &Path, name: &str, pid: u32) -> std::path::PathBuf {
         let dir = root.join(format!("{OWNER_PREFIX}{name}"));
         std::fs::create_dir(&dir).expect("mkdir");
         std::fs::write(dir.join(LEASE_FILE_NAME), b"").expect("write lease");
+        std::fs::create_dir(dir.join(CMDS_DIR_NAME)).expect("mkdir registry");
         std::fs::write(
             dir.join(MARKER_FILE_NAME),
             format!("pid={pid}\ncreated=1\n"),
         )
         .expect("write marker");
         dir
+    }
+
+    /// Write a registry entry naming `handle` into an already-claimed `dir`,
+    /// the way [`register_command`] does for a running command.
+    fn register_handle(dir: &Path, handle: u32) -> std::path::PathBuf {
+        let path = dir.join(CMDS_DIR_NAME).join(handle.to_string());
+        std::fs::write(&path, b"").expect("write registry entry");
+        path
     }
 
     /// Spawn and immediately reap a trivial child process so its pid is
@@ -700,24 +959,37 @@ mod tests {
         pid
     }
 
-    /// The deletion policy in full. Only one of the nine states authorizes
-    /// removal: the owner is provably dead and the lease is provably unheld.
-    /// Everything else — every `Unknown`, every `InUse`, every `Missing` —
-    /// must not delete.
+    /// The deletion policy in full. Only one of the twenty-seven states
+    /// authorizes removal: the owner is provably dead, the lease is provably
+    /// unheld, and the registry is provably idle. Everything else — every
+    /// `Unknown`, every `InUse`, every `Busy`, every `Missing` — must not
+    /// delete.
     #[test]
-    fn only_a_dead_owner_with_a_free_lease_authorizes_removal() {
+    fn removal_needs_a_dead_owner_a_free_lease_and_an_idle_registry() {
         let owners = [Liveness::Alive, Liveness::Dead, Liveness::Unknown];
         let leases = [LeaseState::Free, LeaseState::InUse, LeaseState::Missing];
+        let registries = [
+            CommandsState::Idle,
+            CommandsState::Busy,
+            CommandsState::Missing,
+        ];
+        let mut authorized = 0;
         for owner in owners {
             for lease in leases {
-                let expected = owner == Liveness::Dead && lease == LeaseState::Free;
-                assert_eq!(
-                    may_remove(owner, lease),
-                    expected,
-                    "may_remove({owner:?}, {lease:?})"
-                );
+                for commands in registries {
+                    let expected = owner == Liveness::Dead
+                        && lease == LeaseState::Free
+                        && commands == CommandsState::Idle;
+                    authorized += usize::from(may_remove(owner, lease, commands));
+                    assert_eq!(
+                        may_remove(owner, lease, commands),
+                        expected,
+                        "may_remove({owner:?}, {lease:?}, {commands:?})"
+                    );
+                }
             }
         }
+        assert_eq!(authorized, 1, "exactly one state may delete");
     }
 
     #[test]
@@ -934,35 +1206,59 @@ mod tests {
         assert!(target.exists());
     }
 
+    /// A child that stays up for the whole test, in its own process group on
+    /// Unix so its pid is also its process group id — the same shape
+    /// `shell::run` spawns commands in.
+    fn long_lived_child() -> std::process::Child {
+        let mut cmd = if cfg!(windows) {
+            // `ping` is the portable long sleep on Windows: no console
+            // needed, one probe a second, and a single process rather than a
+            // `cmd` wrapper that would leave a grandchild behind on kill.
+            let mut c = std::process::Command::new("ping");
+            c.args(["-n", "61", "127.0.0.1"]);
+            c
+        } else {
+            let mut c = std::process::Command::new("sleep");
+            c.arg("60");
+            c
+        };
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::null());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt as _;
+            cmd.process_group(0);
+        }
+        cmd.spawn().expect("spawn long-lived child")
+    }
+
     /// The regression for the orphaned-command case in the module docs: the
-    /// process that created the directory is gone, but a command it spawned
-    /// is still running with the inherited lease. The directory must survive
-    /// — and become reclaimable the moment that command exits.
+    /// process that created the directory is gone, a command it spawned is
+    /// still running, and the directory has to survive until that command
+    /// exits.
     ///
-    /// The owner "dying" is modelled by dropping the lease in this process
-    /// after the child has inherited it. That is the same thing the kernel
-    /// does on `SIGKILL`: the owner's descriptor closes, and the lock stays
-    /// held by the inherited one, because an `flock` belongs to the open file
-    /// description rather than to a process.
-    #[cfg(unix)]
+    /// The owner's death is not modelled by tidying up. The claim is dropped,
+    /// the marker is rewritten to a pid that is genuinely dead, and the
+    /// command's registry entry is deliberately leaked with `mem::forget`,
+    /// because that is exactly what a `SIGKILL` leaves behind: an owner that
+    /// never got to deregister anything.
     #[test]
     fn a_command_that_outlives_its_owner_keeps_the_directory() {
         let root = tempdir().expect("tempdir");
         let dir = root.path().join(format!("{OWNER_PREFIX}test-orphan-cmd"));
         std::fs::create_dir(&dir).expect("mkdir");
-        let lease_path = dir.join(LEASE_FILE_NAME);
 
         let claim = claim_dir(&dir).expect("claim");
-        // Spawned after the claim, so it inherits the lease descriptor.
-        let mut child = std::process::Command::new("sleep")
-            .arg("60")
-            .spawn()
-            .expect("spawn long-lived child");
+        // Registered before the spawn and confirmed after, the way
+        // `shell::run` does it.
+        let pending = register_command(&[dir.as_path()]);
+        let mut child = long_lived_child();
+        let handle = child.id();
+        std::mem::forget(pending.confirm(handle));
 
-        // The owner is gone; only the spawned command is left.
+        // The owner is gone: lease released, marker naming a dead pid. The
+        // pid check alone would authorize a delete right here.
         drop(claim);
-        // Its marker still names a dead pid, so the pid check alone would
-        // authorize a delete here.
         std::fs::write(
             dir.join(MARKER_FILE_NAME),
             format!("pid={}\ncreated=1\n", dead_pid()),
@@ -970,9 +1266,9 @@ mod tests {
         .expect("rewrite marker with a dead owner");
 
         assert_eq!(
-            probe_lease(&lease_path),
-            LeaseState::InUse,
-            "the spawned command must still hold the inherited lease"
+            probe_commands(&dir),
+            CommandsState::Busy,
+            "a registered, running command must hold the directory"
         );
         let stats = sweep_stale_dirs(root.path());
         assert_eq!(stats.removed, 0, "{stats:?}");
@@ -982,14 +1278,179 @@ mod tests {
             "a directory still in use by a surviving command must not be removed"
         );
 
-        // Once that command exits, the kernel releases the last reference to
-        // the lease and the directory becomes reclaimable.
+        // The command exits. Its entry is still on disk, because the process
+        // that would have removed it is dead, so what the sweep is really
+        // being asked is whether the thing the entry names is still running.
         child.kill().expect("kill child");
         child.wait().expect("reap child");
-        assert_eq!(probe_lease(&lease_path), LeaseState::Free);
+        assert!(
+            dir.join(CMDS_DIR_NAME).join(handle.to_string()).exists(),
+            "the stale entry must still be on disk, or this proves nothing"
+        );
+        assert_eq!(probe_commands(&dir), CommandsState::Idle);
         let stats = sweep_stale_dirs(root.path());
         assert_eq!(stats.removed, 1, "{stats:?}");
         assert!(!dir.exists());
+    }
+
+    /// The window between "the command is alive" and "the command has a
+    /// name" is covered by the placeholder, and the placeholder alone must
+    /// hold the directory.
+    #[test]
+    fn an_unconfirmed_registration_blocks_removal() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-pending", dead_pid());
+        let pending = register_command(&[target.as_path()]);
+
+        assert_eq!(probe_commands(&target), CommandsState::Busy);
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_in_use, 1, "{stats:?}");
+        assert!(target.exists());
+
+        // Handed back by a spawn that failed, the directory is reclaimable
+        // again.
+        pending.abandon();
+        assert_eq!(probe_commands(&target), CommandsState::Idle);
+        assert_eq!(sweep_stale_dirs(root.path()).removed, 1);
+    }
+
+    /// Deregistration on the normal path is a `Drop`, and without it every
+    /// directory would stay pinned by commands that finished hours ago.
+    #[test]
+    fn dropping_a_command_lifetime_deregisters_it() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-deregister", dead_pid());
+        let registered = register_command(&[target.as_path()]).confirm(std::process::id());
+
+        assert_eq!(
+            probe_commands(&target),
+            CommandsState::Busy,
+            "the handle names this test process, which is alive"
+        );
+        drop(registered);
+        assert_eq!(probe_commands(&target), CommandsState::Idle);
+    }
+
+    /// A command reaches the shim dir and the session dir both, so it is
+    /// registered in both, and either entry is enough to save its directory.
+    #[test]
+    fn a_command_is_registered_in_every_directory_it_can_reach() {
+        let root = tempdir().expect("tempdir");
+        let shim = claimed_dir(root.path(), "test-two-dirs-shim", dead_pid());
+        let session = claimed_dir(root.path(), "test-two-dirs-session", dead_pid());
+        let registered =
+            register_command(&[shim.as_path(), session.as_path()]).confirm(std::process::id());
+
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_in_use, 2, "{stats:?}");
+        assert!(shim.exists() && session.exists());
+
+        drop(registered);
+        assert_eq!(sweep_stale_dirs(root.path()).removed, 2);
+    }
+
+    /// An entry whose name is not a number cannot be checked, and anything
+    /// that cannot be checked holds the directory.
+    #[test]
+    fn an_unreadable_registry_entry_blocks_removal() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-garbage-entry", dead_pid());
+        std::fs::write(target.join(CMDS_DIR_NAME).join("not-a-pid"), b"").expect("write entry");
+
+        assert_eq!(probe_commands(&target), CommandsState::Busy);
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    /// A directory with no registry at all — claimed by an older build, or
+    /// never claimed by this crate — is not accountable and is never deleted.
+    #[test]
+    fn dead_owner_without_a_registry_is_not_swept() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-no-registry", dead_pid());
+        std::fs::remove_dir(target.join(CMDS_DIR_NAME)).expect("remove registry");
+
+        assert_eq!(probe_commands(&target), CommandsState::Missing);
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    /// A registry that is a file rather than a directory is the shape a
+    /// hostile world-writable temp root can plant. It reads as in use.
+    #[test]
+    fn a_registry_that_is_not_a_directory_blocks_removal() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-registry-is-a-file", dead_pid());
+        std::fs::remove_dir(target.join(CMDS_DIR_NAME)).expect("remove registry");
+        std::fs::write(target.join(CMDS_DIR_NAME), b"not a directory").expect("write file");
+
+        assert_eq!(probe_commands(&target), CommandsState::Busy);
+        assert_eq!(sweep_stale_dirs(root.path()).removed, 0);
+        assert!(target.exists());
+    }
+
+    /// `claim_dir` has to leave a registry behind. Without one, every
+    /// directory this crate creates reads as unaccountable forever and the
+    /// sweep reclaims nothing.
+    #[test]
+    fn claiming_a_directory_creates_an_empty_registry() {
+        let root = tempdir().expect("tempdir");
+        let dir = root.path().join(format!("{OWNER_PREFIX}test-claim-registry"));
+        std::fs::create_dir(&dir).expect("mkdir");
+
+        let _claim = claim_dir(&dir).expect("claim");
+
+        assert!(dir.join(CMDS_DIR_NAME).is_dir(), "registry directory");
+        assert_eq!(probe_commands(&dir), CommandsState::Idle);
+    }
+
+    /// The registry names a process *group*, and that is load-bearing rather
+    /// than incidental. A command is a shell that forks, and the shell can
+    /// exit while what it started keeps running with the shim dir on `PATH`.
+    /// A pid check says the command is gone. The group check does not, and
+    /// the group is the same unit `shell::KillGroup` manages.
+    #[cfg(unix)]
+    #[test]
+    fn a_group_whose_leader_exited_is_still_alive() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-group-outlives-leader", dead_pid());
+
+        // A leader that backgrounds a long sleep and exits immediately. With
+        // no job control the sleep stays in the leader's process group.
+        let mut leader = {
+            use std::os::unix::process::CommandExt as _;
+            let mut c = std::process::Command::new("sh");
+            c.args(["-c", "sleep 60 & exit 0"]);
+            c.process_group(0);
+            c.spawn().expect("spawn group leader")
+        };
+        let pgid = leader.id();
+        leader.wait().expect("reap leader");
+
+        assert_eq!(
+            pid_liveness(pgid),
+            Liveness::Dead,
+            "the shell that was the command is gone"
+        );
+        assert_eq!(
+            command_liveness(pgid),
+            Liveness::Alive,
+            "what it left running is not"
+        );
+
+        register_handle(&target, pgid);
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert!(target.exists());
+
+        let _ = nix::sys::signal::killpg(
+            nix::unistd::Pid::from_raw(pgid as i32),
+            nix::sys::signal::Signal::SIGKILL,
+        );
     }
 
     /// A marker that is a FIFO must be skipped, and — the part that matters —

--- a/crates/buzz-dev-mcp/src/sweep.rs
+++ b/crates/buzz-dev-mcp/src/sweep.rs
@@ -933,8 +933,25 @@ mod tests {
         dir
     }
 
+    /// A registry handle that stays alive for as long as this test process
+    /// does. On Unix that has to be a process *group* id, because that is
+    /// what the registry names and what `killpg` can answer for: this
+    /// process's own pid is not a group id unless it happens to be a group
+    /// leader, and under a test runner it is not.
+    fn live_handle() -> u32 {
+        #[cfg(unix)]
+        {
+            nix::unistd::getpgrp().as_raw() as u32
+        }
+        #[cfg(not(unix))]
+        {
+            std::process::id()
+        }
+    }
+
     /// Write a registry entry naming `handle` into an already-claimed `dir`,
     /// the way [`register_command`] does for a running command.
+    #[cfg(unix)]
     fn register_handle(dir: &Path, handle: u32) -> std::path::PathBuf {
         let path = dir.join(CMDS_DIR_NAME).join(handle.to_string());
         std::fs::write(&path, b"").expect("write registry entry");
@@ -1321,12 +1338,12 @@ mod tests {
     fn dropping_a_command_lifetime_deregisters_it() {
         let root = tempdir().expect("tempdir");
         let target = claimed_dir(root.path(), "test-deregister", dead_pid());
-        let registered = register_command(&[target.as_path()]).confirm(std::process::id());
+        let registered = register_command(&[target.as_path()]).confirm(live_handle());
 
         assert_eq!(
             probe_commands(&target),
             CommandsState::Busy,
-            "the handle names this test process, which is alive"
+            "the handle names this test process's group, which is alive"
         );
         drop(registered);
         assert_eq!(probe_commands(&target), CommandsState::Idle);
@@ -1340,7 +1357,7 @@ mod tests {
         let shim = claimed_dir(root.path(), "test-two-dirs-shim", dead_pid());
         let session = claimed_dir(root.path(), "test-two-dirs-session", dead_pid());
         let registered =
-            register_command(&[shim.as_path(), session.as_path()]).confirm(std::process::id());
+            register_command(&[shim.as_path(), session.as_path()]).confirm(live_handle());
 
         let stats = sweep_stale_dirs(root.path());
         assert_eq!(stats.removed, 0, "{stats:?}");

--- a/crates/buzz-dev-mcp/src/sweep.rs
+++ b/crates/buzz-dev-mcp/src/sweep.rs
@@ -1,0 +1,460 @@
+//! Ownership marker + startup sweep for buzz-dev-mcp's per-process temp
+//! directories (issue #6025).
+//!
+//! ## Why this exists
+//!
+//! `shim::Shim::install` and `shell::SharedState::new` each create a
+//! `tempfile::TempDir` (prefixed `buzz-dev-mcp-` and
+//! `buzz-dev-mcp-session-` respectively) whose cleanup runs in `Drop`. When
+//! the MCP server process is killed outright (SIGKILL, a Windows hard
+//! terminate, an ACP harness reaping a stuck agent) `Drop` never runs and the
+//! directory — holding full copies of buzz/rg/tree/git helpers, tens of MB
+//! each — is orphaned. Both prefixes start with `buzz-dev-mcp-`, so a single
+//! sweep over that one prefix catches both.
+//!
+//! ## Design
+//!
+//! An age-based sweep ("delete anything older than N hours") is
+//! deliberately NOT the mechanism here: a session can legitimately run for
+//! days, and deleting its shim/session dir out from under it would break a
+//! live agent mid-command. Instead, every directory this crate creates gets
+//! an ownership marker recording the creating process's pid. At startup we
+//! remove a directory only when we can positively confirm that pid is no
+//! longer running. Every uncertain case — marker missing, marker corrupt,
+//! pid alive, pid liveness undeterminable, or a removal failure — is left
+//! alone and logged. The safe failure mode is a persisted leak, never a
+//! deleted live session.
+
+use std::path::Path;
+
+/// Every directory this crate creates in the system temp dir starts with
+/// this prefix (`buzz-dev-mcp-` for the shim dir, `buzz-dev-mcp-session-`
+/// for the session dir — both match, since the second extends the first).
+pub(crate) const OWNER_PREFIX: &str = "buzz-dev-mcp-";
+
+/// Ownership marker file name, dropped inside every temp dir this crate
+/// creates.
+const MARKER_FILE_NAME: &str = ".buzz-dev-mcp-owner";
+
+/// Write the ownership marker recording this process's pid and creation
+/// time (unix seconds). Trivial `key=value` lines, one per line: a future
+/// field can be appended without breaking older readers (unknown keys are
+/// ignored), and a half-written file simply fails to yield a `pid` rather
+/// than panicking anything downstream.
+///
+/// Best-effort: a write failure only affects a *future* startup sweep, never
+/// this session, so it must not fail directory creation. Logged at `warn`
+/// since it silently degrades the sweep to "never touch this dir".
+pub(crate) fn write_owner_marker(dir: &Path) {
+    let pid = std::process::id();
+    let created = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let path = dir.join(MARKER_FILE_NAME);
+    if let Err(e) = std::fs::write(&path, format!("pid={pid}\ncreated={created}\n")) {
+        tracing::warn!(
+            error = %e,
+            path = %path.display(),
+            "buzz-dev-mcp: failed to write temp dir ownership marker; a future startup sweep will leave this directory alone"
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OwnerMarker {
+    pid: u32,
+}
+
+/// Parse the marker in `dir`. Returns `None` if the marker file is missing,
+/// unreadable, or does not contain a usable `pid` line — all three are
+/// handled identically by [`sweep_one`] (leave the directory alone), so a
+/// half-written or corrupt marker fails exactly as safe as one that was
+/// never written.
+fn read_owner_marker(dir: &Path) -> Option<OwnerMarker> {
+    let text = std::fs::read_to_string(dir.join(MARKER_FILE_NAME)).ok()?;
+    let mut pid = None;
+    for line in text.lines() {
+        if let Some(value) = line.strip_prefix("pid=") {
+            // Reject 0 and anything past a POSIX pid_t: a corrupt or
+            // adversarial `pid=0` would otherwise reach the Unix liveness
+            // check, where `kill(0, ...)` means "every process in my
+            // process group", not "no such process".
+            pid = value
+                .trim()
+                .parse::<u32>()
+                .ok()
+                .filter(|&p| p != 0 && p <= i32::MAX as u32);
+        }
+    }
+    pid.map(|pid| OwnerMarker { pid })
+}
+
+/// Tri-state result of a pid liveness check, kept distinct from a plain
+/// `bool` so every call site has to name the "we don't actually know"
+/// branch instead of silently defaulting one way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Liveness {
+    Alive,
+    Dead,
+    /// Could not determine (e.g. a permissions error probing the pid).
+    /// Treated identically to `Alive` — see module docs.
+    Unknown,
+}
+
+impl Liveness {
+    fn may_delete(self) -> bool {
+        self == Liveness::Dead
+    }
+}
+
+#[cfg(unix)]
+fn pid_liveness(pid: u32) -> Liveness {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    // Signal 0 sends nothing; the kernel still performs the existence and
+    // permission checks, which is exactly the question being asked here.
+    match kill(Pid::from_raw(pid as i32), None) {
+        Ok(()) => Liveness::Alive,
+        Err(Errno::ESRCH) => Liveness::Dead,
+        Err(_) => Liveness::Unknown, // e.g. EPERM: exists, owned by someone else
+    }
+}
+
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn pid_liveness(pid: u32) -> Liveness {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_ACCESS_DENIED, STILL_ACTIVE,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // SAFETY: OpenProcess/GetExitCodeProcess/CloseHandle are plain,
+    // documented Win32 calls used per their contract. `pid` is
+    // attacker-controlled (it comes from a marker file on disk), but
+    // OpenProcess validates it itself and returns NULL rather than
+    // requiring the caller to pre-validate. The handle from a successful
+    // OpenProcess is closed exactly once, immediately after the single
+    // GetExitCodeProcess call that uses it, on every return path.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return if GetLastError() == ERROR_ACCESS_DENIED {
+                // The process exists but this query is denied (e.g. a
+                // protected process) — the safe direction is to assume it's
+                // alive rather than guess it's gone.
+                Liveness::Unknown
+            } else {
+                // Typically ERROR_INVALID_PARAMETER: no such pid.
+                Liveness::Dead
+            };
+        }
+        let mut exit_code: u32 = 0;
+        let ok = GetExitCodeProcess(handle, &mut exit_code);
+        CloseHandle(handle);
+        if ok == 0 {
+            return Liveness::Unknown;
+        }
+        if exit_code == STILL_ACTIVE as u32 {
+            Liveness::Alive
+        } else {
+            Liveness::Dead
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn pid_liveness(_pid: u32) -> Liveness {
+    // No liveness primitive wired up for this target: fail safe by never
+    // confirming "dead", so the sweep never deletes anything here. Keeps
+    // the crate compiling everywhere without pretending to a guarantee it
+    // can't back up.
+    Liveness::Unknown
+}
+
+/// Outcome of one [`sweep_stale_dirs`] run — surfaced so callers can log a
+/// single summary line and tests can assert on behavior without depending
+/// on tracing output.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SweepStats {
+    pub(crate) removed: usize,
+    pub(crate) skipped_alive_or_unknown: usize,
+    pub(crate) skipped_no_marker: usize,
+    pub(crate) errors: usize,
+}
+
+/// Startup sweep: scan `temp_root` for entries left behind by a killed
+/// buzz-dev-mcp process (see module docs). Removes an entry ONLY when its
+/// marker names a pid that is positively confirmed dead. Every other case —
+/// no marker, corrupt marker, pid alive, pid liveness undeterminable, or a
+/// removal failure — is left alone and logged; see module docs for why that
+/// is the safe default.
+///
+/// Best-effort end to end: nothing here returns an error or panics, since a
+/// stuck or misconfigured temp directory must never prevent the MCP server
+/// from starting.
+pub(crate) fn sweep_stale_dirs(temp_root: &Path) -> SweepStats {
+    let mut stats = SweepStats::default();
+
+    let entries = match std::fs::read_dir(temp_root) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                dir = %temp_root.display(),
+                "buzz-dev-mcp: startup sweep could not read the temp directory; skipping"
+            );
+            stats.errors += 1;
+            return stats;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "buzz-dev-mcp: startup sweep: unreadable directory entry; skipping"
+                );
+                stats.errors += 1;
+                continue;
+            }
+        };
+
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue; // never one of ours: tempfile prefixes are plain ASCII
+        };
+        if !name.starts_with(OWNER_PREFIX) {
+            continue;
+        }
+
+        match entry.file_type() {
+            Ok(ft) if ft.is_dir() => {}
+            Ok(_) => continue, // a same-prefixed file is never one of ours
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    entry = %entry.path().display(),
+                    "buzz-dev-mcp: startup sweep: could not stat entry; skipping"
+                );
+                stats.errors += 1;
+                continue;
+            }
+        }
+
+        sweep_one(&entry.path(), &mut stats);
+    }
+
+    stats
+}
+
+fn sweep_one(dir: &Path, stats: &mut SweepStats) {
+    let Some(marker) = read_owner_marker(dir) else {
+        // Legacy rule: a directory with no confirmable owner — either it
+        // predates this change, or its marker is corrupt/half-written — is
+        // never auto-deleted. A dead process cannot be told apart from a
+        // session that has legitimately run for days without a marker to
+        // check, and getting that wrong deletes a live session's binaries
+        // out from under it. So these are left alone for a human (or a
+        // future one-time cleanup tool) rather than guessed at with, say,
+        // an age cutoff. Worst case the pre-existing leak persists — that's
+        // a pre-existing condition, not a regression introduced here.
+        stats.skipped_no_marker += 1;
+        return;
+    };
+
+    if !pid_liveness(marker.pid).may_delete() {
+        stats.skipped_alive_or_unknown += 1;
+        return;
+    }
+
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => {
+            stats.removed += 1;
+            tracing::info!(
+                dir = %dir.display(),
+                pid = marker.pid,
+                "buzz-dev-mcp: removed orphaned temp dir left by a killed process (#6025)"
+            );
+        }
+        Err(e) => {
+            stats.errors += 1;
+            tracing::warn!(
+                error = %e,
+                dir = %dir.display(),
+                pid = marker.pid,
+                "buzz-dev-mcp: startup sweep: failed to remove orphaned temp dir; leaving it"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_marker(dir: &Path, pid: u32) {
+        std::fs::write(
+            dir.join(MARKER_FILE_NAME),
+            format!("pid={pid}\ncreated=1\n"),
+        )
+        .expect("write marker");
+    }
+
+    /// Spawn and immediately reap a trivial child process so its pid is
+    /// guaranteed dead (not a zombie, not merely "probably unused") by the
+    /// time a test uses it — the only reliable way to get a "known dead"
+    /// pid without guessing at an unused number.
+    fn dead_pid() -> u32 {
+        let mut cmd = if cfg!(windows) {
+            let mut c = std::process::Command::new("cmd");
+            c.args(["/C", "exit", "0"]);
+            c
+        } else {
+            std::process::Command::new("true")
+        };
+        let mut child = cmd.spawn().expect("spawn short-lived helper process");
+        let pid = child.id();
+        let _ = child.wait().expect("reap helper process");
+        pid
+    }
+
+    #[test]
+    fn dead_pid_marker_is_swept() {
+        let root = tempdir().expect("tempdir");
+        let target = root.path().join(format!("{OWNER_PREFIX}test-dead"));
+        std::fs::create_dir(&target).expect("mkdir");
+        write_marker(&target, dead_pid());
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats.removed, 1, "{stats:?}");
+        assert!(
+            !target.exists(),
+            "orphaned dir with a dead-pid marker must be removed"
+        );
+    }
+
+    #[test]
+    fn live_pid_marker_is_not_swept() {
+        let root = tempdir().expect("tempdir");
+        let target = root.path().join(format!("{OWNER_PREFIX}test-live"));
+        std::fs::create_dir(&target).expect("mkdir");
+        write_marker(&target, std::process::id()); // this test process: definitely alive
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_alive_or_unknown, 1, "{stats:?}");
+        assert!(
+            target.exists(),
+            "a dir owned by a live pid must survive the sweep"
+        );
+    }
+
+    #[test]
+    fn missing_marker_is_left_alone_per_the_legacy_rule() {
+        // Documents the chosen legacy rule (see sweep_one's doc comment): a
+        // directory with no marker at all — e.g. one created before this
+        // change shipped — is never auto-deleted. There is no way to tell a
+        // pre-fix directory whose owner is long gone apart from one whose
+        // session has legitimately run for days, so the sweep declines to
+        // guess via e.g. an age cutoff.
+        let root = tempdir().expect("tempdir");
+        let target = root.path().join(format!("{OWNER_PREFIX}test-legacy"));
+        std::fs::create_dir(&target).expect("mkdir");
+        // No marker file written.
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_no_marker, 1, "{stats:?}");
+        assert!(
+            target.exists(),
+            "a directory with no marker must survive the sweep"
+        );
+    }
+
+    #[test]
+    fn corrupt_marker_is_treated_like_a_missing_one() {
+        let root = tempdir().expect("tempdir");
+        let target = root.path().join(format!("{OWNER_PREFIX}test-corrupt"));
+        std::fs::create_dir(&target).expect("mkdir");
+        std::fs::write(
+            target.join(MARKER_FILE_NAME),
+            b"not a valid marker\n\x00\xff",
+        )
+        .expect("write corrupt marker");
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_no_marker, 1, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    #[test]
+    fn unrelated_entries_are_ignored() {
+        let root = tempdir().expect("tempdir");
+        let other_dir = root.path().join("some-other-apps-tmp-dir");
+        std::fs::create_dir(&other_dir).expect("mkdir");
+        let other_file = root.path().join(format!("{OWNER_PREFIX}not-a-dir"));
+        std::fs::write(&other_file, b"file, not a directory").expect("write file");
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats, SweepStats::default());
+        assert!(other_dir.exists());
+        assert!(other_file.exists());
+    }
+
+    #[test]
+    fn sweep_tolerates_a_temp_root_that_cannot_be_read() {
+        // Point the sweep at a path that doesn't exist rather than the real
+        // system temp dir. This must degrade to a no-op + error count, not
+        // panic or propagate an error that could abort startup.
+        let missing = std::env::temp_dir().join("buzz-dev-mcp-test-does-not-exist-xyz");
+        let stats = sweep_stale_dirs(&missing);
+        assert_eq!(stats.errors, 1, "{stats:?}");
+        assert_eq!(stats.removed, 0, "{stats:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_tolerates_a_permission_denied_entry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // root bypasses permission checks entirely, so chmod 000 would not
+        // reproduce a permission error under root (e.g. some CI containers)
+        // — skip rather than assert something that can't happen there.
+        if nix::unistd::Uid::effective().is_root() {
+            eprintln!("skipping: running as root, permission checks are bypassed");
+            return;
+        }
+
+        let root = tempdir().expect("tempdir");
+        let target = root.path().join(format!("{OWNER_PREFIX}test-noperm"));
+        std::fs::create_dir(&target).expect("mkdir");
+        write_marker(&target, dead_pid());
+        // Strip all permissions from the child dir so remove_dir_all on it
+        // fails with a permission error instead of succeeding — the sweep
+        // must record the error and move on rather than propagating it.
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o000))
+            .expect("chmod 000");
+
+        let stats = sweep_stale_dirs(root.path());
+
+        // Restore permissions so the tempdir guard can clean up afterwards.
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700))
+            .expect("restore perms for cleanup");
+
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.errors, 1, "{stats:?}");
+    }
+}

--- a/crates/buzz-dev-mcp/src/sweep.rs
+++ b/crates/buzz-dev-mcp/src/sweep.rs
@@ -1,5 +1,5 @@
-//! Ownership marker + startup sweep for buzz-dev-mcp's per-process temp
-//! directories (issue #6025).
+//! Ownership claim (marker + lease) and startup sweep for buzz-dev-mcp's
+//! per-process temp directories (issue #6025).
 //!
 //! ## Why this exists
 //!
@@ -12,18 +12,50 @@
 //! each — is orphaned. Both prefixes start with `buzz-dev-mcp-`, so a single
 //! sweep over that one prefix catches both.
 //!
-//! ## Design
+//! ## What authorizes a delete
 //!
-//! An age-based sweep ("delete anything older than N hours") is
-//! deliberately NOT the mechanism here: a session can legitimately run for
-//! days, and deleting its shim/session dir out from under it would break a
-//! live agent mid-command. Instead, every directory this crate creates gets
-//! an ownership marker recording the creating process's pid. At startup we
-//! remove a directory only when we can positively confirm that pid is no
-//! longer running. Every uncertain case — marker missing, marker corrupt,
-//! pid alive, pid liveness undeterminable, or a removal failure — is left
-//! alone and logged. The safe failure mode is a persisted leak, never a
-//! deleted live session.
+//! An age-based sweep ("delete anything older than N hours") is deliberately
+//! NOT the mechanism here: a session can legitimately run for days, and
+//! deleting its shim/session dir out from under it would break a live agent
+//! mid-command. Instead every directory this crate creates is *claimed*, and
+//! a claim has two independent parts. Both must say "gone" before anything is
+//! removed:
+//!
+//! 1. **Owner marker** — a file recording the creating process's pid. The
+//!    sweep deletes only when that pid is positively confirmed dead.
+//! 2. **Directory lease** — a lock file the creating process holds open, and
+//!    that every command it spawns inherits. The sweep deletes only when the
+//!    lease is provably unheld.
+//!
+//! The pid alone is not enough, and the reason is the shell tool. On Unix a
+//! spawned command gets its own process group (`shell::set_process_group`), so
+//! a `SIGKILL` of the server leaves the command running — the `Drop` guard
+//! that would have killed its group never runs. That surviving command still
+//! has the shim directory first on `PATH` and can invoke `buzz`/`rg`/`tree`/the
+//! git helpers out of it at any later moment. "Owner pid is dead" says nothing
+//! about that command. The lease does: it is held on the open file
+//! description, so an inherited descriptor keeps it held for exactly as long
+//! as any process that came from this server is alive, and it is released by
+//! the kernel the moment the last of them exits — including on `SIGKILL`,
+//! where no user-space cleanup runs at all.
+//!
+//! Windows differs on both halves and is documented at [`acquire_lease`].
+//!
+//! ## Untrusted input
+//!
+//! Everything the sweep reads belongs to some *other* process, in a directory
+//! (`std::env::temp_dir()`) that is world-writable on a typical Unix box. The
+//! marker is therefore parsed as hostile input: opened without following
+//! symlinks and without blocking, rejected unless it is a regular file, and
+//! read under a hard byte cap. A marker that is a FIFO, a device, a symlink,
+//! a directory, or simply too large is skipped, and the sweep moves on.
+//!
+//! ## Failure direction
+//!
+//! Every uncertain case — marker missing, marker corrupt or not a regular
+//! file, lease held or unreadable, pid alive, pid liveness undeterminable, or
+//! a removal failure — leaves the directory alone and logs. The safe failure
+//! mode is a persisted leak, never a deleted live session.
 
 use std::path::Path;
 
@@ -36,29 +68,101 @@ pub(crate) const OWNER_PREFIX: &str = "buzz-dev-mcp-";
 /// creates.
 const MARKER_FILE_NAME: &str = ".buzz-dev-mcp-owner";
 
+/// Lease file name. Held open (and locked, on Unix) for as long as the
+/// directory is in use. See [`acquire_lease`].
+const LEASE_FILE_NAME: &str = ".buzz-dev-mcp-lease";
+
+/// Hard cap on the marker read. A real marker is two short `key=value` lines,
+/// around 40 bytes. Anything bigger is not one of ours and is not read.
+const MAX_MARKER_BYTES: u64 = 256;
+
+/// Live claim on a temp directory: hold this for as long as the directory is
+/// in use, and drop it (or die) to release it.
+///
+/// Dropping releases the lease, which is what makes the directory reclaimable
+/// by a later startup sweep. Callers keep it in the same struct as the
+/// `TempDir` it belongs to, **declared before** that `TempDir`: fields drop in
+/// declaration order, and on Windows the lease file must be closed before
+/// `TempDir` can remove the directory containing it.
+pub(crate) struct DirClaim {
+    _lease: Lease,
+}
+
+/// Claim `dir`: take the lease first, then write the owner marker.
+///
+/// The order matters and is load-bearing. The sweep treats "no marker" as
+/// "never touch this directory", so writing the marker last means a marked
+/// directory always has a lease behind it. If the lease cannot be taken, the
+/// directory gets no marker at all and is permanently off-limits to the
+/// sweep — a leak, which is the failure direction this module chooses every
+/// time.
+///
+/// Best-effort: a failure here only affects a *future* startup sweep, never
+/// this session, so it must not fail directory creation.
+pub(crate) fn claim_dir(dir: &Path) -> Option<DirClaim> {
+    let lease_path = dir.join(LEASE_FILE_NAME);
+    let lease = match acquire_lease(&lease_path) {
+        Ok(lease) => lease,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %lease_path.display(),
+                "buzz-dev-mcp: could not take the temp dir lease; this directory will never be auto-reclaimed"
+            );
+            return None;
+        }
+    };
+
+    if let Err(e) = write_owner_marker(dir) {
+        tracing::warn!(
+            error = %e,
+            dir = %dir.display(),
+            "buzz-dev-mcp: failed to write the temp dir ownership marker; a future startup sweep will leave this directory alone"
+        );
+    }
+
+    Some(DirClaim { _lease: lease })
+}
+
+/// Give up the right to ever reclaim `dir`, by removing its owner marker.
+///
+/// Called when something makes a spawned command's use of the directory
+/// unobservable — see the Windows job-object path in `shell::run`. Removing
+/// the marker downgrades the directory to the same "leave it alone forever"
+/// state as a pre-claim directory. That trades a bounded disk leak for the
+/// guarantee that nothing is deleted under a live command, which is the trade
+/// this module makes everywhere else too.
+pub(crate) fn surrender_claim(dir: &Path) {
+    let path = dir.join(MARKER_FILE_NAME);
+    match std::fs::remove_file(&path) {
+        Ok(()) => tracing::warn!(
+            dir = %dir.display(),
+            "buzz-dev-mcp: surrendered the temp dir ownership claim; this directory will never be auto-reclaimed"
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => tracing::warn!(
+            error = %e,
+            path = %path.display(),
+            "buzz-dev-mcp: could not remove the ownership marker while surrendering the claim"
+        ),
+    }
+}
+
 /// Write the ownership marker recording this process's pid and creation
 /// time (unix seconds). Trivial `key=value` lines, one per line: a future
 /// field can be appended without breaking older readers (unknown keys are
 /// ignored), and a half-written file simply fails to yield a `pid` rather
 /// than panicking anything downstream.
-///
-/// Best-effort: a write failure only affects a *future* startup sweep, never
-/// this session, so it must not fail directory creation. Logged at `warn`
-/// since it silently degrades the sweep to "never touch this dir".
-pub(crate) fn write_owner_marker(dir: &Path) {
+fn write_owner_marker(dir: &Path) -> std::io::Result<()> {
     let pid = std::process::id();
     let created = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let path = dir.join(MARKER_FILE_NAME);
-    if let Err(e) = std::fs::write(&path, format!("pid={pid}\ncreated={created}\n")) {
-        tracing::warn!(
-            error = %e,
-            path = %path.display(),
-            "buzz-dev-mcp: failed to write temp dir ownership marker; a future startup sweep will leave this directory alone"
-        );
-    }
+    std::fs::write(
+        dir.join(MARKER_FILE_NAME),
+        format!("pid={pid}\ncreated={created}\n"),
+    )
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -66,15 +170,34 @@ struct OwnerMarker {
     pid: u32,
 }
 
-/// Parse the marker in `dir`. Returns `None` if the marker file is missing,
-/// unreadable, or does not contain a usable `pid` line — all three are
-/// handled identically by [`sweep_one`] (leave the directory alone), so a
-/// half-written or corrupt marker fails exactly as safe as one that was
-/// never written.
+/// Parse the marker in `dir`, treating it as untrusted input (see module
+/// docs). Returns `None` if the marker file is missing, is not a plain
+/// regular file, is larger than [`MAX_MARKER_BYTES`], is not UTF-8, or does
+/// not contain a usable `pid` line. Every one of those is handled identically
+/// by [`sweep_one`] (leave the directory alone), so a hostile marker fails
+/// exactly as safe as one that was never written.
 fn read_owner_marker(dir: &Path) -> Option<OwnerMarker> {
-    let text = std::fs::read_to_string(dir.join(MARKER_FILE_NAME)).ok()?;
+    use std::io::Read as _;
+
+    let file = open_untrusted_regular_file(&dir.join(MARKER_FILE_NAME))?;
+    // Cheap pre-check on the handle we already hold, so an oversized marker
+    // is rejected without reading it at all.
+    if file.metadata().ok()?.len() > MAX_MARKER_BYTES {
+        return None;
+    }
+    // Bounded read anyway: the file can grow between the fstat and the read.
+    // One byte over the cap is enough to detect the overrun.
+    let mut buf = Vec::new();
+    (&file)
+        .take(MAX_MARKER_BYTES + 1)
+        .read_to_end(&mut buf)
+        .ok()?;
+    if buf.len() as u64 > MAX_MARKER_BYTES {
+        return None;
+    }
+
     let mut pid = None;
-    for line in text.lines() {
+    for line in std::str::from_utf8(&buf).ok()?.lines() {
         if let Some(value) = line.strip_prefix("pid=") {
             // Reject 0 and anything past a POSIX pid_t: a corrupt or
             // adversarial `pid=0` would otherwise reach the Unix liveness
@@ -90,6 +213,54 @@ fn read_owner_marker(dir: &Path) -> Option<OwnerMarker> {
     pid.map(|pid| OwnerMarker { pid })
 }
 
+/// Open a file that some other process owns, for reading, refusing anything
+/// that could block or redirect us.
+///
+/// Unix: `O_NOFOLLOW` rejects a symlinked path outright, `O_NONBLOCK` means
+/// opening a FIFO or a device returns immediately instead of waiting for a
+/// peer, and the `fstat` on the resulting handle (not the path, so nothing
+/// can be swapped underneath it) rejects everything that is not a regular
+/// file. Between them, none of FIFO/symlink-to-FIFO/device/directory can
+/// stall or divert the sweep.
+fn open_untrusted_regular_file(path: &Path) -> Option<std::fs::File> {
+    let file = open_no_follow_no_block(path).ok()?;
+    // fstat on the open handle: a check-then-replace race cannot change what
+    // this handle refers to.
+    if !file.metadata().ok()?.is_file() {
+        return None;
+    }
+    Some(file)
+}
+
+#[cfg(unix)]
+fn open_no_follow_no_block(path: &Path) -> std::io::Result<std::fs::File> {
+    use nix::fcntl::OFlag;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags((OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK).bits())
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_no_follow_no_block(path: &Path) -> std::io::Result<std::fs::File> {
+    // Windows has no `O_NOFOLLOW` and no filesystem FIFOs — a named pipe
+    // lives in the `\\.\pipe\` namespace, not under the temp dir — so a read
+    // here cannot block on a peer that never arrives. What does exist is
+    // reparse points, so reject those before opening. That check is
+    // path-based and therefore racy in principle; unlike Unix's shared
+    // `/tmp`, the Windows temp root is per-user, so winning that race already
+    // requires an account that can write the directory outright.
+    if path.symlink_metadata()?.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to read a temp dir marker through a reparse point",
+        ));
+    }
+    std::fs::File::open(path)
+}
+
 /// Tri-state result of a pid liveness check, kept distinct from a plain
 /// `bool` so every call site has to name the "we don't actually know"
 /// branch instead of silently defaulting one way.
@@ -98,13 +269,167 @@ enum Liveness {
     Alive,
     Dead,
     /// Could not determine (e.g. a permissions error probing the pid).
-    /// Treated identically to `Alive` — see module docs.
     Unknown,
 }
 
-impl Liveness {
-    fn may_delete(self) -> bool {
-        self == Liveness::Dead
+/// Tri-state result of a lease probe, same reasoning as [`Liveness`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LeaseState {
+    /// Provably unheld: nothing that came from the owning server is alive.
+    Free,
+    /// Held by a live process, or unreadable — the two are not distinguished
+    /// because they authorize exactly the same action, which is none.
+    InUse,
+    /// No lease file at all.
+    Missing,
+}
+
+/// The whole deletion policy, as one pure function.
+///
+/// Removal needs positive proof on *both* axes: the process that created the
+/// directory is gone, AND nothing that inherited its lease is still running.
+/// Every other combination — including the three `Missing` cases, since
+/// [`claim_dir`] writes the lease before the marker and so a marked directory
+/// without a lease file is a directory whose state we cannot account for —
+/// leaves the directory alone.
+fn may_remove(owner: Liveness, lease: LeaseState) -> bool {
+    matches!(owner, Liveness::Dead) && matches!(lease, LeaseState::Free)
+}
+
+/// Take the directory lease.
+///
+/// **Unix.** The lock is `flock(LOCK_SH)`, and `FD_CLOEXEC` is cleared on the
+/// descriptor so that every command this process spawns inherits it. `flock`
+/// locks belong to the open file description rather than to a process, so an
+/// inherited descriptor holds the same lock: the lease stays held while the
+/// server or *any* command descended from it is alive, and the kernel drops
+/// it when the last of them exits, `SIGKILL` included. That is what makes the
+/// sweep safe against the orphaned-command case in the module docs.
+///
+/// **Windows.** The handle is opened denying `FILE_SHARE_DELETE`, so the
+/// directory cannot be removed while the server lives, and the probe below
+/// detects the open handle. It is deliberately *not* marked inheritable:
+/// spawned commands there are held in a Job Object with
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (`shell::KillGroup`), so a hard kill
+/// of the server takes the whole command tree with it and no orphan can
+/// outlive the pid check. Inheriting the handle instead would keep a file
+/// open inside the directory during the normal shutdown path, where a
+/// just-terminated child that has not finished exiting would block
+/// `TempDir`'s own cleanup and turn every clean exit into a leak. The one
+/// case where the Job Object cannot be established is handled at the spawn
+/// site, by surrendering the claim (see [`surrender_claim`]).
+#[cfg(unix)]
+fn acquire_lease(path: &Path) -> std::io::Result<Lease> {
+    use nix::fcntl::{fcntl, FcntlArg, FdFlag, Flock, FlockArg};
+
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)?;
+    // Must happen before any command is spawned, which is why the claim is
+    // taken at directory-creation time.
+    fcntl(&file, FcntlArg::F_SETFD(FdFlag::empty()))
+        .map_err(|errno| std::io::Error::from_raw_os_error(errno as i32))?;
+    Flock::lock(file, FlockArg::LockSharedNonblock)
+        .map(|lock| Lease { _lock: lock })
+        .map_err(|(_file, errno)| std::io::Error::from_raw_os_error(errno as i32))
+}
+
+#[cfg(unix)]
+struct Lease {
+    _lock: nix::fcntl::Flock<std::fs::File>,
+}
+
+#[cfg(unix)]
+fn probe_lease(path: &Path) -> LeaseState {
+    use nix::fcntl::{Flock, FlockArg};
+
+    let Some(file) = open_untrusted_regular_file(path) else {
+        return match path.symlink_metadata() {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => LeaseState::Missing,
+            // Present but not a plain regular file we can open: not ours, and
+            // not something to delete a directory over.
+            _ => LeaseState::InUse,
+        };
+    };
+    // An exclusive lock can only be taken when no shared holder is left, so
+    // success means every descendant of the owning server has exited. The
+    // guard is dropped immediately, releasing it again.
+    match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+        Ok(_guard) => LeaseState::Free,
+        // EWOULDBLOCK (someone holds it) and anything else are the same
+        // answer here: not provably free.
+        Err(_) => LeaseState::InUse,
+    }
+}
+
+#[cfg(windows)]
+fn acquire_lease(path: &Path) -> std::io::Result<Lease> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+
+    // Readers and writers are fine; deleters are not. While this handle is
+    // open, the lease file — and so the directory holding it — cannot be
+    // removed by anyone else.
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .open(path)?;
+    Ok(Lease { _file: file })
+}
+
+#[cfg(windows)]
+struct Lease {
+    _file: std::fs::File,
+}
+
+#[cfg(windows)]
+fn probe_lease(path: &Path) -> LeaseState {
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    // Ask for the file with no sharing at all: this succeeds only if nobody
+    // else holds a handle on it.
+    match std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(path)
+    {
+        Ok(_) => LeaseState::Free,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LeaseState::Missing,
+        Err(_) => LeaseState::InUse,
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn acquire_lease(path: &Path) -> std::io::Result<Lease> {
+    // No lease primitive wired up for this target. The file is still created
+    // so the on-disk shape matches every other platform, but the probe below
+    // never reports it free, so nothing here is ever deleted — the same
+    // stance `pid_liveness` takes on an unknown target.
+    std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .map(|file| Lease { _file: file })
+}
+
+#[cfg(not(any(unix, windows)))]
+struct Lease {
+    _file: std::fs::File,
+}
+
+#[cfg(not(any(unix, windows)))]
+fn probe_lease(path: &Path) -> LeaseState {
+    match path.symlink_metadata() {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LeaseState::Missing,
+        _ => LeaseState::InUse,
     }
 }
 
@@ -196,20 +521,19 @@ fn pid_liveness(_pid: u32) -> Liveness {
 pub(crate) struct SweepStats {
     pub(crate) removed: usize,
     pub(crate) skipped_alive_or_unknown: usize,
+    pub(crate) skipped_in_use: usize,
     pub(crate) skipped_no_marker: usize,
     pub(crate) errors: usize,
 }
 
 /// Startup sweep: scan `temp_root` for entries left behind by a killed
 /// buzz-dev-mcp process (see module docs). Removes an entry ONLY when its
-/// marker names a pid that is positively confirmed dead. Every other case —
-/// no marker, corrupt marker, pid alive, pid liveness undeterminable, or a
-/// removal failure — is left alone and logged; see module docs for why that
-/// is the safe default.
+/// marker names a pid that is positively confirmed dead AND its lease is
+/// provably unheld. Every other case is left alone and logged.
 ///
 /// Best-effort end to end: nothing here returns an error or panics, since a
-/// stuck or misconfigured temp directory must never prevent the MCP server
-/// from starting.
+/// stuck or hostile temp directory must never prevent the MCP server from
+/// starting.
 pub(crate) fn sweep_stale_dirs(temp_root: &Path) -> SweepStats {
     sweep_stale_dirs_with(temp_root, &|dir| std::fs::remove_dir_all(dir))
 }
@@ -257,9 +581,11 @@ fn sweep_stale_dirs_with(
             continue;
         }
 
+        // file_type() does not follow symlinks, so a symlink pointing at a
+        // directory elsewhere is not a directory here and is skipped below.
         match entry.file_type() {
             Ok(ft) if ft.is_dir() => {}
-            Ok(_) => continue, // a same-prefixed file is never one of ours
+            Ok(_) => continue, // a same-prefixed file or link is never one of ours
             Err(e) => {
                 tracing::debug!(
                     error = %e,
@@ -280,20 +606,38 @@ fn sweep_stale_dirs_with(
 fn sweep_one(dir: &Path, stats: &mut SweepStats, remove: &dyn Fn(&Path) -> std::io::Result<()>) {
     let Some(marker) = read_owner_marker(dir) else {
         // Legacy rule: a directory with no confirmable owner — either it
-        // predates this change, or its marker is corrupt/half-written — is
-        // never auto-deleted. A dead process cannot be told apart from a
-        // session that has legitimately run for days without a marker to
-        // check, and getting that wrong deletes a live session's binaries
-        // out from under it. So these are left alone for a human (or a
-        // future one-time cleanup tool) rather than guessed at with, say,
-        // an age cutoff. Worst case the pre-existing leak persists — that's
-        // a pre-existing condition, not a regression introduced here.
+        // predates this change, or its marker is corrupt, hostile, or
+        // half-written — is never auto-deleted. A dead process cannot be
+        // told apart from a session that has legitimately run for days
+        // without a marker to check, and getting that wrong deletes a live
+        // session's binaries out from under it. So these are left alone for
+        // a human (or a future one-time cleanup tool) rather than guessed at
+        // with, say, an age cutoff. Worst case the pre-existing leak
+        // persists — that's a pre-existing condition, not a regression
+        // introduced here.
         stats.skipped_no_marker += 1;
         return;
     };
 
-    if !pid_liveness(marker.pid).may_delete() {
-        stats.skipped_alive_or_unknown += 1;
+    let owner = pid_liveness(marker.pid);
+    let lease = probe_lease(&dir.join(LEASE_FILE_NAME));
+    if !may_remove(owner, lease) {
+        if owner == Liveness::Dead {
+            // The creating process is gone but something it spawned still
+            // holds the lease: exactly the orphaned-command case the lease
+            // exists for. Logged at info because it is the interesting one —
+            // the directory will be reclaimed on a later startup, once that
+            // command finishes.
+            stats.skipped_in_use += 1;
+            tracing::info!(
+                dir = %dir.display(),
+                pid = marker.pid,
+                ?lease,
+                "buzz-dev-mcp: startup sweep: owner is gone but the temp dir is still leased; leaving it"
+            );
+        } else {
+            stats.skipped_alive_or_unknown += 1;
+        }
         return;
     }
 
@@ -323,12 +667,19 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    fn write_marker(dir: &Path, pid: u32) {
+    /// Stand in for a directory this crate created: an unheld lease file plus
+    /// a marker naming `pid`. Written by hand rather than via [`claim_dir`]
+    /// because most cases need an owner pid other than this process's.
+    fn claimed_dir(root: &Path, name: &str, pid: u32) -> std::path::PathBuf {
+        let dir = root.join(format!("{OWNER_PREFIX}{name}"));
+        std::fs::create_dir(&dir).expect("mkdir");
+        std::fs::write(dir.join(LEASE_FILE_NAME), b"").expect("write lease");
         std::fs::write(
             dir.join(MARKER_FILE_NAME),
             format!("pid={pid}\ncreated=1\n"),
         )
         .expect("write marker");
+        dir
     }
 
     /// Spawn and immediately reap a trivial child process so its pid is
@@ -349,28 +700,45 @@ mod tests {
         pid
     }
 
+    /// The deletion policy in full. Only one of the nine states authorizes
+    /// removal: the owner is provably dead and the lease is provably unheld.
+    /// Everything else — every `Unknown`, every `InUse`, every `Missing` —
+    /// must not delete.
     #[test]
-    fn dead_pid_marker_is_swept() {
+    fn only_a_dead_owner_with_a_free_lease_authorizes_removal() {
+        let owners = [Liveness::Alive, Liveness::Dead, Liveness::Unknown];
+        let leases = [LeaseState::Free, LeaseState::InUse, LeaseState::Missing];
+        for owner in owners {
+            for lease in leases {
+                let expected = owner == Liveness::Dead && lease == LeaseState::Free;
+                assert_eq!(
+                    may_remove(owner, lease),
+                    expected,
+                    "may_remove({owner:?}, {lease:?})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dead_owner_with_a_free_lease_is_swept() {
         let root = tempdir().expect("tempdir");
-        let target = root.path().join(format!("{OWNER_PREFIX}test-dead"));
-        std::fs::create_dir(&target).expect("mkdir");
-        write_marker(&target, dead_pid());
+        let target = claimed_dir(root.path(), "test-dead", dead_pid());
 
         let stats = sweep_stale_dirs(root.path());
 
         assert_eq!(stats.removed, 1, "{stats:?}");
         assert!(
             !target.exists(),
-            "orphaned dir with a dead-pid marker must be removed"
+            "orphaned dir with a dead-pid marker and a free lease must be removed"
         );
     }
 
     #[test]
     fn live_pid_marker_is_not_swept() {
         let root = tempdir().expect("tempdir");
-        let target = root.path().join(format!("{OWNER_PREFIX}test-live"));
-        std::fs::create_dir(&target).expect("mkdir");
-        write_marker(&target, std::process::id()); // this test process: definitely alive
+        // This test process: definitely alive.
+        let target = claimed_dir(root.path(), "test-live", std::process::id());
 
         let stats = sweep_stale_dirs(root.path());
 
@@ -380,6 +748,23 @@ mod tests {
             target.exists(),
             "a dir owned by a live pid must survive the sweep"
         );
+    }
+
+    /// [`claim_dir`] writes the lease before the marker, so a marked
+    /// directory with no lease file is a directory whose state we cannot
+    /// account for. It is not evidence of an idle directory, so it must not
+    /// be deleted.
+    #[test]
+    fn dead_owner_without_a_lease_file_is_not_swept() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-no-lease", dead_pid());
+        std::fs::remove_file(target.join(LEASE_FILE_NAME)).expect("remove lease");
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_in_use, 1, "{stats:?}");
+        assert!(target.exists());
     }
 
     #[test]
@@ -408,13 +793,47 @@ mod tests {
     #[test]
     fn corrupt_marker_is_treated_like_a_missing_one() {
         let root = tempdir().expect("tempdir");
-        let target = root.path().join(format!("{OWNER_PREFIX}test-corrupt"));
-        std::fs::create_dir(&target).expect("mkdir");
+        let target = claimed_dir(root.path(), "test-corrupt", dead_pid());
         std::fs::write(
             target.join(MARKER_FILE_NAME),
             b"not a valid marker\n\x00\xff",
         )
         .expect("write corrupt marker");
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_no_marker, 1, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    /// A marker bigger than the cap is not read and not trusted, so its
+    /// directory is skipped. Guards the bounded-read rule against a marker
+    /// that has been padded out to something unbounded.
+    #[test]
+    fn oversized_marker_is_skipped() {
+        let root = tempdir().expect("tempdir");
+        let pid = dead_pid();
+        let target = claimed_dir(root.path(), "test-oversized", pid);
+        let mut padded = format!("pid={pid}\n");
+        padded.push_str(&"x".repeat(MAX_MARKER_BYTES as usize * 4));
+        std::fs::write(target.join(MARKER_FILE_NAME), padded).expect("write big marker");
+
+        let stats = sweep_stale_dirs(root.path());
+
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_no_marker, 1, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    /// A marker that is a directory rather than a file must be rejected by
+    /// the regular-file check on the opened handle.
+    #[test]
+    fn marker_that_is_a_directory_is_skipped() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-marker-is-dir", dead_pid());
+        std::fs::remove_file(target.join(MARKER_FILE_NAME)).expect("remove marker");
+        std::fs::create_dir(target.join(MARKER_FILE_NAME)).expect("mkdir marker");
 
         let stats = sweep_stale_dirs(root.path());
 
@@ -461,16 +880,8 @@ mod tests {
     #[test]
     fn removal_failures_are_counted_and_do_not_abort_the_sweep() {
         let root = tempdir().expect("tempdir");
-        let first = root
-            .path()
-            .join(format!("{OWNER_PREFIX}test-remove-fails-a"));
-        let second = root
-            .path()
-            .join(format!("{OWNER_PREFIX}test-remove-fails-b"));
-        for dir in [&first, &second] {
-            std::fs::create_dir(dir).expect("mkdir");
-            write_marker(dir, dead_pid());
-        }
+        let first = claimed_dir(root.path(), "test-remove-fails-a", dead_pid());
+        let second = claimed_dir(root.path(), "test-remove-fails-b", dead_pid());
 
         let stats = sweep_stale_dirs_with(root.path(), &|_dir| {
             Err(std::io::Error::new(
@@ -487,6 +898,192 @@ mod tests {
             first.exists() && second.exists(),
             "a dir whose removal failed must be left in place"
         );
+    }
+
+    /// A live claim keeps its own directory out of the sweep even though the
+    /// marker and lease are the real ones, not hand-written.
+    #[test]
+    fn a_live_claim_protects_its_own_directory() {
+        let root = tempdir().expect("tempdir");
+        let dir = root.path().join(format!("{OWNER_PREFIX}test-live-claim"));
+        std::fs::create_dir(&dir).expect("mkdir");
+
+        let claim = claim_dir(&dir).expect("claim");
+        assert_eq!(probe_lease(&dir.join(LEASE_FILE_NAME)), LeaseState::InUse);
+
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert!(dir.exists());
+
+        drop(claim);
+        assert_eq!(probe_lease(&dir.join(LEASE_FILE_NAME)), LeaseState::Free);
+    }
+
+    /// Surrendering the claim removes the marker, which puts the directory
+    /// permanently out of the sweep's reach.
+    #[test]
+    fn surrendering_a_claim_makes_a_directory_unreclaimable() {
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-surrender", dead_pid());
+
+        surrender_claim(&target);
+
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_no_marker, 1, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    /// The regression for the orphaned-command case in the module docs: the
+    /// process that created the directory is gone, but a command it spawned
+    /// is still running with the inherited lease. The directory must survive
+    /// — and become reclaimable the moment that command exits.
+    ///
+    /// The owner "dying" is modelled by dropping the lease in this process
+    /// after the child has inherited it. That is the same thing the kernel
+    /// does on `SIGKILL`: the owner's descriptor closes, and the lock stays
+    /// held by the inherited one, because an `flock` belongs to the open file
+    /// description rather than to a process.
+    #[cfg(unix)]
+    #[test]
+    fn a_command_that_outlives_its_owner_keeps_the_directory() {
+        let root = tempdir().expect("tempdir");
+        let dir = root.path().join(format!("{OWNER_PREFIX}test-orphan-cmd"));
+        std::fs::create_dir(&dir).expect("mkdir");
+        let lease_path = dir.join(LEASE_FILE_NAME);
+
+        let claim = claim_dir(&dir).expect("claim");
+        // Spawned after the claim, so it inherits the lease descriptor.
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn long-lived child");
+
+        // The owner is gone; only the spawned command is left.
+        drop(claim);
+        // Its marker still names a dead pid, so the pid check alone would
+        // authorize a delete here.
+        std::fs::write(
+            dir.join(MARKER_FILE_NAME),
+            format!("pid={}\ncreated=1\n", dead_pid()),
+        )
+        .expect("rewrite marker with a dead owner");
+
+        assert_eq!(
+            probe_lease(&lease_path),
+            LeaseState::InUse,
+            "the spawned command must still hold the inherited lease"
+        );
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_in_use, 1, "{stats:?}");
+        assert!(
+            dir.exists(),
+            "a directory still in use by a surviving command must not be removed"
+        );
+
+        // Once that command exits, the kernel releases the last reference to
+        // the lease and the directory becomes reclaimable.
+        child.kill().expect("kill child");
+        child.wait().expect("reap child");
+        assert_eq!(probe_lease(&lease_path), LeaseState::Free);
+        let stats = sweep_stale_dirs(root.path());
+        assert_eq!(stats.removed, 1, "{stats:?}");
+        assert!(!dir.exists());
+    }
+
+    /// A marker that is a FIFO must be skipped, and — the part that matters —
+    /// must not block the sweep waiting for a writer that never comes. The
+    /// sweep runs on its own thread so a regression fails on the timeout
+    /// instead of hanging the whole test binary.
+    #[cfg(unix)]
+    #[test]
+    fn marker_that_is_a_fifo_is_skipped_without_blocking() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-fifo", dead_pid());
+        std::fs::remove_file(target.join(MARKER_FILE_NAME)).expect("remove marker");
+        nix::unistd::mkfifo(
+            &target.join(MARKER_FILE_NAME),
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )
+        .expect("mkfifo");
+
+        let scan_root = root.path().to_path_buf();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(sweep_stale_dirs(&scan_root));
+        });
+
+        let stats = rx
+            .recv_timeout(Duration::from_secs(20))
+            .expect("startup sweep blocked on a FIFO marker");
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_no_marker, 1, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    /// Same for a symlinked marker, including one pointing at a FIFO: the
+    /// open refuses to follow it at all.
+    #[cfg(unix)]
+    #[test]
+    fn marker_that_is_a_symlink_to_a_fifo_is_skipped_without_blocking() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-symlink", dead_pid());
+        let fifo = root.path().join("elsewhere.fifo");
+        nix::unistd::mkfifo(
+            &fifo,
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )
+        .expect("mkfifo");
+        std::fs::remove_file(target.join(MARKER_FILE_NAME)).expect("remove marker");
+        std::os::unix::fs::symlink(&fifo, target.join(MARKER_FILE_NAME)).expect("symlink");
+
+        let scan_root = root.path().to_path_buf();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(sweep_stale_dirs(&scan_root));
+        });
+
+        let stats = rx
+            .recv_timeout(Duration::from_secs(20))
+            .expect("startup sweep blocked on a symlinked FIFO marker");
+        assert_eq!(stats.removed, 0, "{stats:?}");
+        assert_eq!(stats.skipped_no_marker, 1, "{stats:?}");
+        assert!(target.exists());
+    }
+
+    /// A lease file that is a FIFO must not block the probe either, and must
+    /// never read as free.
+    #[cfg(unix)]
+    #[test]
+    fn lease_that_is_a_fifo_is_never_free() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let root = tempdir().expect("tempdir");
+        let target = claimed_dir(root.path(), "test-fifo-lease", dead_pid());
+        let lease_path = target.join(LEASE_FILE_NAME);
+        std::fs::remove_file(&lease_path).expect("remove lease");
+        nix::unistd::mkfifo(
+            &lease_path,
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )
+        .expect("mkfifo");
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(probe_lease(&lease_path));
+        });
+        let state = rx
+            .recv_timeout(Duration::from_secs(20))
+            .expect("lease probe blocked on a FIFO");
+        assert_eq!(state, LeaseState::InUse);
     }
 
     /// Only the error code that positively proves a pid has no process

--- a/crates/buzz-dev-mcp/tests/startup_sweep.rs
+++ b/crates/buzz-dev-mcp/tests/startup_sweep.rs
@@ -221,7 +221,10 @@ fn call_shell(server: &mut Child, command: &str) {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         use std::io::BufRead as _;
-        for line in std::io::BufReader::new(stdout).lines().map_while(Result::ok) {
+        for line in std::io::BufReader::new(stdout)
+            .lines()
+            .map_while(Result::ok)
+        {
             if tx.send(line).is_err() {
                 return;
             }
@@ -242,10 +245,7 @@ fn call_shell(server: &mut Child, command: &str) {
         }),
     );
     let hello = read_line_or_timeout(&rx, "initialize response");
-    assert!(
-        hello.contains("\"result\""),
-        "initialize failed: {hello}"
-    );
+    assert!(hello.contains("\"result\""), "initialize failed: {hello}");
 
     send(
         server,
@@ -302,7 +302,11 @@ fn a_command_that_outlives_a_hard_killed_server_keeps_its_shim_until_it_exits() 
         .chain(session)
         .filter(|d| owner_pid_of(d) == Some(server_pid))
         .collect();
-    assert_eq!(own.len(), 2, "expected a shim dir and a session dir: {own:?}");
+    assert_eq!(
+        own.len(),
+        2,
+        "expected a shim dir and a session dir: {own:?}"
+    );
 
     // Resolve a shim binary through PATH now, announce, wait for the test,
     // then check that same binary is still there. `-x` rather than running it
@@ -341,9 +345,10 @@ fn a_command_that_outlives_a_hard_killed_server_keeps_its_shim_until_it_exits() 
     // yet looked at.
     let canary = plant_dir(root.path(), "canary-first", dead_pid());
     let mut replacement = start_server(root.path());
-    wait_until("the replacement's startup sweep to reclaim the canary", || {
-        !canary.exists()
-    });
+    wait_until(
+        "the replacement's startup sweep to reclaim the canary",
+        || !canary.exists(),
+    );
     for dir in &own {
         assert!(
             dir.exists(),
@@ -356,7 +361,9 @@ fn a_command_that_outlives_a_hard_killed_server_keeps_its_shim_until_it_exits() 
     std::fs::write(&go, b"").expect("write the go signal");
     wait_until("the command to finish", || verdict.exists());
     assert_eq!(
-        std::fs::read_to_string(&verdict).expect("read verdict").trim(),
+        std::fs::read_to_string(&verdict)
+            .expect("read verdict")
+            .trim(),
         "present",
         "the surviving command lost the shim binary it resolved before its server died"
     );

--- a/crates/buzz-dev-mcp/tests/startup_sweep.rs
+++ b/crates/buzz-dev-mcp/tests/startup_sweep.rs
@@ -1,0 +1,189 @@
+//! Production-boundary coverage for the temp-dir orphan sweep (#6025).
+//!
+//! The unit tests in `sweep.rs` prove the sweep's policy. They cannot prove
+//! that the policy is *wired to anything*: delete the sweep call from `main`,
+//! or the claim from `Shim::install`, and they all still pass. So this one
+//! drives the real `buzz-dev-mcp` binary and asserts only on what lands in
+//! the temp root, which means it fails if any of the three production
+//! integration points is removed, and it fails if the on-disk names change
+//! under a running session.
+//!
+//! Both phases run against one temp root, handed to the binary through the
+//! platform's temp-dir environment variables, so nothing here touches the
+//! real system temp directory.
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// On-disk contract, deliberately duplicated rather than imported: these are
+/// crate-private in `sweep`, and a test that reads them from the code under
+/// test cannot notice the code under test renaming them.
+const OWNER_PREFIX: &str = "buzz-dev-mcp-";
+const SESSION_PREFIX: &str = "buzz-dev-mcp-session-";
+const MARKER_FILE_NAME: &str = ".buzz-dev-mcp-owner";
+const LEASE_FILE_NAME: &str = ".buzz-dev-mcp-lease";
+
+/// Generous: on Windows the shim directory is five copies of a debug binary
+/// north of 100 MB, so the session directory that follows it can be seconds
+/// away on a loaded CI runner.
+const DEADLINE: Duration = Duration::from_secs(90);
+
+fn wait_until(what: &str, mut cond: impl FnMut() -> bool) {
+    let start = Instant::now();
+    while start.elapsed() < DEADLINE {
+        if cond() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out after {DEADLINE:?} waiting for {what}");
+}
+
+/// Spawn and immediately reap a trivial child so its pid is known dead.
+fn dead_pid() -> u32 {
+    let mut cmd = if cfg!(windows) {
+        let mut c = Command::new("cmd");
+        c.args(["/C", "exit", "0"]);
+        c
+    } else {
+        Command::new("true")
+    };
+    let mut child = cmd.spawn().expect("spawn short-lived helper");
+    let pid = child.id();
+    child.wait().expect("reap helper");
+    pid
+}
+
+/// A directory shaped exactly like one this crate leaves behind: an unheld
+/// lease file plus an owner marker naming `pid`.
+fn plant_dir(root: &Path, name: &str, pid: u32) -> PathBuf {
+    let dir = root.join(format!("{OWNER_PREFIX}{name}"));
+    std::fs::create_dir(&dir).expect("mkdir");
+    std::fs::write(dir.join(LEASE_FILE_NAME), b"").expect("write lease");
+    std::fs::write(
+        dir.join(MARKER_FILE_NAME),
+        format!("pid={pid}\ncreated=1\n"),
+    )
+    .expect("write marker");
+    dir
+}
+
+fn start_server(root: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_buzz-dev-mcp"))
+        // TMPDIR is Unix, TMP/TEMP are Windows. Set all three so the binary's
+        // `std::env::temp_dir()` lands in our scratch root on every platform.
+        .env("TMPDIR", root)
+        .env("TMP", root)
+        .env("TEMP", root)
+        // Held open for the life of the test: the server serves MCP over
+        // stdio, so an open stdin is what keeps it running.
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn buzz-dev-mcp")
+}
+
+fn owner_pid_of(dir: &Path) -> Option<u32> {
+    let text = std::fs::read_to_string(dir.join(MARKER_FILE_NAME)).ok()?;
+    text.lines()
+        .find_map(|l| l.strip_prefix("pid="))
+        .and_then(|v| v.trim().parse().ok())
+}
+
+/// Directories in `root` that this crate created and claimed, split by kind.
+fn claimed_dirs(root: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let mut shim = Vec::new();
+    let mut session = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return (shim, session);
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !name.starts_with(OWNER_PREFIX) || !entry.path().is_dir() {
+            continue;
+        }
+        if !entry.path().join(MARKER_FILE_NAME).exists() {
+            continue;
+        }
+        if name.starts_with(SESSION_PREFIX) {
+            session.push(entry.path());
+        } else {
+            shim.push(entry.path());
+        }
+    }
+    (shim, session)
+}
+
+#[test]
+fn a_real_server_sweeps_orphans_claims_its_own_dirs_and_is_reclaimed_after_a_hard_kill() {
+    let root = tempfile::tempdir().expect("tempdir");
+
+    // An orphan exactly like a hard-killed session leaves: dead owner, lease
+    // released by the kernel when that process died.
+    let orphan = plant_dir(root.path(), "orphan-under-test", dead_pid());
+    // And a directory whose owner is very much alive (this test process). The
+    // sweep must not touch it, which is what separates "reclaims orphans"
+    // from "empties the temp directory".
+    let live = plant_dir(root.path(), "live-under-test", std::process::id());
+
+    let mut server = start_server(root.path());
+    let server_pid = server.id();
+
+    wait_until("the startup sweep to reclaim the planted orphan", || {
+        !orphan.exists()
+    });
+    assert!(
+        live.exists(),
+        "a directory owned by a live process must survive the startup sweep"
+    );
+
+    // Both directories the server creates must be claimed: marker naming the
+    // server, and a lease file beside it. This is what fails if either
+    // `Shim::install` or `SharedState::new` stops claiming.
+    wait_until("the server to create and claim both temp dirs", || {
+        let (shim, session) = claimed_dirs(root.path());
+        shim.iter().any(|d| owner_pid_of(d) == Some(server_pid))
+            && session.iter().any(|d| owner_pid_of(d) == Some(server_pid))
+    });
+
+    let (shim, session) = claimed_dirs(root.path());
+    let own: Vec<PathBuf> = shim
+        .into_iter()
+        .chain(session)
+        .filter(|d| owner_pid_of(d) == Some(server_pid))
+        .collect();
+    assert_eq!(
+        own.len(),
+        2,
+        "expected a shim dir and a session dir: {own:?}"
+    );
+    for dir in &own {
+        assert!(
+            dir.join(LEASE_FILE_NAME).exists(),
+            "claimed dir {} has no lease file",
+            dir.display()
+        );
+    }
+
+    // Phase two, the actual bug: kill the server without giving it any chance
+    // to clean up, then start a replacement. The kernel released the dead
+    // server's lease when it died, so the replacement must reclaim both
+    // directories.
+    server.kill().expect("kill server");
+    server.wait().expect("reap server");
+
+    let mut replacement = start_server(root.path());
+    wait_until(
+        "the replacement to reclaim the killed server's dirs",
+        || own.iter().all(|d| !d.exists()),
+    );
+    assert!(
+        live.exists(),
+        "the live-owner directory must survive the replacement's sweep too"
+    );
+
+    replacement.kill().expect("kill replacement");
+    replacement.wait().expect("reap replacement");
+}

--- a/crates/buzz-dev-mcp/tests/startup_sweep.rs
+++ b/crates/buzz-dev-mcp/tests/startup_sweep.rs
@@ -23,6 +23,7 @@ const OWNER_PREFIX: &str = "buzz-dev-mcp-";
 const SESSION_PREFIX: &str = "buzz-dev-mcp-session-";
 const MARKER_FILE_NAME: &str = ".buzz-dev-mcp-owner";
 const LEASE_FILE_NAME: &str = ".buzz-dev-mcp-lease";
+const CMDS_DIR_NAME: &str = ".buzz-dev-mcp-cmds";
 
 /// Generous: on Windows the shim directory is five copies of a debug binary
 /// north of 100 MB, so the session directory that follows it can be seconds
@@ -56,11 +57,12 @@ fn dead_pid() -> u32 {
 }
 
 /// A directory shaped exactly like one this crate leaves behind: an unheld
-/// lease file plus an owner marker naming `pid`.
+/// lease file, an empty command registry, and an owner marker naming `pid`.
 fn plant_dir(root: &Path, name: &str, pid: u32) -> PathBuf {
     let dir = root.join(format!("{OWNER_PREFIX}{name}"));
     std::fs::create_dir(&dir).expect("mkdir");
     std::fs::write(dir.join(LEASE_FILE_NAME), b"").expect("write lease");
+    std::fs::create_dir(dir.join(CMDS_DIR_NAME)).expect("mkdir registry");
     std::fs::write(
         dir.join(MARKER_FILE_NAME),
         format!("pid={pid}\ncreated=1\n"),
@@ -165,6 +167,11 @@ fn a_real_server_sweeps_orphans_claims_its_own_dirs_and_is_reclaimed_after_a_har
             "claimed dir {} has no lease file",
             dir.display()
         );
+        assert!(
+            dir.join(CMDS_DIR_NAME).is_dir(),
+            "claimed dir {} has no command registry",
+            dir.display()
+        );
     }
 
     // Phase two, the actual bug: kill the server without giving it any chance
@@ -186,4 +193,180 @@ fn a_real_server_sweeps_orphans_claims_its_own_dirs_and_is_reclaimed_after_a_har
 
     replacement.kill().expect("kill replacement");
     replacement.wait().expect("reap replacement");
+}
+
+/// Send one line of JSON-RPC to a server's stdin.
+fn send(server: &mut Child, line: &serde_json::Value) {
+    use std::io::Write as _;
+    let stdin = server.stdin.as_mut().expect("server stdin");
+    writeln!(stdin, "{line}").expect("write to server stdin");
+    stdin.flush().expect("flush server stdin");
+}
+
+/// Read one line from `reader`, or panic after [`DEADLINE`]. Keeps a stalled
+/// handshake from hanging the whole test binary.
+fn read_line_or_timeout(rx: &std::sync::mpsc::Receiver<String>, what: &str) -> String {
+    rx.recv_timeout(DEADLINE)
+        .unwrap_or_else(|e| panic!("no {what} from the server within {DEADLINE:?}: {e}"))
+}
+
+/// Drive the MCP handshake and call the `shell` tool with `command`, without
+/// waiting for its result — the point of every caller here is that the
+/// command outlives the server it was asked of.
+fn call_shell(server: &mut Child, command: &str) {
+    let stdout = server.stdout.take().expect("server stdout");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        use std::io::BufRead as _;
+        for line in std::io::BufReader::new(stdout).lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+
+    send(
+        server,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "startup-sweep-test", "version": "0"},
+            },
+        }),
+    );
+    let hello = read_line_or_timeout(&rx, "initialize response");
+    assert!(
+        hello.contains("\"result\""),
+        "initialize failed: {hello}"
+    );
+
+    send(
+        server,
+        &serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    );
+    send(
+        server,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "shell",
+                "arguments": {"command": command, "timeout_ms": 300_000},
+            },
+        }),
+    );
+}
+
+/// The whole point of the feature, end to end, with nothing modelled by hand.
+///
+/// A real server, a real `shell` tool call, a real `SIGKILL` of that server
+/// while the command is still running, and a real replacement that runs its
+/// startup sweep with the orphaned command still alive. The command must keep
+/// its shim binaries, and the directories must be reclaimed once it is gone
+/// and not one moment before.
+///
+/// Unix only, and that is the point rather than a limitation: on Windows the
+/// command is held in a job object with `KILL_ON_JOB_CLOSE`, so killing the
+/// server takes the command with it and there is no surviving command to
+/// protect.
+#[cfg(unix)]
+#[test]
+fn a_command_that_outlives_a_hard_killed_server_keeps_its_shim_until_it_exits() {
+    let root = tempfile::tempdir().expect("tempdir");
+    // Signals live outside the temp root the servers sweep, so nothing here
+    // can be mistaken for one of the crate's own directories.
+    let signals = tempfile::tempdir().expect("tempdir");
+    let started = signals.path().join("started");
+    let go = signals.path().join("go");
+    let shim_path = signals.path().join("shim-path");
+    let verdict = signals.path().join("verdict");
+
+    let mut server = start_server(root.path());
+    let server_pid = server.id();
+    wait_until("the server to create and claim both temp dirs", || {
+        let (shim, session) = claimed_dirs(root.path());
+        shim.iter().any(|d| owner_pid_of(d) == Some(server_pid))
+            && session.iter().any(|d| owner_pid_of(d) == Some(server_pid))
+    });
+    let (shim, session) = claimed_dirs(root.path());
+    let own: Vec<PathBuf> = shim
+        .into_iter()
+        .chain(session)
+        .filter(|d| owner_pid_of(d) == Some(server_pid))
+        .collect();
+    assert_eq!(own.len(), 2, "expected a shim dir and a session dir: {own:?}");
+
+    // Resolve a shim binary through PATH now, announce, wait for the test,
+    // then check that same binary is still there. `-x` rather than running it
+    // because what is being proved is that the file survived, not what the
+    // multicall binary does when invoked as `rg`.
+    let command = format!(
+        "shim=\"$(command -v rg)\"; printf '%s' \"$shim\" > {shim_path}; touch {started}; \
+         while [ ! -f {go} ]; do sleep 0.1; done; \
+         if [ -x \"$shim\" ]; then echo present > {verdict}; else echo missing > {verdict}; fi",
+        shim_path = shim_path.display(),
+        started = started.display(),
+        go = go.display(),
+        verdict = verdict.display(),
+    );
+    call_shell(&mut server, &command);
+    wait_until("the shell command to start", || started.exists());
+
+    let resolved = std::fs::read_to_string(&shim_path).expect("read resolved shim path");
+    assert!(
+        own.iter().any(|d| Path::new(&resolved).starts_with(d)),
+        "the command resolved `rg` to {resolved}, which is not in either claimed dir {own:?}"
+    );
+
+    // Hard kill. No Drop guards run, nothing is deregistered, and the command
+    // is left running in its own process group.
+    server.kill().expect("kill server");
+    server.wait().expect("reap server");
+    assert!(
+        !verdict.exists(),
+        "the command must still be running after its server was killed"
+    );
+
+    // The replacement sweeps at startup. A freshly planted orphan is the
+    // control: when it disappears, the sweep has demonstrably run, so the
+    // directories that are still there were kept on purpose rather than not
+    // yet looked at.
+    let canary = plant_dir(root.path(), "canary-first", dead_pid());
+    let mut replacement = start_server(root.path());
+    wait_until("the replacement's startup sweep to reclaim the canary", || {
+        !canary.exists()
+    });
+    for dir in &own {
+        assert!(
+            dir.exists(),
+            "the replacement deleted {} while a command was still using it",
+            dir.display()
+        );
+    }
+
+    // Let the command finish, and let it tell us whether its shim survived.
+    std::fs::write(&go, b"").expect("write the go signal");
+    wait_until("the command to finish", || verdict.exists());
+    assert_eq!(
+        std::fs::read_to_string(&verdict).expect("read verdict").trim(),
+        "present",
+        "the surviving command lost the shim binary it resolved before its server died"
+    );
+
+    // And now that it is gone, the directories are reclaimable: the registry
+    // pins them for exactly as long as the command lives, not forever.
+    replacement.kill().expect("kill replacement");
+    replacement.wait().expect("reap replacement");
+    let mut third = start_server(root.path());
+    wait_until(
+        "the third server to reclaim the finished command's dirs",
+        || own.iter().all(|d| !d.exists()),
+    );
+    third.kill().expect("kill third server");
+    third.wait().expect("reap third server");
 }

--- a/crates/buzz-dev-mcp/tests/startup_sweep.rs
+++ b/crates/buzz-dev-mcp/tests/startup_sweep.rs
@@ -196,6 +196,7 @@ fn a_real_server_sweeps_orphans_claims_its_own_dirs_and_is_reclaimed_after_a_har
 }
 
 /// Send one line of JSON-RPC to a server's stdin.
+#[cfg(unix)]
 fn send(server: &mut Child, line: &serde_json::Value) {
     use std::io::Write as _;
     let stdin = server.stdin.as_mut().expect("server stdin");
@@ -205,6 +206,7 @@ fn send(server: &mut Child, line: &serde_json::Value) {
 
 /// Read one line from `reader`, or panic after [`DEADLINE`]. Keeps a stalled
 /// handshake from hanging the whole test binary.
+#[cfg(unix)]
 fn read_line_or_timeout(rx: &std::sync::mpsc::Receiver<String>, what: &str) -> String {
     rx.recv_timeout(DEADLINE)
         .unwrap_or_else(|e| panic!("no {what} from the server within {DEADLINE:?}: {e}"))
@@ -213,6 +215,7 @@ fn read_line_or_timeout(rx: &std::sync::mpsc::Receiver<String>, what: &str) -> S
 /// Drive the MCP handshake and call the `shell` tool with `command`, without
 /// waiting for its result — the point of every caller here is that the
 /// command outlives the server it was asked of.
+#[cfg(unix)]
 fn call_shell(server: &mut Child, command: &str) {
     let stdout = server.stdout.take().expect("server stdout");
     let (tx, rx) = std::sync::mpsc::channel();


### PR DESCRIPTION
Fixes #6025.

`buzz-dev-mcp` creates two `tempfile::TempDir` per server start, the shim dir holding copies of buzz, rg, tree and the git helpers, and the session dir. Cleanup lives in `Drop`. These processes get killed rather than exiting gracefully, so `Drop` never runs and both directories are orphaned. On Windows a hard kill is not catchable at all, so there is no cleanup hook to hang this on in the first place. I measured 104 folders and 5.05 GB over 33 hours on one machine, at 97 MB per shim dir.

## The approach, and why it is not an age sweep

The obvious fix is "delete anything older than 24 hours" and it is wrong. Sessions legitimately run for days, and an age cutoff would rip the binaries and key file out from under a live one. Mine run far longer than a day.

So each directory now gets a small ownership marker, `.buzz-dev-mcp-owner`, recording the creating process's pid and creation time. At startup, before creating its own directories, the server sweeps the system temp dir for `buzz-dev-mcp-` prefixed entries and removes one **only when the marker's pid is positively confirmed dead**.

Every uncertain case is left alone. No marker, corrupt marker, pid alive, or liveness undeterminable, all skipped. That failure direction is the safe one, worst case the leak persists for that directory. The sweep is best-effort end to end and never fails startup, including on a permission error against someone else's temp entry.

Liveness is `nix::sys::signal::kill(pid, None)` on Unix and `OpenProcess` / `GetExitCodeProcess` on Windows. **No new dependencies.** Both crates were already dependencies here for the existing `KillGroup` timeout-kill path. The Unix branch stays fully safe code, the Windows FFI sits behind `#[allow(unsafe_code)]` matching the existing pattern in `shell.rs` and `shim.rs`.

## Known limitation, stated up front

Directories that predate this change have no marker, so they are left alone rather than guessed at. **This PR stops the leak going forward, it does not reclaim the existing backlog.** Reclaiming that safely needs a separate opt-in tool, and I did not want to smuggle a destructive one-off into a bug fix. Happy to follow up with one if you want it.

## Tests

Seven new tests in `sweep.rs`, all pointed at a `tempfile::tempdir()` and never at the real system temp dir.

- dead pid marker is swept
- live pid marker is not swept
- missing marker is left alone, documenting the legacy rule
- corrupt marker is treated like a missing one
- unrelated entries are ignored
- sweep tolerates a temp root that cannot be read
- sweep tolerates a permission denied entry, Unix only with a root-aware skip

The dead pid is obtained deterministically by spawning and reaping a trivial child rather than guessing an unused number.

## Verification

```
rustfmt --check on changed files          clean
cargo clippy -p buzz-dev-mcp --all-targets --all-features -- -D warnings
                                          exit 0, no warnings
cargo test -p buzz-dev-mcp                125 passed, 0 failed
```

One caveat I would rather flag than hide. My local toolchain is `x86_64-pc-windows-gnu`, not the `-msvc` target CI uses, because MSVC Build Tools were not available on this machine. The `windows-sys` calls are target agnostic, but I could not verify against MSVC directly. I also could not cross-compile-check the Unix branch, so I reviewed it by hand, it only calls the safe `nix` wrapper.

Separately, two or three pre-existing `shell::tests::*` cases flake under parallel execution in my sandbox. I reproduced the identical flake on unmodified `main` with the same command, so it is not from this change. Running with `--test-threads=1` is green.
