### PR TITLE
feat(desktop): add agent skill picker to composer

### DIFF
--- a/desktop/src/features/messages/lib/composerAgentSkills.test.mjs
+++ b/desktop/src/features/messages/lib/composerAgentSkills.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  buildSkillInsertion,
+  extractAvailableAgentSkills,
+} from "./composerAgentSkills.ts";
+
+function event(seq, overrides = {}) {
+  return {
+    seq,
+    timestamp: `2026-08-22T00:00:0${seq}.000Z`,
+    kind: "acp_read",
+    agentIndex: 0,
+    channelId: "channel-a",
+    sessionId: "session-a",
+    turnId: "turn-a",
+    payload: {},
+    ...overrides,
+  };
+}
+
+function commandsEvent(seq, commands, overrides = {}) {
+  return event(seq, {
+    payload: {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "available_commands_update",
+          availableCommands: commands,
+        },
+      },
+    },
+    ...overrides,
+  });
+}
+
+describe("extractAvailableAgentSkills", () => {
+  test("returns the latest commands for the current channel and session", () => {
+    const skills = extractAvailableAgentSkills(
+      [
+        commandsEvent(1, [{ name: "old", description: "Old command" }]),
+        commandsEvent(
+          2,
+          [
+            { name: "/review", description: "Review this change" },
+            { name: "plan", description: "Create a plan" },
+            { name: "plan", description: "Duplicate" },
+          ],
+          { sessionId: "session-b" },
+        ),
+      ],
+      "channel-a",
+    );
+
+    assert.deepEqual(skills, [
+      {
+        name: "review",
+        description: "Review this change",
+        inputHint: "",
+      },
+      { name: "plan", description: "Create a plan", inputHint: "" },
+    ]);
+  });
+
+  test("does not leak commands from a previous session", () => {
+    const skills = extractAvailableAgentSkills(
+      [
+        commandsEvent(1, [{ name: "review" }]),
+        event(2, { sessionId: "session-b", kind: "turn_start" }),
+      ],
+      "channel-a",
+    );
+
+    assert.deepEqual(skills, []);
+  });
+
+  test("keeps commands advertised while a new session id is still unknown", () => {
+    const skills = extractAvailableAgentSkills(
+      [
+        commandsEvent(1, [{ name: "review" }], { sessionId: null }),
+        event(2, { kind: "session_resolved" }),
+      ],
+      "channel-a",
+    );
+
+    assert.deepEqual(
+      skills.map((skill) => skill.name),
+      ["review"],
+    );
+  });
+
+  test("ignores command updates from other channels", () => {
+    const skills = extractAvailableAgentSkills(
+      [
+        commandsEvent(1, [{ name: "review" }]),
+        commandsEvent(2, [{ name: "wrong" }], {
+          channelId: "channel-b",
+          sessionId: "session-b",
+        }),
+      ],
+      "channel-a",
+    );
+
+    assert.deepEqual(
+      skills.map((skill) => skill.name),
+      ["review"],
+    );
+  });
+});
+
+describe("buildSkillInsertion", () => {
+  test("inserts a slash command at an empty caret", () => {
+    assert.deepEqual(buildSkillInsertion("", 0, "review"), {
+      insertText: "/review ",
+      replaceFromOffset: 0,
+      replaceToOffset: 0,
+    });
+  });
+
+  test("adds spacing when inserting between words", () => {
+    assert.deepEqual(buildSkillInsertion("helloworld", 5, "/review"), {
+      insertText: " /review ",
+      replaceFromOffset: 5,
+      replaceToOffset: 5,
+    });
+  });
+
+  test("does not duplicate existing whitespace", () => {
+    assert.deepEqual(buildSkillInsertion("hello world", 6, "review"), {
+      insertText: "/review ",
+      replaceFromOffset: 6,
+      replaceToOffset: 6,
+    });
+  });
+
+  test("rejects an invalid command name", () => {
+    assert.equal(buildSkillInsertion("", 0, "two words"), null);
+  });
+});

--- a/desktop/src/features/messages/lib/composerAgentSkills.ts
+++ b/desktop/src/features/messages/lib/composerAgentSkills.ts
@@ -1,0 +1,123 @@
+import type { ObserverEvent } from "@/features/agents/ui/agentSessionTypes";
+
+export type ComposerAgentSkill = {
+  description: string;
+  inputHint: string;
+  name: string;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return typeof value === "object" && value !== null
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeSkill(value: unknown): ComposerAgentSkill | null {
+  const record = asRecord(value);
+  const rawName = record ? asString(record.name) : asString(value);
+  const name = rawName.replace(/^\/+/, "");
+  if (!name || /\s/.test(name)) return null;
+
+  return {
+    description: record ? asString(record.description) : "",
+    inputHint: record ? asString(record.inputHint) : "",
+    name,
+  };
+}
+
+function availableSkillsFromEvent(
+  event: ObserverEvent,
+): ComposerAgentSkill[] | null {
+  const payload = asRecord(event.payload);
+  if (payload?.method !== "session/update") return null;
+  const params = asRecord(payload.params);
+  const update = asRecord(params?.update);
+  if (update?.sessionUpdate !== "available_commands_update") return null;
+  if (!Array.isArray(update.availableCommands)) return [];
+
+  const seen = new Set<string>();
+  const skills: ComposerAgentSkill[] = [];
+  for (const value of update.availableCommands) {
+    const skill = normalizeSkill(value);
+    if (!skill || seen.has(skill.name)) continue;
+    seen.add(skill.name);
+    skills.push(skill);
+  }
+  return skills;
+}
+
+/**
+ * Return the commands most recently advertised by an agent session in a
+ * channel. A newer session without a command update intentionally returns an
+ * empty list instead of leaking stale commands from the previous session.
+ */
+export function extractAvailableAgentSkills(
+  events: readonly ObserverEvent[],
+  channelId: string | null,
+): ComposerAgentSkill[] {
+  const scopedEvents = events.filter((event) => event.channelId === channelId);
+  let latestSessionId: string | null = null;
+  for (let index = scopedEvents.length - 1; index >= 0; index -= 1) {
+    const sessionId = scopedEvents[index]?.sessionId;
+    if (sessionId) {
+      latestSessionId = sessionId;
+      break;
+    }
+  }
+  const latestSessionTurnIds = latestSessionId
+    ? new Set(
+        scopedEvents
+          .filter((event) => event.sessionId === latestSessionId)
+          .map((event) => event.turnId)
+          .filter((turnId): turnId is string => turnId !== null),
+      )
+    : null;
+
+  for (let index = scopedEvents.length - 1; index >= 0; index -= 1) {
+    const event = scopedEvents[index];
+    if (!event) continue;
+    const belongsToLatestSession =
+      !latestSessionId ||
+      event.sessionId === latestSessionId ||
+      (event.sessionId === null &&
+        event.turnId !== null &&
+        latestSessionTurnIds?.has(event.turnId));
+    if (!belongsToLatestSession) continue;
+    const skills = availableSkillsFromEvent(event);
+    if (skills !== null) return skills;
+  }
+  return [];
+}
+
+export function buildSkillInsertion(
+  text: string,
+  cursor: number,
+  skillName: string,
+): {
+  insertText: string;
+  replaceFromOffset: number;
+  replaceToOffset: number;
+} | null {
+  const name = skillName.trim().replace(/^\/+/, "");
+  if (!name || /\s/.test(name)) return null;
+
+  const safeCursor = Math.max(0, Math.min(cursor, text.length));
+  const needsLeadingSpace =
+    safeCursor > 0 && !/\s/.test(text.charAt(safeCursor - 1));
+  const needsTrailingSpace =
+    safeCursor === text.length || !/\s/.test(text.charAt(safeCursor));
+
+  return {
+    insertText: `${needsLeadingSpace ? " " : ""}/${name}${
+      needsTrailingSpace ? " " : ""
+    }`,
+    replaceFromOffset: safeCursor,
+    replaceToOffset: safeCursor,
+  };
+}

--- a/desktop/src/features/messages/lib/useComposerAgentSkills.ts
+++ b/desktop/src/features/messages/lib/useComposerAgentSkills.ts
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+import {
+  getAgentObserverSnapshot,
+  subscribeAgentObserverStore,
+} from "@/features/agents/observerRelayStore";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { extractAvailableAgentSkills } from "./composerAgentSkills";
+
+export function useComposerAgentSkills(
+  agentPubkey: string | null,
+  channelId: string | null,
+) {
+  const [revision, setRevision] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!agentPubkey) return;
+    const normalizedAgentPubkey = normalizePubkey(agentPubkey);
+    return subscribeAgentObserverStore((update) => {
+      if (
+        !update ||
+        normalizePubkey(update.agentPubkey) === normalizedAgentPubkey
+      ) {
+        setRevision((current) => current + 1);
+      }
+    });
+  }, [agentPubkey]);
+
+  if (!agentPubkey) return [];
+  void revision;
+  return extractAvailableAgentSkills(
+    getAgentObserverSnapshot(agentPubkey, true).events,
+    channelId,
+  );
+}

--- a/desktop/src/features/messages/lib/useComposerInsertionActions.ts
+++ b/desktop/src/features/messages/lib/useComposerInsertionActions.ts
@@ -1,0 +1,73 @@
+import * as React from "react";
+
+import type { AutocompleteEdit } from "@/features/messages/lib/useRichTextEditor";
+import {
+  buildSkillInsertion,
+  type ComposerAgentSkill,
+} from "./composerAgentSkills";
+import { useComposerAgentSkills } from "./useComposerAgentSkills";
+
+type AddressedAgent = { displayName: string; pubkey: string };
+type PlainTextCursor = { cursor: number; text: string };
+
+export function useComposerInsertionActions<
+  ChannelSuggestion,
+  EmojiSuggestion,
+>({
+  addressedAgents,
+  applyAutocompleteEdit,
+  channelId,
+  enabled,
+  getPlainTextAndCursor,
+  insertChannel,
+  insertEmoji,
+}: {
+  addressedAgents: readonly AddressedAgent[];
+  applyAutocompleteEdit: (edit: AutocompleteEdit) => void;
+  channelId: string | null;
+  enabled: boolean;
+  getPlainTextAndCursor: () => PlainTextCursor;
+  insertChannel: (
+    suggestion: ChannelSuggestion,
+    cursor: number,
+  ) => AutocompleteEdit;
+  insertEmoji: (
+    suggestion: EmojiSuggestion,
+    cursor: number,
+  ) => AutocompleteEdit;
+}) {
+  const skillAgent =
+    enabled && addressedAgents.length === 1 ? addressedAgents[0] : null;
+  const skills = useComposerAgentSkills(skillAgent?.pubkey ?? null, channelId);
+
+  const applyChannelInsert = React.useCallback(
+    (suggestion: ChannelSuggestion) => {
+      const { cursor } = getPlainTextAndCursor();
+      applyAutocompleteEdit(insertChannel(suggestion, cursor));
+    },
+    [applyAutocompleteEdit, getPlainTextAndCursor, insertChannel],
+  );
+  const applyEmojiInsert = React.useCallback(
+    (suggestion: EmojiSuggestion) => {
+      const { cursor } = getPlainTextAndCursor();
+      applyAutocompleteEdit(insertEmoji(suggestion, cursor));
+    },
+    [applyAutocompleteEdit, getPlainTextAndCursor, insertEmoji],
+  );
+  const insertSkill = React.useCallback(
+    (skill: ComposerAgentSkill) => {
+      const { cursor, text } = getPlainTextAndCursor();
+      const edit = buildSkillInsertion(text, cursor, skill.name);
+      if (edit) applyAutocompleteEdit(edit);
+    },
+    [applyAutocompleteEdit, getPlainTextAndCursor],
+  );
+
+  return {
+    applyChannelInsert,
+    applyEmojiInsert,
+    insertSkill,
+    skillAgentDisplayName: skillAgent?.displayName,
+    skills,
+  };
+}

--- a/desktop/src/features/messages/ui/ComposerSkillPicker.tsx
+++ b/desktop/src/features/messages/ui/ComposerSkillPicker.tsx
@@ -1,0 +1,183 @@
+import { Search, Zap } from "lucide-react";
+import * as React from "react";
+
+import type { ComposerAgentSkill } from "@/features/messages/lib/composerAgentSkills";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+
+type ComposerSkillPickerProps = {
+  agentDisplayName: string;
+  disabled: boolean;
+  onClose: () => void;
+  onSelect: (skill: ComposerAgentSkill) => void;
+  onTriggerMouseDown: () => void;
+  skills: readonly ComposerAgentSkill[];
+};
+
+export const ComposerSkillPicker = React.memo(function ComposerSkillPicker({
+  agentDisplayName,
+  disabled,
+  onClose,
+  onSelect,
+  onTriggerMouseDown,
+  skills,
+}: ComposerSkillPickerProps) {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const [highlightedIndex, setHighlightedIndex] = React.useState(0);
+
+  const filteredSkills = React.useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return skills;
+    return skills.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(normalizedQuery) ||
+        skill.description.toLowerCase().includes(normalizedQuery),
+    );
+  }, [query, skills]);
+
+  const activeHighlightedIndex = Math.min(
+    highlightedIndex,
+    Math.max(filteredSkills.length - 1, 0),
+  );
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        setQuery("");
+        setHighlightedIndex(0);
+        requestAnimationFrame(onClose);
+      }
+    },
+    [onClose],
+  );
+
+  const selectSkill = React.useCallback(
+    (skill: ComposerAgentSkill) => {
+      onSelect(skill);
+      handleOpenChange(false);
+    },
+    [handleOpenChange, onSelect],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "ArrowDown" && filteredSkills.length > 0) {
+        event.preventDefault();
+        setHighlightedIndex((current) =>
+          Math.min(current + 1, filteredSkills.length - 1),
+        );
+      } else if (event.key === "ArrowUp" && filteredSkills.length > 0) {
+        event.preventDefault();
+        setHighlightedIndex((current) => Math.max(current - 1, 0));
+      } else if (event.key === "Enter") {
+        const skill = filteredSkills[activeHighlightedIndex];
+        if (skill) {
+          event.preventDefault();
+          selectSkill(skill);
+        }
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        handleOpenChange(false);
+      }
+    },
+    [activeHighlightedIndex, filteredSkills, handleOpenChange, selectSkill],
+  );
+
+  if (skills.length === 0) return null;
+
+  return (
+    <Popover onOpenChange={handleOpenChange} open={open}>
+      <Tooltip disableHoverableContent>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              aria-label={`Insert a skill for ${agentDisplayName}`}
+              aria-expanded={open}
+              data-testid="composer-skill-picker"
+              disabled={disabled}
+              onMouseDown={onTriggerMouseDown}
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
+              <Zap />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Insert skill</TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        align="start"
+        className="w-80 overflow-hidden p-0"
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        side="top"
+        sideOffset={10}
+      >
+        <div className="border-b border-border/50 px-3 py-2.5">
+          <p className="text-sm font-medium">Skills for {agentDisplayName}</p>
+        </div>
+        <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
+          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <input
+            aria-label="Search skills"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            className="min-w-0 flex-1 border-0 bg-transparent p-0 text-sm outline-none placeholder:text-muted-foreground"
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setHighlightedIndex(0);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Search skills…"
+            ref={(element) => element?.focus()}
+            spellCheck={false}
+            value={query}
+          />
+        </div>
+        <div
+          aria-label={`Available skills for ${agentDisplayName}`}
+          className="max-h-64 overflow-y-auto overscroll-contain p-1"
+          onTouchMoveCapture={(event) => event.stopPropagation()}
+          onWheelCapture={(event) => event.stopPropagation()}
+          role="listbox"
+        >
+          {filteredSkills.length > 0 ? (
+            filteredSkills.map((skill, index) => (
+              <button
+                aria-selected={index === activeHighlightedIndex}
+                className={cn(
+                  "flex w-full flex-col rounded-lg px-3 py-2 text-left outline-none transition-colors",
+                  index === activeHighlightedIndex
+                    ? "bg-muted/70 text-foreground"
+                    : "hover:bg-muted/50",
+                )}
+                key={skill.name}
+                onClick={() => selectSkill(skill)}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                role="option"
+                type="button"
+              >
+                <span className="text-sm font-medium">/{skill.name}</span>
+                {skill.description ? (
+                  <span className="line-clamp-2 text-xs text-muted-foreground">
+                    {skill.description}
+                  </span>
+                ) : null}
+              </button>
+            ))
+          ) : (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              No skills match
+            </p>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+});

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -1,17 +1,11 @@
 import * as React from "react";
 import { EditorContent } from "@tiptap/react";
-import {
-  useChannelLinks,
-  type ChannelSuggestion,
-} from "@/features/messages/lib/useChannelLinks";
+import { useChannelLinks } from "@/features/messages/lib/useChannelLinks";
 import { handleAgentSnapshotPaste } from "@/features/messages/lib/agentSnapshotClipboard";
 import { useComposerAutofocus } from "@/features/messages/lib/useComposerAutofocus";
 import { useDrafts } from "@/features/messages/lib/useDrafts";
 import { resolveSentDraftKey } from "@/features/messages/ui/draftSubmitKey";
-import {
-  useEmojiAutocomplete,
-  type EmojiSuggestion,
-} from "@/features/messages/lib/useEmojiAutocomplete";
+import { useEmojiAutocomplete } from "@/features/messages/lib/useEmojiAutocomplete";
 import { useCustomEmoji } from "@/features/custom-emoji/hooks";
 import {
   findSpoileredImetaMediaUrls,
@@ -73,6 +67,7 @@ import { submitMessageEdit } from "./submitMessageEdit";
 import { prepareBackgroundLinkPreviews } from "@/features/messages/lib/linkPreviewPreparationStore";
 import { useComposerLinkPreviews } from "./useComposerLinkPreviews";
 import { scheduleSettleGatedAutoSubmit } from "./messageComposerAutoSubmit";
+import { useComposerInsertionActions } from "@/features/messages/lib/useComposerInsertionActions";
 import type { MessageComposerProps } from "./MessageComposer.types";
 function MessageComposerImpl({
   audienceContext = null,
@@ -414,28 +409,21 @@ function MessageComposerImpl({
     profiles,
     richText,
   });
-  const applyChannelInsert = React.useCallback(
-    (suggestion: ChannelSuggestion) => {
-      const { cursor } = richText.getPlainTextAndCursor();
-      applyAutocompleteEdit(channelLinks.insertChannel(suggestion, cursor));
-    },
-    [
-      applyAutocompleteEdit,
-      channelLinks.insertChannel,
-      richText.getPlainTextAndCursor,
-    ],
-  );
-  const applyEmojiInsert = React.useCallback(
-    (suggestion: EmojiSuggestion) => {
-      const { cursor } = richText.getPlainTextAndCursor();
-      applyAutocompleteEdit(emojiAutocomplete.insertEmoji(suggestion, cursor));
-    },
-    [
-      applyAutocompleteEdit,
-      emojiAutocomplete.insertEmoji,
-      richText.getPlainTextAndCursor,
-    ],
-  );
+  const {
+    applyChannelInsert,
+    applyEmojiInsert,
+    insertSkill,
+    skillAgentDisplayName,
+    skills,
+  } = useComposerInsertionActions({
+    addressedAgents: lockedAgents,
+    applyAutocompleteEdit,
+    channelId,
+    enabled: editTarget == null,
+    getPlainTextAndCursor: richText.getPlainTextAndCursor,
+    insertChannel: channelLinks.insertChannel,
+    insertEmoji: emojiAutocomplete.insertEmoji,
+  });
   // ── Emoji insertion ─────────────────────────────────────────────────
   const insertEmoji = React.useCallback(
     (emoji: string) => {
@@ -990,9 +978,13 @@ function MessageComposerImpl({
               onOpenMentionPicker={openMentionSettings}
               onPaperclip={handlePaperclipClick}
               onRemoveAddressedAgent={removeAddressedAgent}
+              onSkillPickerClose={richText.focusPreserve}
+              onSkillSelect={insertSkill}
               pulseVersionByPubkey={addressPulse.pulseVersionByPubkey}
               sendDisabled={sendDisabled}
               shakeVersionByPubkey={addressPulse.shakeVersionByPubkey}
+              skillAgentDisplayName={skillAgentDisplayName}
+              skills={skills}
             />
           </form>
         </div>

--- a/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
+++ b/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
@@ -11,8 +11,10 @@ import {
   ComposerSendButton,
 } from "./ComposerAddressControls";
 import { ComposerEmojiPicker } from "./ComposerEmojiPicker";
+import { ComposerSkillPicker } from "./ComposerSkillPicker";
 import { FormattingToolbar } from "./FormattingToolbar";
 import { SelectionFormattingTray } from "./SelectionFormattingTray";
+import type { ComposerAgentSkill } from "@/features/messages/lib/composerAgentSkills";
 
 /** Spring for enter/exit of button groups — all fire simultaneously. */
 const presenceSpring = {
@@ -34,6 +36,8 @@ export const MessageComposerToolbar = React.memo(
     isFormattingOpen,
     isSending,
     isUploading,
+    skillAgentDisplayName,
+    skills,
     onCaptureSelection,
     onEmojiPickerOpenChange,
     onEmojiSelect,
@@ -42,6 +46,8 @@ export const MessageComposerToolbar = React.memo(
     onOpenMentionPicker,
     onPaperclip,
     onRemoveAddressedAgent = ignoreAddressRemoval,
+    onSkillPickerClose,
+    onSkillSelect,
     pulseVersionByPubkey,
     sendDisabled,
     shakeVersionByPubkey,
@@ -55,6 +61,8 @@ export const MessageComposerToolbar = React.memo(
     isFormattingOpen: boolean;
     isSending: boolean;
     isUploading: boolean;
+    skillAgentDisplayName?: string;
+    skills?: readonly ComposerAgentSkill[];
     onCaptureSelection: () => void;
     onEmojiPickerOpenChange: (open: boolean) => void;
     onEmojiSelect: (emoji: string) => void;
@@ -63,6 +71,8 @@ export const MessageComposerToolbar = React.memo(
     onOpenMentionPicker: () => void;
     onPaperclip: () => void;
     onRemoveAddressedAgent?: (pubkey: string) => void;
+    onSkillPickerClose?: () => void;
+    onSkillSelect?: (skill: ComposerAgentSkill) => void;
     pulseVersionByPubkey?: Readonly<Record<string, number>>;
     sendDisabled: boolean;
     shakeVersionByPubkey?: Readonly<Record<string, number>>;
@@ -207,6 +217,16 @@ export const MessageComposerToolbar = React.memo(
                   onTriggerMouseDown={onCaptureSelection}
                   open={isEmojiPickerOpen}
                 />
+                {skillAgentDisplayName && skills && onSkillSelect ? (
+                  <ComposerSkillPicker
+                    agentDisplayName={skillAgentDisplayName}
+                    disabled={composerDisabled}
+                    onClose={onSkillPickerClose ?? (() => {})}
+                    onSelect={onSkillSelect}
+                    onTriggerMouseDown={onCaptureSelection}
+                    skills={skills}
+                  />
+                ) : null}
                 <motion.div
                   initial={{ x: -8, opacity: 0 }}
                   animate={{ x: 0, opacity: 1 }}

--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -133,6 +133,80 @@ async function installAudienceFixtures(
   });
 }
 
+async function seedAvailableSkills(page: Page) {
+  await page.evaluate(
+    ({ agentPubkey, channelId }) => {
+      window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__?.({
+        agentPubkey,
+        events: [
+          {
+            seq: 1,
+            timestamp: "2026-08-22T12:00:00.000Z",
+            kind: "acp_read",
+            agentIndex: 0,
+            channelId,
+            sessionId: "skill-picker-session",
+            turnId: "skill-picker-turn",
+            payload: {
+              method: "session/update",
+              params: {
+                update: {
+                  sessionUpdate: "available_commands_update",
+                  availableCommands: [
+                    {
+                      name: "create_plan",
+                      description: "Create a structured plan for the task",
+                    },
+                    {
+                      name: "research_codebase",
+                      description: "Research and understand the codebase",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      });
+    },
+    { agentPubkey: AGENT_A, channelId: CHANNEL_ID },
+  );
+}
+
+test("inserts a selected agent skill into the composer", async ({ page }) => {
+  await installAudienceFixtures(page);
+  await openGeneral(page);
+
+  const composer = channelComposer(page);
+  await automaticallyMention(composer, "Morgarita");
+  await expect(
+    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await page.screenshot({ path: `${SHOTS}/skill-picker-before.png` });
+  await seedAvailableSkills(page);
+
+  const input = composer.getByTestId("message-input");
+  await input.fill("Start ");
+  await composer.getByTestId("composer-skill-picker").click();
+
+  const search = page.getByRole("textbox", { name: "Search skills" });
+  await expect(search).toBeFocused();
+  await search.fill("structured");
+  await expect(
+    page.getByRole("option", { name: /\/create_plan/ }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("option", { name: /\/research_codebase/ }),
+  ).toHaveCount(0);
+  await waitForAnimations(page);
+  await page.screenshot({ path: `${SHOTS}/skill-picker-after.png` });
+
+  await page.getByRole("option", { name: /\/create_plan/ }).click();
+  await expect(input).toHaveText("Start /create_plan ");
+  await expect(input).toBeFocused();
+});
+
 test("automatically mentions multiple agents from the mention picker", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Adds a searchable skill picker to the message composer when one agent is selected.

It uses the commands advertised by that agent’s current session. You can search the list and insert a slash command at your current cursor position.

Commands are scoped to the current agent, channel, and session so old commands do not appear.

### Related issue

Closes #5741

### Testing

Ran `just ci` successfully.

Added unit tests for command extraction, session handling, and command insertion.

Added a Playwright test covering search, selection, insertion, and restoring focus to the composer.

Before and after screenshots attached.

Before

![Composer before the skill picker opens](https://raw.githubusercontent.com/joebasrawi/buzz/pr-assets-skill-picker/skill-picker-before.png)

After

![Searchable agent skill picker](https://raw.githubusercontent.com/joebasrawi/buzz/pr-assets-skill-picker/skill-picker-after.png)