### PR TITLE
fix(desktop): refine sidebar motion

### DIFF
--- a/desktop/src/shared/ui/sidebar.tsx
+++ b/desktop/src/shared/ui/sidebar.tsx
@@ -350,7 +350,7 @@ const Sidebar = React.forwardRef<
         {/* Sidebar gap on desktop; the offcanvas sibling below also goes invisible, else it paints over the community rail past the overflow-visible shell. */}
         <div
           className={cn(
-            "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+            "relative w-(--sidebar-width) bg-transparent transition-[width] duration-[var(--motion-duration-standard)] ease-[var(--motion-ease-standard)]",
             "group-data-[resizing=true]:transition-none",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
@@ -361,7 +361,7 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "absolute inset-y-0 z-10 hidden h-full w-(--sidebar-width) transition-[left,right,width,visibility] duration-200 ease-linear md:flex",
+            "absolute inset-y-0 z-10 hidden h-full w-(--sidebar-width) transition-[left,right,width,visibility] duration-[var(--motion-duration-standard)] ease-[var(--motion-ease-standard)] md:flex",
             "group-data-[resizing=true]:transition-none group-data-[collapsible=offcanvas]:invisible",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
@@ -379,7 +379,7 @@ const Sidebar = React.forwardRef<
             className="flex h-full w-full flex-col bg-sidebar group-data-[variant=sidebar]:pr-px group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
           >
             <div
-              className="flex h-full w-full origin-top flex-col transition-[opacity,scale,translate] duration-200 ease-linear motion-reduce:transition-none motion-reduce:duration-0 group-data-[collapsible=offcanvas]:translate-x-6 group-data-[collapsible=offcanvas]:scale-95 group-data-[collapsible=offcanvas]:opacity-0"
+              className="flex h-full w-full flex-col transition-opacity duration-[var(--motion-duration-standard)] ease-[var(--motion-ease-standard)] motion-reduce:transition-none motion-reduce:duration-0 group-data-[collapsible=offcanvas]:opacity-0"
               data-sidebar-transition-content
             >
               {children}

--- a/desktop/tests/e2e/sidebar-offcanvas-rail.spec.ts
+++ b/desktop/tests/e2e/sidebar-offcanvas-rail.spec.ts
@@ -91,7 +91,7 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
       await Promise.all(animations.map((animation) => animation.ready));
       for (const animation of animations) {
         animation.pause();
-        animation.currentTime = 100;
+        animation.currentTime = 120;
       }
 
       const buttonBox = button.getBoundingClientRect();
@@ -109,8 +109,6 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
         hitRail: hit === rail || rail.contains(hit),
         opacity: railStyle.opacity,
         sidebarOpacity: Number.parseFloat(sidebarStyle.opacity),
-        sidebarScale: sidebarStyle.scale,
-        sidebarTranslateX: Number.parseFloat(sidebarStyle.translate),
         visibility: railStyle.visibility,
         x: railBox.x,
         y: railBox.y,
@@ -120,7 +118,7 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
       return result;
     });
     expect(transition).not.toBeNull();
-    expect(transition?.durations).toEqual([200, 200, 200]);
+    expect(transition?.durations).toEqual([240]);
     expect(transition).toMatchObject({
       hitRail: true,
       opacity: "1",
@@ -130,18 +128,14 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
     });
     expect(transition?.sidebarOpacity).toBeGreaterThan(0);
     expect(transition?.sidebarOpacity).toBeLessThan(1);
-    expect(transition?.sidebarScale).not.toBe("none");
-    expect(transition?.sidebarScale).not.toBe("0.95");
-    expect(transition?.sidebarTranslateX).toBeGreaterThan(0);
-    expect(transition?.sidebarTranslateX).toBeLessThan(24);
 
     const shell = page.locator(
       '[data-state="collapsed"][data-collapsible="offcanvas"]',
     );
     await expect(shell).toHaveCount(1);
 
-    // Let the 200ms slide finish; visibility flips at the transition's end.
-    await page.waitForTimeout(250);
+    // Let the 240ms slide finish; visibility flips at the transition's end.
+    await page.waitForTimeout(290);
 
     // Second direct child = the sliding sidebar container (first is the gap).
     const offscreenSidebar = shell.locator("> div").nth(1);

--- a/desktop/tests/e2e/sidebar-offcanvas-rail.spec.ts
+++ b/desktop/tests/e2e/sidebar-offcanvas-rail.spec.ts
@@ -63,10 +63,10 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
     const railBoxBeforeCollapse = await communityRail.boundingBox();
     expect(railBoxBeforeCollapse).not.toBeNull();
 
-    // Observe the transition before triggering it, then hold every animated
-    // sidebar-content property at its midpoint. This keeps the regression
-    // causal without making its assertions depend on Playwright or rAF
-    // scheduler latency.
+    // Observe the transition before triggering it, then hold the gap, sliding
+    // panel, and content fade at their shared midpoint. This keeps the
+    // regression causal without making its assertions depend on Playwright or
+    // rAF scheduler latency.
     const transition = await communityButton.evaluate(async (button) => {
       const rail = button.closest('[data-testid="community-rail"]');
       const trigger = document.querySelector<HTMLElement>(
@@ -75,7 +75,17 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
       const sidebarContent = document.querySelector<HTMLElement>(
         "[data-sidebar-transition-content]",
       );
-      if (!(rail instanceof HTMLElement) || !trigger || !sidebarContent) {
+      const sidebarPanel = sidebarContent?.closest<HTMLElement>(
+        '[data-testid="app-sidebar"]',
+      );
+      const sidebarGap = sidebarPanel?.previousElementSibling;
+      if (
+        !(rail instanceof HTMLElement) ||
+        !trigger ||
+        !sidebarContent ||
+        !sidebarPanel ||
+        !(sidebarGap instanceof HTMLElement)
+      ) {
         return null;
       }
 
@@ -87,12 +97,21 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
       trigger.click();
       await transitionStarted;
 
-      const animations = sidebarContent.getAnimations();
+      const animations = [sidebarGap, sidebarPanel, sidebarContent].flatMap(
+        (element) => element.getAnimations(),
+      );
       await Promise.all(animations.map((animation) => animation.ready));
       for (const animation of animations) {
         animation.pause();
         animation.currentTime = 120;
       }
+
+      const standardDuration = getComputedStyle(document.documentElement)
+        .getPropertyValue("--motion-duration-standard")
+        .trim();
+      const standardDurationMs = standardDuration.endsWith("ms")
+        ? Number.parseFloat(standardDuration)
+        : Number.parseFloat(standardDuration) * 1000;
 
       const buttonBox = button.getBoundingClientRect();
       const railBox = rail.getBoundingClientRect();
@@ -106,6 +125,13 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
         durations: animations.map(
           (animation) => animation.effect?.getTiming().duration,
         ),
+        properties: animations.map((animation) =>
+          animation instanceof CSSTransition
+            ? animation.transitionProperty
+            : null,
+        ),
+        standardDuration,
+        standardDurationMs,
         hitRail: hit === rail || rail.contains(hit),
         opacity: railStyle.opacity,
         sidebarOpacity: Number.parseFloat(sidebarStyle.opacity),
@@ -118,7 +144,16 @@ for (const theme of ["buzz", "buzz-dark", "vesper"]) {
       return result;
     });
     expect(transition).not.toBeNull();
-    expect(transition?.durations).toEqual([240]);
+    expect(transition?.standardDurationMs).toBe(240);
+    expect(transition?.properties).toEqual([
+      "width",
+      "left",
+      "visibility",
+      "opacity",
+    ]);
+    expect(transition?.durations).toEqual(
+      Array(4).fill(transition?.standardDurationMs),
+    );
     expect(transition).toMatchObject({
       hitRail: true,
       opacity: "1",

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -572,15 +572,17 @@ test("keeps only search pinned while primary navigation scrolls", async ({
   expect(scrolledMenuBox?.y ?? 0).toBeLessThan(initialMenuBox?.y ?? 0);
 });
 
-test("scales the sidebar backward while its chrome closes", async ({
+test("fades the sidebar without spatial movement while its chrome closes", async ({
   page,
 }) => {
   await page.goto("/");
 
   const sidebar = page.getByTestId("app-sidebar");
   const sidebarSurface = sidebar.locator("[data-sidebar-transition-content]");
+  const sidebarGap = sidebar.locator("..").locator(":scope > div").first();
   await expect(sidebarSurface).toHaveCSS("opacity", "1");
   await expect(sidebarSurface).toHaveCSS("scale", "none");
+  await expect(sidebarSurface).toHaveCSS("translate", "none");
 
   await page.getByRole("button", { name: "Toggle Sidebar" }).click();
 
@@ -595,25 +597,23 @@ test("scales the sidebar backward while its chrome closes", async ({
       return getComputedStyle(sidebarElement).backgroundColor;
     }),
   );
-  await expect(sidebarSurface).toHaveCSS("scale", "0.95");
-  await expect(sidebarSurface).toHaveCSS("translate", "24px");
-  const transformOrigin = await sidebarSurface.evaluate(
-    (element) => getComputedStyle(element).transformOrigin,
-  );
-  const [originX, originY] = transformOrigin.split(" ").map(Number.parseFloat);
-  const surfaceWidth = await sidebarSurface.evaluate(
-    (element) => element.clientWidth,
-  );
-  expect(Math.abs(originX - surfaceWidth / 2)).toBeLessThan(0.5);
-  expect(originY).toBe(0);
-  await expect(sidebarSurface).toHaveCSS(
-    "transition-property",
-    "opacity, scale, translate",
-  );
-  await expect(sidebarSurface).toHaveCSS("transition-duration", "0.2s");
+  await expect(sidebarSurface).toHaveCSS("scale", "none");
+  await expect(sidebarSurface).toHaveCSS("translate", "none");
+  await expect(sidebarSurface).toHaveCSS("transition-property", "opacity");
+  await expect(sidebarSurface).toHaveCSS("transition-duration", "0.24s");
   await expect(sidebarSurface).toHaveCSS(
     "transition-timing-function",
-    "linear",
+    "cubic-bezier(0.25, 1, 0.5, 1)",
+  );
+  await expect(sidebarGap).toHaveCSS("transition-duration", "0.24s");
+  await expect(sidebarGap).toHaveCSS(
+    "transition-timing-function",
+    "cubic-bezier(0.25, 1, 0.5, 1)",
+  );
+  await expect(sidebar).toHaveCSS("transition-duration", "0.24s");
+  await expect(sidebar).toHaveCSS(
+    "transition-timing-function",
+    "cubic-bezier(0.25, 1, 0.5, 1)",
   );
 
   await page.getByRole("button", { name: "Toggle Sidebar" }).click();
@@ -636,8 +636,8 @@ test("disables the sidebar collapse transition for reduced motion", async ({
   await page.getByRole("button", { name: "Toggle Sidebar" }).click();
 
   await expect(sidebarSurface).toHaveCSS("opacity", "0");
-  await expect(sidebarSurface).toHaveCSS("scale", "0.95");
-  await expect(sidebarSurface).toHaveCSS("translate", "24px");
+  await expect(sidebarSurface).toHaveCSS("scale", "none");
+  await expect(sidebarSurface).toHaveCSS("translate", "none");
   await expect(sidebarSurface).toHaveCSS("transition-duration", "0s");
 });
 


### PR DESCRIPTION
## Summary

- use Buzz's shared 240ms standard duration and easing tokens for the sidebar width, chrome, and content fade
- keep the content fade while removing the scale and translation that moved nav links during collapse
- update browser coverage for spatial stability, reduced motion, timing, easing, and community-rail behavior across themes

## Why

The previous top-origin scale pulled nav links upward during collapse, creating unnecessary visual noise. The simultaneous translation added more spatial motion while the sidebar chrome was already sliding away. Keeping the fade preserves the anti-ghosting behavior without moving or shrinking the navigation content.

## Before / after

Left: before. Right: after.

### Normal speed

![Normal-speed sidebar motion comparison](https://raw.githubusercontent.com/kursmark-sq/buzz/pr-media-6690/.github/pr-assets/6690/sidebar-motion-normal.gif)

### 4× slower

![Slowed sidebar motion comparison](https://raw.githubusercontent.com/kursmark-sq/buzz/pr-media-6690/.github/pr-assets/6690/sidebar-motion-4x-slow.gif)

## Test plan

- [x] pre-commit checks: sadscan, desktop fix, attribution, signoff, Git LFS
- [x] pre-push checks: desktop tests, TypeScript, desktop checks, file size, branch scope, org policy, Git LFS
- [x] desktop E2E production bundle
- [x] 5 focused Playwright sidebar motion and community-rail regressions
- [x] full repository gate through formatting, TypeScript, desktop tests/build, mobile analysis, and 2,755 Tauri tests

The full local repository gate reaches the existing `buzz-terminal` PTY fixture `default_prog_child_observes_the_login_argv0`, which times out waiting for `$0` in this environment. This is unrelated to the desktop CSS/test-only change and is the same local fixture timeout documented on #6314.
