### PR TITLE
fix(desktop): stop blocking add-member UI on full channel refetch

### DIFF
--- a/desktop/src/features/channels/hooks.test.mjs
+++ b/desktop/src/features/channels/hooks.test.mjs
@@ -7,6 +7,7 @@ import {
   applyLastMessages,
   canFetchChannelsForIdentity,
   channelsQueryKey,
+  queueChannelStateInvalidation,
   reconcileRefreshedCachedChannel,
   refreshChannelsQuery,
   requireFullChannelList,
@@ -371,4 +372,36 @@ test("invalidateChannelMembersRosters dedupes and targets member keys", async ()
     ["channels", "ch-a", "members"],
     ["channels", "ch-b", "members"],
   ]);
+});
+
+test("queueChannelStateInvalidation_returnsBeforeChannelsRefetchSettles", async () => {
+  let settleRefetch;
+  const refetch = new Promise((resolve) => {
+    settleRefetch = resolve;
+  });
+  let invalidateCalls = 0;
+  const queryClient = {
+    invalidateQueries: async () => {
+      invalidateCalls += 1;
+      await refetch;
+    },
+  };
+
+  const result = queueChannelStateInvalidation(queryClient, "channel-1");
+  assert.equal(
+    result,
+    undefined,
+    "must not return a thenable; awaiting onSettled would re-block Add",
+  );
+
+  assert.equal(invalidateCalls, 1, "the channels query must start immediately");
+  assert.equal(
+    typeof settleRefetch,
+    "function",
+    "the channels refetch must still be pending after the caller returns",
+  );
+
+  settleRefetch();
+  await Promise.resolve();
+  await Promise.resolve();
 });

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -265,6 +265,20 @@ export async function invalidateChannelState(
   ]);
 }
 
+/**
+ * Queue {@link invalidateChannelState} without blocking the caller.
+ *
+ * The channels query refetches every channel. `mutateAsync` waits for
+ * `onSettled`, so awaiting that refetch keeps Add/dialog buttons pending
+ * for seconds after the relay already finished.
+ */
+export function queueChannelStateInvalidation(
+  queryClient: ReturnType<typeof useQueryClient>,
+  channelId: string | null | undefined,
+): void {
+  void invalidateChannelState(queryClient, channelId);
+}
+
 function setChannelArchivedState(
   queryClient: ReturnType<typeof useQueryClient>,
   channelId: string,
@@ -828,11 +842,12 @@ export function useAddChannelMembersMutation(channelId: string | null) {
         });
       }
     },
-    onSettled: async (_data, _err, variables) => {
+    onSettled: (_data, _err, variables) => {
       // Invalidate the effective channel (the one actually mutated) not the
       // live hook-closure channel, which may have changed mid-send.
+      // fire-and-forget: awaiting the channels-list refetch blocks Add.
       const effectiveChannelId = variables?.channelId ?? channelId;
-      await invalidateChannelState(queryClient, effectiveChannelId);
+      queueChannelStateInvalidation(queryClient, effectiveChannelId);
     },
   });
 }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { UserRoundPlus, X } from "lucide-react";
 import {
-  invalidateChannelState,
+  queueChannelStateInvalidation,
   useAddChannelMembersMutation,
   useChannelMembersQuery,
   useChannelsQuery,
@@ -571,7 +571,8 @@ export function MembersSidebar({
             agent: managedAgent,
             ensureRunning: true,
           });
-          await invalidateChannelState(queryClient, channelId);
+          // fire-and-forget: awaiting the channels-list refetch blocks Add.
+          queueChannelStateInvalidation(queryClient, channelId);
         } catch (error) {
           setInviteSubmissionErrors((prev) => [
             ...prev,


### PR DESCRIPTION
## Summary

`useAddChannelMembersMutation` awaited `invalidateChannelState`, which re-fetches every channel before resolving. Because `MembersSidebar` awaits the mutation, the Add button stayed pending after the relay had already accepted the member update.

- Add `queueChannelStateInvalidation`, which starts the cache refresh without making its latency part of the mutation contract.
- Use it from `useAddChannelMembersMutation.onSettled` so `mutateAsync` resolves with the relay mutation.
- Keep the sidebar call fire-and-forget with an explicit `void`.
- Cover the settlement boundary with a regression test that holds the refetch promise open.

This changes interaction timing only; there is no visual layout change to screenshot.

### Related issue

Fixes #6070. The issue timeline has no competing PR cross-reference.

### Testing

Rebased and verified on `main` at `1b7e5ac1b` before push:

- `cd desktop && pnpm exec biome check src/features/channels/` — 149 files clean
- `cd desktop && pnpm exec tsc --noEmit` — clean
- `cd desktop && node --test src/features/channels/hooks.test.mjs` — 13/13 passed
- `cd desktop && node --test src/features/channels/**/*.test.mjs` — 298/298 passed
- DCO Check — passed
