### PR TITLE
docs(nostr): note AUTH ordering and Host-based community routing

### DIFF
--- a/NOSTR.md
+++ b/NOSTR.md
@@ -42,6 +42,84 @@ PGPASSWORD=buzz_dev psql -h localhost -U buzz -d buzz -c \
 # 4. Connect any NIP-29 + NIP-42 client to ws://localhost:3000
 ```
 
+### Connection order: authenticate before your first REQ
+
+The relay issues its NIP-42 `AUTH` challenge **proactively, immediately after the
+WebSocket opens**. Complete the handshake before sending anything else.
+
+A client that opens the socket and sends a `REQ` straight away races that
+challenge. The relay answers the premature subscription with
+`["CLOSED", "<sub-id>", "auth-required: ..."]` while the client is still
+building its `kind:22242` response, so a client whose auth routine reads from
+the same socket will consume that `CLOSED` and discard it as "not the `OK` I am
+waiting for". Auth then succeeds, but the original subscription is gone and no
+`EOSE` is ever coming. The symptom is a client that hangs on its first query
+rather than one that reports an auth error, which sends you looking in the wrong
+place.
+
+The order that works:
+
+```
+1. open socket
+2. read  ["AUTH", "<challenge>"]
+3. send  ["AUTH", <signed kind:22242 event>]
+4. read  ["OK", "<event-id>", true, ""]
+5. now send REQ / EVENT
+```
+
+This is a client-side ordering requirement, not a relay bug — the relay is
+behaving per NIP-42. It is written down here because the failure mode does not
+look like an auth problem.
+
+### Behind a tunnel or reverse proxy: preserve the Host header
+
+The relay resolves which community a connection belongs to from the **`Host`
+header** (see [Community scope](#community-scope)). Anything that rewrites
+`Host` — an SSH tunnel, a port-forward, a reverse proxy with the wrong
+configuration — will point at a host that has no community, and the WebSocket
+upgrade is rejected:
+
+```console
+$ curl -sS -o /dev/null -w '%{http_code}\n' \
+    -H 'Host: relay.example.com' \
+    -H 'Upgrade: websocket' -H 'Connection: Upgrade' \
+    -H 'Sec-WebSocket-Key: <base64>' -H 'Sec-WebSocket-Version: 13' \
+    http://relay.example.com:3000/
+101
+
+$ curl -sS \
+    -H 'Host: 127.0.0.1:13000' \
+    -H 'Upgrade: websocket' -H 'Connection: Upgrade' \
+    -H 'Sec-WebSocket-Key: <base64>' -H 'Sec-WebSocket-Version: 13' \
+    http://relay.example.com:3000/
+relay: no community is configured for this host        # HTTP 404
+```
+
+The relay's error text is explicit, but most WebSocket client libraries discard
+the response body on a failed upgrade and surface only `404`.
+
+**The health endpoints do not catch this.** `GET /_liveness` and the NIP-11
+document both return `200` for a host with no community:
+
+```console
+$ curl -sS -H 'Host: 127.0.0.1:13000' http://relay.example.com:3000/_liveness
+ok
+```
+
+So a monitoring check can report the relay healthy while every WebSocket
+connection through the same path is being refused. If clients cannot connect but
+`/_liveness` is green, compare the `Host` your client sends against the
+`Deployment community ensured` line in the relay log, which records the host
+each community was registered under:
+
+```
+INFO Deployment community ensured  host="relay.example.com:3000"  community=<uuid>
+```
+
+Set your proxy to preserve the original `Host` (`proxy_set_header Host $host` in
+nginx, `ProxyPreserveHost On` in Apache), or have the client send the relay's
+real host explicitly.
+
 ### What Works
 
 | Feature | Status | Notes |


### PR DESCRIPTION
## Summary

Two behaviours of a self-hosted relay that aren't documented, both hit while writing a third-party NIP-29 client against `ghcr.io/block/buzz:main` (relay **0.2.1**, `93114c9`). Neither is a relay bug — in both cases the relay is correct and the *symptom points somewhere else*, which is what cost the time.

**1. AUTH ordering.** The relay challenges proactively on connect. A client that opens the socket and sends a `REQ` immediately races that challenge: the relay answers the premature subscription with `CLOSED: auth-required` while the client is still signing its `kind:22242` response. An auth routine reading the same socket consumes that `CLOSED`, discards it as "not the `OK` I'm waiting for", and auth then succeeds — but the subscription is gone and no `EOSE` is coming. It presents as **a hang on first query, not an auth error**.

Distinct from #4498, which is a cold-start timing race in the desktop client (signer not warm inside the 5s window). This one is ordering rather than timing, and reproduces regardless of how fast the client signs.

**2. Host-based community routing.** Community resolution keys on the `Host` header, so an SSH tunnel or a misconfigured reverse proxy points at a host with no community and the WebSocket upgrade 404s. The relay's error body is explicit — `relay: no community is configured for this host` — but most WebSocket client libraries drop the response body on a failed upgrade and surface a bare `404`.

The part that makes this hard to diagnose: **`/_liveness` and NIP-11 both return `200` for that same wrong `Host`.** Monitoring reports the relay healthy while nothing can connect through that path.

```console
$ curl -so /dev/null -w '%{http_code}\n' -H 'Host: 100.117.105.102:3000' \
    -H 'Upgrade: websocket' -H 'Connection: Upgrade' \
    -H "Sec-WebSocket-Key: $K" -H 'Sec-WebSocket-Version: 13' $RELAY/
101

$ curl -s -H 'Host: 127.0.0.1:13000' \
    -H 'Upgrade: websocket' -H 'Connection: Upgrade' \
    -H "Sec-WebSocket-Key: $K" -H 'Sec-WebSocket-Version: 13' $RELAY/
relay: no community is configured for this host          # 404

$ curl -s -H 'Host: 127.0.0.1:13000' $RELAY/_liveness
ok                                                       # 200
```

The docs now point at the log line that resolves it, since it names the host each community was registered under:

```
INFO Deployment community ensured  host="100.117.105.102:3000"  community=<uuid>
```

Docs only — no code changes, no behaviour changes.

### Related issue

#4498 — related but distinct (cold-start timing vs. connection ordering); this documents the ordering requirement rather than changing behaviour. No existing issue or PR found for the `Host`/proxy case. Adjacent docs work: #3551, #3188.

### Testing

Both reproductions were run against a single-node `deploy/compose` stack on relay 0.2.1 (`93114c9`), with `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true` and `BUZZ_REQUIRE_AUTH_TOKEN=false`. The `curl` sequence above is verbatim output from that host.

The AUTH ordering claim was verified by reordering a client that previously hung on its first `REQ`: authenticating before subscribing, channel discovery (39000/39002), posting kind:9, reading, NIP-50 search and kind:7 reactions all succeed, with two separate agent identities in one channel.

Per `AGENTS.md`'s Product Contract — this is a docs-only change to the self-hosted third-party-client surface and doesn't contradict `VISION_SOVEREIGN.md`; if anything the friction it documents is friction against self-hosting. Happy to fold in a "Tested Clients" row, split this into two PRs, or move the content elsewhere if `NOSTR.md` isn't where you want it.
