### PR TITLE
test(desktop): pin the RelayAgentInfo Tauri payload to snake_case

### DIFF
--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -799,3 +799,62 @@ fn summary_with_drift_serializes_restart_diff_entries() {
         }]))
     );
 }
+
+use super::RelayAgentInfo;
+
+/// `RelayAgentInfo` crosses the Tauri boundary as the payload of
+/// `list_relay_agents` and `revalidate_relay_agents`, and the frontend maps it
+/// by hand: `fromRawRelayAgent` in `desktop/src/shared/api/tauri.ts` reads
+/// `owner_pubkey`, `agent_type`, `channel_ids`, `respond_to` and
+/// `respond_to_allowlist` and rewrites them to camelCase.
+///
+/// That contract is carried entirely by this struct having no `rename_all`.
+/// Adding `#[serde(rename_all = "camelCase")]` — the reflex when a Rust struct
+/// feeds a TypeScript client — would leave all five fields `undefined` on the
+/// other side, with no compiler and no test objecting: `RawRelayAgent` marks
+/// them optional, so the mapper silently produces `null`/`[]` and every relay
+/// agent turns owner-less, typeless and un-mentionable at runtime.
+#[test]
+fn relay_agent_info_wire_keys_are_snake_case() {
+    let wire = serde_json::to_value(RelayAgentInfo {
+        pubkey: "a".repeat(64),
+        owner_pubkey: Some("b".repeat(64)),
+        name: "Scout".to_string(),
+        agent_type: "agent".to_string(),
+        channels: vec!["general".to_string()],
+        channel_ids: vec!["11111111-1111-1111-1111-111111111111".to_string()],
+        capabilities: vec!["chat".to_string()],
+        status: "offline".to_string(),
+        respond_to: Some(RespondTo::Anyone),
+        respond_to_allowlist: vec!["c".repeat(64)],
+    })
+    .expect("relay agent info serializes");
+
+    assert_eq!(
+        wire.get("owner_pubkey"),
+        Some(&serde_json::json!("b".repeat(64)))
+    );
+    assert_eq!(wire.get("agent_type"), Some(&serde_json::json!("agent")));
+    assert_eq!(
+        wire.get("channel_ids"),
+        Some(&serde_json::json!(["11111111-1111-1111-1111-111111111111"]))
+    );
+    assert_eq!(wire.get("respond_to"), Some(&serde_json::json!("anyone")));
+    assert_eq!(
+        wire.get("respond_to_allowlist"),
+        Some(&serde_json::json!([&"c".repeat(64)]))
+    );
+
+    for camel in [
+        "ownerPubkey",
+        "agentType",
+        "channelIds",
+        "respondTo",
+        "respondToAllowlist",
+    ] {
+        assert!(
+            wire.get(camel).is_none(),
+            "{camel} must not appear on the wire: the TypeScript mapper reads the snake_case key"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add one regression test pinning that `RelayAgentInfo` crosses the Tauri boundary with
**snake_case** keys, and that the camelCase spellings never appear on the wire.

No behaviour change — this is a test-only PR closing a silent-failure hole.

## Why

`RelayAgentInfo` is the payload of `list_relay_agents` and `revalidate_relay_agents`, and
the frontend maps it by hand. `fromRawRelayAgent` (`desktop/src/shared/api/tauri.ts:655`)
reads `owner_pubkey`, `agent_type`, `channel_ids`, `respond_to` and `respond_to_allowlist`
and rewrites them to camelCase for the `RelayAgent` type.

That contract rests entirely on the struct *not* carrying `#[serde(rename_all = "camelCase")]`.
Adding it is the reflex when a Rust struct feeds a TypeScript client, and here it fails
silently in both directions:

- `RawRelayAgent` (`tauri.ts:101`) marks all five fields optional, so the mapper does not
  throw — it produces `null` / `[]` / `null`.
- Nothing in the repo asserts the wire shape, so no test goes red.

The runtime result is every relay agent arriving owner-less, typeless, channel-less and
with `respondTo: null` — which `relayAgentIsSharedWithUser`
(`desktop/src/features/agents/lib/agentAutocompleteEligibility.ts:39`) treats as *deny*.
The whole relay directory would quietly stop being mentionable, with a green build.

The blast radius grew recently: `owner_pubkey` and `channel_ids` were added to this struct
after the original mapper, so it is five hand-mapped fields now, not three.

## Validation

`just desktop-tauri-test` runs this (`.github/workflows/ci.yml:204` →
`cd desktop/src-tauri && cargo test --workspace`, path-filtered on `desktop/src-tauri/**`),
so the test actually executes in CI rather than only existing.

Acceptance criterion checked by breaking it, not just by watching it pass: adding
`#[serde(rename_all = "camelCase")]` to `RelayAgentInfo` makes the test fail on the first
assertion (`owner_pubkey` absent); removing it makes it pass again. A contract test that
does not go red when the contract breaks buys nothing.

- `cd desktop/src-tauri && cargo test --workspace relay_agent_info_wire_keys` — 1 passed
- `cargo fmt` clean

## Notes

The test lives next to the existing serde-contract tests in the same file
(`respond_to_serde_is_kebab_case`, and the `needs_restart` / `restart_diff` snake_case
assertion at the end), so it follows the file's established shape rather than introducing
a new one.

Split out of #5483, which I closed as superseded by #6086 / #6182 / #6224 — those PRs
implemented the directory work it proposed, but nothing carried this contract test across.
