### PR TITLE
acp: gate a relay-signed workflow message as its owner

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -231,23 +231,6 @@ async fn is_owner_or_sibling(
     is_sibling
 }
 
-/// Inbound author gate decision: does this author's event fire a turn?
-///
-/// Coarse security policy applied before subscription rules. Both `OwnerOnly`
-/// and `Allowlist` accept the owner and same-owner siblings; `Allowlist`
-/// additionally accepts the explicit external pubkey list.
-///
-/// # DM hardening (`is_dm`)
-///
-/// Clients auto-p-tag every DM participant, so in a DM *any* participant's
-/// message looks like a mention and would fire a turn. Combined with
-/// agent-initiated DMs (the agent can be asked to DM a third party), that
-/// turns `anyone`/`allowlist` modes into transitive access grants: whoever
-/// lands in a DM with the agent can prompt it. To close that hole, when
-/// `is_dm` is true only the owner and cryptographically verified same-owner
-/// siblings may fire a turn — the explicit allowlist and `anyone` mode do
-/// NOT apply inside DMs. `Nobody` still drops everything. Callers must
-/// resolve `is_dm` fail-closed: unknown channel type ⇒ treat as DM.
 /// Resolve the author a workflow-delivered event should be gated as.
 ///
 /// Workflow messages are signed by the relay keypair, not by the
@@ -259,22 +242,51 @@ async fn is_owner_or_sibling(
 /// agent, same words; only the signer differed. Five installed workflows were
 /// firing into that silence.
 ///
-/// `workflow_sink.rs` builds these events with the owner as the **first** `p`
-/// tag, and that ordering is the code's contract rather than an observation.
-/// So the owner can be recovered — but only when the event really came from the
-/// relay.
+/// `workflow_sink.rs:262-268` (buzz-relay) builds these events with the owner
+/// as the **first** `p` tag, then the channel `h` tag, then `buzz:workflow` —
+/// and that ordering is the code's contract rather than an observation, per
+/// the matching comment there. So the owner can be recovered — but only when
+/// the event really came from the relay.
 ///
-/// The signer check is not optional. The `buzz:workflow` tag is plain text any
-/// member could attach, so trusting the tag alone would let anyone who can post
-/// to a channel speak to the agent *as its owner*. The relay guards its own
-/// side the same way — `handlers/event.rs` pairs the tag with
-/// `pubkey == relay_keypair.public_key()` — and this mirrors it.
+/// The signer check is not optional, and nothing else stands in for it.
+/// `buzz:workflow` is plain text any member's client can attach to any event
+/// it sends — the relay does not validate the tag on ingest. The relay's own
+/// use of it, `handlers/event.rs:521-526,528-531`, only *skips re-triggering
+/// workflows* for events the relay itself signed; it never rejects a
+/// member-submitted event carrying the tag. So the tag alone proves nothing,
+/// and the signer equality below (`event.pubkey == signer`) is the *only*
+/// thing standing between a member and owner attribution — get that
+/// comparison wrong and the tag alone lets anyone who can post to a channel
+/// speak to the agent as its owner.
+///
+/// This does move the trust boundary, and that's worth stating plainly:
+/// before this function existed, "this event is from the owner" meant a
+/// signature by the owner's own key. For one configured signer, it now means
+/// "the relay said so." Today `workflow_sink.rs` is the only relay code path
+/// that emits `buzz:workflow`, but the relay signs other event kinds too
+/// (e.g. a relay-signed `KIND_PRESENCE_UPDATE`) — any future relay path that
+/// attaches this tag becomes an owner-impersonation vector without anyone
+/// touching this file. `workflow_sink.rs:263` carries a matching comment
+/// marking the first `p` tag as the identity this function gates the event
+/// as.
+///
+/// `BUZZ_ACP_WORKFLOW_SIGNER` is a second, independently-set trust anchor —
+/// deliberately not derived from the relay URL/connection the client already
+/// authenticates against, so a misconfigured or spoofed connection target
+/// cannot silently grant this power to whatever key answers there. The
+/// operator names the exact pubkey they trust to speak as the owner; leaving
+/// it unset keeps the feature off by default.
 ///
 /// Fail-closed: with `BUZZ_ACP_WORKFLOW_SIGNER` unset, or set to anything other
 /// than this event's signer, the event is gated as its signer exactly as
 /// before. Turning the feature off is the default.
 fn workflow_author(event: &nostr::Event) -> Option<String> {
-    workflow_author_for_signer(event, std::env::var("BUZZ_ACP_WORKFLOW_SIGNER").ok().as_deref())
+    // Read once: this cannot change during the process, and the ingest path
+    // runs per event — a `std::env::var` call there is a lock plus an
+    // allocation for a value that's fixed for the process's lifetime.
+    static SIGNER: std::sync::LazyLock<Option<String>> =
+        std::sync::LazyLock::new(|| std::env::var("BUZZ_ACP_WORKFLOW_SIGNER").ok());
+    workflow_author_for_signer(event, SIGNER.as_deref())
 }
 
 /// The decision itself, with the trusted signer passed in so it can be tested
@@ -295,6 +307,23 @@ fn workflow_author_for_signer(event: &nostr::Event, signer: Option<&str>) -> Opt
     })
 }
 
+/// Inbound author gate decision: does this author's event fire a turn?
+///
+/// Coarse security policy applied before subscription rules. Both `OwnerOnly`
+/// and `Allowlist` accept the owner and same-owner siblings; `Allowlist`
+/// additionally accepts the explicit external pubkey list.
+///
+/// # DM hardening (`is_dm`)
+///
+/// Clients auto-p-tag every DM participant, so in a DM *any* participant's
+/// message looks like a mention and would fire a turn. Combined with
+/// agent-initiated DMs (the agent can be asked to DM a third party), that
+/// turns `anyone`/`allowlist` modes into transitive access grants: whoever
+/// lands in a DM with the agent can prompt it. To close that hole, when
+/// `is_dm` is true only the owner and cryptographically verified same-owner
+/// siblings may fire a turn — the explicit allowlist and `anyone` mode do
+/// NOT apply inside DMs. `Nobody` still drops everything. Callers must
+/// resolve `is_dm` fail-closed: unknown channel type ⇒ treat as DM.
 async fn author_allowed(
     respond_to: &RespondTo,
     allowlist: &HashSet<String>,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -248,6 +248,53 @@ async fn is_owner_or_sibling(
 /// siblings may fire a turn — the explicit allowlist and `anyone` mode do
 /// NOT apply inside DMs. `Nobody` still drops everything. Callers must
 /// resolve `is_dm` fail-closed: unknown channel type ⇒ treat as DM.
+/// Resolve the author a workflow-delivered event should be gated as.
+///
+/// Workflow messages are signed by the relay keypair, not by the
+/// person who created the workflow. Under the default `owner-only` gate that
+/// makes every scheduled message invisible to the agent: the event lands in the
+/// channel, a human reads it, and the agent's session never sees it. Measured
+/// on a live relay — the 05:30 workflow briefing drew no reply, and the same
+/// text pasted by hand at 07:13 drew one in two minutes. Same channel, same
+/// agent, same words; only the signer differed. Five installed workflows were
+/// firing into that silence.
+///
+/// `workflow_sink.rs` builds these events with the owner as the **first** `p`
+/// tag, and that ordering is the code's contract rather than an observation.
+/// So the owner can be recovered — but only when the event really came from the
+/// relay.
+///
+/// The signer check is not optional. The `buzz:workflow` tag is plain text any
+/// member could attach, so trusting the tag alone would let anyone who can post
+/// to a channel speak to the agent *as its owner*. The relay guards its own
+/// side the same way — `handlers/event.rs` pairs the tag with
+/// `pubkey == relay_keypair.public_key()` — and this mirrors it.
+///
+/// Fail-closed: with `BUZZ_ACP_WORKFLOW_SIGNER` unset, or set to anything other
+/// than this event's signer, the event is gated as its signer exactly as
+/// before. Turning the feature off is the default.
+fn workflow_author(event: &nostr::Event) -> Option<String> {
+    workflow_author_for_signer(event, std::env::var("BUZZ_ACP_WORKFLOW_SIGNER").ok().as_deref())
+}
+
+/// The decision itself, with the trusted signer passed in so it can be tested
+/// without touching process environment — a shared env var makes concurrent
+/// tests flaky, and the security-relevant half deserves a deterministic test.
+fn workflow_author_for_signer(event: &nostr::Event, signer: Option<&str>) -> Option<String> {
+    let signer = signer?.trim().to_ascii_lowercase();
+    if signer.is_empty() || event.pubkey.to_hex() != signer {
+        return None;
+    }
+    let mut tags = event.tags.iter().map(|t| t.as_slice());
+    if !tags.clone().any(|t| t.first().map(String::as_str) == Some("buzz:workflow")) {
+        return None;
+    }
+    tags.find_map(|t| match (t.first().map(String::as_str), t.get(1)) {
+        (Some("p"), Some(pubkey)) if !pubkey.is_empty() => Some(pubkey.to_ascii_lowercase()),
+        _ => None,
+    })
+}
+
 async fn author_allowed(
     respond_to: &RespondTo,
     allowlist: &HashSet<String>,
@@ -2866,7 +2913,11 @@ async fn tokio_main() -> Result<()> {
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
                             {
-                                let author = buzz_event.event.pubkey.to_hex();
+                                // A relay-signed workflow message is
+                                // gated as the workflow's owner, not as the
+                                // relay. See `workflow_author`.
+                                let author = workflow_author(&buzz_event.event)
+                                    .unwrap_or_else(|| buzz_event.event.pubkey.to_hex());
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
@@ -5512,6 +5563,88 @@ mod author_gate_tests {
             .await,
             "respond_to=anyone must still drop non-owner authors inside a DM"
         );
+    }
+
+    // `workflow_author_for_signer` recovers the owner from a
+    // relay-signed workflow message. These lock the two halves that matter —
+    // that it works at all, and that it cannot be reached without the relay's
+    // signature.
+    mod workflow_author_tests {
+        use nostr::{EventBuilder, Keys, Tag};
+
+        fn owner_hex() -> String {
+            Keys::generate().public_key().to_hex()
+        }
+
+        /// Shaped like `workflow_sink.rs` produces: owner first `p` tag, then
+        /// the workflow marker.
+        fn event(keys: &Keys, owner_hex: &str, with_marker: bool) -> nostr::Event {
+            let mut tags = vec![Tag::parse(["p", owner_hex]).expect("p tag")];
+            if with_marker {
+                tags.push(Tag::parse(["buzz:workflow", "true"]).expect("workflow tag"));
+            }
+            EventBuilder::text_note("@agent — scheduled briefing")
+                .tags(tags)
+                .sign_with_keys(keys)
+                .expect("sign")
+        }
+
+        #[test]
+        fn relay_signed_workflow_message_is_gated_as_its_owner() {
+            let relay = Keys::generate();
+            let owner = owner_hex();
+            let signer = relay.public_key().to_hex();
+            assert_eq!(
+                super::super::workflow_author_for_signer(&event(&relay, &owner, true), Some(&signer))
+                    .as_deref(),
+                Some(owner.as_str()),
+                "the owner must be recovered from the first p tag"
+            );
+        }
+
+        #[test]
+        fn a_member_cannot_forge_the_workflow_marker() {
+            // The whole point of pairing the tag with the signature. Without
+            // it, anyone who can post to a channel could address the agent as
+            // its owner by attaching two tags.
+            let relay = Keys::generate();
+            let impostor = Keys::generate();
+            let owner = owner_hex();
+            let signer = relay.public_key().to_hex();
+            assert_eq!(
+                super::super::workflow_author_for_signer(&event(&impostor, &owner, true), Some(&signer)),
+                None,
+                "a non-relay signer must never resolve to the owner"
+            );
+        }
+
+        #[test]
+        fn without_configuration_nothing_changes() {
+            // Fail-closed: unconfigured means the previous behaviour exactly.
+            let relay = Keys::generate();
+            let owner = owner_hex();
+            assert_eq!(
+                super::super::workflow_author_for_signer(&event(&relay, &owner, true), None),
+                None
+            );
+            assert_eq!(
+                super::super::workflow_author_for_signer(&event(&relay, &owner, true), Some("   ")),
+                None
+            );
+        }
+
+        #[test]
+        fn a_relay_signed_event_without_the_marker_is_left_alone() {
+            // The relay signs other things too; only workflow messages carry
+            // the marker, and only those may be re-attributed.
+            let relay = Keys::generate();
+            let owner = owner_hex();
+            let signer = relay.public_key().to_hex();
+            assert_eq!(
+                super::super::workflow_author_for_signer(&event(&relay, &owner, false), Some(&signer)),
+                None
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -259,6 +259,12 @@ impl ActionSink for RelayActionSink {
             //    - `buzz:workflow` tag prevents recursive workflow triggering
             //    - one `p` tag per `@Name` that resolves to a channel member,
             //      so mentioned agents are woken (wake is `p`-tag gated)
+            //    - the owner's `p` tag MUST stay first: `buzz-acp`'s
+            //      `workflow_author` (crates/buzz-acp/src/lib.rs) recovers the
+            //      owner identity for this relay-signed event by reading the
+            //      first `p` tag. Reordering it, or adding another `p` tag
+            //      ahead of it, silently changes who the agent gates the
+            //      message as. Do not reorder.
             let mut tags = vec![
                 Tag::parse(["p", &author_pubkey_hex])
                     .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,


### PR DESCRIPTION
Workflow messages are signed by the relay keypair, not by the person who
created the workflow. Under the default owner-only gate that makes every
scheduled message invisible to the agent: the event lands in the channel,
a human reads it, and the agent's session never sees it. Observed live —
a scheduled morning briefing drew no reply, and the same text pasted by
hand minutes later drew one immediately. Same channel, same agent, same
words; only the signer differed.

A relay-signed event carrying the workflow marker is now gated as the
workflow's owner (recovered from the first p tag). The marker alone is
not enough: a non-relay signer never resolves to the owner, so channel
members cannot forge the attribution. Unconfigured behaviour is
unchanged (fail-closed).

Four tests cover recovery, forgery, the unconfigured path, and
relay-signed events without the marker.

