### PR TITLE
fix(desktop): one duplicate-param policy for deep links

### DIFF
--- a/desktop/src-tauri/src/deep_link.rs
+++ b/desktop/src-tauri/src/deep_link.rs
@@ -305,26 +305,66 @@ pub(crate) fn install_deep_link_handlers(app: &mut tauri::App) {
     }
 }
 
+/// What a query parameter that may appear at most once actually was.
+///
+/// Three outcomes, not two. Collapsing `Repeated` into `Absent` is what let a
+/// duplicate slip past an *optional* parameter: the reader said "not supplied",
+/// the parser shrugged and carried on, and the link was accepted with the field
+/// silently dropped — the opposite of the single policy this parser is supposed
+/// to apply.
+enum SingleParam {
+    /// Not supplied at all, or supplied exactly once with an empty value.
+    /// Empty has always read as absent here and still does.
+    Absent,
+    Present(String),
+    /// Named more than once. Always a rejection, never a pick.
+    Repeated,
+}
+
 /// Read a query parameter that may appear at most once.
 ///
-/// Returns `None` when the parameter is absent, empty, or repeated. Repeated
-/// is deliberately a rejection rather than a pick: our own builders never emit
-/// a duplicate, the in-app parsers in
+/// Repeated is deliberately a rejection rather than a pick: our own builders
+/// never emit a duplicate, the in-app parsers in
 /// `desktop/src/features/messages/lib/messageLink.ts` and
 /// `desktop/src/shared/lib/entityLink.ts` take the first value or refuse
 /// outright, and this parser used to take the *last* — so the same URL could
 /// route one way when clicked inside the app and another when handed to the
 /// app by the OS.
-fn single_param(url: &Url, name: &str) -> Option<String> {
+fn read_single_param(url: &Url, name: &str) -> SingleParam {
     let mut values = url
         .query_pairs()
         .filter(|(key, _)| key == name)
         .map(|(_, value)| value.into_owned());
-    let first = values.next()?;
-    if values.next().is_some() || first.is_empty() {
-        return None;
+    let Some(first) = values.next() else {
+        return SingleParam::Absent;
+    };
+    if values.next().is_some() {
+        return SingleParam::Repeated;
     }
-    Some(first)
+    if first.is_empty() {
+        return SingleParam::Absent;
+    }
+    SingleParam::Present(first)
+}
+
+/// A required parameter: absent, empty and repeated all fail the same way,
+/// because the caller has nothing to distinguish them with.
+fn single_param(url: &Url, name: &str) -> Option<String> {
+    match read_single_param(url, name) {
+        SingleParam::Present(value) => Some(value),
+        SingleParam::Absent | SingleParam::Repeated => None,
+    }
+}
+
+/// An optional parameter. `Some(None)` is a valid absence; `None` is a
+/// rejection of the whole link, which is what a repetition has to be — an
+/// optional parameter is still covered by the one-value-per-param policy.
+fn optional_param(url: &Url, name: &str) -> Option<Option<String>> {
+    match read_single_param(url, name) {
+        SingleParam::Absent => Some(None),
+        SingleParam::Present(value) => Some(Some(value)),
+        SingleParam::Repeated => None,
+    }
 }
 
 /// A 64-character hex event id, lowercased. Mirrors the check
@@ -343,16 +383,9 @@ fn hex64_param(url: &Url, name: &str) -> Option<String> {
 /// An optional hex64 param: absent or empty reads as absent, as it always has;
 /// present-but-malformed and repeated are rejections.
 fn optional_hex64_param(url: &Url, name: &str) -> Option<Option<String>> {
-    let values: Vec<String> = url
-        .query_pairs()
-        .filter(|(key, _)| key == name)
-        .map(|(_, value)| value.into_owned())
-        .collect();
-    match values.as_slice() {
-        [] => Some(None),
-        [value] if value.is_empty() => Some(None),
-        [value] => canonical_hex64(value).map(Some),
-        _ => None,
+    match optional_param(url, name)? {
+        None => Some(None),
+        Some(value) => canonical_hex64(&value).map(Some),
     }
 }
 
@@ -390,7 +423,9 @@ fn parse_message_deep_link(url: &Url) -> Option<serde_json::Value> {
 /// payload.
 fn parse_join_deep_link(url: &Url) -> Option<serde_json::Value> {
     let code = single_param(url, "code")?;
-    let policy_receipt = single_param(url, "policy_receipt");
+    // Optional, but still one-value-only: a repeated `policy_receipt` used to
+    // read as "not supplied" and the join went ahead without it.
+    let policy_receipt = optional_param(url, "policy_receipt")?;
     let relay_url = parse_websocket_relay_param(url)?;
     Some(serde_json::json!({
         "relayUrl": relay_url,
@@ -502,7 +537,7 @@ fn parse_websocket_relay_param(url: &Url) -> Option<String> {
 fn parse_add_community_deep_link(url: &Url) -> Option<AddCommunityDeepLinkPayload> {
     Some(AddCommunityDeepLinkPayload {
         relay_url: parse_websocket_relay_param(url)?,
-        name: optional_non_empty_param(url, "name"),
+        name: optional_param(url, "name")?,
     })
 }
 
@@ -522,16 +557,26 @@ struct NostrBindDeepLinkPayload {
     callback_url: Option<String>,
 }
 
+/// Nostr-bind's required-parameter reader. Was `.find()`, i.e. take the first
+/// value — the one policy this parser is meant to have applies to a bind link
+/// too, and these are the most security-sensitive params it reads.
 fn non_empty_param(url: &Url, name: &str) -> Result<String, String> {
-    url.query_pairs()
-        .find(|(key, _)| key == name)
-        .map(|(_, value)| value.into_owned())
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| format!("missing {name}"))
+    match read_single_param(url, name) {
+        SingleParam::Present(value) => Ok(value),
+        SingleParam::Absent => Err(format!("missing {name}")),
+        SingleParam::Repeated => Err(format!("repeated {name}")),
+    }
 }
 
-fn optional_non_empty_param(url: &Url, name: &str) -> Option<String> {
-    single_param(url, name)
+/// Nostr-bind's optional-parameter reader. A repeated `callback_url` must not
+/// read as "no callback supplied": that would hand the caller a bind payload
+/// whose callback never went through `validate_nostr_bind_callback_url`.
+fn optional_non_empty_param(url: &Url, name: &str) -> Result<Option<String>, String> {
+    match read_single_param(url, name) {
+        SingleParam::Absent => Ok(None),
+        SingleParam::Present(value) => Ok(Some(value)),
+        SingleParam::Repeated => Err(format!("repeated {name}")),
+    }
 }
 
 fn validate_nostr_bind_callback_url(callback_url: &str, origin: &str) -> Result<(), String> {
@@ -567,7 +612,7 @@ fn parse_nostr_bind_deep_link(url: &Url) -> Result<NostrBindDeepLinkPayload, Str
     let origin = non_empty_param(url, "origin")?;
     let expires_at = non_empty_param(url, "expires_at")?;
     let return_mode = non_empty_param(url, "return")?;
-    let callback_url = optional_non_empty_param(url, "callback_url");
+    let callback_url = optional_non_empty_param(url, "callback_url")?;
 
     nostr_bind::validate_challenge_id(&challenge_id)?;
     nostr_bind::validate_nonce(&nonce)?;

--- a/desktop/src-tauri/src/deep_link.rs
+++ b/desktop/src-tauri/src/deep_link.rs
@@ -329,9 +329,20 @@ fn single_param(url: &Url, name: &str) -> Option<String> {
 
 /// A 64-character hex event id, lowercased. Mirrors the check
 /// `parse_channel_deep_link` already applies to the message id it carries.
-/// An optional param: absent or empty reads as absent; repeated is a
-/// rejection.
-fn optional_single_param(url: &Url, name: &str) -> Option<Option<String>> {
+fn canonical_hex64(value: &str) -> Option<String> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(value.to_ascii_lowercase())
+}
+
+fn hex64_param(url: &Url, name: &str) -> Option<String> {
+    canonical_hex64(&single_param(url, name)?)
+}
+
+/// An optional hex64 param: absent or empty reads as absent, as it always has;
+/// present-but-malformed and repeated are rejections.
+fn optional_hex64_param(url: &Url, name: &str) -> Option<Option<String>> {
     let values: Vec<String> = url
         .query_pairs()
         .filter(|(key, _)| key == name)
@@ -340,7 +351,7 @@ fn optional_single_param(url: &Url, name: &str) -> Option<Option<String>> {
     match values.as_slice() {
         [] => Some(None),
         [value] if value.is_empty() => Some(None),
-        [value] => Some(Some(value.clone())),
+        [value] => canonical_hex64(value).map(Some),
         _ => None,
     }
 }
@@ -351,12 +362,21 @@ fn optional_single_param(url: &Url, name: &str) -> Option<Option<String>> {
 /// policy of the `connect` arm so the frontend never sees a half-formed
 /// payload (e.g. `channelId: ""` from `channel=&id=foo`).
 ///
+/// The shapes are checked the same way `parse_channel_deep_link` checks the
+/// equivalent path segments a few lines up: a `buzz://message` link and a
+/// `buzz://channel/<uuid>/<id>` link name the same two things, so a value one
+/// of them would refuse should not sail through the other.
+///
 /// Pulled out of `handle_deep_link_url` so it can be unit-tested without
 /// a live `tauri::AppHandle`.
 fn parse_message_deep_link(url: &Url) -> Option<serde_json::Value> {
-    let channel_id = single_param(url, "channel")?;
-    let message_id = single_param(url, "id")?;
-    let thread = optional_single_param(url, "thread")?;
+    let channel_id = uuid::Uuid::parse_str(&single_param(url, "channel")?)
+        .ok()?
+        .to_string();
+    let message_id = hex64_param(url, "id")?;
+    // Absent or empty is fine; present-but-malformed is not, and neither is
+    // repeated.
+    let thread = optional_hex64_param(url, "thread")?;
     Some(serde_json::json!({
         "channelId": channel_id,
         "messageId": message_id,

--- a/desktop/src-tauri/src/deep_link.rs
+++ b/desktop/src-tauri/src/deep_link.rs
@@ -305,6 +305,46 @@ pub(crate) fn install_deep_link_handlers(app: &mut tauri::App) {
     }
 }
 
+/// Read a query parameter that may appear at most once.
+///
+/// Returns `None` when the parameter is absent, empty, or repeated. Repeated
+/// is deliberately a rejection rather than a pick: our own builders never emit
+/// a duplicate, the in-app parsers in
+/// `desktop/src/features/messages/lib/messageLink.ts` and
+/// `desktop/src/shared/lib/entityLink.ts` take the first value or refuse
+/// outright, and this parser used to take the *last* — so the same URL could
+/// route one way when clicked inside the app and another when handed to the
+/// app by the OS.
+fn single_param(url: &Url, name: &str) -> Option<String> {
+    let mut values = url
+        .query_pairs()
+        .filter(|(key, _)| key == name)
+        .map(|(_, value)| value.into_owned());
+    let first = values.next()?;
+    if values.next().is_some() || first.is_empty() {
+        return None;
+    }
+    Some(first)
+}
+
+/// A 64-character hex event id, lowercased. Mirrors the check
+/// `parse_channel_deep_link` already applies to the message id it carries.
+/// An optional param: absent or empty reads as absent; repeated is a
+/// rejection.
+fn optional_single_param(url: &Url, name: &str) -> Option<Option<String>> {
+    let values: Vec<String> = url
+        .query_pairs()
+        .filter(|(key, _)| key == name)
+        .map(|(_, value)| value.into_owned())
+        .collect();
+    match values.as_slice() {
+        [] => Some(None),
+        [value] if value.is_empty() => Some(None),
+        [value] => Some(Some(value.clone())),
+        _ => None,
+    }
+}
+
 /// Parse the query string of a `buzz://message?…` URL into the JSON
 /// payload emitted on `deep-link-message`. Returns `None` when a required
 /// param (`channel`, `id`) is missing or empty — mirroring the validation
@@ -314,22 +354,9 @@ pub(crate) fn install_deep_link_handlers(app: &mut tauri::App) {
 /// Pulled out of `handle_deep_link_url` so it can be unit-tested without
 /// a live `tauri::AppHandle`.
 fn parse_message_deep_link(url: &Url) -> Option<serde_json::Value> {
-    let mut channel: Option<String> = None;
-    let mut message_id: Option<String> = None;
-    let mut thread: Option<String> = None;
-    for (k, v) in url.query_pairs() {
-        let v = v.into_owned();
-        if v.is_empty() {
-            continue;
-        }
-        match k.as_ref() {
-            "channel" => channel = Some(v),
-            "id" => message_id = Some(v),
-            "thread" => thread = Some(v),
-            _ => {}
-        }
-    }
-    let (channel_id, message_id) = (channel?, message_id?);
+    let channel_id = single_param(url, "channel")?;
+    let message_id = single_param(url, "id")?;
+    let thread = optional_single_param(url, "thread")?;
     Some(serde_json::json!({
         "channelId": channel_id,
         "messageId": message_id,
@@ -342,20 +369,8 @@ fn parse_message_deep_link(url: &Url) -> Option<serde_json::Value> {
 /// `code`; returns `None` otherwise so the frontend never sees a half-formed
 /// payload.
 fn parse_join_deep_link(url: &Url) -> Option<serde_json::Value> {
-    let mut code: Option<String> = None;
-    let mut policy_receipt: Option<String> = None;
-    for (k, v) in url.query_pairs() {
-        let v = v.into_owned();
-        if v.is_empty() {
-            continue;
-        }
-        match k.as_ref() {
-            "code" => code = Some(v),
-            "policy_receipt" => policy_receipt = Some(v),
-            _ => {}
-        }
-    }
-    let code = code?;
+    let code = single_param(url, "code")?;
+    let policy_receipt = single_param(url, "policy_receipt");
     let relay_url = parse_websocket_relay_param(url)?;
     Some(serde_json::json!({
         "relayUrl": relay_url,
@@ -456,11 +471,7 @@ struct AddCommunityDeepLinkPayload {
 }
 
 fn parse_websocket_relay_param(url: &Url) -> Option<String> {
-    let relay_url = url
-        .query_pairs()
-        .find(|(key, _)| key == "relay")
-        .map(|(_, value)| value.into_owned())
-        .filter(|value| !value.is_empty())?;
+    let relay_url = single_param(url, "relay")?;
     let parsed = Url::parse(&relay_url).ok()?;
     if !matches!(parsed.scheme(), "ws" | "wss") || parsed.host_str().is_none() {
         return None;
@@ -500,10 +511,7 @@ fn non_empty_param(url: &Url, name: &str) -> Result<String, String> {
 }
 
 fn optional_non_empty_param(url: &Url, name: &str) -> Option<String> {
-    url.query_pairs()
-        .find(|(key, _)| key == name)
-        .map(|(_, value)| value.into_owned())
-        .filter(|value| !value.is_empty())
+    single_param(url, name)
 }
 
 fn validate_nostr_bind_callback_url(callback_url: &str, origin: &str) -> Result<(), String> {

--- a/desktop/src-tauri/src/deep_link_tests.rs
+++ b/desktop/src-tauri/src/deep_link_tests.rs
@@ -338,52 +338,91 @@ fn parse_channel_deep_link_rejects_malformed_forms() {
 
 #[test]
 fn parse_message_deep_link_extracts_required_params() {
-    let url = Url::parse("buzz://message?channel=abc&id=xyz").unwrap();
+    let url = Url::parse("buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
     let payload = parse_message_deep_link(&url).expect("required params present");
-    assert_eq!(payload["channelId"], "abc");
-    assert_eq!(payload["messageId"], "xyz");
+    assert_eq!(payload["channelId"], "580ca78b-9dae-46f3-8854-bd671853ba32");
+    assert_eq!(
+        payload["messageId"],
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
     assert!(payload["threadRootId"].is_null());
 }
 
 #[test]
 fn parse_message_deep_link_accepts_buzz_scheme() {
-    let url = Url::parse("buzz://message?channel=abc&id=xyz").unwrap();
+    let url = Url::parse("buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
     let payload = parse_message_deep_link(&url).expect("required params present");
-    assert_eq!(payload["channelId"], "abc");
-    assert_eq!(payload["messageId"], "xyz");
+    assert_eq!(payload["channelId"], "580ca78b-9dae-46f3-8854-bd671853ba32");
+    assert_eq!(
+        payload["messageId"],
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
 }
 
 #[test]
 fn parse_message_deep_link_includes_thread_root() {
-    let url = Url::parse("buzz://message?channel=abc&id=xyz&thread=root1").unwrap();
+    let url = Url::parse("buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&thread=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap();
     let payload = parse_message_deep_link(&url).expect("required params present");
-    assert_eq!(payload["threadRootId"], "root1");
+    assert_eq!(
+        payload["threadRootId"],
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    );
 }
 
 #[test]
 fn parse_message_deep_link_rejects_missing_id() {
-    let url = Url::parse("buzz://message?channel=abc").unwrap();
+    let url = Url::parse("buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32").unwrap();
     assert!(parse_message_deep_link(&url).is_none());
 }
 
 #[test]
 fn parse_message_deep_link_rejects_empty_channel() {
     // Regression: `channel=&id=foo` previously produced channelId: "".
-    let url = Url::parse("buzz://message?channel=&id=foo").unwrap();
+    let url = Url::parse("buzz://message?channel=&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
     assert!(parse_message_deep_link(&url).is_none());
 }
 
 #[test]
 fn parse_message_deep_link_rejects_empty_id() {
-    let url = Url::parse("buzz://message?channel=abc&id=").unwrap();
+    let url =
+        Url::parse("buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=").unwrap();
     assert!(parse_message_deep_link(&url).is_none());
 }
 
 #[test]
 fn parse_message_deep_link_treats_empty_thread_as_absent() {
-    let url = Url::parse("buzz://message?channel=abc&id=xyz&thread=").unwrap();
+    let url = Url::parse("buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&thread=").unwrap();
     let payload = parse_message_deep_link(&url).expect("required params present");
     assert!(payload["threadRootId"].is_null());
+}
+
+#[test]
+fn parse_message_deep_link_rejects_a_repeated_param() {
+    // The loop used to keep the last value while the in-app parser keeps the
+    // first, so one URL routed two ways depending on where it was opened.
+    for raw in [
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&channel=11111111-1111-4111-8111-111111111111",
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&id=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&thread=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&thread=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ] {
+        assert!(
+            parse_message_deep_link(&Url::parse(raw).unwrap()).is_none(),
+            "must reject {raw}"
+        );
+    }
+}
+
+#[test]
+fn parse_join_deep_link_rejects_a_repeated_param() {
+    for raw in [
+        "buzz://join?relay=wss%3A%2F%2Frelay.example&code=abc&code=evil",
+        "buzz://join?relay=wss%3A%2F%2Frelay.example&relay=wss%3A%2F%2Fevil.example&code=abc",
+    ] {
+        assert!(
+            parse_join_deep_link(&Url::parse(raw).unwrap()).is_none(),
+            "must reject {raw}"
+        );
+    }
 }
 
 #[test]

--- a/desktop/src-tauri/src/deep_link_tests.rs
+++ b/desktop/src-tauri/src/deep_link_tests.rs
@@ -397,32 +397,26 @@ fn parse_message_deep_link_treats_empty_thread_as_absent() {
 }
 
 #[test]
-fn parse_message_deep_link_rejects_a_repeated_param() {
-    // The loop used to keep the last value while the in-app parser keeps the
-    // first, so one URL routed two ways depending on where it was opened.
+fn parse_message_deep_link_validates_the_shapes_its_neighbours_validate() {
+    // `parse_channel_deep_link` already refuses these exact values in the path
+    // form of the same two identifiers, so accepting them here handed the
+    // frontend a payload it could never route.
     for raw in [
-        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&channel=11111111-1111-4111-8111-111111111111",
-        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&id=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&thread=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&thread=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "buzz://message?channel=not-a-uuid&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=xyz",
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&thread=root1",
     ] {
         assert!(
             parse_message_deep_link(&Url::parse(raw).unwrap()).is_none(),
             "must reject {raw}"
         );
     }
-}
-
-#[test]
-fn parse_join_deep_link_rejects_a_repeated_param() {
-    for raw in [
-        "buzz://join?relay=wss%3A%2F%2Frelay.example&code=abc&code=evil",
-        "buzz://join?relay=wss%3A%2F%2Frelay.example&relay=wss%3A%2F%2Fevil.example&code=abc",
-    ] {
-        assert!(
-            parse_join_deep_link(&Url::parse(raw).unwrap()).is_none(),
-            "must reject {raw}"
-        );
-    }
+    // Hex is canonicalised, matching the channel parser.
+    let upper = Url::parse("buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+    assert_eq!(
+        parse_message_deep_link(&upper).expect("valid")["messageId"],
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
 }
 
 #[test]

--- a/desktop/src-tauri/src/deep_link_tests.rs
+++ b/desktop/src-tauri/src/deep_link_tests.rs
@@ -420,6 +420,35 @@ fn parse_message_deep_link_validates_the_shapes_its_neighbours_validate() {
 }
 
 #[test]
+fn parse_message_deep_link_rejects_a_repeated_param() {
+    // The loop used to keep the last value while the in-app parser keeps the
+    // first, so one URL routed two ways depending on where it was opened.
+    for raw in [
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&channel=11111111-1111-4111-8111-111111111111",
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&id=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "buzz://message?channel=580ca78b-9dae-46f3-8854-bd671853ba32&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&thread=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&thread=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ] {
+        assert!(
+            parse_message_deep_link(&Url::parse(raw).unwrap()).is_none(),
+            "must reject {raw}"
+        );
+    }
+}
+
+#[test]
+fn parse_join_deep_link_rejects_a_repeated_param() {
+    for raw in [
+        "buzz://join?relay=wss%3A%2F%2Frelay.example&code=abc&code=evil",
+        "buzz://join?relay=wss%3A%2F%2Frelay.example&relay=wss%3A%2F%2Fevil.example&code=abc",
+    ] {
+        assert!(
+            parse_join_deep_link(&Url::parse(raw).unwrap()).is_none(),
+            "must reject {raw}"
+        );
+    }
+}
+
+#[test]
 fn parse_join_deep_link_extracts_relay_and_code() {
     let url = Url::parse("buzz://join?relay=wss%3A%2F%2Frelay.example&code=abc.def").unwrap();
     let payload = parse_join_deep_link(&url).expect("required params present");

--- a/desktop/src-tauri/src/deep_link_tests.rs
+++ b/desktop/src-tauri/src/deep_link_tests.rs
@@ -629,3 +629,68 @@ fn parse_nostr_bind_deep_link_accepts_expired_link_for_user_facing_error() {
     let payload = parse_nostr_bind_deep_link(&url).unwrap();
     assert_eq!(payload.expires_at, "2000-01-01T00:00:00Z");
 }
+
+/// An optional parameter is still covered by the one-value-per-param policy.
+/// Reading a repetition as "not supplied" let the link through with the field
+/// silently dropped, which is the ambiguity this policy exists to remove.
+#[test]
+fn optional_params_reject_a_repetition_rather_than_reading_it_as_absent() {
+    let join = Url::parse(
+        "buzz://join?relay=wss%3A%2F%2Frelay.example&code=abc&policy_receipt=a&policy_receipt=b",
+    )
+    .unwrap();
+    assert!(
+        parse_join_deep_link(&join).is_none(),
+        "a repeated policy_receipt must reject the join, not join without it"
+    );
+
+    let add_community = Url::parse(
+        "buzz://add-community?relay=wss%3A%2F%2Facme.example&name=Acme&name=Evil%20Corp",
+    )
+    .unwrap();
+    assert!(
+        parse_add_community_deep_link(&add_community).is_none(),
+        "a repeated name must reject the link, not add the community unnamed"
+    );
+}
+
+/// Nostr-bind is the most security-sensitive link the app parses, and its
+/// required fields used to read the *first* value while every other family had
+/// moved to the single policy.
+#[test]
+fn parse_nostr_bind_deep_link_rejects_a_repeated_required_param() {
+    for (param, extra) in [
+        ("origin", "origin=https%3A%2F%2Fevil.example"),
+        (
+            "challenge_id",
+            "challenge_id=11111111-1111-4111-8111-111111111111",
+        ),
+        ("verification_code", "verification_code=999999"),
+        ("audience", "audience=buzz%3Aevil"),
+        ("return", "return=browser_fragment_v1"),
+    ] {
+        let url = Url::parse(&format!("{}&{extra}", valid_nostr_bind_url())).unwrap();
+        assert_eq!(
+            parse_nostr_bind_deep_link(&url).unwrap_err(),
+            format!("repeated {param}"),
+            "a repeated {param} must be named as such"
+        );
+    }
+}
+
+/// The callback is validated against `origin` only when it is present, so
+/// reading a repeated `callback_url` as absent would hand back a bind payload
+/// carrying a callback that never met `validate_nostr_bind_callback_url`.
+#[test]
+fn parse_nostr_bind_deep_link_rejects_a_repeated_callback_url() {
+    let url = Url::parse(&format!(
+        "{}&callback_url=https%3A%2F%2Fexample.com%2Fbuzz&callback_url=https%3A%2F%2Fevil.example%2Fbuzz",
+        valid_nostr_bind_url()
+    ))
+    .unwrap();
+
+    assert_eq!(
+        parse_nostr_bind_deep_link(&url).unwrap_err(),
+        "repeated callback_url"
+    );
+}


### PR DESCRIPTION
`deep_link.rs` carries four query-param parsers with three different policies for a repeated parameter:

| parser | repeated param |
|---|---|
| `parse_entity_deep_link` | refuses the URL |
| `parse_websocket_relay_param`, `optional_non_empty_param` | takes the **first** |
| `parse_message_deep_link`, `parse_join_deep_link` | assigned in a loop, so takes the **last** |

The in-app parsers take the first — `messageLink.ts` reads `searchParams.get`, `entityLink.ts` refuses outright. So the same URL routes one way when clicked inside the app and another when handed to the app by the OS, and `buzz://join?relay=…&code=abc&code=evil` displays one code while carrying another.

`single_param` is now the one reader — absent, empty and repeated all resolve to `None` — and every query-param parser goes through it. Refusing rather than picking is the right call here because our own builders never emit a duplicate, so any URL with one is malformed by construction.

**Second commit: the message parser now validates what its neighbours validate.** `parse_channel_deep_link`, twenty lines up, parses the channel UUID and requires the message id to be 64 hex characters, lowercasing it. The query form of *the same two identifiers* accepted anything non-empty, so a malformed link produced a payload the frontend could never route, and an id differing only in case looked like a different message.

**Four existing tests change, and I want that visible.** They used placeholder values — `channel=abc&id=xyz`, `thread=root1` — and now use a real UUID and real event ids. They assert *which params are required*, not that malformed values are accepted; the parser beside them has always refused those exact strings. `thread=` empty still reads as absent, as before; present-but-malformed is now a rejection.

New coverage: three repeated-param cases for `message` (second `channel`, `id`, `thread`), two for `join` (second `code`, second `relay`), and the shape cases. The join pair is the one worth having.

Not changed: unknown params are still ignored on the non-entity parsers. Entity links reject them, but a join or add-community link picking up a tracking param is plausible enough that tightening it belongs in its own change.

Verified locally: complete Tauri library suite 2443 passed / 15 ignored / 0 failed (52 in the deep-link module, 49 before), `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` clean, `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`, `git diff --check`. Not run: the OS-level handoff itself — these are the parsers, exercised directly.