### PR TITLE
fix(cli): preserve network errors in mention preflight

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -173,11 +173,14 @@ async fn resolve_content_mentions(
         "#d": [channel_id],
         "limit": 1,
     });
-    let member_pubkeys = fetch_member_pubkeys(client, &members_filter)
-        .await
-        .ok_or_else(|| {
-            CliError::Other("could not load channel membership for mention preflight".into())
-        })?;
+    let member_pubkeys = match fetch_member_pubkeys(client, &members_filter).await? {
+        Some(pubkeys) => pubkeys,
+        None => {
+            return Err(CliError::NotFound(format!(
+                "channel {channel_id} has no membership event for mention preflight"
+            )));
+        }
+    };
 
     if !stripped.contains('@') {
         return Ok((member_pubkeys, vec![]));
@@ -188,11 +191,9 @@ async fn resolve_content_mentions(
         "authors": member_pubkeys,
         "limit": member_pubkeys.len(),
     });
-    let profile_events = fetch_events(client, &profiles_filter)
-        .await
-        .ok_or_else(|| {
-            CliError::Other("could not load member profiles for mention resolution".into())
-        })?;
+    // Propagate transport/parse failures as-is so unreachable relays stay
+    // network_error/retryable instead of being rewritten as membership faults.
+    let profile_events = fetch_events(client, &profiles_filter).await?;
 
     let mut name_to_pubkeys: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
@@ -292,23 +293,34 @@ fn event_mention_pubkeys(event: &nostr::Event) -> Vec<String> {
 }
 
 /// Fetch raw events for `filter` via the relay's `/query` endpoint.
-/// Returns `None` on any I/O or parse failure.
+///
+/// Transport and parse failures propagate as `CliError` so callers can preserve
+/// retryable network classification. A well-formed empty array is success.
 async fn fetch_events(
     client: &BuzzClient,
     filter: &serde_json::Value,
-) -> Option<Vec<serde_json::Value>> {
-    let raw = client.query(filter).await.ok()?;
-    let parsed: serde_json::Value = serde_json::from_str(&raw).ok()?;
-    parsed.as_array().cloned()
+) -> Result<Vec<serde_json::Value>, CliError> {
+    let raw = client.query(filter).await?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+        CliError::Other(format!(
+            "failed to parse query response for mention preflight: {e}"
+        ))
+    })?;
+    parsed.as_array().cloned().ok_or_else(|| {
+        CliError::Other("mention preflight query response was not a JSON array".into())
+    })
 }
 
 /// Extract member pubkeys (the `p` tag values) from a single 39002 event.
+///
+/// `Ok(None)` means the relay answered and the channel has no kind 39002
+/// membership event. Transport failures are `Err`.
 async fn fetch_member_pubkeys(
     client: &BuzzClient,
     filter: &serde_json::Value,
-) -> Option<Vec<String>> {
+) -> Result<Option<Vec<String>>, CliError> {
     let events = fetch_events(client, filter).await?;
-    Some(parse_member_pubkeys(events.first()?))
+    Ok(events.first().map(parse_member_pubkeys))
 }
 
 /// Parse member pubkeys from a kind 39002 event JSON value.
@@ -1056,12 +1068,14 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        channel_id_from_event, cmd_get_thread, event_mention_pubkeys, find_root_from_tags,
-        format_events, match_profiles_by_name, merge_message_mentions, missing_members,
-        normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
-        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
-        CliError, Uuid,
+        channel_id_from_event, cmd_get_thread, cmd_send_message, event_mention_pubkeys,
+        find_root_from_tags, format_events, match_profiles_by_name, merge_message_mentions,
+        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        resolve_content_mentions, resolve_names_to_pubkeys, resolve_thread_target,
+        thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient, CliError,
+        SendMessageParams, Uuid,
     };
+    use crate::error::{exit_code, is_retryable_error};
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
@@ -1123,6 +1137,154 @@ mod tests {
 
         assert!(matches!(error, CliError::Usage(_)));
         assert!(error.to_string().contains("invalid UUID"));
+    }
+
+    /// Regression for #6555: an unreachable relay during mention preflight must
+    /// keep the original network_error/retryable=true classification instead of
+    /// being rewritten as a permanent membership fault.
+    #[tokio::test]
+    async fn mention_preflight_preserves_network_error_when_relay_unreachable() {
+        let client =
+            BuzzClient::new("http://127.0.0.1:1".into(), Keys::generate(), None, None).unwrap();
+        let channel = "123e4567-e89b-12d3-a456-426614174000";
+
+        let with_at =
+            resolve_content_mentions(&client, channel, "probe with an @sign in it", false)
+                .await
+                .unwrap_err();
+        assert!(
+            matches!(with_at, CliError::Network(_)),
+            "expected Network, got {with_at:?}"
+        );
+        assert!(is_retryable_error(&with_at));
+        assert_eq!(exit_code(&with_at), 2);
+        assert!(
+            !with_at
+                .to_string()
+                .contains("could not load channel membership for mention preflight"),
+            "must not launder transport failure as membership: {with_at}"
+        );
+
+        let with_explicit = resolve_content_mentions(&client, channel, "no at sign here", true)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(with_explicit, CliError::Network(_)),
+            "explicit --mention path expected Network, got {with_explicit:?}"
+        );
+        assert!(is_retryable_error(&with_explicit));
+        assert_eq!(exit_code(&with_explicit), 2);
+
+        // Bodies without mention processing still skip the preflight entirely.
+        let skipped = resolve_content_mentions(&client, channel, "probe without at sign", false)
+            .await
+            .unwrap();
+        assert_eq!(skipped, (vec![], vec![]));
+    }
+
+    use axum::body::Body;
+    use axum::http::{Response, StatusCode};
+    use axum::routing::post;
+    use axum::Router;
+    use tokio::net::TcpListener;
+
+    const CHANNEL: &str = "123e4567-e89b-12d3-a456-426614174000";
+
+    fn send_params(channel_id: &str, content: &str, mentions: Vec<String>) -> SendMessageParams {
+        SendMessageParams {
+            channel_id: channel_id.to_string(),
+            content: content.to_string(),
+            kind: None,
+            reply_to: None,
+            broadcast: false,
+            files: vec![],
+            mentions,
+        }
+    }
+
+    /// Serve one fixed response body on `POST /query`.
+    async fn query_server(status: StatusCode, body: &'static str) -> String {
+        let app = Router::new().route(
+            "/query",
+            post(move || async move {
+                Response::builder()
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap()
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        format!("http://{addr}")
+    }
+
+    /// An overloaded relay is retryable too, and the preflight must say so.
+    #[tokio::test]
+    async fn relay_503_during_the_preflight_stays_retryable() {
+        let url = query_server(StatusCode::SERVICE_UNAVAILABLE, "relay is overloaded").await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+
+        let error = cmd_send_message(&client, send_params(CHANNEL, "ping @somebody", vec![]))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CliError::Relay { status: 503, .. }),
+            "expected relay 503, got {error:?}"
+        );
+        assert!(
+            is_retryable_error(&error),
+            "503 is retryable, got {error:?}"
+        );
+    }
+
+    /// The relay answered. The channel genuinely has no kind 39002 event.
+    /// That is a real membership fact and it gets its own error, separate
+    /// from any lookup failure.
+    #[tokio::test]
+    async fn a_channel_with_no_membership_event_is_reported_as_not_found() {
+        let url = query_server(StatusCode::OK, "[]").await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+
+        let error = cmd_send_message(&client, send_params(CHANNEL, "ping @somebody", vec![]))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CliError::NotFound(_)),
+            "expected not found, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains(CHANNEL),
+            "the error must name the channel, got {error}"
+        );
+        assert!(
+            !is_retryable_error(&error),
+            "a missing membership record will not fix itself on retry"
+        );
+    }
+
+    /// A 200 carrying something that is not a JSON array is a real defect
+    /// somewhere, and it must not be mistaken for an empty channel.
+    #[tokio::test]
+    async fn a_non_array_query_response_is_reported_as_a_bad_response() {
+        let url = query_server(StatusCode::OK, r#"{"events":[]}"#).await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+
+        let error = cmd_send_message(&client, send_params(CHANNEL, "ping @somebody", vec![]))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CliError::Other(_)),
+            "expected a generic error, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("not a JSON array"),
+            "the error must say what was wrong with the body, got {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Mention preflight discarded transport failures from an unreachable relay (`fetch_events(...).ok()?`) and rewrote them as a permanent membership fault. That flipped retryable true→false and exit 2→4 whenever the body needed mention processing (`@` outside code or `--mention`).

## Root cause

`crates/buzz-cli/src/commands/messages.rs` — membership/profile lookup used `Option`-collapsing on `CliError::Network` instead of propagating `Result`.

## Fix

- Propagate query failures as `Result`
- Reserve `Ok(None)` for a missing kind 39002 membership event → `NotFound`
- Keep retryable network/relay errors intact through preflight

## Why it matters

Agents and wrappers retry on exit 2 / `network_error`. Laundering transport failure as membership makes send look permanently broken while the relay is only down.

## Test plan

```text
cargo fmt -p buzz-cli -- --check crates/buzz-cli/src/commands/messages.rs
cargo test -p buzz-cli --lib commands::messages::tests
# 36 passed @ 207dc3508
```

Named regressions:

- `mention_preflight_preserves_network_error_when_relay_unreachable`
- `relay_503_during_the_preflight_stays_retryable`
- `a_channel_with_no_membership_event_is_reported_as_not_found`
- `a_non_array_query_response_is_reported_as_a_bad_response`

`messages.rs` sha256 @ head: `9e98be7b757f9286387e49b00c3d279c38dd12e9ef831b1dddcd4efb6c820a67`

## Risk

CLI exit codes for membership-empty and bad JSON bodies become more precise (`not_found` / generic other vs blanket error). Wrappers that only checked exit 4 may need to treat 1/2 correctly — that is the intended correction.

## Closest work

none found for this root cause beyond reporter verification on #6555.

## Peer feedback

Addressed @cristiansotogarciaxatech notes: rustfmt on the two `messages.rs` sites; added the three exit-code/path pins offered in review.

Fixes #6555
