### PR TITLE
feat(acp): add opt-in durable session binding store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -829,6 +829,7 @@ name = "buzz-acp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "buzz-core",
  "buzz-persona",
@@ -842,10 +843,12 @@ dependencies = [
  "nix 0.31.3",
  "nostr 0.44.7",
  "reqwest 0.13.4",
+ "rusqlite",
  "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -1712,7 +1715,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2333,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2544,7 +2547,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2767,7 +2770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2838,6 +2841,18 @@ name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -3183,7 +3198,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -3405,6 +3420,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4575,10 +4599,11 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -6028,7 +6053,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7501,7 +7526,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8103,6 +8128,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8172,7 +8211,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8185,7 +8224,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8244,7 +8283,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8527,7 +8566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9024,7 +9063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9122,7 +9161,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.16.1",
- "hashlink",
+ "hashlink 0.11.0",
  "indexmap",
  "log",
  "memchr",
@@ -9652,7 +9691,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9665,7 +9704,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10435,7 +10474,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11019,7 +11058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -62,6 +62,10 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 
+# Durable session bindings (crate-local; workspace sqlx stays Postgres-only)
+rusqlite = { version = "0.37", features = ["bundled"] }
+async-trait = "0.1"
+
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
 
@@ -79,3 +83,4 @@ nix = { version = "0.31", default-features = false, features = ["signal"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 httparse = "1"
+tempfile = "3"

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -200,6 +200,8 @@ pub struct AcpClient {
     /// a JSON-RPC *success*, not `-32601` — which the main loop would read as
     /// a delivered steer and drop the user's message from the queue.
     steering_supported: bool,
+    /// Whether the agent advertised `agentCapabilities.loadSession == true`.
+    load_session_supported: bool,
     /// Per-turn channel for receiving goose-native non-cancelling steer
     /// requests from the main loop. Installed by
     /// [`install_steer_rx`](Self::install_steer_rx) at dispatch and
@@ -559,6 +561,7 @@ impl AcpClient {
             observer_context: ObserverContext::default(),
             active_run_id: None,
             steering_supported: false,
+            load_session_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
@@ -615,6 +618,10 @@ impl AcpClient {
         let result = self.send_request("initialize", params).await?;
         self.steering_supported = result
             .pointer("/_meta/steering/supported")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        self.load_session_supported = result
+            .pointer("/agentCapabilities/loadSession")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         tracing::debug!(target: "acp::init", "initialize response: {result}");
@@ -700,6 +707,27 @@ impl AcpClient {
             .session_new_full(cwd, mcp_servers, system_prompt, session_title)
             .await?
             .session_id)
+    }
+
+    /// Re-attach to an adapter-persisted session via ACP `session/load`.
+    ///
+    /// Gate on [`Self::load_session_supported`]. The adapter may replay the
+    /// session's history as `session/update` notifications before responding;
+    /// the read loop treats out-of-turn updates as passive.
+    pub async fn session_load(
+        &mut self,
+        session_id: &str,
+        cwd: &str,
+        mcp_servers: Vec<McpServer>,
+    ) -> Result<(), AcpError> {
+        let params = serde_json::json!({
+            "sessionId": session_id,
+            "cwd": cwd,
+            "mcpServers": mcp_servers,
+        });
+        self.send_request("session/load", params).await?;
+        tracing::info!(target: "acp::session", "session loaded: {session_id}");
+        Ok(())
     }
 
     /// Replace Goose's native system prompt after `session/new`.
@@ -879,6 +907,16 @@ impl AcpClient {
     /// for the supervisor's post-initialize log line.
     pub fn steering_supported(&self) -> bool {
         self.steering_supported
+    }
+
+    /// Whether the agent advertised `agentCapabilities.loadSession`.
+    pub fn load_session_supported(&self) -> bool {
+        self.load_session_supported
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_load_session_supported(&mut self, value: bool) {
+        self.load_session_supported = value;
     }
 
     /// Consume per-turn usage for NIP-AM publishing. Goose/buzz-agent is an
@@ -4161,6 +4199,78 @@ mod tests {
             !supported,
             "_meta.steering.supported: false must leave steering_supported false"
         );
+    }
+
+    async fn load_session_supported_after_initialize(init_result: &str) -> bool {
+        let script = format!(
+            "read -r _init; printf '%s\\n' '{{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{result}}}'; \\
+             sleep 5",
+            result = init_result,
+        );
+        let mut client = spawn_script(&script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        client.load_session_supported()
+    }
+
+    #[tokio::test]
+    async fn initialize_records_load_session_supported_when_advertised() {
+        let supported = load_session_supported_after_initialize(
+            r#"{"protocolVersion":2,"agentCapabilities":{"loadSession":true}}"#,
+        )
+        .await;
+        assert!(
+            supported,
+            "agentCapabilities.loadSession: true must set load_session_supported"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_leaves_load_session_unsupported_when_absent() {
+        let supported = load_session_supported_after_initialize(
+            r#"{"protocolVersion":2,"agentCapabilities":{}}"#,
+        )
+        .await;
+        assert!(
+            !supported,
+            "absent loadSession must leave load_session_supported false"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_leaves_load_session_unsupported_when_explicitly_false() {
+        let supported = load_session_supported_after_initialize(
+            r#"{"protocolVersion":2,"agentCapabilities":{"loadSession":false}}"#,
+        )
+        .await;
+        assert!(
+            !supported,
+            "loadSession: false must leave load_session_supported false"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_load_wire_shape_and_replayed_update_does_not_wedge() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{"loadSession":true}}}'
+            read -t 2 REQ
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_restored","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"replay"}}}}'
+            echo '{"jsonrpc":"2.0","id":1,"result":{"_receivedRequest":'"$REQ"'}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        assert!(client.load_session_supported());
+        client
+            .session_load("ses_restored", "/tmp", vec![])
+            .await
+            .expect("session_load should succeed after replayed update");
     }
 
     /// Test 2: no `active_run_id` + capability advertised → the bytes on the

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -503,6 +503,13 @@ pub struct CliArgs {
     /// Requires `--lazy-pool`; ignored otherwise. 0 disables idle re-sleep.
     #[arg(long, env = "BUZZ_ACP_IDLE_POOL_SLEEP", default_value_t = 0)]
     pub idle_pool_sleep: u64,
+
+    /// Path to the durable session-binding store (SQLite). When unset, session
+    /// bindings and processed-event dedupe are in-memory only and do not survive
+    /// restarts. The store holds IDs and timestamps only — never prompts, keys,
+    /// or message content.
+    #[arg(long = "session-store", env = "BUZZ_ACP_SESSION_STORE")]
+    pub session_store_path: Option<PathBuf>,
 }
 
 /// Merged NIP-01 subscription filter for a single channel.
@@ -590,6 +597,9 @@ pub struct Config {
     /// woken lazy pool is torn back down to the empty-slot state. 0 = disabled.
     /// Only meaningful when `lazy_pool` is true.
     pub idle_pool_sleep_secs: u64,
+    /// Path to the durable session-binding store. `None` keeps bindings and
+    /// processed-event dedupe in memory only.
+    pub session_store_path: Option<PathBuf>,
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
     /// Replaces the old REST-based owner lookup.
     pub agent_owner: Option<String>,
@@ -1140,6 +1150,7 @@ impl Config {
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
             idle_pool_sleep_secs: args.idle_pool_sleep,
+            session_store_path: args.session_store_path,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
@@ -1164,7 +1175,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{} session_store={}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1187,6 +1198,10 @@ impl Config {
             self.permission_mode,
             respond_to_detail,
             allowed_respond_to_detail,
+            self.session_store_path
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "disabled".into()),
         )
     }
 }
@@ -1513,6 +1528,7 @@ mod tests {
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             idle_pool_sleep_secs: 0,
+            session_store_path: None,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -2247,6 +2263,35 @@ channels = "ALL"
             "300",
         ]);
         assert_eq!(configured.idle_pool_sleep, 300);
+    }
+
+    #[test]
+    fn session_store_defaults_none_and_accepts_cli_value() {
+        let key = "0".repeat(64);
+        let default = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert!(default.session_store_path.is_none());
+
+        let configured = CliArgs::parse_from([
+            "buzz-acp",
+            "--private-key",
+            &key,
+            "--session-store",
+            "/tmp/acp-sessions.db",
+        ]);
+        assert_eq!(
+            configured.session_store_path.as_deref(),
+            Some(std::path::Path::new("/tmp/acp-sessions.db"))
+        );
+    }
+
+    #[test]
+    fn test_summary_includes_session_store_disabled_by_default() {
+        let config = test_config(SubscribeMode::Mentions);
+        let s = config.summary();
+        assert!(
+            s.contains("session_store=disabled"),
+            "summary should include session_store=disabled, got: {s}"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1084,13 +1084,14 @@ async fn publish_relay_observer_event(
 /// Maximum age (seconds) for an observer control frame to be considered fresh.
 const OBSERVER_CONTROL_FRESHNESS_SECS: i64 = 300;
 
-fn handle_relay_observer_control_event(
+async fn handle_relay_observer_control_event(
     keys: &nostr::Keys,
     event: nostr::Event,
     pool: &mut AgentPool,
     observer: Option<&observer::ObserverHandle>,
     owner_pubkey_hex: &str,
     event_publisher: RelayEventPublisher,
+    session_store: Option<&dyn session_store::SessionStore>,
 ) {
     // Defense-in-depth: verify signature even though the relay already checked.
     if let Err(e) = buzz_core::verify_event(&event) {
@@ -1134,7 +1135,7 @@ fn handle_relay_observer_control_event(
             handle_cancel_turn_control(&payload, pool, observer);
         }
         Some("switch_model") => {
-            handle_switch_model_control(&payload, pool, observer);
+            handle_switch_model_control(&payload, pool, observer, session_store).await;
         }
         Some("publish_project_owner_announcements") => {
             handle_publish_project_owner_announcements_control(
@@ -1337,11 +1338,14 @@ fn handle_cancel_turn_control(
 ///
 /// Idle path: validate against the cached catalog *before* invalidating
 /// (pre-cancel guard), then set `desired_model` + invalidate. The override
-/// takes visible effect on the agent's next turn.
-fn handle_switch_model_control(
+/// takes visible effect on the agent's next turn. A successful idle switch
+/// also retires durable bindings so the next prompt cannot `session/load`
+/// the deliberately retired session.
+async fn handle_switch_model_control(
     payload: &serde_json::Value,
     pool: &mut AgentPool,
     observer: Option<&observer::ObserverHandle>,
+    session_store: Option<&dyn session_store::SessionStore>,
 ) {
     let Some(channel_id) = payload
         .get("channelId")
@@ -1390,7 +1394,18 @@ fn handle_switch_model_control(
     } else {
         // Idle path: validate against the cached catalog before invalidating.
         match pool.switch_idle_agent_model(channel_id, model_id, request_id.clone()) {
-            IdleSwitchResult::Switched => "switched",
+            IdleSwitchResult::Switched => {
+                if let Some(store) = session_store {
+                    if let Err(error) = store.remove_bindings_for_channel(channel_id).await {
+                        tracing::warn!(
+                            %error,
+                            %channel_id,
+                            "session store remove_binding failed on idle switch_model"
+                        );
+                    }
+                }
+                "switched"
+            }
             IdleSwitchResult::UnsupportedModel => "unsupported_model",
             IdleSwitchResult::NoIdleAgent => "no_active_turn",
         }
@@ -2639,7 +2654,9 @@ async fn tokio_main() -> Result<()> {
                                     observer.as_ref(),
                                     owner_hex,
                                     relay.event_publisher(),
-                                );
+                                    session_store.as_deref(),
+                                )
+                                .await;
                             } else {
                                 tracing::warn!("observer control frame received but no owner resolved — dropping");
                             }
@@ -8789,5 +8806,103 @@ mod session_store_dedupe_tests {
             .unwrap();
         assert!(skip_if_already_processed(Some(&store), "evt-1").await);
         assert!(!skip_if_already_processed(Some(&store), "evt-2").await);
+    }
+}
+
+#[cfg(test)]
+mod session_store_idle_switch_tests {
+    use super::*;
+    use session_store::{ContextKey, InMemorySessionStore, SessionStore};
+
+    async fn dummy_agent(channel_id: uuid::Uuid) -> OwnedAgent {
+        // Inert `cat` subprocess — the idle switch path never talks to ACP.
+        let mut agent = OwnedAgent {
+            index: 0,
+            acp: AcpClient::spawn("cat", &[], &[], false)
+                .await
+                .expect("spawn cat as inert agent"),
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            desired_model_request_id: None,
+            desired_model_pending_ack: false,
+            startup_effort: None,
+            agent_name: "unknown".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        };
+        agent
+            .state
+            .sessions
+            .insert(channel_id, "retired-sid".into());
+        agent
+    }
+
+    #[tokio::test]
+    async fn session_store_idle_switch_model_removes_channel_bindings() {
+        let store = InMemorySessionStore::new();
+        let channel_id = uuid::Uuid::new_v4();
+        let key = ContextKey::Channel(channel_id).for_worker(0);
+        store.save_binding(&key, "retired-sid").await.unwrap();
+
+        let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(channel_id).await)]);
+        handle_switch_model_control(
+            &serde_json::json!({
+                "channelId": channel_id.to_string(),
+                "modelId": "new-model",
+            }),
+            &mut pool,
+            None,
+            Some(&store),
+        )
+        .await;
+
+        assert!(
+            store.load_binding(&key).await.unwrap().is_none(),
+            "idle switch must retire durable bindings so restore cannot resurrect them"
+        );
+        if let Some(mut agent) = pool.try_claim(Some(channel_id)) {
+            agent.acp.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn session_store_unsupported_idle_switch_keeps_channel_bindings() {
+        let store = InMemorySessionStore::new();
+        let channel_id = uuid::Uuid::new_v4();
+        let key = ContextKey::Channel(channel_id).for_worker(0);
+        store.save_binding(&key, "keep-sid").await.unwrap();
+
+        let mut agent = dummy_agent(channel_id).await;
+        agent.model_capabilities = Some(crate::pool::AgentModelCapabilities {
+            config_options_raw: vec![],
+            available_models_raw: Some(serde_json::json!([])),
+            thought_level_config_id: None,
+        });
+        let mut pool = AgentPool::from_slots(vec![Some(agent)]);
+        handle_switch_model_control(
+            &serde_json::json!({
+                "channelId": channel_id.to_string(),
+                "modelId": "missing-model",
+            }),
+            &mut pool,
+            None,
+            Some(&store),
+        )
+        .await;
+
+        assert_eq!(
+            store
+                .load_binding(&key)
+                .await
+                .unwrap()
+                .expect("rejected switch must not delete the binding")
+                .session_id,
+            "keep-sid"
+        );
+        if let Some(mut agent) = pool.try_claim(Some(channel_id)) {
+            agent.acp.shutdown().await;
+        }
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -9,6 +9,8 @@ mod pool;
 mod pool_lifecycle;
 mod queue;
 mod relay;
+/// Durable session-binding + processed-event store (IDs and timestamps only).
+pub mod session_store;
 mod setup_mode;
 mod usage;
 
@@ -43,6 +45,7 @@ use pool::{
 use pool_lifecycle::PoolLifecycle;
 use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
 use relay::{HarnessRelay, RelayEventPublisher};
+use session_store::skip_if_already_processed;
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
@@ -1958,6 +1961,30 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("buzz-acp starting: {}", config.summary());
 
+    let session_store: Option<std::sync::Arc<dyn session_store::SessionStore>> =
+        if let Some(path) = config.session_store_path.as_ref() {
+            match session_store::sqlite::SqliteSessionStore::open(
+                path,
+                session_store::StoreScope::new(
+                    config.keys.public_key().to_hex(),
+                    &config.relay_url,
+                    config::normalize_agent_command_identity(&config.agent_command),
+                ),
+            ) {
+                Ok(store) => Some(std::sync::Arc::new(store)),
+                Err(error) => {
+                    tracing::error!(
+                        %error,
+                        path = %path.display(),
+                        "failed to open session store; continuing without durable bindings"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
     let observer = config
         .relay_observer
         .then(observer::ObserverHandle::in_process);
@@ -2221,6 +2248,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        session_store: session_store.clone(),
     });
 
     if !config.memory_enabled {
@@ -2715,6 +2743,18 @@ async fn tokio_main() -> Result<()> {
                                     } else {
                                         0
                                     };
+                                    if let Some(store) = session_store.as_ref() {
+                                        if let Err(error) = store
+                                            .remove_binding(&session_store::ContextKey::Channel(ch))
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                %error,
+                                                %ch,
+                                                "session store remove_binding failed on membership removal"
+                                            );
+                                        }
+                                    }
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
@@ -2842,6 +2882,18 @@ async fn tokio_main() -> Result<()> {
                                             );
                                         } else {
                                             let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id);
+                                            if let Some(store) = session_store.as_ref() {
+                                                if let Err(error) = store
+                                                    .remove_binding(&session_store::ContextKey::Channel(buzz_event.channel_id))
+                                                    .await
+                                                {
+                                                    tracing::warn!(
+                                                        %error,
+                                                        channel_id = %buzz_event.channel_id,
+                                                        "session store remove_binding failed on !rotate"
+                                                    );
+                                                }
+                                            }
                                             tracing::info!(
                                                 channel_id = %buzz_event.channel_id,
                                                 invalidated,
@@ -2917,6 +2969,9 @@ async fn tokio_main() -> Result<()> {
                             // backed payload) so the cost is negligible.
                             let event_for_steer = buzz_event.event.clone();
                             let prompt_tag_for_steer = prompt_tag.clone();
+                            if skip_if_already_processed(session_store.as_deref(), &event_id_hex).await {
+                                continue;
+                            }
                             let accepted = queue.push(QueuedEvent {
                                 channel_id: buzz_event.channel_id,
                                 event: buzz_event.event,
@@ -6795,6 +6850,7 @@ mod build_mcp_servers_tests {
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             idle_pool_sleep_secs: 0,
+            session_store_path: None,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -7019,6 +7075,7 @@ mod error_outcome_emission_tests {
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             idle_pool_sleep_secs: 0,
+            session_store_path: None,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -8709,5 +8766,27 @@ mod observer_payload_trim_tests {
         assert!(leaf.starts_with('…'));
         assert!(leaf.ends_with('…'));
         assert!(leaf.contains("[elided"));
+    }
+}
+
+#[cfg(test)]
+mod session_store_dedupe_tests {
+    use super::session_store::{skip_if_already_processed, InMemorySessionStore, SessionStore};
+
+    #[tokio::test]
+    async fn processed_event_is_skipped_unmarked_passes() {
+        let store = InMemorySessionStore::new();
+        let channel_id = uuid::Uuid::new_v4();
+        assert!(
+            !skip_if_already_processed(None, "evt-1").await,
+            "no store means never skip"
+        );
+        assert!(!skip_if_already_processed(Some(&store), "evt-1").await);
+        store
+            .mark_events_processed(channel_id, &["evt-1".to_string()])
+            .await
+            .unwrap();
+        assert!(skip_if_already_processed(Some(&store), "evt-1").await);
+        assert!(!skip_if_already_processed(Some(&store), "evt-2").await);
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2744,9 +2744,8 @@ async fn tokio_main() -> Result<()> {
                                         0
                                     };
                                     if let Some(store) = session_store.as_ref() {
-                                        if let Err(error) = store
-                                            .remove_binding(&session_store::ContextKey::Channel(ch))
-                                            .await
+                                        if let Err(error) =
+                                            store.remove_bindings_for_channel(ch).await
                                         {
                                             tracing::warn!(
                                                 %error,
@@ -2884,7 +2883,9 @@ async fn tokio_main() -> Result<()> {
                                             let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id);
                                             if let Some(store) = session_store.as_ref() {
                                                 if let Err(error) = store
-                                                    .remove_binding(&session_store::ContextKey::Channel(buzz_event.channel_id))
+                                                    .remove_bindings_for_channel(
+                                                        buzz_event.channel_id,
+                                                    )
                                                     .await
                                                 {
                                                     tracing::warn!(

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1735,10 +1735,17 @@ fn send_prompt_result(
 /// Core async function spawned for each prompt.
 ///
 /// Lifecycle:
-fn context_key_for_source(source: &PromptSource) -> crate::session_store::ContextKey {
+fn context_key_for_source(
+    source: &PromptSource,
+    worker_index: usize,
+) -> crate::session_store::ContextKey {
     match source {
-        PromptSource::Channel(cid) => crate::session_store::ContextKey::Channel(*cid),
-        PromptSource::Heartbeat => crate::session_store::ContextKey::Heartbeat,
+        PromptSource::Channel(cid) => {
+            crate::session_store::ContextKey::Channel(*cid).for_worker(worker_index)
+        }
+        PromptSource::Heartbeat => {
+            crate::session_store::ContextKey::Heartbeat.for_worker(worker_index)
+        }
     }
 }
 
@@ -1746,6 +1753,7 @@ fn context_key_label(key: &crate::session_store::ContextKey) -> String {
     match key {
         crate::session_store::ContextKey::Channel(cid) => format!("channel {cid}"),
         crate::session_store::ContextKey::Heartbeat => "heartbeat".to_string(),
+        crate::session_store::ContextKey::Wire(raw) => raw.clone(),
     }
 }
 
@@ -1756,6 +1764,16 @@ async fn store_remove_binding(ctx: &PromptContext, key: &crate::session_store::C
     if let Err(error) = store.remove_binding(key).await {
         tracing::warn!(%error, key = %context_key_label(key), "session store remove_binding failed");
     }
+}
+
+async fn invalidate_source_session(
+    agent: &mut OwnedAgent,
+    ctx: &PromptContext,
+    source: &PromptSource,
+) {
+    let key = context_key_for_source(source, agent.index);
+    agent.state.invalidate(source);
+    store_remove_binding(ctx, &key).await;
 }
 
 async fn store_save_binding(
@@ -1795,6 +1813,7 @@ async fn try_restore_stored_session(
     ctx: &PromptContext,
     key: &crate::session_store::ContextKey,
     channel_id: Option<uuid::Uuid>,
+    channel_type: Option<&str>,
 ) -> Option<String> {
     let store = ctx.session_store.as_ref()?;
     let binding = match store.load_binding(key).await {
@@ -1813,9 +1832,15 @@ async fn try_restore_stored_session(
         let _ = store.remove_binding(key).await;
         return None;
     }
+    let mcp_servers = mcp_servers_with_git_origin(
+        &ctx.mcp_servers,
+        channel_id,
+        channel_type,
+        ctx.session_title.as_deref(),
+    );
     match agent
         .acp
-        .session_load(&binding.session_id, &ctx.cwd, ctx.mcp_servers.clone())
+        .session_load(&binding.session_id, &ctx.cwd, mcp_servers)
         .await
     {
         Ok(()) => {
@@ -2090,14 +2115,17 @@ pub async fn run_prompt_task(
         PromptSource::Channel(cid) => {
             if let Some(sid) = agent.state.sessions.get(cid) {
                 (sid.clone(), false)
-            } else if let Some(sid) = try_restore_stored_session(
-                &mut agent,
-                &ctx,
-                &crate::session_store::ContextKey::Channel(*cid),
-                Some(*cid),
-            )
-            .await
-            {
+            } else if let Some(sid) = {
+                let key = crate::session_store::ContextKey::Channel(*cid).for_worker(agent.index);
+                try_restore_stored_session(
+                    &mut agent,
+                    &ctx,
+                    &key,
+                    Some(*cid),
+                    origin_channel_type.as_deref(),
+                )
+                .await
+            } {
                 (sid, false)
             } else {
                 // The title is channel-qualified (`Agent · #channel`) so one
@@ -2133,7 +2161,8 @@ pub async fn run_prompt_task(
                         agent.acp.notify_session_spawned(&sid);
                         store_save_binding(
                             &ctx,
-                            &crate::session_store::ContextKey::Channel(*cid),
+                            &crate::session_store::ContextKey::Channel(*cid)
+                                .for_worker(agent.index),
                             &sid,
                         )
                         .await;
@@ -2174,14 +2203,10 @@ pub async fn run_prompt_task(
         PromptSource::Heartbeat => {
             if let Some(sid) = &agent.state.heartbeat_session {
                 (sid.clone(), false)
-            } else if let Some(sid) = try_restore_stored_session(
-                &mut agent,
-                &ctx,
-                &crate::session_store::ContextKey::Heartbeat,
-                None,
-            )
-            .await
-            {
+            } else if let Some(sid) = {
+                let key = crate::session_store::ContextKey::Heartbeat.for_worker(agent.index);
+                try_restore_stored_session(&mut agent, &ctx, &key, None, None).await
+            } {
                 (sid, false)
             } else {
                 match create_session_and_apply_model(
@@ -2209,7 +2234,7 @@ pub async fn run_prompt_task(
                         agent.acp.notify_session_spawned(&sid);
                         store_save_binding(
                             &ctx,
-                            &crate::session_store::ContextKey::Heartbeat,
+                            &crate::session_store::ContextKey::Heartbeat.for_worker(agent.index),
                             &sid,
                         )
                         .await;
@@ -2369,7 +2394,7 @@ pub async fn run_prompt_task(
                                 Some(acp_stop_to_core(&stop_reason)),
                             )
                             .await;
-                            agent.state.invalidate(&source);
+                            invalidate_source_session(&mut agent, &ctx, &source).await;
                         }
                         Err(AcpError::AgentExited) => {
                             agent.state.invalidate_all();
@@ -2388,7 +2413,7 @@ pub async fn run_prompt_task(
                                 target: "pool::session",
                                 "cancel_with_cleanup failed during initial_message timeout: {e}"
                             );
-                            agent.state.invalidate(&source);
+                            invalidate_source_session(&mut agent, &ctx, &source).await;
                         }
                     }
                     send_prompt_result(
@@ -2424,7 +2449,7 @@ pub async fn run_prompt_task(
                         target: "pool::session",
                         "initial_message failed for channel {cid}: {e} — invalidating session"
                     );
-                    agent.state.invalidate(&source);
+                    invalidate_source_session(&mut agent, &ctx, &source).await;
                     send_prompt_result(
                         &result_tx,
                         &turn_id,
@@ -2668,7 +2693,7 @@ pub async fn run_prompt_task(
                         {
                             Ok(stop_reason) => {
                                 log_stop_reason(&source, &stop_reason);
-                                agent.state.invalidate(&source);
+                                invalidate_source_session(&mut agent, &ctx, &source).await;
                                 let retry_batch =
                                     requeue_cancelled_batch(&ctx, control_signal, batch);
 
@@ -2705,14 +2730,7 @@ pub async fn run_prompt_task(
                                 if failure.invalidate_all {
                                     agent.state.invalidate_all();
                                 } else {
-                                    agent.state.invalidate(&source);
-                                    if matches!(
-                                        control_signal,
-                                        ControlSignal::Rotate | ControlSignal::SwitchModel { .. }
-                                    ) {
-                                        store_remove_binding(&ctx, &context_key_for_source(&source))
-                                            .await;
-                                    }
+                                    invalidate_source_session(&mut agent, &ctx, &source).await;
                                 }
 
                                 let usage = agent.acp.take_turn_usage();
@@ -2790,7 +2808,11 @@ pub async fn run_prompt_task(
                             control_signal,
                             ControlSignal::Rotate | ControlSignal::SwitchModel { .. }
                         ) {
-                            store_remove_binding(&ctx, &context_key_for_source(&source)).await;
+                            store_remove_binding(
+                                &ctx,
+                                &context_key_for_source(&source, agent.index),
+                            )
+                            .await;
                         }
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
@@ -2863,8 +2885,7 @@ pub async fn run_prompt_task(
                     target: "pool::session",
                     "rotating session for {source:?} after {stop_reason:?}",
                 );
-                agent.state.invalidate(&source);
-                store_remove_binding(&ctx, &context_key_for_source(&source)).await;
+                invalidate_source_session(&mut agent, &ctx, &source).await;
             }
 
             let core_stop = acp_stop_to_core(&stop_reason);
@@ -2975,7 +2996,7 @@ pub async fn run_prompt_task(
                         target: "pool::prompt",
                         "cancel_with_cleanup error: {e} — invalidating session"
                     );
-                    agent.state.invalidate(&source);
+                    invalidate_source_session(&mut agent, &ctx, &source).await;
                     let usage = agent.acp.take_turn_usage();
                     publish_agent_turn_metric(
                         &ctx,
@@ -3030,7 +3051,7 @@ pub async fn run_prompt_task(
             // session state (e.g. bad LLM response). The session is healthy —
             // don't invalidate it. Other errors may have corrupted state.
             if !matches!(e, AcpError::AgentError { .. }) {
-                agent.state.invalidate(&source);
+                invalidate_source_session(&mut agent, &ctx, &source).await;
             }
             let usage = agent.acp.take_turn_usage();
             publish_agent_turn_metric(
@@ -8176,6 +8197,12 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         ) -> Result<(), crate::session_store::SessionStoreError> {
             Err(crate::session_store::SessionStoreError::Io("boom".into()))
         }
+        async fn remove_bindings_for_channel(
+            &self,
+            _channel_id: Uuid,
+        ) -> Result<(), crate::session_store::SessionStoreError> {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
         async fn mark_events_processed(
             &self,
             _channel_id: Uuid,
@@ -8234,6 +8261,13 @@ done"#,
         }
     }
 
+    fn worker_channel_key(
+        channel_id: Uuid,
+        worker_index: usize,
+    ) -> crate::session_store::ContextKey {
+        crate::session_store::ContextKey::Channel(channel_id).for_worker(worker_index)
+    }
+
     fn read_methods(path: &std::path::Path) -> Vec<String> {
         std::fs::read_to_string(path)
             .unwrap_or_default()
@@ -8274,7 +8308,7 @@ done"#,
         let result = result_rx.recv().await.expect("result");
         assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
         let binding = store
-            .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+            .load_binding(&worker_channel_key(channel_id, 0))
             .await
             .unwrap()
             .expect("binding written");
@@ -8289,10 +8323,7 @@ done"#,
         let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
         let channel_id = Uuid::new_v4();
         store
-            .save_binding(
-                &crate::session_store::ContextKey::Channel(channel_id),
-                "stored-sid",
-            )
+            .save_binding(&worker_channel_key(channel_id, 0), "stored-sid")
             .await
             .unwrap();
         store
@@ -8359,10 +8390,7 @@ done"#,
         let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
         let channel_id = Uuid::new_v4();
         store
-            .save_binding(
-                &crate::session_store::ContextKey::Channel(channel_id),
-                "stale-sid",
-            )
+            .save_binding(&worker_channel_key(channel_id, 0), "stale-sid")
             .await
             .unwrap();
         let (acp, capture) = spawn_capture_agent(
@@ -8395,7 +8423,7 @@ done"#,
         let result = result_rx.recv().await.expect("result");
         assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
         let binding = store
-            .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+            .load_binding(&worker_channel_key(channel_id, 0))
             .await
             .unwrap()
             .expect("fresh binding");
@@ -8441,7 +8469,7 @@ done"#,
         assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
         assert!(
             store
-                .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+                .load_binding(&worker_channel_key(channel_id, 0))
                 .await
                 .unwrap()
                 .is_none(),
@@ -8457,10 +8485,7 @@ done"#,
         let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
         let channel_id = Uuid::new_v4();
         store
-            .save_binding(
-                &crate::session_store::ContextKey::Channel(channel_id),
-                "keep-sid",
-            )
+            .save_binding(&worker_channel_key(channel_id, 0), "keep-sid")
             .await
             .unwrap();
         let mut state = SessionState::default();
@@ -8468,7 +8493,7 @@ done"#,
         state.invalidate_all();
         assert!(state.sessions.is_empty());
         let binding = store
-            .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+            .load_binding(&worker_channel_key(channel_id, 0))
             .await
             .unwrap()
             .expect("binding survives agent exit");
@@ -8505,6 +8530,193 @@ done"#,
         assert!(
             matches!(result.outcome, PromptOutcome::Ok(_)),
             "store errors must not fail the turn"
+        );
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    #[tokio::test]
+    async fn session_store_worker_does_not_restore_another_workers_binding() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let channel_id = Uuid::new_v4();
+        store
+            .save_binding(&worker_channel_key(channel_id, 0), "worker0-sid")
+            .await
+            .unwrap();
+        store
+            .save_binding(
+                &crate::session_store::ContextKey::Channel(channel_id),
+                "unscoped-sid",
+            )
+            .await
+            .unwrap();
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/load" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{}}"
+  elif [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"worker1-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"stopReason\":\"end_turn\"}}"
+  fi"#,
+        )
+        .await;
+        let mut agent = store_test_agent(acp);
+        agent.index = 1;
+        agent.acp.set_load_session_supported(true);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(store.clone());
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(channel_id)),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "cross-worker".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
+        let methods = read_methods(&capture);
+        assert!(
+            !methods.contains(&"session/load".to_string()),
+            "worker 1 must not load worker 0 or unscoped bindings: {methods:?}"
+        );
+        assert!(methods.contains(&"session/new".to_string()));
+        assert_eq!(
+            store
+                .load_binding(&worker_channel_key(channel_id, 0))
+                .await
+                .unwrap()
+                .unwrap()
+                .session_id,
+            "worker0-sid"
+        );
+        assert_eq!(
+            store
+                .load_binding(&worker_channel_key(channel_id, 1))
+                .await
+                .unwrap()
+                .unwrap()
+                .session_id,
+            "worker1-sid"
+        );
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    #[tokio::test]
+    async fn session_store_restore_forwards_git_origin_mcp_env() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let channel_id = Uuid::new_v4();
+        store
+            .save_binding(&worker_channel_key(channel_id, 0), "stored-sid")
+            .await
+            .unwrap();
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/load" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{}}"
+  elif [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"fresh-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"stopReason\":\"end_turn\"}}"
+  fi"#,
+        )
+        .await;
+        let mut agent = store_test_agent(acp);
+        agent.acp.set_load_session_supported(true);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(store.clone());
+        ctx.mcp_servers = vec![test_mcp_server()];
+        ctx.channel_info = ChannelInfoResolver::new(
+            std::collections::HashMap::from([(
+                channel_id,
+                crate::relay::ChannelInfo {
+                    name: "stream-chan".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            ctx.rest_client.clone(),
+        );
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(channel_id)),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "restore-origin".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
+        let payload = std::fs::read_to_string(&capture).unwrap_or_default();
+        assert!(
+            payload.contains("session/load"),
+            "expected session/load in {payload}"
+        );
+        assert!(
+            payload.contains("BUZZ_GIT_ORIGIN_CHANNEL_ID"),
+            "restore must inject git-origin env: {payload}"
+        );
+        assert!(
+            payload.contains(&channel_id.to_string()),
+            "restore git-origin must use the channel id: {payload}"
+        );
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    #[tokio::test]
+    async fn session_store_prompt_error_removes_binding() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"err-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{}}"
+  fi"#,
+        )
+        .await;
+        let agent = store_test_agent(acp);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(store.clone());
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        let channel_id = Uuid::new_v4();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(channel_id)),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "prompt-error".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(
+            matches!(result.outcome, PromptOutcome::Error(_)),
+            "expected prompt error"
+        );
+        assert!(
+            store
+                .load_binding(&worker_channel_key(channel_id, 0))
+                .await
+                .unwrap()
+                .is_none(),
+            "for-cause invalidate must delete the binding"
         );
         let mut agent = result.agent;
         agent.acp.shutdown().await;

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1789,6 +1789,19 @@ async fn store_save_binding(
     }
 }
 
+async fn store_retire_channel_bindings(ctx: &PromptContext, channel_id: uuid::Uuid) {
+    let Some(store) = ctx.session_store.as_ref() else {
+        return;
+    };
+    if let Err(error) = store.remove_bindings_for_channel(channel_id).await {
+        tracing::warn!(
+            %error,
+            %channel_id,
+            "session store remove_bindings_for_channel failed"
+        );
+    }
+}
+
 async fn store_mark_events_processed(
     ctx: &PromptContext,
     channel_id: uuid::Uuid,
@@ -2159,6 +2172,7 @@ pub async fn run_prompt_task(
                         // Seed a zero usage baseline: buzz-acp spawned this session
                         // so prior usage is zero by definition — first turn is reliable.
                         agent.acp.notify_session_spawned(&sid);
+                        store_retire_channel_bindings(&ctx, *cid).await;
                         store_save_binding(
                             &ctx,
                             &crate::session_store::ContextKey::Channel(*cid)
@@ -8587,14 +8601,21 @@ done"#,
             "worker 1 must not load worker 0 or unscoped bindings: {methods:?}"
         );
         assert!(methods.contains(&"session/new".to_string()));
-        assert_eq!(
+        assert!(
             store
                 .load_binding(&worker_channel_key(channel_id, 0))
                 .await
                 .unwrap()
+                .is_none(),
+            "fresh create must retire superseded sibling-worker bindings"
+        );
+        assert!(
+            store
+                .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+                .await
                 .unwrap()
-                .session_id,
-            "worker0-sid"
+                .is_none(),
+            "fresh create must retire unscoped channel bindings"
         );
         assert_eq!(
             store

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -641,6 +641,9 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Optional durable session-binding store. `None` keeps today's in-memory
+    /// bindings and processed-event dedupe.
+    pub session_store: Option<std::sync::Arc<dyn crate::session_store::SessionStore>>,
 }
 
 impl AgentPool {
@@ -1732,6 +1735,137 @@ fn send_prompt_result(
 /// Core async function spawned for each prompt.
 ///
 /// Lifecycle:
+fn context_key_for_source(source: &PromptSource) -> crate::session_store::ContextKey {
+    match source {
+        PromptSource::Channel(cid) => crate::session_store::ContextKey::Channel(*cid),
+        PromptSource::Heartbeat => crate::session_store::ContextKey::Heartbeat,
+    }
+}
+
+fn context_key_label(key: &crate::session_store::ContextKey) -> String {
+    match key {
+        crate::session_store::ContextKey::Channel(cid) => format!("channel {cid}"),
+        crate::session_store::ContextKey::Heartbeat => "heartbeat".to_string(),
+    }
+}
+
+async fn store_remove_binding(ctx: &PromptContext, key: &crate::session_store::ContextKey) {
+    let Some(store) = ctx.session_store.as_ref() else {
+        return;
+    };
+    if let Err(error) = store.remove_binding(key).await {
+        tracing::warn!(%error, key = %context_key_label(key), "session store remove_binding failed");
+    }
+}
+
+async fn store_save_binding(
+    ctx: &PromptContext,
+    key: &crate::session_store::ContextKey,
+    session_id: &str,
+) {
+    let Some(store) = ctx.session_store.as_ref() else {
+        return;
+    };
+    if let Err(error) = store.save_binding(key, session_id).await {
+        tracing::warn!(%error, key = %context_key_label(key), "session store save_binding failed");
+    }
+}
+
+async fn store_mark_events_processed(
+    ctx: &PromptContext,
+    channel_id: uuid::Uuid,
+    event_ids: &std::collections::HashSet<String>,
+) {
+    let Some(store) = ctx.session_store.as_ref() else {
+        return;
+    };
+    let ids: Vec<String> = event_ids.iter().cloned().collect();
+    if let Err(error) = store.mark_events_processed(channel_id, &ids).await {
+        tracing::warn!(%error, %channel_id, "session store mark_events_processed failed");
+    }
+}
+
+/// Attempt to re-attach a stored binding via `session/load`.
+///
+/// Returns `Some(session_id)` on success. On missing binding, missing
+/// capability, or load failure the binding is discarded (when present) and
+/// the caller falls through to `session/new`.
+async fn try_restore_stored_session(
+    agent: &mut OwnedAgent,
+    ctx: &PromptContext,
+    key: &crate::session_store::ContextKey,
+    channel_id: Option<uuid::Uuid>,
+) -> Option<String> {
+    let store = ctx.session_store.as_ref()?;
+    let binding = match store.load_binding(key).await {
+        Ok(Some(binding)) => binding,
+        Ok(None) => return None,
+        Err(error) => {
+            tracing::warn!(%error, key = %context_key_label(key), "session store load_binding failed");
+            return None;
+        }
+    };
+    if !agent.acp.load_session_supported() {
+        tracing::warn!(
+            "discarding stale session binding for {}; starting a fresh session",
+            context_key_label(key)
+        );
+        let _ = store.remove_binding(key).await;
+        return None;
+    }
+    match agent
+        .acp
+        .session_load(&binding.session_id, &ctx.cwd, ctx.mcp_servers.clone())
+        .await
+    {
+        Ok(()) => {
+            if let Err(error) = store.touch_binding(key).await {
+                tracing::warn!(%error, "session store touch_binding failed");
+            }
+            if let Some(cid) = channel_id {
+                let delivered = store
+                    .processed_event_ids_for_channel(cid)
+                    .await
+                    .unwrap_or_else(|error| {
+                        tracing::warn!(%error, %cid, "session store processed_event_ids_for_channel failed");
+                        Vec::new()
+                    });
+                agent.state.sessions.insert(cid, binding.session_id.clone());
+                agent.state.deliveries.insert(
+                    cid,
+                    ChannelDeliveryState {
+                        standing_context_sent: true,
+                        delivered_event_ids: delivered.into_iter().collect(),
+                    },
+                );
+            } else {
+                agent.state.heartbeat_session = Some(binding.session_id.clone());
+            }
+            Some(binding.session_id)
+        }
+        Err(error) => {
+            if matches!(
+                error,
+                crate::acp::AcpError::AgentExited | crate::acp::AcpError::Io(_)
+            ) {
+                tracing::warn!(
+                    %error,
+                    "session/load failed because the agent exited; keeping binding for {}",
+                    context_key_label(key)
+                );
+                return None;
+            }
+            tracing::warn!(
+                %error,
+                "discarding stale session binding for {}; starting a fresh session",
+                context_key_label(key)
+            );
+            let _ = store.remove_binding(key).await;
+            None
+        }
+    }
+}
+
 /// 1. Resolve or create a session (channel or heartbeat).
 /// 2. Send `initial_message` on new channel sessions (if configured).
 /// 3. Fetch conversation context if needed (thread reply or DM).
@@ -1956,6 +2090,15 @@ pub async fn run_prompt_task(
         PromptSource::Channel(cid) => {
             if let Some(sid) = agent.state.sessions.get(cid) {
                 (sid.clone(), false)
+            } else if let Some(sid) = try_restore_stored_session(
+                &mut agent,
+                &ctx,
+                &crate::session_store::ContextKey::Channel(*cid),
+                Some(*cid),
+            )
+            .await
+            {
+                (sid, false)
             } else {
                 // The title is channel-qualified (`Agent · #channel`) so one
                 // agent in several channels doesn't produce identical session
@@ -1988,6 +2131,12 @@ pub async fn run_prompt_task(
                         // Seed a zero usage baseline: buzz-acp spawned this session
                         // so prior usage is zero by definition — first turn is reliable.
                         agent.acp.notify_session_spawned(&sid);
+                        store_save_binding(
+                            &ctx,
+                            &crate::session_store::ContextKey::Channel(*cid),
+                            &sid,
+                        )
+                        .await;
                         // Commit canvas only after session creation succeeds (I3).
                         if let Some((pending_cid, section)) = pending_canvas.take() {
                             agent.state.canvas_sections.insert(pending_cid, section);
@@ -2025,6 +2174,15 @@ pub async fn run_prompt_task(
         PromptSource::Heartbeat => {
             if let Some(sid) = &agent.state.heartbeat_session {
                 (sid.clone(), false)
+            } else if let Some(sid) = try_restore_stored_session(
+                &mut agent,
+                &ctx,
+                &crate::session_store::ContextKey::Heartbeat,
+                None,
+            )
+            .await
+            {
+                (sid, false)
             } else {
                 match create_session_and_apply_model(
                     &mut agent,
@@ -2049,6 +2207,12 @@ pub async fn run_prompt_task(
                         agent.state.heartbeat_session = Some(sid.clone());
                         // Seed a zero usage baseline: buzz-acp spawned this session.
                         agent.acp.notify_session_spawned(&sid);
+                        store_save_binding(
+                            &ctx,
+                            &crate::session_store::ContextKey::Heartbeat,
+                            &sid,
+                        )
+                        .await;
                         (sid, true)
                     }
                     Err(AcpError::AgentExited) => {
@@ -2535,13 +2699,20 @@ pub async fn run_prompt_task(
                                 let failure = classify_control_cancel_failure(
                                     &ctx,
                                     error,
-                                    control_signal,
+                                    control_signal.clone(),
                                     batch,
                                 );
                                 if failure.invalidate_all {
                                     agent.state.invalidate_all();
                                 } else {
                                     agent.state.invalidate(&source);
+                                    if matches!(
+                                        control_signal,
+                                        ControlSignal::Rotate | ControlSignal::SwitchModel { .. }
+                                    ) {
+                                        store_remove_binding(&ctx, &context_key_for_source(&source))
+                                            .await;
+                                    }
                                 }
 
                                 let usage = agent.acp.take_turn_usage();
@@ -2603,12 +2774,24 @@ pub async fn run_prompt_task(
                                 standing_sent,
                                 &pending_delivered_event_ids,
                             );
+                            store_mark_events_processed(
+                                &ctx,
+                                *cid,
+                                &pending_delivered_event_ids,
+                            )
+                            .await;
                         }
                         apply_completed_before_control_signal(
                             &mut agent.state,
                             &source,
                             &control_signal,
                         );
+                        if matches!(
+                            control_signal,
+                            ControlSignal::Rotate | ControlSignal::SwitchModel { .. }
+                        ) {
+                            store_remove_binding(&ctx, &context_key_for_source(&source)).await;
+                        }
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
                             &ctx,
@@ -2646,6 +2829,7 @@ pub async fn run_prompt_task(
                     standing_sent,
                     &pending_delivered_event_ids,
                 );
+                store_mark_events_processed(&ctx, *cid, &pending_delivered_event_ids).await;
             } else if !agent.has_system_prompt_support() {
                 agent.state.heartbeat_standing_context_sent = true;
             }
@@ -2680,6 +2864,7 @@ pub async fn run_prompt_task(
                     "rotating session for {source:?} after {stop_reason:?}",
                 );
                 agent.state.invalidate(&source);
+                store_remove_binding(&ctx, &context_key_for_source(&source)).await;
             }
 
             let core_stop = acp_stop_to_core(&stop_reason);
@@ -4702,6 +4887,7 @@ async fn clear_reactions(rest: crate::relay::RestClient, event_ids: Vec<String>)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session_store::SessionStore;
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
 
@@ -6460,12 +6646,13 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             "next-turn".into(),
         )
         .await;
-        let mut result = result_rx.recv().await.expect("next prompt result");
+        let result = result_rx.recv().await.expect("next prompt result");
         assert!(matches!(
             result.outcome,
             PromptOutcome::Ok(StopReason::EndTurn)
         ));
-        result.agent.acp.shutdown().await;
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
         server.abort();
 
         let request: serde_json::Value =
@@ -7953,7 +8140,375 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            session_store: None,
         }
+    }
+
+    struct FailingStore;
+
+    #[async_trait::async_trait]
+    impl crate::session_store::SessionStore for FailingStore {
+        async fn load_binding(
+            &self,
+            _key: &crate::session_store::ContextKey,
+        ) -> Result<
+            Option<crate::session_store::SessionBinding>,
+            crate::session_store::SessionStoreError,
+        > {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
+        async fn save_binding(
+            &self,
+            _key: &crate::session_store::ContextKey,
+            _session_id: &str,
+        ) -> Result<(), crate::session_store::SessionStoreError> {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
+        async fn touch_binding(
+            &self,
+            _key: &crate::session_store::ContextKey,
+        ) -> Result<(), crate::session_store::SessionStoreError> {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
+        async fn remove_binding(
+            &self,
+            _key: &crate::session_store::ContextKey,
+        ) -> Result<(), crate::session_store::SessionStoreError> {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
+        async fn mark_events_processed(
+            &self,
+            _channel_id: Uuid,
+            _event_ids: &[String],
+        ) -> Result<(), crate::session_store::SessionStoreError> {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
+        async fn is_event_processed(
+            &self,
+            _event_id: &str,
+        ) -> Result<bool, crate::session_store::SessionStoreError> {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
+        async fn processed_event_ids_for_channel(
+            &self,
+            _channel_id: Uuid,
+        ) -> Result<Vec<String>, crate::session_store::SessionStoreError> {
+            Err(crate::session_store::SessionStoreError::Io("boom".into()))
+        }
+    }
+
+    async fn spawn_capture_agent(script: &str) -> (AcpClient, std::path::PathBuf) {
+        let capture =
+            std::env::temp_dir().join(format!("buzz-acp-store-{}.ndjson", Uuid::new_v4()));
+        let quoted = capture.to_string_lossy().replace('\'', "'\\''");
+        let wrapped = format!(
+            r#"count=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> '{quoted}'
+  count=$((count + 1))
+  {body}
+done"#,
+            quoted = quoted,
+            body = script,
+        );
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), wrapped], &[], false)
+            .await
+            .expect("spawn capture agent");
+        (acp, capture)
+    }
+
+    fn store_test_agent(acp: AcpClient) -> OwnedAgent {
+        OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            desired_model_request_id: None,
+            desired_model_pending_ack: false,
+            startup_effort: None,
+            agent_name: "legacy-test-agent".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        }
+    }
+
+    fn read_methods(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter_map(|v| v.get("method")?.as_str().map(str::to_string))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn session_store_writes_binding_on_create() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"created-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"stopReason\":\"end_turn\"}}"
+  fi"#,
+        )
+        .await;
+        let agent = store_test_agent(acp);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(store.clone());
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        let channel_id = Uuid::new_v4();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(channel_id)),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "create".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
+        let binding = store
+            .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+            .await
+            .unwrap()
+            .expect("binding written");
+        assert_eq!(binding.session_id, "created-sid");
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    #[tokio::test]
+    async fn session_store_restore_uses_session_load_and_skips_baseline() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let channel_id = Uuid::new_v4();
+        store
+            .save_binding(
+                &crate::session_store::ContextKey::Channel(channel_id),
+                "stored-sid",
+            )
+            .await
+            .unwrap();
+        store
+            .mark_events_processed(channel_id, &["already-done".into()])
+            .await
+            .unwrap();
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/load" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{}}"
+  elif [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"fresh-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"stopReason\":\"end_turn\"}}"
+  fi"#,
+        )
+        .await;
+        let mut agent = store_test_agent(acp);
+        agent.acp.set_load_session_supported(true);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(store.clone());
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(channel_id)),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "restore".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
+        assert_eq!(
+            result
+                .agent
+                .state
+                .sessions
+                .get(&channel_id)
+                .map(String::as_str),
+            Some("stored-sid")
+        );
+        let delivery = result.agent.state.deliveries.get(&channel_id).unwrap();
+        assert!(delivery.standing_context_sent);
+        assert!(delivery.delivered_event_ids.contains("already-done"));
+        let methods = read_methods(&capture);
+        assert!(
+            methods.contains(&"session/load".to_string()),
+            "expected session/load, got {methods:?}"
+        );
+        assert!(
+            !methods.contains(&"session/new".to_string()),
+            "restore must not create a fresh session: {methods:?}"
+        );
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    #[tokio::test]
+    async fn session_store_load_failure_removes_binding_and_creates_fresh() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let channel_id = Uuid::new_v4();
+        store
+            .save_binding(
+                &crate::session_store::ContextKey::Channel(channel_id),
+                "stale-sid",
+            )
+            .await
+            .unwrap();
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/load" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"error\":{\"code\":-32000,\"message\":\"gone\"}}"
+  elif [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"fresh-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"stopReason\":\"end_turn\"}}"
+  fi"#,
+        )
+        .await;
+        let mut agent = store_test_agent(acp);
+        agent.acp.set_load_session_supported(true);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(store.clone());
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(channel_id)),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "load-fail".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
+        let binding = store
+            .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+            .await
+            .unwrap()
+            .expect("fresh binding");
+        assert_eq!(binding.session_id, "fresh-sid");
+        let methods = read_methods(&capture);
+        assert!(methods.contains(&"session/load".to_string()));
+        assert!(methods.contains(&"session/new".to_string()));
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    #[tokio::test]
+    async fn session_store_rotation_removes_binding() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"rot-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"stopReason\":\"end_turn\"}}"
+  fi"#,
+        )
+        .await;
+        let agent = store_test_agent(acp);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(store.clone());
+        ctx.max_turns_per_session = 1;
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        let channel_id = Uuid::new_v4();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(channel_id)),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "rotate".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(matches!(result.outcome, PromptOutcome::Ok(_)));
+        assert!(
+            store
+                .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+                .await
+                .unwrap()
+                .is_none(),
+            "rotation must delete the binding"
+        );
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    #[tokio::test]
+    async fn session_store_agent_exit_keeps_binding() {
+        let store = std::sync::Arc::new(crate::session_store::InMemorySessionStore::new());
+        let channel_id = Uuid::new_v4();
+        store
+            .save_binding(
+                &crate::session_store::ContextKey::Channel(channel_id),
+                "keep-sid",
+            )
+            .await
+            .unwrap();
+        let mut state = SessionState::default();
+        state.sessions.insert(channel_id, "keep-sid".into());
+        state.invalidate_all();
+        assert!(state.sessions.is_empty());
+        let binding = store
+            .load_binding(&crate::session_store::ContextKey::Channel(channel_id))
+            .await
+            .unwrap()
+            .expect("binding survives agent exit");
+        assert_eq!(binding.session_id, "keep-sid");
+    }
+
+    #[tokio::test]
+    async fn session_store_errors_degrade_to_in_memory_behavior() {
+        let (acp, capture) = spawn_capture_agent(
+            r#"method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ "$method" = "session/new" ]; then
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"sessionId\":\"ok-sid\"}}"
+  else
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$((count-1)),\"result\":{\"stopReason\":\"end_turn\"}}"
+  fi"#,
+        )
+        .await;
+        let agent = store_test_agent(acp);
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.session_store = Some(std::sync::Arc::new(FailingStore));
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        run_prompt_task(
+            agent,
+            Some(one_event_batch(Uuid::new_v4())),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "degrade".into(),
+        )
+        .await;
+        let result = result_rx.recv().await.expect("result");
+        assert!(
+            matches!(result.outcome, PromptOutcome::Ok(_)),
+            "store errors must not fail the turn"
+        );
+        let mut agent = result.agent;
+        agent.acp.shutdown().await;
+        let _ = std::fs::remove_file(&capture);
     }
 
     // ── huddle instructions ─────────────────────────────────────────────────

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -5405,4 +5405,17 @@ mod tests {
             "unresolved metadata must not render a Description field; got: {prompt}"
         );
     }
+
+    #[test]
+    fn push_is_unaffected_by_pre_push_processed_event_gate() {
+        // The durable-dedupe gate lives before `queue.push` in lib.rs. This
+        // crate-local queue still accepts any event it is given.
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let accepted = queue.push(make_queued(Uuid::new_v4(), "already processed elsewhere"));
+        assert!(
+            accepted,
+            "queue.push must still accept events; the store gate is pre-push"
+        );
+        assert_eq!(pending_count(&queue), 1);
+    }
 }

--- a/crates/buzz-acp/src/session_store.rs
+++ b/crates/buzz-acp/src/session_store.rs
@@ -1,0 +1,344 @@
+//! Durable session-binding and processed-event store.
+//!
+//! This module is the public seam for restart-safe ACP session reuse and
+//! at-least-once event dedupe. The store holds **IDs and timestamps only** —
+//! never prompts, keys, or room history.
+//!
+//! # Semantics
+//!
+//! - Bindings **survive** agent-subprocess exit, panic recovery, and harness
+//!   shutdown. They are the restart payload. In-memory
+//!   [`SessionState::invalidate_*`](crate::pool::SessionState) does **not**
+//!   imply store deletion.
+//! - Bindings are **deleted** only when a session is deliberately retired or
+//!   proven invalid: rotation (`MaxTokens` / `MaxTurnRequests` /
+//!   `max_turns_per_session`), `ControlSignal::Rotate` / `SwitchModel`,
+//!   channel membership removal, `session/load` failure, or a malformed row.
+//! - Processed-event marking happens only after a successful turn, so
+//!   duplicate relay event IDs produce one reply. A crash mid-turn
+//!   re-processes (at-least-once).
+//!
+//! # Multi-worker invariant
+//!
+//! The store is process-global. In-memory session maps are per-worker.
+//! `EventQueue`'s `in_flight_channels` gate ensures one channel is processed
+//! by one worker at a time, so two workers cannot concurrently load the same
+//! binding.
+//!
+//! # Adapters
+//!
+//! [`InMemorySessionStore`] is for tests and ephemeral runs.
+//! [`sqlite::SqliteSessionStore`] is the opt-in production adapter.
+
+pub mod sqlite;
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+/// Scope pinning a store handle to one agent identity. Set once at open;
+/// rows are keyed by it so one DB file is safe to share across agents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreScope {
+    /// 64-hex agent pubkey, lowercased.
+    pub agent_pubkey: String,
+    /// Relay URL, trimmed, with a trailing `/` stripped.
+    pub relay_url: String,
+    /// Adapter identity from `normalize_agent_command_identity`.
+    pub adapter: String,
+}
+
+impl StoreScope {
+    /// Normalize identity fields used as SQLite composite-key members.
+    pub fn new(
+        agent_pubkey: impl Into<String>,
+        relay_url: impl Into<String>,
+        adapter: impl Into<String>,
+    ) -> Self {
+        Self {
+            agent_pubkey: agent_pubkey.into().to_ascii_lowercase(),
+            relay_url: relay_url.into().trim().trim_end_matches('/').to_string(),
+            adapter: adapter.into(),
+        }
+    }
+}
+
+/// What a session is bound to. Wire format: channel UUID string or `"heartbeat"`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ContextKey {
+    /// A NIP-29 channel.
+    Channel(Uuid),
+    /// The harness heartbeat session.
+    Heartbeat,
+}
+
+impl ContextKey {
+    /// Wire form stored in SQLite (`context_key`).
+    pub fn as_wire(&self) -> String {
+        match self {
+            Self::Channel(id) => id.to_string(),
+            Self::Heartbeat => "heartbeat".to_string(),
+        }
+    }
+}
+
+/// A durable binding: IDs and timestamps only. No prompts, keys, or history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionBinding {
+    /// Adapter session identifier.
+    pub session_id: String,
+    /// Unix seconds when the binding was first written.
+    pub created_at: i64,
+    /// Unix seconds when the binding was last saved or touched.
+    pub last_used_at: i64,
+}
+
+/// Failures from a session store. Callers log and continue — a broken store
+/// must never take the harness down.
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum SessionStoreError {
+    /// Filesystem, lock, or spawn failure.
+    #[error("session store I/O: {0}")]
+    Io(String),
+    /// Schema or row that cannot be interpreted safely.
+    #[error("session store corrupt: {0}")]
+    Corrupt(String),
+}
+
+/// Durable session-binding + processed-event store.
+///
+/// All methods are best-effort from the harness's perspective: callers log
+/// and continue on error.
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    /// Load the binding for `key`, if any.
+    async fn load_binding(
+        &self,
+        key: &ContextKey,
+    ) -> Result<Option<SessionBinding>, SessionStoreError>;
+
+    /// Insert or replace the binding for `key`.
+    async fn save_binding(
+        &self,
+        key: &ContextKey,
+        session_id: &str,
+    ) -> Result<(), SessionStoreError>;
+
+    /// Refresh `last_used_at` without changing `session_id`.
+    async fn touch_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError>;
+
+    /// Delete the binding for `key`. Missing rows are success.
+    async fn remove_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError>;
+
+    /// Whether `event_id` was marked processed after a successful turn.
+    async fn is_event_processed(&self, event_id: &str) -> Result<bool, SessionStoreError>;
+
+    /// Record that `event_ids` were delivered on `channel_id`.
+    async fn mark_events_processed(
+        &self,
+        channel_id: Uuid,
+        event_ids: &[String],
+    ) -> Result<(), SessionStoreError>;
+
+    /// Event IDs previously marked processed for `channel_id`, so a restored
+    /// session can re-seed its in-memory delivered set.
+    async fn processed_event_ids_for_channel(
+        &self,
+        channel_id: Uuid,
+    ) -> Result<Vec<String>, SessionStoreError>;
+}
+
+/// In-memory adapter for tests and ephemeral runs. Bindings do not survive
+/// process restart.
+#[derive(Debug, Default)]
+pub struct InMemorySessionStore {
+    inner: Mutex<InMemoryInner>,
+}
+
+#[derive(Debug, Default)]
+struct InMemoryInner {
+    bindings: HashMap<String, SessionBinding>,
+    events: HashMap<String, (Uuid, i64)>,
+}
+
+impl InMemorySessionStore {
+    /// Empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn now_secs() -> i64 {
+        unix_now_secs()
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, InMemoryInner>, SessionStoreError> {
+        self.inner
+            .lock()
+            .map_err(|e| SessionStoreError::Io(format!("in-memory store poisoned: {e}")))
+    }
+}
+
+#[async_trait]
+impl SessionStore for InMemorySessionStore {
+    async fn load_binding(
+        &self,
+        key: &ContextKey,
+    ) -> Result<Option<SessionBinding>, SessionStoreError> {
+        let inner = self.lock()?;
+        Ok(inner.bindings.get(&key.as_wire()).cloned())
+    }
+
+    async fn save_binding(
+        &self,
+        key: &ContextKey,
+        session_id: &str,
+    ) -> Result<(), SessionStoreError> {
+        let now = Self::now_secs();
+        let mut inner = self.lock()?;
+        let wire = key.as_wire();
+        let created_at = inner
+            .bindings
+            .get(&wire)
+            .map(|b| b.created_at)
+            .unwrap_or(now);
+        inner.bindings.insert(
+            wire,
+            SessionBinding {
+                session_id: session_id.to_string(),
+                created_at,
+                last_used_at: now,
+            },
+        );
+        Ok(())
+    }
+
+    async fn touch_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError> {
+        let now = Self::now_secs();
+        let mut inner = self.lock()?;
+        if let Some(binding) = inner.bindings.get_mut(&key.as_wire()) {
+            binding.last_used_at = now;
+        }
+        Ok(())
+    }
+
+    async fn remove_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError> {
+        self.lock()?.bindings.remove(&key.as_wire());
+        Ok(())
+    }
+
+    async fn is_event_processed(&self, event_id: &str) -> Result<bool, SessionStoreError> {
+        Ok(self.lock()?.events.contains_key(event_id))
+    }
+
+    async fn mark_events_processed(
+        &self,
+        channel_id: Uuid,
+        event_ids: &[String],
+    ) -> Result<(), SessionStoreError> {
+        let now = Self::now_secs();
+        let mut inner = self.lock()?;
+        for event_id in event_ids {
+            inner.events.insert(event_id.clone(), (channel_id, now));
+        }
+        Ok(())
+    }
+
+    async fn processed_event_ids_for_channel(
+        &self,
+        channel_id: Uuid,
+    ) -> Result<Vec<String>, SessionStoreError> {
+        let inner = self.lock()?;
+        Ok(inner
+            .events
+            .iter()
+            .filter(|&(_, (cid, _))| *cid == channel_id)
+            .map(|(id, _)| id.clone())
+            .collect())
+    }
+}
+
+pub(crate) fn unix_now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Best-effort processed-event gate. Store errors degrade to "not processed".
+pub(crate) async fn skip_if_already_processed(
+    store: Option<&dyn SessionStore>,
+    event_id: &str,
+) -> bool {
+    let Some(store) = store else {
+        return false;
+    };
+    match store.is_event_processed(event_id).await {
+        Ok(true) => {
+            tracing::debug!(event_id, "skipping already-processed event");
+            true
+        }
+        Ok(false) => false,
+        Err(error) => {
+            tracing::warn!(%error, event_id, "session store processed-event check failed");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod session_store_in_memory_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn session_store_in_memory_round_trip_and_upsert() {
+        let store = InMemorySessionStore::new();
+        let cid = Uuid::new_v4();
+        let key = ContextKey::Channel(cid);
+
+        assert_eq!(store.load_binding(&key).await.unwrap(), None);
+        store.save_binding(&key, "ses_one").await.unwrap();
+        let first = store.load_binding(&key).await.unwrap().unwrap();
+        assert_eq!(first.session_id, "ses_one");
+
+        store.save_binding(&key, "ses_two").await.unwrap();
+        let second = store.load_binding(&key).await.unwrap().unwrap();
+        assert_eq!(second.session_id, "ses_two");
+        assert_eq!(second.created_at, first.created_at);
+        assert!(second.last_used_at >= first.last_used_at);
+    }
+
+    #[tokio::test]
+    async fn session_store_in_memory_processed_events_are_channel_scoped() {
+        let store = InMemorySessionStore::new();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        store
+            .mark_events_processed(a, &["evt-a".into(), "evt-shared".into()])
+            .await
+            .unwrap();
+        store
+            .mark_events_processed(b, &["evt-b".into()])
+            .await
+            .unwrap();
+
+        assert!(store.is_event_processed("evt-a").await.unwrap());
+        assert!(!store.is_event_processed("evt-missing").await.unwrap());
+        let mut for_a = store.processed_event_ids_for_channel(a).await.unwrap();
+        for_a.sort();
+        assert_eq!(for_a, vec!["evt-a", "evt-shared"]);
+    }
+
+    #[tokio::test]
+    async fn session_store_skip_gate_honors_marked_ids() {
+        let store = InMemorySessionStore::new();
+        store
+            .mark_events_processed(Uuid::new_v4(), &["seen".into()])
+            .await
+            .unwrap();
+        assert!(skip_if_already_processed(Some(&store), "seen").await);
+        assert!(!skip_if_already_processed(Some(&store), "fresh").await);
+        assert!(!skip_if_already_processed(None, "seen").await);
+    }
+}

--- a/crates/buzz-acp/src/session_store.rs
+++ b/crates/buzz-acp/src/session_store.rs
@@ -13,7 +13,9 @@
 //! - Bindings are **deleted** only when a session is deliberately retired or
 //!   proven invalid: rotation (`MaxTokens` / `MaxTurnRequests` /
 //!   `max_turns_per_session`), `ControlSignal::Rotate` / `SwitchModel`,
-//!   channel membership removal, `session/load` failure, or a malformed row.
+//!   channel membership removal, `session/load` failure, a malformed row, or
+//!   a for-cause [`SessionState::invalidate`](crate::pool::SessionState)
+//!   (prompt / idle-timeout / cancel-cleanup errors).
 //! - Processed-event marking happens only after a successful turn, so
 //!   duplicate relay event IDs produce one reply. A crash mid-turn
 //!   re-processes (at-least-once).
@@ -21,9 +23,10 @@
 //! # Multi-worker invariant
 //!
 //! The store is process-global. In-memory session maps are per-worker.
-//! `EventQueue`'s `in_flight_channels` gate ensures one channel is processed
-//! by one worker at a time, so two workers cannot concurrently load the same
-//! binding.
+//! Bindings are keyed by worker slot (`{index}:{context}`) so two adapter
+//! subprocesses never attach the same session id. `EventQueue`'s
+//! `in_flight_channels` gate still ensures one channel is processed by one
+//! worker at a time.
 //!
 //! # Adapters
 //!
@@ -66,12 +69,15 @@ impl StoreScope {
 }
 
 /// What a session is bound to. Wire format: channel UUID string or `"heartbeat"`.
+/// Worker-scoped keys (from [`ContextKey::for_worker`]) use `{index}:{inner}`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ContextKey {
     /// A NIP-29 channel.
     Channel(Uuid),
     /// The harness heartbeat session.
     Heartbeat,
+    /// Opaque pre-formatted wire key, including worker-scoped forms.
+    Wire(String),
 }
 
 impl ContextKey {
@@ -80,8 +86,22 @@ impl ContextKey {
         match self {
             Self::Channel(id) => id.to_string(),
             Self::Heartbeat => "heartbeat".to_string(),
+            Self::Wire(raw) => raw.clone(),
         }
     }
+
+    /// Scope this binding to one pool worker slot.
+    ///
+    /// Two workers must never `session/load` the same adapter session into
+    /// two subprocesses. Wire form: `{worker_index}:{inner}`.
+    pub fn for_worker(&self, worker_index: usize) -> Self {
+        Self::Wire(format!("{worker_index}:{}", self.as_wire()))
+    }
+}
+
+pub(crate) fn context_key_matches_channel(wire: &str, channel_id: Uuid) -> bool {
+    let id = channel_id.to_string();
+    wire == id || wire.ends_with(&format!(":{id}"))
 }
 
 /// A durable binding: IDs and timestamps only. No prompts, keys, or history.
@@ -131,6 +151,12 @@ pub trait SessionStore: Send + Sync {
 
     /// Delete the binding for `key`. Missing rows are success.
     async fn remove_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError>;
+
+    /// Delete every binding for `channel_id`, including worker-scoped keys.
+    ///
+    /// Used when a channel is retired for all workers (membership removal,
+    /// idle `!rotate`). Missing rows are success.
+    async fn remove_bindings_for_channel(&self, channel_id: Uuid) -> Result<(), SessionStoreError>;
 
     /// Whether `event_id` was marked processed after a successful turn.
     async fn is_event_processed(&self, event_id: &str) -> Result<bool, SessionStoreError>;
@@ -225,6 +251,14 @@ impl SessionStore for InMemorySessionStore {
 
     async fn remove_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError> {
         self.lock()?.bindings.remove(&key.as_wire());
+        Ok(())
+    }
+
+    async fn remove_bindings_for_channel(&self, channel_id: Uuid) -> Result<(), SessionStoreError> {
+        let mut inner = self.lock()?;
+        inner
+            .bindings
+            .retain(|wire, _| !context_key_matches_channel(wire, channel_id));
         Ok(())
     }
 
@@ -340,5 +374,52 @@ mod session_store_in_memory_tests {
         assert!(skip_if_already_processed(Some(&store), "seen").await);
         assert!(!skip_if_already_processed(Some(&store), "fresh").await);
         assert!(!skip_if_already_processed(None, "seen").await);
+    }
+
+    #[tokio::test]
+    async fn session_store_worker_keys_and_channel_removal_are_isolated() {
+        let store = InMemorySessionStore::new();
+        let cid = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let worker0 = ContextKey::Channel(cid).for_worker(0);
+        let worker1 = ContextKey::Channel(cid).for_worker(1);
+        let other_key = ContextKey::Channel(other).for_worker(0);
+        store.save_binding(&worker0, "ses_w0").await.unwrap();
+        store.save_binding(&worker1, "ses_w1").await.unwrap();
+        store.save_binding(&other_key, "ses_other").await.unwrap();
+
+        assert_eq!(worker0.as_wire(), format!("0:{cid}"));
+        assert_ne!(worker0.as_wire(), ContextKey::Channel(cid).as_wire());
+        assert_eq!(
+            store
+                .load_binding(&worker0)
+                .await
+                .unwrap()
+                .unwrap()
+                .session_id,
+            "ses_w0"
+        );
+        assert_eq!(
+            store
+                .load_binding(&worker1)
+                .await
+                .unwrap()
+                .unwrap()
+                .session_id,
+            "ses_w1"
+        );
+
+        store.remove_bindings_for_channel(cid).await.unwrap();
+        assert!(store.load_binding(&worker0).await.unwrap().is_none());
+        assert!(store.load_binding(&worker1).await.unwrap().is_none());
+        assert_eq!(
+            store
+                .load_binding(&other_key)
+                .await
+                .unwrap()
+                .unwrap()
+                .session_id,
+            "ses_other"
+        );
     }
 }

--- a/crates/buzz-acp/src/session_store.rs
+++ b/crates/buzz-acp/src/session_store.rs
@@ -24,9 +24,11 @@
 //!
 //! The store is process-global. In-memory session maps are per-worker.
 //! Bindings are keyed by worker slot (`{index}:{context}`) so two adapter
-//! subprocesses never attach the same session id. `EventQueue`'s
-//! `in_flight_channels` gate still ensures one channel is processed by one
-//! worker at a time.
+//! subprocesses never attach the same session id. A fresh channel-session
+//! create retires every binding for that channel (including sibling-worker
+//! keys) before saving, so a later restart cannot restore a superseded
+//! history. `EventQueue`'s `in_flight_channels` gate still ensures one
+//! channel is processed by one worker at a time.
 //!
 //! # Adapters
 //!

--- a/crates/buzz-acp/src/session_store/sqlite.rs
+++ b/crates/buzz-acp/src/session_store/sqlite.rs
@@ -1,0 +1,387 @@
+//! SQLite adapter for [`SessionStore`](super::SessionStore).
+//!
+//! Schema is embedded and applied at open. This is **not** a relay Postgres
+//! migration — do not add anything under the repo `migrations/` directory.
+
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use rusqlite::{params, Connection};
+use uuid::Uuid;
+
+use super::{
+    unix_now_secs, ContextKey, SessionBinding, SessionStore, SessionStoreError, StoreScope,
+};
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS session_bindings (
+  scope_agent TEXT NOT NULL,
+  scope_relay TEXT NOT NULL,
+  scope_adapter TEXT NOT NULL,
+  context_key TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  last_used_at INTEGER NOT NULL,
+  PRIMARY KEY (scope_agent, scope_relay, scope_adapter, context_key)
+);
+CREATE TABLE IF NOT EXISTS processed_events (
+  scope_agent TEXT NOT NULL,
+  scope_relay TEXT NOT NULL,
+  scope_adapter TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  processed_at INTEGER NOT NULL,
+  PRIMARY KEY (scope_agent, scope_relay, scope_adapter, event_id)
+);
+CREATE TABLE IF NOT EXISTS session_store_migrations (
+  name TEXT PRIMARY KEY,
+  applied_at INTEGER NOT NULL
+);
+"#;
+
+const PROCESSED_EVENT_TTL_SECS: i64 = 30 * 24 * 60 * 60;
+
+/// Production SQLite-backed [`SessionStore`].
+pub struct SqliteSessionStore {
+    conn: Arc<Mutex<Connection>>,
+    scope: StoreScope,
+}
+
+impl SqliteSessionStore {
+    /// Open (or create) the store at `path` and apply the embedded schema.
+    pub fn open(path: &Path, scope: StoreScope) -> Result<Self, SessionStoreError> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    SessionStoreError::Io(format!("failed to create session store dir: {e}"))
+                })?;
+            }
+        }
+
+        let conn = Connection::open(path)
+            .map_err(|e| SessionStoreError::Io(format!("failed to open session store: {e}")))?;
+        conn.pragma_update(None, "busy_timeout", 5000)
+            .map_err(|e| SessionStoreError::Io(format!("failed to set busy_timeout: {e}")))?;
+        set_wal_mode(&conn)?;
+        conn.execute_batch(SCHEMA)
+            .map_err(|e| SessionStoreError::Io(format!("failed to initialize schema: {e}")))?;
+        apply_v1_marker(&conn)?;
+        prune_old_processed_events(&conn, &scope)?;
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            scope,
+        })
+    }
+
+    async fn with_conn<T, F>(&self, f: F) -> Result<T, SessionStoreError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Connection, &StoreScope) -> Result<T, SessionStoreError> + Send + 'static,
+    {
+        let conn = Arc::clone(&self.conn);
+        let scope = self.scope.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn
+                .lock()
+                .map_err(|e| SessionStoreError::Io(format!("session store poisoned: {e}")))?;
+            f(&guard, &scope)
+        })
+        .await
+        .map_err(|e| SessionStoreError::Io(format!("session store worker join: {e}")))?
+    }
+}
+
+fn set_wal_mode(conn: &Connection) -> Result<(), SessionStoreError> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match conn.pragma_update(None, "journal_mode", "WAL") {
+            Ok(()) => return Ok(()),
+            Err(error) if sqlite_is_busy(&error) && Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(error) => {
+                return Err(SessionStoreError::Io(format!(
+                    "failed to set WAL mode: {error}"
+                )));
+            }
+        }
+    }
+}
+
+fn sqlite_is_busy(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(inner, _)
+            if matches!(
+                inner.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+    )
+}
+
+fn apply_v1_marker(conn: &Connection) -> Result<(), SessionStoreError> {
+    conn.execute(
+        "INSERT OR IGNORE INTO session_store_migrations (name, applied_at) VALUES (?1, ?2)",
+        params!["v1", unix_now_secs()],
+    )
+    .map_err(|e| SessionStoreError::Io(format!("failed to record schema marker: {e}")))?;
+    Ok(())
+}
+
+fn prune_old_processed_events(
+    conn: &Connection,
+    scope: &StoreScope,
+) -> Result<(), SessionStoreError> {
+    let cutoff = unix_now_secs() - PROCESSED_EVENT_TTL_SECS;
+    let pruned = conn
+        .execute(
+            "DELETE FROM processed_events
+             WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+               AND processed_at < ?4",
+            params![scope.agent_pubkey, scope.relay_url, scope.adapter, cutoff],
+        )
+        .map_err(|e| SessionStoreError::Io(format!("failed to prune processed events: {e}")))?;
+    if pruned > 0 {
+        tracing::debug!(pruned, "pruned expired processed_events rows");
+    }
+    Ok(())
+}
+
+fn load_binding_row(
+    conn: &Connection,
+    scope: &StoreScope,
+    key: &ContextKey,
+) -> Result<Option<SessionBinding>, SessionStoreError> {
+    let wire = key.as_wire();
+    let mut stmt = conn
+        .prepare(
+            "SELECT session_id, created_at, last_used_at FROM session_bindings
+             WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+               AND context_key = ?4",
+        )
+        .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+    let mut rows = stmt
+        .query(params![
+            scope.agent_pubkey,
+            scope.relay_url,
+            scope.adapter,
+            wire
+        ])
+        .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+    let Some(row) = rows
+        .next()
+        .map_err(|e| SessionStoreError::Corrupt(e.to_string()))?
+    else {
+        return Ok(None);
+    };
+    let session_id: String = row
+        .get(0)
+        .map_err(|e| SessionStoreError::Corrupt(e.to_string()))?;
+    let created_at: i64 = row
+        .get(1)
+        .map_err(|e| SessionStoreError::Corrupt(e.to_string()))?;
+    let last_used_at: i64 = row
+        .get(2)
+        .map_err(|e| SessionStoreError::Corrupt(e.to_string()))?;
+    if session_id.trim().is_empty() {
+        tracing::warn!(
+            context_key = %wire,
+            "discarding malformed session binding with empty session_id"
+        );
+        conn.execute(
+            "DELETE FROM session_bindings
+             WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+               AND context_key = ?4",
+            params![scope.agent_pubkey, scope.relay_url, scope.adapter, wire],
+        )
+        .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+        return Ok(None);
+    }
+    Ok(Some(SessionBinding {
+        session_id,
+        created_at,
+        last_used_at,
+    }))
+}
+
+#[async_trait]
+impl SessionStore for SqliteSessionStore {
+    async fn load_binding(
+        &self,
+        key: &ContextKey,
+    ) -> Result<Option<SessionBinding>, SessionStoreError> {
+        let key = key.clone();
+        self.with_conn(move |conn, scope| load_binding_row(conn, scope, &key))
+            .await
+    }
+
+    async fn save_binding(
+        &self,
+        key: &ContextKey,
+        session_id: &str,
+    ) -> Result<(), SessionStoreError> {
+        let key = key.as_wire();
+        let session_id = session_id.to_string();
+        self.with_conn(move |conn, scope| {
+            let now = unix_now_secs();
+            conn.execute(
+                "INSERT INTO session_bindings (
+                    scope_agent, scope_relay, scope_adapter, context_key,
+                    session_id, created_at, last_used_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
+                 ON CONFLICT(scope_agent, scope_relay, scope_adapter, context_key)
+                 DO UPDATE SET session_id = excluded.session_id,
+                               last_used_at = excluded.last_used_at",
+                params![
+                    scope.agent_pubkey,
+                    scope.relay_url,
+                    scope.adapter,
+                    key,
+                    session_id,
+                    now
+                ],
+            )
+            .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn touch_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError> {
+        let key = key.as_wire();
+        self.with_conn(move |conn, scope| {
+            conn.execute(
+                "UPDATE session_bindings SET last_used_at = ?5
+                 WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+                   AND context_key = ?4",
+                params![
+                    scope.agent_pubkey,
+                    scope.relay_url,
+                    scope.adapter,
+                    key,
+                    unix_now_secs()
+                ],
+            )
+            .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn remove_binding(&self, key: &ContextKey) -> Result<(), SessionStoreError> {
+        let key = key.as_wire();
+        self.with_conn(move |conn, scope| {
+            conn.execute(
+                "DELETE FROM session_bindings
+                 WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+                   AND context_key = ?4",
+                params![scope.agent_pubkey, scope.relay_url, scope.adapter, key],
+            )
+            .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn is_event_processed(&self, event_id: &str) -> Result<bool, SessionStoreError> {
+        let event_id = event_id.to_string();
+        self.with_conn(move |conn, scope| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT 1 FROM processed_events
+                     WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+                       AND event_id = ?4",
+                )
+                .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            let exists = stmt
+                .exists(params![
+                    scope.agent_pubkey,
+                    scope.relay_url,
+                    scope.adapter,
+                    event_id
+                ])
+                .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            Ok(exists)
+        })
+        .await
+    }
+
+    async fn mark_events_processed(
+        &self,
+        channel_id: Uuid,
+        event_ids: &[String],
+    ) -> Result<(), SessionStoreError> {
+        let channel_id = channel_id.to_string();
+        let event_ids = event_ids.to_vec();
+        self.with_conn(move |conn, scope| {
+            let now = unix_now_secs();
+            for event_id in event_ids {
+                conn.execute(
+                    "INSERT INTO processed_events (
+                        scope_agent, scope_relay, scope_adapter,
+                        event_id, channel_id, processed_at
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                     ON CONFLICT(scope_agent, scope_relay, scope_adapter, event_id)
+                     DO UPDATE SET channel_id = excluded.channel_id,
+                                   processed_at = excluded.processed_at",
+                    params![
+                        scope.agent_pubkey,
+                        scope.relay_url,
+                        scope.adapter,
+                        event_id,
+                        channel_id,
+                        now
+                    ],
+                )
+                .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    async fn processed_event_ids_for_channel(
+        &self,
+        channel_id: Uuid,
+    ) -> Result<Vec<String>, SessionStoreError> {
+        let channel_id = channel_id.to_string();
+        self.with_conn(move |conn, scope| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT event_id FROM processed_events
+                     WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+                       AND channel_id = ?4",
+                )
+                .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            let rows = stmt
+                .query_map(
+                    params![
+                        scope.agent_pubkey,
+                        scope.relay_url,
+                        scope.adapter,
+                        channel_id
+                    ],
+                    |row| row.get(0),
+                )
+                .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row.map_err(|e| SessionStoreError::Corrupt(e.to_string()))?);
+            }
+            Ok(ids)
+        })
+        .await
+    }
+}
+
+/// Test helper: raw path used by a store after `open`.
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn db_path_for_tests(dir: &Path) -> PathBuf {
+    dir.join("sessions.db")
+}

--- a/crates/buzz-acp/src/session_store/sqlite.rs
+++ b/crates/buzz-acp/src/session_store/sqlite.rs
@@ -288,6 +288,25 @@ impl SessionStore for SqliteSessionStore {
         .await
     }
 
+    async fn remove_bindings_for_channel(&self, channel_id: Uuid) -> Result<(), SessionStoreError> {
+        self.with_conn(move |conn, scope| {
+            conn.execute(
+                "DELETE FROM session_bindings
+                 WHERE scope_agent = ?1 AND scope_relay = ?2 AND scope_adapter = ?3
+                   AND (context_key = ?4 OR context_key LIKE '%:' || ?4)",
+                params![
+                    scope.agent_pubkey,
+                    scope.relay_url,
+                    scope.adapter,
+                    channel_id.to_string()
+                ],
+            )
+            .map_err(|e| SessionStoreError::Io(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
     async fn is_event_processed(&self, event_id: &str) -> Result<bool, SessionStoreError> {
         let event_id = event_id.to_string();
         self.with_conn(move |conn, scope| {

--- a/crates/buzz-acp/tests/session_store_restart.rs
+++ b/crates/buzz-acp/tests/session_store_restart.rs
@@ -245,6 +245,57 @@ async fn session_store_wal_concurrent_open_within_busy_timeout() {
     );
 }
 
+#[tokio::test]
+async fn session_store_worker_scoped_bindings_and_channel_removal() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = db_path(dir.path());
+    let store = SqliteSessionStore::open(&path, scope_a()).expect("open");
+    let channel = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let worker0 = ContextKey::Channel(channel).for_worker(0);
+    let worker1 = ContextKey::Channel(channel).for_worker(1);
+    let other_key = ContextKey::Channel(other).for_worker(0);
+    store
+        .save_binding(&worker0, "ses_w0")
+        .await
+        .expect("save w0");
+    store
+        .save_binding(&worker1, "ses_w1")
+        .await
+        .expect("save w1");
+    store
+        .save_binding(&other_key, "ses_other")
+        .await
+        .expect("save other");
+    drop(store);
+
+    let store = SqliteSessionStore::open(&path, scope_a()).expect("reopen");
+    assert_eq!(
+        store
+            .load_binding(&worker0)
+            .await
+            .expect("load w0")
+            .unwrap()
+            .session_id,
+        "ses_w0"
+    );
+    store
+        .remove_bindings_for_channel(channel)
+        .await
+        .expect("remove channel");
+    assert!(store.load_binding(&worker0).await.unwrap().is_none());
+    assert!(store.load_binding(&worker1).await.unwrap().is_none());
+    assert_eq!(
+        store
+            .load_binding(&other_key)
+            .await
+            .unwrap()
+            .unwrap()
+            .session_id,
+        "ses_other"
+    );
+}
+
 fn table_columns(conn: &rusqlite::Connection, table: &str) -> Vec<String> {
     let mut stmt = conn
         .prepare(&format!("PRAGMA table_info({table})"))

--- a/crates/buzz-acp/tests/session_store_restart.rs
+++ b/crates/buzz-acp/tests/session_store_restart.rs
@@ -1,0 +1,256 @@
+//! Restart and isolation contract for the public session-store API.
+
+use std::path::Path;
+
+use buzz_acp::session_store::sqlite::SqliteSessionStore;
+use buzz_acp::session_store::{ContextKey, SessionStore, StoreScope};
+use rusqlite::params;
+use uuid::Uuid;
+
+fn scope_a() -> StoreScope {
+    StoreScope::new(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "wss://relay.example/",
+        "adapter-a",
+    )
+}
+
+fn scope_b() -> StoreScope {
+    StoreScope::new(
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "wss://relay.example",
+        "adapter-b",
+    )
+}
+
+fn db_path(dir: &Path) -> std::path::PathBuf {
+    dir.join("sessions.db")
+}
+
+#[tokio::test]
+async fn session_store_bindings_survive_reopen() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = db_path(dir.path());
+    let key = ContextKey::Channel(Uuid::new_v4());
+
+    let store = SqliteSessionStore::open(&path, scope_a()).expect("open");
+    store.save_binding(&key, "ses_persist").await.expect("save");
+    let first = store
+        .load_binding(&key)
+        .await
+        .expect("load")
+        .expect("binding");
+    drop(store);
+
+    let store = SqliteSessionStore::open(&path, scope_a()).expect("reopen");
+    let again = store
+        .load_binding(&key)
+        .await
+        .expect("load after reopen")
+        .expect("binding after reopen");
+    assert_eq!(again.session_id, "ses_persist");
+    assert_eq!(again.created_at, first.created_at);
+    assert_eq!(again.last_used_at, first.last_used_at);
+}
+
+#[tokio::test]
+async fn session_store_processed_events_survive_reopen_and_dedupe() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = db_path(dir.path());
+    let channel = Uuid::new_v4();
+
+    let store = SqliteSessionStore::open(&path, scope_a()).expect("open");
+    store
+        .mark_events_processed(channel, &["evt-1".into(), "evt-2".into()])
+        .await
+        .expect("mark");
+    drop(store);
+
+    let store = SqliteSessionStore::open(&path, scope_a()).expect("reopen");
+    assert!(store.is_event_processed("evt-1").await.expect("check 1"));
+    assert!(store.is_event_processed("evt-2").await.expect("check 2"));
+    assert!(!store
+        .is_event_processed("evt-unknown")
+        .await
+        .expect("check unknown"));
+    let mut ids = store
+        .processed_event_ids_for_channel(channel)
+        .await
+        .expect("channel ids");
+    ids.sort();
+    assert_eq!(ids, vec!["evt-1", "evt-2"]);
+}
+
+#[tokio::test]
+async fn session_store_scopes_are_isolated() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = db_path(dir.path());
+    let key = ContextKey::Heartbeat;
+
+    let a = SqliteSessionStore::open(&path, scope_a()).expect("open a");
+    a.save_binding(&key, "ses_a").await.expect("save a");
+
+    let b = SqliteSessionStore::open(&path, scope_b()).expect("open b");
+    b.save_binding(&key, "ses_b").await.expect("save b");
+
+    assert_eq!(
+        a.load_binding(&key)
+            .await
+            .expect("load a")
+            .unwrap()
+            .session_id,
+        "ses_a"
+    );
+    assert_eq!(
+        b.load_binding(&key)
+            .await
+            .expect("load b")
+            .unwrap()
+            .session_id,
+        "ses_b"
+    );
+}
+
+#[tokio::test]
+async fn session_store_malformed_binding_is_discarded_not_resumed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = db_path(dir.path());
+    let channel = Uuid::new_v4();
+    let scope = scope_a();
+
+    {
+        let store = SqliteSessionStore::open(&path, scope.clone()).expect("bootstrap schema");
+        drop(store);
+        let conn = rusqlite::Connection::open(&path).expect("raw open");
+        conn.execute(
+            "INSERT INTO session_bindings (
+                scope_agent, scope_relay, scope_adapter, context_key,
+                session_id, created_at, last_used_at
+             ) VALUES (?1, ?2, ?3, ?4, '', 1, 1)",
+            params![
+                scope.agent_pubkey,
+                scope.relay_url,
+                scope.adapter,
+                channel.to_string()
+            ],
+        )
+        .expect("insert empty session_id");
+    }
+
+    let store = SqliteSessionStore::open(&path, scope.clone()).expect("reopen");
+    let loaded = store
+        .load_binding(&ContextKey::Channel(channel))
+        .await
+        .expect("load malformed");
+    assert!(loaded.is_none(), "malformed binding must not resume");
+
+    let remaining: i64 = {
+        let conn = rusqlite::Connection::open(&path).expect("raw reopen");
+        conn.query_row(
+            "SELECT COUNT(*) FROM session_bindings
+             WHERE scope_agent = ?1 AND context_key = ?2",
+            params![scope.agent_pubkey, channel.to_string()],
+            |row| row.get(0),
+        )
+        .expect("count")
+    };
+    assert_eq!(remaining, 0, "malformed row must be deleted");
+}
+
+#[tokio::test]
+async fn session_store_file_contains_ids_only() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = db_path(dir.path());
+    let store = SqliteSessionStore::open(&path, scope_a()).expect("open");
+    let channel = Uuid::new_v4();
+    store
+        .save_binding(&ContextKey::Channel(channel), "ses_ids_only")
+        .await
+        .expect("save");
+    store
+        .mark_events_processed(channel, &["evt-ids-only".into()])
+        .await
+        .expect("mark");
+    drop(store);
+
+    let bytes = std::fs::read(&path).expect("read db");
+    let haystack = String::from_utf8_lossy(&bytes);
+    assert!(
+        !haystack.contains("SENTINEL_PROMPT_DO_NOT_PERSIST"),
+        "store must never contain a prompt that was never written"
+    );
+    assert!(
+        !haystack.contains("nsec"),
+        "store must not contain key material tokens"
+    );
+
+    let conn = rusqlite::Connection::open(&path).expect("pragma open");
+    let binding_cols = table_columns(&conn, "session_bindings");
+    assert_eq!(
+        binding_cols,
+        vec![
+            "scope_agent",
+            "scope_relay",
+            "scope_adapter",
+            "context_key",
+            "session_id",
+            "created_at",
+            "last_used_at"
+        ]
+    );
+    let event_cols = table_columns(&conn, "processed_events");
+    assert_eq!(
+        event_cols,
+        vec![
+            "scope_agent",
+            "scope_relay",
+            "scope_adapter",
+            "event_id",
+            "channel_id",
+            "processed_at"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn session_store_wal_concurrent_open_within_busy_timeout() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = db_path(dir.path());
+    let a = SqliteSessionStore::open(&path, scope_a()).expect("open a");
+    let b = SqliteSessionStore::open(&path, scope_b()).expect("open b");
+    let key_a = ContextKey::Channel(Uuid::new_v4());
+    let key_b = ContextKey::Channel(Uuid::new_v4());
+
+    let (ra, rb) = tokio::join!(
+        a.save_binding(&key_a, "ses_race_a"),
+        b.save_binding(&key_b, "ses_race_b"),
+    );
+    ra.expect("race write a");
+    rb.expect("race write b");
+    assert_eq!(
+        a.load_binding(&key_a)
+            .await
+            .expect("load a")
+            .unwrap()
+            .session_id,
+        "ses_race_a"
+    );
+    assert_eq!(
+        b.load_binding(&key_b)
+            .await
+            .expect("load b")
+            .unwrap()
+            .session_id,
+        "ses_race_b"
+    );
+}
+
+fn table_columns(conn: &rusqlite::Connection, table: &str) -> Vec<String> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .expect("pragma");
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("rows");
+    rows.map(|r| r.expect("col")).collect()
+}


### PR DESCRIPTION
## Summary

Adds an opt-in SQLite session-binding and processed-event store to `buzz-acp` so a stored ACP session can survive harness restart, duplicate relay event IDs produce one reply, and invalid bindings are discarded instead of silently forking history.

Default remains in-memory. Set `--session-store PATH` or `BUZZ_ACP_SESSION_STORE` to enable. The store holds IDs and timestamps only.

Closes PAN-3.

## Why

Session maps lived only in memory. A restart always called `session/new` and forked history. Event dedupe was also in-memory, so a re-REQ after restart could prompt twice.

## What landed

Branch `feat/PAN-3-session-store` on pinned `main` `0720f5380ce8a6c050afac159f8462c06cd51ab5`.

Commits (DCO-signed):
- `5b3fdcd5b` feat(acp): add durable session binding store
- `a18e48d13` fix(acp): scope session bindings per worker and harden restore
- `c11e582ec` fix(acp): drop bindings on idle model switch and retire sibling keys

HEAD: `c11e582ec17293f0036f4363e1b26d2fdde86c71`
Diff: 10 files, +2374 / -39, `crates/buzz-acp` plus mechanical root `Cargo.lock`.

New:
- `crates/buzz-acp/src/session_store.rs`
- `crates/buzz-acp/src/session_store/sqlite.rs`
- `crates/buzz-acp/tests/session_store_restart.rs`

Changed: `config.rs`, `acp.rs`, `pool.rs`, `lib.rs`, `queue.rs`, `Cargo.toml`.

Behavior:
- Restore uses ACP `session/load` only when the adapter advertises `loadSession`. Failure or missing capability deletes the binding and warns, then creates a fresh session.
- Bindings are worker-scoped. A fresh channel create retires sibling-worker keys first.
- Processed events are marked only after a successful turn.
- Store errors never take the harness down.
- No Pantheon names. IDs and timestamps only.

## Verification

Independent gate: `cargo test -p buzz-acp session_store`, `cargo test -p buzz-acp pool`, `cargo test -p buzz-acp`, `cargo fmt --all --check`, `cargo clippy -p buzz-acp --all-targets -- -D warnings` all exit 0 at 2026-08-24T10:17:02Z.

This is a generic upstreamable seam. Hosts must pass a stable store path; Desktop/gateway launcher wiring is out of scope.