### PR TITLE
fix(desktop): refresh agent directory after channel invite

### DIFF
--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -799,11 +799,20 @@ export function useAddChannelMembersMutation(channelId: string | null) {
         });
       }
     },
-    onSettled: async (_data, _err, variables) => {
+    onSettled: async (data, _err, variables) => {
       // Invalidate the effective channel (the one actually mutated) not the
       // live hook-closure channel, which may have changed mid-send.
       const effectiveChannelId = variables?.channelId ?? channelId;
-      await invalidateChannelState(queryClient, effectiveChannelId);
+      await Promise.all([
+        invalidateChannelState(queryClient, effectiveChannelId),
+        ...(variables?.role === "bot" && data?.added.length
+          ? [
+              queryClient.invalidateQueries({
+                queryKey: ["relay-agents"],
+              }),
+            ]
+          : []),
+      ]);
     },
   });
 }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -7399,6 +7399,14 @@ async function handleAddChannelMembers(
         joined_at: new Date().toISOString(),
         display_name: mockDisplayNames.get(pubkey) ?? null,
       });
+
+      const relayAgent = mockRelayAgents.find(
+        (agent) => normalizePubkey(agent.pubkey) === normalizePubkey(pubkey),
+      );
+      if (relayAgent && !relayAgent.channel_ids.includes(targetChannel.id)) {
+        relayAgent.channel_ids.push(targetChannel.id);
+        relayAgent.channels.push(targetChannel.name);
+      }
     }
 
     syncMockChannel(targetChannel);

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -3894,6 +3894,22 @@ test("members sidebar can invite relay-authorized agents", async ({ page }) => {
   await expect(
     page.getByTestId(`channel-user-search-result-${DM_RELAY_AGENT_PUBKEY}`),
   ).toBeVisible();
+
+  await page
+    .getByTestId(`channel-user-search-result-${DM_RELAY_AGENT_PUBKEY}`)
+    .click();
+  await expect
+    .poll(async () =>
+      commandCount(await readCommandLog(page), "add_channel_members"),
+    )
+    .toBeGreaterThan(0);
+
+  await page.keyboard.press("Escape");
+  const input = page.getByTestId("message-input");
+  await input.fill("@quinn");
+  await expect(
+    page.getByTestId("mention-autocomplete").getByText("quinn"),
+  ).toBeVisible();
 });
 
 test("members sidebar hides relay agents that are not authorized", async ({


### PR DESCRIPTION
## Summary

- refresh the authoritative relay-agent directory after a successful bot channel addition
- leave human and failed invitation behavior unchanged
- extend the existing members-sidebar regression through invite to immediate `@mention`

## Why

Desktop refreshed channel membership after an invite, but it left the cached relay-agent directory stale. Mention eligibility reads that directory, so a newly invited remote agent stayed unavailable until a later poll.

## Security and compatibility

This does not optimistically authorize the agent. The composer admits it only after the relay-directory refetch confirms the new channel membership. Existing human invites and failed bot invites do not trigger the extra refresh.

## Related work

Addresses the Desktop portion of #6380.

Controlling work order: [BAC-110](https://linear.app/scale-lean/issue/BAC-110/fix-immediate-remote-agent-mentionability-after-buzz-channel-invite)

## Testing

- focused Playwright regression: `pnpm --dir desktop exec playwright test --project=smoke tests/e2e/channels.spec.ts --grep 'members sidebar can invite relay-authorized agents'` (`1 passed`)
- full repository gate: `just ci` (passed)
- no visual UI change, so no screenshot is needed

After relay acceptance, the picker is right here, right now instead of waiting for the next poll.
