### PR TITLE
fix(scripts): govern .mjs in the desktop and web file-size ratchets

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -1,58 +1,10 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runFileSizeCheck } from "../../scripts/check-file-sizes-core.mjs";
+import { rules } from "./file-size-rules.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
-
-const MAX_LINES = 1000;
-
-const rules = [
-  { root: "src-tauri/src", extensions: new Set([".rs"]), maxLines: MAX_LINES },
-  // Workspace member crates. Without this the ratchet's only Rust root is
-  // `src-tauri/src`, and a crate under `src-tauri/crates/` is born outside the
-  // repo's one size discipline -- silently, since the check still exits 0.
-  {
-    root: "src-tauri/crates",
-    extensions: new Set([".rs"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/app",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/features",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/shared/api",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/shared/context",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/shared/lib",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/shared/ui",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/shared/styles",
-    extensions: new Set([".css"]),
-    maxLines: MAX_LINES,
-  },
-];
 
 await runFileSizeCheck({
   projectRoot,

--- a/desktop/scripts/file-size-rules.mjs
+++ b/desktop/scripts/file-size-rules.mjs
@@ -1,0 +1,60 @@
+// Rule table for the Desktop file-size ratchet, kept in its own module so tests
+// can assert the real configuration instead of a restatement of it. The runner
+// (`check-file-sizes.mjs`) stays unconditional: a module that both exports its
+// rules and self-guards its execution can silently stop gating, which is the
+// same class of failure this table's `.mjs` coverage exists to prevent.
+
+export const MAX_LINES = 1000;
+
+// Desktop's test suite is `*.test.mjs` by convention and its shared test rigs
+// are plain `.mjs` modules, so listing only `.ts`/`.tsx` here left all of them
+// outside the ceiling AGENTS.md documents as enforced -- inside roots this
+// ratchet already governs, and silently, since the check still exits 0.
+export const SCRIPT_EXTENSIONS = new Set([".ts", ".tsx", ".mjs"]);
+
+export const rules = [
+  { root: "src-tauri/src", extensions: new Set([".rs"]), maxLines: MAX_LINES },
+  // Workspace member crates. Without this the ratchet's only Rust root is
+  // `src-tauri/src`, and a crate under `src-tauri/crates/` is born outside the
+  // repo's one size discipline -- silently, since the check still exits 0.
+  {
+    root: "src-tauri/crates",
+    extensions: new Set([".rs"]),
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/app",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/features",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/shared/api",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/shared/context",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/shared/lib",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/shared/ui",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/shared/styles",
+    extensions: new Set([".css"]),
+    maxLines: MAX_LINES,
+  },
+];

--- a/scripts/check-file-sizes-core.test.mjs
+++ b/scripts/check-file-sizes-core.test.mjs
@@ -152,6 +152,8 @@ test("every script root governs .mjs alongside .ts and .tsx", () => {
 // Runs the real desktop rule table against a throwaway repository in a child
 // process. A child keeps `process.exitCode` and `console.error` out of this
 // test's own process, where a leaked exit code would mark the whole file failed.
+const COMPLETION_SENTINEL = "__file_size_gate_completed__";
+
 function runDesktopGate({ fixtureRoot, baseRef }) {
   const result = spawnSync(
     process.execPath,
@@ -166,6 +168,9 @@ function runDesktopGate({ fixtureRoot, baseRef }) {
         rules,
         label: "Desktop",
       });
+      // Printed only if the awaited call returned normally. On stdout so it
+      // cannot be confused with any part of the violation report.
+      process.stdout.write(${JSON.stringify(COMPLETION_SENTINEL)});
       `,
     ],
     {
@@ -181,15 +186,20 @@ function runDesktopGate({ fixtureRoot, baseRef }) {
     },
   );
   // Node exits 1 for an uncaught exception too, so status alone cannot tell a
-  // ratchet violation from a crash. The runner's only output is its violation
-  // report, so a failing status must carry that report to count as a real
-  // violation; anything else is the harness breaking, not the gate deciding.
+  // ratchet violation from a crash. Split the two questions: the sentinel proves
+  // the gate ran to completion, and only then does the exit status mean a policy
+  // decision. Asserting on the report heading alone would accept a child that
+  // started printing violations and then crashed part-way through.
+  assert.ok(
+    result.stdout.includes(COMPLETION_SENTINEL),
+    `the ratchet child did not run to completion (exit ${result.status}, signal ${result.signal}), so it crashed rather than gated:\n${result.stderr}`,
+  );
   const failed = result.status === 1;
   if (failed) {
     assert.match(
       result.stderr,
       /file size ratchet failed \(base /,
-      `the ratchet child exited 1 without reporting a violation, so it crashed rather than gated:\n${result.stderr}`,
+      `the ratchet child exited 1 without reporting a violation:\n${result.stderr}`,
     );
   } else {
     assert.equal(

--- a/scripts/check-file-sizes-core.test.mjs
+++ b/scripts/check-file-sizes-core.test.mjs
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { rules as desktopRules } from "../desktop/scripts/file-size-rules.mjs";
+import { rules as webRules } from "../web/scripts/file-size-rules.mjs";
 import {
   allowedLineCount,
   countLines,
@@ -116,4 +119,160 @@ test("an inherited oversized file may hold or shrink but not grow", () => {
       .violates,
     true,
   );
+});
+
+// --- The gate's own coverage ---------------------------------------------
+//
+// An omitted extension does not fail loudly: `runFileSizeCheck` skips the file
+// and the check still exits 0, so an uncovered root looks exactly like a clean
+// one. That makes the allowlist something to assert rather than assume. These
+// read the real rule tables the runners execute, not a restatement of them.
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("every script root governs .mjs alongside .ts and .tsx", () => {
+  for (const [label, rules] of [
+    ["desktop", desktopRules],
+    ["web", webRules],
+  ]) {
+    const scriptRoots = rules.filter((rule) => rule.extensions.has(".ts"));
+    assert.ok(
+      scriptRoots.length > 0,
+      `${label} declares no TypeScript roots, so this assertion cannot fail for the reason it exists; the rule table shape changed`,
+    );
+    for (const rule of scriptRoots) {
+      assert.ok(
+        rule.extensions.has(".mjs"),
+        `${label} root ${rule.root} governs .ts but not .mjs, so test modules and shared rigs there sit outside the ${rule.maxLines}-line ceiling`,
+      );
+    }
+  }
+});
+
+// Runs the real desktop rule table against a throwaway repository in a child
+// process. A child keeps `process.exitCode` and `console.error` out of this
+// test's own process, where a leaked exit code would mark the whole file failed.
+function runDesktopGate({ fixtureRoot, baseRef }) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `
+      import { runFileSizeCheck } from ${JSON.stringify(path.join(scriptsDir, "check-file-sizes-core.mjs"))};
+      import { rules } from ${JSON.stringify(path.join(scriptsDir, "..", "desktop", "scripts", "file-size-rules.mjs"))};
+      await runFileSizeCheck({
+        projectRoot: ${JSON.stringify(path.join(fixtureRoot, "desktop"))},
+        rules,
+        label: "Desktop",
+      });
+      `,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(
+            ([key]) => !key.startsWith("GIT_"),
+          ),
+        ),
+        CHECK_FILE_SIZES_BASE: baseRef,
+      },
+    },
+  );
+  // Node exits 1 for an uncaught exception too, so status alone cannot tell a
+  // ratchet violation from a crash. The runner's only output is its violation
+  // report, so a failing status must carry that report to count as a real
+  // violation; anything else is the harness breaking, not the gate deciding.
+  const failed = result.status === 1;
+  if (failed) {
+    assert.match(
+      result.stderr,
+      /file size ratchet failed \(base /,
+      `the ratchet child exited 1 without reporting a violation, so it crashed rather than gated:\n${result.stderr}`,
+    );
+  } else {
+    assert.equal(
+      result.status,
+      0,
+      `the ratchet child exited ${result.status} (signal ${result.signal}):\n${result.stderr}`,
+    );
+  }
+  return { failed, output: result.stderr };
+}
+
+function fixtureRepo(prefix) {
+  const repo = mkdtempSync(path.join(tmpdir(), prefix));
+  mkdirSync(path.join(repo, "desktop/src/features/agents"), {
+    recursive: true,
+  });
+  git(repo, "init", "-b", "main");
+  git(repo, "config", "user.name", "Test");
+  git(repo, "config", "user.email", "test@example.com");
+  return repo;
+}
+
+test("the desktop rules hold a new .mjs file in a governed root to the ceiling", () => {
+  const repo = fixtureRepo("file-size-mjs-new-");
+  git(repo, "commit", "--allow-empty", "-m", "base");
+  const target = "desktop/src/features/agents/oversize.test.mjs";
+
+  // `countLines` counts a trailing newline as a final empty line, so N repeats
+  // of a newline-terminated line is N + 1 lines. Land exactly on the ceiling.
+  writeFileSync(path.join(repo, target), `${"// line\n".repeat(999)}// line`);
+  const atCeiling = runDesktopGate({ fixtureRoot: repo, baseRef: "HEAD" });
+  assert.equal(
+    atCeiling.failed,
+    false,
+    `a new .mjs at exactly the ceiling must pass: ${atCeiling.output}`,
+  );
+
+  writeFileSync(path.join(repo, target), "// line\n".repeat(1000));
+  const overCeiling = runDesktopGate({ fixtureRoot: repo, baseRef: "HEAD" });
+  assert.equal(
+    overCeiling.failed,
+    true,
+    "a new 1001-line .mjs under src/features must violate the ceiling",
+  );
+  assert.match(
+    overCeiling.output,
+    /src\/features\/agents\/oversize\.test\.mjs: new -> 1001 lines \(allowed 1000\)/,
+  );
+});
+
+test("an inherited oversize .mjs holds or shrinks but may not grow", () => {
+  const repo = fixtureRepo("file-size-mjs-inherited-");
+  const target = "desktop/src/features/agents/inherited.test.mjs";
+
+  // Commit it already over the ceiling, as the existing oversize suites are.
+  writeFileSync(path.join(repo, target), "// line\n".repeat(1199));
+  git(repo, "add", "-A");
+  git(repo, "commit", "-m", "inherited oversize test module");
+  const baseRef = git(repo, "rev-parse", "HEAD");
+
+  // Same line count, different content: an edit that does not grow the file.
+  writeFileSync(path.join(repo, target), "// edit\n".repeat(1199));
+  const held = runDesktopGate({ fixtureRoot: repo, baseRef });
+  assert.equal(
+    held.failed,
+    false,
+    `an inherited oversize .mjs must be grandfathered, not failed on sight: ${held.output}`,
+  );
+
+  writeFileSync(path.join(repo, target), "// line\n".repeat(1100));
+  const shrunk = runDesktopGate({ fixtureRoot: repo, baseRef });
+  assert.equal(
+    shrunk.failed,
+    false,
+    `shrinking an inherited oversize .mjs must pass: ${shrunk.output}`,
+  );
+
+  writeFileSync(path.join(repo, target), "// line\n".repeat(1200));
+  const grown = runDesktopGate({ fixtureRoot: repo, baseRef });
+  assert.equal(
+    grown.failed,
+    true,
+    "growing past the inherited size must fail the ratchet",
+  );
+  assert.match(grown.output, /1200 -> 1201 \(\+1\) lines \(allowed 1200\)/);
 });

--- a/web/scripts/check-file-sizes.mjs
+++ b/web/scripts/check-file-sizes.mjs
@@ -1,29 +1,10 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runFileSizeCheck } from "../../scripts/check-file-sizes-core.mjs";
+import { rules } from "./file-size-rules.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
-
-const MAX_LINES = 1000;
-
-const rules = [
-  {
-    root: "src/app",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/features",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-  {
-    root: "src/shared/api",
-    extensions: new Set([".ts", ".tsx"]),
-    maxLines: MAX_LINES,
-  },
-];
 
 await runFileSizeCheck({
   projectRoot,

--- a/web/scripts/file-size-rules.mjs
+++ b/web/scripts/file-size-rules.mjs
@@ -1,0 +1,26 @@
+// Rule table for the Web file-size ratchet. See the sibling Desktop table for
+// why the rules live apart from the runner.
+
+export const MAX_LINES = 1000;
+
+// `.mjs` is listed alongside `.ts`/`.tsx` so a future test rig or script module
+// under these roots is governed from birth rather than discovered later.
+export const SCRIPT_EXTENSIONS = new Set([".ts", ".tsx", ".mjs"]);
+
+export const rules = [
+  {
+    root: "src/app",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/features",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+  {
+    root: "src/shared/api",
+    extensions: SCRIPT_EXTENSIONS,
+    maxLines: MAX_LINES,
+  },
+];


### PR DESCRIPTION
## Problem

`AGENTS.md:608` states the 1000-line ceiling is "enforced across Desktop, Web, and Mobile by the repository-level `just file-size-check` gate (`just check`, CI, and every pre-push)." For `.mjs` files it is not.

The desktop and web rule tables listed only `.ts`/`.tsx` for their script roots, and `runFileSizeCheck` skips any file whose extension is absent from its rule's allowlist:

```js
if (!rule || !rule.extensions.has(path.extname(relativePath))) continue;
```

This is not a path oversight — the governed roots are correct and `src/features` is already covered. `.mjs` is filtered out *inside* roots the ratchet already walks. Desktop's test suite is `*.test.mjs` by convention and its shared test rigs (`observedUnreadTestHarness.mjs` and friends) are plain `.mjs` modules, so **545 files under already-governed roots sat outside the ceiling.**

The failure mode is silent and indistinguishable from success: an uncovered file makes the check exit 0 exactly like a clean one. Found when review caught a 1253-line test file on #6720 that `just file-size-check`, `just check`, the pre-push hook, and CI had all passed. Refs #6726.

### The gap, demonstrated on a clean `main` checkout

```
$ python3 -c "open('desktop/src/features/agents/zz_probe.test.mjs','w').write('// probe\n'*1500)"
$ node desktop/scripts/check-file-sizes.mjs ; echo "exit=$?"
exit=0                                          # 1501 lines, passes

$ mv ...zz_probe.test.mjs ...zz_probe.ts        # byte-identical content
$ node desktop/scripts/check-file-sizes.mjs ; echo "exit=$?"
Desktop file size ratchet failed (base HEAD):
- src/features/agents/zz_probe.ts: new -> 1501 lines (allowed 1000)
exit=1
```

## Change

Add `.mjs` to the existing extension sets for the roots already governed in `desktop/scripts/check-file-sizes.mjs` and `web/scripts/check-file-sizes.mjs`. **No new roots and no change to the limit.** Rust (`.rs`) and CSS roots are untouched.

The rule tables move into a `file-size-rules.mjs` module per project so the tests can assert the configuration the runners actually execute rather than a restatement of it. The runners stay unconditional — a module that both exports its rules and self-guards its own execution can silently stop gating, which is the same failure class this PR closes.

### No splits required: the gate is a ratchet, not an absolute bound

`allowedLineCount` returns `baseLines` when the base file already exceeds the max, so an inherited oversize file is grandfathered at its committed size and may only hold or shrink:

```js
export function allowedLineCount(baseLines, maxLines) {
  return baseLines == null || baseLines <= maxLines ? maxLines : baseLines;
}
```

New files are still held to 1000 from birth. That is exactly the discipline `AGENTS.md:608` already claims.

## Grandfathered debt now visible to the gate

Twelve `.mjs` files under governed roots exceed the ceiling. Counts are `countLines` semantics — what the gate itself prints, which counts a trailing newline as a final line:

| lines | file |
|------:|------|
| 2453 | `desktop/src/features/agents/activeAgentTurnsStore.test.mjs` |
| 2237 | `desktop/src/features/community-members/useCommunityJoinAlerts.test.mjs` |
| 2080 | `desktop/src/features/agents/ui/agentSessionTranscript.test.mjs` |
| 1876 | `desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs` |
| 1567 | `desktop/src/features/agents/ui/editAgentProviderDiscovery.test.mjs` |
| 1445 | `desktop/src/features/agents/ui/createAgentLocalModeGate.test.mjs` |
| 1439 | `desktop/src/shared/ui/markdown.test.mjs` |
| 1408 | `desktop/src/features/messages/lib/useDrafts.test.mjs` |
| 1358 | `desktop/src/shared/api/relayReconnectReplay.test.mjs` |
| 1190 | `desktop/src/features/agents/ingestArchivedObserverEvents.test.mjs` |
| 1132 | `desktop/src/features/terminal/terminalBannerWave.test.mjs` |
| 1038 | `desktop/src/features/terminal/TerminalSubstrate.test.mjs` |

Each is now pinned at that number. None may grow; all may shrink. Web has no `.mjs` under its governed roots today, so its rule change is purely forward-looking.

## Verification

**The ratchet claim, tested against all twelve at once on a clean checkout** — not reasoned from the source:

```
# rewrite each of the 12 without changing its line count
$ node desktop/scripts/check-file-sizes.mjs ; echo "exit=$?"
exit=0                                          # grandfathered

# add exactly one line to each of the 12
$ node desktop/scripts/check-file-sizes.mjs ; echo "exit=$?"
Desktop file size ratchet failed (base HEAD):
- src/features/agents/activeAgentTurnsStore.test.mjs: 2453 -> 2454 (+1) lines (allowed 2453)
- src/features/agents/ingestArchivedObserverEvents.test.mjs: 1190 -> 1191 (+1) lines (allowed 1190)
  ... all 12 listed with their inherited limits ...
exit=1
```

The original 1501-line `.mjs` probe now exits 1, and the same file at exactly 1000 lines exits 0 — the ceiling moved onto `.mjs` without tightening for anyone.

**Three new tests, each proven non-vacuous by reverting the thing it covers, in isolation:**

| mutation | fails |
|---|---|
| desktop table back to `.ts`/`.tsx` | all 3, allowlist test naming `desktop root src/app` |
| web table back to `.ts`/`.tsx` | the allowlist test alone, naming `web root src/app` |
| `allowedLineCount` → always `maxLines` | the 2 inherited-size tests (incl. the pre-existing one) |

The two behavioural tests drive the real rule table against throwaway git repositories in a child process, so a leaked `process.exitCode` cannot mark the suite failed.

**Two vacuity traps in the harness itself**, worth naming because they are the same shape as the bug — a check that cannot distinguish the outcome it reports from a failure to reach it.

First: the guard asserted the exit status was 0 or 1, assuming a crash produced neither. Node exits 1 for an uncaught exception, so a broken harness was indistinguishable from a detected violation.

Second, caught in review: requiring the violation report proved the gate *started* reporting, not that it *finished*. A child that printed the report and then crashed before returning still read as a completed policy decision. The eval script now writes a completion sentinel to stdout after the awaited call returns, and the harness requires it on both the exit-0 and exit-1 paths — the sentinel proves normal completion, and only then does the exit status carry the policy result.

Proven against the case the previous guard missed. Injecting a throw after the full violation report is emitted but before the gate returns:

```
old guard (report heading only)  9 passing / 0 failing   <- crash read as a pass
new guard (completion sentinel)  7 passing / 2 failing   <- "did not run to
                                                            completion ...
                                                            crashed rather than gated"
```

A throw injected immediately after the heading fails with the same assertion rather than being misattributed to a missing violation line, and pointing the child at a nonexistent rules module fails the same way instead of passing.

The allowlist test also asserts it found TypeScript roots at all, so a future rule-table reshape cannot make it pass by iterating an empty list.

**Gates at the committed head `b9d77258d`, clean tree, same shell:**

- `node --test scripts/check-file-sizes-core.test.mjs` — 9 passing / 0 failing (6 pre-existing + 3 new)
- all four project runners (desktop, web, mobile, plus policy tests) exit 0
- full desktop suite `5434 passing / 0 failing` — not scoped; unchanged by this PR, since these tests live in `scripts/`
- `tsc --noEmit` clean; `biome check` at main's baseline (2 warnings / 2 infos); px-text and pubkey-truncation clean
- all 7 pre-push hooks green, `file-size-check` among them

## Follow-up not in this PR

`mobile/scripts/check-file-sizes.mjs` governs `lib` for `.dart` only. Whether Dart-adjacent tooling files there deserve coverage is a separate judgment for mobile owners, so I left it alone.
