### PR TITLE
fix(sdk): reject overlong pubkeys in build_add_member / build_remove_member

### DIFF
--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -578,10 +578,10 @@ pub fn build_add_member(
     target_pubkey: &str,
     role: Option<MemberRole>,
 ) -> Result<EventBuilder, SdkError> {
-    check_hex_len(target_pubkey, 64, "target_pubkey")?;
+    let target_pubkey = check_pubkey_hex(target_pubkey, "target_pubkey")?;
     let mut tags = vec![
         tag(&["h", &channel_id.to_string()])?,
-        tag(&["p", &target_pubkey.to_ascii_lowercase()])?,
+        tag(&["p", &target_pubkey])?,
     ];
     if let Some(r) = role {
         tags.push(tag(&["role", r.as_str()])?);
@@ -594,10 +594,10 @@ pub fn build_remove_member(
     channel_id: Uuid,
     target_pubkey: &str,
 ) -> Result<EventBuilder, SdkError> {
-    check_hex_len(target_pubkey, 64, "target_pubkey")?;
+    let target_pubkey = check_pubkey_hex(target_pubkey, "target_pubkey")?;
     let tags = vec![
         tag(&["h", &channel_id.to_string()])?,
-        tag(&["p", &target_pubkey.to_ascii_lowercase()])?,
+        tag(&["p", &target_pubkey])?,
     ];
     Ok(EventBuilder::new(Kind::Custom(9001), "").tags(tags))
 }
@@ -2958,6 +2958,59 @@ mod tests {
         let ev = sign(build_remove_member(cid, pubkey).unwrap());
         assert_eq!(ev.kind.as_u16(), 9001);
         assert!(has_tag(&ev, "p", pubkey));
+    }
+
+    #[test]
+    fn add_member_rejects_overlong_pubkey() {
+        // Relay `extract_p_tag_bytes` requires exactly 64 hex; the SDK must
+        // reject 65+ hex here rather than sign a `p` tag the relay drops.
+        let cid = uuid();
+        let err = build_add_member(cid, &"a".repeat(65), None::<MemberRole>).unwrap_err();
+        assert!(
+            matches!(err, SdkError::InvalidInput(_)),
+            "expected InvalidInput for overlong pubkey, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn remove_member_rejects_overlong_pubkey() {
+        let cid = uuid();
+        let err = build_remove_member(cid, &"a".repeat(100)).unwrap_err();
+        assert!(
+            matches!(err, SdkError::InvalidInput(_)),
+            "expected InvalidInput for overlong pubkey, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn add_member_rejects_short_pubkey() {
+        let cid = uuid();
+        let err = build_add_member(cid, &"a".repeat(63), None::<MemberRole>).unwrap_err();
+        assert!(
+            matches!(err, SdkError::InvalidInput(_)),
+            "expected InvalidInput for short pubkey, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn remove_member_rejects_nonhex_pubkey() {
+        let cid = uuid();
+        let err = build_remove_member(cid, &"z".repeat(64)).unwrap_err();
+        assert!(
+            matches!(err, SdkError::InvalidInput(_)),
+            "expected InvalidInput for non-hex pubkey, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn add_member_lowercases_mixed_case_pubkey() {
+        // `check_pubkey_hex` returns the lowercased value; the resulting
+        // event should carry the lowercased pubkey in its `p` tag.
+        let cid = uuid();
+        let upper = "ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234";
+        let lower = upper.to_ascii_lowercase();
+        let ev = sign(build_add_member(cid, upper, None::<MemberRole>).unwrap());
+        assert!(has_tag(&ev, "p", &lower));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`buzz_sdk::builders::build_add_member` and `build_remove_member` validate `target_pubkey` with a minimum-length check (`check_hex_len(_, 64, _)`) where the wire format requires an exact 64-hex length. An overlong all-hex string is accepted and signed into the `p` tag. The relay's `extract_p_tag_bytes` then fails to decode it, and the kind:9000/9001 admin validator turns that into a confusing `missing p tag` error even though the caller did supply a `p` tag.

Reported at block/buzz#6375.

## Root cause

`crates/buzz-sdk/src/builders.rs` had:

```rust
check_hex_len(target_pubkey, 64, "target_pubkey")?;
```

`check_hex_len` is the right helper for abbreviated git shas (`commit_sha` min 7, `parent_commit` min 7), where `>= N` is the contract. It is the wrong helper for a Nostr pubkey. The relay requires exactly 64 hex (`buzz-relay/src/handlers/side_effects.rs:2366-2379` and `buzz-relay/src/handlers/moderation_commands.rs:561-575`). The SDK's own test `moderation_ban_rejects_overlong_pubkey` documents the exact-64 contract; the ban builder uses the exact-length helper `check_pubkey_hex` and rejects 65-char hex. The two `p`-tag builders I touched are the only ones that still do not honor it.

As a secondary nit, the error variant was `SdkError::InvalidDiffMeta` (a git-diff-metadata error) for a channel member pubkey. `check_pubkey_hex` returns `InvalidInput`, matching every sibling builder.

## Fix

Swap both call sites to the existing `check_pubkey_hex`. No new helper; it already returns the lowercased value, so the explicit `to_ascii_lowercase()` on the tag can use its return value directly:

```rust
let target_pubkey = check_pubkey_hex(target_pubkey, "target_pubkey")?;
let mut tags = vec![
    tag(&["h", &channel_id.to_string()])?,
    tag(&["p", &target_pubkey])?,
];
```

## Verification

Sabotage run (pre-fix, current upstream/main at `a9640c7cc`):

```
add_member_rejects_overlong_pubkey   FAILED  (got Ok with 65-char p tag)
remove_member_rejects_overlong_pubkey FAILED (got Ok with 100-char p tag)
add_member_rejects_short_pubkey      FAILED  (InvalidDiffMeta, want InvalidInput)
remove_member_rejects_nonhex_pubkey  FAILED  (InvalidDiffMeta, want InvalidInput)
add_member_lowercases_mixed_case_pubkey ok
```

Post-fix on this branch (`0018e3abc`):

```
cargo test -p buzz-sdk --lib
   ... 267 passed; 0 failed
```

Build & lint:

```
cargo build -p buzz-cli       ok
cargo build -p buzz-relay     ok
cargo clippy -p buzz-sdk -p buzz-cli --all-targets -- -D warnings   ok
cargo fmt -p buzz-sdk -p buzz-cli -- --check                        ok
```

The CLI template-apply path (`crates/buzz-cli/src/commands/channels.rs:747`) passes `agent.pubkey` straight through with no length check. After this fix, an overlong `pubkey` there now fails locally with `InvalidInput` instead of signing an unusable event. Other CLI call sites already `validate_hex64` upfront, so this is a behavior change only for callers that were already sending invalid data.

## Risks

- Behavior change: any caller currently passing 65+ hex chars to these two builders will now see `InvalidInput` instead of a downstream `missing p tag`. Their events were already being rejected by the relay, so the change converts a remote failure into a local one.
- No public-API addition or removal; the function signatures are unchanged.
- No security claim: the relay rejects the event, so the practical impact is a signed-but-unusable event and a misleading error, not a bad membership write.

Fixes #6375