### PR TITLE
fix(desktop): remember Inbox Show unread only

### DIFF
--- a/desktop/src/features/home/lib/inboxUnreadOnlyPreference.test.mjs
+++ b/desktop/src/features/home/lib/inboxUnreadOnlyPreference.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  INBOX_UNREAD_ONLY_KEY,
+  readInboxUnreadOnlyPreference,
+  resetInboxUnreadOnlyPreferenceForTests,
+  writeInboxUnreadOnlyPreference,
+} from "./inboxUnreadOnlyPreference.ts";
+
+function installStorage() {
+  const data = new Map();
+  globalThis.window = {
+    localStorage: {
+      getItem: (key) => (data.has(key) ? data.get(key) : null),
+      setItem: (key, value) => {
+        data.set(key, String(value));
+      },
+    },
+  };
+  return data;
+}
+
+test("unread-only defaults off and remembers on", () => {
+  installStorage();
+  resetInboxUnreadOnlyPreferenceForTests();
+  assert.equal(readInboxUnreadOnlyPreference(), false);
+  writeInboxUnreadOnlyPreference(true);
+  resetInboxUnreadOnlyPreferenceForTests();
+  assert.equal(readInboxUnreadOnlyPreference(), true);
+});
+
+test("unread-only remembers off after it was on", () => {
+  const data = installStorage();
+  resetInboxUnreadOnlyPreferenceForTests();
+  writeInboxUnreadOnlyPreference(true);
+  writeInboxUnreadOnlyPreference(false);
+  resetInboxUnreadOnlyPreferenceForTests();
+  assert.equal(data.get(INBOX_UNREAD_ONLY_KEY), "0");
+  assert.equal(readInboxUnreadOnlyPreference(), false);
+});
+
+test("in-memory value wins after a write even if storage is empty", () => {
+  installStorage();
+  resetInboxUnreadOnlyPreferenceForTests();
+  writeInboxUnreadOnlyPreference(true);
+  assert.equal(readInboxUnreadOnlyPreference(), true);
+});

--- a/desktop/src/features/home/lib/inboxUnreadOnlyPreference.ts
+++ b/desktop/src/features/home/lib/inboxUnreadOnlyPreference.ts
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+export const INBOX_UNREAD_ONLY_KEY = "buzz.desktop.inbox-unread-only";
+
+let memory: boolean | null = null;
+
+function storage(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readInboxUnreadOnlyPreference(): boolean {
+  if (memory !== null) return memory;
+  const raw = storage()?.getItem(INBOX_UNREAD_ONLY_KEY);
+  memory = raw === "1";
+  return memory;
+}
+
+export function writeInboxUnreadOnlyPreference(checked: boolean): void {
+  memory = checked;
+  const store = storage();
+  if (!store) return;
+  try {
+    store.setItem(INBOX_UNREAD_ONLY_KEY, checked ? "1" : "0");
+  } catch {
+    // Quota / private-mode — in-memory still holds for this session.
+  }
+}
+
+/** Test-only. */
+export function resetInboxUnreadOnlyPreferenceForTests(): void {
+  memory = null;
+}
+
+export function useInboxUnreadOnlyPreference(): [
+  boolean,
+  (checked: boolean) => void,
+] {
+  const [unreadOnly, setUnreadOnly] = React.useState(
+    readInboxUnreadOnlyPreference,
+  );
+  const persist = React.useCallback((checked: boolean) => {
+    writeInboxUnreadOnlyPreference(checked);
+    setUnreadOnly(checked);
+  }, []);
+  return [unreadOnly, persist];
+}

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -72,8 +72,8 @@ import { AUXILIARY_PANEL_SINGLE_COLUMN_BREAKPOINT_PX } from "@/shared/layout/Aux
 import { useHistorySearchState } from "@/shared/hooks/useHistorySearchState";
 import { ProfilePanelProvider } from "@/shared/context/ProfilePanelContext";
 import { Button } from "@/shared/ui/button";
+import { useInboxUnreadOnlyPreference } from "@/features/home/lib/inboxUnreadOnlyPreference";
 import { HomeMembersSidebarOverlay } from "./HomeMembersSidebarOverlay";
-
 const INBOX_SEARCH_KEYS = [
   "item",
   "profile",
@@ -110,7 +110,7 @@ export function HomeView({
     homeInboxWidthPx > 0 &&
     homeInboxWidthPx < INBOX_SINGLE_COLUMN_BREAKPOINT_PX;
   const [filter, setFilter] = React.useState<InboxFilter>("all");
-  const [unreadOnly, setUnreadOnly] = React.useState(false);
+  const [unreadOnly, persistUnreadOnly] = useInboxUnreadOnlyPreference();
   // Explicit selections are mirrored to the URL (`?item=`), so back/forward
   // restores the detail pane each history entry was showing and reloads
   // restore it from the URL. Default/automatic selection stays local-only —
@@ -745,7 +745,7 @@ export function HomeView({
                 handleUserSelectItem(null);
                 setSelectedReminderId(reminderId);
               }}
-              onUnreadOnlyChange={setUnreadOnly}
+              onUnreadOnlyChange={persistUnreadOnly}
               reminderPubkey={currentPubkey}
               reminders={pendingReminders}
               selectedConversationId={selectedConversationId}


### PR DESCRIPTION
## Summary

Inbox **Show unread only** reset every time you left and came back, because `HomeView` remounts with `useState(false)`.

Persist the switch in `localStorage` (`buzz.desktop.inbox-unread-only`) and read it on mount. An in-memory cache covers the same session if storage is unavailable.

## Test

- Unit: `desktop/src/features/home/lib/inboxUnreadOnlyPreference.test.mjs`
- Manual: Inbox → Show unread only on → open a channel → Inbox again. Switch stays on.

Small UX. No protocol change. Take it or leave it.