### PR TITLE
fix(desktop): deliver Windows notifications and clear false "blocked" banner

### DIFF
--- a/desktop/src/features/notifications/lib/desktop.ts
+++ b/desktop/src/features/notifications/lib/desktop.ts
@@ -5,8 +5,13 @@ import {
   isPermissionGranted,
   onAction,
   requestPermission,
+  sendNotification,
 } from "@tauri-apps/plugin-notification";
-import { isLinuxPlatform, isMacPlatform } from "@/shared/lib/platform";
+import {
+  isLinuxPlatform,
+  isMacPlatform,
+  isWindowsPlatform,
+} from "@/shared/lib/platform";
 
 // Backend event emitted when a native Linux notification is clicked or a
 // queued macOS activation becomes available. See src-tauri notification code.
@@ -143,6 +148,19 @@ export async function getDesktopNotificationPermissionState(): Promise<DesktopNo
       if (!shouldUseMacDevelopmentFallback(error)) {
         return "default";
       }
+    }
+  }
+
+  // On Windows the app runs in WebView2, whose DOM `Notification.permission`
+  // reports "denied" by default even though native toasts are delivered by the
+  // Tauri notification plugin. Trusting the DOM value falsely surfaces the
+  // "notifications are blocked" banner and refuses the enable toggle, so read
+  // the plugin (the real delivery path here) as the source of truth instead.
+  if (isTauri() && isWindowsPlatform()) {
+    try {
+      return (await isPermissionGranted()) ? "granted" : "default";
+    } catch {
+      return "default";
     }
   }
 
@@ -440,6 +458,26 @@ export async function sendDesktopNotification(
       // UNUserNotificationCenter is unavailable to the unbundled executable
       // used by Tauri dev. Preserve the previous macOS development behavior by
       // falling through to the notification plugin; packaged apps use native UN.
+    }
+  }
+
+  // On Windows the DOM `Notification` API inside WebView2 does not surface an OS
+  // toast. Post through the Tauri notification plugin, which uses the native
+  // Windows toast system. Click-through comes back via the plugin's `onAction`
+  // listener (registered for non-Linux, non-macOS platforms in
+  // listenForDesktopNotificationActions), which reads the target from `extra`.
+  // `silent` avoids the toast doubling the app's own in-app notification sound.
+  if (isTauri() && isWindowsPlatform()) {
+    try {
+      sendNotification({
+        title: payload.title,
+        body: payload.body,
+        extra: notificationExtra(payload.target),
+        silent: true,
+      });
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/desktop/src/shared/lib/platform.ts
+++ b/desktop/src/shared/lib/platform.ts
@@ -23,6 +23,15 @@ export function isLinuxPlatform(): boolean {
   );
 }
 
+/** Returns true on Windows desktops (navigator.platform reports "Win32"/"Win64"). */
+export function isWindowsPlatform(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  return /win/i.test(navigator.platform);
+}
+
 /**
  * The platform's normal application-shortcut modifier:
  * - macOS: Command (Meta)


### PR DESCRIPTION
## Problem

On **Windows**, the desktop app's **Settings → Notifications** pane shows two red banners at once — "Desktop notifications are blocked. Enable them in your system settings." and "Desktop notifications are blocked for Buzz…" — the enable toggle bounces straight back to off, and **no notification sound ever plays**. None of this is caused by the user's Windows settings, and no Windows setting can clear it.

## Root cause

The app runs in **WebView2** on Windows, whose DOM `Notification.permission` reports `"denied"` by default even though native toasts are actually delivered by the Tauri notification plugin (`notification:default` capability, already wired up).

1. `getDesktopNotificationPermissionState()` trusted that DOM value before ever consulting the plugin, so it returned `"denied"` on Windows → the "blocked" banner shows and the enable toggle is refused.
2. Because the toggle can't turn on and `sendDesktopNotification()` bails out early on a non-`granted` state, `didSend` is `false`, so `playNotificationSound()` (an in-app `<audio>` element, independent of the OS toast) never fires — hence no sound.
3. Separately, `sendDesktopNotification()` posted only via the DOM `Notification` API on Windows, which WebView2 does not surface as an OS toast.

macOS (WKWebView, native UN delegate) and Linux (WebKitGTK, D-Bus backend) don't hit this because their permission and delivery paths differ.

## Fix

- **Permission detection:** on Windows under Tauri, read the notification plugin (`isPermissionGranted()`) as the source of truth instead of the misleading WebView2 DOM value. Clears both banners, unblocks the toggle, and lets the in-app sound play.
- **Delivery:** route Windows sends through the plugin's `sendNotification()` (native Windows toast). Click-through arrives via the existing `onAction` listener (already registered for non-Linux/non-macOS), which reads the target from `extra`; `silent: true` avoids doubling the app's own notification sound.
- Adds an `isWindowsPlatform()` helper. **macOS and Linux paths are unchanged.**

## Test plan

- [x] `tsc --noEmit` — clean
- [x] Biome — clean
- [x] Desktop unit tests — full suite green (5397 passing) via pre-push hooks; notification suite green locally
- [ ] **Needs a Windows box** (can't be verified from macOS): with a packaged build, confirm the banners are gone, the toggle turns on, a mention/DM while backgrounded plays the sound **and** shows a native Windows toast, and clicking the toast opens the right conversation. Note: Windows only surfaces toasts for an *installed* app, so verify on a packaged build, not a raw `tauri dev` run.