### PR TITLE
fix(desktop): show remote agent activity in DMs

### DIFF
--- a/desktop/src/features/channels/ui/useChannelActivityTyping.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelActivityTyping.test.mjs
@@ -12,11 +12,44 @@ import {
   channelScopedBotTypingPubkeyKey,
   mergeMemberAgentFlagsIntoProfiles,
 } from "./useChannelActivityTyping.ts";
+import {
+  buildChannelAgentSessionCandidates,
+  getChannelAgentSessionAgents,
+} from "./useChannelAgentSessions.ts";
 
 const AGENT =
   "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234";
 const AGENT_2 =
   "dcba4321dcba4321dcba4321dcba4321dcba4321dcba4321dcba4321dcba4321";
+
+it("keeps a directory-known Hermes agent in DM activity when it is a member", () => {
+  const channelMembers = [{ pubkey: AGENT, role: "bot" }];
+  const candidates = buildChannelAgentSessionCandidates({
+    channelMembers,
+    managedAgents: [],
+    relayAgents: [
+      {
+        pubkey: AGENT,
+        name: "Hermes",
+        status: "online",
+        channelIds: ["ordinary-channel"],
+        channels: ["Ordinary channel"],
+      },
+    ],
+  });
+
+  const agents = getChannelAgentSessionAgents({
+    activeChannel: { channelType: "dm", name: "Hermes DM" },
+    activeChannelId: "dm-channel",
+    agents: candidates,
+    channelMembers,
+  });
+
+  assert.deepEqual(
+    agents.map((agent) => agent.pubkey),
+    [AGENT],
+  );
+});
 
 describe("channelScopedBotTypingPubkeyKey", () => {
   it("excludes thread-scoped typing entries", () => {

--- a/desktop/src/features/channels/ui/useChannelAgentSessions.ts
+++ b/desktop/src/features/channels/ui/useChannelAgentSessions.ts
@@ -142,6 +142,10 @@ export function getChannelAgentSessionAgents({
       channelIds.includes(activeChannelId) ||
       channels.includes(activeChannel.name);
 
+    if (activeChannel.channelType === "dm") {
+      return memberPubkeys?.has(normalizedPubkey) ?? matchesDeclaredChannel;
+    }
+
     if (agent.agentSource === "member-bot") {
       return botMemberPubkeys?.has(normalizedPubkey) ?? matchesDeclaredChannel;
     }


### PR DESCRIPTION
## Summary

- Keep a directory-known remote agent in the DM agent-session set when the agent is an actual DM member.
- Preserve the existing declared-channel scope rules for streams and forums.
- Add one production-path regression covering a remote Hermes agent whose ordinary-channel scopes do not match the DM.

The agent was alive and kicking, but Desktop classified its DM typing as human activity because its declared ordinary-channel scopes did not match the DM identifier. The separate typing path still rendered `Hermes is typing...`, while the detailed agent activity surface had no matching agent session.

DM membership is already the authoritative relationship for that conversation. This change uses it only after the identity has entered the managed, relay-directory, or member-bot candidate set. It does not turn arbitrary DM participants into agents and does not change relay authorization.

### Related issue

Fixes #6439

Controlling work order: [BAC-118](https://linear.app/scale-lean/issue/BAC-118/restore-detailed-hermes-activity-in-buzz-direct-messages)

### Testing

- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/channels/ui/useChannelActivityTyping.test.mjs`: 11 passed, 0 failed.
- `pnpm -C desktop typecheck`: passed.
- `pnpm exec biome check src/features/channels/ui/useChannelAgentSessions.ts src/features/channels/ui/useChannelActivityTyping.test.mjs`: passed.
- `just ci`: passed on macOS with Flutter 3.41.7. This includes 5,250 Desktop tests, 2,701 Desktop Rust tests with 18 ignored, and 1,552 mobile tests.

Screenshots are not included because this changes no layout or copy. It restores the existing detailed activity surface for the affected DM classification path. The focused regression exercises the production candidate builder and session filter together.
