### PR TITLE
Fix duplicate-name user search results

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -538,3 +538,20 @@ test("coalesceAgentAutocompleteCandidates: leaves non-agents alone", () => {
 
   assert.deepEqual(coalesce([first, second]), [first, second]);
 });
+
+test("coalesceAgentAutocompleteCandidates: keeps same-name global people distinct", () => {
+  const first = makeAgent({
+    pubkey: PUB_A,
+    displayName: "Will",
+    isAgent: false,
+    isGlobalSearchResult: true,
+  });
+  const second = makeAgent({
+    pubkey: PUB_B,
+    displayName: "Will",
+    isAgent: false,
+    isGlobalSearchResult: true,
+  });
+
+  assert.deepEqual(coalesce([first, second]), [first, second]);
+});

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -317,29 +317,6 @@ function isPreferredAgentCandidate<T extends AgentAutocompleteCandidate>(
   return false;
 }
 
-export function coalesceAutocompleteCandidatesByKey<T>(
-  candidates: readonly T[],
-  getKey: (candidate: T) => string | null,
-) {
-  const output: T[] = [];
-  const indexesByKey = new Map<string, number>();
-
-  for (const candidate of candidates) {
-    const key = getKey(candidate);
-    if (!key) {
-      output.push(candidate);
-      continue;
-    }
-
-    if (!indexesByKey.has(key)) {
-      indexesByKey.set(key, output.length);
-      output.push(candidate);
-    }
-  }
-
-  return output;
-}
-
 export function coalesceAgentAutocompleteCandidates<
   T extends AgentAutocompleteCandidate,
 >(

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -142,6 +142,24 @@ export function CreateAgentRespondToField({
       ),
     [allowlistSet, isArchivedDiscovery, userSearchResults],
   );
+  const searchViewportRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const viewport = searchViewportRef.current;
+    if (
+      !viewport ||
+      !userSearchQuery.hasNextPage ||
+      userSearchQuery.isFetchingNextPage ||
+      viewport.scrollHeight > viewport.clientHeight
+    ) {
+      return;
+    }
+
+    void userSearchQuery.fetchNextPage();
+  }, [
+    userSearchQuery.fetchNextPage,
+    userSearchQuery.hasNextPage,
+    userSearchQuery.isFetchingNextPage,
+  ]);
   const handleSearchScroll = useUserSearchFetchMoreOnScroll(userSearchQuery);
 
   const pasteParsed = React.useMemo(
@@ -261,6 +279,7 @@ export function CreateAgentRespondToField({
           onAddRawPubkey={handleAddRawPubkey}
           onAddSearchResult={handleAddSearchResult}
           onSearchScroll={handleSearchScroll}
+          searchViewportRef={searchViewportRef}
           onPasteTextChange={setPasteText}
           onQueryChange={setQuery}
           onRemove={handleRemove}
@@ -296,6 +315,7 @@ function AllowlistPicker({
   onAddRawPubkey,
   onAddSearchResult,
   onSearchScroll,
+  searchViewportRef,
   onPasteTextChange,
   onQueryChange,
   onRemove,
@@ -318,6 +338,7 @@ function AllowlistPicker({
   onAddRawPubkey: (pubkey: string) => void;
   onAddSearchResult: (user: UserSearchResult) => void;
   onSearchScroll: (event: React.UIEvent<HTMLDivElement>) => void;
+  searchViewportRef: React.RefObject<HTMLDivElement | null>;
   onPasteTextChange: (value: string) => void;
   onQueryChange: (value: string) => void;
   onRemove: (pubkey: string) => void;
@@ -414,66 +435,69 @@ function AllowlistPicker({
               <p className="px-2 py-1 text-sm text-muted-foreground">
                 Searching…
               </p>
-            ) : searchResults.length > 0 ? (
+            ) : (
               <div
                 className="max-h-44 space-y-1 overflow-y-auto"
                 onScroll={onSearchScroll}
+                ref={searchViewportRef}
               >
-                {searchResults.map((result) => (
+                {searchResults.length > 0 ? (
+                  searchResults.map((result) => (
+                    <button
+                      className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
+                      data-testid={`agent-respond-to-result-${result.pubkey}`}
+                      key={result.pubkey}
+                      onClick={() => onAddSearchResult(result)}
+                      type="button"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <UserAvatar
+                          avatarUrl={result.avatarUrl}
+                          displayName={formatSearchUserName(result)}
+                          size="xs"
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium leading-5">
+                            {formatSearchUserName(result)}
+                          </p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {formatSearchUserSecondary(result)}
+                          </p>
+                        </div>
+                      </div>
+                      <span className="text-xs text-muted-foreground">Add</span>
+                    </button>
+                  ))
+                ) : queryIsHexPubkey ? (
                   <button
                     className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
-                    data-testid={`agent-respond-to-result-${result.pubkey}`}
-                    key={result.pubkey}
-                    onClick={() => onAddSearchResult(result)}
+                    data-testid="agent-respond-to-add-raw-pubkey"
+                    onClick={() => onAddRawPubkey(deferredQuery.toLowerCase())}
                     type="button"
                   >
                     <div className="flex items-center gap-2 min-w-0">
                       <UserAvatar
-                        avatarUrl={result.avatarUrl}
-                        displayName={formatSearchUserName(result)}
+                        avatarUrl={null}
+                        displayName={truncatePubkey(deferredQuery)}
                         size="xs"
                       />
                       <div className="min-w-0">
                         <p className="truncate text-sm font-medium leading-5">
-                          {formatSearchUserName(result)}
+                          {truncatePubkey(deferredQuery)}
                         </p>
                         <p className="truncate text-xs text-muted-foreground">
-                          {formatSearchUserSecondary(result)}
+                          Add pubkey directly
                         </p>
                       </div>
                     </div>
                     <span className="text-xs text-muted-foreground">Add</span>
                   </button>
-                ))}
+                ) : (
+                  <p className="px-2 py-1 text-sm text-muted-foreground">
+                    No matching users.
+                  </p>
+                )}
               </div>
-            ) : queryIsHexPubkey ? (
-              <button
-                className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
-                data-testid="agent-respond-to-add-raw-pubkey"
-                onClick={() => onAddRawPubkey(deferredQuery.toLowerCase())}
-                type="button"
-              >
-                <div className="flex items-center gap-2 min-w-0">
-                  <UserAvatar
-                    avatarUrl={null}
-                    displayName={truncatePubkey(deferredQuery)}
-                    size="xs"
-                  />
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium leading-5">
-                      {truncatePubkey(deferredQuery)}
-                    </p>
-                    <p className="truncate text-xs text-muted-foreground">
-                      Add pubkey directly
-                    </p>
-                  </div>
-                </div>
-                <span className="text-xs text-muted-foreground">Add</span>
-              </button>
-            ) : (
-              <p className="px-2 py-1 text-sm text-muted-foreground">
-                No matching users.
-              </p>
             )}
           </div>
         ) : null}

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -7,7 +7,11 @@ import {
 import { truncatePubkey } from "@/shared/lib/pubkey";
 import { PubKey } from "@/shared/ui/PubKey";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
-import { useUserSearchQuery } from "@/features/profile/hooks";
+import {
+  useFlattenedUserSearchResults,
+  useInfiniteUserSearchQuery,
+  useUserSearchFetchMoreOnScroll,
+} from "@/features/profile/hooks";
 import type { RespondToMode, UserSearchResult } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
@@ -123,20 +127,22 @@ export function CreateAgentRespondToField({
     () => new Set(allowlist.map((p) => p.toLowerCase())),
     [allowlist],
   );
-  const userSearchQuery = useUserSearchQuery(deferredQuery, {
+  const userSearchQuery = useInfiniteUserSearchQuery(deferredQuery, {
     enabled: mode === "allowlist" && deferredQuery.length > 0,
-    limit: 8,
+    limit: 50,
   });
   const isArchivedDiscovery = useIsArchivedPredicate();
+  const userSearchResults = useFlattenedUserSearchResults(userSearchQuery.data);
   const searchResults = React.useMemo(
     () =>
-      (userSearchQuery.data ?? []).filter(
+      userSearchResults.filter(
         (user) =>
           !allowlistSet.has(user.pubkey.toLowerCase()) &&
           !isArchivedDiscovery(user.pubkey),
       ),
-    [allowlistSet, isArchivedDiscovery, userSearchQuery.data],
+    [allowlistSet, isArchivedDiscovery, userSearchResults],
   );
+  const handleSearchScroll = useUserSearchFetchMoreOnScroll(userSearchQuery);
 
   const pasteParsed = React.useMemo(
     () => parsePubkeyInput(pasteText),
@@ -254,6 +260,7 @@ export function CreateAgentRespondToField({
           onAddFromPaste={handleAddFromPaste}
           onAddRawPubkey={handleAddRawPubkey}
           onAddSearchResult={handleAddSearchResult}
+          onSearchScroll={handleSearchScroll}
           onPasteTextChange={setPasteText}
           onQueryChange={setQuery}
           onRemove={handleRemove}
@@ -288,6 +295,7 @@ function AllowlistPicker({
   onAddFromPaste,
   onAddRawPubkey,
   onAddSearchResult,
+  onSearchScroll,
   onPasteTextChange,
   onQueryChange,
   onRemove,
@@ -309,6 +317,7 @@ function AllowlistPicker({
   onAddFromPaste: () => void;
   onAddRawPubkey: (pubkey: string) => void;
   onAddSearchResult: (user: UserSearchResult) => void;
+  onSearchScroll: (event: React.UIEvent<HTMLDivElement>) => void;
   onPasteTextChange: (value: string) => void;
   onQueryChange: (value: string) => void;
   onRemove: (pubkey: string) => void;
@@ -406,7 +415,10 @@ function AllowlistPicker({
                 Searching…
               </p>
             ) : searchResults.length > 0 ? (
-              <div className="max-h-44 space-y-1 overflow-y-auto">
+              <div
+                className="max-h-44 space-y-1 overflow-y-auto"
+                onScroll={onSearchScroll}
+              >
                 {searchResults.map((result) => (
                   <button
                     className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -147,6 +147,9 @@ export function CreateAgentRespondToField({
   );
   const searchViewportRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
+    // Filtered count changes can turn an active page from scrollable into a
+    // dead end after allowlist paste/add, so it is intentionally a signal.
+    void searchResults.length;
     const viewport = searchViewportRef.current;
     if (
       !viewport ||
@@ -159,6 +162,7 @@ export function CreateAgentRespondToField({
 
     void userSearchQuery.fetchNextPage();
   }, [
+    searchResults.length,
     userSearchQuery.fetchNextPage,
     userSearchQuery.hasNextPage,
     userSearchQuery.isFetchingNextPage,

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -70,10 +70,13 @@ function formatSearchUserName(user: UserSearchResult) {
 function formatSearchUserSecondary(user: UserSearchResult) {
   const displayName = user.displayName?.trim();
   const nip05Handle = user.nip05Handle?.trim();
-  if (displayName && nip05Handle) {
-    return nip05Handle;
-  }
-  return truncatePubkey(user.pubkey);
+  return displayName && nip05Handle ? nip05Handle : null;
+}
+
+function formatSearchUserAccessibleName(user: UserSearchResult) {
+  const name = formatSearchUserName(user);
+  const secondary = formatSearchUserSecondary(user);
+  return `Add ${name}${secondary ? `, ${secondary}` : ""}, public key ${user.pubkey}`;
 }
 
 const RESPOND_TO_OPTIONS: PersonaDropdownOption[] = [
@@ -443,12 +446,10 @@ function AllowlistPicker({
               >
                 {searchResults.length > 0 ? (
                   searchResults.map((result) => (
-                    <button
+                    <div
                       className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
                       data-testid={`agent-respond-to-result-${result.pubkey}`}
                       key={result.pubkey}
-                      onClick={() => onAddSearchResult(result)}
-                      type="button"
                     >
                       <div className="flex items-center gap-2 min-w-0">
                         <UserAvatar
@@ -460,13 +461,27 @@ function AllowlistPicker({
                           <p className="truncate text-sm font-medium leading-5">
                             {formatSearchUserName(result)}
                           </p>
-                          <p className="truncate text-xs text-muted-foreground">
-                            {formatSearchUserSecondary(result)}
-                          </p>
+                          {formatSearchUserSecondary(result) ? (
+                            <p className="truncate text-xs text-muted-foreground">
+                              {formatSearchUserSecondary(result)}
+                            </p>
+                          ) : null}
+                          <PubKey
+                            className="text-xs text-muted-foreground"
+                            pubkey={result.pubkey}
+                            testId={`agent-respond-to-result-pubkey-${result.pubkey}`}
+                          />
                         </div>
                       </div>
-                      <span className="text-xs text-muted-foreground">Add</span>
-                    </button>
+                      <button
+                        aria-label={formatSearchUserAccessibleName(result)}
+                        className="text-xs text-muted-foreground"
+                        onClick={() => onAddSearchResult(result)}
+                        type="button"
+                      >
+                        Add
+                      </button>
+                    </div>
                   ))
                 ) : queryIsHexPubkey ? (
                   <button

--- a/desktop/src/features/forum/ui/ForumComposer.tsx
+++ b/desktop/src/features/forum/ui/ForumComposer.tsx
@@ -122,7 +122,8 @@ export function ForumComposer({
     onEditLink: (info) => onEditLinkRef.current?.(info),
     onLinkSelectionChange: (info) => onLinkSelectionChangeRef.current?.(info),
     onLinkShortcut: () => onLinkShortcutRef.current?.() ?? false,
-    onUpdate: ({ cursor, text }) => {
+    onUpdate: ({ cursor, text, textChange }) => {
+      mentions.reconcileMentionIdentities(text, textChange);
       const markdown = richText.getMarkdown();
       setContent(markdown);
       contentRef.current = markdown;
@@ -238,8 +239,9 @@ export function ForumComposer({
       channelLinks.clearChannels();
       setIsEmojiPickerOpen(false);
       try {
+        const mentionText = richText.getPlainTextAndCursor().text.trim();
         const pubkeys = await mentions.revalidateMentionPubkeys(
-          mentions.extractMentionPubkeys(trimmed),
+          mentions.extractMentionPubkeys(mentionText),
         );
 
         // Reuse the shared send-path builder so forum/notes posts emit the same
@@ -291,6 +293,7 @@ export function ForumComposer({
       mentions.clearMentions,
       channelLinks.clearChannels,
       richText.clearContent,
+      richText.getPlainTextAndCursor,
       richText.setContent,
     ],
   );

--- a/desktop/src/features/messages/lib/draftMentionRefs.test.mjs
+++ b/desktop/src/features/messages/lib/draftMentionRefs.test.mjs
@@ -29,7 +29,14 @@ test("edit mention refs resolve from visible text and loaded profiles", () => {
       profiles,
       () => false,
     ),
-    [{ displayName: "Alice", isAgent: false, pubkey: ALICE }],
+    [
+      {
+        displayName: "Alice",
+        isAgent: false,
+        offset: 20,
+        pubkey: ALICE,
+      },
+    ],
   );
 
   const target = buildMessageComposerEditTarget(
@@ -38,6 +45,40 @@ test("edit mention refs resolve from visible text and loaded profiles", () => {
     () => false,
   );
   assert.deepEqual(target.unresolvedMentionPubkeys, []);
+});
+
+test("edit mention refs preserve duplicate-name identity by tag and occurrence order", () => {
+  const content = "@Will asks @Will";
+  const profilesByPubkey = {
+    [ALICE]: { displayName: "Will" },
+    [BOB]: { displayName: "Will" },
+  };
+
+  assert.deepEqual(
+    resolveEditMentionRefs(
+      content,
+      [
+        ["p", ALICE],
+        ["p", BOB],
+      ],
+      profilesByPubkey,
+      (pubkey) => pubkey === BOB,
+    ),
+    [
+      {
+        displayName: "Will",
+        isAgent: false,
+        offset: 0,
+        pubkey: ALICE,
+      },
+      {
+        displayName: "Will",
+        isAgent: true,
+        offset: 11,
+        pubkey: BOB,
+      },
+    ],
+  );
 });
 
 test("shared edit mention state preserves tagged identities while profiles are unavailable", () => {
@@ -80,7 +121,12 @@ test("edit target separates resolved refs from identities missing profiles", () 
   );
 
   assert.deepEqual(target.mentionRefs, [
-    { displayName: "Alice", isAgent: false, pubkey: ALICE },
+    {
+      displayName: "Alice",
+      isAgent: false,
+      offset: 20,
+      pubkey: ALICE,
+    },
   ]);
   assert.deepEqual(target.unresolvedMentionPubkeys, [BOB]);
 });

--- a/desktop/src/features/messages/lib/draftMentionRefs.ts
+++ b/desktop/src/features/messages/lib/draftMentionRefs.ts
@@ -1,4 +1,7 @@
-import { hasMention } from "@/features/messages/lib/hasMention";
+import {
+  getMentionOffsets,
+  hasMention,
+} from "@/features/messages/lib/hasMention";
 import { imetaMediaFromTags } from "@/features/messages/lib/imetaMediaMarkdown";
 import type { DraftMentionRef } from "@/features/messages/lib/useDrafts";
 import type { TimelineMessage } from "@/features/messages/types";
@@ -6,8 +9,8 @@ import type { MessageComposerEditTarget } from "@/features/messages/ui/MessageCo
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
+  collectProfileAliases,
   getMentionTagPubkey,
-  resolveMentionProps,
 } from "@/shared/lib/resolveMentionNames";
 
 export function resolveEditMentionRefs(
@@ -16,25 +19,36 @@ export function resolveEditMentionRefs(
   profiles: UserProfileLookup | undefined,
   isAgentPubkey: (pubkey: string) => boolean,
 ): DraftMentionRef[] {
-  const { mentionNames, mentionPubkeysByName } = resolveMentionProps(
-    tags,
-    profiles,
-  );
-  const refs = (mentionNames ?? [])
-    .filter((displayName) => hasMention(content, displayName))
-    .flatMap((displayName) => {
-      const pubkey = mentionPubkeysByName?.[displayName.toLowerCase()];
-      return pubkey
-        ? [
-            {
-              displayName,
-              pubkey,
-              isAgent: isAgentPubkey(normalizePubkey(pubkey)),
-            },
-          ]
-        : [];
-    });
-  return refs;
+  const offsetsByAlias = new Map<string, number[]>();
+  const nextOccurrenceByAlias = new Map<string, number>();
+  const refs: DraftMentionRef[] = [];
+
+  for (const tag of tags ?? []) {
+    const pubkey = getMentionTagPubkey(tag);
+    if (!pubkey) continue;
+
+    const normalizedPubkey = normalizePubkey(pubkey);
+    for (const alias of collectProfileAliases(profiles?.[normalizedPubkey])) {
+      const key = alias.toLowerCase();
+      const offsets =
+        offsetsByAlias.get(key) ?? getMentionOffsets(content, alias);
+      offsetsByAlias.set(key, offsets);
+      const occurrenceIndex = nextOccurrenceByAlias.get(key) ?? 0;
+      const offset = offsets[occurrenceIndex];
+      if (offset === undefined) continue;
+
+      nextOccurrenceByAlias.set(key, occurrenceIndex + 1);
+      refs.push({
+        displayName: alias,
+        pubkey: normalizedPubkey,
+        isAgent: isAgentPubkey(normalizedPubkey),
+        offset,
+      });
+      break;
+    }
+  }
+
+  return refs.sort((left, right) => (left.offset ?? 0) - (right.offset ?? 0));
 }
 
 function unresolvedEditMentionPubkeys(
@@ -124,8 +138,18 @@ function normalizeDraftMentionRefs(
   for (const ref of refs) {
     const displayName = ref.displayName.trim();
     const pubkey = normalizePubkey(ref.pubkey);
-    if (displayName && pubkey) {
-      normalized.push({ displayName, pubkey, isAgent: ref.isAgent });
+    if (
+      displayName &&
+      pubkey &&
+      (ref.offset === undefined ||
+        (Number.isInteger(ref.offset) && ref.offset >= 0))
+    ) {
+      normalized.push({
+        displayName,
+        pubkey,
+        isAgent: ref.isAgent,
+        ...(ref.offset !== undefined ? { offset: ref.offset } : {}),
+      });
     }
   }
   return normalized;

--- a/desktop/src/features/messages/lib/linkPreviewContent.ts
+++ b/desktop/src/features/messages/lib/linkPreviewContent.ts
@@ -1,10 +1,38 @@
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { Transaction } from "@tiptap/pm/state";
+import type { MentionTextChange } from "./mentionIdentityRefs";
 
 import { buildPlainTextProjection } from "./plainTextProjection";
+
+function projectTransactionTextChange(
+  tr: Transaction,
+): MentionTextChange | null {
+  // StepMap coordinates after the first map belong to intermediate documents,
+  // not `tr.before`/`tr.doc`. Only project the single-step/single-range shape;
+  // callers fail closed for anything more complex.
+  if (tr.mapping.maps.length !== 1) return null;
+
+  const ranges: Array<[number, number, number, number]> = [];
+  tr.mapping.maps[0].forEach((oldFrom, oldTo, newFrom, newTo) => {
+    ranges.push([oldFrom, oldTo, newFrom, newTo]);
+  });
+  if (ranges.length !== 1) return null;
+
+  const [oldFrom, oldTo, newFrom, newTo] = ranges[0];
+  const previous = buildPlainTextProjection(tr.before);
+  const next = buildPlainTextProjection(tr.doc);
+  return {
+    oldFrom: previous.mapPMToTextOffset(oldFrom),
+    oldTo: previous.mapPMToTextOffset(oldTo),
+    newFrom: next.mapPMToTextOffset(newFrom),
+    newTo: next.mapPMToTextOffset(newTo),
+  };
+}
 
 export function buildPreviewUpdate(
   doc: ProseMirrorNode,
   selectionAnchor: number,
+  transaction?: Transaction,
 ) {
   const projection = buildPlainTextProjection(doc);
   const plainText = projection.text;
@@ -20,5 +48,6 @@ export function buildPreviewUpdate(
     cursor: projection.mapPMToTextOffset(selectionAnchor),
     linkPreviewContent: [plainText, ...hrefs].join("\n"),
     text: plainText,
+    textChange: transaction ? projectTransactionTextChange(transaction) : null,
   };
 }

--- a/desktop/src/features/messages/lib/mentionCandidates.ts
+++ b/desktop/src/features/messages/lib/mentionCandidates.ts
@@ -57,22 +57,6 @@ export function mentionCandidateLabel(candidate: MentionCandidate) {
   );
 }
 
-export function globalSearchIdentityKey(candidate: MentionCandidate) {
-  if (
-    !candidate.isGlobalSearchResult ||
-    candidate.isMember ||
-    candidate.isAgent
-  ) {
-    return null;
-  }
-
-  const label = candidate.displayName?.trim().toLowerCase();
-  if (!label) return null;
-
-  const secondaryLabel = candidate.secondaryLabel?.trim().toLowerCase() ?? "";
-  return `global-person:${label}:${secondaryLabel}`;
-}
-
 function findTeamMemberTarget(
   persona: AgentPersona,
   candidates: readonly MentionCandidate[],

--- a/desktop/src/features/messages/lib/mentionIdentityRefs.test.mjs
+++ b/desktop/src/features/messages/lib/mentionIdentityRefs.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  collectOccurrenceManagedNames,
+  isOccurrenceManagedName,
+  reconcileMentionIdentityRefs,
+  restoreMentionIdentityRefs,
+  snapshotMentionIdentityRefs,
+} from "./mentionIdentityRefs.ts";
+
+const FIRST = "1".repeat(64);
+const SECOND = "2".repeat(64);
+const refs = [
+  { displayName: "Will", pubkey: FIRST, isAgent: false, offset: 0 },
+  { displayName: "Will", pubkey: SECOND, isAgent: true, offset: 10 },
+];
+
+test("deleting either same-name occurrence retains only the other identity", () => {
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(refs, "@Will and @Will", "and @Will"),
+    [{ ...refs[1], offset: 4 }],
+  );
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(refs, "@Will and @Will", "@Will and "),
+    [refs[0]],
+  );
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(refs, "@Will and @Will", "@Will and ", {
+      oldFrom: 10,
+      oldTo: 15,
+      newFrom: 10,
+      newTo: 10,
+    }),
+    [refs[0]],
+  );
+});
+
+test("editing before same-name mentions rebases both occurrences", () => {
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(
+      refs,
+      "@Will and @Will",
+      "hey @Will and @Will",
+    ),
+    [
+      { ...refs[0], offset: 4 },
+      { ...refs[1], offset: 14 },
+    ],
+  );
+});
+
+test("autocomplete replacement retains its pre-registered identity", () => {
+  const autocompleteRef = { ...refs[0], offset: 0, id: "autocomplete-1" };
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(
+      [autocompleteRef],
+      "@Wi",
+      "@Will ",
+      {
+        oldFrom: 0,
+        oldTo: 3,
+        newFrom: 0,
+        newTo: 6,
+      },
+      new Set([autocompleteRef.id]),
+    ),
+    [autocompleteRef],
+  );
+});
+
+test("editing inside a mention drops only the intersected identity", () => {
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(refs, "@Will and @Will", "@Wills and @Will"),
+    [{ ...refs[1], offset: 11 }],
+  );
+});
+
+test("unprojectable editor updates fail closed at unchanged offsets", () => {
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(
+      refs,
+      "@Will and @Will",
+      "x @Will and @Will",
+      null,
+    ),
+    [],
+  );
+});
+
+test("invalid supplied ranges drop identities", () => {
+  assert.deepEqual(
+    reconcileMentionIdentityRefs(refs, "@Will and @Will", "@Will and @Will!", {
+      oldFrom: -1,
+      oldTo: 0,
+      newFrom: 0,
+      newTo: 1,
+    }),
+    [],
+  );
+});
+
+test("restoration uses persisted offsets when one duplicate occurrence was removed", () => {
+  const persisted = snapshotMentionIdentityRefs(refs);
+  assert.deepEqual(restoreMentionIdentityRefs("@Will and ", persisted), [
+    refs[0],
+  ]);
+});
+
+test("restoration drops explicit stale offsets instead of reassigning identity", () => {
+  assert.deepEqual(
+    restoreMentionIdentityRefs("@Will", [{ ...refs[1], offset: 10 }]),
+    [],
+  );
+});
+
+test("restored names stay occurrence-managed after explicit offsets go stale", () => {
+  const managedNames = collectOccurrenceManagedNames([
+    { ...refs[1], offset: 10 },
+  ]);
+
+  assert.equal(isOccurrenceManagedName("Will", managedNames), true);
+  assert.equal(isOccurrenceManagedName("will", managedNames), true);
+  assert.equal(isOccurrenceManagedName("Alice", managedNames), false);
+});
+
+test("legacy refs without offsets restore same-name identities in order", () => {
+  assert.deepEqual(
+    restoreMentionIdentityRefs(
+      "@Will and @Will",
+      refs.map(({ offset: _offset, ...ref }) => ref),
+    ),
+    refs,
+  );
+});
+
+test("draft refs restore same-name identities and agent flags in occurrence order", () => {
+  const persisted = snapshotMentionIdentityRefs(refs);
+  assert.deepEqual(
+    persisted.map(({ offset: _offset, ...ref }) => ref),
+    [
+      { displayName: "Will", pubkey: FIRST, isAgent: false },
+      { displayName: "Will", pubkey: SECOND, isAgent: true },
+    ],
+  );
+  assert.deepEqual(
+    restoreMentionIdentityRefs("@Will and @Will", persisted),
+    refs,
+  );
+});

--- a/desktop/src/features/messages/lib/mentionIdentityRefs.ts
+++ b/desktop/src/features/messages/lib/mentionIdentityRefs.ts
@@ -1,0 +1,202 @@
+import { getMentionOffsets } from "./hasMention";
+import type { DraftMentionRef } from "./useDrafts";
+
+export type MentionTextChange = {
+  oldFrom: number;
+  oldTo: number;
+  newFrom: number;
+  newTo: number;
+};
+
+export type MentionIdentityRef = DraftMentionRef & {
+  offset: number;
+  /** Ephemeral selection token; never persisted with a draft/edit snapshot. */
+  id?: string;
+};
+
+export function collectOccurrenceManagedNames(
+  refs: readonly DraftMentionRef[],
+): Set<string> {
+  return new Set(
+    refs.map((ref) => ref.displayName.trim().toLowerCase()).filter(Boolean),
+  );
+}
+
+export function isOccurrenceManagedName(
+  displayName: string | null | undefined,
+  managedNames: ReadonlySet<string>,
+): boolean {
+  return Boolean(
+    displayName && managedNames.has(displayName.trim().toLowerCase()),
+  );
+}
+
+function inferSingleTextChange(
+  previousText: string,
+  nextText: string,
+): MentionTextChange {
+  let prefix = 0;
+  const maxPrefix = Math.min(previousText.length, nextText.length);
+  while (
+    prefix < maxPrefix &&
+    previousText.charCodeAt(prefix) === nextText.charCodeAt(prefix)
+  ) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+  const maxSuffix = Math.min(
+    previousText.length - prefix,
+    nextText.length - prefix,
+  );
+  while (
+    suffix < maxSuffix &&
+    previousText.charCodeAt(previousText.length - 1 - suffix) ===
+      nextText.charCodeAt(nextText.length - 1 - suffix)
+  ) {
+    suffix += 1;
+  }
+
+  return {
+    oldFrom: prefix,
+    oldTo: previousText.length - suffix,
+    newFrom: prefix,
+    newTo: nextText.length - suffix,
+  };
+}
+
+function isMentionAt(text: string, ref: MentionIdentityRef): boolean {
+  return getMentionOffsets(text, ref.displayName).includes(ref.offset);
+}
+
+function isValidChange(
+  change: MentionTextChange,
+  previousText: string,
+  nextText: string,
+): boolean {
+  return (
+    Number.isInteger(change.oldFrom) &&
+    Number.isInteger(change.oldTo) &&
+    Number.isInteger(change.newFrom) &&
+    Number.isInteger(change.newTo) &&
+    change.oldFrom >= 0 &&
+    change.oldFrom <= change.oldTo &&
+    change.oldTo <= previousText.length &&
+    change.newFrom >= 0 &&
+    change.newFrom <= change.newTo &&
+    change.newTo <= nextText.length
+  );
+}
+
+/**
+ * Rebase occurrence-bound mention identities through one editor update.
+ * An edit intersecting a token drops that identity; edits before it shift it.
+ * A `null` change means the editor update could not be projected safely, so
+ * only identities that remain at their exact offsets survive.
+ */
+export function reconcileMentionIdentityRefs(
+  refs: readonly MentionIdentityRef[],
+  previousText: string,
+  nextText: string,
+  suppliedChange?: MentionTextChange | null,
+  allowedOverlappingIds: ReadonlySet<string> = new Set(),
+): MentionIdentityRef[] {
+  if (refs.length === 0) return [];
+  if (previousText === nextText) return [...refs];
+  if (suppliedChange === null) {
+    return refs.filter((ref) => isMentionAt(nextText, ref));
+  }
+
+  const change =
+    suppliedChange ?? inferSingleTextChange(previousText, nextText);
+  if (!isValidChange(change, previousText, nextText)) return [];
+
+  const oldRemovedLength = change.oldTo - change.oldFrom;
+  const insertedLength = change.newTo - change.newFrom;
+  const delta = insertedLength - oldRemovedLength;
+
+  return refs
+    .flatMap((ref) => {
+      const tokenEnd = ref.offset + 1 + ref.displayName.length;
+      let offset = ref.offset;
+
+      if (oldRemovedLength === 0) {
+        if (change.oldFrom <= ref.offset) {
+          offset += delta;
+        } else if (change.oldFrom < tokenEnd) {
+          return [];
+        }
+      } else if (tokenEnd <= change.oldFrom) {
+        // The mention is wholly before the replaced range.
+      } else if (ref.offset >= change.oldTo) {
+        offset += delta;
+      } else if (
+        !ref.id ||
+        !allowedOverlappingIds.has(ref.id) ||
+        !isMentionAt(nextText, ref)
+      ) {
+        return [];
+      }
+
+      const rebased = { ...ref, offset };
+      return isMentionAt(nextText, rebased) ? [rebased] : [];
+    })
+    .sort((left, right) => left.offset - right.offset);
+}
+
+/** Restore persisted refs by assigning same-name identities to occurrences in order. */
+export function restoreMentionIdentityRefs(
+  text: string,
+  refs: readonly DraftMentionRef[],
+): MentionIdentityRef[] {
+  const nextOffsetByName = new Map<string, number>();
+  const offsetsByName = new Map<string, number[]>();
+  const restored: MentionIdentityRef[] = [];
+
+  for (const ref of refs) {
+    const displayName = ref.displayName.trim();
+    const pubkey = ref.pubkey.trim().toLowerCase();
+    if (
+      !displayName ||
+      !pubkey ||
+      (ref.offset !== undefined &&
+        (!Number.isInteger(ref.offset) || ref.offset < 0))
+    ) {
+      continue;
+    }
+
+    const key = displayName.toLowerCase();
+    const offsets =
+      offsetsByName.get(key) ?? getMentionOffsets(text, displayName);
+    offsetsByName.set(key, offsets);
+    const persistedOffset = ref.offset;
+    const offset =
+      persistedOffset !== undefined
+        ? offsets.includes(persistedOffset)
+          ? persistedOffset
+          : undefined
+        : offsets[nextOffsetByName.get(key) ?? 0];
+    if (offset === undefined) continue;
+
+    nextOffsetByName.set(
+      key,
+      Math.max(nextOffsetByName.get(key) ?? 0, offsets.indexOf(offset) + 1),
+    );
+    restored.push({ ...ref, displayName, pubkey, offset });
+  }
+
+  return restored.sort((left, right) => left.offset - right.offset);
+}
+
+export function snapshotMentionIdentityRefs(
+  refs: readonly MentionIdentityRef[],
+): DraftMentionRef[] {
+  return [...refs]
+    .sort((left, right) => left.offset - right.offset)
+    .map(({ displayName, pubkey, isAgent, offset }) => ({
+      displayName,
+      pubkey: pubkey.toLowerCase(),
+      isAgent,
+      offset,
+    }));
+}

--- a/desktop/src/features/messages/lib/useDraftMentionRouting.ts
+++ b/desktop/src/features/messages/lib/useDraftMentionRouting.ts
@@ -1,6 +1,13 @@
 import * as React from "react";
 
 import type { DraftMentionRef } from "./useDrafts";
+import {
+  collectOccurrenceManagedNames,
+  isOccurrenceManagedName,
+  restoreMentionIdentityRefs,
+  snapshotMentionIdentityRefs,
+  type MentionIdentityRef,
+} from "./mentionIdentityRefs";
 
 import { trimMapToSize } from "@/shared/lib/trimMapToSize";
 import {
@@ -10,6 +17,9 @@ import {
 
 export function useDraftMentionRouting(params: {
   mentionMapRef: React.MutableRefObject<Map<string, string>>;
+  mentionIdentityRefsRef: React.MutableRefObject<MentionIdentityRef[]>;
+  occurrenceManagedNamesRef: React.MutableRefObject<Set<string>>;
+  mentionTextRef: React.MutableRefObject<string>;
   personaMentionMapRef: React.MutableRefObject<Map<string, string>>;
   selectedAgentNamesRef: React.MutableRefObject<string[]>;
   cancelAutocomplete: () => void;
@@ -17,20 +27,57 @@ export function useDraftMentionRouting(params: {
   setSelectedAgentNames: (names: string[]) => void;
 }): {
   getDraftMentionRefs: (content: string) => DraftMentionRef[];
-  restoreDraftMentionRefs: (refs: readonly DraftMentionRef[]) => void;
+  restoreDraftMentionRefs: (
+    refs: readonly DraftMentionRef[],
+    content?: string,
+  ) => void;
 } {
   const getDraftMentionRefs = React.useCallback(
-    (content: string) =>
-      snapshotDraftMentionRefs(
-        content,
-        params.mentionMapRef.current,
-        params.selectedAgentNamesRef.current,
-      ),
-    [params.mentionMapRef, params.selectedAgentNamesRef],
+    (content: string) => {
+      const occurrenceRefs = snapshotMentionIdentityRefs(
+        params.mentionIdentityRefsRef.current,
+      );
+      const occurrencePubkeys = new Set(
+        occurrenceRefs.map((ref) => ref.pubkey.toLowerCase()),
+      );
+      const occurrenceNames = new Set([
+        ...params.occurrenceManagedNamesRef.current,
+        ...occurrenceRefs.map((ref) => ref.displayName.trim().toLowerCase()),
+      ]);
+      return [
+        ...occurrenceRefs,
+        ...snapshotDraftMentionRefs(
+          content,
+          params.mentionMapRef.current,
+          params.selectedAgentNamesRef.current,
+        ).filter(
+          (ref) =>
+            !occurrencePubkeys.has(ref.pubkey.toLowerCase()) &&
+            !isOccurrenceManagedName(ref.displayName, occurrenceNames),
+        ),
+      ];
+    },
+    [
+      params.mentionIdentityRefsRef,
+      params.mentionMapRef,
+      params.occurrenceManagedNamesRef,
+      params.selectedAgentNamesRef,
+    ],
   );
   const restoreDraftMentionRefs = React.useCallback(
-    (refs: readonly DraftMentionRef[]) => {
+    (refs: readonly DraftMentionRef[], content?: string) => {
       params.cancelAutocomplete();
+      if (refs.length === 0 && content === undefined) {
+        params.mentionTextRef.current = "";
+      } else if (content !== undefined) {
+        params.mentionTextRef.current = content;
+      }
+      params.occurrenceManagedNamesRef.current =
+        collectOccurrenceManagedNames(refs);
+      params.mentionIdentityRefsRef.current = restoreMentionIdentityRefs(
+        params.mentionTextRef.current,
+        refs,
+      ).map(({ id: _id, ...ref }) => ref);
       const { names, agentNames } = replaceWithDraftMentionRefs(
         refs,
         params.mentionMapRef.current,

--- a/desktop/src/features/messages/lib/useDrafts.ts
+++ b/desktop/src/features/messages/lib/useDrafts.ts
@@ -44,6 +44,8 @@ export type DraftMentionRef = {
   displayName: string;
   pubkey: string;
   isAgent: boolean;
+  /** Plain-text offset for exact same-name occurrence restoration. */
+  offset?: number;
 };
 
 export type DraftState = {
@@ -234,7 +236,9 @@ function isValidDraftState(v: unknown): v is DraftState {
         ref.displayName.trim().length === 0 ||
         typeof ref.pubkey !== "string" ||
         ref.pubkey.trim().length === 0 ||
-        typeof ref.isAgent !== "boolean",
+        typeof ref.isAgent !== "boolean" ||
+        (ref.offset !== undefined &&
+          (!Number.isInteger(ref.offset) || ref.offset < 0)),
     )
   ) {
     return false;
@@ -361,7 +365,8 @@ function draftStatesEqual(a: DraftState, b: DraftState): boolean {
     if (
       ar.displayName !== br.displayName ||
       ar.pubkey !== br.pubkey ||
-      ar.isAgent !== br.isAgent
+      ar.isAgent !== br.isAgent ||
+      ar.offset !== br.offset
     ) {
       return false;
     }

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -13,7 +13,6 @@ import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomplete";
 import {
   coalesceAgentAutocompleteCandidates,
-  coalesceAutocompleteCandidatesByKey,
   filterAdmittedMentionPubkeys,
   filterCachedAgentSuggestions,
   getAdmittedAgentPubkeys,
@@ -53,7 +52,6 @@ import {
   formatSearchUserDisplayName,
   formatSearchUserSecondaryLabel,
   formatTeamMention,
-  globalSearchIdentityKey,
   type MentionCandidate,
   mentionCandidateLabel,
 } from "./mentionCandidates";
@@ -393,10 +391,7 @@ export function useMentions(
       }))
       .filter((candidate) => candidate.displayName.trim().length > 0);
     return coalesceAgentAutocompleteCandidates(
-      coalesceAutocompleteCandidatesByKey(
-        [...candidatesByPubkey.values(), ...personaCandidates],
-        globalSearchIdentityKey,
-      ),
+      [...candidatesByPubkey.values(), ...personaCandidates],
       {
         currentPubkey,
         getLabel: mentionCandidateLabel,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -30,6 +30,12 @@ import {
 } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { AutocompleteEdit } from "./useRichTextEditor";
+import {
+  isOccurrenceManagedName,
+  reconcileMentionIdentityRefs,
+  type MentionIdentityRef,
+  type MentionTextChange,
+} from "./mentionIdentityRefs";
 import type {
   AgentPersona,
   ChannelMember,
@@ -80,6 +86,12 @@ export function useMentions(
     React.useState<string[]>([]);
   const selectedAgentMentionNamesRef = React.useRef<string[]>([]);
   const selectedAgentMentionPubkeysRef = React.useRef<Set<string>>(new Set());
+  const mentionIdentityRefsRef = React.useRef<MentionIdentityRef[]>([]);
+  const occurrenceManagedNamesRef = React.useRef<Set<string>>(new Set());
+  const pendingMentionIdentityIdsRef = React.useRef<Set<string>>(new Set());
+  const pendingMentionReplacementChangeRef =
+    React.useRef<MentionTextChange | null>(null);
+  const mentionTextRef = React.useRef("");
   selectedAgentMentionNamesRef.current = selectedAgentMentionNames;
   const mentionMapRef = React.useRef<Map<string, string>>(new Map());
   const personaMentionMapRef = React.useRef<Map<string, string>>(new Map());
@@ -603,17 +615,44 @@ export function useMentions(
       const insertText = teamMembers
         ? formatTeamMention(displayName, teamMembers)
         : `@${displayName} `;
+      const startIndex =
+        flushedMentionStartIndexRef.current ?? mentionStartIndex;
+      flushedMentionStartIndexRef.current = null;
 
       const mentions = mentionMapRef.current;
       const personaMentions = personaMentionMapRef.current;
       const selectedMentions = teamMembers ?? [suggestion];
+      let nextOccurrenceOffset = teamMembers ? insertText.indexOf("@") : 0;
       for (const selected of selectedMentions) {
+        const selectedOffset = teamMembers
+          ? insertText.indexOf(`@${selected.displayName}`, nextOccurrenceOffset)
+          : 0;
+        const offset = startIndex + Math.max(selectedOffset, 0);
+        if (teamMembers) {
+          nextOccurrenceOffset =
+            selectedOffset + selected.displayName.length + 1;
+        }
         if (selected.kind === "persona" && selected.personaId) {
           personaMentions.set(selected.displayName, selected.personaId);
           mentions.delete(selected.displayName);
         } else if (selected.pubkey) {
           mentions.set(selected.displayName, selected.pubkey);
           personaMentions.delete(selected.displayName);
+          const normalizedName = selected.displayName.trim().toLowerCase();
+          occurrenceManagedNamesRef.current.add(normalizedName);
+          const normalizedPubkey = normalizePubkey(selected.pubkey);
+          const id = crypto.randomUUID();
+          pendingMentionIdentityIdsRef.current.add(id);
+          mentionIdentityRefsRef.current.push({
+            id,
+            displayName: selected.displayName,
+            pubkey: normalizedPubkey,
+            isAgent:
+              suggestion.kind === "team" ||
+              suggestion.isAgent === true ||
+              knownAgentPubkeys.has(normalizedPubkey),
+            offset,
+          });
         }
       }
       setSelectedMentionNames((current) => {
@@ -654,10 +693,13 @@ export function useMentions(
       trimMapToSize(personaMentions, 200);
       setMentionQuery(null);
       setMentionSelectedIndex(0);
+      pendingMentionReplacementChangeRef.current = {
+        oldFrom: startIndex,
+        oldTo: selectionEnd,
+        newFrom: startIndex,
+        newTo: startIndex + insertText.length,
+      };
 
-      const startIndex =
-        flushedMentionStartIndexRef.current ?? mentionStartIndex;
-      flushedMentionStartIndexRef.current = null;
       return {
         replaceFromOffset: startIndex,
         replaceToOffset: selectionEnd,
@@ -668,21 +710,47 @@ export function useMentions(
   );
 
   const registerMentionPubkey = React.useCallback(
-    (displayName: string, pubkey: string, options?: { isAgent?: boolean }) => {
+    (
+      displayName: string,
+      pubkey: string,
+      options?: { isAgent?: boolean; offset?: number },
+    ) => {
       const trimmedName = displayName.trim();
       if (!trimmedName) {
         return;
       }
 
-      mentionMapRef.current.set(trimmedName, pubkey);
+      const normalizedPubkey = normalizePubkey(pubkey);
+      if (options?.offset !== undefined) {
+        occurrenceManagedNamesRef.current.add(trimmedName.toLowerCase());
+      }
+      const existingIdentity = mentionIdentityRefsRef.current.find(
+        (ref) =>
+          ref.offset === options?.offset &&
+          ref.displayName.toLowerCase() === trimmedName.toLowerCase() &&
+          ref.pubkey === normalizedPubkey,
+      );
+      mentionMapRef.current.set(trimmedName, normalizedPubkey);
       personaMentionMapRef.current.delete(trimmedName);
       trimMapToSize(mentionMapRef.current, 200);
+      if (options?.offset !== undefined && !existingIdentity) {
+        const id = crypto.randomUUID();
+        pendingMentionIdentityIdsRef.current.add(id);
+        mentionIdentityRefsRef.current.push({
+          id,
+          displayName: trimmedName,
+          pubkey: normalizedPubkey,
+          isAgent: options.isAgent === true,
+          offset: options.offset,
+        });
+      }
 
       setSelectedMentionNames((current) =>
         appendUniqueName(current, trimmedName),
       );
 
       if (options?.isAgent) {
+        selectedAgentMentionPubkeysRef.current.add(normalizedPubkey);
         setSelectedAgentMentionNames((current) => {
           const next = appendUniqueName(current, trimmedName);
           selectedAgentMentionNamesRef.current = next;
@@ -707,11 +775,21 @@ export function useMentions(
       replaceToOffset: number;
       isAgent?: boolean;
     }): AutocompleteEdit => {
-      registerMentionPubkey(displayName, pubkey, { isAgent });
+      const insertText = `@${displayName.trim()} `;
+      registerMentionPubkey(displayName, pubkey, {
+        isAgent,
+        offset: replaceFromOffset,
+      });
+      pendingMentionReplacementChangeRef.current = {
+        oldFrom: replaceFromOffset,
+        oldTo: replaceToOffset,
+        newFrom: replaceFromOffset,
+        newTo: replaceFromOffset + insertText.length,
+      };
       return {
         replaceFromOffset,
         replaceToOffset,
-        insertText: `@${displayName.trim()} `,
+        insertText,
       };
     },
     [registerMentionPubkey],
@@ -779,16 +857,49 @@ export function useMentions(
     [],
   );
 
+  const reconcileMentionIdentities = React.useCallback(
+    (text: string, textChange?: MentionTextChange | null) => {
+      const effectiveTextChange =
+        pendingMentionIdentityIdsRef.current.size > 0
+          ? pendingMentionReplacementChangeRef.current
+          : textChange;
+      mentionIdentityRefsRef.current = reconcileMentionIdentityRefs(
+        mentionIdentityRefsRef.current,
+        mentionTextRef.current,
+        text,
+        effectiveTextChange,
+        pendingMentionIdentityIdsRef.current,
+      );
+      pendingMentionIdentityIdsRef.current.clear();
+      pendingMentionReplacementChangeRef.current = null;
+      mentionTextRef.current = text;
+    },
+    [],
+  );
+
   const extractMentionPubkeysForCurrentMentions = React.useCallback(
     (text: string): string[] => {
+      reconcileMentionIdentities(text);
+      const occurrencePubkeys = mentionIdentityRefsRef.current.map(
+        (ref) => ref.pubkey,
+      );
+      const occurrenceNames = occurrenceManagedNamesRef.current;
       const extracted = extractMentionPubkeys({
         text,
-        selectedMentions: mentionMapRef.current,
+        selectedMentions: new Map(
+          [...mentionMapRef.current].filter(
+            ([displayName]) =>
+              !isOccurrenceManagedName(displayName, occurrenceNames),
+          ),
+        ),
         selectedDisplayNames: personaMentionMapRef.current.keys(),
-        memberCandidates: mentionCandidates,
+        memberCandidates: mentionCandidates.filter(
+          (candidate) =>
+            !isOccurrenceManagedName(candidate.displayName, occurrenceNames),
+        ),
       });
       return filterAdmittedMentionPubkeys(
-        extracted,
+        [...occurrencePubkeys, ...extracted],
         new Set([
           ...agentIdentityPubkeys,
           ...selectedAgentMentionPubkeysRef.current,
@@ -796,7 +907,12 @@ export function useMentions(
         admittedAgentPubkeys,
       );
     },
-    [admittedAgentPubkeys, agentIdentityPubkeys, mentionCandidates],
+    [
+      admittedAgentPubkeys,
+      agentIdentityPubkeys,
+      mentionCandidates,
+      reconcileMentionIdentities,
+    ],
   );
   const getSelectedAgentPubkeys = React.useRef(
     () => selectedAgentMentionPubkeysRef.current,
@@ -850,6 +966,11 @@ export function useMentions(
     cancelMentionAutocomplete();
     mentionMapRef.current.clear();
     personaMentionMapRef.current.clear();
+    mentionIdentityRefsRef.current = [];
+    occurrenceManagedNamesRef.current.clear();
+    pendingMentionIdentityIdsRef.current.clear();
+    pendingMentionReplacementChangeRef.current = null;
+    mentionTextRef.current = "";
     selectedAgentMentionNamesRef.current = [];
     selectedAgentMentionPubkeysRef.current.clear();
     setSelectedMentionNames([]);
@@ -859,6 +980,9 @@ export function useMentions(
   const { getDraftMentionRefs, restoreDraftMentionRefs } =
     useDraftMentionRouting({
       mentionMapRef,
+      mentionIdentityRefsRef,
+      occurrenceManagedNamesRef,
+      mentionTextRef,
       personaMentionMapRef,
       selectedAgentNamesRef: selectedAgentMentionNamesRef,
       cancelAutocomplete: cancelMentionAutocomplete,
@@ -955,6 +1079,7 @@ export function useMentions(
     extractMentionPersonas,
     extractMentionPubkeys: extractMentionPubkeysForCurrentMentions,
     revalidateMentionPubkeys,
+    reconcileMentionIdentities,
     getDraftMentionRefs,
     getMentionDisplayName,
     handleMentionKeyDown,

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -636,13 +636,17 @@ export function useRichTextEditor({
           return handler();
         },
       },
-      onUpdate: ({ editor: ed }) => {
+      onUpdate: ({ editor: ed, transaction }) => {
         // Keep the hot typing path lightweight. Markdown serialization is
         // still available through `getMarkdown()` for send/draft boundaries;
         // per-keystroke consumers only need textarea-shaped plain text for
         // autocomplete and empty/non-empty state.
         onUpdateRef.current?.(
-          buildPreviewUpdate(ed.state.doc, ed.state.selection.anchor),
+          buildPreviewUpdate(
+            ed.state.doc,
+            ed.state.selection.anchor,
+            transaction,
+          ),
         );
       },
     },

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -93,6 +93,7 @@ function MessageComposerImpl({
   typingParentEventId = null,
   typingRootEventId = null,
 }: MessageComposerProps) {
+  const plainTextRef = React.useRef("");
   const {
     contentRef,
     isContentEmpty,
@@ -181,6 +182,7 @@ function MessageComposerImpl({
       setComposerContent(content);
       richText.setContent(content);
     },
+    getMentionText: () => richText.getPlainTextAndCursor().text,
     clearContent: () => {
       setComposerContent("");
       richText.clearContent();
@@ -266,9 +268,11 @@ function MessageComposerImpl({
     onEditLink: (info) => onEditLinkRef.current?.(info),
     onLinkSelectionChange: (info) => onLinkSelectionChangeRef.current?.(info),
     onLinkShortcut: () => onLinkShortcutRef.current?.() ?? false,
-    onUpdate: ({ cursor, linkPreviewContent, text }) => {
+    onUpdate: ({ cursor, linkPreviewContent, text, textChange }) => {
+      plainTextRef.current = text;
       setComposerContentFromText(text);
       setPreviewContent(linkPreviewContent);
+      mentions.reconcileMentionIdentities(text, textChange);
       mentions.updateMentionQuery(text, cursor);
       channelLinks.updateChannelQuery(text, cursor);
       emojiAutocomplete.updateEmojiQuery(text, cursor);
@@ -361,7 +365,12 @@ function MessageComposerImpl({
       richText.setContent(editableBody);
       // Seed pending imeta with removable originals before saving the edit.
       // New attachments can then be added through the same row.
-      mentions.restoreDraftMentionRefs(editTarget.mentionRefs ?? []);
+      mentions.restoreDraftMentionRefs(
+        (editTarget.mentionRefs ?? []).map(
+          ({ offset: _offset, ...ref }) => ref,
+        ),
+        richText.getPlainTextAndCursor().text,
+      );
       media.setPendingImeta(editableImeta);
       media.clearQueuedAttachments();
       setSpoileredAttachmentUrls(
@@ -520,9 +529,9 @@ function MessageComposerImpl({
         content: trimmed,
         editTargetId: editTargetRef.current.id,
         customEmoji,
-        originalContent: editTargetRef.current.body,
         ownerPubkey: ownerPubkeyRef.current,
         editTarget: editTargetRef.current,
+        mentionText: plainTextRef.current.trim(),
         getMentionRefs: mentions.getDraftMentionRefs,
         pendingImeta: media.pendingImetaRef.current,
         queuedAttachments: media.queuedAttachmentsRef.current,
@@ -590,6 +599,7 @@ function MessageComposerImpl({
       await mentionSendFlow.sendMessageWithMentionFlow({
         capturedChannelId: channelId,
         capturedThreadContext,
+        mentionText: plainTextRef.current.trim(),
         pendingImeta: currentPendingImeta,
         queuedAttachments: currentQueuedAttachments,
         linkPreviewTags: preparedLinkPreviews ? [] : getReadyLinkPreviewTags(),

--- a/desktop/src/features/messages/ui/submitMessageEdit.test.mjs
+++ b/desktop/src/features/messages/ui/submitMessageEdit.test.mjs
@@ -9,21 +9,23 @@ function baseOptions(
   save,
   {
     content = "hello @Missing User",
+    mentionText = content,
     editTarget = {
       mentionRefs: [],
       unresolvedMentionPubkeys: [UNRESOLVED_USER],
     },
+    getMentionRefs = () => [],
   } = {},
 ) {
   return {
     clearComposer: () => {},
     content,
+    mentionText,
     customEmoji: [],
     editTarget,
     editTargetId: "event-id",
     extractMentionPubkeys: () => [],
-    getMentionRefs: () => [],
-    originalContent: content,
+    getMentionRefs,
     ownerPubkey: "a".repeat(64),
     pendingImeta: [],
     queuedAttachments: [],
@@ -71,6 +73,7 @@ test("edit save uses edit-target refs that resolve after edit-open", async () =>
           mentionRefs: [resolvedRef],
           unresolvedMentionPubkeys: [],
         },
+        getMentionRefs: () => [resolvedRef],
       },
     ),
   );
@@ -78,6 +81,57 @@ test("edit save uses edit-target refs that resolve after edit-open", async () =>
   assert.deepEqual(saved, {
     content: "hello @Missing User",
     tags: [["mention", UNRESOLVED_USER]],
+    mentionPubkeys: [],
+    eventId: "event-id",
+  });
+});
+
+test("edit save drops a stale duplicate-name identity without legacy fallback", async () => {
+  const first = "1".repeat(64);
+  const staleLastSelected = "2".repeat(64);
+  let saved;
+
+  await submitMessageEdit({
+    ...baseOptions(
+      async (content, tags, mentionPubkeys, eventId) => {
+        saved = { content, tags, mentionPubkeys, eventId };
+      },
+      {
+        content: "@Will",
+        mentionText: "@Will",
+        editTarget: {
+          mentionRefs: [
+            {
+              displayName: "Will",
+              isAgent: false,
+              offset: 0,
+              pubkey: first,
+            },
+            {
+              displayName: "Will",
+              isAgent: false,
+              offset: 10,
+              pubkey: staleLastSelected,
+            },
+          ],
+          unresolvedMentionPubkeys: [],
+        },
+        getMentionRefs: () => [
+          {
+            displayName: "Will",
+            isAgent: false,
+            offset: 0,
+            pubkey: first,
+          },
+        ],
+      },
+    ),
+    extractMentionPubkeys: () => [first],
+  });
+
+  assert.deepEqual(saved, {
+    content: "@Will",
+    tags: [["mention", first]],
     mentionPubkeys: [],
     eventId: "event-id",
   });
@@ -91,7 +145,11 @@ test("edit save revalidates added mentions immediately before save", async () =>
       calls.push(["save", mentionPubkeys]);
     }),
     content: "hello @Agent",
-    originalContent: "hello",
+    mentionText: "hello @Agent",
+    editTarget: {
+      mentionRefs: [],
+      unresolvedMentionPubkeys: [],
+    },
     extractMentionPubkeys: (content) =>
       content.includes("@Agent") ? [agent] : [],
     revalidateMentionPubkeys: async (pubkeys) => {
@@ -106,6 +164,43 @@ test("edit save revalidates added mentions immediately before save", async () =>
   ]);
 });
 
+test("edit diff extracts current occurrence state once", async () => {
+  const existing = "e".repeat(64);
+  const added = "f".repeat(64);
+  const extracted = [];
+
+  await submitMessageEdit({
+    ...baseOptions(async () => {}),
+    content: "@Will @Will",
+    mentionText: "@Will @Will",
+    editTarget: {
+      mentionRefs: [
+        {
+          displayName: "Will",
+          isAgent: false,
+          offset: 0,
+          pubkey: existing,
+        },
+      ],
+      unresolvedMentionPubkeys: [],
+    },
+    extractMentionPubkeys: (content) => {
+      extracted.push(content);
+      return [existing, added];
+    },
+    getMentionRefs: () => [
+      { displayName: "Will", isAgent: false, offset: 0, pubkey: existing },
+      { displayName: "Will", isAgent: false, offset: 6, pubkey: added },
+    ],
+    revalidateMentionPubkeys: async (pubkeys) => {
+      assert.deepEqual(pubkeys, [added]);
+      return pubkeys;
+    },
+  });
+
+  assert.deepEqual(extracted, ["@Will @Will"]);
+});
+
 test("edit upload pause revalidates revoked mentions only after upload completes", async () => {
   const agent = "d".repeat(64);
   const calls = [];
@@ -115,7 +210,11 @@ test("edit upload pause revalidates revoked mentions only after upload completes
       calls.push(["save", mentionPubkeys]);
     }),
     content: "hello @Agent",
-    originalContent: "hello",
+    mentionText: "hello @Agent",
+    editTarget: {
+      mentionRefs: [],
+      unresolvedMentionPubkeys: [],
+    },
     extractMentionPubkeys: (content) =>
       content.includes("@Agent") ? [agent] : [],
     queuedAttachments: [

--- a/desktop/src/features/messages/ui/submitMessageEdit.ts
+++ b/desktop/src/features/messages/ui/submitMessageEdit.ts
@@ -1,6 +1,5 @@
 import type { QueuedMediaAttachment } from "@/features/messages/lib/backgroundMediaUploadStore";
 import { enqueueBackgroundMediaUpload } from "@/features/messages/lib/backgroundMediaUploadStore";
-import { hasMention } from "@/features/messages/lib/hasMention";
 import type { DraftMentionRef } from "@/features/messages/lib/useDrafts";
 import type { MessageComposerEditTarget } from "@/features/messages/ui/MessageComposer.types";
 import {
@@ -15,6 +14,7 @@ import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
 
 type EditDraft = {
   content: string;
+  mentionText: string;
   mentionRefs: DraftMentionRef[];
   pendingImeta: ImetaMedia[];
   queuedAttachments: QueuedMediaAttachment[];
@@ -24,11 +24,13 @@ type EditDraft = {
 
 type SubmitMessageEditOptions = Omit<
   EditDraft,
-  "mentionRefs" | "unresolvedMentionPubkeys"
+  "mentionText" | "mentionRefs" | "unresolvedMentionPubkeys"
 > & {
   clearComposer: () => void;
   customEmoji: ReadonlyArray<CustomEmoji>;
   extractMentionPubkeys: (content: string) => string[];
+  /** Plain-text projection matching occurrence offsets. */
+  mentionText: string;
   getMentionRefs: (content: string) => DraftMentionRef[];
   editTargetId: string;
   enqueueUpload?: typeof enqueueBackgroundMediaUpload;
@@ -36,10 +38,9 @@ type SubmitMessageEditOptions = Omit<
     MessageComposerEditTarget,
     "mentionRefs" | "unresolvedMentionPubkeys"
   >;
-  originalContent: string;
   ownerPubkey: string | null;
   restoreComposer: (draft: EditDraft) => void;
-  restoreMentionRefs: (refs: DraftMentionRef[]) => void;
+  restoreMentionRefs: (refs: DraftMentionRef[], content?: string) => void;
   revalidateMentionPubkeys: (pubkeys: readonly string[]) => Promise<string[]>;
   shouldRestoreComposer: () => boolean;
   setDeferredUploadPending: (isPending: boolean) => void;
@@ -60,8 +61,8 @@ export async function submitMessageEdit({
   enqueueUpload = enqueueBackgroundMediaUpload,
   editTarget,
   extractMentionPubkeys,
+  mentionText,
   getMentionRefs,
-  originalContent,
   ownerPubkey,
   pendingImeta,
   queuedAttachments,
@@ -74,15 +75,10 @@ export async function submitMessageEdit({
   setUploadError,
   spoileredAttachmentUrls,
 }: SubmitMessageEditOptions): Promise<void> {
-  const currentMentionRefs = editTarget.mentionRefs ?? [];
   const draft: EditDraft = {
     content,
-    mentionRefs: [
-      ...getMentionRefs(content),
-      ...currentMentionRefs.filter((ref) =>
-        hasMention(content, ref.displayName),
-      ),
-    ],
+    mentionText,
+    mentionRefs: getMentionRefs(mentionText),
     pendingImeta: [...pendingImeta],
     queuedAttachments: [...queuedAttachments],
     spoileredAttachmentUrls: new Set(spoileredAttachmentUrls),
@@ -91,12 +87,17 @@ export async function submitMessageEdit({
   const restoreDraft = () => {
     if (shouldRestoreComposer()) {
       restoreComposer(draft);
-      restoreMentionRefs(draft.mentionRefs);
+      restoreMentionRefs(draft.mentionRefs, draft.mentionText);
     }
   };
+  const currentMentionPubkeys = extractMentionPubkeys(mentionText);
+  const originalMentionPubkeys = [
+    ...(editTarget.mentionRefs ?? []).map(({ pubkey }) => pubkey),
+    ...(editTarget.unresolvedMentionPubkeys ?? []),
+  ];
   const addedMentionPubkeys = diffAddedMentionPubkeys(
-    extractMentionPubkeys(originalContent),
-    extractMentionPubkeys(content),
+    originalMentionPubkeys,
+    currentMentionPubkeys,
     ownerPubkey ?? "",
   );
   const hasQueuedAttachments = draft.queuedAttachments.length > 0;

--- a/desktop/src/features/messages/ui/useDraftPersistSnapshot.ts
+++ b/desktop/src/features/messages/ui/useDraftPersistSnapshot.ts
@@ -24,7 +24,10 @@ type UseDraftPersistLifecycleParams = {
   /** Snapshot selected mention identities still present in current content. */
   getMentionRefs: (content: string) => DraftMentionRef[];
   /** Replace mention routing/highlight state when a draft is restored or cleared. */
-  restoreMentionRefs: (refs: readonly DraftMentionRef[]) => void;
+  restoreMentionRefs: (
+    refs: readonly DraftMentionRef[],
+    content?: string,
+  ) => void;
   /** Live `pendingImeta` from React state — used for render-time ref sync. */
   livePendingImeta: ImetaMedia[];
   /** Async setter for pendingImeta — called after the synchronous snapshot. */
@@ -44,6 +47,8 @@ type UseDraftPersistLifecycleParams = {
   takeQueuedAttachmentsForDraft?: (draftKey: string) => QueuedMediaAttachment[];
   /** Set the rich-text editor content from a draft string. */
   setContent: (content: string) => void;
+  /** Called after setContent so the editor's plain projection is current. */
+  getMentionText?: () => string;
   /** Clear the rich-text editor content (no-draft path). */
   clearContent: () => void;
   /** Set the spoilered attachment URLs state. */
@@ -88,6 +93,7 @@ type UseDraftPersistLifecycleParams = {
 export function useDraftPersistLifecycle({
   effectiveDraftKey,
   channelId,
+  getMentionText,
   loadDraft,
   persistDraft,
   getMentionRefs,
@@ -137,7 +143,10 @@ export function useDraftPersistLifecycle({
     const saved = effectiveDraftKey ? loadDraft(effectiveDraftKey) : undefined;
     if (saved) {
       setContent(saved.content);
-      restoreMentionRefs(saved.mentionRefs ?? []);
+      restoreMentionRefs(
+        saved.mentionRefs ?? [],
+        getMentionText?.() ?? saved.content,
+      );
       // Set the persist-snapshot ref SYNCHRONOUSLY before calling the async
       // state setter, so the cleanup closure (which may fire before the state
       // update commits in React StrictMode's simulate-unmount pass) reads the
@@ -167,7 +176,7 @@ export function useDraftPersistLifecycle({
           channelId ?? effectiveDraftKey,
           [...pendingImetaForPersistRef.current],
           [...spoileredAttachmentUrlsRef.current],
-          getMentionRefs(content),
+          getMentionRefs(getMentionText?.() ?? content),
         );
       }
     };

--- a/desktop/src/features/messages/ui/useMentionSendFlow.helpers.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.helpers.ts
@@ -25,6 +25,7 @@ export type PendingNonMemberMentionSend = {
   preparedManagedAgents?: ManagedAgent[];
   readyAgentPubkeys?: string[];
   savedContent: string;
+  savedMentionText: string;
   savedImeta: ImetaMedia[];
   queuedAttachments: QueuedMediaAttachment[];
   savedSpoileredAttachmentUrls: Set<string>;
@@ -46,6 +47,8 @@ export type SendMessageWithMentionFlowInput = {
   sentDraftKey: string | null | undefined;
   recoveryDraftKey: string | null | undefined;
   spoileredAttachmentUrls?: ReadonlySet<string>;
+  /** Plain-text projection matching the occurrence-offset coordinate space. */
+  mentionText: string;
   trimmed: string;
   audienceGeneration?: number;
   audienceRevision?: number | null;

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -541,7 +541,10 @@ export function useMentionSendFlow({
           richText.setContent(draft.savedContent);
           setPendingImeta(draft.savedImeta);
           restoreQueuedAttachments(draft.queuedAttachments);
-          mentions.restoreDraftMentionRefs(draft.savedMentionRefs);
+          mentions.restoreDraftMentionRefs(
+            draft.savedMentionRefs,
+            draft.savedMentionText,
+          );
           setSpoileredAttachmentUrls?.(
             new Set(draft.savedSpoileredAttachmentUrls),
           );
@@ -681,6 +684,7 @@ export function useMentionSendFlow({
     async ({
       capturedChannelId,
       capturedThreadContext = null,
+      mentionText,
       pendingImeta,
       queuedAttachments = [],
       linkPreviewTags = [],
@@ -707,7 +711,7 @@ export function useMentionSendFlow({
       try {
         if (isSendCancelled()) return;
         const dmThreadAgentMentionErrorMessage = dmThreadAgentMentionError({
-          trimmed,
+          trimmed: mentionText,
           isThreadReply: capturedThreadContext != null,
           channelType,
           extractMentionPersonas: mentions.extractMentionPersonas,
@@ -753,7 +757,7 @@ export function useMentionSendFlow({
           createdPersonaAgentPubkeys.map(normalizePubkey),
         );
         const explicitMentionPubkeys = uniqueNormalizedPubkeys([
-          ...mentions.extractMentionPubkeys(trimmed),
+          ...mentions.extractMentionPubkeys(mentionText),
           ...createdPersonaAgentPubkeys,
         ]);
         const explicitAgentPubkeys = explicitMentionPubkeys.filter(
@@ -804,12 +808,13 @@ export function useMentionSendFlow({
               ? []
               : createdPersonaAgentPubkeys,
           savedContent: trimmed,
+          savedMentionText: mentionText,
           savedImeta: [...pendingImeta],
           queuedAttachments: [...queuedAttachments],
           savedSpoileredAttachmentUrls: new Set(spoileredAttachmentUrls),
           sentDraftKey,
           recoveryDraftKey,
-          savedMentionRefs: mentions.getDraftMentionRefs(trimmed),
+          savedMentionRefs: mentions.getDraftMentionRefs(mentionText),
           audienceGeneration,
           audienceRevision,
           explicitAgentPubkeys,

--- a/desktop/src/shared/lib/resolveMentionNames.ts
+++ b/desktop/src/shared/lib/resolveMentionNames.ts
@@ -18,7 +18,7 @@ export function getMentionTagPubkey(tag: string[]): string | null {
  * to a pubkey. Emitting every known alias — display name, kind-0 `name`, and
  * the NIP-05 local part — keeps rendered chips and pubkey resolution in sync.
  */
-function collectProfileAliases(
+export function collectProfileAliases(
   profile: UserProfileSummary | undefined,
 ): string[] {
   if (!profile) {

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -145,8 +145,16 @@ test("selected-people search keeps same-name people independently selectable", a
       },
     ],
     searchProfiles: [
-      { pubkey: firstWillPubkey, displayName: "Will" },
-      { pubkey: secondWillPubkey, displayName: "Will" },
+      {
+        pubkey: firstWillPubkey,
+        displayName: "Will",
+        nip05Handle: "will@example.com",
+      },
+      {
+        pubkey: secondWillPubkey,
+        displayName: "Will",
+        nip05Handle: "will@example.com",
+      },
     ],
   });
   await page.goto("/");
@@ -162,18 +170,52 @@ test("selected-people search keeps same-name people independently selectable", a
     `agent-respond-to-result-${secondWillPubkey}`,
   );
   await expect(firstWill).toContainText("Will");
+  await expect(firstWill).toContainText("will@example.com");
   await expect(firstWill).toContainText("11111111…1111");
   await expect(secondWill).toContainText("Will");
+  await expect(secondWill).toContainText("will@example.com");
   await expect(secondWill).toContainText("22222222…2222");
+  const firstAdd = firstWill.getByRole("button", {
+    name: `Add Will, will@example.com, public key ${firstWillPubkey}`,
+  });
+  const secondAdd = secondWill.getByRole("button", {
+    name: `Add Will, will@example.com, public key ${secondWillPubkey}`,
+  });
+  await expect(firstAdd).toBeVisible();
+  await expect(secondAdd).toBeVisible();
   await page
     .getByTestId("agent-respond-to-allowlist")
     .screenshot({ path: `${SHOTS}/duplicate-will-selected-people.png` });
 
-  await secondWill.click();
+  await secondAdd.focus();
+  await secondAdd.press("Enter");
   await expect(
     page.getByTestId(`agent-respond-to-chip-${secondWillPubkey}`),
   ).toBeVisible();
-  await expect(firstWill).toHaveCount(0);
+  await expect(
+    page.getByTestId(`agent-respond-to-chip-${firstWillPubkey}`),
+  ).toHaveCount(0);
+  await page.getByRole("button", { name: "Save access" }).click();
+  const updateCommand = await page.evaluate(
+    (agentPubkey) =>
+      window.__BUZZ_E2E_COMMAND_LOG__?.findLast(
+        (entry) =>
+          entry.command === "update_managed_agent" &&
+          (entry.payload as { input?: { pubkey?: string } })?.input?.pubkey ===
+            agentPubkey,
+      ),
+    agent.pubkey,
+  );
+  expect(updateCommand?.payload).toMatchObject({
+    input: {
+      pubkey: agent.pubkey,
+      respondTo: "allowlist",
+      respondToAllowlist: [secondWillPubkey],
+    },
+  });
+  expect(updateCommand?.payload).not.toMatchObject({
+    input: { respondToAllowlist: [firstWillPubkey] },
+  });
 });
 
 for (const selectedFirstPageCount of [50, 49]) {

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -165,6 +165,9 @@ test("selected-people search keeps same-name people independently selectable", a
   await expect(firstWill).toContainText("11111111…1111");
   await expect(secondWill).toContainText("Will");
   await expect(secondWill).toContainText("22222222…2222");
+  await page
+    .getByTestId("agent-respond-to-allowlist")
+    .screenshot({ path: `${SHOTS}/duplicate-will-selected-people.png` });
 
   await secondWill.click();
   await expect(
@@ -172,6 +175,56 @@ test("selected-people search keeps same-name people independently selectable", a
   ).toBeVisible();
   await expect(firstWill).toHaveCount(0);
 });
+
+for (const selectedFirstPageCount of [50, 49]) {
+  test(`selected-people search fetches past a ${
+    selectedFirstPageCount === 50 ? "fully filtered" : "non-scrollable"
+  } first page`, async ({ page }) => {
+    const firstPageProfiles = Array.from({ length: 50 }, (_, index) => ({
+      pubkey: (index + 1).toString(16).padStart(64, "0"),
+      displayName: `Will ${String(index).padStart(2, "0")}`,
+    }));
+    const targetPubkey = "f".repeat(64);
+    const agent = TEST_IDENTITIES.charlie;
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: agent.pubkey,
+          name: "Hack Day Helper",
+          status: "running",
+          channelNames: ["general"],
+          respondTo: "allowlist",
+          respondToAllowlist: firstPageProfiles
+            .slice(0, selectedFirstPageCount)
+            .map((profile) => profile.pubkey),
+        },
+      ],
+      searchProfiles: [
+        ...firstPageProfiles,
+        { pubkey: targetPubkey, displayName: "Will Target" },
+      ],
+    });
+    await page.goto("/");
+    await openAgentAccessDialog(page, agent.pubkey);
+
+    await page.getByTestId("agent-respond-to-search").fill("Will");
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() =>
+            (window.__BUZZ_E2E_COMMAND_LOG__ ?? [])
+              .filter((entry) => entry.command === "search_users")
+              .map((entry) => entry.payload),
+          ),
+        { message: "search should request the second result page" },
+      )
+      .toContainEqual(expect.objectContaining({ cursor: "2" }));
+    await expect(
+      page.getByTestId(`agent-respond-to-result-${targetPubkey}`),
+    ).toContainText("Will Target");
+  });
+}
 
 test("full agent editor tightens the exact sidebar agent instance", async ({
   page,

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -268,6 +268,60 @@ for (const selectedFirstPageCount of [50, 49]) {
   });
 }
 
+test("selected-people search refills after paste filters an active page", async ({
+  page,
+}) => {
+  const firstPageProfiles = Array.from({ length: 50 }, (_, index) => ({
+    pubkey: (index + 1).toString(16).padStart(64, "0"),
+    displayName: `Will ${String(index).padStart(2, "0")}`,
+  }));
+  const targetPubkey = "f".repeat(64);
+  const agent = TEST_IDENTITIES.charlie;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Hack Day Helper",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "allowlist",
+        respondToAllowlist: [],
+      },
+    ],
+    searchProfiles: [
+      ...firstPageProfiles,
+      { pubkey: targetPubkey, displayName: "Will Target" },
+    ],
+  });
+  await page.goto("/");
+  await openAgentAccessDialog(page, agent.pubkey);
+  await page.getByTestId("agent-respond-to-search").fill("Will");
+  await expect(
+    page.getByTestId(`agent-respond-to-result-${firstPageProfiles[0].pubkey}`),
+  ).toBeVisible();
+
+  await page.getByTestId("agent-respond-to-toggle-direct").click();
+  await page
+    .getByTestId("agent-respond-to-paste")
+    .fill(firstPageProfiles.map((profile) => profile.pubkey).join("\n"));
+  await page.getByTestId("agent-respond-to-paste-add").click();
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          (window.__BUZZ_E2E_COMMAND_LOG__ ?? [])
+            .filter((entry) => entry.command === "search_users")
+            .map((entry) => entry.payload),
+        ),
+      { message: "filtered active results should request the second page" },
+    )
+    .toContainEqual(expect.objectContaining({ cursor: "2" }));
+  await expect(
+    page.getByTestId(`agent-respond-to-result-${targetPubkey}`),
+  ).toContainText("Will Target");
+});
+
 test("full agent editor tightens the exact sidebar agent instance", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -128,6 +128,51 @@ test("open agent access explains the available access before save", async ({
   await expect(warning).toHaveCount(0);
 });
 
+test("selected-people search keeps same-name people independently selectable", async ({
+  page,
+}) => {
+  const firstWillPubkey = "1".repeat(64);
+  const secondWillPubkey = "2".repeat(64);
+  const agent = TEST_IDENTITIES.charlie;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Hack Day Helper",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+      },
+    ],
+    searchProfiles: [
+      { pubkey: firstWillPubkey, displayName: "Will" },
+      { pubkey: secondWillPubkey, displayName: "Will" },
+    ],
+  });
+  await page.goto("/");
+  await openAgentAccessDialog(page, agent.pubkey);
+
+  await page.getByTestId("agent-respond-to-select").selectOption("allowlist");
+  await page.getByTestId("agent-respond-to-search").fill("Will");
+
+  const firstWill = page.getByTestId(
+    `agent-respond-to-result-${firstWillPubkey}`,
+  );
+  const secondWill = page.getByTestId(
+    `agent-respond-to-result-${secondWillPubkey}`,
+  );
+  await expect(firstWill).toContainText("Will");
+  await expect(firstWill).toContainText("11111111…1111");
+  await expect(secondWill).toContainText("Will");
+  await expect(secondWill).toContainText("22222222…2222");
+
+  await secondWill.click();
+  await expect(
+    page.getByTestId(`agent-respond-to-chip-${secondWillPubkey}`),
+  ).toBeVisible();
+  await expect(firstWill).toHaveCount(0);
+});
+
 test("full agent editor tightens the exact sidebar agent instance", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/inbox-edit.spec.ts
+++ b/desktop/tests/e2e/inbox-edit.spec.ts
@@ -22,6 +22,13 @@ const COLD_SELECTED_ORIGINAL_CONTENT = "Cold Inbox reply original text.";
 const COLD_SELECTED_RETRACTED_CONTENT = "Cold Inbox reply retracted edit text.";
 const COLD_SIBLING_ORIGINAL_CONTENT = "Cold Inbox sibling reply original text.";
 const COLD_SIBLING_EDITED_CONTENT = "Cold Inbox sibling reply edited text.";
+const DUPLICATE_MENTION_MESSAGE_ID = "3d".repeat(32);
+const DROPPED_MENTION_MESSAGE_ID = "4e".repeat(32);
+const DUPLICATE_MENTION_CONTENT = "**@Will** @Will edit lifecycle";
+const DUPLICATE_MENTION_PLAIN_TEXT = "@Will @Will edit lifecycle";
+const DROPPED_MENTION_CONTENT = "@Will @Will drop lifecycle";
+const FIRST_WILL_PUBKEY = "1".repeat(64);
+const SECOND_WILL_PUBKEY = "2".repeat(64);
 const ATTACHMENT_URL = `https://mock.relay/media/${"a".repeat(64)}.pdf`;
 const ATTACHMENT_FILENAME = "inbox-edit-proof.pdf";
 const SHOTS = "test-results/inbox-edit";
@@ -319,6 +326,147 @@ test("editing an immediate attachment reply preserves its media tags", async ({
   await expect(replyRow).toContainText("Attachment reply after editing.");
   await expect(replyRow.getByTestId("file-card")).toContainText(
     ATTACHMENT_FILENAME,
+  );
+});
+
+test("editing duplicate same-name mentions preserves identities and drops a removed occurrence", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    searchProfiles: [
+      { pubkey: FIRST_WILL_PUBKEY, displayName: "Will" },
+      { pubkey: SECOND_WILL_PUBKEY, displayName: "Will" },
+    ],
+  });
+  await page.goto("/");
+  await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+  await page.waitForFunction(
+    () =>
+      typeof (window as MockWindow).__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__ ===
+      "function",
+  );
+
+  await page.evaluate(
+    ({
+      channelId,
+      content,
+      currentPubkey,
+      droppedContent,
+      droppedMessageId,
+      firstWill,
+      messageId,
+      secondWill,
+    }) => {
+      const pushFeedItem = (window as MockWindow)
+        .__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__;
+      if (!pushFeedItem) {
+        throw new Error("Mock feed helper is not installed.");
+      }
+      const createdAt = Math.floor(Date.now() / 1_000);
+      for (const id of [messageId, droppedMessageId]) {
+        pushFeedItem({
+          category: "mention",
+          channel_id: channelId,
+          channel_name: "general",
+          content: id === messageId ? content : droppedContent,
+          created_at: id === messageId ? createdAt : createdAt - 1,
+          id,
+          kind: 9,
+          pubkey: currentPubkey,
+          tags: [
+            ["h", channelId],
+            ["p", firstWill],
+            ["p", secondWill],
+          ],
+        });
+      }
+    },
+    {
+      channelId: GENERAL_CHANNEL_ID,
+      content: DUPLICATE_MENTION_CONTENT,
+      currentPubkey: CURRENT_PUBKEY,
+      droppedContent: DROPPED_MENTION_CONTENT,
+      droppedMessageId: DROPPED_MENTION_MESSAGE_ID,
+      firstWill: FIRST_WILL_PUBKEY,
+      messageId: DUPLICATE_MENTION_MESSAGE_ID,
+      secondWill: SECOND_WILL_PUBKEY,
+    },
+  );
+
+  await page
+    .getByTestId(`home-inbox-item-${DUPLICATE_MENTION_MESSAGE_ID}`)
+    .click();
+  const detail = page.getByTestId("home-inbox-detail");
+  await openMoreActions(page, DUPLICATE_MENTION_MESSAGE_ID);
+  await page
+    .getByTestId(`edit-message-${DUPLICATE_MENTION_MESSAGE_ID}`)
+    .click();
+  await expect(detail.getByTestId("edit-target")).toBeVisible();
+
+  const input = detail.getByTestId("message-input");
+  await expect(input).toHaveText(DUPLICATE_MENTION_PLAIN_TEXT);
+  await input.press("Enter");
+
+  let editPayload = await page.evaluate(() => {
+    const payloads = (window as MockWindow).__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [];
+    return payloads.findLast((entry) => entry.command === "edit_message")
+      ?.payload as
+      | {
+          input?: { mentionPubkeys?: string[]; mentionTags?: string[][] };
+        }
+      | undefined;
+  });
+  expect(editPayload?.input).toEqual(
+    expect.objectContaining({
+      mentionPubkeys: [],
+      mentionTags: [
+        ["mention", FIRST_WILL_PUBKEY],
+        ["mention", SECOND_WILL_PUBKEY],
+      ],
+    }),
+  );
+
+  await page
+    .getByTestId(`home-inbox-item-${DROPPED_MENTION_MESSAGE_ID}`)
+    .click();
+  await openMoreActions(page, DROPPED_MENTION_MESSAGE_ID);
+  await page.getByTestId(`edit-message-${DROPPED_MENTION_MESSAGE_ID}`).click();
+  await expect(input).toHaveText(DROPPED_MENTION_CONTENT);
+  await input.evaluate((element) => {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    const range = document.createRange();
+    let remaining = "@Will ".length;
+    let node = walker.nextNode();
+    if (!node) throw new Error("message input text node was not found");
+    range.setStart(node, 0);
+    while (node && remaining > (node.textContent?.length ?? 0)) {
+      remaining -= node.textContent?.length ?? 0;
+      node = walker.nextNode();
+    }
+    if (!node) throw new Error("first mention range was not found");
+    range.setEnd(node, remaining);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
+  await input.press("Backspace");
+  await expect(input).toHaveText("@Will drop lifecycle");
+  await page.keyboard.press("Enter");
+
+  editPayload = await page.evaluate(() => {
+    const payloads = (window as MockWindow).__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [];
+    return payloads.findLast((entry) => entry.command === "edit_message")
+      ?.payload as
+      | {
+          input?: { mentionPubkeys?: string[]; mentionTags?: string[][] };
+        }
+      | undefined;
+  });
+  expect(editPayload?.input).toEqual(
+    expect.objectContaining({
+      mentionPubkeys: [],
+      mentionTags: [["mention", SECOND_WILL_PUBKEY]],
+    }),
   );
 });
 

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -734,6 +734,76 @@ for (const selectedWill of ["first", "second"] as const) {
   });
 }
 
+test("autocomplete preserves and removes exact same-name identities", async ({
+  page,
+}) => {
+  const firstWillPubkey = "1".repeat(64);
+  const secondWillPubkey = "2".repeat(64);
+  await installMockBridge(page, {
+    searchProfiles: [
+      { pubkey: firstWillPubkey, displayName: "Will" },
+      { pubkey: secondWillPubkey, displayName: "Will" },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@Will");
+  await autocomplete(page)
+    .getByTestId(`mention-suggestion-${firstWillPubkey}`)
+    .click();
+  await page.keyboard.type("@Will");
+  await autocomplete(page)
+    .getByTestId(`mention-suggestion-${secondWillPubkey}`)
+    .click();
+  await page.keyboard.type("hello both");
+
+  const message = "@Will @Will hello both";
+  await expect(input).toHaveText(message);
+  await page.getByTestId("send-message").click();
+  await page.getByRole("button", { name: "Invite" }).click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, message))
+    .toEqual([firstWillPubkey, secondWillPubkey]);
+
+  await input.fill("@Will");
+  await autocomplete(page)
+    .getByTestId(`mention-suggestion-${firstWillPubkey}`)
+    .click();
+  await page.keyboard.type("@Will");
+  await autocomplete(page)
+    .getByTestId(`mention-suggestion-${secondWillPubkey}`)
+    .click();
+  await page.keyboard.type("survivor");
+  await input.evaluate((element) => {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    const range = document.createRange();
+    let remaining = "@Will ".length;
+    let node = walker.nextNode();
+    if (!node) throw new Error("message input text node was not found");
+    range.setStart(node, 0);
+    while (node && remaining > node.textContent.length) {
+      remaining -= node.textContent.length;
+      node = walker.nextNode();
+    }
+    if (!node) throw new Error("first mention range was not found");
+    range.setEnd(node, remaining);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
+  await input.press("Backspace");
+
+  const survivorMessage = "@Will survivor";
+  await expect(input).toHaveText(survivorMessage);
+  await page.getByTestId("send-message").click();
+  await page.getByRole("button", { name: "Invite" }).click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, survivorMessage))
+    .toEqual([secondWillPubkey]);
+});
+
 test("mention autocomplete caps global people search at 50 results", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -686,42 +686,47 @@ test("autocomplete searches global non-member people from the first typed charac
   await expect(tessaRow.getByText("not in channel")).toBeVisible();
 });
 
-test("autocomplete keeps same-name global people independently selectable", async ({
-  page,
-}) => {
-  const firstWillPubkey = "1".repeat(64);
-  const secondWillPubkey = "2".repeat(64);
-  await installMockBridge(page, {
-    searchProfiles: [
-      { pubkey: firstWillPubkey, displayName: "Will" },
-      { pubkey: secondWillPubkey, displayName: "Will" },
-    ],
+for (const selectedWill of ["first", "second"] as const) {
+  test(`autocomplete selects the exact ${selectedWill} same-name global person`, async ({
+    page,
+  }) => {
+    const firstWillPubkey = "1".repeat(64);
+    const secondWillPubkey = "2".repeat(64);
+    const selectedPubkey =
+      selectedWill === "first" ? firstWillPubkey : secondWillPubkey;
+    await installMockBridge(page, {
+      searchProfiles: [
+        { pubkey: firstWillPubkey, displayName: "Will" },
+        { pubkey: secondWillPubkey, displayName: "Will" },
+      ],
+    });
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+
+    await page.getByTestId("message-input").fill("@Will");
+
+    const dropdown = autocomplete(page);
+    const firstWill = dropdown.getByTestId(
+      `mention-suggestion-${firstWillPubkey}`,
+    );
+    const secondWill = dropdown.getByTestId(
+      `mention-suggestion-${secondWillPubkey}`,
+    );
+    await expect(firstWill).toBeVisible();
+    await expect(secondWill).toBeVisible();
+    await expect(dropdown.getByTestId("mention-collision-npub")).toHaveCount(2);
+
+    await dropdown.getByTestId(`mention-suggestion-${selectedPubkey}`).click();
+    await page.keyboard.type(`hello ${selectedWill}`);
+    const message = `@Will hello ${selectedWill}`;
+    await expect(page.getByTestId("message-input")).toHaveText(message);
+    await page.getByTestId("send-message").click();
+    await page.getByRole("button", { name: "Invite" }).click();
+    await expect
+      .poll(() => readOutgoingMentionPubkeys(page, message))
+      .toEqual([selectedPubkey]);
   });
-  await page.goto("/");
-  await page.getByTestId("channel-general").click();
-
-  await page.getByTestId("message-input").fill("@Will");
-
-  const dropdown = autocomplete(page);
-  const firstWill = dropdown.getByTestId(
-    `mention-suggestion-${firstWillPubkey}`,
-  );
-  const secondWill = dropdown.getByTestId(
-    `mention-suggestion-${secondWillPubkey}`,
-  );
-  await expect(firstWill).toBeVisible();
-  await expect(secondWill).toBeVisible();
-  await expect(dropdown.getByTestId("mention-collision-npub")).toHaveCount(2);
-
-  await secondWill.click();
-  await page.keyboard.type("hello");
-  await expect(page.getByTestId("message-input")).toHaveText("@Will hello");
-  await page.getByTestId("send-message").click();
-  await page.getByRole("button", { name: "Invite" }).click();
-  await expect
-    .poll(() => readOutgoingMentionPubkeys(page, "@Will hello"))
-    .toEqual([secondWillPubkey]);
-});
+}
 
 test("mention autocomplete caps global people search at 50 results", async ({
   page,

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -8,6 +8,7 @@ import {
 
 const MOCK_VIEWER_PUBKEY = "deadbeef".repeat(8);
 const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const SHOTS = "test-results/mentions";
 
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
@@ -715,6 +716,11 @@ for (const selectedWill of ["first", "second"] as const) {
     await expect(firstWill).toBeVisible();
     await expect(secondWill).toBeVisible();
     await expect(dropdown.getByTestId("mention-collision-npub")).toHaveCount(2);
+    if (selectedWill === "first") {
+      await dropdown.screenshot({
+        path: `${SHOTS}/duplicate-will-autocomplete.png`,
+      });
+    }
 
     await dropdown.getByTestId(`mention-suggestion-${selectedPubkey}`).click();
     await page.keyboard.type(`hello ${selectedWill}`);

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -2461,33 +2461,6 @@ test("global non-member people can be selected from channel mentions", async ({
   await expect(dropdown.getByText("not in channel")).toBeVisible();
 });
 
-test("duplicate global people with the same visible identity collapse in channel mentions", async ({
-  page,
-}) => {
-  await installMockBridge(page, {
-    searchProfiles: [
-      {
-        pubkey: CASEY_PROFILE_PUBKEY,
-        displayName: "Pip",
-      },
-      {
-        pubkey:
-          "2222222222222222222222222222222222222222222222222222222222222222",
-        displayName: "Pip",
-      },
-    ],
-  });
-  await page.goto("/");
-  await page.getByTestId("channel-general").click();
-  await expect(page.getByTestId("chat-title")).toHaveText("general");
-
-  const input = page.getByTestId("message-input");
-  await input.fill("@pip");
-
-  const dropdown = autocomplete(page);
-  await expect(dropdown.locator("button", { hasText: "Pip" })).toHaveCount(1);
-});
-
 test("sent non-member person mention uses the normal mention style", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -686,6 +686,43 @@ test("autocomplete searches global non-member people from the first typed charac
   await expect(tessaRow.getByText("not in channel")).toBeVisible();
 });
 
+test("autocomplete keeps same-name global people independently selectable", async ({
+  page,
+}) => {
+  const firstWillPubkey = "1".repeat(64);
+  const secondWillPubkey = "2".repeat(64);
+  await installMockBridge(page, {
+    searchProfiles: [
+      { pubkey: firstWillPubkey, displayName: "Will" },
+      { pubkey: secondWillPubkey, displayName: "Will" },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+
+  await page.getByTestId("message-input").fill("@Will");
+
+  const dropdown = autocomplete(page);
+  const firstWill = dropdown.getByTestId(
+    `mention-suggestion-${firstWillPubkey}`,
+  );
+  const secondWill = dropdown.getByTestId(
+    `mention-suggestion-${secondWillPubkey}`,
+  );
+  await expect(firstWill).toBeVisible();
+  await expect(secondWill).toBeVisible();
+  await expect(dropdown.getByTestId("mention-collision-npub")).toHaveCount(2);
+
+  await secondWill.click();
+  await page.keyboard.type("hello");
+  await expect(page.getByTestId("message-input")).toHaveText("@Will hello");
+  await page.getByTestId("send-message").click();
+  await page.getByRole("button", { name: "Invite" }).click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, "@Will hello"))
+    .toEqual([secondWillPubkey]);
+});
+
 test("mention autocomplete caps global people search at 50 results", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- preserve distinct people with the same display name in mention autocomplete by keeping pubkey as identity
- paginate the selected-people agent access search in 50-result pages, matching add-member completeness
- keep duplicate names distinguishable with existing NIP-05 or truncated-pubkey secondary labels

## Testing
- `cd desktop && pnpm build:e2e`
- `cd desktop && pnpm exec playwright test tests/e2e/mentions.spec.ts tests/e2e/agent-access-warning.spec.ts --project=smoke --grep "same-name"`
- pre-push: desktop check, TypeScript, and all 5,278 desktop JS tests
