### PR TITLE
feat(acp): enforce machine heavy-run lease

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -13,6 +13,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
 
+#[cfg(unix)]
+use crate::heavy_run_guard::HeavyRunGuard;
 use crate::observer::{ObserverContext, ObserverHandle};
 use crate::usage::{TurnUsage, UsageTracker};
 
@@ -139,6 +141,9 @@ fn build_initialize_params() -> serde_json::Value {
 pub struct AcpClient {
     /// The agent child process (kept alive to prevent zombie).
     child: Child,
+    /// Keeps the per-agent command shims alive for the lifetime of the adapter.
+    #[cfg(unix)]
+    _heavy_run_guard: Option<HeavyRunGuard>,
     /// Write end of the agent's stdin pipe.
     stdin: ChildStdin,
     /// Framed reader over the agent's stdout pipe (line-oriented, bounded).
@@ -466,6 +471,9 @@ impl AcpClient {
             // Callers MUST still call shutdown().await for guaranteed cleanup.
             .kill_on_drop(true);
 
+        #[cfg(unix)]
+        let heavy_run_guard = HeavyRunGuard::install(&mut cmd, command)?;
+
         // Per-persona env vars (e.g., GOOSE_PROVIDER, BUZZ_AGENT_PROVIDER).
         // For most keys, operator precedence wins: skip injection if already set
         // in the parent environment.
@@ -536,6 +544,8 @@ impl AcpClient {
 
         Ok(Self {
             child,
+            #[cfg(unix)]
+            _heavy_run_guard: heavy_run_guard,
             stdin,
             reader: FramedRead::new(stdout, LinesCodec::new_with_max_length(MAX_LINE_SIZE)),
             next_id: 0,

--- a/crates/buzz-acp/src/heavy_run_guard.rs
+++ b/crates/buzz-acp/src/heavy_run_guard.rs
@@ -1,0 +1,203 @@
+//! Machine-local admission control for commands executed inside ACP adapters.
+//!
+//! Adapters execute tools themselves, so `session/update` arrives too late to
+//! gate a command. When the operator has installed the Buzz heavy-run lease,
+//! prepend shims to the adapter's PATH before it starts.
+
+use crate::acp::AcpError;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+use uuid::Uuid;
+
+const SHIM_NAMES: &[&str] = &["npm", "pnpm", "bun", "npx", "node", "next", "playwright"];
+
+pub(crate) struct HeavyRunGuard {
+    directory: PathBuf,
+}
+
+impl HeavyRunGuard {
+    pub(crate) fn install(
+        cmd: &mut Command,
+        agent_command: &str,
+    ) -> Result<Option<Self>, AcpError> {
+        let Some(home) = std::env::var_os("HOME") else {
+            return Ok(None);
+        };
+        let lease = std::env::var_os("BUZZ_HEAVY_RUN_LEASE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(&home).join(".buzz/scripts/heavy-run-lease.sh"));
+        if !lease.is_file() {
+            return Ok(None);
+        }
+
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let root = PathBuf::from(home).join(".buzz/.scratch/acp-heavy-command-shims");
+        fs::create_dir_all(&root)?;
+        let guard_id = Uuid::new_v4();
+        let directory = root.join(format!("{}-{guard_id}", std::process::id()));
+        fs::create_dir(&directory)?;
+        let script = shim_script();
+        for name in SHIM_NAMES {
+            let path = directory.join(name);
+            fs::write(&path, script)?;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))?;
+        }
+
+        let mut paths = vec![directory.clone()];
+        paths.extend(std::env::split_paths(&original_path));
+        let guarded_path = std::env::join_paths(paths).map_err(|error| {
+            AcpError::Protocol(format!("invalid PATH for heavy-run guard: {error}"))
+        })?;
+        let nonce = std::env::var("BUZZ_MANAGED_AGENT_START_NONCE")
+            .unwrap_or_else(|_| std::process::id().to_string());
+        let identity = Path::new(agent_command)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("agent");
+        cmd.env("PATH", guarded_path)
+            .env("BUZZ_HEAVY_RUN_LEASE", &lease)
+            .env("BUZZ_HEAVY_RUN_ORIGINAL_PATH", original_path)
+            .env(
+                "BUZZ_HEAVY_RUN_LABEL",
+                format!("{identity}-{nonce}-{guard_id}"),
+            );
+        Ok(Some(Self { directory }))
+    }
+}
+
+impl Drop for HeavyRunGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.directory);
+    }
+}
+
+fn shim_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+name=${0##*/}
+original_path=${BUZZ_HEAVY_RUN_ORIGINAL_PATH:?}
+lease=${BUZZ_HEAVY_RUN_LEASE:?}
+label=${BUZZ_HEAVY_RUN_LABEL:?}
+real=$(PATH=$original_path command -v "$name" || true)
+if [ -z "$real" ]; then
+  echo "buzz heavy-run guard: unwrapped $name not found" >&2
+  exit 127
+fi
+heavy=0
+case "$name" in
+  npm|pnpm|bun)
+    case " ${*:-} " in
+      *" run build "*|*" test "*|*" run test:all "*|*" run test:full "*|*" run test:suite "*|*" run test:render "*|*" run "*browser*|*" run "*screenshot*|*" run "*capture*) heavy=1 ;;
+    esac ;;
+  npx)
+    case " ${*:-} " in
+      *" next build "*|*" playwright "*|*" browser"*|*" screenshot"*|*" capture"*) heavy=1 ;;
+    esac ;;
+  next) [ "${1:-}" = build ] && heavy=1 ;;
+  node)
+    for arg in "$@"; do [ "$arg" = --test ] && heavy=1; done ;;
+  playwright) heavy=1 ;;
+esac
+if [ "$heavy" -eq 1 ]; then
+  exec "$lease" "$label-$name" -- "$real" "$@"
+fi
+exec "$real" "$@"
+"#
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shim_script;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::process::Command;
+    use uuid::Uuid;
+
+    fn executable(path: &Path, body: &str) {
+        fs::write(path, body).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    #[test]
+    fn classifier_contains_required_heavy_and_nonheavy_fallthrough_paths() {
+        let script = shim_script();
+        for required in [
+            "run build",
+            "run test:all",
+            "run test:render",
+            "next build",
+            "--test",
+            "playwright",
+        ] {
+            assert!(
+                script.contains(required),
+                "missing classification for {required}"
+            );
+        }
+        assert!(
+            script.contains("exec \"$real\" \"$@\""),
+            "non-heavy commands must bypass the lease"
+        );
+    }
+
+    #[test]
+    fn scratch_heavy_command_blocks_then_admits_while_lint_bypasses() {
+        let root = std::env::temp_dir().join(format!("buzz-heavy-guard-{}", Uuid::new_v4()));
+        let shim_dir = root.join("shims");
+        let real_dir = root.join("real");
+        let scratch = root.join("disposable-scratch-checkout");
+        fs::create_dir_all(&shim_dir).unwrap();
+        fs::create_dir_all(&real_dir).unwrap();
+        fs::create_dir_all(&scratch).unwrap();
+
+        let shim = shim_dir.join("npm");
+        let real = real_dir.join("npm");
+        let lease = root.join("lease.sh");
+        let held = root.join("held");
+        let ran = root.join("ran");
+        let leased = root.join("leased");
+        executable(&shim, shim_script());
+        executable(
+            &real,
+            &format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n", ran.display()),
+        );
+        executable(
+            &lease,
+            &format!(
+                "#!/bin/sh\nprintf called >> '{}'\n[ -e '{}' ] && exit 75\nshift\n[ \"$1\" = -- ] && shift\nexec \"$@\"\n",
+                leased.display(),
+                held.display()
+            ),
+        );
+
+        let invoke = |args: &[&str]| {
+            Command::new(&shim)
+                .args(args)
+                .current_dir(&scratch)
+                .env("BUZZ_HEAVY_RUN_ORIGINAL_PATH", &real_dir)
+                .env("BUZZ_HEAVY_RUN_LEASE", &lease)
+                .env("BUZZ_HEAVY_RUN_LABEL", "agent-session")
+                .status()
+                .unwrap()
+        };
+
+        fs::write(&held, "held").unwrap();
+        assert_eq!(invoke(&["run", "test:render"]).code(), Some(75));
+        assert!(!ran.exists(), "blocked command must not execute");
+
+        fs::remove_file(&held).unwrap();
+        assert!(invoke(&["run", "test:render"]).success());
+        assert!(fs::read_to_string(&ran)
+            .unwrap()
+            .contains("run test:render"));
+
+        let lease_calls = fs::read_to_string(&leased).unwrap();
+        assert!(invoke(&["run", "lint"]).success());
+        assert_eq!(fs::read_to_string(&leased).unwrap(), lease_calls);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4,6 +4,8 @@ mod acp;
 mod config;
 mod engram_fetch;
 mod filter;
+#[cfg(unix)]
+mod heavy_run_guard;
 mod observer;
 mod pool;
 mod pool_lifecycle;


### PR DESCRIPTION
## Summary

- install a per-adapter PATH shim layer when the machine-local heavy-run lease exists
- route builds, full/render test suites, direct `node --test`, and browser/screenshot harnesses through the lease before execution
- derive lease labels from adapter identity, managed-session nonce, and a per-adapter UUID
- leave non-heavy commands on the original PATH

## Why the shim boundary

ACP adapters execute tools internally; Buzz receives `session/update` only after execution starts. Injecting shims before the adapter process starts is the earliest boundary Buzz controls, and it covers disposable/old checkouts without changing repository scripts or CI.

## Verification

- negative control: replacing only the `test:render` classifier made the scratch-checkout test fail because the held-lease command exited 0 instead of 75
- restored bytes matched the recorded SHA-256
- full committed `buzz-acp` package suite: 672 unit tests + 9 lifecycle integration tests passed at `3f787c427b9a466dba6ce5ab133c2cc9b1fab697`

Buzz issue: `22eb36a5fe5a00b88e3d73083cf7d502a9527ab9082fca2056baf61d93de925d`
