### PR TITLE
fix(sdk,desktop): keep self-targeted p tags on issue assignment and the generic signer

### DIFF
--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -1243,7 +1243,15 @@ fn build_git_issue_assignee_operation(
         tags.push(tag(&["prior", &prior])?);
     }
 
-    Ok(EventBuilder::new(Kind::Custom(1), content).tags(tags))
+    // `allow_self_tagging` because an assignee may be the signer, and that is
+    // the normal case: an agent claiming work, or a person clicking "Assign to
+    // me". `nostr` removes a `p` tag matching the author by default, which
+    // silently produced assignment events naming nobody — the operation
+    // published, the comment read "Assigned this issue to …", and the assignee
+    // list stayed empty. Here the `p` tags *are* the payload, not a mention.
+    Ok(EventBuilder::new(Kind::Custom(1), content)
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Status to apply to a patch or issue root (kind:1630/1631/1632/1633, NIP-34).
@@ -3606,6 +3614,55 @@ mod tests {
         };
         let err = build_git_issue(&repo, "", "body", &GitIssueMeta::default()).unwrap_err();
         assert!(matches!(err, SdkError::InvalidInput(_)));
+    }
+
+    /// The failure this guards: `nostr` removes a `p` tag naming the author
+    /// unless `allow_self_tagging` is set, so a self-assignment published an
+    /// event with no assignee in it. The comment log still read "Assigned this
+    /// issue to …" while the assignee list stayed empty — for agents claiming
+    /// their own work and for anyone clicking "Assign to me".
+    #[test]
+    fn self_assignment_keeps_the_assignee() {
+        let keys = Keys::generate();
+        let me = keys.public_key().to_hex();
+        let repo = GitRepoCoord {
+            owner: "a".repeat(64),
+            id: "repo".to_string(),
+        };
+        let builder = build_git_issue_assignment(
+            &repo,
+            &"d".repeat(64),
+            std::slice::from_ref(&me),
+            "Assigned this issue to me",
+        )
+        .unwrap();
+        let ev = builder.sign_with_keys(&keys).unwrap();
+        assert!(
+            has_tag(&ev, "p", &me),
+            "the assignee is the payload, not a mention: {:?}",
+            ev.tags
+        );
+    }
+
+    /// Unassigning yourself is the same shape and failed the same way.
+    #[test]
+    fn self_unassignment_keeps_the_assignee() {
+        let keys = Keys::generate();
+        let me = keys.public_key().to_hex();
+        let repo = GitRepoCoord {
+            owner: "a".repeat(64),
+            id: "repo".to_string(),
+        };
+        let ev = build_git_issue_unassignment(
+            &repo,
+            &"d".repeat(64),
+            std::slice::from_ref(&me),
+            "Unassigned me from this issue",
+        )
+        .unwrap()
+        .sign_with_keys(&keys)
+        .unwrap();
+        assert!(has_tag(&ev, "p", &me));
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -120,7 +120,14 @@ pub async fn sign_event(
             .map(|tag| Tag::parse(tag).map_err(|error| format!("invalid tag: {error}")))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut builder = EventBuilder::new(Kind::Custom(kind), content).tags(nostr_tags);
+        // Sign exactly the tags the caller composed. `nostr` otherwise removes
+        // any `p` tag naming the author, which made this signer silently drop
+        // part of what it was handed — the self-assignment path in
+        // `issueAssignments.ts` published assignments with no assignee. A
+        // caller that does not want a self `p` tag simply does not add one.
+        let mut builder = EventBuilder::new(Kind::Custom(kind), content)
+            .tags(nostr_tags)
+            .allow_self_tagging();
         if let Some(created_at) = created_at {
             builder = builder.custom_created_at(Timestamp::from(created_at));
         }

--- a/desktop/src-tauri/src/commands/project_git_recipient_notes.rs
+++ b/desktop/src-tauri/src/commands/project_git_recipient_notes.rs
@@ -116,7 +116,13 @@ fn build_labeled_recipient_note_event(
         .map(Tag::parse)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("build {label} tags: {error}"))?;
-    let mut builder = EventBuilder::new(Kind::TextNote, content).tags(tags);
+    // The recipients are the payload here, and one of them may be the signer —
+    // assigning yourself, or requesting your own review. `nostr` strips a `p`
+    // tag matching the author unless told not to, which turned those into
+    // events naming nobody. See the same call in `buzz-sdk`.
+    let mut builder = EventBuilder::new(Kind::TextNote, content)
+        .tags(tags)
+        .allow_self_tagging();
     if let Some(created_at) = created_at {
         builder = builder.custom_created_at(Timestamp::from_secs(created_at));
     }


### PR DESCRIPTION
Fixes the self-referential `p` tag strip (#4326) at the point where it keeps
recurring, and covers the case that is visible in the UI.

## What is broken today

In Buzz Desktop, open any task in a project and click **Assign to me**. Nothing
happens. Click **Unassign** on yourself and nothing happens either — the
operation reports success, a comment appears in the task's history reading
"Assigned this issue to …" / "Unassigned … from this task", and the Assignees
row is unchanged.

Assigning or unassigning *anyone else* works.

## Why

Assignment is modelled as a kind:1 note whose `p` tags are the assignees.
`nostr`'s `EventBuilder::build_with_ctx` removes any `p` tag matching the
author's public key unless `allow_self_tagging()` was called, so when the
assignee is the signer the published event carries no `p` tag at all. The
reducer that derives assignees from those notes then adds or removes nobody,
while the human-readable content still names the person.

The event id hashes over the tags that were actually signed, so this is not a
relay-side strip — the tag never existed on the wire.

## What this changes

Three call sites, all of which build `p` tags as *payload* rather than as
mentions:

- `buzz-sdk`: `build_git_issue_assignee_operation` — the assign/unassign
  builder used by the CLI and by Desktop's managed-owner path.
- `desktop`: `build_labeled_recipient_note_event` — Desktop's labelled
  recipient notes, which also covers review requests.
- `desktop`: the `sign_event` command — the generic signer used from the
  TypeScript side, which is the path the Assignees row actually goes through.

The third is the one worth arguing about, and I think it is the real defect. A
generic signing command's contract is to sign the tags it was given. Silently
discarding one makes it lie to every caller, and each new builder inherits the
trap — which is why this issue keeps being fixed one builder at a time
(#4975 merged for messages and forum notes; #4338, #4484, #3384 open for
membership and PR status). A caller that does not want a self `p` tag simply
does not add one.

## Tests

Two regression tests in `buzz-sdk`, mirroring the existing
`message_preserves_self_mention_p_tag` pattern: a self-assignment and a
self-unassignment each keep the assignee's `p` tag through signing.

## Verification

Reproduced and fixed against a local relay: before, clicking **Assign to me**
published an event with tags `["e", "a", "t", "prior"]` and no assignee
appeared; after, the same click keeps the `p` tag and the name sticks. Existing
events are not repaired — the reducer replays history, and those events
genuinely carry no assignee — so a task assigned before the fix needs
reassigning once.
