### PR TITLE
fix(acp): keep MCP private keys out of process argv

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -111,6 +111,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
+| `BUZZ_KEYCHAIN_SERVICE` | no | — | macOS Keychain service for the MCP server's Buzz identity. When set, ACP session JSON carries this identifier instead of `BUZZ_PRIVATE_KEY`. Requires `BUZZ_ACP_MCP_COMMAND`. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -469,6 +469,17 @@ impl AcpClient {
             // Callers MUST still call shutdown().await for guaranteed cleanup.
             .kill_on_drop(true);
 
+        // The harness needs BUZZ_PRIVATE_KEY for relay signing, but an adapter
+        // configured for Keychain delegation must receive only the service
+        // identifier. Some adapters serialize MCP environment values into argv.
+        let uses_keychain_service = extra_env
+            .iter()
+            .any(|(key, _)| key == crate::config::MCP_KEYCHAIN_SERVICE_ENV);
+        if uses_keychain_service {
+            cmd.env_remove("BUZZ_PRIVATE_KEY");
+            cmd.env_remove("BUZZ_ACP_PRIVATE_KEY");
+        }
+
         // Per-persona env vars (e.g., GOOSE_PROVIDER, BUZZ_AGENT_PROVIDER).
         // For most keys, operator precedence wins: skip injection if already set
         // in the parent environment.
@@ -504,6 +515,11 @@ impl AcpClient {
         }
 
         for (key, value) in extra_env {
+            if uses_keychain_service
+                && matches!(key.as_str(), "BUZZ_PRIVATE_KEY" | "BUZZ_ACP_PRIVATE_KEY")
+            {
+                continue;
+            }
             if key == "CODEX_CONFIG" && codex_merge_active {
                 // Handled by build_codex_config_env; skip here to avoid double-setting.
                 continue;

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -267,6 +267,11 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_MCP_COMMAND", default_value = "")]
     pub mcp_command: String,
 
+    /// macOS Keychain service containing the Buzz private key for the MCP server.
+    /// When set, the service identifier replaces BUZZ_PRIVATE_KEY in ACP session JSON.
+    #[arg(long, env = "BUZZ_KEYCHAIN_SERVICE", hide_env_values = true)]
+    pub keychain_service: Option<String>,
+
     /// Idle timeout: max seconds of silence before killing a turn.
     /// Resets on any agent stdout activity.
     #[arg(long, env = "BUZZ_ACP_IDLE_TIMEOUT")]
@@ -521,6 +526,8 @@ pub struct Config {
     pub agent_command: String,
     pub agent_args: Vec<String>,
     pub mcp_command: String,
+    /// macOS Keychain service delegated to the MCP server instead of a private key.
+    pub keychain_service: Option<String>,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
     pub agents: u32,
@@ -755,6 +762,10 @@ pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'sta
         _ => &[],
     }
 }
+
+/// Environment variable passed to a local MCP server so it can resolve the
+/// Buzz identity without serializing the private key into ACP session JSON.
+pub(crate) const MCP_KEYCHAIN_SERVICE_ENV: &str = "BUZZ_KEYCHAIN_SERVICE";
 
 /// Build the `CODEX_CONFIG` environment variable that enables full outbound
 /// network access in Codex's macOS Seatbelt sandbox.
@@ -1078,6 +1089,37 @@ impl Config {
         let mut persona_env_vars = Vec::new();
         let model = args.model;
 
+        let keychain_service = match args.keychain_service.as_deref() {
+            Some(raw) => {
+                let service = raw.trim();
+                if service.is_empty() {
+                    return Err(ConfigError::ConfigFile(
+                        "BUZZ_KEYCHAIN_SERVICE must not be empty when configured".into(),
+                    ));
+                }
+                Some(service.to_owned())
+            }
+            None => None,
+        };
+        if let Some(service) = &keychain_service {
+            #[cfg(not(target_os = "macos"))]
+            return Err(ConfigError::ConfigFile(
+                "BUZZ_KEYCHAIN_SERVICE is only supported on macOS".into(),
+            ));
+            if args.mcp_command.is_empty() {
+                return Err(ConfigError::ConfigFile(
+                    "BUZZ_KEYCHAIN_SERVICE requires BUZZ_ACP_MCP_COMMAND".into(),
+                ));
+            }
+            if service.chars().any(char::is_control) || service.chars().count() > 255 {
+                return Err(ConfigError::ConfigFile(
+                    "BUZZ_KEYCHAIN_SERVICE must be 1-255 characters with no control characters"
+                        .into(),
+                ));
+            }
+            persona_env_vars.push((MCP_KEYCHAIN_SERVICE_ENV.into(), service.clone()));
+        }
+
         // Inject CODEX_CONFIG so the @agentclientprotocol/codex-acp adapter (1.x)
         // opens the Seatbelt network sandbox for buzz-cli (an MCP subprocess). No-op
         // for non-Codex agents or unparseable relay URLs.
@@ -1097,6 +1139,7 @@ impl Config {
             agent_command,
             agent_args,
             mcp_command: args.mcp_command,
+            keychain_service,
             idle_timeout_secs,
             max_turn_duration_secs,
             agents: args.agents,
@@ -1478,6 +1521,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "".into(),
+            keychain_service: None,
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -3019,5 +3063,22 @@ channels = "ALL"
             "Found secret-bearing env args without hide_env_values=true. \
              Add `hide_env_values = true` to each: {violations:?}"
         );
+    }
+
+    #[test]
+    fn empty_keychain_service_fails_closed() {
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--mcp-command",
+            "buzz-dev-mcp",
+            "--keychain-service",
+            " ",
+        ])
+        .expect("clap should preserve an explicitly blank service for validation");
+
+        let error = Config::from_args(args).expect_err("blank service must not fall back");
+        assert!(error.to_string().contains("must not be empty"));
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -5043,12 +5043,17 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
         command: config.mcp_command.clone(),
         args: vec![],
         env: {
-            let mut env = vec![
-                EnvVar {
-                    name: "BUZZ_RELAY_URL".into(),
-                    value: config.relay_url.clone(),
-                },
-                EnvVar {
+            let mut env = vec![EnvVar {
+                name: "BUZZ_RELAY_URL".into(),
+                value: config.relay_url.clone(),
+            }];
+            if let Some(service) = &config.keychain_service {
+                env.push(EnvVar {
+                    name: config::MCP_KEYCHAIN_SERVICE_ENV.into(),
+                    value: service.clone(),
+                });
+            } else {
+                env.push(EnvVar {
                     name: "BUZZ_PRIVATE_KEY".into(),
                     // bech32 encoding of a valid secret key is infallible.
                     // Panic here is correct: injecting a bogus secret would cause
@@ -5058,8 +5063,8 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
                         .secret_key()
                         .to_bech32()
                         .expect("secret key bech32 encoding should never fail"),
-                },
-            ];
+                });
+            }
             // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
             // so the MCP server can attach it to every signed event.
             if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
@@ -6760,6 +6765,7 @@ mod build_mcp_servers_tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "test-mcp-server".into(),
+            keychain_service: None,
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -6817,6 +6823,25 @@ mod build_mcp_servers_tests {
         assert!(
             names.contains(&"BUZZ_PRIVATE_KEY"),
             "missing BUZZ_PRIVATE_KEY; got {names:?}"
+        );
+    }
+
+    #[test]
+    fn session_new_mcp_server_passes_keychain_service_not_private_key() {
+        let mut config = test_config();
+        config.keychain_service = Some("buzz-agent-test".into());
+        let servers = build_mcp_servers(&config);
+
+        let env = &servers[0].env;
+        assert_eq!(
+            env.iter()
+                .find(|entry| entry.name == config::MCP_KEYCHAIN_SERVICE_ENV)
+                .map(|entry| entry.value.as_str()),
+            Some("buzz-agent-test")
+        );
+        assert!(
+            !env.iter().any(|entry| entry.name == "BUZZ_PRIVATE_KEY"),
+            "the MCP session environment must not serialize the private key"
         );
     }
 
@@ -6984,6 +7009,7 @@ mod error_outcome_emission_tests {
             agent_command: "true".into(),
             agent_args: vec![],
             mcp_command: "test-mcp-server".into(),
+            keychain_service: None,
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/crates/buzz-dev-mcp/src/lib.rs
+++ b/crates/buzz-dev-mcp/src/lib.rs
@@ -8,7 +8,11 @@ use rmcp::{
     ErrorData, ServerHandler, ServiceExt,
 };
 use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::process::Command;
 use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use zeroize::Zeroize;
 
 mod paths;
 mod read_file;
@@ -170,6 +174,8 @@ async fn async_main(cmd: String) -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(buzz_cli::run_from_args(std::env::args()).await);
     }
 
+    load_keychain_private_key()?;
+
     // MCP server mode — safe to init tracing now.
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
@@ -183,6 +189,88 @@ async fn async_main(cmd: String) -> Result<(), Box<dyn std::error::Error>> {
     let service = DevMcp::new(state).serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
+}
+
+/// Resolve a macOS Keychain-backed Buzz identity for this MCP process.
+///
+/// A configured service is authoritative: lookup or validation failure aborts
+/// startup instead of falling back to an inherited credential.
+#[cfg(target_os = "macos")]
+fn load_keychain_private_key() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(service) = std::env::var("BUZZ_KEYCHAIN_SERVICE")
+        .ok()
+        .filter(|service| !service.is_empty())
+    else {
+        return Ok(());
+    };
+    std::env::remove_var("BUZZ_KEYCHAIN_SERVICE");
+    let account = std::env::var("USER")
+        .ok()
+        .filter(|account| !account.is_empty())
+        .ok_or("buzz-dev-mcp: USER is unavailable for Keychain lookup")?;
+
+    let output = Command::new("/usr/bin/security")
+        .args([
+            "find-generic-password",
+            "-a",
+            &account,
+            "-s",
+            &service,
+            "-w",
+        ])
+        .output()
+        .map_err(|error| format!("buzz-dev-mcp: failed to run Keychain lookup: {error}"))?;
+    if !output.status.success() {
+        return Err("buzz-dev-mcp: Keychain service is unavailable".into());
+    }
+
+    let mut stored = String::from_utf8(output.stdout)
+        .map_err(|_| "buzz-dev-mcp: Keychain service returned non-UTF-8 data")?;
+    while stored.ends_with(['\r', '\n']) {
+        stored.pop();
+    }
+    let result = (|| {
+        let private_key = keychain_private_key_value(&stored);
+        if private_key.is_empty() || nostr::Keys::parse(private_key).is_err() {
+            return Err("buzz-dev-mcp: Keychain service returned an invalid private key".into());
+        }
+        std::env::set_var("BUZZ_PRIVATE_KEY", private_key);
+        Ok(())
+    })();
+    stored.zeroize();
+    result
+}
+
+/// Preserve a raw key while accepting the legacy `pubkey:private-key` value.
+#[cfg(target_os = "macos")]
+fn keychain_private_key_value(value: &str) -> &str {
+    value
+        .split_once(':')
+        .map(|(_, private_key)| private_key)
+        .unwrap_or(value)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn load_keychain_private_key() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod keychain_tests {
+    use super::keychain_private_key_value;
+
+    #[test]
+    fn preserves_raw_private_key() {
+        assert_eq!(keychain_private_key_value("nsec1rawtest"), "nsec1rawtest");
+    }
+
+    #[test]
+    fn strips_legacy_prefix() {
+        assert_eq!(
+            keychain_private_key_value("pubkey:nsec1prefixedtest"),
+            "nsec1prefixedtest"
+        );
+    }
 }
 
 /// Suppress the console window that Windows otherwise allocates for every

--- a/crates/buzz-dev-mcp/src/lib.rs
+++ b/crates/buzz-dev-mcp/src/lib.rs
@@ -197,10 +197,7 @@ async fn async_main(cmd: String) -> Result<(), Box<dyn std::error::Error>> {
 /// startup instead of falling back to an inherited credential.
 #[cfg(target_os = "macos")]
 fn load_keychain_private_key() -> Result<(), Box<dyn std::error::Error>> {
-    let Some(service) = std::env::var("BUZZ_KEYCHAIN_SERVICE")
-        .ok()
-        .filter(|service| !service.is_empty())
-    else {
+    let Some(service) = keychain_service_from_env(std::env::var("BUZZ_KEYCHAIN_SERVICE"))? else {
         return Ok(());
     };
     std::env::remove_var("BUZZ_KEYCHAIN_SERVICE");
@@ -241,6 +238,22 @@ fn load_keychain_private_key() -> Result<(), Box<dyn std::error::Error>> {
     result
 }
 
+#[cfg(target_os = "macos")]
+fn keychain_service_from_env(
+    value: Result<String, std::env::VarError>,
+) -> Result<Option<String>, &'static str> {
+    match value {
+        Ok(service) if service.is_empty() => {
+            Err("buzz-dev-mcp: BUZZ_KEYCHAIN_SERVICE must not be empty")
+        }
+        Ok(service) => Ok(Some(service)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err("buzz-dev-mcp: BUZZ_KEYCHAIN_SERVICE must be valid UTF-8")
+        }
+    }
+}
+
 /// Preserve a raw key while accepting the legacy `pubkey:private-key` value.
 #[cfg(target_os = "macos")]
 fn keychain_private_key_value(value: &str) -> &str {
@@ -257,7 +270,16 @@ fn load_keychain_private_key() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(all(test, target_os = "macos"))]
 mod keychain_tests {
-    use super::keychain_private_key_value;
+    use super::{keychain_private_key_value, keychain_service_from_env};
+
+    #[test]
+    fn rejects_empty_keychain_service() {
+        let error = keychain_service_from_env(Ok(String::new())).unwrap_err();
+        assert_eq!(
+            error,
+            "buzz-dev-mcp: BUZZ_KEYCHAIN_SERVICE must not be empty"
+        );
+    }
 
     #[test]
     fn preserves_raw_private_key() {


### PR DESCRIPTION
## Summary

**Problem:** When `buzz-acp` spawns a local MCP server via `BUZZ_ACP_MCP_COMMAND`, it injects `BUZZ_PRIVATE_KEY` into that child process's environment. Depending on the ACP adapter and how it launches its own MCP subprocess, environment values can end up reflected into the process's argv — which is visible to any other process on the same host (e.g. via `ps -eww` or `/proc/<pid>/cmdline`). That's a materially larger exposure surface than "the child holds the secret in its own env block."

**Fix:** add an opt-in macOS Keychain delegation path for the MCP-server credential:
- A new `BUZZ_KEYCHAIN_SERVICE` config option (requires `BUZZ_ACP_MCP_COMMAND` to also be set). When configured, `buzz-acp` passes only the Keychain *service identifier* to the MCP subprocess's environment instead of the raw private key, and explicitly removes `BUZZ_PRIVATE_KEY` / `BUZZ_ACP_PRIVATE_KEY` from that subprocess's env so nothing sensitive is available to inherit or reflect.
- `buzz-dev-mcp` resolves the real key at its own startup, via `/usr/bin/security find-generic-password`, zeroizes the intermediate buffer once parsed, and **fails closed**: if the service is missing, empty, unreadable, or the stored value doesn't parse as a valid key, the process aborts startup rather than silently falling back to an inherited `BUZZ_PRIVATE_KEY`.
- Second commit (`3d894d9b`) closes a gap in the first: an explicitly-set-but-*empty* `BUZZ_KEYCHAIN_SERVICE` previously behaved as if delegation weren't configured at all (silently ignored). It now returns a startup error instead, matching the fail-closed intent.

**Scope:** opt-in and macOS-only (`#[cfg(target_os = "macos")]`). Default behavior (private key injected directly into the MCP subprocess's env, no Keychain involved) is unchanged when `BUZZ_KEYCHAIN_SERVICE` isn't set.

### Related issue
None found — searched open/closed issues and PRs for "keychain", "private key argv" in block/buzz.

## Testing

Ran locally against a clean cherry-pick onto current `origin/main`:

- `cargo test -p buzz-acp -p buzz-dev-mcp` — **102 passed, 0 failed**. Includes new coverage added by these commits: the MCP session env carries the Keychain service id and never `BUZZ_PRIVATE_KEY` when delegation is active, empty-service fails config validation closed, the legacy `pubkey:key` stored-value format is still accepted, and empty-service is rejected at MCP-process startup too.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (full workspace).

No manual/UI testing needed (no UI surface changed).
