### PR TITLE
fix(desktop): classify long-path checkout failures as actionable repo errors

### DIFF
--- a/desktop/src/features/projects/lib/projectRepoAvailability.test.mjs
+++ b/desktop/src/features/projects/lib/projectRepoAvailability.test.mjs
@@ -45,6 +45,23 @@ test("classifies branch and network failures", () => {
   );
 });
 
+test("classifies long-path checkout failures as path errors", () => {
+  assert.equal(
+    projectRepoUnavailableReason(
+      new Error(
+        "error: unable to create file <...>/a_file_with_a_long_name.md: Filename too long",
+      ),
+    ),
+    "path",
+  );
+  assert.equal(
+    projectRepoUnavailableReason(
+      new Error("fatal: unable to checkout working tree"),
+    ),
+    "path",
+  );
+});
+
 test("keeps unmatched failures generic", () => {
   assert.equal(
     projectRepoUnavailableReason(new Error("git exited with status 128")),
@@ -105,6 +122,14 @@ test("never rewrites non-missing reasons", () => {
     }),
     "network",
   );
+  assert.equal(
+    refineRepoUnavailableReason({
+      reason: "path",
+      repositoryChannelId: "22222222-2222-4222-8222-222222222222",
+      memberChannelIds: [],
+    }),
+    "path",
+  );
 });
 
 test("presents access failures without exposing the relay's masked 404", () => {
@@ -112,5 +137,13 @@ test("presents access failures without exposing the relay's masked 404", () => {
     description:
       "Repository access is granted through its channel, and you’re not a member. Ask the repository owner for an invite.",
     title: "Repository access restricted",
+  });
+});
+
+test("presents long-path failures with actionable copy", () => {
+  assert.deepEqual(projectRepoUnavailablePresentation("path"), {
+    description:
+      "The repository contains paths longer than the local filesystem allows (Windows MAX_PATH). Enable long paths in your git config or Windows settings, then retry.",
+    title: "Paths exceed local limit",
   });
 });

--- a/desktop/src/features/projects/lib/projectRepoAvailability.ts
+++ b/desktop/src/features/projects/lib/projectRepoAvailability.ts
@@ -4,6 +4,7 @@ export type ProjectRepoUnavailableReason =
   | "unbound"
   | "authentication"
   | "network"
+  | "path"
   | "ref"
   | "unknown";
 
@@ -41,6 +42,11 @@ const PROJECT_REPO_UNAVAILABLE_PRESENTATIONS: Record<
     description:
       "The Buzz git service could not be reached. Check your connection and try again.",
     title: "Couldn’t reach repository",
+  },
+  path: {
+    description:
+      "The repository contains paths longer than the local filesystem allows (Windows MAX_PATH). Enable long paths in your git config or Windows settings, then retry.",
+    title: "Paths exceed local limit",
   },
   ref: {
     description:
@@ -99,6 +105,9 @@ export function projectRepoUnavailableReason(
     )
   ) {
     return "network";
+  }
+  if (/filename too long|unable to checkout working tree/.test(message)) {
+    return "path";
   }
   return "unknown";
 }

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -271,6 +271,11 @@ function RepositoryUnavailableIndicator({
       description: "The Buzz git service could not be reached.",
       label: "Unreachable",
     },
+    path: {
+      description:
+        "The repository contains paths longer than the local filesystem allows.",
+      label: "Path too long",
+    },
     ref: {
       description: "The advertised branch is missing from the git remote.",
       label: "Branch missing",

--- a/desktop/src/features/projects/ui/ProjectRepositoryUnavailableState.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryUnavailableState.tsx
@@ -6,6 +6,7 @@ import {
   LockKeyhole,
   MessageCircle,
   RefreshCw,
+  TriangleAlert,
 } from "lucide-react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
@@ -26,6 +27,7 @@ const UNAVAILABLE_ICONS = {
   access: LockKeyhole,
   unbound: LockKeyhole,
   network: CloudOff,
+  path: TriangleAlert,
   ref: GitBranch,
   unknown: CircleAlert,
 } satisfies Record<ProjectRepoUnavailableReason, typeof CircleAlert>;


### PR DESCRIPTION
## Summary

`projectRepoUnavailableReason` returns `unknown` whenever a git failure mentions `filename too long` or `unable to checkout working tree`, so the Projects panel falls back to the generic "Repository unavailable" copy and the user has no hint that the cause is a fixable local git setting.

This is the second reported instance of a specific, fixable local-git problem being flattened into the `unknown` bucket (#5989 notes the Windows MAX_PATH case, sibling of #5348 for the macOS git <2.46 case). The panel needs a reason it can route to actionable copy.

### Changes

- Add a new `path` reason to `ProjectRepoUnavailableReason` that matches `/filename too long|unable to checkout working tree/`.
- Give `path` actionable copy ("Paths exceed local limit") pointing the user at `core.longpaths` and the Windows long-path setting.
- Register a `TriangleAlert` icon in `ProjectRepositoryUnavailableState.tsx` and a "Path too long" status row in `ProjectCards.tsx` so the card-level indicator stays in sync with the full panel.
- Cover the new reason with three tests (classification, refinement pass-through, presentation).

The `core.longpaths` injection itself ships in #6095. That PR resolves the user-visible failure on machines where git's own setting is the lever; this PR ships the classification half so the panel can render meaningful text once the config fix lands — and also for any user whose `core.longpaths` is unreachable for other reasons (e.g. they did not know to set it, or a future code path produces the same git error string).

### Related issue

Fixes the classification half of #5989.

The reporter's option 1 (one-line config injection) is PR #6095. This PR is option 3 from the same report. The two are independent and can land in either order; the panel classification is correct with or without the config injection, and the config injection is correct with or without the classification.

### Testing

`pnpm typecheck` from `desktop/` clean.

`node --import ./test-loader.mjs --experimental-strip-types --test src/features/projects/lib/projectRepoAvailability.test.mjs`: 12 passed, 0 failed (3 new: classification, refinement pass-through, presentation).

`pnpm lint`: 3 warnings / 2 infos, all pre-existing and unrelated to the touched files.

Manual: `projectRepoUnavailableReason` returns `path` for both fixture strings from the issue ("Filename too long" and "fatal: unable to checkout working tree"); `refineRepoUnavailableReason` leaves `path` untouched, matching its behavior for other non-`missing` reasons; `projectRepoUnavailablePresentation('path')` returns the expected `{title, description}` pair.