### PR TITLE
fix(acp): steer edited mentions with lifecycle fencing

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4648,6 +4648,9 @@ fn recover_panicked_agent(
         return;
     };
     let i = meta.agent_index;
+    // The panicked ownership can never return its `OwnedAgent`; do not let its
+    // pending membership invalidations leak into a fresh process reusing slot i.
+    pool.discard_checked_out_session_invalidations(i);
 
     // Requeue BEFORE mark_complete (same rationale as handle_prompt_result).
     if let Some(batch) = meta.recoverable_batch {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1556,14 +1556,16 @@ struct NativeSteerPrepared {
     prompt_blocks: Vec<String>,
 }
 
-/// Async edit enrichment may finish after channel membership changed. Such
-/// prepared work is stale: removal drains its queue reservation, and it must
-/// never be forwarded into either the removed membership period or a later
-/// re-added period.
+/// Async edit enrichment may finish after channel membership changed or after
+/// its queue reservation was recovered/consumed. Such prepared work is stale:
+/// it must never be forwarded into a removed/later membership period or into a
+/// replacement turn that already received the recovered edit.
 fn native_steer_preparation_is_stale(
+    queue: &EventQueue,
     removed_channels: &HashSet<Uuid>,
     membership_generations: &HashMap<Uuid, u64>,
     channel_id: Uuid,
+    event_id: &str,
     prepared_generation: u64,
 ) -> bool {
     removed_channels.contains(&channel_id)
@@ -1572,6 +1574,7 @@ fn native_steer_preparation_is_stale(
             .copied()
             .unwrap_or(0)
             != prepared_generation
+        || !queue.has_native_steer_reservation(channel_id, event_id)
 }
 
 /// Reserve an edit before its asynchronous enrichment starts, returning the
@@ -3380,16 +3383,19 @@ Typing(Uuid, String, ThreadTags),
                 event,
                 prompt_blocks,
             })) => {
+                let event_id = event.id.to_hex();
                 if native_steer_preparation_is_stale(
+                    &queue,
                     &removed_channels,
                     &membership_generations,
                     channel_id,
+                    &event_id,
                     membership_generation,
                 ) {
                     tracing::debug!(
                         %channel_id,
-                        event_id = %event.id.to_hex(),
-                        "discarding native steer prepared after channel removal"
+                        %event_id,
+                        "discarding native steer prepared after its reservation became stale"
                     );
                     continue;
                 }
@@ -9481,9 +9487,11 @@ mod native_edit_membership_lifecycle_tests {
         // instead be discarded, leaving neither queued nor withheld work to
         // steer, release, or resurrect.
         assert!(native_steer_preparation_is_stale(
+            &queue,
             &removed_channels,
             &generations,
             channel_id,
+            &event_id,
             prepared_generation,
         ));
         queue.release_native_steer(channel_id, &event_id);

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3003,6 +3003,12 @@ Typing(Uuid, String, ThreadTags),
                                     let native_attempted = if matches!(signal, ControlSignal::Steer)
                                     {
                                         if queue::edit_target_id(&event_for_steer).is_some() {
+                                            let event_id = event_for_steer.id.to_hex();
+                                            let reserved = queue.mark_native_steer_pending(
+                                                buzz_event.channel_id,
+                                                &event_id,
+                                            );
+                                            debug_assert!(reserved, "accepted edit must still be queued");
                                             let tx = native_steer_tx.clone();
                                             let ctx = Arc::clone(&ctx);
                                             let channel_id = buzz_event.channel_id;
@@ -3298,10 +3304,11 @@ Typing(Uuid, String, ThreadTags),
                     &mut pool,
                     &mut queue,
                     channel_id,
-                    event,
+                    event.clone(),
                     prompt_blocks,
                     &steer_ack_tx,
                 ) {
+                    queue.release_native_steer(channel_id, &event.id.to_hex());
                     signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
                 }
             }
@@ -3833,25 +3840,14 @@ fn try_native_steer(
 
     match pool.send_steer(channel_id, request) {
         Ok(()) => {
-            // Withhold the queued event synchronously BEFORE spawning
-            // the watcher: this closes the race where `mark_complete`
-            // clears `in_flight_channels` and a stray `flush_next` could
-            // re-deliver the event via normal dispatch. See
-            // `EventQueue::mark_native_steer_pending` docs at queue.rs:606.
+            // Ordinary events are withheld after send. Edit preparation reserves
+            // its event before leaving the main loop, so this is idempotent.
             let withheld = queue.mark_native_steer_pending(channel_id, &event_id_hex);
             if !withheld {
-                // Race: the event was already drained out of the queue
-                // before we got here (e.g. a concurrent flush picked it
-                // up). The steer is on the wire; if it succeeds the
-                // agent gets it via the native path AND normal
-                // dispatch — duplicate delivery is benign (agent gets
-                // the same message twice). Log so this is visible if it
-                // ever happens in production.
-                tracing::warn!(
+                tracing::debug!(
                     channel = %channel_id,
                     event_id = %event_id_hex,
-                    "native steer accepted by read loop but event was not in queue to withhold \
-                     — possible duplicate delivery if steer succeeds"
+                    "native steer event was already reserved during async preparation"
                 );
             }
             let ack_tx_clone = steer_ack_tx.clone();

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1634,6 +1634,9 @@ fn readd_channel_after_membership_change(removed_channels: &mut HashSet<Uuid>, c
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
+    /// Visible message that owns lifecycle reactions for this delivery. Edits
+    /// react on their original target rather than on the auxiliary edit event.
+    reaction_event_id: String,
     /// Membership generation in which the steer was sent. Late acknowledgements
     /// from an earlier membership epoch must have no queue, ledger, or fallback
     /// effects after removal/re-add.
@@ -3152,32 +3155,47 @@ Typing(Uuid, String, ThreadTags),
                                                 Some(membership_generation) => {
                                                     // No await or other pool mutation occurs
                                                     // between the availability check and this
-                                                    // capture, so the same task still owns it.
-                                                    let originating_turn_id = pool
+                                                    // capture. Still fail closed if the task
+                                                    // disappears: release the preparation so
+                                                    // the caller's cancel+merge fallback owns
+                                                    // delivery rather than aborting the harness.
+                                                    if let Some(originating_turn_id) = pool
                                                         .native_steer_turn_id(
                                                             channel_id,
                                                             membership_generation,
                                                         )
-                                                        .expect("available native steer has a turn");
-                                                    let tx = native_steer_tx.clone();
-                                                    let ctx = Arc::clone(&ctx);
-                                                    tokio::spawn(async move {
-                                                        let prompt_blocks = pool::format_native_steer_prompt(
-                                                            channel_id,
-                                                            event_for_steer.clone(),
-                                                            prompt_tag_for_steer,
-                                                            &ctx,
-                                                        )
-                                                        .await;
-                                                        let _ = tx.send(NativeSteerPrepared {
-                                                            channel_id,
-                                                            membership_generation,
-                                                            originating_turn_id,
-                                                            event: event_for_steer,
-                                                            prompt_blocks,
+                                                    {
+                                                        let tx = native_steer_tx.clone();
+                                                        let ctx = Arc::clone(&ctx);
+                                                        tokio::spawn(async move {
+                                                            let prompt_blocks = pool::format_native_steer_prompt(
+                                                                channel_id,
+                                                                event_for_steer.clone(),
+                                                                prompt_tag_for_steer,
+                                                                &ctx,
+                                                            )
+                                                            .await;
+                                                            let _ = tx.send(NativeSteerPrepared {
+                                                                channel_id,
+                                                                membership_generation,
+                                                                originating_turn_id,
+                                                                event: event_for_steer,
+                                                                prompt_blocks,
+                                                            });
                                                         });
-                                                    });
-                                                    true
+                                                        true
+                                                    } else {
+                                                        queue.release_native_steer(
+                                                            channel_id,
+                                                            &event_id,
+                                                        );
+                                                        tracing::debug!(
+                                                            %channel_id,
+                                                            %event_id,
+                                                            "native edit steer turn disappeared during reservation; falling back to cancel+merge"
+                                                        );
+                                                        false
+                                                    }
                                                 }
                                                 None => {
                                                     tracing::warn!(
@@ -3560,6 +3578,7 @@ Typing(Uuid, String, ThreadTags),
             Some(PoolEvent::SteerAck(SteerAckEvent {
                 channel_id,
                 event_id,
+                reaction_event_id,
                 membership_generation,
                 ack,
             })) => {
@@ -3701,6 +3720,11 @@ Typing(Uuid, String, ThreadTags),
                 }
                 if drop_withheld {
                     queue.remove_event(channel_id, &event_id);
+                    let rest = ctx.rest_client.clone();
+                    tokio::spawn(async move {
+                        pool::reaction_remove(&rest, &reaction_event_id, "👀").await;
+                        pool::reaction_remove(&rest, &reaction_event_id, "💬").await;
+                    });
                 }
                 if release_withheld {
                     queue.release_native_steer(channel_id, &event_id);
@@ -4119,6 +4143,10 @@ fn signal_in_flight_task_matching(
 ///
 /// The withheld event is NOT released here on `false` because no withhold
 /// was established: `mark_native_steer_pending` only runs on `Ok(())`.
+fn native_steer_reaction_target(event: &nostr::Event) -> String {
+    queue::reaction_target_id(event)
+}
+
 fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
@@ -4129,6 +4157,7 @@ fn try_native_steer(
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
     let event_id_hex = event.id.to_hex();
+    let reaction_event_id = native_steer_reaction_target(&event);
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
     let request = pool::SteerRequest {
@@ -4156,6 +4185,7 @@ fn try_native_steer(
                 let _ = ack_tx_clone.send(SteerAckEvent {
                     channel_id,
                     event_id: event_id_for_watcher,
+                    reaction_event_id,
                     membership_generation,
                     ack,
                 });
@@ -9741,6 +9771,12 @@ mod native_edit_membership_lifecycle_tests {
             harness_name: "goose".into(),
             relay_url: "ws://127.0.0.1:0".into(),
         })
+    }
+
+    #[test]
+    fn native_steer_edit_cleans_reactions_on_original_target() {
+        let target = "ab".repeat(32);
+        assert_eq!(native_steer_reaction_target(&edit_event(&target)), target);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3076,9 +3076,13 @@ Typing(Uuid, String, ThreadTags),
                                         if queue.has_native_steer_reservations(
                                             buzz_event.channel_id,
                                         ) {
+                                            let released = queue.release_native_steers(
+                                                buzz_event.channel_id,
+                                            );
                                             tracing::debug!(
                                                 channel_id = %buzz_event.channel_id,
-                                                "native steer preparation already pending; preserving channel order via cancel+merge"
+                                                released,
+                                                "native steer preparation already pending; releasing reservations for ordered cancel+merge"
                                             );
                                             false
                                         } else if is_edit

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3071,7 +3071,19 @@ Typing(Uuid, String, ThreadTags),
                                     // agent.
                                     let native_attempted = if matches!(signal, ControlSignal::Steer)
                                     {
-                                        if queue::edit_target_id(&event_for_steer).is_some() {
+                                        let is_edit =
+                                            queue::edit_target_id(&event_for_steer).is_some();
+                                        if queue.has_native_steer_reservations(
+                                            buzz_event.channel_id,
+                                        ) {
+                                            tracing::debug!(
+                                                channel_id = %buzz_event.channel_id,
+                                                "native steer preparation already pending; preserving channel order via cancel+merge"
+                                            );
+                                            false
+                                        } else if is_edit
+                                            && pool.native_steer_available(buzz_event.channel_id)
+                                        {
                                             let event_id = event_for_steer.id.to_hex();
                                             let channel_id = buzz_event.channel_id;
                                             match reserve_native_edit_preparation(
@@ -3109,6 +3121,12 @@ Typing(Uuid, String, ThreadTags),
                                                     false
                                                 }
                                             }
+                                        } else if is_edit {
+                                            tracing::debug!(
+                                                channel_id = %buzz_event.channel_id,
+                                                "native edit steer unavailable before preparation; falling back to cancel+merge"
+                                            );
+                                            false
                                         } else {
                                             let prompt_blocks =
                                                 pool::format_native_steer_prompt_sync(

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1552,6 +1552,10 @@ struct NativeSteerPrepared {
     /// Membership generation captured when this edit was reserved. A removal
     /// advances the generation even if the agent is subsequently re-added.
     membership_generation: u64,
+    /// Turn that owned the channel when preparation started. Membership alone
+    /// is insufficient: the turn can complete and a replacement can start in
+    /// the same membership generation while enrichment is outstanding.
+    originating_turn_id: String,
     event: nostr::Event,
     prompt_blocks: Vec<String>,
 }
@@ -1560,6 +1564,7 @@ struct NativeSteerPrepared {
 /// its queue reservation was recovered/consumed. Such prepared work is stale:
 /// it must never be forwarded into a removed/later membership period or into a
 /// replacement turn that already received the recovered edit.
+#[allow(clippy::too_many_arguments)]
 fn native_steer_preparation_is_stale(
     queue: &EventQueue,
     removed_channels: &HashSet<Uuid>,
@@ -1567,9 +1572,12 @@ fn native_steer_preparation_is_stale(
     channel_id: Uuid,
     event_id: &str,
     prepared_generation: u64,
+    originating_turn_id: &str,
+    current_turn_id: Option<&str>,
 ) -> bool {
     removed_channels.contains(&channel_id)
         || native_steer_ack_is_stale(membership_generations, channel_id, prepared_generation)
+        || current_turn_id != Some(originating_turn_id)
         || !queue.has_native_steer_reservation(channel_id, event_id)
 }
 
@@ -3142,6 +3150,15 @@ Typing(Uuid, String, ThreadTags),
                                                 &event_id,
                                             ) {
                                                 Some(membership_generation) => {
+                                                    // No await or other pool mutation occurs
+                                                    // between the availability check and this
+                                                    // capture, so the same task still owns it.
+                                                    let originating_turn_id = pool
+                                                        .native_steer_turn_id(
+                                                            channel_id,
+                                                            membership_generation,
+                                                        )
+                                                        .expect("available native steer has a turn");
                                                     let tx = native_steer_tx.clone();
                                                     let ctx = Arc::clone(&ctx);
                                                     tokio::spawn(async move {
@@ -3155,6 +3172,7 @@ Typing(Uuid, String, ThreadTags),
                                                         let _ = tx.send(NativeSteerPrepared {
                                                             channel_id,
                                                             membership_generation,
+                                                            originating_turn_id,
                                                             event: event_for_steer,
                                                             prompt_blocks,
                                                         });
@@ -3468,10 +3486,14 @@ Typing(Uuid, String, ThreadTags),
             Some(PoolEvent::NativeSteerPrepared(NativeSteerPrepared {
                 channel_id,
                 membership_generation,
+                originating_turn_id,
                 event,
                 prompt_blocks,
             })) => {
                 let event_id = event.id.to_hex();
+                let current_turn_id = pool
+                    .channel_turn_id(channel_id, membership_generation)
+                    .map(str::to_owned);
                 if native_steer_preparation_is_stale(
                     &queue,
                     &removed_channels,
@@ -3479,12 +3501,38 @@ Typing(Uuid, String, ThreadTags),
                     channel_id,
                     &event_id,
                     membership_generation,
+                    &originating_turn_id,
+                    current_turn_id.as_deref(),
                 ) {
                     tracing::debug!(
                         %channel_id,
                         %event_id,
                         "discarding native steer prepared after its reservation became stale"
                     );
+                    // If only the owning turn changed, the reserved edit still
+                    // needs normal delivery. Release it and steer/cancel the
+                    // replacement turn rather than either injecting it into
+                    // that turn or leaving it orphaned in the side table.
+                    if !removed_channels.contains(&channel_id)
+                        && !native_steer_ack_is_stale(
+                            &membership_generations,
+                            channel_id,
+                            membership_generation,
+                        )
+                        && queue.has_native_steer_reservation(channel_id, &event_id)
+                    {
+                        release_prepared_native_steer_fallback(
+                            &mut pool,
+                            &mut queue,
+                            channel_id,
+                            &event_id,
+                            &ctx,
+                            &membership_generations,
+                            &typing_tx,
+                            &mut last_activity,
+                            &mut typing_channels,
+                        );
+                    }
                     continue;
                 }
                 if !try_native_steer(
@@ -4323,17 +4371,23 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
 ///
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
 /// dead-letter path so neither duplicates the tokio::spawn block.
+fn failure_notice_thread_tags(batch: &FlushBatch) -> ThreadTags {
+    batch.failure_thread_tags.clone().unwrap_or_else(|| {
+        batch
+            .events
+            .last()
+            .map(|be| queue::parse_thread_tags(&be.event))
+            .unwrap_or_default()
+    })
+}
+
 fn spawn_failure_notice(
     rest_client: Option<&relay::RestClient>,
     batch: &FlushBatch,
     content: String,
 ) {
     if let Some(rest) = rest_client {
-        let thread_tags = batch
-            .events
-            .last()
-            .map(|be| queue::parse_thread_tags(&be.event))
-            .unwrap_or_default();
+        let thread_tags = failure_notice_thread_tags(batch);
         let rest = rest.clone();
         let channel_id = batch.channel_id;
         tokio::spawn(async move {
@@ -8475,6 +8529,7 @@ mod error_outcome_emission_tests {
                 }],
                 cancelled_events: vec![],
                 cancel_reason: None,
+                failure_thread_tags: None,
             }
         };
 
@@ -8584,6 +8639,7 @@ mod error_outcome_emission_tests {
                 }],
                 cancelled_events: vec![],
                 cancel_reason: None,
+                failure_thread_tags: None,
             }
         };
 
@@ -8707,6 +8763,7 @@ mod error_outcome_emission_tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let result = PromptResult {
             agent,
@@ -8803,6 +8860,7 @@ mod error_outcome_emission_tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let result = PromptResult {
             agent,
@@ -8882,6 +8940,7 @@ mod error_outcome_emission_tests {
             }],
             cancelled_events: vec![],
             cancel_reason: Some(CancelReason::Steer),
+            failure_thread_tags: None,
         };
 
         let agent = dummy_agent(0).await;
@@ -9209,6 +9268,7 @@ mod error_outcome_emission_tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let auth_error = acp::AcpError::AgentError {
@@ -9297,6 +9357,7 @@ mod error_outcome_emission_tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // Usage-credits error — AgentError but NOT an auth error.
@@ -9682,6 +9743,33 @@ mod native_edit_membership_lifecycle_tests {
         })
     }
 
+    #[test]
+    fn failure_notice_prefers_resolved_edit_thread_routing() {
+        let channel_id = Uuid::new_v4();
+        let root = "cd".repeat(32);
+        let parent = "ef".repeat(32);
+        let resolved = ThreadTags {
+            root_event_id: Some(root.clone()),
+            parent_event_id: Some(parent.clone()),
+            mentioned_pubkeys: vec![],
+        };
+        let batch = FlushBatch {
+            channel_id,
+            events: vec![queue::BatchEvent {
+                event: edit_event(&"ab".repeat(32)),
+                prompt_tag: "@mention".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+            failure_thread_tags: Some(resolved),
+        };
+
+        let actual = failure_notice_thread_tags(&batch);
+        assert_eq!(actual.root_event_id.as_deref(), Some(root.as_str()));
+        assert_eq!(actual.parent_event_id.as_deref(), Some(parent.as_str()));
+    }
+
     #[tokio::test]
     async fn prepared_native_steer_rejection_releases_and_dispatches_immediately() {
         let channel_id = Uuid::new_v4();
@@ -9702,6 +9790,7 @@ mod native_edit_membership_lifecycle_tests {
         let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(0).await)]);
         let mut last_activity = tokio::time::Instant::now();
         let mut typing_channels = HashMap::new();
+        let (typing_tx, _typing_rx) = mpsc::unbounded_channel();
         release_prepared_native_steer_fallback(
             &mut pool,
             &mut queue,
@@ -9709,10 +9798,10 @@ mod native_edit_membership_lifecycle_tests {
             &event_id,
             &prompt_context(),
             &HashMap::new(),
+            &typing_tx,
             &mut last_activity,
             &mut typing_channels,
-        )
-        .await;
+        );
 
         assert!(typing_channels.contains_key(&channel_id));
         assert_eq!(
@@ -9770,6 +9859,39 @@ mod native_edit_membership_lifecycle_tests {
     }
 
     #[test]
+    fn prepared_edit_is_stale_after_replacement_turn_starts() {
+        let channel_id = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        assert!(queue.push(QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "@mention".into(),
+        }));
+        let generations = HashMap::new();
+        let generation =
+            reserve_native_edit_preparation(&mut queue, &generations, channel_id, &event_id)
+                .expect("edit reservation");
+
+        assert!(native_steer_preparation_is_stale(
+            &queue,
+            &HashSet::new(),
+            &generations,
+            channel_id,
+            &event_id,
+            generation,
+            "originating-turn",
+            Some("replacement-turn"),
+        ));
+        assert!(
+            queue.has_native_steer_reservation(channel_id, &event_id),
+            "replacement-turn staleness preserves the reservation for fallback delivery"
+        );
+    }
+
+    #[test]
     fn late_prepared_edit_is_discarded_across_remove_then_readd() {
         let channel_id = Uuid::new_v4();
         let event = edit_event(&"ab".repeat(32));
@@ -9813,6 +9935,8 @@ mod native_edit_membership_lifecycle_tests {
             channel_id,
             &event_id,
             prepared_generation,
+            "originating-turn",
+            Some("originating-turn"),
         ));
         queue.release_native_steer(channel_id, &event_id);
         assert!(queue.flush_next().is_none());

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1549,15 +1549,29 @@ struct RespawnResult {
 /// `event_id` is the hex id of the single event the steer carried.
 struct NativeSteerPrepared {
     channel_id: Uuid,
+    /// Membership generation captured when this edit was reserved. A removal
+    /// advances the generation even if the agent is subsequently re-added.
+    membership_generation: u64,
     event: nostr::Event,
     prompt_blocks: Vec<String>,
 }
 
-/// Async edit enrichment may finish after channel membership was revoked.
-/// Such prepared work is stale: removal drains its queue reservation, and it
-/// must never be forwarded to an otherwise still-live ACP turn.
-fn native_steer_preparation_is_stale(removed_channels: &HashSet<Uuid>, channel_id: Uuid) -> bool {
+/// Async edit enrichment may finish after channel membership changed. Such
+/// prepared work is stale: removal drains its queue reservation, and it must
+/// never be forwarded into either the removed membership period or a later
+/// re-added period.
+fn native_steer_preparation_is_stale(
+    removed_channels: &HashSet<Uuid>,
+    membership_generations: &HashMap<Uuid, u64>,
+    channel_id: Uuid,
+    prepared_generation: u64,
+) -> bool {
     removed_channels.contains(&channel_id)
+        || membership_generations
+            .get(&channel_id)
+            .copied()
+            .unwrap_or(0)
+            != prepared_generation
 }
 
 struct SteerAckEvent {
@@ -2389,6 +2403,9 @@ let (typing_tx, mut typing_rx) = mpsc::unbounded_channel::<(Uuid, String, Thread
     // causal invalidation is needed, add a monotonic epoch counter per channel
     // and capture it in TaskMeta at dispatch time.
     let mut removed_channels: HashSet<Uuid> = HashSet::new();
+    // Incremented on removal, rather than reset on re-add, so asynchronous
+    // edit preparation cannot cross a membership boundary.
+    let mut membership_generations: HashMap<Uuid, u64> = HashMap::new();
 
     //
     // One SlotCircuit per agent slot. crash_times entries are pruned to the last
@@ -2739,6 +2756,8 @@ Typing(Uuid, String, ThreadTags),
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
+                                    let generation = membership_generations.entry(ch).or_default();
+                                    *generation = generation.wrapping_add(1);
                                     typing_channels.remove(&ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
@@ -3019,6 +3038,10 @@ Typing(Uuid, String, ThreadTags),
                                             let tx = native_steer_tx.clone();
                                             let ctx = Arc::clone(&ctx);
                                             let channel_id = buzz_event.channel_id;
+                                            let membership_generation = membership_generations
+                                                .get(&channel_id)
+                                                .copied()
+                                                .unwrap_or(0);
                                             tokio::spawn(async move {
                                                 let prompt_blocks = pool::format_native_steer_prompt(
                                                     channel_id,
@@ -3029,6 +3052,7 @@ Typing(Uuid, String, ThreadTags),
                                                 .await;
                                                 let _ = tx.send(NativeSteerPrepared {
                                                     channel_id,
+                                                    membership_generation,
                                                     event: event_for_steer,
                                                     prompt_blocks,
                                                 });
@@ -3304,10 +3328,16 @@ Typing(Uuid, String, ThreadTags),
             }
             Some(PoolEvent::NativeSteerPrepared(NativeSteerPrepared {
                 channel_id,
+                membership_generation,
                 event,
                 prompt_blocks,
             })) => {
-                if native_steer_preparation_is_stale(&removed_channels, channel_id) {
+                if native_steer_preparation_is_stale(
+                    &removed_channels,
+                    &membership_generations,
+                    channel_id,
+                    membership_generation,
+                ) {
                     tracing::debug!(
                         %channel_id,
                         event_id = %event.id.to_hex(),

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2897,9 +2897,13 @@ Typing(Uuid, String, ThreadTags),
                             if is_cancel {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
+                                        let fired = signal_current_membership_task(
                                             &mut pool,
                                             buzz_event.channel_id,
+                                            membership_generations
+                                                .get(&buzz_event.channel_id)
+                                                .copied()
+                                                .unwrap_or(0),
                                             ControlSignal::Cancel,
                                         );
                                         if !fired {
@@ -2935,9 +2939,13 @@ Typing(Uuid, String, ThreadTags),
                             if is_rotate {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
+                                        let fired = signal_current_membership_task(
                                             &mut pool,
                                             buzz_event.channel_id,
+                                            membership_generations
+                                                .get(&buzz_event.channel_id)
+                                                .copied()
+                                                .unwrap_or(0),
                                             ControlSignal::Rotate,
                                         );
                                         if fired {
@@ -3192,9 +3200,13 @@ Typing(Uuid, String, ThreadTags),
                                         false
                                     };
                                     if !native_attempted {
-                                        signal_in_flight_task(
+                                        signal_current_membership_task(
                                             &mut pool,
                                             buzz_event.channel_id,
+                                            membership_generations
+                                                .get(&buzz_event.channel_id)
+                                                .copied()
+                                                .unwrap_or(0),
                                             signal,
                                         );
                                     }
@@ -3651,7 +3663,12 @@ Typing(Uuid, String, ThreadTags),
                     // front of `queues[channel_id]`, so the cancel
                     // will pick it up as part of the merged batch and
                     // re-prompt the agent.
-                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    signal_current_membership_task(
+                        &mut pool,
+                        channel_id,
+                        membership_generation,
+                        ControlSignal::Steer,
+                    );
                 }
                 // After releasing a withheld event, give dispatch a chance
                 // to re-flush. If the prompt is still in flight, the
@@ -3988,14 +4005,41 @@ fn signal_in_flight_task(
     channel_id: uuid::Uuid,
     mode: ControlSignal,
 ) -> bool {
-    let entry = pool
-        .task_map_mut()
-        .values_mut()
-        .find(|m| m.channel_id == Some(channel_id));
+    signal_in_flight_task_matching(pool, channel_id, None, mode)
+}
+
+/// Send a control signal only to a task dispatched in `membership_generation`.
+/// A task left running across remove/re-add belongs to an earlier generation
+/// and must not be cancelled or steered by work from the new membership epoch.
+fn signal_current_membership_task(
+    pool: &mut AgentPool,
+    channel_id: uuid::Uuid,
+    membership_generation: u64,
+    mode: ControlSignal,
+) -> bool {
+    signal_in_flight_task_matching(pool, channel_id, Some(membership_generation), mode)
+}
+
+fn signal_in_flight_task_matching(
+    pool: &mut AgentPool,
+    channel_id: uuid::Uuid,
+    membership_generation: Option<u64>,
+    mode: ControlSignal,
+) -> bool {
+    let entry = pool.task_map_mut().values_mut().find(|meta| {
+        meta.channel_id == Some(channel_id)
+            && membership_generation
+                .is_none_or(|generation| meta.membership_generation == Some(generation))
+    });
 
     if let Some(meta) = entry {
         if let Some(tx) = meta.control_tx.take() {
-            tracing::info!(channel = %channel_id, ?mode, "control signal sent to in-flight task");
+            tracing::info!(
+                channel = %channel_id,
+                membership_generation,
+                ?mode,
+                "control signal sent to in-flight task"
+            );
             let _ = tx.send(mode);
             return true;
         }
@@ -4016,8 +4060,8 @@ fn signal_in_flight_task(
 /// Returns `true` if the native attempt was accepted by the read loop
 /// (capacity-1 mpsc `try_send` succeeded, event withheld synchronously,
 /// ack watcher spawned). On `true` the caller MUST NOT issue the
-/// universal cancel+merge `ControlSignal::Steer` fallback — the watcher
-/// will issue it from the ack arm if the native attempt fails.
+/// universal cancel+merge fallback. If the native attempt fails, the watcher
+/// issues that fallback only to a task from the same membership generation.
 ///
 /// Returns `false` if `pool.send_steer` failed (no in-flight task,
 /// `steer_tx` already full from a prior in-flight steer, or read loop
@@ -4098,7 +4142,16 @@ fn release_prepared_native_steer_fallback(
     typing_channels: &mut HashMap<Uuid, ThreadTags>,
 ) {
     queue.release_native_steer(channel_id, event_id);
-    signal_in_flight_task(pool, channel_id, ControlSignal::Steer);
+    let membership_generation = membership_generations
+        .get(&channel_id)
+        .copied()
+        .unwrap_or(0);
+    signal_current_membership_task(
+        pool,
+        channel_id,
+        membership_generation,
+        ControlSignal::Steer,
+    );
     for (channel_id, thread_tags) in dispatch_pending(
         pool,
         queue,
@@ -5705,6 +5758,69 @@ mod owner_control_command_tests {
             !typing_channels.contains_key(&channel_id),
             "a completed turn must not resurrect its typing indicator"
         );
+    }
+
+    #[tokio::test]
+    async fn post_readd_signal_does_not_reach_prior_membership_task() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let old_generation = 4;
+        let current_generation = 5;
+        let (old_control_tx, mut old_control_rx) = tokio::sync::oneshot::channel();
+
+        let old_abort_handle = pool.join_set.spawn(async {});
+        pool.task_map_mut().insert(
+            old_abort_handle.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                membership_generation: Some(old_generation),
+                turn_id: "pre-removal-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(old_control_tx),
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        assert!(!signal_current_membership_task(
+            &mut pool,
+            channel_id,
+            current_generation,
+            ControlSignal::Steer,
+        ));
+        assert!(matches!(
+            old_control_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+
+        let (current_control_tx, current_control_rx) = tokio::sync::oneshot::channel();
+        let current_abort_handle = pool.join_set.spawn(async {});
+        pool.task_map_mut().insert(
+            current_abort_handle.id(),
+            pool::TaskMeta {
+                agent_index: 1,
+                channel_id: Some(channel_id),
+                membership_generation: Some(current_generation),
+                turn_id: "post-readd-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(current_control_tx),
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        assert!(signal_current_membership_task(
+            &mut pool,
+            channel_id,
+            current_generation,
+            ControlSignal::Steer,
+        ));
+        assert_eq!(current_control_rx.await.unwrap(), ControlSignal::Steer);
+        assert!(matches!(
+            old_control_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2557,9 +2557,14 @@ Typing(Uuid, String, ThreadTags),
             // called on relay events or pool results, neither of which
             // arrive when the channel is silent.
             if queue.has_flushable_work() {
-                for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
-                {
+                for (channel_id, thread_tags) in dispatch_pending(
+                    &mut pool,
+                    &mut queue,
+                    &ctx,
+                    &membership_generations,
+                    &typing_tx,
+                    &mut last_activity,
+                ) {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -2609,9 +2614,14 @@ Typing(Uuid, String, ThreadTags),
         // this, batches requeued during crash recovery sit idle until the
         // next relay event arrives — which can be minutes on quiet channels.
         if respawn_collected {
-            for (channel_id, thread_tags) in
-                dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
-            {
+            for (channel_id, thread_tags) in dispatch_pending(
+                &mut pool,
+                &mut queue,
+                &ctx,
+                &membership_generations,
+                &typing_tx,
+                &mut last_activity,
+            ) {
                 typing_channels.insert(channel_id, thread_tags);
             }
         }
@@ -3107,7 +3117,13 @@ Typing(Uuid, String, ThreadTags),
                                             // and drive fallback/dispatch as needed.
                                             sent_steer_pending
                                         } else if is_edit
-                                            && pool.native_steer_available(buzz_event.channel_id)
+                                            && pool.native_steer_available(
+                                                buzz_event.channel_id,
+                                                membership_generations
+                                                    .get(&buzz_event.channel_id)
+                                                    .copied()
+                                                    .unwrap_or(0),
+                                            )
                                         {
                                             let event_id = event_for_steer.id.to_hex();
                                             let channel_id = buzz_event.channel_id;
@@ -3186,8 +3202,8 @@ Typing(Uuid, String, ThreadTags),
                             }
                             if pool_ready {
                                 for (channel_id, thread_tags) in
-                                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
-                                {
+                                    dispatch_pending(&mut pool, &mut queue, &ctx, &membership_generations, &typing_tx, &mut last_activity)
+                                                        {
                                     typing_channels.insert(channel_id, thread_tags);
                                 }
                             }
@@ -3286,8 +3302,8 @@ Typing(Uuid, String, ThreadTags),
                     } else if queue.has_flushable_work() {
                         tracing::debug!("heartbeat_skipped_events");
                         for (channel_id, thread_tags) in
-                            dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
-                        {
+                            dispatch_pending(&mut pool, &mut queue, &ctx, &membership_generations, &typing_tx, &mut last_activity)
+                                        {
                             typing_channels.insert(channel_id, thread_tags);
                         }
                     } else if pool.any_idle() {
@@ -3360,6 +3376,7 @@ Typing(Uuid, String, ThreadTags),
                     *result,
                     &mut heartbeat_in_flight,
                     &removed_channels,
+                    &membership_generations,
                     &mut crash_history,
                     &respawn_tx,
                     &mut respawn_tasks,
@@ -3375,6 +3392,7 @@ Typing(Uuid, String, ThreadTags),
                     &config,
                     &mut heartbeat_in_flight,
                     &removed_channels,
+                    &membership_generations,
                     &mut typing_channels,
                     &mut crash_history,
                     &respawn_tx,
@@ -3384,9 +3402,14 @@ Typing(Uuid, String, ThreadTags),
                 {
                     break;
                 }
-                for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
-                {
+                for (channel_id, thread_tags) in dispatch_pending(
+                    &mut pool,
+                    &mut queue,
+                    &ctx,
+                    &membership_generations,
+                    &typing_tx,
+                    &mut last_activity,
+                ) {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -3399,6 +3422,7 @@ Typing(Uuid, String, ThreadTags),
                     join_error,
                     &mut heartbeat_in_flight,
                     &removed_channels,
+                    &membership_generations,
                     &mut typing_channels,
                     &mut crash_history,
                     &respawn_tx,
@@ -3409,9 +3433,14 @@ Typing(Uuid, String, ThreadTags),
                     tracing::error!("all agents dead — exiting");
                     break;
                 }
-                for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
-                {
+                for (channel_id, thread_tags) in dispatch_pending(
+                    &mut pool,
+                    &mut queue,
+                    &ctx,
+                    &membership_generations,
+                    &typing_tx,
+                    &mut last_activity,
+                ) {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -3461,6 +3490,8 @@ Typing(Uuid, String, ThreadTags),
                         channel_id,
                         &event.id.to_hex(),
                         &ctx,
+                        &membership_generations,
+                        &typing_tx,
                         &mut last_activity,
                         &mut typing_channels,
                     );
@@ -3629,9 +3660,14 @@ Typing(Uuid, String, ThreadTags),
                 // tear down the in-flight task; on its completion the
                 // queue drains. We still try here in case the in-flight
                 // task has already returned.
-                for (channel_id, thread_tags) in
-                    dispatch_pending(&mut pool, &mut queue, &ctx, &typing_tx, &mut last_activity)
-                {
+                for (channel_id, thread_tags) in dispatch_pending(
+                    &mut pool,
+                    &mut queue,
+                    &ctx,
+                    &membership_generations,
+                    &typing_tx,
+                    &mut last_activity,
+                ) {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -3661,6 +3697,7 @@ Typing(Uuid, String, ThreadTags),
                             &mut pool,
                             &mut queue,
                             &ctx,
+                            &membership_generations,
                             &typing_tx,
                             &mut last_activity,
                         ) {
@@ -4007,7 +4044,7 @@ fn try_native_steer(
         ack_tx,
     };
 
-    match pool.send_steer(channel_id, request) {
+    match pool.send_steer(channel_id, membership_generation, request) {
         Ok(()) => {
             // Ordinary events are withheld after send. Edit preparation reserves
             // its event before leaving the main loop, so this is idempotent.
@@ -4048,18 +4085,28 @@ fn try_native_steer(
 /// was withheld before asynchronous preparation, so release it, request the
 /// universal cancel+merge fallback, and immediately try dispatch in case the
 /// original turn already ended.
+#[allow(clippy::too_many_arguments)]
 fn release_prepared_native_steer_fallback(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     channel_id: Uuid,
     event_id: &str,
     ctx: &Arc<PromptContext>,
+    membership_generations: &HashMap<Uuid, u64>,
+    typing_tx: &mpsc::UnboundedSender<(Uuid, ThreadTags)>,
     last_activity: &mut tokio::time::Instant,
     typing_channels: &mut HashMap<Uuid, ThreadTags>,
 ) {
     queue.release_native_steer(channel_id, event_id);
     signal_in_flight_task(pool, channel_id, ControlSignal::Steer);
-    for (channel_id, thread_tags) in dispatch_pending(pool, queue, ctx, last_activity) {
+    for (channel_id, thread_tags) in dispatch_pending(
+        pool,
+        queue,
+        ctx,
+        membership_generations,
+        typing_tx,
+        last_activity,
+    ) {
         typing_channels.insert(channel_id, thread_tags);
     }
 }
@@ -4087,6 +4134,7 @@ fn dispatch_pending(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
+    membership_generations: &HashMap<Uuid, u64>,
     typing_tx: &mpsc::UnboundedSender<(Uuid, String, ThreadTags)>,
     last_activity: &mut tokio::time::Instant,
 ) -> Vec<(Uuid, ThreadTags)> {
@@ -4163,6 +4211,12 @@ fn dispatch_pending(
             pool::TaskMeta {
                 agent_index,
                 channel_id: Some(channel_id),
+                membership_generation: Some(
+                    membership_generations
+                        .get(&channel_id)
+                        .copied()
+                        .unwrap_or(0),
+                ),
                 turn_id,
                 recoverable_batch,
                 control_tx: Some(control_tx),
@@ -4243,6 +4297,7 @@ fn handle_prompt_result(
     mut result: PromptResult,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
+    membership_generations: &HashMap<Uuid, u64>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
@@ -4251,12 +4306,22 @@ fn handle_prompt_result(
 ) -> LoopAction {
     let before = pool.task_map().len();
     let agent_index = result.agent.index;
-    let successful_steer_deliveries = pool
+    let task_meta = pool
         .task_map()
         .values()
-        .find(|meta| meta.agent_index == agent_index)
+        .find(|meta| meta.agent_index == agent_index);
+    let successful_steer_deliveries = task_meta
         .map(|meta| meta.successful_steer_deliveries.clone())
         .unwrap_or_default();
+    let task_membership_is_current = task_meta
+        .and_then(|meta| meta.channel_id.zip(meta.membership_generation))
+        .is_none_or(|(channel_id, generation)| {
+            membership_generations
+                .get(&channel_id)
+                .copied()
+                .unwrap_or(0)
+                == generation
+        });
     pool.task_map_mut()
         .retain(|_, meta| meta.agent_index != agent_index);
     debug_assert_eq!(before, pool.task_map().len() + 1);
@@ -4295,9 +4360,10 @@ fn handle_prompt_result(
     // every retry starts at attempt 1 — defeating exponential backoff and
     // dead-letter protection.
     if let Some(batch) = result.batch.take() {
-        // Don't requeue batches for channels the agent was removed from —
-        // those events are stale and should be silently dropped.
-        if !removed_channels.contains(&batch.channel_id) {
+        // Don't requeue batches from a removed membership generation. Re-add
+        // clears the current removal marker, but the task generation remains
+        // stale and its pre-removal work must not cross into the new epoch.
+        if !removed_channels.contains(&batch.channel_id) && task_membership_is_current {
             if matches!(
                 result.outcome,
                 PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
@@ -4391,9 +4457,10 @@ fn handle_prompt_result(
             tracing::debug!(
                 channel_id = %batch.channel_id,
                 events = batch.events.len(),
-                "dropping failed batch for removed channel"
+                task_membership_is_current,
+                "dropping failed batch from removed or stale membership generation"
             );
-            hard_timeout_fate_suffix = Some(" — batch dropped (channel removed)");
+            hard_timeout_fate_suffix = Some(" — batch dropped (channel membership changed)");
         }
     }
 
@@ -4636,6 +4703,7 @@ fn recover_panicked_agent(
     join_error: tokio::task::JoinError,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
+    membership_generations: &HashMap<Uuid, u64>,
     typing_channels: &mut HashMap<Uuid, ThreadTags>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
@@ -4655,7 +4723,10 @@ fn recover_panicked_agent(
     // Requeue BEFORE mark_complete (same rationale as handle_prompt_result).
     if let Some(batch) = meta.recoverable_batch {
         if let Some(ch) = meta.channel_id {
-            if !removed_channels.contains(&ch) {
+            if !removed_channels.contains(&ch)
+                && meta.membership_generation
+                    == Some(membership_generations.get(&ch).copied().unwrap_or(0))
+            {
                 // Dead-letter on exhaustion is logged inside requeue(); a
                 // panic path has no outcome to report, so no notice here.
                 let _ = queue.requeue(batch);
@@ -4737,6 +4808,7 @@ fn drain_ready_join_results(
     config: &Config,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
+    membership_generations: &HashMap<Uuid, u64>,
     typing_channels: &mut HashMap<Uuid, ThreadTags>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
@@ -4753,6 +4825,7 @@ fn drain_ready_join_results(
                 join_error,
                 heartbeat_in_flight,
                 removed_channels,
+                membership_generations,
                 typing_channels,
                 crash_history,
                 respawn_tx,
@@ -4809,6 +4882,7 @@ fn dispatch_heartbeat(
         pool::TaskMeta {
             agent_index,
             channel_id: None,
+            membership_generation: None,
             turn_id,
             recoverable_batch: None,
             control_tx: None,
@@ -5646,6 +5720,7 @@ mod owner_control_command_tests {
             pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: Some(control_tx),
@@ -7772,6 +7847,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                membership_generation: None,
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7811,6 +7887,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -7844,6 +7921,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                membership_generation: None,
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7883,6 +7961,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -7959,6 +8038,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                membership_generation: None,
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7997,6 +8077,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8024,6 +8105,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8060,6 +8142,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8101,6 +8184,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                membership_generation: None,
                 turn_id: "panic-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8133,6 +8217,7 @@ mod error_outcome_emission_tests {
             join_error,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut typing_channels,
             &mut crash_history,
             &respawn_tx,
@@ -8194,6 +8279,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    membership_generation: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -8227,6 +8313,7 @@ mod error_outcome_emission_tests {
                 result,
                 &mut heartbeat_in_flight,
                 &removed_channels,
+                &HashMap::new(),
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
@@ -8286,6 +8373,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    membership_generation: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -8318,6 +8406,7 @@ mod error_outcome_emission_tests {
                 result,
                 &mut heartbeat_in_flight,
                 &removed_channels,
+                &HashMap::new(),
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
@@ -8392,6 +8481,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    membership_generation: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -8424,6 +8514,7 @@ mod error_outcome_emission_tests {
                 result,
                 &mut heartbeat_in_flight,
                 &removed_channels,
+                &HashMap::new(),
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
@@ -8469,6 +8560,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8516,6 +8608,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8564,6 +8657,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8610,6 +8704,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8681,6 +8776,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8726,6 +8822,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8821,6 +8918,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8859,6 +8957,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -9010,6 +9109,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -9042,6 +9142,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -9096,6 +9197,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                membership_generation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -9128,6 +9230,7 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -9489,9 +9592,11 @@ mod native_edit_membership_lifecycle_tests {
             channel_id,
             &event_id,
             &prompt_context(),
+            &HashMap::new(),
             &mut last_activity,
             &mut typing_channels,
-        );
+        )
+        .await;
 
         assert!(typing_channels.contains_key(&channel_id));
         assert_eq!(

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2410,7 +2410,7 @@ async fn tokio_main() -> Result<()> {
     //      withheld event in `EventQueue::withheld_native_steer` until
     //      `IN_FLIGHT_DEADLINE_SECS` expires.
     let (steer_ack_tx, mut steer_ack_rx) = mpsc::unbounded_channel::<SteerAckEvent>();
-let (typing_tx, mut typing_rx) = mpsc::unbounded_channel::<(Uuid, String, ThreadTags)>();
+    let (typing_tx, mut typing_rx) = mpsc::unbounded_channel::<(Uuid, String, ThreadTags)>();
     // Edit-aware native steer enrichment performs bounded REST lookups. Keep it
     // off the relay select arm, then return the immutable prompt payload here
     // for queue/pool mutation on the main loop.
@@ -2492,7 +2492,7 @@ let (typing_tx, mut typing_rx) = mpsc::unbounded_channel::<(Uuid, String, Thread
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
-Typing(Uuid, String, ThreadTags),
+        Typing(Uuid, String, ThreadTags),
         NativeSteerPrepared(NativeSteerPrepared),
         Wake(u32, Result<AgentPool, String>),
     }
@@ -4215,7 +4215,7 @@ fn release_prepared_native_steer_fallback(
     event_id: &str,
     ctx: &Arc<PromptContext>,
     membership_generations: &HashMap<Uuid, u64>,
-    typing_tx: &mpsc::UnboundedSender<(Uuid, ThreadTags)>,
+    typing_tx: &mpsc::UnboundedSender<(Uuid, String, ThreadTags)>,
     last_activity: &mut tokio::time::Instant,
     typing_channels: &mut HashMap<Uuid, ThreadTags>,
 ) {
@@ -5817,6 +5817,7 @@ mod owner_control_command_tests {
             pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                membership_generation: Some(0),
                 turn_id: turn_id.into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -9839,7 +9840,10 @@ mod native_edit_membership_lifecycle_tests {
             &mut typing_channels,
         );
 
-        assert!(typing_channels.contains_key(&channel_id));
+        assert!(
+            !typing_channels.contains_key(&channel_id),
+            "edit typing waits for the prompt task's resolved routing scope"
+        );
         assert_eq!(
             pool.task_map().len(),
             1,
@@ -9951,13 +9955,17 @@ mod native_edit_membership_lifecycle_tests {
         // drains the reservation and advances generation; re-add restores
         // access without revalidating old prepared work.
         let mut removed_channels = HashSet::new();
-        assert!(remove_channel_for_membership_change(
+        let drained = remove_channel_for_membership_change(
             &mut queue,
             &mut removed_channels,
             &mut generations,
             channel_id,
-        )
-        .is_empty());
+        );
+        assert_eq!(
+            drained,
+            vec!["ab".repeat(32)],
+            "removal returns the reserved edit's visible reaction target"
+        );
         readd_channel_after_membership_change(&mut removed_channels, channel_id);
 
         // This is the completion-arm guard. A false result would enter

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1569,12 +1569,20 @@ fn native_steer_preparation_is_stale(
     prepared_generation: u64,
 ) -> bool {
     removed_channels.contains(&channel_id)
-        || membership_generations
-            .get(&channel_id)
-            .copied()
-            .unwrap_or(0)
-            != prepared_generation
+        || native_steer_ack_is_stale(membership_generations, channel_id, prepared_generation)
         || !queue.has_native_steer_reservation(channel_id, event_id)
+}
+
+fn native_steer_ack_is_stale(
+    membership_generations: &HashMap<Uuid, u64>,
+    channel_id: Uuid,
+    sent_generation: u64,
+) -> bool {
+    membership_generations
+        .get(&channel_id)
+        .copied()
+        .unwrap_or(0)
+        != sent_generation
 }
 
 /// Reserve an edit before its asynchronous enrichment starts, returning the
@@ -1618,6 +1626,10 @@ fn readd_channel_after_membership_change(removed_channels: &mut HashSet<Uuid>, c
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
+    /// Membership generation in which the steer was sent. Late acknowledgements
+    /// from an earlier membership epoch must have no queue, ledger, or fallback
+    /// effects after removal/re-add.
+    membership_generation: u64,
     /// `Ok` if the read loop sent any of the locked `SteerAck` variants.
     /// `Err` if the oneshot was dropped without a send — should not happen
     /// under the current read-loop drains, but if it ever does the main
@@ -3153,6 +3165,10 @@ Typing(Uuid, String, ThreadTags),
                                                 buzz_event.channel_id,
                                                 event_for_steer,
                                                 prompt_blocks,
+                                                membership_generations
+                                                    .get(&buzz_event.channel_id)
+                                                    .copied()
+                                                    .unwrap_or(0),
                                                 &steer_ack_tx,
                                             )
                                         }
@@ -3436,6 +3452,7 @@ Typing(Uuid, String, ThreadTags),
                     channel_id,
                     event.clone(),
                     prompt_blocks,
+                    membership_generation,
                     &steer_ack_tx,
                 ) {
                     release_prepared_native_steer_fallback(
@@ -3452,8 +3469,22 @@ Typing(Uuid, String, ThreadTags),
             Some(PoolEvent::SteerAck(SteerAckEvent {
                 channel_id,
                 event_id,
+                membership_generation,
                 ack,
             })) => {
+                if native_steer_ack_is_stale(
+                    &membership_generations,
+                    channel_id,
+                    membership_generation,
+                ) {
+                    tracing::debug!(
+                        %channel_id,
+                        %event_id,
+                        membership_generation,
+                        "discarding native steer acknowledgement from stale membership generation"
+                    );
+                    continue;
+                }
                 // Mid-turn steer attempt resolved (either transport:
                 // `_goose/unstable/session/steer` or `_session/steering`).
                 // Locked semantics (Eva + Max + Perci, unanimous on Option X):
@@ -3965,6 +3996,7 @@ fn try_native_steer(
     channel_id: uuid::Uuid,
     event: nostr::Event,
     prompt_blocks: Vec<String>,
+    membership_generation: u64,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
     let event_id_hex = event.id.to_hex();
@@ -3995,6 +4027,7 @@ fn try_native_steer(
                 let _ = ack_tx_clone.send(SteerAckEvent {
                     channel_id,
                     event_id: event_id_for_watcher,
+                    membership_generation,
                     ack,
                 });
             });
@@ -4227,6 +4260,10 @@ fn handle_prompt_result(
     pool.task_map_mut()
         .retain(|_, meta| meta.agent_index != agent_index);
     debug_assert_eq!(before, pool.task_map().len() + 1);
+    // Membership removal records invalidation against checked-out ownership,
+    // not current membership. Apply it before acknowledging successful steer
+    // delivery so remove/re-add cannot resurrect the earlier epoch's session.
+    pool.invalidate_checked_out_sessions(&mut result.agent);
     if let PromptSource::Channel(channel_id) = &result.source {
         // The task may have invalidated this session before returning. Never
         // resurrect delivery state for a dead session; its replacement must
@@ -9479,6 +9516,33 @@ mod native_edit_membership_lifecycle_tests {
             "a missing queue entry must not panic or claim a native attempt"
         );
         assert!(queue.flush_next().is_none());
+    }
+
+    #[test]
+    fn sent_steer_ack_is_discarded_across_remove_then_readd() {
+        let channel_id = Uuid::new_v4();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        let mut generations = HashMap::new();
+        let sent_generation = generations.get(&channel_id).copied().unwrap_or(0);
+        let mut removed_channels = HashSet::new();
+
+        remove_channel_for_membership_change(
+            &mut queue,
+            &mut removed_channels,
+            &mut generations,
+            channel_id,
+        );
+        readd_channel_after_membership_change(&mut removed_channels, channel_id);
+
+        assert!(native_steer_ack_is_stale(
+            &generations,
+            channel_id,
+            sent_generation
+        ));
+        assert!(
+            !removed_channels.contains(&channel_id),
+            "staleness survives re-add for both successful and failed late acks"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3076,15 +3076,24 @@ Typing(Uuid, String, ThreadTags),
                                         if queue.has_native_steer_reservations(
                                             buzz_event.channel_id,
                                         ) {
-                                            let released = queue.release_native_steers(
+                                            let released = queue.release_native_steer_preparations(
+                                                buzz_event.channel_id,
+                                            );
+                                            let sent_steer_pending = queue.has_sent_native_steer(
                                                 buzz_event.channel_id,
                                             );
                                             tracing::debug!(
                                                 channel_id = %buzz_event.channel_id,
                                                 released,
-                                                "native steer preparation already pending; releasing reservations for ordered cancel+merge"
+                                                sent_steer_pending,
+                                                "native steer reservation already pending; released preparations and retained sent steers"
                                             );
-                                            false
+                                            // A sent steer must settle before later work can
+                                            // cancel or replace its turn. Treat it as an
+                                            // accepted native attempt so the later event stays
+                                            // queued; the ack arm will settle the reservation
+                                            // and drive fallback/dispatch as needed.
+                                            sent_steer_pending
                                         } else if is_edit
                                             && pool.native_steer_available(buzz_event.channel_id)
                                         {
@@ -3971,6 +3980,7 @@ fn try_native_steer(
             // Ordinary events are withheld after send. Edit preparation reserves
             // its event before leaving the main loop, so this is idempotent.
             let withheld = queue.mark_native_steer_pending(channel_id, &event_id_hex);
+            queue.mark_native_steer_sent(channel_id, &event_id_hex);
             if !withheld {
                 tracing::debug!(
                     channel = %channel_id,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2993,8 +2993,10 @@ async fn tokio_main() -> Result<()> {
                                             buzz_event.channel_id,
                                             event_for_steer,
                                             prompt_tag_for_steer,
+                                            &ctx,
                                             &steer_ack_tx,
-                                        );
+                                        )
+                                        .await;
                                     if !native_attempted {
                                         signal_in_flight_task(
                                             &mut pool,
@@ -3754,40 +3756,21 @@ fn signal_in_flight_task(
 ///
 /// The withheld event is NOT released here on `false` because no withhold
 /// was established: `mark_native_steer_pending` only runs on `Ok(())`.
-fn try_native_steer(
+async fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     channel_id: uuid::Uuid,
     event: nostr::Event,
     prompt_tag: String,
+    ctx: &PromptContext,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
-    // Build the steer body: framing strings come from
-    // `queue::native_steer_framing()` (Eva's drift-proof requirement —
-    // native and cancel+merge fallback share these so the agent gets the
-    // same orientation regardless of transport). The single event block
-    // is rendered by `queue::format_event_block`, the same function
-    // `queue::format_prompt` uses internally for `[Buzz event: …]`
-    // sections, so the rendering also cannot drift.
-    //
-    // Passing `None` for `channel_info` / `profile_lookup` is intentional:
-    // native steer is a *delta* into a live turn — the agent already saw
-    // channel context and the actor's profile in the original prompt,
-    // duplicating it here would defeat the point of non-cancelling
-    // steering (which is to inject only what's new).
-    let (header, closing) = queue::native_steer_framing();
     let event_id_hex = event.id.to_hex();
-    let be = queue::BatchEvent {
-        event,
-        prompt_tag: prompt_tag.clone(),
-        received_at: std::time::Instant::now(),
-    };
-    let event_block = queue::format_event_block(channel_id, None, &be, None);
-    let body = format!("{header}\n\n[Buzz event: {prompt_tag}]\n{event_block}\n\n{closing}");
+    let prompt_blocks = pool::format_native_steer_prompt(channel_id, event, prompt_tag, ctx).await;
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
     let request = pool::SteerRequest {
-        prompt_blocks: vec![body],
+        prompt_blocks,
         ack_tx,
     };
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1574,6 +1574,44 @@ fn native_steer_preparation_is_stale(
             != prepared_generation
 }
 
+/// Reserve an edit before its asynchronous enrichment starts, returning the
+/// membership generation that completion must still match.
+fn reserve_native_edit_preparation(
+    queue: &mut EventQueue,
+    membership_generations: &HashMap<Uuid, u64>,
+    channel_id: Uuid,
+    event_id: &str,
+) -> Option<u64> {
+    queue
+        .mark_native_steer_pending(channel_id, event_id)
+        .then(|| {
+            membership_generations
+                .get(&channel_id)
+                .copied()
+                .unwrap_or(0)
+        })
+}
+
+/// Apply the queue and membership state transition for a channel removal.
+/// The generation deliberately advances even if a later add restores access.
+fn remove_channel_for_membership_change(
+    queue: &mut EventQueue,
+    removed_channels: &mut HashSet<Uuid>,
+    membership_generations: &mut HashMap<Uuid, u64>,
+    channel_id: Uuid,
+) -> Vec<String> {
+    let drained_ids = queue.drain_channel(channel_id);
+    removed_channels.insert(channel_id);
+    let generation = membership_generations.entry(channel_id).or_default();
+    *generation = generation.wrapping_add(1);
+    drained_ids
+}
+
+/// Restore current membership without validating work prepared before removal.
+fn readd_channel_after_membership_change(removed_channels: &mut HashSet<Uuid>, channel_id: Uuid) {
+    removed_channels.remove(&channel_id);
+}
+
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
@@ -2723,7 +2761,7 @@ Typing(Uuid, String, ThreadTags),
                                 if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION {
                                     // Clear removal tracking so sessions are not
                                     // stripped for a legitimately re-added channel.
-                                    removed_channels.remove(&ch);
+                                    readd_channel_after_membership_change(&mut removed_channels, ch);
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
@@ -2747,7 +2785,12 @@ Typing(Uuid, String, ThreadTags),
                                     // removed channel. Events already in-flight will
                                     // complete normally (the relay may reject actions if
                                     // the agent lost access).
-                                    let drained_ids = queue.drain_channel(ch);
+                                    let drained_ids = remove_channel_for_membership_change(
+                                        &mut queue,
+                                        &mut removed_channels,
+                                        &mut membership_generations,
+                                        ch,
+                                    );
                                     let invalidated = if pool_ready {
                                         pool.invalidate_channel_sessions(ch)
                                     } else {
@@ -2755,9 +2798,6 @@ Typing(Uuid, String, ThreadTags),
                                     };
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
-                                    removed_channels.insert(ch);
-                                    let generation = membership_generations.entry(ch).or_default();
-                                    *generation = generation.wrapping_add(1);
                                     typing_channels.remove(&ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
@@ -3030,18 +3070,16 @@ Typing(Uuid, String, ThreadTags),
                                     {
                                         if queue::edit_target_id(&event_for_steer).is_some() {
                                             let event_id = event_for_steer.id.to_hex();
-                                            let reserved = queue.mark_native_steer_pending(
-                                                buzz_event.channel_id,
+                                            let channel_id = buzz_event.channel_id;
+                                            let membership_generation = reserve_native_edit_preparation(
+                                                &mut queue,
+                                                &membership_generations,
+                                                channel_id,
                                                 &event_id,
-                                            );
-                                            debug_assert!(reserved, "accepted edit must still be queued");
+                                            )
+                                            .expect("accepted edit must still be queued");
                                             let tx = native_steer_tx.clone();
                                             let ctx = Arc::clone(&ctx);
-                                            let channel_id = buzz_event.channel_id;
-                                            let membership_generation = membership_generations
-                                                .get(&channel_id)
-                                                .copied()
-                                                .unwrap_or(0);
                                             tokio::spawn(async move {
                                                 let prompt_blocks = pool::format_native_steer_prompt(
                                                     channel_id,
@@ -9242,5 +9280,65 @@ mod observer_payload_trim_tests {
         assert!(leaf.starts_with('…'));
         assert!(leaf.ends_with('…'));
         assert!(leaf.contains("[elided"));
+    }
+}
+
+#[cfg(test)]
+mod native_edit_membership_lifecycle_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind};
+
+    fn edit_event(target: &str) -> nostr::Event {
+        EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .tags([nostr::Tag::parse(["e", target]).expect("target tag")])
+            .sign_with_keys(&Keys::generate())
+            .expect("signed edit")
+    }
+
+    #[test]
+    fn late_prepared_edit_is_discarded_across_remove_then_readd() {
+        let channel_id = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        assert!(queue.push(QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "@mention".into(),
+        }));
+
+        // This is the production reservation/capture boundary used before the
+        // detached REST preparation task is spawned.
+        let mut generations = HashMap::new();
+        let prepared_generation =
+            reserve_native_edit_preparation(&mut queue, &generations, channel_id, &event_id)
+                .expect("accepted edit is reserved before preparation");
+
+        // These are the production removal and re-add transitions. Removal
+        // drains the reservation and advances generation; re-add restores
+        // access without revalidating old prepared work.
+        let mut removed_channels = HashSet::new();
+        assert!(remove_channel_for_membership_change(
+            &mut queue,
+            &mut removed_channels,
+            &mut generations,
+            channel_id,
+        )
+        .is_empty());
+        readd_channel_after_membership_change(&mut removed_channels, channel_id);
+
+        // This is the completion-arm guard. A false result would enter
+        // try_native_steer or its release/fallback path; stale completion must
+        // instead be discarded, leaving neither queued nor withheld work to
+        // steer, release, or resurrect.
+        assert!(native_steer_preparation_is_stale(
+            &removed_channels,
+            &generations,
+            channel_id,
+            prepared_generation,
+        ));
+        queue.release_native_steer(channel_id, &event_id);
+        assert!(queue.flush_next().is_none());
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1547,6 +1547,12 @@ struct RespawnResult {
 /// Carries enough identity to operate on the right withheld event in
 /// `EventQueue::withheld_native_steer`: `channel_id` is the routing key,
 /// `event_id` is the hex id of the single event the steer carried.
+struct NativeSteerPrepared {
+    channel_id: Uuid,
+    event: nostr::Event,
+    prompt_blocks: Vec<String>,
+}
+
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
@@ -2319,7 +2325,11 @@ async fn tokio_main() -> Result<()> {
     //      withheld event in `EventQueue::withheld_native_steer` until
     //      `IN_FLIGHT_DEADLINE_SECS` expires.
     let (steer_ack_tx, mut steer_ack_rx) = mpsc::unbounded_channel::<SteerAckEvent>();
-    let (typing_tx, mut typing_rx) = mpsc::unbounded_channel::<(Uuid, String, ThreadTags)>();
+let (typing_tx, mut typing_rx) = mpsc::unbounded_channel::<(Uuid, String, ThreadTags)>();
+    // Edit-aware native steer enrichment performs bounded REST lookups. Keep it
+    // off the relay select arm, then return the immutable prompt payload here
+    // for queue/pool mutation on the main loop.
+    let (native_steer_tx, mut native_steer_rx) = mpsc::unbounded_channel::<NativeSteerPrepared>();
 
     // ── Step 7: Shutdown signal ───────────────────────────────────────────────
     let (shutdown_tx, mut shutdown_rx) = watch::channel(());
@@ -2394,7 +2404,8 @@ async fn tokio_main() -> Result<()> {
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
-        Typing(Uuid, String, ThreadTags),
+Typing(Uuid, String, ThreadTags),
+        NativeSteerPrepared(NativeSteerPrepared),
         Wake(u32, Result<AgentPool, String>),
     }
 
@@ -2558,6 +2569,9 @@ async fn tokio_main() -> Result<()> {
                 }
                 Some((channel_id, turn_id, scope)) = typing_rx.recv() => {
                     Some(PoolEvent::Typing(channel_id, turn_id, scope))
+                }
+                Some(prepared) = native_steer_rx.recv() => {
+                    Some(PoolEvent::NativeSteerPrepared(prepared))
                 }
                 Some((attempt, result)) = wake_rx.recv(), if config.lazy_pool && !pool_ready => {
                     Some(PoolEvent::Wake(attempt, result))
@@ -2986,17 +3000,46 @@ async fn tokio_main() -> Result<()> {
                                     // to the universal cancel+merge `Steer`
                                     // signal so the event still reaches the
                                     // agent.
-                                    let native_attempted = matches!(signal, ControlSignal::Steer)
-                                        && try_native_steer(
-                                            &mut pool,
-                                            &mut queue,
-                                            buzz_event.channel_id,
-                                            event_for_steer,
-                                            prompt_tag_for_steer,
-                                            &ctx,
-                                            &steer_ack_tx,
-                                        )
-                                        .await;
+                                    let native_attempted = if matches!(signal, ControlSignal::Steer)
+                                    {
+                                        if queue::edit_target_id(&event_for_steer).is_some() {
+                                            let tx = native_steer_tx.clone();
+                                            let ctx = Arc::clone(&ctx);
+                                            let channel_id = buzz_event.channel_id;
+                                            tokio::spawn(async move {
+                                                let prompt_blocks = pool::format_native_steer_prompt(
+                                                    channel_id,
+                                                    event_for_steer.clone(),
+                                                    prompt_tag_for_steer,
+                                                    &ctx,
+                                                )
+                                                .await;
+                                                let _ = tx.send(NativeSteerPrepared {
+                                                    channel_id,
+                                                    event: event_for_steer,
+                                                    prompt_blocks,
+                                                });
+                                            });
+                                            true
+                                        } else {
+                                            let prompt_blocks =
+                                                pool::format_native_steer_prompt_sync(
+                                                    buzz_event.channel_id,
+                                                    &event_for_steer,
+                                                    &prompt_tag_for_steer,
+                                                );
+                                            try_native_steer(
+                                                &mut pool,
+                                                &mut queue,
+                                                buzz_event.channel_id,
+                                                event_for_steer,
+                                                prompt_blocks,
+                                                &steer_ack_tx,
+                                            )
+                                        }
+                                    } else {
+                                        false
+                                    };
                                     if !native_attempted {
                                         signal_in_flight_task(
                                             &mut pool,
@@ -3245,6 +3288,22 @@ async fn tokio_main() -> Result<()> {
                     &turn_id,
                     scope,
                 );
+            }
+            Some(PoolEvent::NativeSteerPrepared(NativeSteerPrepared {
+                channel_id,
+                event,
+                prompt_blocks,
+            })) => {
+                if !try_native_steer(
+                    &mut pool,
+                    &mut queue,
+                    channel_id,
+                    event,
+                    prompt_blocks,
+                    &steer_ack_tx,
+                ) {
+                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                }
             }
             Some(PoolEvent::SteerAck(SteerAckEvent {
                 channel_id,
@@ -3756,17 +3815,15 @@ fn signal_in_flight_task(
 ///
 /// The withheld event is NOT released here on `false` because no withhold
 /// was established: `mark_native_steer_pending` only runs on `Ok(())`.
-async fn try_native_steer(
+fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     channel_id: uuid::Uuid,
     event: nostr::Event,
-    prompt_tag: String,
-    ctx: &PromptContext,
+    prompt_blocks: Vec<String>,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
     let event_id_hex = event.id.to_hex();
-    let prompt_blocks = pool::format_native_steer_prompt(channel_id, event, prompt_tag, ctx).await;
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
     let request = pool::SteerRequest {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1553,6 +1553,13 @@ struct NativeSteerPrepared {
     prompt_blocks: Vec<String>,
 }
 
+/// Async edit enrichment may finish after channel membership was revoked.
+/// Such prepared work is stale: removal drains its queue reservation, and it
+/// must never be forwarded to an otherwise still-live ACP turn.
+fn native_steer_preparation_is_stale(removed_channels: &HashSet<Uuid>, channel_id: Uuid) -> bool {
+    removed_channels.contains(&channel_id)
+}
+
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
@@ -3300,6 +3307,14 @@ Typing(Uuid, String, ThreadTags),
                 event,
                 prompt_blocks,
             })) => {
+                if native_steer_preparation_is_stale(&removed_channels, channel_id) {
+                    tracing::debug!(
+                        %channel_id,
+                        event_id = %event.id.to_hex(),
+                        "discarding native steer prepared after channel removal"
+                    );
+                    continue;
+                }
                 if !try_native_steer(
                     &mut pool,
                     &mut queue,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3071,31 +3071,41 @@ Typing(Uuid, String, ThreadTags),
                                         if queue::edit_target_id(&event_for_steer).is_some() {
                                             let event_id = event_for_steer.id.to_hex();
                                             let channel_id = buzz_event.channel_id;
-                                            let membership_generation = reserve_native_edit_preparation(
+                                            match reserve_native_edit_preparation(
                                                 &mut queue,
                                                 &membership_generations,
                                                 channel_id,
                                                 &event_id,
-                                            )
-                                            .expect("accepted edit must still be queued");
-                                            let tx = native_steer_tx.clone();
-                                            let ctx = Arc::clone(&ctx);
-                                            tokio::spawn(async move {
-                                                let prompt_blocks = pool::format_native_steer_prompt(
-                                                    channel_id,
-                                                    event_for_steer.clone(),
-                                                    prompt_tag_for_steer,
-                                                    &ctx,
-                                                )
-                                                .await;
-                                                let _ = tx.send(NativeSteerPrepared {
-                                                    channel_id,
-                                                    membership_generation,
-                                                    event: event_for_steer,
-                                                    prompt_blocks,
-                                                });
-                                            });
-                                            true
+                                            ) {
+                                                Some(membership_generation) => {
+                                                    let tx = native_steer_tx.clone();
+                                                    let ctx = Arc::clone(&ctx);
+                                                    tokio::spawn(async move {
+                                                        let prompt_blocks = pool::format_native_steer_prompt(
+                                                            channel_id,
+                                                            event_for_steer.clone(),
+                                                            prompt_tag_for_steer,
+                                                            &ctx,
+                                                        )
+                                                        .await;
+                                                        let _ = tx.send(NativeSteerPrepared {
+                                                            channel_id,
+                                                            membership_generation,
+                                                            event: event_for_steer,
+                                                            prompt_blocks,
+                                                        });
+                                                    });
+                                                    true
+                                                }
+                                                None => {
+                                                    tracing::warn!(
+                                                        %channel_id,
+                                                        %event_id,
+                                                        "native edit steer preparation could not reserve queued event; falling back to cancel+merge"
+                                                    );
+                                                    false
+                                                }
+                                            }
                                         } else {
                                             let prompt_blocks =
                                                 pool::format_native_steer_prompt_sync(
@@ -3391,8 +3401,15 @@ Typing(Uuid, String, ThreadTags),
                     prompt_blocks,
                     &steer_ack_tx,
                 ) {
-                    queue.release_native_steer(channel_id, &event.id.to_hex());
-                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    release_prepared_native_steer_fallback(
+                        &mut pool,
+                        &mut queue,
+                        channel_id,
+                        &event.id.to_hex(),
+                        &ctx,
+                        &mut last_activity,
+                        &mut typing_channels,
+                    );
                 }
             }
             Some(PoolEvent::SteerAck(SteerAckEvent {
@@ -3953,6 +3970,26 @@ fn try_native_steer(
             );
             false
         }
+    }
+}
+
+/// Recover a prepared edit whose native steer could not be accepted. The edit
+/// was withheld before asynchronous preparation, so release it, request the
+/// universal cancel+merge fallback, and immediately try dispatch in case the
+/// original turn already ended.
+fn release_prepared_native_steer_fallback(
+    pool: &mut AgentPool,
+    queue: &mut EventQueue,
+    channel_id: Uuid,
+    event_id: &str,
+    ctx: &Arc<PromptContext>,
+    last_activity: &mut tokio::time::Instant,
+    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+) {
+    queue.release_native_steer(channel_id, event_id);
+    signal_in_flight_task(pool, channel_id, ControlSignal::Steer);
+    for (channel_id, thread_tags) in dispatch_pending(pool, queue, ctx, last_activity) {
+        typing_channels.insert(channel_id, thread_tags);
     }
 }
 
@@ -9293,6 +9330,117 @@ mod native_edit_membership_lifecycle_tests {
             .tags([nostr::Tag::parse(["e", target]).expect("target tag")])
             .sign_with_keys(&Keys::generate())
             .expect("signed edit")
+    }
+
+    async fn dummy_agent(index: usize) -> OwnedAgent {
+        OwnedAgent {
+            index,
+            acp: AcpClient::spawn("cat", &[], &[], false)
+                .await
+                .expect("spawn inert agent"),
+            state: Default::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            desired_model_request_id: None,
+            desired_model_pending_ack: false,
+            startup_effort: None,
+            agent_name: "unknown".into(),
+            protocol_version: 1,
+            goose_system_prompt_supported: None,
+        }
+    }
+
+    fn prompt_context() -> Arc<PromptContext> {
+        let keys = Keys::generate();
+        let rest_client = relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:0".into(),
+            keys: keys.clone(),
+            auth_tag_json: None,
+        };
+        Arc::new(PromptContext {
+            mcp_servers: vec![],
+            initial_message: None,
+            idle_timeout: Duration::from_secs(60),
+            max_turn_duration: Duration::from_secs(120),
+            turn_liveness_interval: Duration::ZERO,
+            dedup_mode: DedupMode::Queue,
+            system_prompt: None,
+            session_title: None,
+            team_instructions: None,
+            heartbeat_prompt: None,
+            base_prompt: None,
+            cwd: ".".into(),
+            channel_info: pool::ChannelInfoResolver::new(HashMap::new(), rest_client.clone()),
+            rest_client,
+            context_message_limit: 0,
+            max_turns_per_session: 0,
+            permission_mode: config::PermissionMode::Default,
+            agent_keys: keys,
+            agent_owner_pubkey: None,
+            memory_enabled: false,
+            harness_name: "goose".into(),
+            relay_url: "ws://127.0.0.1:0".into(),
+        })
+    }
+
+    #[tokio::test]
+    async fn prepared_native_steer_rejection_releases_and_dispatches_immediately() {
+        let channel_id = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        assert!(queue.push(QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "@mention".into(),
+        }));
+        assert!(queue.mark_native_steer_pending(channel_id, &event_id));
+
+        // The original turn completed while edit enrichment ran. The native
+        // transport rejection must synchronously release and re-dispatch the
+        // edit; no maintenance tick may be needed to observe the work.
+        let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(0).await)]);
+        let mut last_activity = tokio::time::Instant::now();
+        let mut typing_channels = HashMap::new();
+        release_prepared_native_steer_fallback(
+            &mut pool,
+            &mut queue,
+            channel_id,
+            &event_id,
+            &prompt_context(),
+            &mut last_activity,
+            &mut typing_channels,
+        );
+
+        assert!(typing_channels.contains_key(&channel_id));
+        assert_eq!(
+            pool.task_map().len(),
+            1,
+            "released edit dispatched exactly once"
+        );
+        assert!(
+            queue.flush_next().is_none(),
+            "dispatch consumed the released edit"
+        );
+    }
+
+    #[test]
+    fn unreservable_edit_leaves_universal_fallback_work_queued() {
+        let channel_id = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        let generations = HashMap::new();
+
+        assert_eq!(
+            reserve_native_edit_preparation(&mut queue, &generations, channel_id, &event_id),
+            None,
+            "a missing queue entry must not panic or claim a native attempt"
+        );
+        assert!(queue.flush_next().is_none());
     }
 
     #[test]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -60,6 +60,9 @@ pub struct SuccessfulSteerDelivery {
 pub struct TaskMeta {
     pub agent_index: usize,
     pub channel_id: Option<Uuid>,
+    /// Membership generation in which this channel task was dispatched.
+    /// Heartbeat tasks have no channel generation.
+    pub membership_generation: Option<u64>,
     /// Identifies terminal events when the task panics before returning a result.
     pub turn_id: String,
     /// Clone of batch for Queue mode panic recovery.
@@ -746,24 +749,31 @@ impl AgentPool {
             .any(|meta| meta.channel_id == Some(channel_id) && meta.turn_id == turn_id)
     }
 
-    /// Return whether the current channel task can accept a native steer now.
+    /// Return whether the current-generation channel task can accept a native
+    /// steer now.
+    ///
+    /// Membership generation is part of task ownership: after remove/re-add,
+    /// a still-running task from the prior generation must not accept new work.
     ///
     /// This is a main-loop preflight for edit enrichment: avoid withholding an
     /// edit and performing REST work when the task has no steer transport or
     /// its capacity-one request slot is already occupied. Availability can
     /// still change while enrichment runs, so callers must retain the normal
     /// send-time fallback.
-    pub fn native_steer_available(&self, channel_id: Uuid) -> bool {
+    pub fn native_steer_available(&self, channel_id: Uuid, membership_generation: u64) -> bool {
         self.task_map
             .values()
-            .find(|meta| meta.channel_id == Some(channel_id))
+            .find(|meta| {
+                meta.channel_id == Some(channel_id)
+                    && meta.membership_generation == Some(membership_generation)
+            })
             .and_then(|meta| meta.steer_tx.as_ref())
             .is_some_and(|tx| !tx.is_closed() && tx.capacity() > 0)
     }
-    }
 
     /// Try to send a goose-native steer request to the in-flight task for
-    /// `channel_id`.
+    /// `channel_id` in `membership_generation`. A task from an earlier
+    /// remove/re-add generation is treated as completed for this request.
     ///
     /// Returns `Ok(())` if the request was accepted by the read loop's
     /// receiver (capacity-1 mpsc; one slot is the single in-flight steer
@@ -787,12 +797,16 @@ impl AgentPool {
     pub fn send_steer(
         &mut self,
         channel_id: Uuid,
+        membership_generation: u64,
         request: SteerRequest,
     ) -> Result<(), SteerError> {
         let meta = self
             .task_map
             .values_mut()
-            .find(|m| m.channel_id == Some(channel_id))
+            .find(|m| {
+                m.channel_id == Some(channel_id)
+                    && m.membership_generation == Some(membership_generation)
+            })
             .ok_or(SteerError::PromptCompleted)?;
         let tx = meta
             .steer_tx
@@ -4984,6 +4998,43 @@ mod tests {
             &session_new,
             PermissionMode::Auto.as_wire_str()
         ));
+    }
+
+    #[tokio::test]
+    async fn native_steer_rejects_task_from_prior_membership_generation() {
+        let channel_id = Uuid::new_v4();
+        let old_generation = 4;
+        let current_generation = 5;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel(1);
+        pool.task_map_mut().insert(
+            task_id,
+            TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                membership_generation: Some(old_generation),
+                turn_id: "pre-removal-turn".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: Some(steer_tx),
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        assert!(pool.native_steer_available(channel_id, old_generation));
+        assert!(!pool.native_steer_available(channel_id, current_generation));
+
+        let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
+        let request = SteerRequest {
+            prompt_blocks: vec!["post-readd work".into()],
+            ack_tx,
+        };
+        assert!(matches!(
+            pool.send_steer(channel_id, current_generation, request),
+            Err(SteerError::PromptCompleted)
+        ));
+        assert!(steer_rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -780,9 +780,11 @@ impl AgentPool {
                     && meta.membership_generation == Some(membership_generation)
             })
             .filter(|meta| {
-                meta.steer_tx
-                    .as_ref()
-                    .is_some_and(|tx| !tx.is_closed() && tx.capacity() > 0)
+                meta.control_tx.is_some()
+                    && meta
+                        .steer_tx
+                        .as_ref()
+                        .is_some_and(|tx| !tx.is_closed() && tx.capacity() > 0)
             })
             .map(|meta| meta.turn_id.clone())
     }
@@ -835,6 +837,11 @@ impl AgentPool {
                     && m.membership_generation == Some(membership_generation)
             })
             .ok_or(SteerError::PromptCompleted)?;
+        if meta.control_tx.is_none() {
+            return Err(SteerError::Transport(
+                "turn cancellation already committed".into(),
+            ));
+        }
         let tx = meta
             .steer_tx
             .as_ref()
@@ -1953,6 +1960,14 @@ pub async fn run_prompt_task(
         .unwrap_or_default();
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
 
+    // Establish the edit target as the failure-routing floor before any
+    // fallible session setup. Once the original event is resolved below this
+    // is refined to its visible thread, but session/new and initial-message
+    // failures must never fall back to the invisible edit event or channel root.
+    if let Some(ref mut batch) = batch {
+        initialize_edit_failure_routing(batch);
+    }
+
     //
     // Core memory is delivered inside the system prompt the harness already
     // builds (system role for protocol >= 2, the `[System]` user-message
@@ -2445,18 +2460,10 @@ pub async fn run_prompt_task(
                 let _ = tx.send((b.channel_id, turn_id.clone(), scope));
             }
         }
-        b.failure_thread_tags = b.events.last().and_then(|event| {
-            crate::queue::edit_target_id(&event.event).map(|target_event_id| {
-                resolved_edit
-                    .as_ref()
-                    .map(crate::queue::ResolvedEdit::reply_thread_tags)
-                    .unwrap_or_else(|| crate::queue::ThreadTags {
-                        root_event_id: Some(target_event_id.clone()),
-                        parent_event_id: Some(target_event_id),
-                        mentioned_pubkeys: Vec::new(),
-                    })
-            })
-        });
+        b.failure_thread_tags = resolved_edit
+            .as_ref()
+            .map(crate::queue::ResolvedEdit::reply_thread_tags)
+            .or_else(|| b.failure_thread_tags.clone());
 
         // Build prompt from batch with context enrichment.
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
@@ -3444,6 +3451,18 @@ fn typing_scope_for_event(
     resolved_edit
         .map(|edit| edit.target_thread_tags.clone())
         .unwrap_or_else(|| crate::queue::parse_thread_tags(event))
+}
+
+/// Establish failure routing for an edit batch without network access.
+/// Resolution may later refine this target fallback to the original thread.
+fn initialize_edit_failure_routing(batch: &mut FlushBatch) {
+    batch.failure_thread_tags = batch.events.last().and_then(|event| {
+        crate::queue::edit_target_id(&event.event).map(|target_event_id| crate::queue::ThreadTags {
+            root_event_id: Some(target_event_id.clone()),
+            parent_event_id: Some(target_event_id),
+            mentioned_pubkeys: Vec::new(),
+        })
+    });
 }
 
 /// Resolve a kind:40003 edit through its original event for reply routing.
@@ -5048,6 +5067,7 @@ mod tests {
         let mut pool = AgentPool::from_slots(vec![None]);
         let task_id = pool.join_set.spawn(async {}).id();
         let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel(1);
+        let (control_tx, _control_rx) = tokio::sync::oneshot::channel();
         pool.task_map_mut().insert(
             task_id,
             TaskMeta {
@@ -5056,7 +5076,7 @@ mod tests {
                 membership_generation: Some(old_generation),
                 turn_id: "pre-removal-turn".into(),
                 recoverable_batch: None,
-                control_tx: None,
+                control_tx: Some(control_tx),
                 steer_tx: Some(steer_tx),
                 successful_steer_deliveries: HashSet::new(),
             },
@@ -5075,6 +5095,67 @@ mod tests {
             Err(SteerError::PromptCompleted)
         ));
         assert!(steer_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn native_steer_rejects_task_after_cancellation_is_committed() {
+        let channel_id = Uuid::new_v4();
+        let generation = 2;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel(1);
+        pool.task_map_mut().insert(
+            task_id,
+            TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                membership_generation: Some(generation),
+                turn_id: "cancelling-turn".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: Some(steer_tx),
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        assert!(!pool.native_steer_available(channel_id, generation));
+        let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
+        let request = SteerRequest {
+            prompt_blocks: vec!["late edit".into()],
+            ack_tx,
+        };
+        assert!(matches!(
+            pool.send_steer(channel_id, generation, request),
+            Err(SteerError::Transport(message)) if message.contains("cancellation")
+        ));
+        assert!(steer_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn edit_failure_routing_is_initialized_before_resolution() {
+        let target = "ab".repeat(32);
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .tags([Tag::parse(["e", target.as_str()]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap();
+        let mut batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+            failure_thread_tags: None,
+        };
+
+        initialize_edit_failure_routing(&mut batch);
+
+        let routing = batch.failure_thread_tags.expect("edit target fallback");
+        assert_eq!(routing.root_event_id.as_deref(), Some(target.as_str()));
+        assert_eq!(routing.parent_event_id.as_deref(), Some(target.as_str()));
     }
 
     #[test]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2445,18 +2445,17 @@ pub async fn run_prompt_task(
                 let _ = tx.send((b.channel_id, turn_id.clone(), scope));
             }
         }
-        b.failure_thread_tags = crate::queue::edit_target_id(
-            &b.events.last().expect("non-empty batch").event,
-        )
-        .map(|target_event_id| {
-            resolved_edit
-                .as_ref()
-                .map(crate::queue::ResolvedEdit::reply_thread_tags)
-                .unwrap_or_else(|| crate::queue::ThreadTags {
-                    root_event_id: Some(target_event_id.clone()),
-                    parent_event_id: Some(target_event_id),
-                    mentioned_pubkeys: Vec::new(),
-                })
+        b.failure_thread_tags = b.events.last().and_then(|event| {
+            crate::queue::edit_target_id(&event.event).map(|target_event_id| {
+                resolved_edit
+                    .as_ref()
+                    .map(crate::queue::ResolvedEdit::reply_thread_tags)
+                    .unwrap_or_else(|| crate::queue::ThreadTags {
+                        root_event_id: Some(target_event_id.clone()),
+                        parent_event_id: Some(target_event_id),
+                        mentioned_pubkeys: Vec::new(),
+                    })
+            })
         });
 
         // Build prompt from batch with context enrichment.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3391,6 +3391,73 @@ pub(crate) async fn resolve_edit_routing(
     })
 }
 
+/// Resolve an edit-aware native-steer delta through the same routing and
+/// context boundary as ordinary batch dispatch. This keeps successful native
+/// steering from exposing the invisible kind:40003 event as a reply anchor.
+pub(crate) async fn format_native_steer_prompt(
+    channel_id: Uuid,
+    event: nostr::Event,
+    prompt_tag: String,
+    ctx: &PromptContext,
+) -> Vec<String> {
+    let batch = FlushBatch {
+        channel_id,
+        events: vec![crate::queue::BatchEvent {
+            event,
+            prompt_tag,
+            received_at: std::time::Instant::now(),
+        }],
+        cancelled_events: Vec::new(),
+        cancel_reason: None,
+    };
+    if crate::queue::edit_target_id(&batch.events[0].event).is_none() {
+        let (header, closing) = crate::queue::native_steer_framing();
+        let event = &batch.events[0];
+        return vec![format!(
+            "{header}\n\n[Buzz event: {}]\n{}\n\n{closing}",
+            event.prompt_tag,
+            crate::queue::format_event_block(channel_id, None, event, None)
+        )];
+    }
+    let channel_info = ctx.channel_info.resolve(channel_id).await;
+    let resolved_edit = resolve_edit_routing(&batch.events[0].event, &ctx.rest_client).await;
+    let conversation_context = if ctx.context_message_limit > 0 {
+        match resolved_edit
+            .as_ref()
+            .and_then(|edit| edit.target_thread_tags.root_event_id.as_deref())
+        {
+            Some(root_id) => {
+                fetch_thread_context(
+                    channel_id,
+                    root_id,
+                    ctx.context_message_limit,
+                    ctx.agent_keys.public_key(),
+                    &ctx.rest_client,
+                )
+                .await
+            }
+            None => fetch_conversation_context(&batch, &channel_info, ctx).await,
+        }
+    } else {
+        None
+    };
+    let profile_lookup =
+        fetch_prompt_profile_lookup(&batch, conversation_context.as_ref(), &ctx.rest_client).await;
+
+    crate::queue::format_native_steer_prompt(
+        &batch,
+        &crate::queue::FormatPromptArgs {
+            channel_info: channel_info.as_ref(),
+            conversation_context: conversation_context.as_ref(),
+            profile_lookup: profile_lookup.as_ref(),
+            resolved_edit: resolved_edit.as_ref(),
+            has_system_prompt_support: true,
+            standing_context_sent: true,
+            ..Default::default()
+        },
+    )
+}
+
 /// Fetch conversation context (thread or DM) for a batch before prompting.
 ///
 /// Returns `None` if:

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3391,6 +3391,23 @@ pub(crate) async fn resolve_edit_routing(
     })
 }
 
+pub(crate) fn format_native_steer_prompt_sync(
+    channel_id: Uuid,
+    event: &nostr::Event,
+    prompt_tag: &str,
+) -> Vec<String> {
+    let (header, closing) = crate::queue::native_steer_framing();
+    let event = crate::queue::BatchEvent {
+        event: event.clone(),
+        prompt_tag: prompt_tag.to_string(),
+        received_at: std::time::Instant::now(),
+    };
+    vec![format!(
+        "{header}\n\n[Buzz event: {prompt_tag}]\n{}\n\n{closing}",
+        crate::queue::format_event_block(channel_id, None, &event, None)
+    )]
+}
+
 /// Resolve an edit-aware native-steer delta through the same routing and
 /// context boundary as ordinary batch dispatch. This keeps successful native
 /// steering from exposing the invisible kind:40003 event as a reply anchor.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -761,14 +761,41 @@ impl AgentPool {
     /// still change while enrichment runs, so callers must retain the normal
     /// send-time fallback.
     pub fn native_steer_available(&self, channel_id: Uuid, membership_generation: u64) -> bool {
+        self.native_steer_turn_id(channel_id, membership_generation)
+            .is_some()
+    }
+
+    /// Return the exact turn currently accepting native steers for this
+    /// channel membership. Async preparation captures this identity so a late
+    /// completion cannot cross into a replacement turn in the same generation.
+    pub fn native_steer_turn_id(
+        &self,
+        channel_id: Uuid,
+        membership_generation: u64,
+    ) -> Option<String> {
         self.task_map
             .values()
             .find(|meta| {
                 meta.channel_id == Some(channel_id)
                     && meta.membership_generation == Some(membership_generation)
             })
-            .and_then(|meta| meta.steer_tx.as_ref())
-            .is_some_and(|tx| !tx.is_closed() && tx.capacity() > 0)
+            .filter(|meta| {
+                meta.steer_tx
+                    .as_ref()
+                    .is_some_and(|tx| !tx.is_closed() && tx.capacity() > 0)
+            })
+            .map(|meta| meta.turn_id.clone())
+    }
+
+    /// Return the identity of the task currently owning this channel epoch.
+    pub fn channel_turn_id(&self, channel_id: Uuid, membership_generation: u64) -> Option<&str> {
+        self.task_map
+            .values()
+            .find(|meta| {
+                meta.channel_id == Some(channel_id)
+                    && meta.membership_generation == Some(membership_generation)
+            })
+            .map(|meta| meta.turn_id.as_str())
     }
 
     /// Try to send a goose-native steer request to the in-flight task for
@@ -1834,7 +1861,7 @@ fn send_prompt_result(
 #[allow(clippy::too_many_arguments)]
 pub async fn run_prompt_task(
     mut agent: OwnedAgent,
-    batch: Option<FlushBatch>,
+    mut batch: Option<FlushBatch>,
     prompt_text: Option<String>,
     ctx: Arc<PromptContext>,
     result_tx: mpsc::UnboundedSender<PromptResult>,
@@ -2404,7 +2431,7 @@ pub async fn run_prompt_task(
             )
         };
         vec![text]
-    } else if let Some(ref b) = batch {
+    } else if let Some(ref mut b) = batch {
         // Resolve edit routing once inside the prompt task. This keeps the
         // network lookup off the shared relay loop and gives typing, prompt,
         // reply, reaction, and failure routing one authority.
@@ -2418,6 +2445,19 @@ pub async fn run_prompt_task(
                 let _ = tx.send((b.channel_id, turn_id.clone(), scope));
             }
         }
+        b.failure_thread_tags = crate::queue::edit_target_id(
+            &b.events.last().expect("non-empty batch").event,
+        )
+        .map(|target_event_id| {
+            resolved_edit
+                .as_ref()
+                .map(crate::queue::ResolvedEdit::reply_thread_tags)
+                .unwrap_or_else(|| crate::queue::ThreadTags {
+                    root_event_id: Some(target_event_id.clone()),
+                    parent_event_id: Some(target_event_id),
+                    mentioned_pubkeys: Vec::new(),
+                })
+        });
 
         // Build prompt from batch with context enrichment.
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
@@ -3483,6 +3523,7 @@ pub(crate) async fn format_native_steer_prompt(
         }],
         cancelled_events: Vec::new(),
         cancel_reason: None,
+        failure_thread_tags: None,
     };
     if crate::queue::edit_target_id(&batch.events[0].event).is_none() {
         let (header, closing) = crate::queue::native_steer_framing();
@@ -6162,6 +6203,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let context = ConversationContext::Thread {
             messages: vec![ContextMessage {
@@ -6410,6 +6452,7 @@ done"#
                 }],
                 cancelled_events: vec![],
                 cancel_reason: None,
+                failure_thread_tags: None,
             };
             run_prompt_task(
                 agent,
@@ -6497,6 +6540,7 @@ done"#
                 received_at: std::time::Instant::now(),
             }],
             cancel_reason: Some(crate::queue::CancelReason::Steer),
+            failure_thread_tags: None,
         };
         let next_batch = FlushBatch {
             channel_id,
@@ -6507,6 +6551,7 @@ done"#
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // Return both merged events as DM history. They must be excluded from
@@ -6663,6 +6708,7 @@ done"#
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // The local REST bridge returns the already-delivered steer as DM
@@ -7171,6 +7217,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -299,6 +299,10 @@ pub struct AgentPool {
     result_rx: mpsc::UnboundedReceiver<PromptResult>,
     pub join_set: JoinSet<()>,
     task_map: HashMap<tokio::task::Id, TaskMeta>,
+    /// Channels whose sessions must be invalidated when a currently checked-out
+    /// agent returns. Unlike current membership, this survives a remove/re-add
+    /// race so a session from the earlier membership epoch cannot be reused.
+    checked_out_session_invalidations: HashMap<usize, HashSet<Uuid>>,
 }
 
 /// Result returned by a completed prompt task.
@@ -659,6 +663,7 @@ impl AgentPool {
             result_rx,
             join_set: JoinSet::new(),
             task_map: HashMap::new(),
+            checked_out_session_invalidations: HashMap::new(),
         }
     }
 
@@ -883,7 +888,23 @@ impl AgentPool {
                 }
             }
         }
+        for meta in self.task_map.values() {
+            self.checked_out_session_invalidations
+                .entry(meta.agent_index)
+                .or_default()
+                .insert(channel_id);
+        }
         count
+    }
+
+    /// Apply and consume membership-epoch invalidations recorded while this
+    /// agent was checked out.
+    pub fn invalidate_checked_out_sessions(&mut self, agent: &mut OwnedAgent) {
+        if let Some(channels) = self.checked_out_session_invalidations.remove(&agent.index) {
+            for channel_id in channels {
+                agent.state.invalidate_channel(&channel_id);
+            }
+        }
     }
 
     /// Idle-path model switch: set `desired_model` on the idle agent for

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -741,6 +741,22 @@ impl AgentPool {
             .any(|meta| meta.channel_id == Some(channel_id) && meta.turn_id == turn_id)
     }
 
+    /// Return whether the current channel task can accept a native steer now.
+    ///
+    /// This is a main-loop preflight for edit enrichment: avoid withholding an
+    /// edit and performing REST work when the task has no steer transport or
+    /// its capacity-one request slot is already occupied. Availability can
+    /// still change while enrichment runs, so callers must retain the normal
+    /// send-time fallback.
+    pub fn native_steer_available(&self, channel_id: Uuid) -> bool {
+        self.task_map
+            .values()
+            .find(|meta| meta.channel_id == Some(channel_id))
+            .and_then(|meta| meta.steer_tx.as_ref())
+            .is_some_and(|tx| !tx.is_closed() && tx.capacity() > 0)
+    }
+    }
+
     /// Try to send a goose-native steer request to the in-flight task for
     /// `channel_id`.
     ///

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -897,6 +897,12 @@ impl AgentPool {
         count
     }
 
+    /// Discard membership invalidations belonging to an agent ownership that
+    /// terminated without returning its `OwnedAgent` (for example, a panic).
+    pub fn discard_checked_out_session_invalidations(&mut self, agent_index: usize) {
+        self.checked_out_session_invalidations.remove(&agent_index);
+    }
+
     /// Apply and consume membership-epoch invalidations recorded while this
     /// agent was checked out.
     pub fn invalidate_checked_out_sessions(&mut self, agent: &mut OwnedAgent) {
@@ -7034,6 +7040,21 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         // Nothing changed.
         assert_eq!(s.sessions.len(), 2);
         assert_eq!(s.turn_counts.len(), 2);
+    }
+
+    #[test]
+    fn panicked_ownership_invalidations_do_not_reach_reused_slot() {
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let channel_id = Uuid::new_v4();
+        pool.checked_out_session_invalidations
+            .entry(0)
+            .or_default()
+            .insert(channel_id);
+
+        // Panic recovery discards the dead ownership before a replacement can
+        // reuse slot 0.
+        pool.discard_checked_out_session_invalidations(0);
+        assert!(!pool.checked_out_session_invalidations.contains_key(&0));
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -96,6 +96,7 @@ pub struct FlushBatch {
 /// ```text
 /// State:
 ///   queues:               Map<channel_id, VecDeque<QueuedEvent>>  (capped at MAX_PENDING_PER_CHANNEL)
+///   withheld_native_steer: Map<channel_id, Vec<QueuedEvent>>       (native reservations)
 ///   in_flight_channels:   HashSet<Uuid>
 ///   in_flight_deadlines:  Map<channel_id, Instant>                (auto-expire after in_flight_deadline)
 ///   retry_after:          Map<channel_id, Instant>
@@ -106,8 +107,8 @@ pub struct FlushBatch {
 ///   push(event):
 ///     if dedup_mode == Drop AND in_flight_channels.contains(event.channel_id):
 ///       debug log + discard
-///     else if queues[channel].len() >= MAX_PENDING_PER_CHANNEL:
-///       drop oldest (pop_front), warn, push_back new event
+///     else if queued + withheld events for channel reach MAX_PENDING_PER_CHANNEL:
+///       drop oldest queued event, or reject the new event if all slots are withheld
 ///     else:
 ///       queues[event.channel_id].push_back(event)
 ///
@@ -237,17 +238,39 @@ impl EventQueue {
             );
             return false;
         }
-        let queue = self.queues.entry(event.channel_id).or_default();
-        // Enforce per-channel depth cap: drop oldest to make room.
-        if queue.len() >= MAX_PENDING_PER_CHANNEL {
-            queue.pop_front();
-            tracing::warn!(
-                channel_id = %event.channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "queue depth cap reached — dropped oldest event"
-            );
+        let channel_id = event.channel_id;
+        let withheld = self
+            .withheld_native_steer
+            .get(&channel_id)
+            .map_or(0, Vec::len);
+        let queued = self.queues.get(&channel_id).map_or(0, VecDeque::len);
+        // A native-steer reservation owns its event until its asynchronous
+        // attempt resolves, so it counts toward the per-channel cap too.
+        // Never evict a withheld reservation: its completion may still steer.
+        // If every slot is reserved, reject the new event rather than creating
+        // an unbounded preparation task or violating exact-once delivery.
+        if queued + withheld >= MAX_PENDING_PER_CHANNEL {
+            if self
+                .queues
+                .get_mut(&channel_id)
+                .and_then(VecDeque::pop_front)
+                .is_some()
+            {
+                tracing::warn!(
+                    %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "queue depth cap reached — dropped oldest queued event"
+                );
+            } else {
+                tracing::warn!(
+                    %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "queue depth cap reached by native steer reservations — dropped new event"
+                );
+                return false;
+            }
         }
-        queue.push_back(event);
+        self.queues.entry(channel_id).or_default().push_back(event);
         true
     }
 
@@ -4879,6 +4902,26 @@ mod tests {
     /// steer must be invisible to both `flush_next` and `has_flushable_work`.
     /// The withhold is the whole point of the side table — it must close the
     /// `mark_complete` → ack race window.
+    #[test]
+    fn test_native_steer_reservations_count_toward_channel_cap() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        for i in 0..MAX_PENDING_PER_CHANNEL {
+            let qe = make_queued(ch, &format!("reserved-{i}"));
+            let event_id = qe.event.id.to_hex();
+            assert!(q.push(qe));
+            assert!(q.mark_native_steer_pending(ch, &event_id));
+        }
+        assert_eq!(q.withheld_native_steer[&ch].len(), MAX_PENDING_PER_CHANNEL);
+        assert!(
+            !q.push(make_queued(ch, "over-cap")),
+            "all cap slots are reserved, so a new event must not create another preparation"
+        );
+        assert_eq!(q.withheld_native_steer[&ch].len(), MAX_PENDING_PER_CHANNEL);
+        assert!(q.queues.get(&ch).is_none());
+    }
+
     #[test]
     fn test_native_steer_withhold_only_channel_not_flushable() {
         let mut q = EventQueue::new(DedupMode::Queue);

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -87,6 +87,9 @@ pub struct FlushBatch {
     /// [`Steer`](CancelReason::Steer) framing if a merge somehow lacks a reason
     /// (see [`MergeFraming::for_reason`]).
     pub cancel_reason: Option<CancelReason>,
+    /// Thread routing resolved while constructing an edit-triggered prompt.
+    /// Terminal failure notices must use the same visible routing authority.
+    pub failure_thread_tags: Option<ThreadTags>,
 }
 
 /// Per-channel event queue with per-channel in-flight enforcement.
@@ -360,6 +363,7 @@ impl EventQueue {
                             events: cancelled,
                             cancelled_events: vec![],
                             cancel_reason,
+                            failure_thread_tags: None,
                         });
                     }
                     None => return None,
@@ -429,6 +433,7 @@ impl EventQueue {
             events,
             cancelled_events,
             cancel_reason,
+            failure_thread_tags: None,
         })
     }
 
@@ -1714,6 +1719,22 @@ pub struct ResolvedEdit {
     pub target_thread_tags: ThreadTags,
 }
 
+impl ResolvedEdit {
+    /// Visible reply destination for notices tied to this edit. Threaded
+    /// originals retain their root/parent; a top-level original becomes both
+    /// so the notice replies to it rather than publishing at channel root.
+    pub fn reply_thread_tags(&self) -> ThreadTags {
+        if self.target_thread_tags.root_event_id.is_some() {
+            return self.target_thread_tags.clone();
+        }
+        ThreadTags {
+            root_event_id: Some(self.target_event_id.clone()),
+            parent_event_id: Some(self.target_event_id.clone()),
+            mentioned_pubkeys: self.target_thread_tags.mentioned_pubkeys.clone(),
+        }
+    }
+}
+
 /// Arguments for [`format_prompt`] beyond the required [`FlushBatch`].
 #[derive(Default)]
 pub struct FormatPromptArgs<'a> {
@@ -2351,6 +2372,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -2385,6 +2407,7 @@ mod tests {
                 received_at: Instant::now(),
             }],
             cancel_reason: reason,
+            failure_thread_tags: None,
         }
     }
 
@@ -2523,6 +2546,7 @@ mod tests {
                 received_at: Instant::now(),
             }],
             cancel_reason: Some(CancelReason::Steer),
+            failure_thread_tags: None,
         };
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
         assert!(prompt.contains("New messages — arrived while you were working — 2 events]"));
@@ -2573,6 +2597,7 @@ mod tests {
                 received_at: Instant::now(),
             }],
             cancel_reason: Some(CancelReason::Steer),
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -2752,6 +2777,7 @@ mod tests {
             ],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -2780,6 +2806,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -2803,6 +2830,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let core = "[Agent Memory — core]\nbe helpful";
         let prompt = format_prompt(
@@ -2835,6 +2863,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let prompt = format_prompt(
             &batch,
@@ -2865,6 +2894,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let core = "[Agent Memory — core]\nbe helpful";
         let prompt = format_prompt(
@@ -2892,6 +2922,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // format_prompt no longer accepts or emits base_prompt/system_prompt.
@@ -2916,6 +2947,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let core = "[Agent Memory — core]\nremember this";
@@ -2974,6 +3006,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let canvas = "[Channel Canvas]\ncanvas content";
         let core = "[Agent Memory — core]\nremember this";
@@ -3027,6 +3060,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(
@@ -3065,6 +3099,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let ctx = ConversationContext::Thread {
@@ -3583,6 +3618,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "engineering".into(),
@@ -3615,6 +3651,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "DM".into(),
@@ -3654,6 +3691,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -3682,6 +3720,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ctx = ConversationContext::Thread {
             messages: vec![
@@ -3728,6 +3767,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "DM".into(),
@@ -3779,6 +3819,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ctx = ConversationContext::Thread {
             messages: vec![ContextMessage {
@@ -3987,6 +4028,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "DM".into(),
@@ -4054,6 +4096,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let trigger_only_prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -4087,6 +4130,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "DM".into(),
@@ -4136,6 +4180,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "DM".into(),
@@ -4177,6 +4222,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -4201,6 +4247,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -4224,6 +4271,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -4679,6 +4727,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // No profile lookup → sender treated as human → human-facing thread
@@ -4721,6 +4770,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "DM".into(),
@@ -4756,6 +4806,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // Top-level human message (no lookup → human): the reply opens a new
@@ -4785,6 +4836,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let ci = PromptChannelInfo {
             name: "DM".into(),
@@ -4828,6 +4880,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // Human-facing (no lookup) deep reply: anchor to the thread ROOT to
@@ -4864,6 +4917,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
@@ -4906,6 +4960,7 @@ mod tests {
             ],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // Scope derives from the last (threaded) event; human-facing → anchor
@@ -4943,6 +4998,7 @@ mod tests {
             ],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
 
         // Last event is top-level and human-facing → opens a new thread
@@ -4969,6 +5025,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         }
     }
 
@@ -5248,6 +5305,8 @@ mod tests {
             ch,
             &event_id,
             0,
+            "expired-turn",
+            Some("replacement-turn"),
         ));
     }
 
@@ -5479,6 +5538,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let prompt = format_prompt(
             &batch,
@@ -5508,6 +5568,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let prompt = format_prompt(
             &batch,
@@ -5536,6 +5597,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         };
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
         assert!(
@@ -5767,6 +5829,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         }
     }
 
@@ -5908,6 +5971,8 @@ mod tests {
             ch,
             &event_id,
             0,
+            "expired-turn",
+            Some("replacement-turn"),
         ));
 
         // A late preparation is discarded by the main loop. Its reservation
@@ -5939,6 +6004,8 @@ mod tests {
             ch,
             &event_id,
             prepared_generation,
+            "pre-removal-turn",
+            Some("replacement-turn"),
         ));
     }
 
@@ -6138,6 +6205,7 @@ mod tests {
             }],
             cancelled_events: vec![],
             cancel_reason: None,
+            failure_thread_tags: None,
         }
     }
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -5469,6 +5469,37 @@ mod tests {
     }
 
     #[test]
+    fn removed_channel_discards_late_async_edit_steer_preparation() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        q.push(QueuedEvent {
+            channel_id: ch,
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "@mention".into(),
+        });
+        q.in_flight_channels.insert(ch);
+        q.in_flight_deadlines
+            .insert(ch, Instant::now() + Duration::from_secs(60));
+
+        assert!(q.mark_native_steer_pending(ch, &event_id));
+        q.drain_channel(ch);
+        let removed_channels = HashSet::from([ch]);
+        assert!(crate::native_steer_preparation_is_stale(
+            &removed_channels,
+            ch
+        ));
+
+        // A late preparation is discarded by the main loop. Its reservation
+        // was already drained, so release cannot resurrect stale work.
+        q.release_native_steer(ch, &event_id);
+        q.mark_complete(ch);
+        assert!(q.flush_next().is_none());
+    }
+
+    #[test]
     fn native_steer_edit_uses_original_thread_anchor() {
         let original_id = "66".repeat(32);
         let root_id = "77".repeat(32);

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -906,6 +906,29 @@ impl EventQueue {
         }
     }
 
+    /// Release every native-steer reservation for `channel_id` to the queue
+    /// front, preserving original FIFO order. Detached edit preparation then
+    /// observes its missing reservation and discards the stale completion.
+    pub fn release_native_steers(&mut self, channel_id: Uuid) -> usize {
+        let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
+            return 0;
+        };
+        let n = entries.len();
+        let queue = self.queues.entry(channel_id).or_default();
+        for qe in entries.into_iter().rev() {
+            queue.push_front(qe);
+        }
+        while queue.len() > MAX_PENDING_PER_CHANNEL {
+            queue.pop_back();
+            tracing::warn!(
+                channel_id = %channel_id,
+                limit = MAX_PENDING_PER_CHANNEL,
+                "withheld-steer release overflow — dropped newest event to enforce cap"
+            );
+        }
+        n
+    }
+
     /// Bulk-release every withheld event for `channel_id` back to the queue
     /// front, preserving relative FIFO order.
     ///
@@ -920,21 +943,9 @@ impl EventQueue {
     /// composes to original-FIFO order at the queue front (same discipline
     /// as `requeue_preserve_timestamps` at line 453).
     fn recover_withheld_for_expired_channel(&mut self, channel_id: Uuid) {
-        let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
+        let n = self.release_native_steers(channel_id);
+        if n == 0 {
             return;
-        };
-        let n = entries.len();
-        let queue = self.queues.entry(channel_id).or_default();
-        for qe in entries.into_iter().rev() {
-            queue.push_front(qe);
-        }
-        while queue.len() > MAX_PENDING_PER_CHANNEL {
-            queue.pop_back();
-            tracing::warn!(
-                channel_id = %channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "withheld-steer recovery overflow — dropped newest event to enforce cap"
-            );
         }
         tracing::warn!(
             channel_id = %channel_id,
@@ -5093,6 +5104,32 @@ mod tests {
             &event_id,
             0,
         ));
+    }
+
+    #[test]
+    fn releasing_pending_preparation_restores_fifo_ahead_of_later_event() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let edit = make_queued_at(ch, "edit", Duration::from_millis(20));
+        let edit_id = edit.event.id.to_hex();
+        let later = make_queued_at(ch, "later", Duration::from_millis(10));
+        let later_id = later.event.id.to_hex();
+        q.push(edit);
+        assert!(q.mark_native_steer_pending(ch, &edit_id));
+        q.push(later);
+
+        // A later event triggers cancel+merge. Releasing the pending edit first
+        // makes both events visible to the next flush in original arrival order;
+        // the detached preparation will be stale because its reservation is gone.
+        assert_eq!(q.release_native_steers(ch), 1);
+        assert!(!q.has_native_steer_reservation(ch, &edit_id));
+        let replacement = q.flush_next().expect("both events should dispatch");
+        let ids: Vec<_> = replacement
+            .events
+            .iter()
+            .map(|event| event.event.id.to_hex())
+            .collect();
+        assert_eq!(ids, vec![edit_id, later_id]);
     }
 
     /// Bulk-release on expiry must preserve original FIFO. The

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -828,6 +828,13 @@ impl EventQueue {
         true
     }
 
+    /// Return whether this channel has any native-steer reservation in flight.
+    pub fn has_native_steer_reservations(&self, channel_id: Uuid) -> bool {
+        self.withheld_native_steer
+            .get(&channel_id)
+            .is_some_and(|entries| !entries.is_empty())
+    }
+
     /// Return whether this exact event still owns a native-steer reservation.
     ///
     /// Async edit preparation uses this at completion time: deadline recovery,
@@ -5025,6 +5032,8 @@ mod tests {
         q.in_flight_deadlines.insert(ch, Instant::now());
         q.in_flight_batch_sizes.insert(ch, 1);
         assert!(q.mark_native_steer_pending(ch, &event_id));
+        assert!(q.has_native_steer_reservations(ch));
+        assert!(q.has_native_steer_reservation(ch, &event_id));
 
         // Force the in-flight deadline to be in the past, simulating the
         // steer ack never arriving and the read loop hanging long enough
@@ -5042,6 +5051,8 @@ mod tests {
 
         // The withheld event has been moved back to `queues[ch]`.
         assert!(q.withheld_native_steer.is_empty());
+        assert!(!q.has_native_steer_reservations(ch));
+        assert!(!q.has_native_steer_reservation(ch, &event_id));
         assert_eq!(pending_count(&q), 1);
 
         // Normal dispatch delivers it.

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -828,6 +828,17 @@ impl EventQueue {
         true
     }
 
+    /// Return whether this exact event still owns a native-steer reservation.
+    ///
+    /// Async edit preparation uses this at completion time: deadline recovery,
+    /// membership removal, or any other reservation settlement removes the
+    /// entry, so a late preparation cannot steer a replacement turn.
+    pub fn has_native_steer_reservation(&self, channel_id: Uuid, event_id: &str) -> bool {
+        self.withheld_native_steer
+            .get(&channel_id)
+            .is_some_and(|entries| entries.iter().any(|qe| qe.event.id.to_hex() == event_id))
+    }
+
     /// Release a single withheld event back to the front of
     /// `queues[channel_id]`, preserving its original `received_at`.
     ///
@@ -5042,6 +5053,37 @@ mod tests {
         assert_eq!(batch.events[0].event.id.to_hex(), event_id);
     }
 
+    #[test]
+    fn recovered_reservation_invalidates_late_native_steer_preparation() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let qe = make_queued(ch, "prepared edit");
+        let event_id = qe.event.id.to_hex();
+        q.push(qe);
+        q.in_flight_channels.insert(ch);
+        q.in_flight_deadlines
+            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.in_flight_batch_sizes.insert(ch, 1);
+        assert!(q.mark_native_steer_pending(ch, &event_id));
+
+        // Deadline recovery releases the reservation and normal dispatch takes
+        // the edit into a replacement turn.
+        let replacement = q.flush_next().expect("recovered edit should dispatch");
+        assert_eq!(replacement.events.len(), 1);
+        assert_eq!(replacement.events[0].event.id.to_hex(), event_id);
+
+        // The detached enrichment completion from the expired turn must not be
+        // allowed to steer that replacement turn with the same edit again.
+        assert!(crate::native_steer_preparation_is_stale(
+            &q,
+            &HashSet::new(),
+            &HashMap::new(),
+            ch,
+            &event_id,
+            0,
+        ));
+    }
+
     /// Bulk-release on expiry must preserve original FIFO. The
     /// implementation iterates the side-table entries in reverse and
     /// `push_front`s each — composing to original-FIFO at the queue front.
@@ -5532,9 +5574,11 @@ mod tests {
         let removed_channels = HashSet::from([ch]);
         let membership_generations = HashMap::new();
         assert!(crate::native_steer_preparation_is_stale(
+            &q,
             &removed_channels,
             &membership_generations,
             ch,
+            &event_id,
             0,
         ));
 
@@ -5548,6 +5592,8 @@ mod tests {
     #[test]
     fn removed_then_readded_channel_discards_late_async_edit_preparation() {
         let ch = Uuid::new_v4();
+        let event_id = "ab".repeat(32);
+        let q = EventQueue::new(DedupMode::Queue);
         // Preparation was reserved during the original membership period.
         let prepared_generation = 0;
         let mut membership_generations = HashMap::from([(ch, prepared_generation)]);
@@ -5559,9 +5605,11 @@ mod tests {
         *membership_generations.get_mut(&ch).unwrap() += 1;
 
         assert!(crate::native_steer_preparation_is_stale(
+            &q,
             &removed_channels,
             &membership_generations,
             ch,
+            &event_id,
             prepared_generation,
         ));
     }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -5487,9 +5487,12 @@ mod tests {
         assert!(q.mark_native_steer_pending(ch, &event_id));
         q.drain_channel(ch);
         let removed_channels = HashSet::from([ch]);
+        let membership_generations = HashMap::new();
         assert!(crate::native_steer_preparation_is_stale(
             &removed_channels,
-            ch
+            &membership_generations,
+            ch,
+            0,
         ));
 
         // A late preparation is discarded by the main loop. Its reservation
@@ -5497,6 +5500,27 @@ mod tests {
         q.release_native_steer(ch, &event_id);
         q.mark_complete(ch);
         assert!(q.flush_next().is_none());
+    }
+
+    #[test]
+    fn removed_then_readded_channel_discards_late_async_edit_preparation() {
+        let ch = Uuid::new_v4();
+        // Preparation was reserved during the original membership period.
+        let prepared_generation = 0;
+        let mut membership_generations = HashMap::from([(ch, prepared_generation)]);
+        let mut removed_channels = HashSet::from([ch]);
+
+        // Re-add makes the channel usable again but must not validate work
+        // which was prepared before the intervening removal.
+        removed_channels.remove(&ch);
+        *membership_generations.get_mut(&ch).unwrap() += 1;
+
+        assert!(crate::native_steer_preparation_is_stale(
+            &removed_channels,
+            &membership_generations,
+            ch,
+            prepared_generation,
+        ));
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -4919,7 +4919,7 @@ mod tests {
             "all cap slots are reserved, so a new event must not create another preparation"
         );
         assert_eq!(q.withheld_native_steer[&ch].len(), MAX_PENDING_PER_CHANNEL);
-        assert!(q.queues.get(&ch).is_none());
+        assert!(!q.queues.contains_key(&ch));
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -165,6 +165,16 @@ pub struct EventQueue {
     /// by `flush_next` / `has_flushable_work` (recover, not log-and-drop —
     /// the events were never delivered to the agent).
     withheld_native_steer: HashMap<Uuid, Vec<QueuedEvent>>,
+    /// Event ids whose reserved payload has already been accepted by the
+    /// in-flight task's steer transport and is awaiting its acknowledgement.
+    /// Reservations absent from this set are still only being prepared and
+    /// may be safely released before cancel+merge.
+    sent_native_steers: HashMap<Uuid, HashSet<String>>,
+    /// Channels whose prompt task returned while a sent native steer still
+    /// awaits acknowledgement. The acknowledgement is the authority that
+    /// settles delivery, so replacement dispatch must remain fenced until it
+    /// consumes or restores that event.
+    completed_awaiting_native_steer: HashSet<Uuid>,
     /// Duration after which an in-flight channel is auto-expired as orphaned.
     /// Must be strictly greater than `max_turn_duration` so a turn running to
     /// the hard cap returns via `mark_complete` before the backstop fires.
@@ -189,6 +199,8 @@ impl EventQueue {
             cancelled_batches: HashMap::new(),
             cancel_reasons: HashMap::new(),
             withheld_native_steer: HashMap::new(),
+            sent_native_steers: HashMap::new(),
+            completed_awaiting_native_steer: HashSet::new(),
             in_flight_deadline: Duration::from_secs(DEFAULT_IN_FLIGHT_DEADLINE_SECS),
         }
     }
@@ -390,7 +402,6 @@ impl EventQueue {
                 received_at: qe.received_at,
             })
             .collect();
-
         // Remove the queue entry if now empty.
         if self.queues.get(&channel_id).is_some_and(|q| q.is_empty()) {
             self.queues.remove(&channel_id);
@@ -432,6 +443,22 @@ impl EventQueue {
     ///
     /// Also cleans up any already-expired `retry_after` entry.
     pub fn mark_complete(&mut self, channel_id: Uuid) {
+        if self.has_sent_native_steer(channel_id) {
+            // A result can win the main loop's select before the native-steer
+            // watcher posts its ack. Keep this channel in-flight: otherwise a
+            // later queued event can start a replacement turn before a neutral
+            // ack restores the older withheld event.
+            self.completed_awaiting_native_steer.insert(channel_id);
+            return;
+        }
+        self.clear_complete(channel_id);
+    }
+
+    /// Clear a channel after its prompt and every sent native steer have
+    /// settled. Kept private so only `mark_complete` and acknowledgement
+    /// settlement can open the replacement-dispatch gate.
+    fn clear_complete(&mut self, channel_id: Uuid) {
+        self.completed_awaiting_native_steer.remove(&channel_id);
         self.in_flight_channels.remove(&channel_id);
         self.in_flight_deadlines.remove(&channel_id);
         self.in_flight_batch_sizes.remove(&channel_id);
@@ -766,6 +793,8 @@ impl EventQueue {
         self.retry_after.remove(&channel_id);
         self.retry_counts.remove(&channel_id);
         self.cancel_reasons.remove(&channel_id);
+        self.sent_native_steers.remove(&channel_id);
+        self.completed_awaiting_native_steer.remove(&channel_id);
         // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
         // will expire (auto-cleaning the channel). Removing deadlines without
@@ -846,6 +875,60 @@ impl EventQueue {
             .is_some_and(|entries| entries.iter().any(|qe| qe.event.id.to_hex() == event_id))
     }
 
+    /// Mark an existing reservation as accepted by the steer transport.
+    pub fn mark_native_steer_sent(&mut self, channel_id: Uuid, event_id: &str) {
+        if self.has_native_steer_reservation(channel_id, event_id) {
+            self.sent_native_steers
+                .entry(channel_id)
+                .or_default()
+                .insert(event_id.to_string());
+        }
+    }
+
+    /// Return whether this channel has a sent steer awaiting acknowledgement.
+    pub fn has_sent_native_steer(&self, channel_id: Uuid) -> bool {
+        self.sent_native_steers
+            .get(&channel_id)
+            .is_some_and(|ids| !ids.is_empty())
+    }
+
+    /// Release only reservations that are still in asynchronous preparation.
+    /// Sent steers remain withheld until their acknowledgement settles them.
+    pub fn release_native_steer_preparations(&mut self, channel_id: Uuid) -> usize {
+        let sent = self.sent_native_steers.get(&channel_id);
+        let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) else {
+            return 0;
+        };
+        let mut released = Vec::new();
+        let mut i = 0;
+        while i < entries.len() {
+            let event_id = entries[i].event.id.to_hex();
+            if sent.is_some_and(|ids| ids.contains(&event_id)) {
+                i += 1;
+            } else {
+                released.push(entries.remove(i));
+            }
+        }
+        if entries.is_empty() {
+            self.withheld_native_steer.remove(&channel_id);
+        }
+        let n = released.len();
+        let queue = self.queues.entry(channel_id).or_default();
+        for event in released.into_iter().rev() {
+            queue.push_front(event);
+        }
+        n
+    }
+
+    /// Open a completion fence once the last sent steer has settled.
+    fn settle_sent_native_steer(&mut self, channel_id: Uuid) {
+        if self.completed_awaiting_native_steer.contains(&channel_id)
+            && !self.has_sent_native_steer(channel_id)
+        {
+            self.clear_complete(channel_id);
+        }
+    }
+
     /// Release a single withheld event back to the front of
     /// `queues[channel_id]`, preserving its original `received_at`.
     ///
@@ -867,9 +950,16 @@ impl EventQueue {
             return;
         };
         let qe = entries.remove(pos);
+        if let Some(sent) = self.sent_native_steers.get_mut(&channel_id) {
+            sent.remove(event_id);
+            if sent.is_empty() {
+                self.sent_native_steers.remove(&channel_id);
+            }
+        }
         if entries.is_empty() {
             self.withheld_native_steer.remove(&channel_id);
         }
+        self.settle_sent_native_steer(channel_id);
         // Push to FRONT so original `received_at` keeps the event at the head
         // of the channel's queue. Per-channel cap is enforced below in case
         // a flood of events arrived during the ack window.
@@ -892,6 +982,12 @@ impl EventQueue {
     /// event has been "delivered" via the non-cancelling path and must not
     /// be redelivered via normal dispatch. Idempotent across both stores.
     pub fn remove_event(&mut self, channel_id: Uuid, event_id: &str) {
+        if let Some(sent) = self.sent_native_steers.get_mut(&channel_id) {
+            sent.remove(event_id);
+            if sent.is_empty() {
+                self.sent_native_steers.remove(&channel_id);
+            }
+        }
         if let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) {
             entries.retain(|qe| qe.event.id.to_hex() != event_id);
             if entries.is_empty() {
@@ -904,6 +1000,7 @@ impl EventQueue {
                 self.queues.remove(&channel_id);
             }
         }
+        self.settle_sent_native_steer(channel_id);
     }
 
     /// Release every native-steer reservation for `channel_id` to the queue
@@ -913,6 +1010,8 @@ impl EventQueue {
         let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
             return 0;
         };
+        self.sent_native_steers.remove(&channel_id);
+        self.settle_sent_native_steer(channel_id);
         let n = entries.len();
         let queue = self.queues.entry(channel_id).or_default();
         for qe in entries.into_iter().rev() {
@@ -2023,6 +2122,25 @@ mod tests {
         let event = EventBuilder::new(Kind::Custom(9), content)
             .custom_created_at(Timestamp::from(created_at_secs))
             .tags([])
+            .sign_with_keys(&keys)
+            .unwrap();
+        QueuedEvent {
+            channel_id,
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "test".into(),
+        }
+    }
+
+    fn make_edit_queued_created_at(
+        channel_id: Uuid,
+        target: &str,
+        created_at_secs: u64,
+    ) -> QueuedEvent {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .custom_created_at(Timestamp::from(created_at_secs))
+            .tags([nostr::Tag::parse(["e", target]).unwrap()])
             .sign_with_keys(&keys)
             .unwrap();
         QueuedEvent {
@@ -5104,6 +5222,141 @@ mod tests {
             &event_id,
             0,
         ));
+    }
+
+    /// Replay arrives newest-first. Chronology must be restored before the
+    /// edit boundary is selected, or the newer ordinary event starts a turn
+    /// before the older edit can recover its original-message routing.
+    #[test]
+    fn replay_orders_before_partitioning_at_edit_boundaries() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let older = make_queued_created_at(ch, "older", 100);
+        let older_id = older.event.id.to_hex();
+        let edit = make_edit_queued_created_at(ch, &"cd".repeat(32), 200);
+        let edit_id = edit.event.id.to_hex();
+        let newer = make_queued_created_at(ch, "newer", 300);
+        let newer_id = newer.event.id.to_hex();
+
+        // Production relay replay order: newest first.
+        q.push(newer);
+        q.push(edit);
+        q.push(older);
+
+        let first = q
+            .flush_next()
+            .expect("older ordinary event dispatches first");
+        assert_eq!(
+            first
+                .events
+                .iter()
+                .map(|event| event.event.id.to_hex())
+                .collect::<Vec<_>>(),
+            vec![older_id],
+        );
+        q.mark_complete(ch);
+        let second = q.flush_next().expect("edit dispatches at its own boundary");
+        assert_eq!(second.events[0].event.id.to_hex(), edit_id);
+        q.mark_complete(ch);
+        let third = q
+            .flush_next()
+            .expect("newer ordinary event remains after edit");
+        assert_eq!(third.events[0].event.id.to_hex(), newer_id);
+    }
+
+    #[test]
+    fn sent_steer_fences_replacement_until_ack_settles() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.push(make_queued(ch, "original turn"));
+        let _original = q.flush_next().expect("initial prompt in flight");
+
+        let steered = make_edit_queued_created_at(ch, &"cd".repeat(32), 100);
+        let steered_id = steered.event.id.to_hex();
+        let replacement = make_queued_created_at(ch, "later replacement", 200);
+        let replacement_id = replacement.event.id.to_hex();
+        q.push(steered);
+        assert!(q.mark_native_steer_pending(ch, &steered_id));
+        q.mark_native_steer_sent(ch, &steered_id);
+        q.push(replacement);
+
+        // Adversarial select schedule: prompt result is processed before the
+        // delayed neutral acknowledgement. It must not start replacement work.
+        q.mark_complete(ch);
+        assert!(q.is_channel_in_flight(ch));
+        assert!(
+            q.flush_next().is_none(),
+            "sent steer fences replacement dispatch"
+        );
+
+        // Neutral acknowledgement restores the older steered event and opens
+        // the fence atomically, so chronological delivery cannot reverse.
+        q.release_native_steer(ch, &steered_id);
+        let restored = q
+            .flush_next()
+            .expect("neutral ack restores the steer first");
+        assert_eq!(restored.events[0].event.id.to_hex(), steered_id);
+        q.mark_complete(ch);
+        let later = q.flush_next().expect("replacement follows settled steer");
+        assert_eq!(later.events[0].event.id.to_hex(), replacement_id);
+    }
+
+    #[test]
+    fn mixed_batch_stops_before_edit_and_dispatches_edit_separately() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let first = make_queued_at(ch, "first", Duration::from_millis(30));
+        let first_id = first.event.id.to_hex();
+        let edit = edit_event(&"cd".repeat(32));
+        let edit_id = edit.id.to_hex();
+        let later = make_queued_at(ch, "later", Duration::from_millis(10));
+        let later_id = later.event.id.to_hex();
+        q.push(first);
+        q.push(QueuedEvent {
+            channel_id: ch,
+            event: edit,
+            received_at: Instant::now() - Duration::from_millis(20),
+            prompt_tag: "@mention".into(),
+        });
+        q.push(later);
+
+        let first_batch = q.flush_next().expect("pre-edit event should dispatch");
+        assert_eq!(first_batch.events.len(), 1);
+        assert_eq!(first_batch.events[0].event.id.to_hex(), first_id);
+        q.mark_complete(ch);
+
+        let edit_batch = q.flush_next().expect("edit should dispatch separately");
+        assert_eq!(edit_batch.events.len(), 1);
+        assert_eq!(edit_batch.events[0].event.id.to_hex(), edit_id);
+        q.mark_complete(ch);
+
+        let later_batch = q
+            .flush_next()
+            .expect("post-edit event should remain queued");
+        assert_eq!(later_batch.events.len(), 1);
+        assert_eq!(later_batch.events[0].event.id.to_hex(), later_id);
+    }
+
+    #[test]
+    fn releasing_preparations_does_not_release_sent_steer() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let sent = make_queued_at(ch, "sent", Duration::from_millis(20));
+        let sent_id = sent.event.id.to_hex();
+        let later = make_queued_at(ch, "later", Duration::from_millis(10));
+        q.push(sent);
+        assert!(q.mark_native_steer_pending(ch, &sent_id));
+        q.mark_native_steer_sent(ch, &sent_id);
+        q.push(later);
+
+        assert_eq!(q.release_native_steer_preparations(ch), 0);
+        assert!(q.has_native_steer_reservation(ch, &sent_id));
+        assert!(q.has_sent_native_steer(ch));
+        q.remove_event(ch, &sent_id);
+        assert!(!q.has_sent_native_steer(ch));
+        let replacement = q.flush_next().expect("only later event should dispatch");
+        assert_eq!(replacement.events.len(), 1);
+        assert_ne!(replacement.events[0].event.id.to_hex(), sent_id);
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -794,7 +794,10 @@ impl EventQueue {
         self.retry_counts.remove(&channel_id);
         self.cancel_reasons.remove(&channel_id);
         self.sent_native_steers.remove(&channel_id);
-        self.completed_awaiting_native_steer.remove(&channel_id);
+        // If the prompt already completed behind a sent-steer acknowledgement
+        // fence, removing the reservation settles that fence immediately.
+        // Otherwise preserve the genuinely running prompt and its deadline.
+        self.settle_sent_native_steer(channel_id);
         // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
         // will expire (auto-cleaning the channel). Removing deadlines without
@@ -1705,7 +1708,9 @@ pub(crate) fn reaction_target_id(event: &Event) -> String {
 /// Original-message routing recovered for a kind:40003 edit event.
 #[derive(Debug, Clone)]
 pub struct ResolvedEdit {
+    /// Event ID of the verified kind:40003 edit target.
     pub target_event_id: String,
+    /// Thread routing tags parsed from the verified target event.
     pub target_thread_tags: ThreadTags,
 }
 
@@ -4323,6 +4328,28 @@ mod tests {
         let drained = q.drain_channel(ch);
         assert_eq!(drained.len(), 1);
         assert!(any_in_flight(&q)); // in-flight unaffected
+    }
+
+    #[test]
+    fn drain_channel_clears_completed_native_steer_fence() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.push(make_queued(ch, "original turn"));
+        let _batch = q.flush_next().expect("initial prompt in flight");
+
+        let steered = make_edit_queued_created_at(ch, &"cd".repeat(32), 100);
+        let steered_id = steered.event.id.to_hex();
+        q.push(steered);
+        assert!(q.mark_native_steer_pending(ch, &steered_id));
+        q.mark_native_steer_sent(ch, &steered_id);
+        q.mark_complete(ch);
+        assert!(q.is_channel_in_flight(ch));
+
+        q.drain_channel(ch);
+        assert!(
+            !q.is_channel_in_flight(ch),
+            "removal settles a fence whose prompt already completed"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1911,6 +1911,21 @@ pub(crate) fn native_steer_framing() -> (&'static str, &'static str) {
     (framing.new_header_single, framing.closing_note)
 }
 
+/// Format the delta delivered through native steering.
+///
+/// Routing and context use the same formatter as ordinary dispatch, while the
+/// native framing remains a concise "weave this into the live turn" envelope.
+pub(crate) fn format_native_steer_prompt(
+    batch: &FlushBatch,
+    args: &FormatPromptArgs<'_>,
+) -> Vec<String> {
+    let (header, closing) = native_steer_framing();
+    let mut sections = format_prompt(batch, args);
+    sections.insert(0, header.to_string());
+    sections.push(closing.to_string());
+    sections
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5421,6 +5436,46 @@ mod tests {
         let edit = edit_event(&original_id);
         let edit_id = edit.id.to_hex();
         let prompt = format_prompt(&one_event_batch(edit), &FormatPromptArgs::default()).join("\n");
+        assert!(prompt.contains(&format!("--reply-to {original_id}")));
+        assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
+    }
+
+    #[test]
+    fn native_steer_edit_uses_original_thread_anchor() {
+        let original_id = "66".repeat(32);
+        let root_id = "77".repeat(32);
+        let batch = one_event_batch(edit_event(&original_id));
+        let edit_id = batch.events[0].event.id.to_hex();
+        let prompt = format_native_steer_prompt(
+            &batch,
+            &FormatPromptArgs {
+                resolved_edit: Some(&ResolvedEdit {
+                    target_event_id: original_id,
+                    target_thread_tags: ThreadTags {
+                        root_event_id: Some(root_id.clone()),
+                        parent_event_id: Some("88".repeat(32)),
+                        mentioned_pubkeys: vec![],
+                    },
+                }),
+                ..Default::default()
+            },
+        )
+        .join("\n");
+
+        assert!(prompt.contains(&format!("--reply-to {root_id}")));
+        assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
+        let (header, closing) = native_steer_framing();
+        assert!(prompt.contains(header));
+        assert!(prompt.contains(closing));
+    }
+
+    #[test]
+    fn native_steer_edit_fetch_failure_anchors_target_never_auxiliary_event() {
+        let original_id = "99".repeat(32);
+        let batch = one_event_batch(edit_event(&original_id));
+        let edit_id = batch.events[0].event.id.to_hex();
+        let prompt = format_native_steer_prompt(&batch, &FormatPromptArgs::default()).join("\n");
+
         assert!(prompt.contains(&format!("--reply-to {original_id}")));
         assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
     }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -5441,6 +5441,34 @@ mod tests {
     }
 
     #[test]
+    fn async_edit_steer_reservation_prevents_normal_redispatch() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let event = edit_event(&"aa".repeat(32));
+        let event_id = event.id.to_hex();
+        q.push(QueuedEvent {
+            channel_id: ch,
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "@mention".into(),
+        });
+        q.in_flight_channels.insert(ch);
+        q.in_flight_deadlines
+            .insert(ch, Instant::now() + Duration::from_secs(60));
+
+        assert!(q.mark_native_steer_pending(ch, &event_id));
+        q.mark_complete(ch);
+        assert!(
+            q.flush_next().is_none(),
+            "reserved edit must not redispatch"
+        );
+
+        q.release_native_steer(ch, &event_id);
+        let batch = q.flush_next().expect("failed preparation restores edit");
+        assert_eq!(batch.events[0].event.id.to_hex(), event_id);
+    }
+
+    #[test]
     fn native_steer_edit_uses_original_thread_anchor() {
         let original_id = "66".repeat(32);
         let root_id = "77".repeat(32);

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -771,7 +771,8 @@ impl EventQueue {
     /// Also clears any `retry_after` throttle for the channel.
     ///
     /// Returns the visible event IDs that own lifecycle reactions for every
-    /// dropped event so the caller can clean up any 👀 added at queue-push time.
+    /// dropped queued or reserved event. Edit events therefore contribute
+    /// their original target IDs rather than their auxiliary kind:40003 IDs.
     pub fn drain_channel(&mut self, channel_id: Uuid) -> Vec<String> {
         let mut ids: HashSet<String> = HashSet::new();
         if let Some(events) = self.queues.remove(&channel_id) {
@@ -4320,6 +4321,25 @@ mod tests {
         let drained: HashSet<String> = q.drain_channel(ch).into_iter().collect();
         assert_eq!(drained, HashSet::from([queued_target, withheld_target]));
         assert!(q.withheld_native_steer.is_empty());
+    }
+
+    #[test]
+    fn drain_channel_returns_visible_reaction_targets_for_queued_and_reserved_edits() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let queued_target = "ab".repeat(32);
+        let reserved_target = "cd".repeat(32);
+
+        q.push(make_edit_queued_created_at(ch, &queued_target, 100));
+        let reserved = make_edit_queued_created_at(ch, &reserved_target, 101);
+        let reserved_id = reserved.event.id.to_hex();
+        q.push(reserved);
+        assert!(q.mark_native_steer_pending(ch, &reserved_id));
+
+        let drained: HashSet<String> = q.drain_channel(ch).into_iter().collect();
+        assert_eq!(drained, HashSet::from([queued_target, reserved_target]));
+        assert!(!q.has_native_steer_reservations(ch));
+        assert_eq!(pending_count(&q), 0);
     }
 
     #[test]


### PR DESCRIPTION
🤖
## Summary
Once edit mentions are active, an edit arriving during an agent turn should steer that live turn when the ACP client supports native steering. Asynchronous preparation and channel membership changes make that path lifecycle-sensitive; this final stack slice adds native steering with explicit ownership and generation fences.

- Resolves and reserves eligible edit steers without blocking the relay loop, then acknowledges only after native delivery is accepted.
- Falls back exactly once to queued delivery when native steering is unavailable or preparation fails.
- Preserves the original-message/thread routing established by #4741 for steer acknowledgements, failures, and later turn output.
- Fences prepared, in-flight, and fallback work by membership generation so removal and re-addition cannot revive stale edits.
- Releases reservations and ownership across cancellation, supersession, shutdown, and failed delivery paths.

### Stack position
**3 of 3 — native steer and lifecycle fencing**, based on #6131 (`larry/pr-4741-activation`).

Previous: #6131, which is based on #4741.

### Related issue
None found. Split from #4741's original combined scope.

### Testing
- `cargo test -p buzz-acp --all-targets` — 816 unit tests and 9 lifecycle tests passed
- `cargo check -p buzz-acp`
