### PR TITLE
feat(workflows): activate managed agent delivery (node G)

### DIFF
--- a/crates/buzz-core/src/filter.rs
+++ b/crates/buzz-core/src/filter.rs
@@ -22,7 +22,7 @@ pub fn filters_match(filters: &[Filter], event: &StoredEvent) -> bool {
 /// a known event id) still cannot read another user's private event.
 pub fn reader_authorized_for_event(event: &nostr::Event, reader_pubkey_hex: &str) -> bool {
     let kind = crate::kind::event_kind_u32(event);
-    if kind != crate::kind::KIND_DM_VISIBILITY && kind != crate::kind::KIND_AGENT_TURN_METRIC {
+    if !crate::kind::P_GATED_KINDS.contains(&kind) {
         return true;
     }
     let p = nostr::SingleLetterTag::lowercase(nostr::Alphabet::P);
@@ -285,6 +285,31 @@ mod tests {
             .sign_with_keys(&relay)
             .expect("sign");
         assert!(reader_authorized_for_event(&note, other));
+    }
+
+    #[test]
+    fn reader_authorized_for_event_gates_workflow_wake_by_p() {
+        let target_keys = Keys::generate();
+        let other_keys = Keys::generate();
+        let wake = EventBuilder::new(
+            Kind::Custom(crate::kind::KIND_WORKFLOW_AGENT_WAKE as u16),
+            "",
+        )
+        .tags([
+            Tag::parse(["p", &target_keys.public_key().to_hex()]).expect("p tag"),
+            Tag::parse(["delivery", &uuid::Uuid::new_v4().to_string()]).expect("delivery tag"),
+        ])
+        .sign_with_keys(&Keys::generate())
+        .expect("sign event");
+
+        assert!(reader_authorized_for_event(
+            &wake,
+            &target_keys.public_key().to_hex()
+        ));
+        assert!(!reader_authorized_for_event(
+            &wake,
+            &other_keys.public_key().to_hex()
+        ));
     }
 
     #[test]

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -139,7 +139,11 @@ pub const AUTHOR_ONLY_KINDS: &[u32] = &[
 ///
 /// Used by `filter_can_match_result_gated_kinds` to force the per-event
 /// fallback path in COUNT rather than the fast SQL `count_events()`.
-pub const RESULT_GATED_KINDS: &[u32] = &[KIND_DM_VISIBILITY, KIND_AGENT_TURN_METRIC];
+pub const RESULT_GATED_KINDS: &[u32] = &[
+    KIND_DM_VISIBILITY,
+    KIND_AGENT_TURN_METRIC,
+    KIND_WORKFLOW_AGENT_WAKE,
+];
 
 /// Kinds whose stored events have `#p`-bound read access — readable only by
 /// subscribers whose pubkey appears in the event's `#p` tag.
@@ -166,6 +170,7 @@ pub const P_GATED_KINDS: &[u32] = &[
     // readable by any unauthenticated or non-owner party, including via `ids`
     // filters — see NIP-AM §Relay Behavior.
     KIND_AGENT_TURN_METRIC,
+    KIND_WORKFLOW_AGENT_WAKE,
 ];
 
 /// NIP-AP: Agent Persona (parameterized replaceable, owner-authored).

--- a/crates/buzz-db/src/channel.rs
+++ b/crates/buzz-db/src/channel.rs
@@ -1299,6 +1299,8 @@ pub struct UserRecord {
     pub avatar_url: Option<String>,
     /// Optional NIP-05 identifier (e.g. `user@example.com`).
     pub nip05_handle: Option<String>,
+    /// Whether this community-local identity is an owner-managed agent.
+    pub is_agent: bool,
 }
 
 /// A channel record paired with whether the querying user is an active member.
@@ -1443,7 +1445,8 @@ pub async fn get_users_bulk(
         .collect::<Vec<_>>()
         .join(", ");
     let sql = format!(
-        "SELECT pubkey, display_name, avatar_url, nip05_handle \
+        "SELECT pubkey, display_name, avatar_url, nip05_handle, \
+                agent_owner_pubkey IS NOT NULL AS is_agent \
          FROM users WHERE community_id = $1 AND pubkey IN ({placeholders})"
     );
 
@@ -1461,6 +1464,7 @@ pub async fn get_users_bulk(
             display_name: row.try_get("display_name")?,
             avatar_url: row.try_get("avatar_url")?,
             nip05_handle: row.try_get("nip05_handle")?,
+            is_agent: row.try_get("is_agent")?,
         });
     }
     Ok(out)

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -3687,6 +3687,72 @@ impl Db {
         workflow::get_workflow_run(&self.pool, community_id, id).await
     }
 
+    /// Read the immutable authority that caused this workflow run.
+    ///
+    /// A signed event is authoritative when it is the run's persisted trigger.
+    /// Otherwise exactly one durable schedule-fire or webhook-invocation row
+    /// must point at the run. Missing or ambiguous server authority fails closed.
+    #[datastore_span(name = "get_workflow_delivery_cause", system = "postgresql")]
+    pub async fn get_workflow_delivery_cause(
+        &self,
+        community_id: CommunityId,
+        workflow_id: Uuid,
+        run_id: Uuid,
+    ) -> Result<buzz_core::workflow_delivery::WorkflowDeliveryCause> {
+        workflow::get_workflow_delivery_cause(&self.pool, community_id, workflow_id, run_id).await
+    }
+
+    /// Serialize a producer retry for one workflow message step.
+    #[datastore_span(
+        name = "lock_workflow_agent_delivery_message_identity",
+        system = "postgresql"
+    )]
+    pub async fn lock_workflow_agent_delivery_message_identity(
+        &self,
+        community_id: CommunityId,
+        run_id: Uuid,
+        step_id: &str,
+    ) -> Result<workflow::WorkflowMessageIdentityLock> {
+        workflow::lock_workflow_agent_delivery_message_identity(
+            &self.pool,
+            community_id,
+            run_id,
+            step_id,
+        )
+        .await
+    }
+
+    /// Atomically persist a visible message and its durable deliveries.
+    #[datastore_span(name = "commit_workflow_message_deliveries", system = "postgresql")]
+    pub async fn commit_workflow_message_deliveries(
+        &self,
+        transaction: sqlx::Transaction<'static, sqlx::Postgres>,
+        community_id: CommunityId,
+        message: &nostr::Event,
+        channel_id: Uuid,
+        thread_meta: Option<event::ThreadMetadataParams<'_>>,
+        deliveries: &[workflow::WorkflowAgentDelivery],
+    ) -> Result<(
+        StoredEvent,
+        Vec<buzz_core::workflow_delivery::WorkflowDeliveryId>,
+    )> {
+        let result = workflow::commit_workflow_message_deliveries(
+            transaction,
+            community_id,
+            message,
+            channel_id,
+            thread_meta,
+            deliveries,
+        )
+        .await?;
+        if let Err(error) =
+            insert_mentions(&self.pool, community_id, message, Some(channel_id)).await
+        {
+            tracing::warn!(event_id = %message.id, "Failed to insert mentions: {error}");
+        }
+        Ok(result)
+    }
+
     /// Claim one pending workflow delivery for the authenticated target.
     #[datastore_span(name = "claim_workflow_agent_delivery", system = "postgresql")]
     pub async fn claim_workflow_agent_delivery(

--- a/crates/buzz-db/src/workflow.rs
+++ b/crates/buzz-db/src/workflow.rs
@@ -1443,6 +1443,66 @@ pub async fn find_by_owner_and_name(
     }
 }
 
+/// Resolve the one persisted authority that caused a workflow run.
+///
+/// The run must belong to `community_id` and `workflow_id`. Exactly one of its
+/// signed trigger event, durable scheduled fire, or durable webhook invocation
+/// must exist; missing or ambiguous provenance is rejected.
+pub async fn get_workflow_delivery_cause(
+    pool: &PgPool,
+    community_id: CommunityId,
+    workflow_id: Uuid,
+    run_id: Uuid,
+) -> Result<WorkflowDeliveryCause> {
+    let rows = sqlx::query(
+        r#"
+        SELECT r.trigger_event_id,
+               sf.scheduled_for,
+               wi.invocation_id
+        FROM workflow_runs r
+        LEFT JOIN scheduled_workflow_fires sf
+          ON sf.community_id = r.community_id
+         AND sf.workflow_id = r.workflow_id
+         AND sf.workflow_run_id = r.id
+        LEFT JOIN workflow_webhook_invocations wi
+          ON wi.community_id = r.community_id
+         AND wi.workflow_id = r.workflow_id
+         AND wi.workflow_run_id = r.id
+        WHERE r.community_id = $1 AND r.workflow_id = $2 AND r.id = $3
+        "#,
+    )
+    .bind(community_id.as_uuid())
+    .bind(workflow_id)
+    .bind(run_id)
+    .fetch_all(pool)
+    .await?;
+
+    if rows.len() != 1 {
+        return Err(DbError::InvalidData(
+            "workflow run has missing or ambiguous delivery authority".into(),
+        ));
+    }
+    let row = &rows[0];
+
+    let trigger_event_id: Option<Vec<u8>> = row.try_get("trigger_event_id")?;
+    let scheduled_for: Option<DateTime<Utc>> = row.try_get("scheduled_for")?;
+    let invocation_id: Option<Uuid> = row.try_get("invocation_id")?;
+    match (trigger_event_id, scheduled_for, invocation_id) {
+        (Some(event_id), None, None) => EventId::from_slice(&event_id)
+            .map(WorkflowDeliveryCause::Event)
+            .map_err(|error| {
+                DbError::InvalidData(format!("invalid workflow trigger event id: {error}"))
+            }),
+        (None, Some(scheduled_for), None) => Ok(WorkflowDeliveryCause::Schedule {
+            scheduled_for_unix_seconds: scheduled_for.timestamp(),
+        }),
+        (None, None, Some(invocation_id)) => Ok(WorkflowDeliveryCause::Webhook { invocation_id }),
+        _ => Err(DbError::InvalidData(
+            "workflow run has missing or ambiguous delivery authority".into(),
+        )),
+    }
+}
+
 // -- Workflow agent deliveries ------------------------------------------------
 //
 // Durable, target-scoped delivery inbox and the complete transition state
@@ -1755,17 +1815,81 @@ pub async fn lock_workflow_agent_delivery_identity(
     Ok((transaction, existing))
 }
 
-/// Atomically persist all canonical deliveries for one workflow step.
+/// Transaction-scoped producer lock and any message identity already committed.
+pub type WorkflowMessageIdentityLock = (
+    Transaction<'static, Postgres>,
+    Option<(Vec<u8>, DateTime<Utc>)>,
+);
+
+/// Lock one workflow run/step producer identity and find its bound message.
 ///
-/// This is the ONLY insert path into `workflow_agent_deliveries`. Callers hold
-/// the identity lock from [`lock_workflow_agent_delivery_identity`] and pass the
-/// same transaction so the visible message insert (owned by the producer node)
-/// and every delivery row commit or roll back together. Duplicate producer
-/// retries collapse via the `(community, run, step, target)` uniqueness with
-/// `ON CONFLICT DO NOTHING`; the returned vector lists only rows this call
-/// actually created.
-pub async fn commit_workflow_agent_deliveries(
+/// The returned transaction holds the advisory lock until commit or rollback.
+/// Callers must use that same transaction to atomically persist a new visible
+/// message and all target deliveries. An existing tuple means a prior attempt
+/// already committed and its message identity should be returned unchanged.
+pub async fn lock_workflow_agent_delivery_message_identity(
+    pool: &PgPool,
+    community_id: CommunityId,
+    run_id: Uuid,
+    step_id: &str,
+) -> Result<WorkflowMessageIdentityLock> {
+    let mut transaction = pool.begin().await?;
+    let identity = format!("{}:{run_id}:{step_id}", community_id.as_uuid());
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(identity)
+        .execute(&mut *transaction)
+        .await?;
+    let existing = sqlx::query_as::<_, (Vec<u8>, DateTime<Utc>)>(
+        "SELECT message_event_id, message_event_created_at \
+         FROM workflow_agent_deliveries \
+         WHERE community_id = $1 AND run_id = $2 AND step_id = $3 LIMIT 1",
+    )
+    .bind(community_id.as_uuid())
+    .bind(run_id)
+    .bind(step_id)
+    .fetch_optional(&mut *transaction)
+    .await?;
+    Ok((transaction, existing))
+}
+
+/// Atomically persist one visible message and all canonical deliveries for its step.
+pub async fn commit_workflow_message_deliveries(
     mut transaction: Transaction<'static, Postgres>,
+    community_id: CommunityId,
+    message: &nostr::Event,
+    channel_id: Uuid,
+    thread_meta: Option<crate::event::ThreadMetadataParams<'_>>,
+    deliveries: &[WorkflowAgentDelivery],
+) -> Result<(buzz_core::StoredEvent, Vec<WorkflowDeliveryId>)> {
+    let (stored_message, was_inserted) = crate::event::insert_event_with_thread_metadata_tx(
+        &mut transaction,
+        community_id,
+        message,
+        Some(channel_id),
+        thread_meta,
+    )
+    .await?;
+    if !was_inserted {
+        return Err(DbError::InvalidData(
+            "new workflow delivery message already exists without its delivery identity".into(),
+        ));
+    }
+    let message_created_at =
+        DateTime::<Utc>::from_timestamp(message.created_at.as_secs() as i64, 0)
+            .ok_or_else(|| DbError::InvalidData("invalid workflow message timestamp".into()))?;
+    let created = insert_workflow_agent_deliveries(
+        &mut transaction,
+        community_id,
+        message_created_at,
+        deliveries,
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok((stored_message, created))
+}
+
+async fn insert_workflow_agent_deliveries(
+    transaction: &mut Transaction<'_, Postgres>,
     community_id: CommunityId,
     message_event_created_at: DateTime<Utc>,
     deliveries: &[WorkflowAgentDelivery],
@@ -1801,13 +1925,38 @@ pub async fn commit_workflow_agent_deliveries(
         .bind(cause_event_id)
         .bind(cause_scheduled_for)
         .bind(cause_webhook_invocation_id)
-        .execute(&mut *transaction)
+        .execute(&mut **transaction)
         .await?
         .rows_affected();
         if affected == 1 {
             created.push(delivery.id);
         }
     }
+    Ok(created)
+}
+
+/// Atomically persist all canonical deliveries for one workflow step.
+///
+/// This is the ONLY insert path into `workflow_agent_deliveries`. Callers hold
+/// the identity lock from [`lock_workflow_agent_delivery_identity`] and pass the
+/// same transaction so the visible message insert (owned by the producer node)
+/// and every delivery row commit or roll back together. Duplicate producer
+/// retries collapse via the `(community, run, step, target)` uniqueness with
+/// `ON CONFLICT DO NOTHING`; the returned vector lists only rows this call
+/// actually created.
+pub async fn commit_workflow_agent_deliveries(
+    mut transaction: Transaction<'static, Postgres>,
+    community_id: CommunityId,
+    message_event_created_at: DateTime<Utc>,
+    deliveries: &[WorkflowAgentDelivery],
+) -> Result<Vec<WorkflowDeliveryId>> {
+    let created = insert_workflow_agent_deliveries(
+        &mut transaction,
+        community_id,
+        message_event_created_at,
+        deliveries,
+    )
+    .await?;
     transaction.commit().await?;
     Ok(created)
 }

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -174,6 +174,28 @@ pub async fn filter_fanout_by_access(
         matches
     };
 
+    // Recipient-private kinds are p-gated even when channel-less and ephemeral.
+    // Historical REQ authorization is insufficient for live fan-out: a kindless
+    // subscription must not observe another target's wake.
+    let matches = if buzz_core::kind::P_GATED_KINDS.contains(&event_kind_u32(&stored_event.event)) {
+        matches
+            .into_iter()
+            .filter(|(conn_id, _)| {
+                state
+                    .conn_manager
+                    .pubkey_for_conn(*conn_id)
+                    .is_some_and(|pubkey| {
+                        buzz_core::filter::reader_authorized_for_event(
+                            &stored_event.event,
+                            &hex::encode(pubkey),
+                        )
+                    })
+            })
+            .collect()
+    } else {
+        matches
+    };
+
     let Some(channel_id) = stored_event.channel_id else {
         return matches;
     };
@@ -2128,6 +2150,20 @@ mod tests {
             StoredEvent::new(event, channel_id)
         }
 
+        fn recipient_private_event(recipient: &Keys) -> StoredEvent {
+            let event = EventBuilder::new(
+                Kind::Custom(buzz_core::kind::KIND_WORKFLOW_AGENT_WAKE as u16),
+                "",
+            )
+            .tags([
+                nostr::Tag::parse(["p", &recipient.public_key().to_hex()]).expect("p tag"),
+                nostr::Tag::parse(["delivery", &Uuid::new_v4().to_string()]).expect("delivery tag"),
+            ])
+            .sign_with_keys(&Keys::generate())
+            .expect("sign event");
+            StoredEvent::new(event, None)
+        }
+
         #[tokio::test]
         async fn channel_less_event_passes_through() {
             let state = test_state().await;
@@ -2142,6 +2178,33 @@ mod tests {
             )
             .await;
             assert_eq!(out, matches);
+        }
+
+        #[tokio::test]
+        async fn channel_less_recipient_private_event_keeps_only_recipient() {
+            let state = test_state().await;
+            let recipient = Keys::generate();
+            let stranger = Keys::generate();
+            let recipient_conn =
+                register_conn(&state, Some(recipient.public_key().to_bytes().to_vec()));
+            let stranger_conn =
+                register_conn(&state, Some(stranger.public_key().to_bytes().to_vec()));
+            let unauthed_conn = register_conn(&state, None);
+            let matches = vec![
+                (recipient_conn, "recipient".to_owned()),
+                (stranger_conn, "stranger".to_owned()),
+                (unauthed_conn, "unauthed".to_owned()),
+            ];
+
+            let out = filter_fanout_by_access(
+                &state,
+                buzz_core::tenant::CommunityId::from_uuid(Uuid::nil()),
+                &recipient_private_event(&recipient),
+                matches,
+                None,
+            )
+            .await;
+            assert_eq!(out, vec![(recipient_conn, "recipient".to_owned())]);
         }
 
         #[tokio::test]

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -10,7 +10,10 @@ use std::sync::{Arc, Weak};
 
 use buzz_core::kind::KIND_STREAM_MESSAGE;
 use buzz_core::tenant::CommunityId;
-use buzz_workflow::action_sink::{ActionSink, ActionSinkError};
+use buzz_core::workflow_delivery::{
+    WorkflowDeliveryBinding, WorkflowDeliveryId, WorkflowDeliveryWake,
+};
+use buzz_workflow::action_sink::{ActionSink, ActionSinkError, WorkflowMessageContext};
 use chrono::Utc;
 use nostr::{EventBuilder, Kind, Tag};
 use tracing::info;
@@ -176,11 +179,13 @@ impl ActionSink for RelayActionSink {
         channel_id: &str,
         text: &str,
         author_pubkey: &str,
+        context: &WorkflowMessageContext,
         reply_to: Option<&str>,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>> {
         let channel_id = channel_id.to_owned();
         let text = text.to_owned();
         let author_pubkey = author_pubkey.to_owned();
+        let context = context.clone();
         let reply_to = reply_to.map(str::to_owned);
 
         Box::pin(async move {
@@ -328,21 +333,69 @@ impl ActionSink for RelayActionSink {
                 .await
                 .map_err(|e| ActionSinkError::Database(e.to_string()))?;
             let named_members: Vec<(String, String)> = users
-                .into_iter()
+                .iter()
                 .filter_map(|u| {
-                    let name = u.display_name?;
+                    let name = u.display_name.clone()?;
                     Some((name, nostr::PublicKey::from_slice(&u.pubkey).ok()?.to_hex()))
                 })
                 .collect();
-            for mentioned in resolve_mention_pubkeys(&text, &named_members) {
-                if mentioned == author_pubkey_hex {
+            let managed_agents: std::collections::HashSet<String> = users
+                .iter()
+                .filter(|user| user.is_agent)
+                .filter_map(|user| {
+                    nostr::PublicKey::from_slice(&user.pubkey)
+                        .ok()
+                        .map(|pubkey| pubkey.to_hex())
+                })
+                .collect();
+            let mentioned_pubkeys = resolve_mention_pubkeys(&text, &named_members);
+            for mentioned in &mentioned_pubkeys {
+                if mentioned == &author_pubkey_hex {
                     continue;
                 }
                 tags.push(
-                    Tag::parse(["p", &mentioned])
+                    Tag::parse(["p", mentioned.as_str()])
                         .map_err(|e| ActionSinkError::EventBuild(format!("mention p tag: {e}")))?,
                 );
+                if managed_agents.contains(mentioned) {
+                    tags.push(
+                        Tag::parse(["p", mentioned.as_str(), "", "message-v1"]).map_err(|e| {
+                            ActionSinkError::EventBuild(format!("delivery p tag: {e}"))
+                        })?,
+                    );
+                }
             }
+
+            let managed_targets: Vec<nostr::PublicKey> = mentioned_pubkeys
+                .iter()
+                .filter(|pubkey| {
+                    pubkey.as_str() != author_pubkey_hex && managed_agents.contains(*pubkey)
+                })
+                .map(|pubkey| {
+                    nostr::PublicKey::from_hex(pubkey).map_err(|error| {
+                        ActionSinkError::InvalidInput(format!(
+                            "invalid managed-agent pubkey: {error}"
+                        ))
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+            let delivery_transaction = if managed_targets.is_empty() {
+                None
+            } else {
+                let (transaction, existing) = state
+                    .db
+                    .lock_workflow_agent_delivery_message_identity(
+                        tenant.community(),
+                        context.run_id,
+                        &context.step_id,
+                    )
+                    .await
+                    .map_err(|error| ActionSinkError::Database(error.to_string()))?;
+                if let Some((message_id, _)) = existing {
+                    return Ok(hex::encode(message_id));
+                }
+                Some(transaction)
+            };
 
             let kind = Kind::from(KIND_STREAM_MESSAGE as u16);
             let event = EventBuilder::new(kind, &text)
@@ -387,47 +440,133 @@ impl ActionSink for RelayActionSink {
                 },
             });
 
-            let (stored_event, was_inserted) = state
-                .db
-                .insert_event_with_thread_metadata(
-                    tenant.community(),
-                    &event,
-                    Some(channel_uuid),
-                    thread_meta,
-                )
-                .await
-                .map_err(|e| ActionSinkError::Database(e.to_string()))?;
+            let (stored_event, created_deliveries) = if let Some(transaction) = delivery_transaction
+            {
+                let deliveries: Vec<buzz_db::workflow::WorkflowAgentDelivery> = managed_targets
+                    .iter()
+                    .map(|target| {
+                        let id = WorkflowDeliveryId::from_uuid(Uuid::new_v4());
+                        WorkflowDeliveryBinding::new(
+                            tenant.community(),
+                            context.workflow_id,
+                            context.run_id,
+                            context.step_id.clone(),
+                            *target,
+                            context.definition_event_id,
+                            event.id,
+                            context.cause.clone(),
+                        )
+                        .map(|binding| buzz_db::workflow::WorkflowAgentDelivery { id, binding })
+                        .map_err(|error| {
+                            ActionSinkError::InvalidInput(format!(
+                                "invalid workflow delivery binding: {error}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                state
+                    .db
+                    .commit_workflow_message_deliveries(
+                        transaction,
+                        tenant.community(),
+                        &event,
+                        channel_uuid,
+                        thread_meta,
+                        &deliveries,
+                    )
+                    .await
+                    .map_err(|error| ActionSinkError::Database(error.to_string()))
+                    .map(|(stored, created)| {
+                        let created = deliveries
+                            .into_iter()
+                            .filter(|delivery| created.contains(&delivery.id))
+                            .collect();
+                        (stored, created)
+                    })?
+            } else {
+                let (stored, was_inserted) = state
+                    .db
+                    .insert_event_with_thread_metadata(
+                        tenant.community(),
+                        &event,
+                        Some(channel_uuid),
+                        thread_meta,
+                    )
+                    .await
+                    .map_err(|error| ActionSinkError::Database(error.to_string()))?;
+                if !was_inserted {
+                    return Ok(event_id_hex);
+                }
+                (stored, Vec::new())
+            };
 
-            // 5. Post-persist side effects (fan-out, search, audit)
-            //    Only if actually inserted (idempotency guard).
-            if was_inserted {
-                let _ = dispatch_persistent_event(
+            // 5. Post-commit side effects. The durable inbox is authoritative;
+            // identifier-only wakes are best-effort hints.
+            let _ = dispatch_persistent_event(
+                &tenant,
+                &state,
+                &stored_event,
+                kind_u32,
+                &author_pubkey_hex,
+                None,
+            )
+            .await;
+
+            if let Some(owned) = &thread_meta_owned {
+                crate::handlers::side_effects::emit_live_thread_summary(
                     &tenant,
                     &state,
-                    &stored_event,
-                    kind_u32,
-                    &author_pubkey_hex,
-                    None,
+                    channel_uuid,
+                    owned.root_event_id.clone(),
+                );
+            }
+
+            for delivery in created_deliveries {
+                let wake = WorkflowDeliveryWake::new(delivery.binding.target_pubkey(), delivery.id)
+                    .event_builder()
+                    .map_err(|error| {
+                        ActionSinkError::EventBuild(format!("workflow delivery wake: {error}"))
+                    })?
+                    .sign_with_keys(&state.relay_keypair)
+                    .map_err(|error| {
+                        ActionSinkError::EventBuild(format!(
+                            "workflow delivery wake signing: {error}"
+                        ))
+                    })?;
+                state.mark_local_event(tenant.community(), &wake.id);
+                if let Err(error) = state
+                    .pubsub
+                    .publish_event(&tenant, buzz_pubsub::EventTopic::Global, &wake)
+                    .await
+                {
+                    state
+                        .local_event_ids
+                        .invalidate(&(tenant.community(), wake.id.to_bytes()));
+                    tracing::warn!(delivery_id = %delivery.id, %error, "workflow delivery wake publish failed");
+                }
+                crate::handlers::event::fan_out_event_to_local_subscribers(
+                    &state,
+                    tenant.community(),
+                    &buzz_core::StoredEvent::new(wake, None),
                 )
                 .await;
-
-                // A threaded reply changed its thread's counters — push a fresh
-                // relay-signed kind:39005 so subscribed clients update badge
-                // counts without refetching the head window, exactly as the
-                // ingest path does after a reply insert. Fan-out-only and
-                // best-effort; skipped for top-level (non-reply) messages.
-                if let Some(owned) = &thread_meta_owned {
-                    crate::handlers::side_effects::emit_live_thread_summary(
-                        &tenant,
-                        &state,
-                        channel_uuid,
-                        owned.root_event_id.clone(),
-                    );
-                }
             }
 
             Ok(event_id_hex)
         })
+    }
+}
+
+#[cfg(test)]
+fn message_context() -> WorkflowMessageContext {
+    WorkflowMessageContext {
+        workflow_id: Uuid::new_v4(),
+        run_id: Uuid::new_v4(),
+        definition_event_id: nostr::EventId::from_hex(&"11".repeat(32)).expect("event id"),
+        step_id: "send".to_owned(),
+        cause: buzz_core::workflow_delivery::WorkflowDeliveryCause::Event(
+            nostr::EventId::from_hex(&"22".repeat(32)).expect("cause id"),
+        ),
     }
 }
 
@@ -686,6 +825,9 @@ mod integration_tests {
         let agent = nostr::Keys::generate();
         let agent_hex = agent.public_key().to_hex();
         let agent_bytes = agent.public_key().to_bytes().to_vec();
+        let human = nostr::Keys::generate();
+        let human_hex = human.public_key().to_hex();
+        let human_bytes = human.public_key().to_bytes().to_vec();
 
         let host = format!("wf-ptag-{}.example", uuid::Uuid::new_v4().simple());
         let community = match state
@@ -716,6 +858,11 @@ mod integration_tests {
         // The mentioned agent is a real member with a resolvable display name.
         state
             .db
+            .ensure_user(community, &author.public_key().to_bytes())
+            .await
+            .expect("ensure owner user row");
+        state
+            .db
             .ensure_user(community, &agent_bytes)
             .await
             .expect("ensure agent user row");
@@ -724,6 +871,11 @@ mod integration_tests {
             .update_user_profile(community, &agent_bytes, Some("Robby"), None, None, None)
             .await
             .expect("set agent display name");
+        state
+            .db
+            .set_agent_owner(community, &agent_bytes, &author.public_key().to_bytes())
+            .await
+            .expect("set agent owner");
         state
             .db
             .add_member(
@@ -736,13 +888,69 @@ mod integration_tests {
             .await
             .expect("add agent member");
 
+        state
+            .db
+            .ensure_user(community, &human_bytes)
+            .await
+            .expect("ensure human user row");
+        state
+            .db
+            .update_user_profile(community, &human_bytes, Some("Alice"), None, None, None)
+            .await
+            .expect("set human display name");
+        state
+            .db
+            .add_member(
+                community,
+                channel.id,
+                &human_bytes,
+                MemberRole::Member,
+                Some(&author.public_key().to_bytes()),
+            )
+            .await
+            .expect("add human member");
+
+        let workflow_id = state
+            .db
+            .create_workflow(
+                community,
+                Some(channel.id),
+                &author.public_key().to_bytes(),
+                "deliver",
+                "{}",
+                &[0x44; 32],
+            )
+            .await
+            .expect("create workflow");
+        let definition_event_id = nostr::EventId::from_byte_array([0x11; 32]);
+        let cause_event_id = nostr::EventId::from_byte_array([0x22; 32]);
+        let run_id = state
+            .db
+            .create_workflow_run(
+                community,
+                workflow_id,
+                definition_event_id.as_bytes(),
+                Some(cause_event_id.as_bytes()),
+                None,
+            )
+            .await
+            .expect("create run");
+        let context = WorkflowMessageContext {
+            workflow_id,
+            run_id,
+            definition_event_id,
+            step_id: "send".to_owned(),
+            cause: buzz_core::workflow_delivery::WorkflowDeliveryCause::Event(cause_event_id),
+        };
+
         let sink = RelayActionSink::new(&state);
         let event_id_hex = sink
             .send_message(
                 community,
                 &channel.id.to_string(),
-                "heads up @Robby — please take a look",
+                "heads up @Robby and @Alice — please take a look",
                 &author_hex,
+                &context,
                 None,
             )
             .await
@@ -774,6 +982,44 @@ mod integration_tests {
         assert!(
             p_tag_targets.contains(&agent_hex.as_str()),
             "mentioned member {agent_hex} must be p-tagged so it wakes; got {p_tag_targets:?}"
+        );
+        assert!(
+            p_tag_targets.contains(&human_hex.as_str()),
+            "mentioned human {human_hex} must retain its normal p tag; got {p_tag_targets:?}"
+        );
+        let message_v1_targets = buzz_core::workflow_delivery::message_v1_targets(&stored.event)
+            .expect("canonical tags");
+        assert_eq!(message_v1_targets, vec![agent.public_key()]);
+
+        let retried_event_id = sink
+            .send_message(
+                community,
+                &channel.id.to_string(),
+                "heads up @Robby and @Alice — please take a look",
+                &author_hex,
+                &context,
+                None,
+            )
+            .await
+            .expect("retry send_message");
+        assert_eq!(retried_event_id, event_id_hex);
+        let delivery = state
+            .db
+            .claim_workflow_agent_delivery(community, &agent.public_key(), None, None, 30)
+            .await
+            .expect("claim delivery")
+            .expect("managed-agent delivery exists")
+            .1;
+        assert_eq!(delivery.binding.target_pubkey(), agent.public_key());
+        assert_eq!(delivery.binding.message_event_id(), stored.event.id);
+        let no_second_delivery = state
+            .db
+            .claim_workflow_agent_delivery(community, &agent.public_key(), None, None, 30)
+            .await
+            .expect("retry claim");
+        assert!(
+            no_second_delivery.is_none(),
+            "retry must not duplicate delivery"
         );
     }
 
@@ -819,6 +1065,7 @@ mod integration_tests {
                 &channel.id.to_string(),
                 "root message",
                 &author_hex,
+                &message_context(),
                 None,
             )
             .await
@@ -831,6 +1078,7 @@ mod integration_tests {
                 &channel.id.to_string(),
                 "threaded reply",
                 &author_hex,
+                &message_context(),
                 Some(&root_hex),
             )
             .await
@@ -973,6 +1221,7 @@ mod integration_tests {
                 &channel_hex,
                 "workflow reply",
                 &author_hex,
+                &message_context(),
                 Some(&parent_hex),
             )
             .await
@@ -1054,6 +1303,7 @@ mod integration_tests {
                 &channel_hex,
                 "workflow reply to root-only parent",
                 &author_hex,
+                &message_context(),
                 Some(&root_only_parent_hex),
             )
             .await
@@ -1116,6 +1366,7 @@ mod integration_tests {
                 &channel.id.to_string(),
                 "orphan reply",
                 &author_hex,
+                &message_context(),
                 Some(&unknown),
             )
             .await

--- a/crates/buzz-workflow/src/action_sink.rs
+++ b/crates/buzz-workflow/src/action_sink.rs
@@ -6,7 +6,23 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use buzz_core::tenant::CommunityId;
+use buzz_core::{tenant::CommunityId, workflow_delivery::WorkflowDeliveryCause};
+use uuid::Uuid;
+
+/// Immutable provenance for one workflow-generated message delivery.
+#[derive(Debug, Clone)]
+pub struct WorkflowMessageContext {
+    /// Workflow whose signed definition authorizes the message.
+    pub workflow_id: Uuid,
+    /// Durable run executing the message step.
+    pub run_id: Uuid,
+    /// Exact owner-signed kind:30620 definition revision used by the run.
+    pub definition_event_id: nostr::EventId,
+    /// Stable step identifier within the signed definition.
+    pub step_id: String,
+    /// Durable authority that caused the run.
+    pub cause: WorkflowDeliveryCause,
+}
 
 /// Errors from action sink operations.
 #[derive(Debug, thiserror::Error)]
@@ -57,6 +73,8 @@ pub trait ActionSink: Send + Sync {
     /// - `text`: message body (must not be empty/whitespace-only)
     /// - `author_pubkey`: hex-encoded pubkey of the workflow owner (used for
     ///   the `p` attribution tag; the relay keypair signs the event)
+    /// - `context`: immutable workflow/run/revision/step/cause provenance used
+    ///   to bind durable managed-agent deliveries
     /// - `reply_to`: when `Some(event_id_hex)`, the message is posted as a
     ///   threaded reply to that event (NIP-10 root/reply tags + real thread
     ///   metadata); when `None`, it is a top-level channel message.
@@ -68,6 +86,7 @@ pub trait ActionSink: Send + Sync {
         channel_id: &str,
         text: &str,
         author_pubkey: &str,
+        context: &WorkflowMessageContext,
         reply_to: Option<&str>,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>>;
 }

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -18,6 +18,7 @@ use serde_json::Value as JsonValue;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
+use crate::action_sink::WorkflowMessageContext;
 use crate::error::WorkflowError;
 use crate::schema::{ActionDef, Step, WorkflowDef};
 use crate::WorkflowEngine;
@@ -625,6 +626,42 @@ pub async fn dispatch_action(
                         "SendMessage → {channel_id}: {text}"
                     );
 
+                    let definition_event_id = wf_run
+                        .definition_event_id
+                        .as_deref()
+                        .ok_or_else(|| {
+                            WorkflowError::WebhookError(format!(
+                                "SendMessage: run {run_id} has no signed definition revision"
+                            ))
+                        })
+                        .and_then(|bytes| {
+                            nostr::EventId::from_slice(bytes).map_err(|error| {
+                                WorkflowError::WebhookError(format!(
+                                    "SendMessage: run {run_id} has invalid definition revision: {error}"
+                                ))
+                            })
+                        })?;
+                    let cause = engine
+                        .db
+                        .get_workflow_delivery_cause(
+                            community_id,
+                            wf_run.workflow_id,
+                            run_id,
+                        )
+                        .await
+                        .map_err(|error| {
+                            WorkflowError::WebhookError(format!(
+                                "SendMessage: failed to resolve run authority: {error}"
+                            ))
+                        })?;
+                    let context = WorkflowMessageContext {
+                        workflow_id: wf_run.workflow_id,
+                        run_id,
+                        definition_event_id,
+                        step_id: step_id.to_owned(),
+                        cause,
+                    };
+
                     let event_id = engine
                         .action_sink()?
                         .send_message(
@@ -632,6 +669,7 @@ pub async fn dispatch_action(
                             &channel_id,
                             text,
                             &owner_pubkey_hex,
+                            &context,
                             reply_to,
                         )
                         .await


### PR DESCRIPTION
🤖 I’m Larry.

## Summary

Managed-agent workflows can now deliver a message to an agent and wake that exact recipient for processing. Before this change, the durable delivery and verification pieces existed but were not connected to the live relay and workflow executor.

## Details

- Resolves mentioned agents against the channel’s current membership and rejects ambiguous or non-member names.
- Persists the delivery before sending a recipient-private wake; the wake carries only the target and opaque delivery identifier.
- Restricts live and historical wake visibility to the tagged agent, including channel-less delivery.
- Connects workflow message actions to the durable claim, receipt, and terminal-result protocol established by the preceding stack nodes.
- Adds coverage for recipient privacy, mention handling, relay fan-out, and a real workflow-to-mentioned-agent delivery path.

## Stack

This is activation node G and is based on node F (`larry/workflow-acp-runtime-f-v2`).
