### PR TITLE
feat(desktop): name the computer an agent lives on — core (device identity, split from #6259)

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "futures-util",
+ "gethostname",
  "getrandom 0.2.17",
  "hex",
  "image",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -127,6 +127,9 @@ chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2.3.3"
 uuid = { version = "1", features = ["v4", "v5"] }
+# Seeds the first-run device label from the OS host name. Already in the
+# lock file as a transitive dep, so this edge adds no new crate.
+gethostname = "1"
 png = "0.18"
 # wayland-data-control: without it arboard is X11-only on Linux, so copies made
 # in a Wayland session land in XWayland's clipboard where Wayland-native apps

--- a/desktop/src-tauri/src/commands/agent_discovery/relay_directory.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/relay_directory.rs
@@ -289,6 +289,8 @@ mod tests {
                 status: "offline".to_string(),
                 respond_to: None,
                 respond_to_allowlist: Vec::new(),
+                device_id: None,
+                device_label: None,
             },
             RelayAgentInfo {
                 pubkey: "c".repeat(64),
@@ -301,6 +303,8 @@ mod tests {
                 status: "online".to_string(),
                 respond_to: None,
                 respond_to_allowlist: Vec::new(),
+                device_id: None,
+                device_label: None,
             },
         ];
 
@@ -327,6 +331,8 @@ mod tests {
             status: "online".to_string(),
             respond_to: None,
             respond_to_allowlist: Vec::new(),
+            device_id: None,
+            device_label: None,
         }];
 
         retain_agents_allowed_by_build(&mut agents, false);

--- a/desktop/src-tauri/src/commands/personas/inbound/inbound_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound/inbound_tests.rs
@@ -885,6 +885,8 @@ fn inbound_managed_agent_content(
         parallelism: 1,
         respond_to: crate::managed_agents::RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
+        device_id: None,
+        device_label: None,
     }
 }
 

--- a/desktop/src-tauri/src/device_identity.rs
+++ b/desktop/src-tauri/src/device_identity.rs
@@ -1,0 +1,551 @@
+//! Stable per-install device identity.
+//!
+//! Buzz agents carry device-local secrets: `apply_inbound_managed_agent` is a
+//! deliberate no-op on no-match, so a persona synced to a second computer mints
+//! a *fresh* keypair there. One name, N pubkeys, N computers — and nothing in
+//! the UI says which computer an agent actually lives on. This module supplies
+//! that missing noun.
+//!
+//! # What this is NOT
+//!
+//! It is not [`crate::managed_agents::runtime::current_instance_id`]. That
+//! returns the Tauri *bundle identifier* — a build constant, identical on every
+//! machine — and exists to keep a dev build from reaping a packaged build's
+//! processes on the SAME computer. The two answer different questions and must
+//! stay separate.
+//!
+//! # Storage
+//!
+//! `<app-data>/agents/device.json`, written `0o600` via
+//! `atomic_write_json_restricted` — the same pattern the agent store and
+//! `global-agent-config.json` use.
+//!
+//! # Privacy
+//!
+//! `device_label` is published in a world-readable kind:30177 event (see
+//! [`crate::managed_agents::agent_events`]), so it starts **opaque** —
+//! `device-<8 hex>`, derived from the id and saying nothing about the machine.
+//! Host names routinely contain a real person's name, so the OS host name is
+//! only ever *offered* as a suggestion ([`hostname_suggestion`]) and reaches the
+//! relay solely when the owner applies it via [`set_device_label`]. Every label,
+//! whichever boundary it arrives from — typed, loaded from disk, or received
+//! from a peer — passes [`validate_device_label`], the same visible-text policy
+//! that guards agent definition text. The opaque `device_id` alone is enough to
+//! tell N devices apart.
+
+use std::path::{Path, PathBuf};
+use std::sync::{PoisonError, RwLock};
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+
+use crate::managed_agents::definition_validation::validate_device_label;
+use crate::managed_agents::storage::{atomic_write_json_restricted, managed_agents_base_dir};
+
+/// Stable identity of the computer this Buzz install runs on.
+///
+/// Distinguishes two devices signed into the same Buzz account. Minted
+/// once at first run and never rotated; the label is user-editable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceIdentity {
+    /// Opaque uuid v4 (simple hex, 32 chars). Never derived from hardware.
+    pub device_id: String,
+    /// Human label shown beside this device's agents on other devices. Starts
+    /// opaque (`device-<8 hex>`); the owner may rename it, including to the OS
+    /// host name, which is never applied without that explicit choice.
+    pub device_label: String,
+    /// RFC 3339 first-run timestamp. Diagnostics only.
+    pub created_at: String,
+}
+
+/// Process-wide cache of the resolved identity.
+///
+/// `None` until [`ensure`] runs, which only happens inside the Tauri `setup`
+/// hook. Unit tests never boot the app, so every existing test observes `None`
+/// and its published projections are byte-identical to before this module
+/// existed.
+static CURRENT: RwLock<Option<DeviceIdentity>> = RwLock::new(None);
+
+/// Normalize a user-supplied device label.
+///
+/// Trims, then enforces the shared visible-text policy
+/// ([`validate_device_label`]) — which rejects not only `Cc` control
+/// characters but the `Cf` format characters `char::is_control` misses, such as
+/// zero-width spaces and bidi overrides. An over-long label is **refused, not
+/// truncated**: silently publishing something other than what the owner typed
+/// is worse than telling them it is too long.
+fn sanitize_label(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    validate_device_label(trimmed)?;
+    Ok(trimmed.to_string())
+}
+
+/// The opaque, id-derived label every device starts with.
+///
+/// Deliberately says nothing about the machine. See [`mint_identity`].
+fn opaque_label(device_id: &str) -> String {
+    format!("device-{}", device_id.chars().take(8).collect::<String>())
+}
+
+/// Validate a `device_id` against the shape [`mint_identity`] produces:
+/// 32 lowercase hex digits (a uuid v4 in simple form).
+///
+/// Shared with the inbound relay path, which must not trust a peer's value.
+pub(crate) fn validate_device_id(device_id: &str) -> Result<(), String> {
+    if device_id.len() == 32
+        && device_id
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase())
+    {
+        return Ok(());
+    }
+    Err("device id must be 32 lowercase hex characters".to_string())
+}
+
+/// Validate a whole identity, whichever boundary it arrived from.
+fn validate_identity(identity: &DeviceIdentity) -> Result<(), String> {
+    validate_device_id(&identity.device_id)?;
+    validate_device_label(&identity.device_label)
+}
+
+/// The OS host name, offered to the owner as a suggested device name.
+///
+/// Returns `None` when the host name is unusable — empty, over-long, or
+/// carrying characters the label policy refuses. This is only ever a
+/// *suggestion*: nothing here reaches the relay until the owner applies it.
+pub fn hostname_suggestion() -> Option<String> {
+    let host = gethostname::gethostname();
+    let host = host.to_string_lossy();
+    sanitize_label(&host).ok()
+}
+
+/// Mint a brand-new identity with an **opaque** label.
+///
+/// The label is *not* seeded from the OS host name. Host names routinely carry
+/// a real person's name ("marys-macbook"), and this label is published in a
+/// world-readable kind:30177 event — so seeding from it would publish that name
+/// before the owner had seen any warning or had a chance to edit it. The owner
+/// opts into the host name explicitly, via [`hostname_suggestion`] surfaced in
+/// the device-name settings card.
+fn mint_identity() -> DeviceIdentity {
+    let device_id = uuid::Uuid::new_v4().simple().to_string();
+    let device_label = opaque_label(&device_id);
+    DeviceIdentity {
+        device_id,
+        device_label,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+/// Persist `identity` to `path`, `0o600`, atomically.
+fn write_identity_at(path: &Path, identity: &DeviceIdentity) -> Result<(), String> {
+    let payload = serde_json::to_vec_pretty(identity)
+        .map_err(|e| format!("failed to serialize device identity: {e}"))?;
+    atomic_write_json_restricted(path, &payload)
+}
+
+/// Load the identity at `path`, minting and persisting a fresh one when the
+/// file is absent, unreadable, malformed, **or invalid**.
+///
+/// Deserializing proves only that the JSON has the right shape. The stored file
+/// is on disk, editable by hand, and survives downgrades — so the contents are
+/// revalidated here against the same policy [`set_label`] enforces. Without
+/// that, a hand-edited `device.json` carrying a 5000-character label or a bidi
+/// override would be published to the relay unchecked.
+///
+/// A file that fails either step is preserved as `device.json.corrupt` (best
+/// effort) and replaced. Losing the identity only *relabels* a device — it
+/// never touches agent data — so this path must never fail the caller.
+fn load_or_create_at(path: &Path) -> Result<DeviceIdentity, String> {
+    if path.exists() {
+        match std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read device identity: {e}"))
+            .and_then(|content| {
+                serde_json::from_str::<DeviceIdentity>(&content)
+                    .map_err(|e| format!("failed to parse device identity: {e}"))
+            })
+            .and_then(|identity| {
+                validate_identity(&identity)
+                    .map(|()| identity)
+                    .map_err(|e| format!("stored device identity is invalid: {e}"))
+            }) {
+            Ok(identity) => return Ok(identity),
+            Err(error) => {
+                let corrupt = path.with_extension("json.corrupt");
+                if let Err(rename_error) = std::fs::rename(path, &corrupt) {
+                    tracing::warn!(
+                        "device identity: could not preserve corrupt file: {rename_error}"
+                    );
+                }
+                tracing::warn!("device identity: minting a fresh identity ({error})");
+            }
+        }
+    }
+
+    let identity = mint_identity();
+    write_identity_at(path, &identity)?;
+    Ok(identity)
+}
+
+/// Replace the label on the identity at `path`, minting one first if needed.
+fn set_label_at(path: &Path, label: &str) -> Result<DeviceIdentity, String> {
+    let device_label = sanitize_label(label)?;
+    let mut identity = load_or_create_at(path)?;
+    identity.device_label = device_label;
+    write_identity_at(path, &identity)?;
+    Ok(identity)
+}
+
+fn device_identity_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(managed_agents_base_dir(app)?.join("device.json"))
+}
+
+fn cache(identity: &DeviceIdentity) {
+    let mut guard = CURRENT.write().unwrap_or_else(PoisonError::into_inner);
+    *guard = Some(identity.clone());
+}
+
+/// Load or create this install's device identity and populate the process
+/// cache read by [`current`].
+///
+/// Idempotent: safe to call more than once. Called once from the Tauri `setup`
+/// hook, after boot migrations and before identity resolution.
+pub fn ensure(app: &AppHandle) -> Result<DeviceIdentity, String> {
+    let path = device_identity_path(app)?;
+    let identity = load_or_create_at(&path)?;
+    cache(&identity);
+    Ok(identity)
+}
+
+/// The cached device identity, or `None` when [`ensure`] has not run.
+///
+/// `None` is a supported answer, not an error: unit tests and any code path
+/// that runs before the Tauri `setup` hook simply publish no device stamp.
+pub fn current() -> Option<DeviceIdentity> {
+    CURRENT
+        .read()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone()
+}
+
+/// Serializes every test that reads or writes [`CURRENT`].
+///
+/// `CURRENT` is process-global and Rust runs a binary's tests on parallel
+/// threads, so without this a test that seeds a device would race one asserting
+/// there is none. That is exactly the failure mode of the crate's known-flaky
+/// `claude_spawn_uses_the_probed_cli_executable`, which mutates the global
+/// `PATH`; do not reproduce it here.
+#[cfg(test)]
+pub(crate) static DEVICE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII seam letting a test exercise a code path that branches on a device
+/// being cached. Holds [`DEVICE_TEST_LOCK`] and restores the previous value on
+/// drop, so tests stay order-independent.
+///
+/// Test-only: `#[cfg(test)]` keeps it out of every release artifact, so the
+/// cache stays writable only by [`ensure`] and [`set_label`] in production.
+#[cfg(test)]
+pub(crate) struct DeviceGuard {
+    previous: Option<DeviceIdentity>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl DeviceGuard {
+    /// Install `identity` as the cached device for the guard's lifetime.
+    pub(crate) fn set(identity: Option<DeviceIdentity>) -> Self {
+        let _lock = DEVICE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let previous = CURRENT
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        *CURRENT.write().unwrap_or_else(PoisonError::into_inner) = identity;
+        Self { previous, _lock }
+    }
+
+    /// A deterministic device for assertions.
+    pub(crate) fn sample() -> DeviceIdentity {
+        DeviceIdentity {
+            device_id: "0123456789abcdef0123456789abcdef".to_string(),
+            device_label: "studio-mac".to_string(),
+            created_at: "2026-01-01T00:00:00+00:00".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for DeviceGuard {
+    fn drop(&mut self) {
+        *CURRENT.write().unwrap_or_else(PoisonError::into_inner) = self.previous.take();
+    }
+}
+
+/// Rename this device, persisting and caching the result.
+///
+/// The new label reaches other devices on the next kind:30177 republish. The
+/// [`set_device_label`] command triggers that republish immediately via the
+/// managed-agent reconcile; calling this function directly leaves propagation
+/// to the next agent mutation or app restart.
+pub fn set_label(app: &AppHandle, label: &str) -> Result<DeviceIdentity, String> {
+    let path = device_identity_path(app)?;
+    let identity = set_label_at(&path, label)?;
+    cache(&identity);
+    Ok(identity)
+}
+
+/// Return this install's device identity, minting it on first call.
+#[tauri::command]
+pub fn get_device_identity(app: AppHandle) -> Result<DeviceIdentity, String> {
+    ensure(&app)
+}
+
+/// Return the OS host name as a *suggested* device name, or `None` when it is
+/// unusable under the label policy.
+///
+/// Purely advisory: the settings card offers it, and nothing is published until
+/// the owner applies it via [`set_device_label`]. See [`mint_identity`] for why
+/// the host name is not the default.
+#[tauri::command]
+pub fn get_device_name_suggestion() -> Option<String> {
+    hostname_suggestion()
+}
+
+/// Rename this device and republish the **active community's** local agents so
+/// its members see the new label without waiting for the next app restart.
+///
+/// Scope, stated precisely because it is narrower than it looks: republishing
+/// needs a retention scope, and a scope carries the owner keys for one
+/// `(owner, relay)` pair — which are only resolved for the community currently
+/// applied. Agents in the owner's *other* configured communities keep
+/// publishing the old label until that community is next activated, at which
+/// point `run_event_sync` reconciles them with the current label. So
+/// propagation is eventual everywhere, immediate only here.
+///
+/// Republishing every scope up front would mean resolving owner keys for
+/// communities that are not applied — a change to identity handling, not to
+/// this command, and out of scope for Stage 0.
+///
+/// The republish is best-effort in the other direction too: a rename that
+/// persists locally but cannot reach the retention store still succeeds, and
+/// propagates on the next agent mutation or restart.
+#[tauri::command]
+pub fn set_device_label(app: AppHandle, label: String) -> Result<DeviceIdentity, String> {
+    let identity = set_label(&app, &label)?;
+    republish_agent_records(&app);
+    Ok(identity)
+}
+
+/// Best-effort re-reconcile of every local managed-agent record so a changed
+/// device label reaches the relay now. `retain_agent_record`'s content-equality
+/// guard means records whose projection did not change stay untouched.
+fn republish_agent_records(app: &AppHandle) {
+    use tauri::Manager;
+
+    let state = app.state::<crate::app_state::AppState>();
+    match crate::managed_agents::retention::active_retention_scope(app, &state) {
+        Ok(scope) => crate::managed_agents::reconcile::reconcile_agents_to_events(
+            app,
+            &scope.owner_keys,
+            &scope.db_path,
+        ),
+        Err(error) => {
+            tracing::warn!("device identity: label republish skipped: {error}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_label_trims() {
+        assert_eq!(sanitize_label("  mfeth-win \t").unwrap(), "mfeth-win");
+    }
+
+    #[test]
+    fn sanitize_label_rejects_empty() {
+        assert!(sanitize_label("").is_err());
+        assert!(sanitize_label("   ").is_err());
+    }
+
+    #[test]
+    fn sanitize_label_rejects_control_characters() {
+        assert!(sanitize_label("mfeth\u{0}win").is_err());
+        assert!(sanitize_label("mfeth\nwin").is_err());
+    }
+
+    /// Over-long labels are refused, never silently shortened: publishing
+    /// something other than what the owner typed is the worse failure.
+    #[test]
+    fn sanitize_label_rejects_over_thirty_two_chars() {
+        assert!(sanitize_label(&"a".repeat(33)).is_err());
+        assert_eq!(sanitize_label(&"a".repeat(32)).unwrap(), "a".repeat(32));
+    }
+
+    /// `char::is_control` covers only category `Cc`. These are `Cf`, and a bidi
+    /// override can visually reorder the text rendered around the label.
+    #[test]
+    fn sanitize_label_rejects_format_characters_is_control_would_miss() {
+        assert!(!'\u{202E}'.is_control(), "precondition: RLO is not Cc");
+        assert!(!'\u{200B}'.is_control(), "precondition: ZWSP is not Cc");
+        assert!(sanitize_label("mfeth\u{202E}win").is_err(), "bidi override");
+        assert!(
+            sanitize_label("mfeth\u{200B}win").is_err(),
+            "zero width space"
+        );
+        assert!(sanitize_label("mfeth\u{2066}win").is_err(), "bidi isolate");
+    }
+
+    #[test]
+    fn opaque_label_is_derived_from_the_id() {
+        assert_eq!(
+            opaque_label("0123456789abcdef0123456789abcdef"),
+            "device-01234567"
+        );
+    }
+
+    /// A minted identity must not leak the OS host name — it is published
+    /// world-readable before the owner has seen any warning.
+    #[test]
+    fn mint_identity_uses_an_opaque_label_not_the_hostname() {
+        let identity = mint_identity();
+        assert_eq!(identity.device_label, opaque_label(&identity.device_id));
+        assert!(identity.device_label.starts_with("device-"));
+        let host = gethostname::gethostname().to_string_lossy().to_string();
+        if !host.trim().is_empty() {
+            assert_ne!(identity.device_label, host.trim());
+        }
+        validate_identity(&identity).expect("a minted identity must be valid");
+    }
+
+    #[test]
+    fn validate_device_id_accepts_only_lowercase_hex_of_length_32() {
+        assert!(validate_device_id("0123456789abcdef0123456789abcdef").is_ok());
+        assert!(validate_device_id("0123456789ABCDEF0123456789ABCDEF").is_err());
+        assert!(validate_device_id("tooshort").is_err());
+        assert!(validate_device_id(&"a".repeat(33)).is_err());
+        assert!(validate_device_id("g123456789abcdef0123456789abcdef").is_err());
+    }
+
+    /// Deserializing proves shape, not validity. A hand-edited file must be
+    /// quarantined and replaced rather than published.
+    #[test]
+    fn load_or_create_replaces_a_syntactically_valid_but_invalid_identity() {
+        // Built through serde rather than written as a literal: an unescaped
+        // U+202E in source trips rustc's own
+        // `text_direction_codepoint_in_literal` lint — the same hazard this
+        // validation exists to keep out of the relay.
+        let bad_id = serde_json::json!({
+            "deviceId": "nothex",
+            "deviceLabel": "ok",
+            "createdAt": "2026-01-01T00:00:00Z",
+        })
+        .to_string();
+        let bad_label = serde_json::json!({
+            "deviceId": "0123456789abcdef0123456789abcdef",
+            "deviceLabel": "mfeth\u{202E}win",
+            "createdAt": "2026-01-01T00:00:00Z",
+        })
+        .to_string();
+
+        for bad in [bad_id.as_str(), bad_label.as_str()] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("device.json");
+            std::fs::write(&path, bad).unwrap();
+
+            let identity = load_or_create_at(&path)
+                .expect("an invalid stored file must never fail the caller");
+            validate_identity(&identity).expect("the replacement must be valid");
+            assert!(path.with_extension("json.corrupt").exists(), "quarantined");
+            // And the replacement sticks.
+            assert_eq!(load_or_create_at(&path).unwrap(), identity);
+        }
+    }
+
+    #[test]
+    fn hostname_suggestion_is_valid_when_present() {
+        if let Some(suggestion) = hostname_suggestion() {
+            validate_device_label(&suggestion)
+                .expect("a suggestion offered to the owner must already be valid");
+        }
+    }
+
+    #[test]
+    fn device_identity_round_trips_as_camel_case() {
+        let identity = DeviceIdentity {
+            device_id: "0123456789abcdef0123456789abcdef".to_string(),
+            device_label: "mfeth-win".to_string(),
+            created_at: "2026-08-18T00:00:00+00:00".to_string(),
+        };
+        let json = serde_json::to_string(&identity).unwrap();
+        assert!(json.contains("\"deviceId\""), "{json}");
+        assert!(json.contains("\"deviceLabel\""), "{json}");
+        assert!(json.contains("\"createdAt\""), "{json}");
+        assert!(!json.contains("device_id"), "{json}");
+
+        let parsed: DeviceIdentity = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, identity);
+    }
+
+    #[test]
+    fn load_or_create_mints_then_reuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("device.json");
+
+        let first = load_or_create_at(&path).unwrap();
+        assert_eq!(first.device_id.chars().count(), 32);
+        assert!(!first.device_label.is_empty());
+        assert!(path.exists());
+
+        let second = load_or_create_at(&path).unwrap();
+        assert_eq!(first, second, "identity must be stable across loads");
+    }
+
+    #[test]
+    fn corrupt_file_is_preserved_and_replaced() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("device.json");
+        std::fs::write(&path, "{ not json at all").unwrap();
+
+        let identity = load_or_create_at(&path).expect("corrupt file must never fail the caller");
+        assert_eq!(identity.device_id.chars().count(), 32);
+        assert!(
+            dir.path().join("device.json.corrupt").exists(),
+            "the corrupt file must be preserved"
+        );
+        // The replacement is durable.
+        assert_eq!(load_or_create_at(&path).unwrap(), identity);
+    }
+
+    #[test]
+    fn set_label_persists_and_keeps_the_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("device.json");
+
+        let minted = load_or_create_at(&path).unwrap();
+        let renamed = set_label_at(&path, "  Studio Mac  ").unwrap();
+        assert_eq!(renamed.device_label, "Studio Mac");
+        assert_eq!(renamed.device_id, minted.device_id);
+        assert_eq!(load_or_create_at(&path).unwrap(), renamed);
+    }
+
+    #[test]
+    fn set_label_rejects_an_unusable_label() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("device.json");
+        assert!(set_label_at(&path, "   ").is_err());
+        assert!(set_label_at(&path, "bad\nlabel").is_err());
+    }
+
+    #[test]
+    fn current_is_none_before_ensure_runs() {
+        // Guards the zero-churn contract: every pre-existing unit test sees no
+        // device stamp because the Tauri setup hook never ran, so no existing
+        // published-projection assertion has to change.
+        assert!(current().is_none());
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod builderlab;
 mod channel_head_cache;
 mod commands;
 mod deep_link;
+mod device_identity;
 mod egress_guard;
 mod event_sync;
 mod events;
@@ -245,20 +246,7 @@ pub fn run() {
             // ── Phase 2: boot-time sentinel wipe ──────────────────────────────
             // Must run before migrations and identity resolution so the wipe
             // completes atomically on crash recovery.
-            //
-            // init_nest_dir is called early here (normally it runs inside
-            // run_boot_migrations) so reset::run_boot_reset can call nest_dir().
-            let reset_outcome = if let Ok(data_dir) = app_handle.path().app_data_dir() {
-                let is_dev_for_reset = data_dir
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(crate::migration::is_dev_data_dir_name)
-                    .unwrap_or(false);
-                crate::managed_agents::init_nest_dir(is_dev_for_reset);
-                crate::reset::run_boot_reset(&data_dir)
-            } else {
-                crate::reset::ResetOutcome::default()
-            };
+            let reset_outcome = crate::reset::run_boot_reset_for_app(&app_handle);
 
             if reset_outcome.failed {
                 // Surface reset-failed state — skip identity resolution and
@@ -276,6 +264,12 @@ pub fn run() {
                 migration::run_boot_migrations_after_reset(&app_handle);
             } else {
                 migration::run_boot_migrations(&app_handle);
+            }
+
+            // Stable per-install device identity. Non-fatal: without it the
+            // app simply publishes no device label on its agents.
+            if let Err(e) = device_identity::ensure(&app_handle) {
+                eprintln!("buzz-desktop: device identity unavailable: {e}");
             }
 
             // Resolve persisted identity key (env var → file → generate+save).
@@ -721,6 +715,9 @@ pub fn run() {
             put_agent_session_config,
             get_global_agent_config,
             set_global_agent_config,
+            device_identity::get_device_identity,
+            device_identity::set_device_label,
+            device_identity::get_device_name_suggestion,
             mesh_start_node,
             mesh_stop_node,
             mesh_node_status,

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -21,6 +21,11 @@
 //! - `backend` — `Provider { config }` is an opaque blob that may hold secrets.
 //! - any runtime field (`runtime_pid`, `last_*`, `backend_agent_id`, …) — these
 //!   mutate on every start/stop and describe transient process state.
+//!
+//! The device fields (`device_id` / `device_label`) ARE publishable: they name
+//! the install that holds this instance's secret — public, non-secret, and
+//! user-editable — and they do not mutate on start/stop, so they are identity,
+//! not runtime state.
 
 use buzz_core_pkg::kind::KIND_MANAGED_AGENT;
 use nostr::{EventBuilder, Kind, Tag};
@@ -57,6 +62,13 @@ pub struct ManagedAgentEventContent {
     /// public keys, not secrets.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub respond_to_allowlist: Vec<String>,
+    /// Opaque id of the device that holds this instance's secret and runs
+    /// it. Absent on events published before device identity shipped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_id: Option<String>,
+    /// Human label for that device. Public, non-secret, user-editable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_label: Option<String>,
 }
 
 /// Project a `ManagedAgentRecord` onto the content fields published in
@@ -77,6 +89,26 @@ pub fn agent_event_content(record: &ManagedAgentRecord) -> ManagedAgentEventCont
     // restore path. This branch retires once every record is
     // definition-backed (B5 backfill).
     let definition_linked = record.persona_id.is_some();
+    // Device fields describe the INSTANCE (which install holds its secret),
+    // never the definition, so they are emitted regardless of slimming.
+    // `None` before the Tauri setup hook runs — unit tests publish no stamp.
+    //
+    // Only a LOCAL backend is device-bound. A `Provider` backend's body runs
+    // elsewhere — deployed to Kubernetes from a laptop, say — and stays online
+    // after this install sleeps, so stamping it with this Desktop would make
+    // the mention UI claim "only that device can reply" about a machine that is
+    // not where the agent runs. Such a record publishes no device at all and
+    // degrades to the same "no device information" rendering as a pre-Stage-0
+    // peer.
+    //
+    // Future work (out of scope for Stage 0): a provider-backed agent still has
+    // a *custody* device — the install holding its secret — which is a
+    // different coordinate from its *execution* location. Distinguishing the
+    // two needs a protocol change, not a second stamp here.
+    let device = match record.backend {
+        super::BackendKind::Local => crate::device_identity::current(),
+        super::BackendKind::Provider { .. } => None,
+    };
     ManagedAgentEventContent {
         name: record.name.clone(),
         persona_id: record.persona_id.clone(),
@@ -103,6 +135,8 @@ pub fn agent_event_content(record: &ManagedAgentRecord) -> ManagedAgentEventCont
         parallelism: record.parallelism,
         respond_to: record.respond_to,
         respond_to_allowlist: record.respond_to_allowlist.clone(),
+        device_id: device.as_ref().map(|d| d.device_id.clone()),
+        device_label: device.as_ref().map(|d| d.device_label.clone()),
     }
 }
 
@@ -458,6 +492,127 @@ mod tests {
         assert!(!json.contains("env_vars"));
         assert!(!json.contains("agent_command"));
         assert!(!json.contains("backend"));
+    }
+
+    /// Zero-churn contract: `device_identity::current()` is `None` outside a
+    /// booted app, so the projection serializes exactly as it did before the
+    /// device fields existed. This is why no other test in the crate changed.
+    #[test]
+    fn projection_omits_device_fields_without_a_device_identity() {
+        // Takes the guard (with `None`) purely to serialize against the tests
+        // below that seed a device — `CURRENT` is process-global.
+        let _guard = crate::device_identity::DeviceGuard::set(None);
+        assert!(
+            crate::device_identity::current().is_none(),
+            "unit tests must never boot the device identity"
+        );
+        let content = agent_event_content(&sample_agent());
+        assert_eq!(content.device_id, None);
+        assert_eq!(content.device_label, None);
+
+        let json = serde_json::to_string(&content).unwrap();
+        assert!(!json.contains("deviceId"), "{json}");
+        assert!(!json.contains("device_id"), "{json}");
+        assert!(!json.contains("deviceLabel"), "{json}");
+        assert!(!json.contains("device_label"), "{json}");
+    }
+
+    /// A local-backend agent's secret lives on this install, so it is the one
+    /// case where naming this computer is true.
+    #[test]
+    fn projection_stamps_the_device_for_a_local_backend() {
+        use crate::device_identity::DeviceGuard;
+        let device = DeviceGuard::sample();
+        let _guard = DeviceGuard::set(Some(device.clone()));
+
+        let mut record = sample_agent();
+        record.backend = super::super::BackendKind::Local;
+
+        let content = agent_event_content(&record);
+        assert_eq!(
+            content.device_id.as_deref(),
+            Some(device.device_id.as_str())
+        );
+        assert_eq!(
+            content.device_label.as_deref(),
+            Some(device.device_label.as_str())
+        );
+    }
+
+    /// A provider-backed agent's body runs elsewhere and outlives this install,
+    /// so stamping it here would make the mention UI claim "only that device can
+    /// reply" about a machine that is not where the agent runs.
+    #[test]
+    fn projection_omits_the_device_for_a_provider_backend() {
+        use crate::device_identity::DeviceGuard;
+        let _guard = DeviceGuard::set(Some(DeviceGuard::sample()));
+
+        let mut record = sample_agent();
+        record.backend = super::super::BackendKind::Provider {
+            id: "buzz-backend-x".to_string(),
+            config: serde_json::json!({ "cluster": "staging" }),
+        };
+
+        let content = agent_event_content(&record);
+        assert_eq!(
+            content.device_id, None,
+            "a remote body must not be given this computer's id"
+        );
+        assert_eq!(content.device_label, None);
+
+        let json = serde_json::to_string(&content).unwrap();
+        assert!(!json.contains("deviceId"), "{json}");
+        assert!(!json.contains("deviceLabel"), "{json}");
+    }
+
+    /// Mixed-fleet back-compat: a 30177 event published by a build that predates
+    /// device identity parses cleanly, with both fields absent rather than an
+    /// invented value.
+    #[test]
+    fn from_event_without_device_keys_yields_none() {
+        use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag};
+        let content = serde_json::json!({
+            "name": "Bumble",
+            "parallelism": 1,
+            "respond_to": "owner-only",
+        });
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(KIND_MANAGED_AGENT as u16), content.to_string())
+            .tags(vec![Tag::parse(["d", "agentpubkeyhex"]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap();
+        let event = nostr::Event::from_json(event.as_json()).unwrap();
+
+        let parsed = managed_agent_content_from_event(&event).unwrap();
+        assert_eq!(parsed.device_id, None);
+        assert_eq!(parsed.device_label, None);
+    }
+
+    /// The forward direction of the same contract: an event that DOES carry the
+    /// device fields round-trips them.
+    #[test]
+    fn from_event_reads_device_fields_when_present() {
+        use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag};
+        let content = serde_json::json!({
+            "name": "Bumble",
+            "parallelism": 1,
+            "respond_to": "owner-only",
+            "device_id": "0123456789abcdef0123456789abcdef",
+            "device_label": "mfeth-win",
+        });
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(KIND_MANAGED_AGENT as u16), content.to_string())
+            .tags(vec![Tag::parse(["d", "agentpubkeyhex"]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap();
+        let event = nostr::Event::from_json(event.as_json()).unwrap();
+
+        let parsed = managed_agent_content_from_event(&event).unwrap();
+        assert_eq!(
+            parsed.device_id.as_deref(),
+            Some("0123456789abcdef0123456789abcdef")
+        );
+        assert_eq!(parsed.device_label.as_deref(), Some("mfeth-win"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/definition_validation.rs
+++ b/desktop/src-tauri/src/managed_agents/definition_validation.rs
@@ -79,6 +79,32 @@ pub(crate) fn validate_managed_agent_definition_text(
     validate_agent_definition_text(name, executable_prompt)
 }
 
+/// Maximum length of a device label, in `char`s.
+pub(crate) const MAX_DEVICE_LABEL_CHARS: usize = 32;
+
+/// Validate a device label against the same visible-text policy as agent
+/// definition text.
+///
+/// A device label names the computer an agent lives on and is published in a
+/// world-readable kind:30177 event, then rendered beside an agent's name in
+/// other people's clients. That makes it the same class of input as a display
+/// name: `char::is_control` alone would pass zero-width characters (U+200B) and
+/// bidi overrides (U+202E), which are Unicode category `Cf` and can visually
+/// reorder the text around them.
+pub(crate) fn validate_device_label(label: &str) -> Result<(), String> {
+    let trimmed = label.trim();
+    if trimmed.is_empty() {
+        return Err("Device name must not be empty".to_string());
+    }
+    let count = trimmed.chars().count();
+    if count > MAX_DEVICE_LABEL_CHARS {
+        return Err(format!(
+            "Device name is too long ({count} characters, max {MAX_DEVICE_LABEL_CHARS})"
+        ));
+    }
+    validate_visible_text(trimmed, "Device name", false)
+}
+
 /// Reject control and default-ignorable characters in human-reviewed text.
 ///
 /// The shared executable-definition invariant: a recipient reviews a visible

--- a/desktop/src-tauri/src/managed_agents/harness_catalog_types.rs
+++ b/desktop/src-tauri/src/managed_agents/harness_catalog_types.rs
@@ -1,0 +1,167 @@
+//! Wire types for the ACP runtime catalog: which harnesses this install can
+//! run, whether each is installed and logged in, and the results of trying to
+//! install one.
+//!
+//! Split out of `types.rs`, which had reached the desktop file-size ceiling;
+//! these are the harness/prerequisite DTOs and share no state with the
+//! managed-agent record types left behind. Re-exported through
+//! `managed_agents::*`, so every existing import path still resolves.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AcpAvailabilityStatus {
+    Available,
+    AdapterMissing,
+    /// Adapter binary is present but unsupported — either the deprecated
+    /// package or a version below the supported floor. Reinstall required.
+    AdapterOutdated,
+    CliMissing,
+    NotInstalled,
+}
+
+/// Authentication/login status for a CLI-based ACP runtime. Serializes as a tagged union
+/// `{ status: "...", diagnostic?: "..." }` so the TypeScript side can exhaustively switch on `status`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum AuthStatus {
+    /// The CLI reported a successful login.
+    LoggedIn,
+    /// The CLI exited non-zero without a config-parse signal.
+    LoggedOut,
+    /// The CLI exited non-zero and its stderr contains a config-parse error.
+    ConfigInvalid {
+        /// Trimmed excerpt of the stderr message.
+        diagnostic: String,
+    },
+    /// This runtime does not have a login step (e.g. goose, buzz-agent).
+    NotApplicable,
+    /// Probe was not attempted (runtime unavailable or probe timed out).
+    Unknown,
+}
+
+/// Origin of an ACP runtime catalog entry. Serializes as a lowercase string so the TypeScript consumer can switch on it without numeric comparisons.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessSource {
+    /// Compiled into the app — one of the four first-class runtimes.
+    Builtin,
+    /// Static preset entry with bundled logo, PATH-probed, not editable/deletable.
+    Preset,
+    /// Loaded at runtime from the user's `custom_harnesses/` directory.
+    Custom,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AcpRuntimeCatalogEntry {
+    pub id: String,
+    pub label: String,
+    pub avatar_url: String,
+    pub availability: AcpAvailabilityStatus,
+    pub command: Option<String>,
+    pub binary_path: Option<String>,
+    pub default_args: Vec<String>,
+    pub mcp_command: Option<String>,
+    /// Environment variable used to apply the initial model, when supported.
+    pub model_env_var: Option<String>,
+    /// Environment variable used to apply the selected LLM provider, when supported.
+    pub provider_env_var: Option<String>,
+    /// Environment variable used to apply thinking effort, when supported.
+    pub thinking_env_var: Option<String>,
+    /// Canonical accepted effort values for this runtime, in display order.
+    /// Serialized from `KnownAcpRuntime::effort_normalization.canonical` for
+    /// runtimes with a static finite vocabulary (e.g. Goose). `None` for
+    /// runtimes with no canonicalization contract (buzz-agent uses a
+    /// provider/model catalog; Claude/Codex/unknown runtimes accept any string).
+    ///
+    /// The renderer uses this to drive choices and validation, replacing the
+    /// TS-side `GOOSE_EFFORT_CANONICAL_VALUES` duplicate. When non-null, the
+    /// `harnessNative` effort field uses this list exclusively — `off` and all
+    /// other valid Goose values are always present when this is Goose, so
+    /// `useEffortAutoClear` never incorrectly deletes a valid saved value.
+    pub effort_canonical_values: Option<Vec<String>>,
+    pub max_tokens_env_var: Option<String>,
+    pub context_limit_env_var: Option<String>,
+    pub max_rounds_env_var: Option<String>,
+    pub install_hint: String,
+    pub install_instructions_url: String,
+    /// true when at least one automated install step is available
+    pub can_auto_install: bool,
+    /// true when this runtime depends on a separately installed vendor CLI.
+    pub requires_external_cli: bool,
+    pub underlying_cli_path: Option<String>,
+    /// true when an npm adapter step is pending but Node.js / npm is absent.
+    /// The UI hides the Install button and shows a Node.js install callout.
+    pub node_required: bool,
+    /// Login/authentication status for CLI-based runtimes.
+    pub auth_status: AuthStatus,
+    /// Hint for completing authentication, shown when `auth_status` is not `logged_in`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub login_hint: Option<String>,
+    /// Whether this entry came from the compiled-in catalog or a user-supplied
+    /// JSON file in `custom_harnesses/`. The UI uses this to decide editability.
+    pub source: HarnessSource,
+    /// Definition-level env vars for `source: custom` entries; populated from
+    /// `HarnessDefinition.env` so saves don't silently erase existing vars.
+    /// Absent for builtin/preset entries. Skipped when empty in serialization.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub definition_env: BTreeMap<String, String>,
+    /// Spawn-time parallelism cap; absent for uncapped harnesses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_parallelism: Option<u32>,
+}
+
+/// Result of a single install step (CLI or adapter).
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallStepResult {
+    pub step: String,
+    pub command: String,
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i32>,
+    /// Actionable guidance shown in the UI when this step failed due to a
+    /// recognized condition (e.g. EACCES writing Buzz's private npm prefix).
+    /// `None` when the step succeeded or no pattern matched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+/// Aggregate result of installing a runtime (may include CLI + adapter steps).
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallRuntimeResult {
+    pub success: bool,
+    pub steps: Vec<InstallStepResult>,
+    /// Number of local agents successfully stopped and restarted after a
+    /// successful install. Mirrors `GlobalAgentConfigSaveResult.restarted_count`.
+    pub restarted_count: u32,
+    /// Number of agents whose stop succeeded but respawn failed.
+    /// Mirrors `GlobalAgentConfigSaveResult.failed_restart_count`.
+    pub failed_restart_count: u32,
+    /// Install log file for this run, when one was written. The UI surfaces it
+    /// on failure so a user can read the full retry history instead of only the
+    /// last step's truncated output. `None` when no log could be opened.
+    pub log_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandAvailabilityInfo {
+    pub command: String,
+    pub resolved_path: Option<String>,
+    pub available: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverManagedAgentPrereqsRequest {
+    pub acp_command: Option<String>,
+    pub mcp_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagedAgentPrereqsInfo {
+    pub acp: CommandAvailabilityInfo,
+    pub mcp: CommandAvailabilityInfo,
+}

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -15,12 +15,15 @@ pub(crate) mod bestie_assignment;
 pub(crate) mod claude_config;
 pub(crate) mod config_bridge;
 pub(crate) mod custom_harnesses;
-mod definition_validation;
+// `pub(crate)` so the device-identity and inbound-directory paths can reuse the
+// one visible-text policy instead of growing a second, drifting copy.
+pub(crate) mod definition_validation;
 mod discovery;
 pub(crate) mod effective_config;
 mod env_vars;
 pub(crate) mod git_bash;
 pub(crate) mod global_config;
+mod harness_catalog_types;
 mod managed_node_paths;
 mod nest;
 pub(crate) mod parallelism;
@@ -86,6 +89,7 @@ pub(crate) use global_config::{
     load_global_agent_config, resolve_effective_model_provider, save_global_agent_config,
     validate_global_config, GlobalAgentConfig,
 };
+pub use harness_catalog_types::*;
 pub(crate) use managed_node_paths::*;
 pub use nest::*;
 pub use parallelism::{acp_agents_value, effective_parallelism, harness_max_parallelism};

--- a/desktop/src-tauri/src/managed_agents/reconcile/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/reconcile/tests.rs
@@ -400,3 +400,38 @@ fn retain_agent_record_is_noop_when_unchanged() {
         "no pending_sync churn for an unchanged record"
     );
 }
+
+/// The 9 key-less DEFINITION rows in a real store (empty `pubkey`, no secret)
+/// are skipped by the reconcile loop, so they never mint a kind:30177
+/// coordinate and therefore never carry a device stamp. Pins the boundary that
+/// makes "every keyed record in this store is THIS device's" true.
+#[test]
+fn keyless_definition_row_publishes_no_device() {
+    let dir = TempDir::new().unwrap();
+    let keys = nostr::Keys::generate();
+    write_store(
+        &dir,
+        &[
+            sample_record("", "keyless-definition"),
+            sample_record("d".repeat(64).as_str(), "keyed-instance"),
+        ],
+    );
+
+    // Only the keyed instance reconciles.
+    assert_eq!(reconcile_agents_in_dir(dir.path(), &keys).unwrap(), 1);
+
+    let conn = open_retention_db(&dir.path().join("retention.db")).unwrap();
+    let pending = get_pending_sync(&conn).unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].d_tag, "d".repeat(64));
+    assert!(
+        get_retained_event(&conn, KIND_MANAGED_AGENT, &keys.public_key().to_hex(), "")
+            .unwrap()
+            .is_none(),
+        "a key-less definition row must never get an event coordinate"
+    );
+    // No device stamp on the wire either — `device_identity::current()` is
+    // `None` in unit tests, so the projection stays byte-identical to before.
+    assert!(!pending[0].raw_event.contains("device_id"));
+    assert!(!pending[0].raw_event.contains("device_label"));
+}

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -1,6 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::PathBuf, process::Child};
 
+// Re-exported, not merely imported: `ManagedAgentRecord` embeds it, and
+// callers that already say `managed_agents::types::AcpAvailabilityStatus`
+// keep resolving after the harness DTOs moved to their own module.
+pub use super::harness_catalog_types::AcpAvailabilityStatus;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BackendKind {
@@ -226,6 +231,16 @@ pub struct RelayAgentInfo {
     pub respond_to: Option<RespondTo>,
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,
+    /// Opaque id of the device that runs this agent, as published on its
+    /// kind:30177 record. `None` for legacy kind:10100 directory entries and
+    /// for records published before device identity shipped.
+    #[serde(default)]
+    pub device_id: Option<String>,
+    /// Human label for that device — what the UI shows to say "on mfeth-win".
+    /// Owner-authenticated: it only reaches here through a 30177 coordinate
+    /// whose author matches the agent's signed NIP-OA owner.
+    #[serde(default)]
+    pub device_label: Option<String>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ManagedAgentRecord {
@@ -469,7 +484,7 @@ pub struct ManagedAgentRecord {
     /// Canonical, harness-agnostic startup effort level. This is the single
     /// persisted effort authority: at spawn the launch projection
     /// (`config_bridge::effort`) resolves the effective value over this column
-    /// and all env tiers, then emits it under the destination runtime's native
+    /// and all env tiers, then emits it under the resolution runtime's native
     /// key — `GOOSE_THINKING_EFFORT` for Goose, `BUZZ_AGENT_THINKING_EFFORT` for
     /// buzz-agent, or the `BUZZ_ACP_EFFORT_LEVEL` startup sentinel for
     /// Claude/Codex and keyless/unknown adapters. Preserved across runtime
@@ -600,162 +615,6 @@ pub struct CreateManagedAgentResponse {
 pub struct ManagedAgentLogResponse {
     pub content: String,
     pub log_path: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum AcpAvailabilityStatus {
-    Available,
-    AdapterMissing,
-    /// Adapter binary is present but unsupported — either the deprecated
-    /// package or a version below the supported floor. Reinstall required.
-    AdapterOutdated,
-    CliMissing,
-    NotInstalled,
-}
-
-/// Authentication/login status for a CLI-based ACP runtime. Serializes as a tagged union
-/// `{ status: "...", diagnostic?: "..." }` so the TypeScript side can exhaustively switch on `status`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case", tag = "status")]
-pub enum AuthStatus {
-    /// The CLI reported a successful login.
-    LoggedIn,
-    /// The CLI exited non-zero without a config-parse signal.
-    LoggedOut,
-    /// The CLI exited non-zero and its stderr contains a config-parse error.
-    ConfigInvalid {
-        /// Trimmed excerpt of the stderr message.
-        diagnostic: String,
-    },
-    /// This runtime does not have a login step (e.g. goose, buzz-agent).
-    NotApplicable,
-    /// Probe was not attempted (runtime unavailable or probe timed out).
-    Unknown,
-}
-
-/// Origin of an ACP runtime catalog entry. Serializes as a lowercase string so the TypeScript consumer can switch on it without numeric comparisons.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum HarnessSource {
-    /// Compiled into the app — one of the four first-class runtimes.
-    Builtin,
-    /// Static preset entry with bundled logo, PATH-probed, not editable/deletable.
-    Preset,
-    /// Loaded at runtime from the user's `custom_harnesses/` directory.
-    Custom,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct AcpRuntimeCatalogEntry {
-    pub id: String,
-    pub label: String,
-    pub avatar_url: String,
-    pub availability: AcpAvailabilityStatus,
-    pub command: Option<String>,
-    pub binary_path: Option<String>,
-    pub default_args: Vec<String>,
-    pub mcp_command: Option<String>,
-    /// Environment variable used to apply the initial model, when supported.
-    pub model_env_var: Option<String>,
-    /// Environment variable used to apply the selected LLM provider, when supported.
-    pub provider_env_var: Option<String>,
-    /// Environment variable used to apply thinking effort, when supported.
-    pub thinking_env_var: Option<String>,
-    /// Canonical accepted effort values for this runtime, in display order.
-    /// Serialized from `KnownAcpRuntime::effort_normalization.canonical` for
-    /// runtimes with a static finite vocabulary (e.g. Goose). `None` for
-    /// runtimes with no canonicalization contract (buzz-agent uses a
-    /// provider/model catalog; Claude/Codex/unknown runtimes accept any string).
-    ///
-    /// The renderer uses this to drive choices and validation, replacing the
-    /// TS-side `GOOSE_EFFORT_CANONICAL_VALUES` duplicate. When non-null, the
-    /// `harnessNative` effort field uses this list exclusively — `off` and all
-    /// other valid Goose values are always present when this is Goose, so
-    /// `useEffortAutoClear` never incorrectly deletes a valid saved value.
-    pub effort_canonical_values: Option<Vec<String>>,
-    pub max_tokens_env_var: Option<String>,
-    pub context_limit_env_var: Option<String>,
-    pub max_rounds_env_var: Option<String>,
-    pub install_hint: String,
-    pub install_instructions_url: String,
-    /// true when at least one automated install step is available
-    pub can_auto_install: bool,
-    /// true when this runtime depends on a separately installed vendor CLI.
-    pub requires_external_cli: bool,
-    pub underlying_cli_path: Option<String>,
-    /// true when an npm adapter step is pending but Node.js / npm is absent.
-    /// The UI hides the Install button and shows a Node.js install callout.
-    pub node_required: bool,
-    /// Login/authentication status for CLI-based runtimes.
-    pub auth_status: AuthStatus,
-    /// Hint for completing authentication, shown when `auth_status` is not `logged_in`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub login_hint: Option<String>,
-    /// Whether this entry came from the compiled-in catalog or a user-supplied
-    /// JSON file in `custom_harnesses/`. The UI uses this to decide editability.
-    pub source: HarnessSource,
-    /// Definition-level env vars for `source: custom` entries; populated from
-    /// `HarnessDefinition.env` so saves don't silently erase existing vars.
-    /// Absent for builtin/preset entries. Skipped when empty in serialization.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub definition_env: BTreeMap<String, String>,
-    /// Spawn-time parallelism cap; absent for uncapped harnesses.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_parallelism: Option<u32>,
-}
-
-/// Result of a single install step (CLI or adapter).
-#[derive(Debug, Clone, Serialize)]
-pub struct InstallStepResult {
-    pub step: String,
-    pub command: String,
-    pub success: bool,
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: Option<i32>,
-    /// Actionable guidance shown in the UI when this step failed due to a
-    /// recognized condition (e.g. EACCES writing Buzz's private npm prefix).
-    /// `None` when the step succeeded or no pattern matched.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hint: Option<String>,
-}
-
-/// Aggregate result of installing a runtime (may include CLI + adapter steps).
-#[derive(Debug, Clone, Serialize)]
-pub struct InstallRuntimeResult {
-    pub success: bool,
-    pub steps: Vec<InstallStepResult>,
-    /// Number of local agents successfully stopped and restarted after a
-    /// successful install. Mirrors `GlobalAgentConfigSaveResult.restarted_count`.
-    pub restarted_count: u32,
-    /// Number of agents whose stop succeeded but respawn failed.
-    /// Mirrors `GlobalAgentConfigSaveResult.failed_restart_count`.
-    pub failed_restart_count: u32,
-    /// Install log file for this run, when one was written. The UI surfaces it
-    /// on failure so a user can read the full retry history instead of only the
-    /// last step's truncated output. `None` when no log could be opened.
-    pub log_path: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct CommandAvailabilityInfo {
-    pub command: String,
-    pub resolved_path: Option<String>,
-    pub available: bool,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DiscoverManagedAgentPrereqsRequest {
-    pub acp_command: Option<String>,
-    pub mcp_command: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ManagedAgentPrereqsInfo {
-    pub acp: CommandAvailabilityInfo,
-    pub mcp: CommandAvailabilityInfo,
 }
 
 #[derive(Debug, Serialize)]

--- a/desktop/src-tauri/src/nostr_convert/agent_directory.rs
+++ b/desktop/src-tauri/src/nostr_convert/agent_directory.rs
@@ -4,6 +4,8 @@ use std::collections::{BTreeSet, HashMap};
 
 use nostr::Event;
 
+use crate::device_identity::validate_device_id;
+use crate::managed_agents::definition_validation::validate_device_label;
 use crate::managed_agents::{agent_events::managed_agent_content_from_event, RelayAgentInfo};
 
 use super::{agents_from_events, first_tag_value, profile_valid_oa_owner_pubkey, tags_named};
@@ -168,6 +170,22 @@ fn relay_agent_from_managed_policy(agent_pubkey: &str, event: &Event) -> Option<
         status: "unknown".to_string(),
         respond_to: Some(content.respond_to),
         respond_to_allowlist: content.respond_to_allowlist,
+        // Owner authentication proves *who wrote this*, not that what they
+        // wrote is well-formed. A sibling device running an older, buggy, or
+        // tampered-with build can publish any string here, and these two values
+        // are rendered verbatim beside an agent's name — so they are validated
+        // like any other untrusted input before they reach the UI.
+        //
+        // A value that fails degrades to `None` on its own. Dropping the whole
+        // directory entry over a bad label would hide a real, reachable agent;
+        // dropping just the label falls back to the same "no device
+        // information" rendering as a peer that predates Stage 0.
+        device_id: content
+            .device_id
+            .filter(|id| validate_device_id(id).is_ok()),
+        device_label: content
+            .device_label
+            .filter(|label| validate_device_label(label).is_ok()),
     })
 }
 

--- a/desktop/src-tauri/src/nostr_convert/tests.rs
+++ b/desktop/src-tauri/src/nostr_convert/tests.rs
@@ -452,6 +452,125 @@ fn managed_agent_directory_accepts_only_the_verified_owner_policy() {
     assert_eq!(agents[0].respond_to_allowlist, vec![viewer_pubkey]);
 }
 
+/// The device label reaches the directory only through an owner-verified
+/// coordinate, and stays `None` for a record published by a build that predates
+/// device identity.
+#[test]
+fn managed_agent_directory_surfaces_the_owner_verified_device_label() {
+    let agent_keys = Keys::generate();
+    let owner_keys = Keys::generate();
+    let agent_pubkey = agent_keys.public_key().to_hex();
+
+    let auth_tag_json =
+        buzz_sdk_pkg::nip_oa::compute_auth_tag(&owner_keys, &agent_keys.public_key(), "")
+            .expect("compute auth tag");
+    let auth_tag_values: Vec<String> =
+        serde_json::from_str(&auth_tag_json).expect("parse auth tag json");
+    let profile = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Bumble"}"#)
+        .tags([Tag::parse(auth_tag_values).expect("parse auth tag")])
+        .sign_with_keys(&agent_keys)
+        .expect("sign profile");
+
+    let stamped = EventBuilder::new(
+        Kind::Custom(30177),
+        serde_json::json!({
+            "name": "Bumble",
+            "parallelism": 1,
+            "respond_to": "anyone",
+            "device_id": "0123456789abcdef0123456789abcdef",
+            "device_label": "mfeth-win",
+        })
+        .to_string(),
+    )
+    .tags([Tag::parse(["d", agent_pubkey.as_str()]).expect("parse d tag")])
+    .sign_with_keys(&owner_keys)
+    .expect("sign managed-agent event");
+
+    let agents = relay_agents_from_managed_agent_events(&[stamped], std::slice::from_ref(&profile));
+    assert_eq!(agents.len(), 1);
+    assert_eq!(
+        agents[0].device_id.as_deref(),
+        Some("0123456789abcdef0123456789abcdef")
+    );
+    assert_eq!(agents[0].device_label.as_deref(), Some("mfeth-win"));
+
+    // An unstamped record from an older build yields no label — never a
+    // fabricated one.
+    let unstamped = managed_agent_event(&owner_keys, &agent_pubkey, "Bumble", "anyone", &[]);
+    let agents =
+        relay_agents_from_managed_agent_events(&[unstamped], std::slice::from_ref(&profile));
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].device_id, None);
+    assert_eq!(agents[0].device_label, None);
+}
+
+/// Owner authentication proves authorship, not well-formedness: a sibling
+/// device on an older, buggy, or tampered build can sign anything. A bad value
+/// must degrade to `None` on its own without hiding a real, reachable agent.
+#[test]
+fn managed_agent_directory_drops_invalid_device_metadata_but_keeps_the_agent() {
+    let agent_keys = Keys::generate();
+    let owner_keys = Keys::generate();
+    let agent_pubkey = agent_keys.public_key().to_hex();
+
+    let auth_tag_json =
+        buzz_sdk_pkg::nip_oa::compute_auth_tag(&owner_keys, &agent_keys.public_key(), "")
+            .expect("compute auth tag");
+    let auth_tag_values: Vec<String> =
+        serde_json::from_str(&auth_tag_json).expect("parse auth tag json");
+    let profile = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Bumble"}"#)
+        .tags([Tag::parse(auth_tag_values).expect("parse auth tag")])
+        .sign_with_keys(&agent_keys)
+        .expect("sign profile");
+
+    // A bidi override in the label and a malformed id, both correctly signed.
+    let hostile = EventBuilder::new(
+        Kind::Custom(30177),
+        serde_json::json!({
+            "name": "Bumble",
+            "parallelism": 1,
+            "respond_to": "anyone",
+            "device_id": "not-a-uuid",
+            "device_label": "mfeth\u{202E}win",
+        })
+        .to_string(),
+    )
+    .tags([Tag::parse(["d", agent_pubkey.as_str()]).expect("parse d tag")])
+    .sign_with_keys(&owner_keys)
+    .expect("sign managed-agent event");
+
+    let agents = relay_agents_from_managed_agent_events(&[hostile], std::slice::from_ref(&profile));
+    assert_eq!(agents.len(), 1, "the agent itself must still be reachable");
+    assert_eq!(agents[0].name, "Bumble");
+    assert_eq!(agents[0].device_id, None, "malformed id dropped");
+    assert_eq!(agents[0].device_label, None, "bidi-bearing label dropped");
+
+    // An over-long label is refused by the same policy.
+    let long = EventBuilder::new(
+        Kind::Custom(30177),
+        serde_json::json!({
+            "name": "Bumble",
+            "parallelism": 1,
+            "respond_to": "anyone",
+            "device_id": "0123456789abcdef0123456789abcdef",
+            "device_label": "a".repeat(33),
+        })
+        .to_string(),
+    )
+    .tags([Tag::parse(["d", agent_pubkey.as_str()]).expect("parse d tag")])
+    .sign_with_keys(&owner_keys)
+    .expect("sign managed-agent event");
+
+    let agents = relay_agents_from_managed_agent_events(&[long], std::slice::from_ref(&profile));
+    assert_eq!(agents.len(), 1);
+    assert_eq!(
+        agents[0].device_id.as_deref(),
+        Some("0123456789abcdef0123456789abcdef"),
+        "a valid id survives its label being dropped"
+    );
+    assert_eq!(agents[0].device_label, None);
+}
+
 #[test]
 fn managed_agent_directory_rejects_agents_without_verified_owner_profiles() {
     let owner_keys = Keys::generate();

--- a/desktop/src-tauri/src/reset.rs
+++ b/desktop/src-tauri/src/reset.rs
@@ -155,6 +155,29 @@ pub(crate) fn run_boot_reset(app_data_dir: &Path) -> ResetOutcome {
     run_boot_reset_with_keychain(ctx)
 }
 
+/// Phase 2 as `setup()` needs it: resolve the app-data dir, prime the nest
+/// path, and run the wipe.
+///
+/// `init_nest_dir` has to happen here rather than inside
+/// `run_boot_migrations`, because `run_boot_reset` calls `nest_dir()` and the
+/// wipe runs *before* migrations. Returns a default (no-op) outcome when the
+/// platform cannot give us an app-data dir, which is the same thing an absent
+/// sentinel produces.
+pub(crate) fn run_boot_reset_for_app(app_handle: &tauri::AppHandle) -> ResetOutcome {
+    use tauri::Manager as _;
+
+    let Ok(data_dir) = app_handle.path().app_data_dir() else {
+        return ResetOutcome::default();
+    };
+    let is_dev = data_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(crate::migration::is_dev_data_dir_name)
+        .unwrap_or(false);
+    crate::managed_agents::init_nest_dir(is_dev);
+    run_boot_reset(&data_dir)
+}
+
 /// Deterministic trash path: `<original>.reset-trash`. Unlike PID-based names,
 /// any boot can discover and clean trash from a prior crashed attempt.
 fn trash_path(original: &Path) -> PathBuf {

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -37,12 +37,13 @@ import {
   installAcpRuntime,
   invokeTauri,
   listManagedAgents,
-  listRelayAgents,
   saveCustomHarness,
   updateManagedAgent,
 } from "@/shared/api/tauri";
 import type { HarnessDefinitionInput } from "@/shared/api/tauri";
 import { discoverAcpRuntimes } from "@/shared/api/tauriAcpDiscovery";
+import { getDeviceIdentity } from "@/shared/api/tauriDeviceIdentity";
+import { listRelayAgents } from "@/shared/api/tauriRelayAgents";
 import {
   setManagedAgentAutoRestart,
   setManagedAgentStartOnAppLaunch,
@@ -368,6 +369,24 @@ export function useManagedAgentPrereqsQuery(
         mcpCommand: normalizedMcpCommand || undefined,
       }),
     staleTime: 15_000,
+  });
+}
+
+export const deviceIdentityQueryKey = ["device-identity"] as const;
+
+/**
+ * The device identity of this install.
+ *
+ * Machine-scoped, NOT community-scoped: it must survive a community
+ * switch, so it is deliberately absent from `resetCommunityState()` in
+ * `desktop/src/features/communities/useCommunityInit.ts`. Do not add it
+ * there.
+ */
+export function useDeviceIdentityQuery() {
+  return useQuery({
+    queryKey: deviceIdentityQueryKey,
+    queryFn: getDeviceIdentity,
+    staleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/desktop/src/features/agents/lib/agentDeviceLabel.test.mjs
+++ b/desktop/src/features/agents/lib/agentDeviceLabel.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeAgentDevice } from "./agentDeviceLabel.ts";
+
+test("device label stays silent for a local agent with no name collision", () => {
+  assert.equal(
+    describeAgentDevice({
+      isLocal: true,
+      deviceLabel: "this-mac",
+      hasNameCollision: false,
+    }),
+    null,
+  );
+  assert.equal(
+    describeAgentDevice({
+      isLocal: true,
+      deviceLabel: null,
+      hasNameCollision: false,
+    }),
+    null,
+  );
+});
+
+test("device label names this device when a local agent collides on name", () => {
+  assert.equal(
+    describeAgentDevice({
+      isLocal: true,
+      deviceLabel: "mfeth-win",
+      hasNameCollision: true,
+    }),
+    "on this device",
+  );
+  assert.equal(
+    describeAgentDevice({
+      isLocal: true,
+      deviceLabel: null,
+      hasNameCollision: true,
+    }),
+    "on this device",
+  );
+});
+
+test("device label names the remote device when one is published", () => {
+  assert.equal(
+    describeAgentDevice({
+      isLocal: false,
+      deviceLabel: "mfeth-win",
+      hasNameCollision: true,
+    }),
+    "on mfeth-win",
+  );
+  assert.equal(
+    describeAgentDevice({
+      isLocal: false,
+      deviceLabel: "mfeth-win",
+      hasNameCollision: false,
+    }),
+    "on mfeth-win",
+  );
+  assert.equal(
+    describeAgentDevice({
+      isLocal: false,
+      deviceLabel: "  mfeth-win  ",
+      hasNameCollision: false,
+    }),
+    "on mfeth-win",
+  );
+});
+
+test("device label never fabricates a name for a remote agent without one", () => {
+  for (const deviceLabel of [null, undefined, "", "   ", "\t\n"]) {
+    assert.equal(
+      describeAgentDevice({
+        isLocal: false,
+        deviceLabel,
+        hasNameCollision: false,
+      }),
+      "on another device",
+    );
+  }
+});

--- a/desktop/src/features/agents/lib/agentDeviceLabel.ts
+++ b/desktop/src/features/agents/lib/agentDeviceLabel.ts
@@ -1,0 +1,38 @@
+/**
+ * Describes which computer an agent lives on, for a UI that must
+ * distinguish same-named agents minted on different devices.
+ *
+ * The same account signed in on several computers mints a *separate*
+ * keypair per computer for the same agent, so a channel can show four
+ * identical "Winnie" entries of which only one is runnable here. This is
+ * the copy that tells them apart.
+ *
+ * Returns `null` when there is nothing informative to say — a local agent
+ * with no name collision is on this device by definition, and saying so
+ * would be noise for the single-device majority.
+ *
+ * | isLocal | deviceLabel | hasNameCollision | result               |
+ * | ------- | ----------- | ---------------- | -------------------- |
+ * | true    | any         | false            | `null` (no noise)    |
+ * | true    | any         | true             | `"on this device"`   |
+ * | false   | `"mfeth-win"` | any            | `"on mfeth-win"`     |
+ * | false   | null/empty  | any              | `"on another device"`|
+ *
+ * A whitespace-only label counts as absent. A wrong device name is worse
+ * than no device name, so a missing label is never filled in with a guess.
+ */
+export function describeAgentDevice(input: {
+  /** True when this pubkey has a record in the local managed-agent store. */
+  isLocal: boolean;
+  /** Device label read off the agent's kind:30177 event, if any. */
+  deviceLabel?: string | null;
+  /** True when another visible suggestion shares this display name. */
+  hasNameCollision: boolean;
+}): string | null {
+  if (input.isLocal) {
+    return input.hasNameCollision ? "on this device" : null;
+  }
+
+  const label = input.deviceLabel?.trim();
+  return label ? `on ${label}` : "on another device";
+}

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -114,6 +114,10 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
               : "offline",
           respondTo: agent.respondTo,
           respondToAllowlist: agent.respondToAllowlist,
+          // Local managed agents are always on this device, so there is no
+          // sibling device to disambiguate against here.
+          deviceId: null,
+          deviceLabel: null,
         });
       }
     }

--- a/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
+++ b/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { AgentDefaultsSettingsCard } from "./AgentDefaultsSettingsCard";
+import { DeviceNameSettingsCard } from "./DeviceNameSettingsCard";
 import {
   setKeepMentionedAgentsPinned,
   useKeepMentionedAgentsPinned,
@@ -48,6 +49,7 @@ export function AgentsSettingsPanel() {
             />
           </SettingsOptionRow>
         </SettingsOptionGroup>
+        <DeviceNameSettingsCard />
         <PreventSleepSettingsCard />
         <HarnessesSettingsPanel />
         <AgentDefaultsSettingsCard />

--- a/desktop/src/features/settings/ui/DeviceNameSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/DeviceNameSettingsCard.tsx
@@ -1,0 +1,150 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import * as React from "react";
+import { toast } from "sonner";
+
+import {
+  deviceIdentityQueryKey,
+  useDeviceIdentityQuery,
+} from "@/features/agents/hooks";
+import {
+  getDeviceNameSuggestion,
+  setDeviceLabel,
+} from "@/shared/api/tauriDeviceIdentity";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+
+/** Backend cap on the device label; mirrored here so the field stops typing at it. */
+const DEVICE_LABEL_MAX_LENGTH = 32;
+
+/**
+ * Shows and renames this install's device label.
+ *
+ * The label is published on each local agent's kind:30177 event so the same
+ * account's other devices can tell duplicate agent names apart, which is why
+ * the subcopy spells out that it leaves the machine.
+ */
+export function DeviceNameSettingsCard() {
+  const queryClient = useQueryClient();
+  const deviceIdentity = useDeviceIdentityQuery();
+  const savedLabel = deviceIdentity.data?.deviceLabel ?? "";
+  const [draftLabel, setDraftLabel] = React.useState(savedLabel);
+  const [editedLabel, setEditedLabel] = React.useState(false);
+
+  // Seed the field from the query the first time it resolves, but never stomp
+  // on what the user is currently typing.
+  React.useEffect(() => {
+    if (!editedLabel) {
+      setDraftLabel(savedLabel);
+    }
+  }, [editedLabel, savedLabel]);
+
+  const renameDevice = useMutation({
+    mutationFn: (label: string) => setDeviceLabel(label),
+    onSuccess: (identity) => {
+      setEditedLabel(false);
+      setDraftLabel(identity.deviceLabel);
+      void queryClient.invalidateQueries({ queryKey: deviceIdentityQueryKey });
+      toast.success("Device name updated");
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        error instanceof Error ? error.message : "Could not rename this device",
+      );
+    },
+  });
+
+  // The OS host name is only ever *offered*. A device's name starts opaque
+  // (`device-xxxxxxxx`) precisely because host names routinely carry a real
+  // person's name and this label is published world-readable — so the owner
+  // opts in here, seeing the warning above before anything leaves the machine.
+  const [suggestion, setSuggestion] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    let cancelled = false;
+    void getDeviceNameSuggestion()
+      .then((value) => {
+        if (!cancelled) {
+          setSuggestion(value);
+        }
+      })
+      .catch(() => {
+        // Advisory only — a device with no usable host name simply gets no
+        // suggestion, which is not worth surfacing as an error.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const trimmedLabel = draftLabel.trim();
+  const showSuggestion =
+    suggestion !== null &&
+    suggestion !== savedLabel &&
+    suggestion !== trimmedLabel;
+  const saveDisabled =
+    trimmedLabel.length === 0 ||
+    trimmedLabel === savedLabel ||
+    renameDevice.isPending ||
+    !deviceIdentity.data;
+
+  return (
+    <div className="min-w-0 space-y-3">
+      <SettingsOptionGroup data-testid="device-name-card" title="This device">
+        <SettingsOptionRow className="flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+          <div className="min-w-0">
+            <label className="text-sm font-medium" htmlFor="device-name-input">
+              Device name
+            </label>
+            <p
+              className="text-sm font-normal text-muted-foreground/70"
+              data-settings-subcopy
+            >
+              Shown next to this device's agents when you view them from your
+              other devices. Published with your agents, so avoid personal
+              details.
+            </p>
+            {showSuggestion ? (
+              <button
+                className="mt-1 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                data-testid="device-name-use-hostname"
+                onClick={() => {
+                  setEditedLabel(true);
+                  setDraftLabel(suggestion);
+                }}
+                type="button"
+              >
+                Use this computer's name ({suggestion})
+              </button>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Input
+              className="w-48"
+              data-testid="device-name-input"
+              disabled={!deviceIdentity.data || renameDevice.isPending}
+              id="device-name-input"
+              maxLength={DEVICE_LABEL_MAX_LENGTH}
+              onChange={(event) => {
+                setEditedLabel(true);
+                setDraftLabel(event.target.value);
+              }}
+              value={draftLabel}
+            />
+            <Button
+              data-testid="device-name-save"
+              disabled={saveDisabled}
+              onClick={() => {
+                renameDevice.mutate(trimmedLabel);
+              }}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              Save
+            </Button>
+          </div>
+        </SettingsOptionRow>
+      </SettingsOptionGroup>
+    </div>
+  );
+}

--- a/desktop/src/shared/api/relayDirectoryTypes.ts
+++ b/desktop/src/shared/api/relayDirectoryTypes.ts
@@ -1,0 +1,35 @@
+import type { RespondToMode } from "./types";
+
+export type RelayMemberRole = "owner" | "admin" | "member";
+
+export type RelayMember = {
+  pubkey: string;
+  role: RelayMemberRole;
+  addedBy: string | null;
+  createdAt: string;
+};
+
+export type RelayAgent = {
+  pubkey: string;
+  ownerPubkey: string | null;
+  name: string;
+  agentType: string;
+  channels: string[];
+  channelIds: string[];
+  capabilities: string[];
+  /** Policy-only discovery has no liveness evidence. */
+  status: "online" | "away" | "offline" | "unknown";
+  respondTo: RespondToMode | null;
+  respondToAllowlist: string[];
+  /** Opaque id of the device that holds this agent's secret. */
+  deviceId: string | null;
+  /** Human label for that device, or null on pre-feature events. */
+  deviceLabel: string | null;
+};
+
+/** Identity of the computer this Buzz install runs on. */
+export type DeviceIdentity = {
+  deviceId: string;
+  deviceLabel: string;
+  createdAt: string;
+};

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -17,7 +17,6 @@ import type {
   HomeFeedResponse,
   ManagedAgent,
   ManagedAgentBackend,
-  RelayAgent,
   RelayMember,
   RelayMemberRole,
   PresenceLookup,
@@ -98,18 +97,6 @@ type RawSearchResponse = {
   found: number;
 };
 
-type RawRelayAgent = {
-  pubkey: string;
-  owner_pubkey?: string | null;
-  name: string;
-  agent_type: string;
-  channels: string[];
-  channel_ids: string[];
-  capabilities: string[];
-  status: RelayAgent["status"];
-  respond_to?: RelayAgent["respondTo"];
-  respond_to_allowlist?: string[];
-};
 import type { RestartDiffEntry as RawRestartDiffEntry } from "./restartDiff";
 export type RawManagedAgent = {
   pubkey: string;
@@ -610,21 +597,6 @@ export async function createAuthEvent(input: {
   const eventJson = await invokeTauri<string>("create_auth_event", input);
   return JSON.parse(eventJson) as RelayEvent;
 }
-function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
-  return {
-    pubkey: agent.pubkey,
-    ownerPubkey: agent.owner_pubkey ?? null,
-    name: agent.name,
-    agentType: agent.agent_type,
-    channels: agent.channels,
-    channelIds: agent.channel_ids ?? [],
-    capabilities: agent.capabilities,
-    status: agent.status,
-    respondTo: agent.respond_to ?? null,
-    respondToAllowlist: agent.respond_to_allowlist ?? [],
-  };
-}
-
 export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
   return {
     pubkey: agent.pubkey,
@@ -767,12 +739,6 @@ export async function changeRelayMemberRole(
   newRole: string,
 ): Promise<void> {
   await invokeTauri("change_relay_member_role", { targetPubkey, newRole });
-}
-
-export async function listRelayAgents(): Promise<RelayAgent[]> {
-  return (await invokeTauri<RawRelayAgent[]>("list_relay_agents")).map(
-    fromRawRelayAgent,
-  );
 }
 
 export async function listManagedAgents(): Promise<ManagedAgent[]> {

--- a/desktop/src/shared/api/tauriDeviceIdentity.ts
+++ b/desktop/src/shared/api/tauriDeviceIdentity.ts
@@ -1,0 +1,32 @@
+import { invokeTauri } from "@/shared/api/tauri";
+import type { DeviceIdentity } from "@/shared/api/types";
+
+/** Read this install's device identity, minting one on first call. */
+export async function getDeviceIdentity(): Promise<DeviceIdentity> {
+  return invokeTauri<DeviceIdentity>("get_device_identity");
+}
+
+/**
+ * Rename this device.
+ *
+ * The backend trims and rejects an empty, over-long (>32 char), or
+ * invisible-character-bearing label — including the zero-width and bidi
+ * codepoints `char::is_control` misses — then republishes the label on the
+ * active community's local agents, so callers need no follow-up write. The
+ * owner's other communities pick it up when next activated.
+ */
+export async function setDeviceLabel(label: string): Promise<DeviceIdentity> {
+  return invokeTauri<DeviceIdentity>("set_device_label", { label });
+}
+
+/**
+ * The OS host name, offered as a suggested device name.
+ *
+ * `null` when the host name is unusable under the label policy. This is only a
+ * suggestion: a device's name starts opaque (`device-xxxxxxxx`) and the host
+ * name — which routinely contains a real person's name — is never published
+ * until the owner applies it.
+ */
+export async function getDeviceNameSuggestion(): Promise<string | null> {
+  return invokeTauri<string | null>("get_device_name_suggestion");
+}

--- a/desktop/src/shared/api/tauriRelayAgents.ts
+++ b/desktop/src/shared/api/tauriRelayAgents.ts
@@ -1,7 +1,8 @@
 import { invokeTauri } from "@/shared/api/tauri";
 import type { RelayAgent } from "@/shared/api/types";
 
-type RawRelayAgent = {
+/** Wire shape of a relay agent directory entry. */
+export type RawRelayAgent = {
   pubkey: string;
   owner_pubkey?: string | null;
   name: string;
@@ -12,17 +13,13 @@ type RawRelayAgent = {
   status: RelayAgent["status"];
   respond_to?: RelayAgent["respondTo"];
   respond_to_allowlist?: string[];
+  device_id?: string | null;
+  device_label?: string | null;
 };
 
-export async function revalidateRelayAgents(
-  pubkeys: string[],
-  channelId?: string,
-): Promise<RelayAgent[]> {
-  const agents = await invokeTauri<RawRelayAgent[]>("revalidate_relay_agents", {
-    pubkeys,
-    channelId,
-  });
-  return agents.map((agent) => ({
+/** Normalize a wire relay agent, defaulting fields absent on older payloads. */
+export function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
+  return {
     pubkey: agent.pubkey,
     ownerPubkey: agent.owner_pubkey ?? null,
     name: agent.name,
@@ -33,5 +30,25 @@ export async function revalidateRelayAgents(
     status: agent.status,
     respondTo: agent.respond_to ?? null,
     respondToAllowlist: agent.respond_to_allowlist ?? [],
-  }));
+    deviceId: agent.device_id ?? null,
+    deviceLabel: agent.device_label ?? null,
+  };
+}
+
+/** List the agents visible in the viewer's relay agent directory. */
+export async function listRelayAgents(): Promise<RelayAgent[]> {
+  return (await invokeTauri<RawRelayAgent[]>("list_relay_agents")).map(
+    fromRawRelayAgent,
+  );
+}
+
+export async function revalidateRelayAgents(
+  pubkeys: string[],
+  channelId?: string,
+): Promise<RelayAgent[]> {
+  const agents = await invokeTauri<RawRelayAgent[]>("revalidate_relay_agents", {
+    pubkeys,
+    channelId,
+  });
+  return agents.map(fromRawRelayAgent);
 }

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -253,28 +253,15 @@ export type {
 } from "./searchTypes";
 
 // ── Relay Members ────────────────────────────────────────────────────────────
+// Types live in ./relayDirectoryTypes (extracted by the device-identity
+// feature); RelayAgent.status there includes upstream's "unknown" state.
 
-export type RelayMemberRole = "owner" | "admin" | "member";
-
-export type RelayMember = {
-  pubkey: string;
-  role: RelayMemberRole;
-  addedBy: string | null;
-  createdAt: string;
-};
-export type RelayAgent = {
-  pubkey: string;
-  ownerPubkey: string | null;
-  name: string;
-  agentType: string;
-  channels: string[];
-  channelIds: string[];
-  capabilities: string[];
-  /** Policy-only discovery has no liveness evidence. */
-  status: "online" | "away" | "offline" | "unknown";
-  respondTo: RespondToMode | null;
-  respondToAllowlist: string[];
-};
+export type {
+  DeviceIdentity,
+  RelayAgent,
+  RelayMember,
+  RelayMemberRole,
+} from "./relayDirectoryTypes";
 
 export type ManagedAgentRuntimeLifecycle =
   | "starting"


### PR DESCRIPTION
Supersedes the conflict-free backend half of #6259 ("name the computer an agent lives on"). The mention-UI half of #6259 conflicts semantically with #6337/#6401 (`agentProvenance`) and needs a product decision, so this PR carries only the parts that merge cleanly onto current `main`.

## What this adds

- `device_identity.rs` (+551): opaque 32-hex `device_id` minted per install, user-editable `device_label` (validated: non-empty, ≤32 chars, control/format chars rejected), stable across restarts, persisted atomically
- Agent event projection stamps `device_id`/`device_label` on kind:30177 records for **local backends only** — a provider-backed agent publishes `device: null` (it does not run on the owner's computer)
- `RelayAgentInfo` gains optional `device_id`/`device_label` (`#[serde(default)]`), projected from the directory
- `DeviceNameSettingsCard` UI (Settings → Agents), mounted before `PreventSleepSettingsCard`
- `listRelayAgents` moves from `tauri.ts` to `tauriRelayAgents.ts` with the new fields

## Why split from #6259

1. **`origin/main` moved 38+ commits** since #6259's last rebase; all three textual conflicts are mention-UI files (`MentionAutocomplete.tsx`, `useMentionSendFlow.ts`, `AgentsSettingsPanel.tsx`) where #6315/#6337/#6401 landed a competing disambiguator. Resolving them textually would ship two disambiguators in one suggestion row.
2. **This branch is a fresh three-way integration, not a cherry-pick.** Files were taken from a `git merge-tree` of #6259 × `origin/main` (preserving upstream's `0.5.17→0.5.18` bump and `custom_harness_dir` in `lib.rs`), with the panel wiring applied semantically to current `main` rather than copying #6259's stale whole-file version.
3. **Fixes a latent defect in #6259 itself:** three test-only `RelayAgentInfo` literals in `relay_directory.rs` were never updated for the new fields. `#[serde(default)]` does not fill struct literals, so `cargo check --tests` fails on #6259's head `4e0764d4b` (verified: exit 101, 3× `E0063`). This branch adds `device_id: None, device_label: None` to those three sites (detailed on #6259: https://github.com/block/buzz/pull/6259#issuecomment-5396072442).

## Verification (all on this branch's head, macOS 15.6 arm64, rustc 1.95.0)

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo check --locked --tests` (tauri) | pass, 0 errors |
| `device_identity::` suite | 16/16 |
| `managed_agents::agent_events::` suite | 16/16 |
| `tsc --noEmit` (desktop) | pass, 0 errors |
| `agentDeviceLabel.test.mjs` | 4/4 |

Negative control on the core invariant: flipping only the `BackendKind::Provider` arm of the device stamp to `current()` fails exactly one test — `projection_omits_the_device_for_a_provider_backend` ("a remote body must not be given this computer's id") — with 15/16 passing. Restored, 16/16. So the local-vs-provider gate is behaviorally pinned, not just compiled.

Independently reproduced by @ScaleLeanChris on #6259 (macOS): `agentDeviceLabel.test.mjs` 4/4, focused Tauri device-identity tests 13/13, TS checking clean — the files exercised there are unchanged by the rebase.

## Scope / limitations

- Desktop only; no mobile changes.
- The mention-UI disambiguation (device label in `@` autocomplete) intentionally remains unlanded pending reconciliation with `agentProvenance` (#6337/#6401).
- Future work noted in-code: a provider-backed agent still has a *custody* device (the install holding its secret) distinct from its execution location — distinguishing them needs a protocol change, out of scope here.
