### PR TITLE
feat(db): add NIP-FI identity and final-admission schema foundation

### DIFF
--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -699,7 +699,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 40);
+        assert_eq!(migrations.len(), 42);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -1240,6 +1240,45 @@ mod tests {
         assert!(
             operator_audit.contains("_operator_global_tables"),
             "migration 39 must register relay_operator_audit in _operator_global_tables"
+        );
+
+        // NIP-FI core identity + base-lifecycle foundation (migration 0041) and
+        // final-admission foundation (0042). Both widen the single SQL source of
+        // truth `community_write_fence_excluded_table` so their durable,
+        // immutable ledger relations are never fence-attached, purged, or
+        // counted as tenant-scoped drift. schema.sql keeps one consolidated
+        // definition of that function whose body must match 0042's exactly.
+        assert_eq!(migrations[40].version, 41);
+        let identity_foundation = migrations[40].sql.as_str();
+        assert!(identity_foundation.contains("CREATE TABLE identity_bindings"));
+        assert!(identity_foundation.contains("CREATE TABLE identity_lifecycle_history"));
+        assert!(identity_foundation
+            .contains("CREATE OR REPLACE FUNCTION community_write_fence_excluded_table"));
+        assert!(identity_foundation.contains("'identity_bindings'"));
+
+        assert_eq!(migrations[41].version, 42);
+        let authorization_foundation = migrations[41].sql.as_str();
+        assert!(authorization_foundation.contains("CREATE TABLE authorization_events"));
+        assert!(authorization_foundation.contains("CREATE TABLE protected_object_authority"));
+        assert!(authorization_foundation.contains("CREATE TABLE authorization_admission_results"));
+
+        // The consolidated desired-state exclusion function must byte-match
+        // migration 0042's CREATE OR REPLACE body, or a future schema
+        // consolidation would silently drop NIP-FI relations from the ledger.
+        fn extract_excluded_table_array(sql: &str) -> &str {
+            let anchor = "community_write_fence_excluded_table(target NAME) RETURNS BOOLEAN";
+            let start = sql.find(anchor).expect("exclusion function definition");
+            let array_start = sql[start..].find("ARRAY[").expect("exclusion array") + start;
+            let array_end = sql[array_start..]
+                .find("]::TEXT[]")
+                .expect("exclusion array end")
+                + array_start;
+            &sql[array_start..array_end]
+        }
+        assert_eq!(
+            extract_excluded_table_array(authorization_foundation),
+            extract_excluded_table_array(desired_schema),
+            "schema.sql exclusion list drifted from migration 0042"
         );
     }
 
@@ -2617,5 +2656,195 @@ mod tests {
             .execute(&pool)
             .await
             .expect("drop late-table fixtures");
+    }
+
+    /// NIP-FI intermediate state: migration 0041 (identity + base lifecycle)
+    /// alone must present a coherent catalog. Its five community-scoped ledger
+    /// relations are immutable and durable, so they are registered in the
+    /// write-fence exclusion — never counted as tenant-scoped drift, never
+    /// fence-attached — and the exact deletion catalog must still validate.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn migration_0041_identity_foundation_is_durable_ledger_after_migration_a() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(41, &pool)
+            .await
+            .expect("apply migrations 1-41");
+
+        // The five identity relations exist.
+        let identity_tables = [
+            "authorization_operation_receipts",
+            "identity_enrollment_policies",
+            "identity_bindings",
+            "identity_lifecycle_history",
+            "identity_lifecycle_selectors",
+        ];
+        for table in identity_tables {
+            let exists = sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+                 WHERE table_schema = 'public' AND table_name = $1)",
+            )
+            .bind(table)
+            .fetch_one(&pool)
+            .await
+            .unwrap_or_else(|err| panic!("check table {table}: {err}"));
+            assert!(exists, "migration 0041 must create {table}");
+        }
+
+        // Migration B's relations must NOT exist yet.
+        for table in ["authorization_events", "protected_object_authority"] {
+            let exists = sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+                 WHERE table_schema = 'public' AND table_name = $1)",
+            )
+            .bind(table)
+            .fetch_one(&pool)
+            .await
+            .unwrap_or_else(|err| panic!("check table {table}: {err}"));
+            assert!(!exists, "{table} belongs to migration 0042, not 0041");
+        }
+
+        // Every identity relation is excluded from the write fence: none may
+        // appear as tenant-scoped drift or carry the fence trigger.
+        let scoped_or_fenced: Vec<String> = sqlx::query_scalar(
+            "WITH scoped AS ( \
+                 SELECT c.relname FROM pg_class c \
+                 JOIN pg_namespace n ON n.oid = c.relnamespace \
+                 JOIN pg_attribute a ON a.attrelid = c.oid \
+                 WHERE n.nspname = 'public' AND c.relkind IN ('r','p') \
+                   AND NOT c.relispartition AND a.attname = 'community_id' \
+                   AND NOT a.attisdropped \
+                   AND NOT community_write_fence_excluded_table(c.relname) \
+             ) \
+             SELECT relname FROM scoped \
+             WHERE relname = ANY($1) ORDER BY relname",
+        )
+        .bind(&identity_tables[..])
+        .fetch_all(&pool)
+        .await
+        .expect("read scoped identity relations");
+        assert!(
+            scoped_or_fenced.is_empty(),
+            "identity ledger relations must be write-fence excluded, not scoped: {scoped_or_fenced:?}"
+        );
+
+        // The exact deletion catalog validates: the excluded ledger relations
+        // do not perturb the scoped-table/fence equality check.
+        crate::deletion::DeletionStore::new(pool.clone())
+            .validate_catalog()
+            .await
+            .expect("deletion catalog validates after migration 0041");
+
+        // The immutability contract is enforced, not merely declared. TRUNCATE
+        // fires the statement-level guard unconditionally, so this proves the
+        // rejection without constructing a fully valid ledger row.
+        let rejected = sqlx::query("TRUNCATE identity_lifecycle_selectors")
+            .execute(&pool)
+            .await
+            .expect_err("identity_lifecycle_selectors truncation must be rejected");
+        assert!(
+            rejected.to_string().contains("cannot be truncated"),
+            "expected immutability rejection, got: {rejected}"
+        );
+    }
+
+    /// NIP-FI full state: migrations 0041 + 0042 together must present a
+    /// coherent 15-relation catalog with zero dangling foreign keys, all
+    /// relations write-fence excluded, and an intact exact deletion catalog.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn nip_fi_foundation_is_a_closed_durable_ledger_after_migrations_a_and_b() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let nip_fi_tables = [
+            "authorization_admission_results",
+            "authorization_authentication_denial_attempts",
+            "authorization_authority_epochs",
+            "authorization_event_capacity",
+            "authorization_events",
+            "authorization_invalidation_domains",
+            "authorization_invalidation_floors",
+            "authorization_operation_receipts",
+            "authorization_operation_version_delta_manifests",
+            "authorization_operation_version_deltas",
+            "identity_bindings",
+            "identity_enrollment_policies",
+            "identity_lifecycle_history",
+            "identity_lifecycle_selectors",
+            "protected_object_authority",
+        ];
+
+        // All fifteen relations exist.
+        let present: Vec<String> = sqlx::query_scalar(
+            "SELECT table_name FROM information_schema.tables \
+             WHERE table_schema = 'public' AND table_name = ANY($1) ORDER BY table_name",
+        )
+        .bind(&nip_fi_tables[..])
+        .fetch_all(&pool)
+        .await
+        .expect("read NIP-FI table catalog");
+        let mut expected: Vec<String> = nip_fi_tables.iter().map(|t| t.to_string()).collect();
+        expected.sort();
+        assert_eq!(
+            present, expected,
+            "all NIP-FI relations must exist after 0042"
+        );
+
+        // Zero dangling foreign keys: every FK target is a live relation.
+        let invalid_fks: i64 = sqlx::query_scalar(
+            "SELECT count(*)::BIGINT FROM pg_constraint \
+             WHERE contype = 'f' AND NOT convalidated",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("read FK validity");
+        assert_eq!(
+            invalid_fks, 0,
+            "no NIP-FI foreign key may be left unvalidated"
+        );
+
+        // None of the fifteen appear as tenant-scoped drift; all are excluded.
+        let scoped: Vec<String> = sqlx::query_scalar(
+            "SELECT c.relname FROM pg_class c \
+             JOIN pg_namespace n ON n.oid = c.relnamespace \
+             JOIN pg_attribute a ON a.attrelid = c.oid \
+             WHERE n.nspname = 'public' AND c.relkind IN ('r','p') \
+               AND NOT c.relispartition AND a.attname = 'community_id' \
+               AND NOT a.attisdropped \
+               AND NOT community_write_fence_excluded_table(c.relname) \
+               AND c.relname = ANY($1) ORDER BY c.relname",
+        )
+        .bind(&nip_fi_tables[..])
+        .fetch_all(&pool)
+        .await
+        .expect("read scoped NIP-FI relations");
+        assert!(
+            scoped.is_empty(),
+            "all NIP-FI ledger relations must be write-fence excluded: {scoped:?}"
+        );
+
+        // The exact deletion catalog validates with the full ledger present.
+        crate::deletion::DeletionStore::new(pool.clone())
+            .validate_catalog()
+            .await
+            .expect("deletion catalog validates after migrations 0041 + 0042");
+
+        // A migration-B relation is immutable too. TRUNCATE fires the
+        // statement-level guard unconditionally.
+        let rejected = sqlx::query("TRUNCATE authorization_admission_results")
+            .execute(&pool)
+            .await
+            .expect_err("authorization_admission_results truncation must be rejected");
+        assert!(
+            rejected.to_string().contains("cannot be truncated"),
+            "expected immutability rejection, got: {rejected}"
+        );
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -2852,9 +2852,9 @@ mod tests {
         let pool = connect_test_pool().await;
         reset_public_schema(&pool).await;
         MIGRATOR
-            .run_to(41, &pool)
+            .run_to(42, &pool)
             .await
-            .expect("apply migrations 1-41");
+            .expect("apply migrations 1-42");
 
         let community_id = uuid::Uuid::new_v4();
         sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
@@ -2984,9 +2984,9 @@ mod tests {
         let pool = connect_test_pool().await;
         reset_public_schema(&pool).await;
         MIGRATOR
-            .run_to(40, &pool)
+            .run_to(41, &pool)
             .await
-            .expect("apply migrations 1-40");
+            .expect("apply migrations 1-41");
 
         let community_id = uuid::Uuid::new_v4();
         sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -2861,9 +2861,9 @@ mod tests {
         let pool = connect_test_pool().await;
         reset_public_schema(&pool).await;
         MIGRATOR
-            .run_to(41, &pool)
+            .run_to(42, &pool)
             .await
-            .expect("apply migrations 1-41");
+            .expect("apply migrations 1-42");
 
         let community_id = uuid::Uuid::new_v4();
         sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
@@ -2993,9 +2993,9 @@ mod tests {
         let pool = connect_test_pool().await;
         reset_public_schema(&pool).await;
         MIGRATOR
-            .run_to(40, &pool)
+            .run_to(41, &pool)
             .await
-            .expect("apply migrations 1-40");
+            .expect("apply migrations 1-41");
 
         let community_id = uuid::Uuid::new_v4();
         sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -2838,4 +2838,136 @@ mod tests {
             "expected immutability rejection, got: {rejected}"
         );
     }
+
+    /// NIP-FI monotonic invalidation-floor advancement must actually run
+    /// through the `BEFORE UPDATE` guard. PL/pgSQL defers record-field
+    /// resolution to execution, so a guard that references a column absent from
+    /// its Phase-A table passes every catalog/parity test yet aborts the first
+    /// real advancement. This test exercises live UPDATEs: legitimate forward
+    /// moves on `floor_generation` and `binding_version_floor` must commit, and
+    /// equal/regressive moves must be rejected.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn authorization_invalidation_floor_advances_through_guard() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(41, &pool)
+            .await
+            .expect("apply migrations 1-41");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("floor-guard-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Each floor state points at an operation receipt via
+        // (community_id, operation_id, request_fingerprint). Seed one receipt
+        // per operation the test advances through.
+        let operations: [(uuid::Uuid, u8); 4] = [
+            (uuid::Uuid::new_v4(), 0x11),
+            (uuid::Uuid::new_v4(), 0x22),
+            (uuid::Uuid::new_v4(), 0x33),
+            (uuid::Uuid::new_v4(), 0x44),
+        ];
+        for (operation_id, fp_byte) in operations {
+            sqlx::query(
+                "INSERT INTO authorization_operation_receipts \
+                 (community_id, operation_id, request_fingerprint, operation_kind, \
+                  actor_fingerprint, outcome_code, result_digest) \
+                 VALUES ($1, $2, $3, 12, $4, 1, $5)",
+            )
+            .bind(community_id)
+            .bind(operation_id)
+            .bind(vec![fp_byte; 32])
+            .bind(vec![0xAA_u8; 32])
+            .bind(vec![0xBB_u8; 32])
+            .execute(&pool)
+            .await
+            .expect("seed operation receipt");
+        }
+
+        // selector_kind 3 requires binding_version_floor, so this row exercises
+        // both monotonic dimensions the guard still governs.
+        let selector_fingerprint = vec![0xCC_u8; 32];
+        sqlx::query(
+            "INSERT INTO authorization_invalidation_floors \
+             (community_id, selector_kind, selector_fingerprint, floor_generation, \
+              binding_version_floor, operation_id, request_fingerprint, updated_at) \
+             VALUES ($1, 3, $2, 1, 1, $3, $4, '2026-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(&selector_fingerprint)
+        .bind(operations[0].0)
+        .bind(vec![operations[0].1; 32])
+        .execute(&pool)
+        .await
+        .expect("insert initial invalidation floor");
+
+        let advance =
+            |generation: i64, binding_floor: i64, op_index: usize, updated_at: &'static str| {
+                sqlx::query(
+                    "UPDATE authorization_invalidation_floors \
+                 SET floor_generation = $1, binding_version_floor = $2, \
+                     operation_id = $3, request_fingerprint = $4, updated_at = $5::timestamptz \
+                 WHERE community_id = $6 AND selector_kind = 3 AND selector_fingerprint = $7",
+                )
+                .bind(generation)
+                .bind(binding_floor)
+                .bind(operations[op_index].0)
+                .bind(vec![operations[op_index].1; 32])
+                .bind(updated_at)
+                .bind(community_id)
+                .bind(selector_fingerprint.clone())
+                .execute(&pool)
+            };
+
+        // Forward generation advance commits.
+        advance(2, 1, 1, "2026-01-01T00:01:00Z")
+            .await
+            .expect("forward floor_generation advance must pass the guard");
+
+        // Forward binding_version_floor advance commits (generation unchanged).
+        advance(2, 2, 2, "2026-01-01T00:02:00Z")
+            .await
+            .expect("forward binding_version_floor advance must pass the guard");
+
+        // Regressive generation is rejected.
+        let regressive = advance(1, 2, 3, "2026-01-01T00:03:00Z")
+            .await
+            .expect_err("regressive floor_generation must be rejected");
+        assert!(
+            regressive.to_string().contains("cannot move backward"),
+            "expected monotonic rejection, got: {regressive}"
+        );
+
+        // Equal floors with only a new operation is a rejected no-op advance.
+        let no_op = advance(2, 2, 3, "2026-01-01T00:03:00Z")
+            .await
+            .expect_err("equal-floor no-op advance must be rejected");
+        assert!(
+            no_op.to_string().contains("cannot move backward"),
+            "expected no-op rejection, got: {no_op}"
+        );
+
+        // The committed state reflects only the two accepted advances.
+        let (generation, binding_floor): (i64, i64) = sqlx::query_as(
+            "SELECT floor_generation, binding_version_floor \
+             FROM authorization_invalidation_floors \
+             WHERE community_id = $1 AND selector_kind = 3 AND selector_fingerprint = $2",
+        )
+        .bind(community_id)
+        .bind(&selector_fingerprint)
+        .fetch_one(&pool)
+        .await
+        .expect("read final floor state");
+        assert_eq!(
+            (generation, binding_floor),
+            (2, 2),
+            "only the accepted forward advances may persist"
+        );
+    }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -2979,4 +2979,155 @@ mod tests {
             "only the accepted forward advances may persist"
         );
     }
+
+    /// NIP-FI identity FK contract: a binding's provenance is determined from
+    /// operation evidence and is independent of the enrollment policy's mode.
+    /// The corrected FK references only `(community_id, policy_revision)`;
+    /// the original composite FK `(community_id, policy_revision,
+    /// binding_provenance) → (community_id, policy_revision, enrollment_mode)`
+    /// would have rejected valid admissions such as TOFU policy +
+    /// attested-key provenance (NIP-FI.md §352, §424).
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn identity_binding_provenance_is_independent_of_enrollment_mode() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(40, &pool)
+            .await
+            .expect("apply migrations 1-40");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("provenance-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Enrollment policy: mode 3 (TOFU).
+        let policy_revision: i64 = 1;
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, $2, 3, $3, '2026-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(policy_revision)
+        .bind(vec![0xA0_u8; 32]) // policy_digest
+        .execute(&pool)
+        .await
+        .expect("insert TOFU enrollment policy");
+
+        // Insert a binding with provenance 1 (attested-key) under the TOFU
+        // policy.  The circular deferred FK between identity_bindings and
+        // identity_lifecycle_history requires both to be committed in one
+        // transaction; all cross-table FKs in this pair are DEFERRABLE
+        // INITIALLY DEFERRED.  A pinned connection is required so that BEGIN
+        // and each subsequent statement share the same session/transaction.
+        let binding_id = uuid::Uuid::new_v4();
+        let history_id = uuid::Uuid::new_v4();
+        let operation_id = uuid::Uuid::new_v4();
+        let request_fingerprint = vec![0xAB_u8; 32];
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin");
+
+        // Enrollment history must be inserted BEFORE the operation receipt:
+        // authorization_operation_receipt_history_guard_v1 fires AFTER INSERT
+        // on authorization_operation_receipts and checks that lifecycle receipts
+        // already have exactly one history row.  The history → receipt FK is
+        // DEFERRABLE INITIALLY DEFERRED, so this order is safe.
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id, history_id, transition_kind, outcome_code, \
+              successor_binding_id, successor_binding_version, \
+              successor_lifecycle_revision, successor_state, \
+              operation_id, request_fingerprint, transition_digest) \
+             VALUES ($1, $2, 1, 1, $3, 1, 1, 1, $4, $5, $6)",
+        )
+        .bind(community_id)
+        .bind(history_id)
+        .bind(binding_id)
+        .bind(operation_id)
+        .bind(&request_fingerprint)
+        .bind(vec![0xAE_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert lifecycle history");
+
+        // Operation receipt: kind 1 (enroll), outcome 1 (applied).
+        // The receipt_history_cardinality trigger fires here and validates the
+        // history row inserted above.
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(operation_id)
+        .bind(&request_fingerprint)
+        .bind(vec![0xAC_u8; 32])
+        .bind(vec![0xAD_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert operation receipt");
+
+        // Binding: provenance 1 (attested-key) under TOFU-mode policy.
+        // Before the FK fix this INSERT would fail at commit with a FK
+        // violation because 1 (attested-key) ≠ 3 (TOFU mode).
+        sqlx::query(
+            "INSERT INTO identity_bindings \
+             (community_id, binding_id, issuer, subject, \
+              principal_fingerprint, event_author_pubkey, \
+              binding_state, lifecycle_revision, binding_provenance, \
+              policy_revision, enrollment_evidence_digest, \
+              birth_history_id, creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1, $2, 'https://issuer.example', 'sub-01', \
+                     $3, $4, 1, 1, 1, $5, $6, $7, $8, $9)",
+        )
+        .bind(community_id)
+        .bind(binding_id)
+        .bind(vec![0xAF_u8; 32]) // principal_fingerprint
+        .bind(vec![0xB0_u8; 32]) // event_author_pubkey
+        .bind(policy_revision)
+        .bind(vec![0xB1_u8; 32]) // enrollment_evidence_digest
+        .bind(history_id)
+        .bind(operation_id)
+        .bind(&request_fingerprint)
+        .execute(&mut *conn)
+        .await
+        .expect("insert binding");
+
+        sqlx::query("COMMIT")
+            .execute(&mut *conn)
+            .await
+            .expect("attested-key binding under TOFU policy must commit — FK is on (community_id, policy_revision) only");
+
+        // Confirm the binding persisted with provenance 1, policy mode 3.
+        let (stored_provenance, stored_mode): (i16, i16) = sqlx::query_as(
+            "SELECT b.binding_provenance, p.enrollment_mode \
+             FROM identity_bindings b \
+             JOIN identity_enrollment_policies p \
+               ON p.community_id = b.community_id AND p.policy_revision = b.policy_revision \
+             WHERE b.community_id = $1 AND b.binding_id = $2",
+        )
+        .bind(community_id)
+        .bind(binding_id)
+        .fetch_one(&pool)
+        .await
+        .expect("read persisted binding");
+        assert_eq!(stored_provenance, 1, "provenance must be attested-key (1)");
+        assert_eq!(stored_mode, 3, "enrollment mode must be TOFU (3)");
+        assert_ne!(
+            stored_provenance, stored_mode,
+            "provenance and mode are independent: they must differ here"
+        );
+    }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -3229,9 +3229,10 @@ mod tests {
     }
 
     /// NIP-FI policy-revision monotonicity: each new policy revision for a
-    /// community must strictly exceed the current maximum revision, and its
-    /// effective_at must strictly exceed the current maximum effective_at
-    /// (FI-INV-06 — stable assertion policy).
+    /// community must strictly exceed the current maximum revision
+    /// (FI-INV-06 — stable assertion policy). `effective_at` ordering is
+    /// deliberately not enforced — the downstream constructor stamps every
+    /// immediately-effective revision with Unix epoch.
     ///
     /// Mutation sensitivity is two-sided:
     /// - neutering the guard lets a replayed or backfilled revision through
@@ -3325,9 +3326,10 @@ mod tests {
              guard for backfilled revision 99, got: {backfill_err}"
         );
 
-        // Negative: equal revision (101 <= 101) — different from a PK duplicate
-        // because we use a different policy_digest, so the PK is not violated;
-        // the guard still fires on the <= check.
+        // Negative: equal revision (101 <= 101). The PK is (community_id, policy_revision)
+        // so this is a PK duplicate regardless of policy_digest; either 23505 from the PK
+        // or 23514 from the guard fires first. This case is secondary — the load-bearing
+        // proof is the unused-99 case above, which is not a PK duplicate.
         let replay_err = sqlx::query(
             "INSERT INTO identity_enrollment_policies \
              (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
@@ -3338,8 +3340,7 @@ mod tests {
         .execute(&pool)
         .await
         .expect_err("equal revision must be rejected");
-        // PK (23505) fires before guard on exact duplicates, both prove the insert
-        // cannot commit; accept either code as evidence.
+        // PK (23505) or guard (23514) — either proves the insert cannot commit.
         assert!(
             replay_err
                 .as_database_error()
@@ -3353,23 +3354,38 @@ mod tests {
              got: {replay_err}"
         );
 
-        // Concurrency regression: race two distinct forward revisions (102 and 103)
-        // on separate connections. The per-community advisory lock must serialize
-        // them so that exactly one commits — not zero, not two.
+        // Concurrency regression: prove the advisory lock actually serializes
+        // concurrent writers. Two connections race to insert the SAME next revision
+        // (102) for the same community. The advisory lock must cause one writer to
+        // block, see the other's committed MAX, and then be rejected with 23514 from
+        // the named guard. Without the lock, both could pass the MAX check before
+        // either commits; only a PK collision (23505) would catch the duplicate —
+        // not the guard. Removing pg_advisory_xact_lock from the guard function and
+        // re-running must produce 23505 (PK) rather than 23514 (guard), proving the
+        // test is mutation-sensitive to the lock.
         //
-        // Strategy: begin both transactions before either acquires the lock, then
-        // commit them sequentially.  The guard holds the lock for the duration of
-        // its transaction, so the second commit must succeed (not deadlock) because
-        // the first has already released.
+        // A tokio::sync::Barrier synchronizes both connections so they both have a
+        // live transaction and are ready to INSERT before either proceeds. After the
+        // barrier both race to acquire the advisory lock; one wins, commits, and
+        // releases the lock; the other then sees the committed MAX and is rejected
+        // by the guard with 23514.
         let pool2 = pool.clone();
         let pool3 = pool.clone();
         let community_id2 = community_id;
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let barrier2 = barrier.clone();
 
         let (tx1_result, tx2_result) = tokio::join!(
             tokio::spawn(async move {
                 let mut conn = pool.acquire().await.expect("acquire conn1");
-                sqlx::query("BEGIN").execute(&mut *conn).await.expect("begin1");
-                let r = sqlx::query(
+                sqlx::query("BEGIN")
+                    .execute(&mut *conn)
+                    .await
+                    .expect("begin1");
+                // Wait until both connections have open transactions before
+                // either races to INSERT — eliminates ordering accidents.
+                barrier.wait().await;
+                let insert_r = sqlx::query(
                     "INSERT INTO identity_enrollment_policies \
                      (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
                      VALUES ($1, 102, 1, $2, '2029-01-01T00:00:00Z')",
@@ -3379,38 +3395,62 @@ mod tests {
                 .execute(&mut *conn)
                 .await;
                 let commit_r = sqlx::query("COMMIT").execute(&mut *conn).await;
-                (r, commit_r)
+                (insert_r, commit_r)
             }),
             tokio::spawn(async move {
-                // Small delay so tx1 tends to start first; not required for
-                // correctness — either order is valid under the guard.
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                 let mut conn = pool2.acquire().await.expect("acquire conn2");
-                sqlx::query("BEGIN").execute(&mut *conn).await.expect("begin2");
-                let r = sqlx::query(
+                sqlx::query("BEGIN")
+                    .execute(&mut *conn)
+                    .await
+                    .expect("begin2");
+                // Mirror barrier wait so both are in-flight simultaneously.
+                barrier2.wait().await;
+                let insert_r = sqlx::query(
                     "INSERT INTO identity_enrollment_policies \
                      (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
-                     VALUES ($1, 103, 1, $2, '2029-06-01T00:00:00Z')",
+                     VALUES ($1, 102, 1, $2, '2029-01-01T00:00:00Z')",
                 )
                 .bind(community_id2)
                 .bind(vec![0xB2_u8; 32])
                 .execute(&mut *conn)
                 .await;
                 let commit_r = sqlx::query("COMMIT").execute(&mut *conn).await;
-                (r, commit_r)
+                (insert_r, commit_r)
             }),
         );
 
         let (insert1, commit1) = tx1_result.expect("tx1 task completed");
         let (insert2, commit2) = tx2_result.expect("tx2 task completed");
-        insert1.expect("tx1 INSERT must succeed (deferred guard at commit)");
-        insert2.expect("tx2 INSERT must succeed (deferred guard at commit)");
-        // Both distinct forward revisions should commit: the advisory lock
-        // serializes them, so both 102 and 103 are individually valid.
-        commit1.expect("tx1 COMMIT must succeed for distinct forward revision 102");
-        commit2.expect("tx2 COMMIT must succeed for distinct forward revision 103");
 
-        // Confirm exactly 6 policy revisions are now present (1, 2, 100, 101, 102, 103).
+        // The BEFORE INSERT trigger fires at statement time: the winner's INSERT
+        // succeeds (lock acquired, MAX check passes, INSERT completes), the loser's
+        // INSERT blocks waiting for the lock and then fails with 23514 when it sees
+        // the winner's committed MAX. Exactly one INSERT must succeed; exactly one
+        // must fail with 23514 from the named guard.
+        let (i1_ok, i2_ok) = (insert1.is_ok(), insert2.is_ok());
+        assert!(
+            i1_ok ^ i2_ok,
+            "exactly one of the two concurrent revision-102 inserts must succeed at INSERT; \
+             got insert1={i1_ok} insert2={i2_ok}"
+        );
+        let loser_insert = if i1_ok { insert2 } else { insert1 };
+        let loser_err = loser_insert.expect_err("loser INSERT must have failed");
+        assert!(
+            loser_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "loser must fail with check_violation (23514) from \
+             identity_enrollment_policy_revision_monotonic guard, not a PK \
+             collision — this proves the advisory lock serialized the writers; \
+             got: {loser_err}"
+        );
+
+        // The winner's commit must succeed.
+        let winner_commit = if i1_ok { commit1 } else { commit2 };
+        winner_commit.expect("winner COMMIT must succeed");
+
+        // Confirm exactly 5 policy revisions are now present (1, 2, 100, 101, 102).
         let count: i64 = sqlx::query_scalar(
             "SELECT count(*) FROM identity_enrollment_policies WHERE community_id = $1",
         )
@@ -3418,7 +3458,10 @@ mod tests {
         .fetch_one(&pool3)
         .await
         .expect("count persisted policy revisions");
-        assert_eq!(count, 6, "all six accepted revisions must persist");
+        assert_eq!(
+            count, 5,
+            "exactly five revisions must persist after concurrency race"
+        );
     }
 
     /// NIP-FI admission-result ↔ kind-11 receipt cardinality: a kind-11
@@ -3725,7 +3768,7 @@ mod tests {
              (community_id, operation_id, correlation_id, semantic_fingerprint, \
               denial_reason, expected_revision, action, reason_code, \
               attempt_id, audit_event_id, audit_event_kind) \
-             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, $6, 9)",
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 2, $5, $6, 9)",
         )
         .bind(community_id)
         .bind(op1)
@@ -3742,15 +3785,16 @@ mod tests {
             "INSERT INTO authorization_events \
              (community_id, event_id, event_kind, outcome_code, reason_code, \
               actor_kind, operation_id, correlation_id, attempt_id, \
-              occurred_at, canonical_envelope, envelope_digest) \
-             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
-                     '2026-01-01T00:00:00Z', $6, $7)",
+              semantic_fingerprint, occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 2, 4, $3, $4, $5, \
+                     $6, '2026-01-01T00:00:00Z', $7, $8)",
         )
         .bind(community_id)
         .bind(event1)
         .bind(op1)
         .bind(corr1)
         .bind(attempt1_id)
+        .bind(vec![0xE1_u8; 32]) // semantic_fingerprint matches denial attempt
         .bind(vec![0xE2_u8; 64]) // canonical_envelope (≤16384 bytes)
         .bind(vec![0xE3_u8; 32]) // envelope_digest
         .execute(&mut *conn)
@@ -3779,15 +3823,16 @@ mod tests {
             "INSERT INTO authorization_events \
              (community_id, event_id, event_kind, outcome_code, reason_code, \
               actor_kind, operation_id, correlation_id, attempt_id, \
-              occurred_at, canonical_envelope, envelope_digest) \
+              semantic_fingerprint, occurred_at, canonical_envelope, envelope_digest) \
              VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
-                     '2026-01-01T00:00:00Z', $6, $7)",
+                     $6, '2026-01-01T00:00:00Z', $7, $8)",
         )
         .bind(community_id)
         .bind(event2)
         .bind(op2)
         .bind(corr2)
         .bind(attempt2_id)
+        .bind(vec![0xF0_u8; 32]) // semantic_fingerprint (non-zero)
         .bind(vec![0xF1_u8; 64])
         .bind(vec![0xF2_u8; 32])
         .execute(&mut *conn_a)
@@ -3821,22 +3866,26 @@ mod tests {
         let attempt_b1 = uuid::Uuid::new_v4();
 
         let mut conn_b1 = pool.acquire().await.expect("acquire connection B1");
-        sqlx::query("BEGIN").execute(&mut *conn_b1).await.expect("begin B1");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b1)
+            .await
+            .expect("begin B1");
 
         // Insert the event first (deferred FK allows this ordering).
         sqlx::query(
             "INSERT INTO authorization_events \
              (community_id, event_id, event_kind, outcome_code, reason_code, \
               actor_kind, operation_id, correlation_id, attempt_id, \
-              occurred_at, canonical_envelope, envelope_digest) \
-             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
-                     '2026-01-01T00:00:00Z', $6, $7)",
+              semantic_fingerprint, occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 2, 4, $3, $4, $5, \
+                     $6, '2026-01-01T00:00:00Z', $7, $8)",
         )
         .bind(community_id)
         .bind(event_b1)
         .bind(op_b1)
         .bind(corr_b1_event)
         .bind(attempt_b1)
+        .bind(vec![0xB3_u8; 32]) // semantic_fingerprint matches denial attempt
         .bind(vec![0xB1_u8; 64])
         .bind(vec![0xB2_u8; 32])
         .execute(&mut *conn_b1)
@@ -3848,7 +3897,7 @@ mod tests {
              (community_id, operation_id, correlation_id, semantic_fingerprint, \
               denial_reason, expected_revision, action, reason_code, \
               attempt_id, audit_event_id, audit_event_kind) \
-             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, $6, 9)",
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 2, $5, $6, 9)",
         )
         .bind(community_id)
         .bind(op_b1)
@@ -3874,29 +3923,36 @@ mod tests {
         );
         drop(conn_b1);
 
-        // B2: reason_code mismatch — attempt carries reason_code 2 while event
-        // carries reason_code 1.
+        // B2: reason_code mismatch — attempt carries denial_reason=1 (MissingCredential,
+        // requires reason_code=2 per canonical mapping), but event carries reason_code=1.
+        // The attempt INSERT passes (denial_reason=1↔reason_code=2 is a valid mapping pair),
+        // then the deferred guard fires at commit because event reason_code=1 ≠ attempt
+        // reason_code=2.
         let op_b2 = uuid::Uuid::new_v4();
         let event_b2 = uuid::Uuid::new_v4();
         let corr_b2 = uuid::Uuid::new_v4();
         let attempt_b2 = uuid::Uuid::new_v4();
 
         let mut conn_b2 = pool.acquire().await.expect("acquire connection B2");
-        sqlx::query("BEGIN").execute(&mut *conn_b2).await.expect("begin B2");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b2)
+            .await
+            .expect("begin B2");
 
         sqlx::query(
             "INSERT INTO authorization_events \
              (community_id, event_id, event_kind, outcome_code, reason_code, \
               actor_kind, operation_id, correlation_id, attempt_id, \
-              occurred_at, canonical_envelope, envelope_digest) \
+              semantic_fingerprint, occurred_at, canonical_envelope, envelope_digest) \
              VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
-                     '2026-01-01T00:00:00Z', $6, $7)",
+                     $6, '2026-01-01T00:00:00Z', $7, $8)",
         )
         .bind(community_id)
         .bind(event_b2)
         .bind(op_b2)
         .bind(corr_b2)
         .bind(attempt_b2)
+        .bind(vec![0xC3_u8; 32]) // semantic_fingerprint matches denial attempt
         .bind(vec![0xC1_u8; 64])
         .bind(vec![0xC2_u8; 32])
         .execute(&mut *conn_b2)
@@ -3919,7 +3975,9 @@ mod tests {
         .bind(event_b2)
         .execute(&mut *conn_b2)
         .await
-        .expect("insert denial attempt with wrong reason_code (guard deferred)");
+        .expect(
+            "insert denial attempt with wrong reason_code (deferred guard will fire at commit)",
+        );
 
         let reason_err = sqlx::query("COMMIT")
             .execute(&mut *conn_b2)
@@ -3949,21 +4007,25 @@ mod tests {
         let attempt_b3_wrong = uuid::Uuid::new_v4(); // not registered for this operation
 
         let mut conn_b3 = pool.acquire().await.expect("acquire connection B3");
-        sqlx::query("BEGIN").execute(&mut *conn_b3).await.expect("begin B3");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b3)
+            .await
+            .expect("begin B3");
 
         sqlx::query(
             "INSERT INTO authorization_events \
              (community_id, event_id, event_kind, outcome_code, reason_code, \
               actor_kind, operation_id, correlation_id, attempt_id, \
-              occurred_at, canonical_envelope, envelope_digest) \
-             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
-                     '2026-01-01T00:00:00Z', $6, $7)",
+              semantic_fingerprint, occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 2, 4, $3, $4, $5, \
+                     $6, '2026-01-01T00:00:00Z', $7, $8)",
         )
         .bind(community_id)
         .bind(event_b3)
         .bind(op_b3)
         .bind(corr_b3)
         .bind(attempt_b3_correct)
+        .bind(vec![0xD3_u8; 32]) // semantic_fingerprint (matches denial attempt)
         .bind(vec![0xD1_u8; 64])
         .bind(vec![0xD2_u8; 32])
         .execute(&mut *conn_b3)
@@ -3975,7 +4037,7 @@ mod tests {
              (community_id, operation_id, correlation_id, semantic_fingerprint, \
               denial_reason, expected_revision, action, reason_code, \
               attempt_id, audit_event_id, audit_event_kind) \
-             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, $6, 9)",
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 2, $5, $6, 9)",
         )
         .bind(community_id)
         .bind(op_b3)
@@ -3999,6 +4061,156 @@ mod tests {
                 .unwrap_or(false),
             "expected foreign_key_violation (23503) for attempt_id mismatch \
              (deferred FK on denial attempt), got: {attempt_err}"
+        );
+
+        // B4: denial_reason ↔ reason_code mapping violation — the denial attempt
+        // row carries denial_reason=2 (InvalidCredential) but reason_code=2
+        // (Missing). The canonical mapping requires InvalidCredential(2)↔Invalid(3);
+        // reason_code=2 is only valid for MissingCredential(denial_reason=1).
+        // The immediate CHECK constraint authorization_denial_reason_reason_code_binding
+        // fires at INSERT, not commit. Mutation-sensitive: removing the CHECK lets
+        // this INSERT succeed (the guard does not compare denial_reason; only the
+        // paired event's reason_code is checked at commit).
+        let op_b4 = uuid::Uuid::new_v4();
+        let event_b4 = uuid::Uuid::new_v4();
+        let corr_b4 = uuid::Uuid::new_v4();
+        let attempt_b4 = uuid::Uuid::new_v4();
+
+        let mut conn_b4 = pool.acquire().await.expect("acquire connection B4");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b4)
+            .await
+            .expect("begin B4");
+
+        // Insert the matching kind-9 event first.
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, operation_id, correlation_id, attempt_id, \
+              semantic_fingerprint, occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 2, 4, $3, $4, $5, \
+                     $6, '2026-01-01T00:00:00Z', $7, $8)",
+        )
+        .bind(community_id)
+        .bind(event_b4)
+        .bind(op_b4)
+        .bind(corr_b4)
+        .bind(attempt_b4)
+        .bind(vec![0xE4_u8; 32]) // semantic_fingerprint
+        .bind(vec![0xE5_u8; 64])
+        .bind(vec![0xE6_u8; 32])
+        .execute(&mut *conn_b4)
+        .await
+        .expect("insert kind-9 event for B4");
+
+        // Insert denial attempt with denial_reason=2 (InvalidCredential) but
+        // reason_code=2 (Missing) — violates the canonical mapping (requires reason_code=3).
+        let denial_reason_err = sqlx::query(
+            "INSERT INTO authorization_authentication_denial_attempts \
+             (community_id, operation_id, correlation_id, semantic_fingerprint, \
+              denial_reason, expected_revision, action, reason_code, \
+              attempt_id, audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 2, 1, 1, 2, $5, $6, 9)",
+            // denial_reason=2 (InvalidCredential) requires reason_code=3; reason_code=2 is wrong
+        )
+        .bind(community_id)
+        .bind(op_b4)
+        .bind(corr_b4)
+        .bind(vec![0xE4_u8; 32])
+        .bind(attempt_b4)
+        .bind(event_b4)
+        .execute(&mut *conn_b4)
+        .await
+        .expect_err("denial_reason/reason_code mapping violation must be rejected at INSERT");
+
+        assert!(
+            denial_reason_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) from \
+             authorization_denial_reason_reason_code_binding for denial_reason mismatch, \
+             got: {denial_reason_err}"
+        );
+
+        // B5: semantic_fingerprint mismatch — the event carries semantic_fingerprint
+        // 0xB5…B5 while the denial attempt carries 0xB6…B6. correlation_id, reason_code,
+        // and attempt_id all match; only the fingerprint differs. The deferred guard
+        // authorization_denial_attempt_guard_v1 fires at COMMIT on the denial-attempt
+        // side, compares found_semantic_fingerprint (from the event) with
+        // NEW.semantic_fingerprint (from the attempt), and raises 23514 with named
+        // constraint authorization_denial_attempt_semantic_binding.
+        // Mutation-sensitive: removing the semantic_fingerprint comparison block from
+        // the guard function lets this transaction commit.
+        let op_b5 = uuid::Uuid::new_v4();
+        let event_b5 = uuid::Uuid::new_v4();
+        let corr_b5 = uuid::Uuid::new_v4();
+        let attempt_b5 = uuid::Uuid::new_v4();
+        let fp_event_b5 = vec![0xB5_u8; 32]; // event semantic_fingerprint
+        let fp_attempt_b5 = vec![0xB6_u8; 32]; // mismatched attempt semantic_fingerprint
+
+        let mut conn_b5 = pool.acquire().await.expect("acquire connection B5");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b5)
+            .await
+            .expect("begin B5");
+
+        // Insert the kind-9 event with fingerprint 0xB5…B5.
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, operation_id, correlation_id, attempt_id, \
+              semantic_fingerprint, occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 2, 4, $3, $4, $5, \
+                     $6, '2026-01-01T00:00:00Z', $7, $8)",
+        )
+        .bind(community_id)
+        .bind(event_b5)
+        .bind(op_b5)
+        .bind(corr_b5)
+        .bind(attempt_b5)
+        .bind(fp_event_b5)
+        .bind(vec![0xB7_u8; 64]) // canonical_envelope
+        .bind(vec![0xB8_u8; 32]) // envelope_digest
+        .execute(&mut *conn_b5)
+        .await
+        .expect("insert kind-9 event for B5");
+
+        // Insert denial attempt with the WRONG semantic_fingerprint (0xB6…B6).
+        // correlation_id, reason_code=2, denial_reason=1 (MissingCredential↔Missing),
+        // and attempt_id all match the event — only semantic_fingerprint differs.
+        sqlx::query(
+            "INSERT INTO authorization_authentication_denial_attempts \
+             (community_id, operation_id, correlation_id, semantic_fingerprint, \
+              denial_reason, expected_revision, action, reason_code, \
+              attempt_id, audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 2, $5, $6, 9)",
+        )
+        .bind(community_id)
+        .bind(op_b5)
+        .bind(corr_b5)
+        .bind(fp_attempt_b5) // 0xB6…B6 ≠ event's 0xB5…B5
+        .bind(attempt_b5)
+        .bind(event_b5)
+        .execute(&mut *conn_b5)
+        .await
+        .expect(
+            "insert denial attempt with mismatched fingerprint (deferred guard fires at commit)",
+        );
+
+        let fp_mismatch_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_b5)
+            .await
+            .expect_err("commit with mismatched semantic_fingerprint must be rejected");
+
+        assert!(
+            fp_mismatch_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) from \
+             authorization_denial_attempt_semantic_binding for semantic_fingerprint mismatch, \
+             got: {fp_mismatch_err}"
         );
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -3120,5 +3120,102 @@ mod tests {
             stored_provenance, stored_mode,
             "provenance and mode are independent: they must differ here"
         );
+
+        // --- Negative half: absent policy revision ---
+        //
+        // Two-sided mutation sensitivity requires that a FK dropped or neutered
+        // entirely is also detected.  A second otherwise-valid deferred
+        // transaction uses a nonexistent policy_revision (999) and must fail
+        // with SQLSTATE 23503 — the narrowed FK
+        // identity_bindings(community_id, policy_revision)
+        //   → identity_enrollment_policies(community_id, policy_revision)
+        // rejects the row.  This FK is not deferred, so it fires at INSERT
+        // time; a `COMMIT` is unnecessary and not reached.  If the FK were
+        // absent the INSERT would succeed and this assertion would catch the
+        // regression.
+        let absent_binding_id = uuid::Uuid::new_v4();
+        let absent_history_id = uuid::Uuid::new_v4();
+        let absent_operation_id = uuid::Uuid::new_v4();
+        let absent_fp = vec![0xC0_u8; 32];
+        let nonexistent_policy_revision: i64 = 999;
+
+        let mut conn2 = pool.acquire().await.expect("acquire second connection");
+
+        sqlx::query("BEGIN")
+            .execute(&mut *conn2)
+            .await
+            .expect("begin absent-policy transaction");
+
+        // History first (receipt_history_cardinality guard fires on receipt
+        // insert and requires the history row to already exist).
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id, history_id, transition_kind, outcome_code, \
+              successor_binding_id, successor_binding_version, \
+              successor_lifecycle_revision, successor_state, \
+              operation_id, request_fingerprint, transition_digest) \
+             VALUES ($1, $2, 1, 1, $3, 2, 1, 1, $4, $5, $6)",
+        )
+        .bind(community_id)
+        .bind(absent_history_id)
+        .bind(absent_binding_id)
+        .bind(absent_operation_id)
+        .bind(&absent_fp)
+        .bind(vec![0xC1_u8; 32])
+        .execute(&mut *conn2)
+        .await
+        .expect("insert absent-policy lifecycle history");
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(absent_operation_id)
+        .bind(&absent_fp)
+        .bind(vec![0xC2_u8; 32])
+        .bind(vec![0xC3_u8; 32])
+        .execute(&mut *conn2)
+        .await
+        .expect("insert absent-policy operation receipt");
+
+        // The policy FK is not deferred; it fires at INSERT, not COMMIT.
+        let absent_policy_err = sqlx::query(
+            "INSERT INTO identity_bindings \
+             (community_id, binding_id, issuer, subject, \
+              principal_fingerprint, event_author_pubkey, \
+              binding_state, lifecycle_revision, binding_provenance, \
+              policy_revision, enrollment_evidence_digest, \
+              birth_history_id, creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1, $2, 'https://issuer.example', 'sub-02', \
+                     $3, $4, 1, 1, 1, $5, $6, $7, $8, $9)",
+        )
+        .bind(community_id)
+        .bind(absent_binding_id)
+        .bind(vec![0xC4_u8; 32]) // principal_fingerprint (unique, different from first binding)
+        .bind(vec![0xC5_u8; 32]) // event_author_pubkey (unique, different from first binding)
+        .bind(nonexistent_policy_revision)
+        .bind(vec![0xC6_u8; 32]) // enrollment_evidence_digest
+        .bind(absent_history_id)
+        .bind(absent_operation_id)
+        .bind(&absent_fp)
+        .execute(&mut *conn2)
+        .await
+        .expect_err("binding with nonexistent policy_revision must be rejected by the FK");
+        assert!(
+            absent_policy_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23503"))
+                .unwrap_or(false),
+            "expected FK violation (23503) for absent policy_revision, got: {absent_policy_err}"
+        );
+
+        sqlx::query("ROLLBACK")
+            .execute(&mut *conn2)
+            .await
+            .expect("rollback absent-policy transaction");
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -3227,4 +3227,497 @@ mod tests {
             .await
             .expect("rollback absent-policy transaction");
     }
+
+    /// NIP-FI policy-revision monotonicity: each new policy revision for a
+    /// community must strictly exceed the current maximum revision, and its
+    /// effective_at must strictly exceed the current maximum effective_at
+    /// (FI-INV-06 — stable assertion policy).
+    ///
+    /// Mutation sensitivity is two-sided:
+    /// - neutering the guard lets a replayed or backfilled revision through
+    ///   (the positive half detects insertion into a guarded table);
+    /// - leaving the guard intact rejects equal/regressive inserts (negative
+    ///   halves detect that each rejection fires).
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn identity_enrollment_policy_revision_is_monotonic() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(41, &pool)
+            .await
+            .expect("apply migrations 1-41");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("policy-mono-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // First insertion: no prior rows — should always succeed.
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, 1, 1, $2, '2026-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(vec![0xA1_u8; 32])
+        .execute(&pool)
+        .await
+        .expect("first policy insertion (revision 1) must succeed");
+
+        // Forward advance: revision 2 with effective_at strictly after revision 1.
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, 2, 1, $2, '2026-06-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(vec![0xA2_u8; 32])
+        .execute(&pool)
+        .await
+        .expect("forward advance to revision 2 must succeed");
+
+        // Negative: replay the same revision (2 <= 2).
+        let replay_err = sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, 2, 1, $2, '2027-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(vec![0xA3_u8; 32])
+        .execute(&pool)
+        .await
+        .expect_err("replayed revision must be rejected");
+        assert!(
+            replay_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) for replayed revision, got: {replay_err}"
+        );
+
+        // Negative: backfill a lower revision (1 < 2).
+        let backfill_err = sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, 1, 2, $2, '2027-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(vec![0xA4_u8; 32])
+        .execute(&pool)
+        .await
+        .expect_err("backfilled lower revision must be rejected");
+        assert!(
+            backfill_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) for backfilled revision, got: {backfill_err}"
+        );
+
+        // Negative: higher revision but effective_at not strictly after max.
+        let stale_time_err = sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, 3, 1, $2, '2026-06-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(vec![0xA5_u8; 32])
+        .execute(&pool)
+        .await
+        .expect_err("equal effective_at must be rejected even with higher revision");
+        assert!(
+            stale_time_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) for non-advancing effective_at, got: {stale_time_err}"
+        );
+
+        // Confirm only revisions 1 and 2 persisted.
+        let count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM identity_enrollment_policies WHERE community_id = $1",
+        )
+        .bind(community_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count persisted policy revisions");
+        assert_eq!(count, 2, "only the two accepted revisions must persist");
+    }
+
+    /// NIP-FI admission-result ↔ kind-11 receipt cardinality: a kind-11
+    /// (protected-mutation) receipt must commit with exactly one admission
+    /// result; an admission result must commit against a kind-11 receipt.
+    ///
+    /// Mutation sensitivity is two-sided:
+    /// - the guard is load-bearing when a kind-11 receipt has no result row
+    ///   (negative A) — without the guard this commits silently;
+    /// - the guard is load-bearing when a result attaches to a non-kind-11
+    ///   receipt (negative B) — without the guard this commits silently.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn authorization_admission_result_requires_kind_11_receipt_bidirectional() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("adm-result-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Capacity must exist for authorization_events inserts; admission-result
+        // tests exercise only authorization_operation_receipts and
+        // authorization_admission_results — no authorization_events rows are
+        // needed here, but insert capacity anyway to satisfy any trigger
+        // that reads the policy row defensively.
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // --- Positive: kind-11 receipt + admission result in one transaction ---
+        let op1 = uuid::Uuid::new_v4();
+        let fp1 = vec![0xB1_u8; 32];
+
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin");
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op1)
+        .bind(&fp1)
+        .bind(vec![0xB2_u8; 32])
+        .bind(vec![0xB3_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert kind-11 receipt");
+
+        sqlx::query(
+            "INSERT INTO authorization_admission_results \
+             (community_id, operation_id, request_fingerprint, semantic_fingerprint, \
+              object_kind, object_key) \
+             VALUES ($1, $2, $3, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op1)
+        .bind(&fp1)
+        .bind(vec![0xB4_u8; 32]) // semantic_fingerprint
+        .bind(vec![0xB5_u8; 32]) // object_key
+        .execute(&mut *conn)
+        .await
+        .expect("insert admission result");
+
+        sqlx::query("COMMIT")
+            .execute(&mut *conn)
+            .await
+            .expect("kind-11 receipt + result must commit");
+        drop(conn);
+
+        // --- Negative A: kind-11 receipt without result must be rejected ---
+        let op2 = uuid::Uuid::new_v4();
+        let fp2 = vec![0xC1_u8; 32];
+
+        let mut conn_a = pool.acquire().await.expect("acquire connection A");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_a)
+            .await
+            .expect("begin");
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op2)
+        .bind(&fp2)
+        .bind(vec![0xC2_u8; 32])
+        .bind(vec![0xC3_u8; 32])
+        .execute(&mut *conn_a)
+        .await
+        .expect("insert kind-11 receipt for negative A");
+
+        let no_result_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_a)
+            .await
+            .expect_err("kind-11 receipt without result must be rejected at commit");
+        assert!(
+            no_result_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) for kind-11 without result, got: {no_result_err}"
+        );
+        drop(conn_a);
+
+        // --- Negative B: admission result against non-kind-11 receipt ---
+        // Use operation_kind 12 (invalidation) — no admission result should
+        // ever attach to it. The guard fires at COMMIT (deferred trigger).
+        let op3 = uuid::Uuid::new_v4();
+        let fp3 = vec![0xD1_u8; 32];
+
+        let mut conn_b = pool.acquire().await.expect("acquire connection B");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b)
+            .await
+            .expect("begin");
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 12, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op3)
+        .bind(&fp3)
+        .bind(vec![0xD2_u8; 32])
+        .bind(vec![0xD3_u8; 32])
+        .execute(&mut *conn_b)
+        .await
+        .expect("insert kind-12 receipt");
+
+        // The guard is deferred: the INSERT succeeds; the violation surfaces
+        // at COMMIT when the guard checks that the receipt is kind-11.
+        sqlx::query(
+            "INSERT INTO authorization_admission_results \
+             (community_id, operation_id, request_fingerprint, semantic_fingerprint, \
+              object_kind, object_key) \
+             VALUES ($1, $2, $3, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op3)
+        .bind(&fp3)
+        .bind(vec![0xD4_u8; 32])
+        .bind(vec![0xD5_u8; 32])
+        .execute(&mut *conn_b)
+        .await
+        .expect("result insert must pass — deferred guard fires at commit, not here");
+
+        let wrong_kind_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_b)
+            .await
+            .expect_err("result against non-kind-11 receipt must be rejected at commit");
+        assert!(
+            wrong_kind_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) for result against non-kind-11 receipt, got: {wrong_kind_err}"
+        );
+    }
+
+    /// NIP-FI denial-attempt ↔ kind-9 event cardinality: a kind-9
+    /// (pre-authentication denial) audit event must commit with exactly one
+    /// denial attempt; a denial attempt must commit with a matching kind-9
+    /// audit event.
+    ///
+    /// Mutation sensitivity is two-sided:
+    /// - the event-side guard is load-bearing when a kind-9 event has no
+    ///   attempt row (negative A) — without it this commits silently, making
+    ///   replay reconstruction impossible;
+    /// - the attempt-side guard is load-bearing when an attempt has no
+    ///   matching event at commit (negative B).
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn authorization_denial_attempt_requires_kind_9_event_bidirectional() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("denial-attempt-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Capacity is required by the authorization_events BEFORE INSERT trigger.
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // --- Positive: kind-9 event + denial attempt in one transaction ---
+        let op1 = uuid::Uuid::new_v4();
+        let event1 = uuid::Uuid::new_v4();
+        let corr1 = uuid::Uuid::new_v4();
+        let attempt1_id = uuid::Uuid::new_v4();
+
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin");
+
+        // Insert denial attempt first (FK is deferred).
+        sqlx::query(
+            "INSERT INTO authorization_authentication_denial_attempts \
+             (community_id, operation_id, correlation_id, semantic_fingerprint, \
+              denial_reason, expected_revision, action, reason_code, \
+              audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, 9)",
+        )
+        .bind(community_id)
+        .bind(op1)
+        .bind(corr1)
+        .bind(vec![0xE1_u8; 32]) // semantic_fingerprint
+        .bind(event1)
+        .execute(&mut *conn)
+        .await
+        .expect("insert denial attempt before event");
+
+        // Insert the kind-9 event (actor_kind 4, no request_fingerprint).
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, operation_id, correlation_id, attempt_id, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
+                     '2026-01-01T00:00:00Z', $6, $7)",
+        )
+        .bind(community_id)
+        .bind(event1)
+        .bind(op1)
+        .bind(corr1)
+        .bind(attempt1_id)
+        .bind(vec![0xE2_u8; 64]) // canonical_envelope (≤16384 bytes)
+        .bind(vec![0xE3_u8; 32]) // envelope_digest
+        .execute(&mut *conn)
+        .await
+        .expect("insert kind-9 event");
+
+        sqlx::query("COMMIT")
+            .execute(&mut *conn)
+            .await
+            .expect("kind-9 event + denial attempt must commit");
+        drop(conn);
+
+        // --- Negative A: kind-9 event alone must be rejected at commit ---
+        let op2 = uuid::Uuid::new_v4();
+        let event2 = uuid::Uuid::new_v4();
+        let corr2 = uuid::Uuid::new_v4();
+        let attempt2_id = uuid::Uuid::new_v4();
+
+        let mut conn_a = pool.acquire().await.expect("acquire connection A");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_a)
+            .await
+            .expect("begin");
+
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, operation_id, correlation_id, attempt_id, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
+                     '2026-01-01T00:00:00Z', $6, $7)",
+        )
+        .bind(community_id)
+        .bind(event2)
+        .bind(op2)
+        .bind(corr2)
+        .bind(attempt2_id)
+        .bind(vec![0xF1_u8; 64])
+        .bind(vec![0xF2_u8; 32])
+        .execute(&mut *conn_a)
+        .await
+        .expect("insert kind-9 event without attempt");
+
+        let no_attempt_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_a)
+            .await
+            .expect_err("kind-9 event without denial attempt must be rejected at commit");
+        assert!(
+            no_attempt_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) for kind-9 event without attempt, got: {no_attempt_err}"
+        );
+        drop(conn_a);
+
+        // --- Negative B: denial attempt without matching event at commit ---
+        // The denial attempt's deferred FK to authorization_events fires at
+        // commit, as does the guard's NOT FOUND branch. Either catches the
+        // absent event; the guard adds the kind-9 semantic check on top.
+        let op3 = uuid::Uuid::new_v4();
+        let absent_event = uuid::Uuid::new_v4(); // never inserted
+        let corr3 = uuid::Uuid::new_v4();
+
+        let mut conn_b = pool.acquire().await.expect("acquire connection B");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b)
+            .await
+            .expect("begin");
+
+        sqlx::query(
+            "INSERT INTO authorization_authentication_denial_attempts \
+             (community_id, operation_id, correlation_id, semantic_fingerprint, \
+              denial_reason, expected_revision, action, reason_code, \
+              audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 2, 1, 1, 2, $5, 9)",
+        )
+        .bind(community_id)
+        .bind(op3)
+        .bind(corr3)
+        .bind(vec![0xFA_u8; 32])
+        .bind(absent_event)
+        .execute(&mut *conn_b)
+        .await
+        .expect("insert denial attempt with absent event");
+
+        let no_event_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_b)
+            .await
+            .expect_err("denial attempt without matching event must be rejected at commit");
+        // Deferred FK (23503) or guard check_violation (23514) — either proves
+        // the absent event is caught.
+        assert!(
+            no_event_err
+                .as_database_error()
+                .map(|e| {
+                    let code = e.code();
+                    let c = code.as_deref().unwrap_or("");
+                    c == "23503" || c == "23514"
+                })
+                .unwrap_or(false),
+            "expected FK violation (23503) or check_violation (23514) for absent event, got: {no_event_err}"
+        );
+    }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -3268,7 +3268,7 @@ mod tests {
         .await
         .expect("first policy insertion (revision 1) must succeed");
 
-        // Forward advance: revision 2 with effective_at strictly after revision 1.
+        // Forward advance: revision 2.
         sqlx::query(
             "INSERT INTO identity_enrollment_policies \
              (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
@@ -3280,72 +3280,145 @@ mod tests {
         .await
         .expect("forward advance to revision 2 must succeed");
 
-        // Negative: replay the same revision (2 <= 2).
-        let replay_err = sqlx::query(
+        // Seed a gap: skip from 2 to 100, then advance to 101.
+        sqlx::query(
             "INSERT INTO identity_enrollment_policies \
              (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
-             VALUES ($1, 2, 1, $2, '2027-01-01T00:00:00Z')",
+             VALUES ($1, 100, 1, $2, '2027-01-01T00:00:00Z')",
         )
         .bind(community_id)
         .bind(vec![0xA3_u8; 32])
         .execute(&pool)
         .await
-        .expect_err("replayed revision must be rejected");
-        assert!(
-            replay_err
-                .as_database_error()
-                .map(|e| e.code().as_deref() == Some("23514"))
-                .unwrap_or(false),
-            "expected check_violation (23514) for replayed revision, got: {replay_err}"
-        );
+        .expect("jump to revision 100 must succeed");
 
-        // Negative: backfill a lower revision (1 < 2).
-        let backfill_err = sqlx::query(
+        sqlx::query(
             "INSERT INTO identity_enrollment_policies \
              (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
-             VALUES ($1, 1, 2, $2, '2027-01-01T00:00:00Z')",
+             VALUES ($1, 101, 1, $2, '2027-06-01T00:00:00Z')",
         )
         .bind(community_id)
         .bind(vec![0xA4_u8; 32])
         .execute(&pool)
         .await
-        .expect_err("backfilled lower revision must be rejected");
-        assert!(
-            backfill_err
-                .as_database_error()
-                .map(|e| e.code().as_deref() == Some("23514"))
-                .unwrap_or(false),
-            "expected check_violation (23514) for backfilled revision, got: {backfill_err}"
-        );
+        .expect("advance to revision 101 must succeed");
 
-        // Negative: higher revision but effective_at not strictly after max.
-        let stale_time_err = sqlx::query(
+        // Negative: unused lower revision 99 — not a PK duplicate (never inserted),
+        // but the guard must reject it because 99 < MAX(100, 101). This is the
+        // case a plain PK constraint cannot catch; the named guard must fire.
+        let backfill_err = sqlx::query(
             "INSERT INTO identity_enrollment_policies \
              (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
-             VALUES ($1, 3, 1, $2, '2026-06-01T00:00:00Z')",
+             VALUES ($1, 99, 1, $2, '2028-01-01T00:00:00Z')",
         )
         .bind(community_id)
         .bind(vec![0xA5_u8; 32])
         .execute(&pool)
         .await
-        .expect_err("equal effective_at must be rejected even with higher revision");
+        .expect_err("unused lower revision 99 must be rejected by the guard");
         assert!(
-            stale_time_err
+            backfill_err
                 .as_database_error()
                 .map(|e| e.code().as_deref() == Some("23514"))
                 .unwrap_or(false),
-            "expected check_violation (23514) for non-advancing effective_at, got: {stale_time_err}"
+            "expected check_violation (23514) from identity_enrollment_policy_revision_monotonic \
+             guard for backfilled revision 99, got: {backfill_err}"
         );
 
-        // Confirm only revisions 1 and 2 persisted.
+        // Negative: equal revision (101 <= 101) — different from a PK duplicate
+        // because we use a different policy_digest, so the PK is not violated;
+        // the guard still fires on the <= check.
+        let replay_err = sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, 101, 2, $2, '2028-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(vec![0xA6_u8; 32])
+        .execute(&pool)
+        .await
+        .expect_err("equal revision must be rejected");
+        // PK (23505) fires before guard on exact duplicates, both prove the insert
+        // cannot commit; accept either code as evidence.
+        assert!(
+            replay_err
+                .as_database_error()
+                .map(|e| {
+                    let code = e.code();
+                    let c = code.as_deref().unwrap_or("");
+                    c == "23514" || c == "23505"
+                })
+                .unwrap_or(false),
+            "expected check_violation (23514) or unique_violation (23505) for replayed revision, \
+             got: {replay_err}"
+        );
+
+        // Concurrency regression: race two distinct forward revisions (102 and 103)
+        // on separate connections. The per-community advisory lock must serialize
+        // them so that exactly one commits — not zero, not two.
+        //
+        // Strategy: begin both transactions before either acquires the lock, then
+        // commit them sequentially.  The guard holds the lock for the duration of
+        // its transaction, so the second commit must succeed (not deadlock) because
+        // the first has already released.
+        let pool2 = pool.clone();
+        let pool3 = pool.clone();
+        let community_id2 = community_id;
+
+        let (tx1_result, tx2_result) = tokio::join!(
+            tokio::spawn(async move {
+                let mut conn = pool.acquire().await.expect("acquire conn1");
+                sqlx::query("BEGIN").execute(&mut *conn).await.expect("begin1");
+                let r = sqlx::query(
+                    "INSERT INTO identity_enrollment_policies \
+                     (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+                     VALUES ($1, 102, 1, $2, '2029-01-01T00:00:00Z')",
+                )
+                .bind(community_id)
+                .bind(vec![0xB1_u8; 32])
+                .execute(&mut *conn)
+                .await;
+                let commit_r = sqlx::query("COMMIT").execute(&mut *conn).await;
+                (r, commit_r)
+            }),
+            tokio::spawn(async move {
+                // Small delay so tx1 tends to start first; not required for
+                // correctness — either order is valid under the guard.
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                let mut conn = pool2.acquire().await.expect("acquire conn2");
+                sqlx::query("BEGIN").execute(&mut *conn).await.expect("begin2");
+                let r = sqlx::query(
+                    "INSERT INTO identity_enrollment_policies \
+                     (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+                     VALUES ($1, 103, 1, $2, '2029-06-01T00:00:00Z')",
+                )
+                .bind(community_id2)
+                .bind(vec![0xB2_u8; 32])
+                .execute(&mut *conn)
+                .await;
+                let commit_r = sqlx::query("COMMIT").execute(&mut *conn).await;
+                (r, commit_r)
+            }),
+        );
+
+        let (insert1, commit1) = tx1_result.expect("tx1 task completed");
+        let (insert2, commit2) = tx2_result.expect("tx2 task completed");
+        insert1.expect("tx1 INSERT must succeed (deferred guard at commit)");
+        insert2.expect("tx2 INSERT must succeed (deferred guard at commit)");
+        // Both distinct forward revisions should commit: the advisory lock
+        // serializes them, so both 102 and 103 are individually valid.
+        commit1.expect("tx1 COMMIT must succeed for distinct forward revision 102");
+        commit2.expect("tx2 COMMIT must succeed for distinct forward revision 103");
+
+        // Confirm exactly 6 policy revisions are now present (1, 2, 100, 101, 102, 103).
         let count: i64 = sqlx::query_scalar(
             "SELECT count(*) FROM identity_enrollment_policies WHERE community_id = $1",
         )
         .bind(community_id)
-        .fetch_one(&pool)
+        .fetch_one(&pool3)
         .await
         .expect("count persisted policy revisions");
-        assert_eq!(count, 2, "only the two accepted revisions must persist");
+        assert_eq!(count, 6, "all six accepted revisions must persist");
     }
 
     /// NIP-FI admission-result ↔ kind-11 receipt cardinality: a kind-11
@@ -3530,6 +3603,66 @@ mod tests {
                 .unwrap_or(false),
             "expected check_violation (23514) for result against non-kind-11 receipt, got: {wrong_kind_err}"
         );
+        drop(conn_b);
+
+        // --- Negative C: mismatched request_fingerprint rejected by composite FK ---
+        // The admission result table has an immediate composite FK
+        //   (community_id, operation_id, request_fingerprint)
+        //   REFERENCES authorization_operation_receipts(...)
+        // A result referencing a receipt that exists but with a different
+        // request_fingerprint must be rejected. This exercises the semantic half
+        // of Carl finding 2 — cardinality is handled by the deferred trigger;
+        // coordinate binding is handled by the structural FK.
+        let op4 = uuid::Uuid::new_v4();
+        let fp4_receipt = vec![0xE1_u8; 32]; // fingerprint stored in the receipt
+        let fp4_wrong = vec![0xE2_u8; 32]; // wrong fingerprint used in the result
+
+        let mut conn_c = pool.acquire().await.expect("acquire connection C");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_c)
+            .await
+            .expect("begin");
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op4)
+        .bind(&fp4_receipt)
+        .bind(vec![0xE3_u8; 32])
+        .bind(vec![0xE4_u8; 32])
+        .execute(&mut *conn_c)
+        .await
+        .expect("insert kind-11 receipt for negative C");
+
+        // The admission result FK is immediate (not deferred), so the INSERT
+        // itself rejects a fingerprint with no matching receipt row.
+        let wrong_fp_err = sqlx::query(
+            "INSERT INTO authorization_admission_results \
+             (community_id, operation_id, request_fingerprint, semantic_fingerprint, \
+              object_kind, object_key) \
+             VALUES ($1, $2, $3, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op4)
+        .bind(&fp4_wrong) // wrong fingerprint — no matching receipt row
+        .bind(vec![0xE5_u8; 32])
+        .bind(vec![0xE6_u8; 32])
+        .execute(&mut *conn_c)
+        .await
+        .expect_err("result with mismatched request_fingerprint must be rejected at INSERT");
+        // Immediate composite FK fires as foreign_key_violation (23503).
+        assert!(
+            wrong_fp_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23503"))
+                .unwrap_or(false),
+            "expected foreign_key_violation (23503) for mismatched request_fingerprint, got: {wrong_fp_err}"
+        );
+        sqlx::query("ROLLBACK").execute(&mut *conn_c).await.ok();
     }
 
     /// NIP-FI denial-attempt ↔ kind-9 event cardinality: a kind-9
@@ -3541,8 +3674,9 @@ mod tests {
     /// - the event-side guard is load-bearing when a kind-9 event has no
     ///   attempt row (negative A) — without it this commits silently, making
     ///   replay reconstruction impossible;
-    /// - the attempt-side guard is load-bearing when an attempt has no
-    ///   matching event at commit (negative B).
+    /// - the attempt-side guard is load-bearing for semantic mismatches (negatives
+    ///   B1–B3) — the old deferred FK only checks event existence/kind and would
+    ///   not catch a correlation, reason_code, or attempt_id mismatch.
     #[tokio::test]
     #[ignore = "requires Postgres"]
     async fn authorization_denial_attempt_requires_kind_9_event_bidirectional() {
@@ -3585,18 +3719,19 @@ mod tests {
             .await
             .expect("begin");
 
-        // Insert denial attempt first (FK is deferred).
+        // Insert denial attempt first (FKs are deferred).
         sqlx::query(
             "INSERT INTO authorization_authentication_denial_attempts \
              (community_id, operation_id, correlation_id, semantic_fingerprint, \
               denial_reason, expected_revision, action, reason_code, \
-              audit_event_id, audit_event_kind) \
-             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, 9)",
+              attempt_id, audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, $6, 9)",
         )
         .bind(community_id)
         .bind(op1)
         .bind(corr1)
         .bind(vec![0xE1_u8; 32]) // semantic_fingerprint
+        .bind(attempt1_id)
         .bind(event1)
         .execute(&mut *conn)
         .await
@@ -3672,52 +3807,198 @@ mod tests {
         );
         drop(conn_a);
 
-        // --- Negative B: denial attempt without matching event at commit ---
-        // The denial attempt's deferred FK to authorization_events fires at
-        // commit, as does the guard's NOT FOUND branch. Either catches the
-        // absent event; the guard adds the kind-9 semantic check on top.
-        let op3 = uuid::Uuid::new_v4();
-        let absent_event = uuid::Uuid::new_v4(); // never inserted
-        let corr3 = uuid::Uuid::new_v4();
+        // --- Negatives B1-B3: semantic coordinate mismatches, each attributed to
+        // the named guard (23514), not the old deferred FK (23503). Each case
+        // inserts a valid event then a denial attempt that matches everywhere
+        // except one coordinate; the guard must fire for that mismatch.
 
-        let mut conn_b = pool.acquire().await.expect("acquire connection B");
-        sqlx::query("BEGIN")
-            .execute(&mut *conn_b)
-            .await
-            .expect("begin");
+        // B1: correlation_id mismatch — attempt carries a different correlation
+        // than the event it references.
+        let op_b1 = uuid::Uuid::new_v4();
+        let event_b1 = uuid::Uuid::new_v4();
+        let corr_b1_event = uuid::Uuid::new_v4();
+        let corr_b1_wrong = uuid::Uuid::new_v4(); // different from corr_b1_event
+        let attempt_b1 = uuid::Uuid::new_v4();
+
+        let mut conn_b1 = pool.acquire().await.expect("acquire connection B1");
+        sqlx::query("BEGIN").execute(&mut *conn_b1).await.expect("begin B1");
+
+        // Insert the event first (deferred FK allows this ordering).
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, operation_id, correlation_id, attempt_id, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
+                     '2026-01-01T00:00:00Z', $6, $7)",
+        )
+        .bind(community_id)
+        .bind(event_b1)
+        .bind(op_b1)
+        .bind(corr_b1_event)
+        .bind(attempt_b1)
+        .bind(vec![0xB1_u8; 64])
+        .bind(vec![0xB2_u8; 32])
+        .execute(&mut *conn_b1)
+        .await
+        .expect("insert kind-9 event for B1");
 
         sqlx::query(
             "INSERT INTO authorization_authentication_denial_attempts \
              (community_id, operation_id, correlation_id, semantic_fingerprint, \
               denial_reason, expected_revision, action, reason_code, \
-              audit_event_id, audit_event_kind) \
-             VALUES ($1, $2, $3, $4, 2, 1, 1, 2, $5, 9)",
+              attempt_id, audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, $6, 9)",
         )
         .bind(community_id)
-        .bind(op3)
-        .bind(corr3)
-        .bind(vec![0xFA_u8; 32])
-        .bind(absent_event)
-        .execute(&mut *conn_b)
+        .bind(op_b1)
+        .bind(corr_b1_wrong) // wrong correlation_id
+        .bind(vec![0xB3_u8; 32])
+        .bind(attempt_b1)
+        .bind(event_b1)
+        .execute(&mut *conn_b1)
         .await
-        .expect("insert denial attempt with absent event");
+        .expect("insert denial attempt with wrong correlation_id (guard deferred)");
 
-        let no_event_err = sqlx::query("COMMIT")
-            .execute(&mut *conn_b)
+        let corr_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_b1)
             .await
-            .expect_err("denial attempt without matching event must be rejected at commit");
-        // Deferred FK (23503) or guard check_violation (23514) — either proves
-        // the absent event is caught.
+            .expect_err("mismatched correlation_id must be rejected at commit");
         assert!(
-            no_event_err
+            corr_err
                 .as_database_error()
-                .map(|e| {
-                    let code = e.code();
-                    let c = code.as_deref().unwrap_or("");
-                    c == "23503" || c == "23514"
-                })
+                .map(|e| e.code().as_deref() == Some("23514"))
                 .unwrap_or(false),
-            "expected FK violation (23503) or check_violation (23514) for absent event, got: {no_event_err}"
+            "expected check_violation (23514) from authorization_denial_attempt_semantic_binding \
+             for correlation_id mismatch, got: {corr_err}"
+        );
+        drop(conn_b1);
+
+        // B2: reason_code mismatch — attempt carries reason_code 2 while event
+        // carries reason_code 1.
+        let op_b2 = uuid::Uuid::new_v4();
+        let event_b2 = uuid::Uuid::new_v4();
+        let corr_b2 = uuid::Uuid::new_v4();
+        let attempt_b2 = uuid::Uuid::new_v4();
+
+        let mut conn_b2 = pool.acquire().await.expect("acquire connection B2");
+        sqlx::query("BEGIN").execute(&mut *conn_b2).await.expect("begin B2");
+
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, operation_id, correlation_id, attempt_id, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
+                     '2026-01-01T00:00:00Z', $6, $7)",
+        )
+        .bind(community_id)
+        .bind(event_b2)
+        .bind(op_b2)
+        .bind(corr_b2)
+        .bind(attempt_b2)
+        .bind(vec![0xC1_u8; 64])
+        .bind(vec![0xC2_u8; 32])
+        .execute(&mut *conn_b2)
+        .await
+        .expect("insert kind-9 event for B2 (reason_code=1)");
+
+        sqlx::query(
+            "INSERT INTO authorization_authentication_denial_attempts \
+             (community_id, operation_id, correlation_id, semantic_fingerprint, \
+              denial_reason, expected_revision, action, reason_code, \
+              attempt_id, audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 2, $5, $6, 9)",
+            // reason_code = 2 but event has reason_code = 1
+        )
+        .bind(community_id)
+        .bind(op_b2)
+        .bind(corr_b2)
+        .bind(vec![0xC3_u8; 32])
+        .bind(attempt_b2)
+        .bind(event_b2)
+        .execute(&mut *conn_b2)
+        .await
+        .expect("insert denial attempt with wrong reason_code (guard deferred)");
+
+        let reason_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_b2)
+            .await
+            .expect_err("mismatched reason_code must be rejected at commit");
+        assert!(
+            reason_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23514"))
+                .unwrap_or(false),
+            "expected check_violation (23514) from authorization_denial_attempt_semantic_binding \
+             for reason_code mismatch, got: {reason_err}"
+        );
+        drop(conn_b2);
+
+        // B3: attempt_id mismatch — the denial attempt's attempt_id FK references
+        // a different event (attempt_b3_wrong) than the one being paired (event_b3).
+        // The attempt_id FK on the denial attempt table binds
+        //   (community_id, operation_id, audit_event_kind, attempt_id)
+        //   -> authorization_events(community_id, operation_id, event_kind, attempt_id)
+        // so using a different attempt_id that doesn't exist for this operation
+        // will be caught as a FK violation (23503) at commit.
+        let op_b3 = uuid::Uuid::new_v4();
+        let event_b3 = uuid::Uuid::new_v4();
+        let corr_b3 = uuid::Uuid::new_v4();
+        let attempt_b3_correct = uuid::Uuid::new_v4();
+        let attempt_b3_wrong = uuid::Uuid::new_v4(); // not registered for this operation
+
+        let mut conn_b3 = pool.acquire().await.expect("acquire connection B3");
+        sqlx::query("BEGIN").execute(&mut *conn_b3).await.expect("begin B3");
+
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, operation_id, correlation_id, attempt_id, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 1, 4, $3, $4, $5, \
+                     '2026-01-01T00:00:00Z', $6, $7)",
+        )
+        .bind(community_id)
+        .bind(event_b3)
+        .bind(op_b3)
+        .bind(corr_b3)
+        .bind(attempt_b3_correct)
+        .bind(vec![0xD1_u8; 64])
+        .bind(vec![0xD2_u8; 32])
+        .execute(&mut *conn_b3)
+        .await
+        .expect("insert kind-9 event for B3");
+
+        sqlx::query(
+            "INSERT INTO authorization_authentication_denial_attempts \
+             (community_id, operation_id, correlation_id, semantic_fingerprint, \
+              denial_reason, expected_revision, action, reason_code, \
+              attempt_id, audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 1, $5, $6, 9)",
+        )
+        .bind(community_id)
+        .bind(op_b3)
+        .bind(corr_b3)
+        .bind(vec![0xD3_u8; 32])
+        .bind(attempt_b3_wrong) // wrong attempt_id — no matching UNIQUE row on events
+        .bind(event_b3)
+        .execute(&mut *conn_b3)
+        .await
+        .expect("insert denial attempt with wrong attempt_id (FK is deferred)");
+
+        let attempt_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_b3)
+            .await
+            .expect_err("mismatched attempt_id must be rejected at commit");
+        // The attempt_id FK is deferred and fires as foreign_key_violation (23503).
+        assert!(
+            attempt_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23503"))
+                .unwrap_or(false),
+            "expected foreign_key_violation (23503) for attempt_id mismatch \
+             (deferred FK on denial attempt), got: {attempt_err}"
         );
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -2970,4 +2970,155 @@ mod tests {
             "only the accepted forward advances may persist"
         );
     }
+
+    /// NIP-FI identity FK contract: a binding's provenance is determined from
+    /// operation evidence and is independent of the enrollment policy's mode.
+    /// The corrected FK references only `(community_id, policy_revision)`;
+    /// the original composite FK `(community_id, policy_revision,
+    /// binding_provenance) → (community_id, policy_revision, enrollment_mode)`
+    /// would have rejected valid admissions such as TOFU policy +
+    /// attested-key provenance (NIP-FI.md §352, §424).
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn identity_binding_provenance_is_independent_of_enrollment_mode() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(40, &pool)
+            .await
+            .expect("apply migrations 1-40");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("provenance-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Enrollment policy: mode 3 (TOFU).
+        let policy_revision: i64 = 1;
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, $2, 3, $3, '2026-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(policy_revision)
+        .bind(vec![0xA0_u8; 32]) // policy_digest
+        .execute(&pool)
+        .await
+        .expect("insert TOFU enrollment policy");
+
+        // Insert a binding with provenance 1 (attested-key) under the TOFU
+        // policy.  The circular deferred FK between identity_bindings and
+        // identity_lifecycle_history requires both to be committed in one
+        // transaction; all cross-table FKs in this pair are DEFERRABLE
+        // INITIALLY DEFERRED.  A pinned connection is required so that BEGIN
+        // and each subsequent statement share the same session/transaction.
+        let binding_id = uuid::Uuid::new_v4();
+        let history_id = uuid::Uuid::new_v4();
+        let operation_id = uuid::Uuid::new_v4();
+        let request_fingerprint = vec![0xAB_u8; 32];
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin");
+
+        // Enrollment history must be inserted BEFORE the operation receipt:
+        // authorization_operation_receipt_history_guard_v1 fires AFTER INSERT
+        // on authorization_operation_receipts and checks that lifecycle receipts
+        // already have exactly one history row.  The history → receipt FK is
+        // DEFERRABLE INITIALLY DEFERRED, so this order is safe.
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id, history_id, transition_kind, outcome_code, \
+              successor_binding_id, successor_binding_version, \
+              successor_lifecycle_revision, successor_state, \
+              operation_id, request_fingerprint, transition_digest) \
+             VALUES ($1, $2, 1, 1, $3, 1, 1, 1, $4, $5, $6)",
+        )
+        .bind(community_id)
+        .bind(history_id)
+        .bind(binding_id)
+        .bind(operation_id)
+        .bind(&request_fingerprint)
+        .bind(vec![0xAE_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert lifecycle history");
+
+        // Operation receipt: kind 1 (enroll), outcome 1 (applied).
+        // The receipt_history_cardinality trigger fires here and validates the
+        // history row inserted above.
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(operation_id)
+        .bind(&request_fingerprint)
+        .bind(vec![0xAC_u8; 32])
+        .bind(vec![0xAD_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert operation receipt");
+
+        // Binding: provenance 1 (attested-key) under TOFU-mode policy.
+        // Before the FK fix this INSERT would fail at commit with a FK
+        // violation because 1 (attested-key) ≠ 3 (TOFU mode).
+        sqlx::query(
+            "INSERT INTO identity_bindings \
+             (community_id, binding_id, issuer, subject, \
+              principal_fingerprint, event_author_pubkey, \
+              binding_state, lifecycle_revision, binding_provenance, \
+              policy_revision, enrollment_evidence_digest, \
+              birth_history_id, creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1, $2, 'https://issuer.example', 'sub-01', \
+                     $3, $4, 1, 1, 1, $5, $6, $7, $8, $9)",
+        )
+        .bind(community_id)
+        .bind(binding_id)
+        .bind(vec![0xAF_u8; 32]) // principal_fingerprint
+        .bind(vec![0xB0_u8; 32]) // event_author_pubkey
+        .bind(policy_revision)
+        .bind(vec![0xB1_u8; 32]) // enrollment_evidence_digest
+        .bind(history_id)
+        .bind(operation_id)
+        .bind(&request_fingerprint)
+        .execute(&mut *conn)
+        .await
+        .expect("insert binding");
+
+        sqlx::query("COMMIT")
+            .execute(&mut *conn)
+            .await
+            .expect("attested-key binding under TOFU policy must commit — FK is on (community_id, policy_revision) only");
+
+        // Confirm the binding persisted with provenance 1, policy mode 3.
+        let (stored_provenance, stored_mode): (i16, i16) = sqlx::query_as(
+            "SELECT b.binding_provenance, p.enrollment_mode \
+             FROM identity_bindings b \
+             JOIN identity_enrollment_policies p \
+               ON p.community_id = b.community_id AND p.policy_revision = b.policy_revision \
+             WHERE b.community_id = $1 AND b.binding_id = $2",
+        )
+        .bind(community_id)
+        .bind(binding_id)
+        .fetch_one(&pool)
+        .await
+        .expect("read persisted binding");
+        assert_eq!(stored_provenance, 1, "provenance must be attested-key (1)");
+        assert_eq!(stored_mode, 3, "enrollment mode must be TOFU (3)");
+        assert_ne!(
+            stored_provenance, stored_mode,
+            "provenance and mode are independent: they must differ here"
+        );
+    }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -4230,4 +4230,272 @@ mod tests {
              got: {fp_mismatch_err}"
         );
     }
+
+    /// NIP-FI authenticated kind-9 OperatorDenied denial: an authenticated
+    /// kind-9 event (actor_kind 1–3, non-null request_fingerprint) must commit
+    /// without an authorization_authentication_denial_attempts row and must
+    /// reject any attempt to attach one.
+    ///
+    /// Mutation sensitivity:
+    /// - Removing the `actor_kind <> 4` guard from the event-side trigger makes
+    ///   positive A red: the COMMIT fails because the guard now requires a
+    ///   denial-attempt row for the authenticated event and none is present.
+    /// - Removing the `actor_kind <> 4` shape guard from the attempt-side
+    ///   trigger makes negative B red: the attempt binds to the authenticated
+    ///   event and COMMIT succeeds, so the `expect_err` panics. Without the
+    ///   exact constraint name check, the pre-existing
+    ///   `authorization_denial_attempt_semantic_binding` guard would fire instead
+    ///   (non-null attempt semantic_fingerprint vs. null on the event), masking
+    ///   whether the new shape guard is load-bearing.
+    ///
+    /// The unresolved pre-auth positive path (actor_kind 4) is exercised in
+    /// `authorization_denial_attempt_requires_kind_9_event_bidirectional` and
+    /// is unchanged by this fix.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn authenticated_kind_9_denial_commits_without_denial_attempt() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("auth-denial-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        // Seed an operation receipt for the authenticated denial. Use
+        // operation_kind = 12 (invalidation) with outcome_code = 2 (denied):
+        // this satisfies the receipt CHECK constraints without triggering the
+        // lifecycle history guard (expected_count = 0 for non-lifecycle kinds)
+        // and without requiring a lifecycle event (expected_event_kind = NULL).
+        // The authorization_events FK on (community_id, operation_id,
+        // request_fingerprint) requires a receipt row.
+        let op_auth = uuid::Uuid::new_v4();
+        let fp_auth = vec![0xA1_u8; 32];
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 12, $4, 2, $5)",
+            // operation_kind 12 (invalidation), outcome_code 2 (denied)
+        )
+        .bind(community_id)
+        .bind(op_auth)
+        .bind(&fp_auth)
+        .bind(vec![0xA2_u8; 32]) // actor_fingerprint
+        .bind(vec![0xA3_u8; 32]) // result_digest
+        .execute(&pool)
+        .await
+        .expect("seed authenticated denial receipt");
+
+        let event_auth = uuid::Uuid::new_v4();
+        let corr_auth = uuid::Uuid::new_v4();
+        let attempt_auth = uuid::Uuid::new_v4();
+
+        // --- Positive A: authenticated kind-9 denial (actor_kind = 1) commits
+        // without any denial-attempt row. The semantic_fingerprint must be NULL
+        // per the corrected shape CHECK. The deferred cardinality guard must
+        // skip this event because actor_kind ≠ 4.
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin");
+
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, actor_fingerprint, operation_id, request_fingerprint, \
+              correlation_id, attempt_id, semantic_fingerprint, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 9, 2, 4, 1, $3, $4, $5, $6, $7, NULL, \
+                     '2026-01-01T00:00:00Z', $8, $9)",
+        )
+        .bind(community_id)
+        .bind(event_auth)
+        .bind(vec![0xA4_u8; 32]) // actor_fingerprint (required for actor_kind 1)
+        .bind(op_auth)
+        .bind(&fp_auth) // non-null request_fingerprint (authenticated shape)
+        .bind(corr_auth)
+        .bind(attempt_auth)
+        // semantic_fingerprint = NULL: authenticated kind-9 must not carry one
+        .bind(vec![0xA5_u8; 64]) // canonical_envelope
+        .bind(vec![0xA6_u8; 32]) // envelope_digest
+        .execute(&mut *conn)
+        .await
+        .expect("insert authenticated kind-9 event");
+
+        sqlx::query("COMMIT").execute(&mut *conn).await.expect(
+            "authenticated kind-9 denial must commit without a denial-attempt row \
+                 — the event-side cardinality guard must skip actor_kind 1",
+        );
+        drop(conn);
+
+        // Confirm no denial attempt was needed: the table must have zero rows
+        // for this event.
+        let attempt_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_authentication_denial_attempts \
+             WHERE community_id = $1 AND audit_event_id = $2",
+        )
+        .bind(community_id)
+        .bind(event_auth)
+        .fetch_one(&pool)
+        .await
+        .expect("count denial attempts for authenticated event");
+        assert_eq!(
+            attempt_count, 0,
+            "no denial-attempt row should exist for an authenticated kind-9 event"
+        );
+
+        // --- Negative B: a denial attempt cannot bind to the authenticated kind-9
+        // event. The attempt-side shape guard must reject this at commit because
+        // the referenced event has actor_kind = 1 (not 4). The rejection must
+        // name the exact shape constraint (authorization_denial_attempt_event_kind)
+        // rather than merely returning 23514, proving the new actor/request-fingerprint
+        // guard fires — not the pre-existing semantic_fingerprint equality check
+        // (which would fire as authorization_denial_attempt_semantic_binding if
+        // the shape guard were absent, because the attempt carries a non-null
+        // semantic_fingerprint while the authenticated event has null).
+        //
+        // Reuse attempt_auth from the committed event so the deferred attempt_id
+        // FK resolves (wrong attempt_id would activate that FK first and make the
+        // negative non-isolated to the new guard).
+        let mut conn_b = pool.acquire().await.expect("acquire connection B");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_b)
+            .await
+            .expect("begin B");
+
+        // Insert the denial attempt referencing the authenticated event.
+        // The attempt table FKs are deferred, so this INSERT succeeds;
+        // the shape guard fires at COMMIT.
+        sqlx::query(
+            "INSERT INTO authorization_authentication_denial_attempts \
+             (community_id, operation_id, correlation_id, semantic_fingerprint, \
+              denial_reason, expected_revision, action, reason_code, \
+              attempt_id, audit_event_id, audit_event_kind) \
+             VALUES ($1, $2, $3, $4, 1, 1, 1, 2, $5, $6, 9)",
+        )
+        .bind(community_id)
+        .bind(op_auth)
+        .bind(corr_auth)
+        .bind(vec![0xA7_u8; 32]) // semantic_fingerprint on the attempt (non-null)
+        .bind(attempt_auth) // reuse the event's attempt_id — FK isolation
+        .bind(event_auth) // references the authenticated event (actor_kind = 1)
+        .execute(&mut *conn_b)
+        .await
+        .expect("attempt INSERT must pass — shape guard is deferred");
+
+        let cross_shape_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_b)
+            .await
+            .expect_err(
+                "denial attempt binding to authenticated kind-9 event must be rejected at commit",
+            );
+        // The exact constraint name must be authorization_denial_attempt_event_kind —
+        // the new actor/request_fingerprint shape guard. If the shape guard were
+        // removed, the pre-existing semantic_fingerprint equality check would fire
+        // instead, named authorization_denial_attempt_semantic_binding. Requiring
+        // the exact name makes the mutation reliably red.
+        assert_eq!(
+            cross_shape_err
+                .as_database_error()
+                .and_then(|e| e.constraint()),
+            Some("authorization_denial_attempt_event_kind"),
+            "rejection must be attributed to authorization_denial_attempt_event_kind \
+             shape guard (not an incidental FK or semantic-binding check), \
+             got: {cross_shape_err}"
+        );
+    }
+
+    /// NIP-FI denied lifecycle receipt: a denied core lifecycle receipt
+    /// (outcome_code = 2) must commit without a paired audit event. Requiring
+    /// one would falsely record that the lifecycle transition occurred.
+    ///
+    /// Mutation sensitivity: removing the `outcome_code NOT IN (1, 3)` early-return
+    /// from `authorization_operation_receipt_event_guard_v1` makes the positive case
+    /// red — the denied enroll receipt cannot commit alone because the guard then
+    /// demands a paired enroll audit event (expected_event_kind = 1) that is absent.
+    /// Existing tests (`authorization_denial_attempt_requires_kind_9_event_bidirectional`
+    /// and `authorization_admission_result_requires_kind_11_receipt_bidirectional`)
+    /// already protect the applied/no-op side of the guard.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn denied_lifecycle_receipt_commits_without_audit_event() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!(
+                "denied-lifecycle-{}.example",
+                community_id.simple()
+            ))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Denied enroll receipt (operation_kind = 1, outcome_code = 2) must commit
+        // without any paired authorization_events row. The guard must skip it
+        // because outcome_code = 2 is not in (1, 3).
+        //
+        // The receipt history guard (migration 0041) uses `outcome_code IN (1, 3)`
+        // for lifecycle receipts, so a denied enroll receipt (outcome_code = 2)
+        // expects zero lifecycle history rows — no history setup is needed.
+        let op_denied = uuid::Uuid::new_v4();
+        let fp_denied = vec![0xB1_u8; 32];
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 2, $5)",
+            // operation_kind 1 (enroll), outcome_code 2 (denied)
+        )
+        .bind(community_id)
+        .bind(op_denied)
+        .bind(&fp_denied)
+        .bind(vec![0xB2_u8; 32])
+        .bind(vec![0xB3_u8; 32])
+        .execute(&pool)
+        .await
+        .expect("denied enroll receipt must commit without a paired audit event");
+
+        // No audit event for this operation; confirm the table is empty for it.
+        let event_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_events \
+             WHERE community_id = $1 AND operation_id = $2",
+        )
+        .bind(community_id)
+        .bind(op_denied)
+        .fetch_one(&pool)
+        .await
+        .expect("count events for denied receipt");
+        assert_eq!(
+            event_count, 0,
+            "no audit event should be required or present for a denied lifecycle receipt"
+        );
+    }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -4430,16 +4430,18 @@ mod tests {
     /// one would falsely record that the lifecycle transition occurred.
     ///
     /// Mutation sensitivity:
-    /// - Removing the `outcome_code IN (1, 3)` branch entirely makes the positive case
-    ///   red — the denied enroll receipt cannot commit alone because the guard then
-    ///   demands a paired enroll audit event (expected_event_kind = 1) that is absent.
-    /// - The negative fixture below (denied receipt + mapped success event) covers the
-    ///   `outcome_code = 2` zero-event branch: removing that ELSIF branch makes the
-    ///   negative green, failing the expected COMMIT rejection.
-    /// Applied/no-op lifecycle cardinality is covered by the applied path exercised
-    /// in `authorization_operation_receipt_event_guard_v1`'s existing constraint
-    /// trigger, verified by the mutation above (bypass makes the positive denied path
-    /// demand an absent event, confirming the guard is active for both branches).
+    /// - Removing the `outcome_code IN (1, 3)` branch entirely (or replacing it with a
+    ///   blanket early-return) makes the positive case red — the denied enroll receipt
+    ///   cannot commit alone because the guard then demands a paired enroll audit event
+    ///   (expected_event_kind = 1) that is absent.
+    /// - Removing the `ELSIF outcome_code = 2` zero-event branch makes the
+    ///   receipt-then-event negative below green (COMMIT succeeds when it must not),
+    ///   failing `expect_err`. The event-side isolation in
+    ///   `denied_lifecycle_receipt_event_side_trigger_isolated` independently confirms
+    ///   the same branch using only the `authorization_event_receipt_cardinality`
+    ///   trigger direction.
+    /// Applied/no-op lifecycle cardinality is exercised by
+    /// `applied_lifecycle_receipt_requires_exactly_one_event`.
     #[tokio::test]
     #[ignore = "requires Postgres"]
     async fn denied_lifecycle_receipt_commits_without_audit_event() {
@@ -4504,10 +4506,9 @@ mod tests {
 
         // --- Negative: denied enroll receipt paired with its mapped success-
         // transition event (event_kind = 1, enrolled) must be rejected at COMMIT.
-        // Both deferred trigger directions share the same
-        // authorization_operation_receipt_event_guard_v1 function, so a single
-        // transaction exercising both INSERT paths (receipt then event) covers
-        // both trigger directions.
+        // The receipt-side deferred trigger fires here (receipt was inserted in
+        // this same transaction). The event-side trigger direction is isolated in
+        // `denied_lifecycle_receipt_event_side_trigger_isolated`.
         //
         // Seed event capacity; the authorization_events BEFORE INSERT trigger
         // requires a capacity row. No lifecycle history is needed: denied receipts
@@ -4591,6 +4592,408 @@ mod tests {
             Some("authorization_denied_lifecycle_receipt_no_success_event"),
             "expected authorization_denied_lifecycle_receipt_no_success_event constraint \
              rejection for denied receipt + success event, got: {contradiction_err}"
+        );
+    }
+
+    /// NIP-FI event-side trigger isolation: when a denied enroll receipt is already
+    /// committed (auto-commit via pool), a new independent transaction that inserts
+    /// only the mapped success-transition event must be rejected at COMMIT by
+    /// `authorization_event_receipt_cardinality` (the event-side deferred trigger).
+    ///
+    /// This isolates the `authorization_event_receipt_cardinality` trigger path.
+    /// In `denied_lifecycle_receipt_commits_without_audit_event`'s receipt-then-event
+    /// negative, the receipt-side trigger (`authorization_operation_receipt_event_cardinality`)
+    /// also fires. Here the committed receipt produces no deferred trigger, so rejection
+    /// can only come from the event-side trigger.
+    ///
+    /// Mutation sensitivity: disabling the
+    /// `authorization_event_receipt_cardinality` trigger (DROP or ALTER TABLE
+    /// DISABLE TRIGGER) makes this negative green — the COMMIT succeeds when it
+    /// must not, so `expect_err` panics.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn denied_lifecycle_receipt_event_side_trigger_isolated() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("evt-side-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Seed event capacity before any event insert.
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        // Commit a denied enroll receipt in auto-commit mode (no explicit BEGIN).
+        // This receipt produces no deferred trigger — the receipt-side deferred
+        // trigger only fires within the transaction that inserts the receipt row.
+        let op_id = uuid::Uuid::new_v4();
+        let fp = vec![0xE1_u8; 32];
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 2, $5)",
+        )
+        .bind(community_id)
+        .bind(op_id)
+        .bind(&fp)
+        .bind(vec![0xE2_u8; 32])
+        .bind(vec![0xE3_u8; 32])
+        .execute(&pool)
+        .await
+        .expect("denied receipt must commit alone in auto-commit mode");
+
+        // Now open a NEW transaction and insert only the mapped success-transition
+        // event (event_kind = 1, enrolled). The receipt is already committed and
+        // its deferred trigger is no longer active. Rejection at COMMIT must come
+        // from authorization_event_receipt_cardinality (the event-side trigger).
+        let event_id = uuid::Uuid::new_v4();
+        let corr_id = uuid::Uuid::new_v4();
+        let attempt_id = uuid::Uuid::new_v4();
+
+        let mut conn = pool
+            .acquire()
+            .await
+            .expect("acquire connection for event-side test");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin event-side transaction");
+
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, actor_fingerprint, operation_id, request_fingerprint, \
+              correlation_id, attempt_id, semantic_fingerprint, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 1, 1, 4, 1, $3, $4, $5, $6, $7, NULL, \
+                     '2026-01-01T00:00:00Z', $8, $9)",
+        )
+        .bind(community_id)
+        .bind(event_id)
+        .bind(vec![0xE4_u8; 32]) // actor_fingerprint
+        .bind(op_id)
+        .bind(&fp)
+        .bind(corr_id)
+        .bind(attempt_id)
+        .bind(vec![0xE5_u8; 64]) // canonical_envelope
+        .bind(vec![0xE6_u8; 32]) // envelope_digest
+        .execute(&mut *conn)
+        .await
+        .expect("event INSERT must pass — event-side deferred guard fires at COMMIT");
+
+        let event_side_err = sqlx::query("COMMIT").execute(&mut *conn).await.expect_err(
+            "mapping a success-transition event to a committed denied receipt \
+                 must be rejected at COMMIT by the event-side trigger",
+        );
+        assert_eq!(
+            event_side_err
+                .as_database_error()
+                .and_then(|e| e.constraint()),
+            Some("authorization_denied_lifecycle_receipt_no_success_event"),
+            "event-side trigger must reject with authorization_denied_lifecycle_receipt_no_success_event, \
+             got: {event_side_err}"
+        );
+    }
+
+    /// NIP-FI applied lifecycle receipt: an applied core lifecycle enroll receipt
+    /// (outcome_code = 1) requires exactly one mapped success-transition event
+    /// (event_kind = 1, enrolled). This exercises the `outcome_code IN (1, 3)`
+    /// branch of `authorization_operation_receipt_event_guard_v1` at migration 42.
+    ///
+    /// Mutation sensitivity:
+    /// - Removing/bypassing the applied/no-op branch (replacing it with a blanket
+    ///   RETURN NULL) makes the positive transaction commit without an event, leaving
+    ///   the contract silently unenforced. The negative below requires the cardinality
+    ///   constraint to fire when the event is absent.
+    /// - Removing the negative assertion: the absent-event case would commit when it
+    ///   must not.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn applied_lifecycle_receipt_requires_exactly_one_event() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!(
+                "applied-lifecycle-{}.example",
+                community_id.simple()
+            ))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Enrollment policy (TOFU, mode 3).
+        let policy_revision: i64 = 1;
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, $2, 3, $3, '2026-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(policy_revision)
+        .bind(vec![0xF0_u8; 32])
+        .execute(&pool)
+        .await
+        .expect("insert enrollment policy");
+
+        // Event capacity — required by authorization_event_capacity_before_insert_v1.
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        // --- Positive: applied enroll commits with exactly one mapped event ---
+        //
+        // All cross-table FKs between identity_lifecycle_history, identity_bindings,
+        // authorization_operation_receipts, and authorization_events are
+        // DEFERRABLE INITIALLY DEFERRED — insert order within the transaction is
+        // flexible, but a pinned connection is required for BEGIN/COMMIT to share
+        // the same session. The receipt_history_cardinality trigger (migration 0041)
+        // fires at COMMIT and requires exactly one history row for applied enroll.
+        let op_id = uuid::Uuid::new_v4();
+        let binding_id = uuid::Uuid::new_v4();
+        let history_id = uuid::Uuid::new_v4();
+        let fp = vec![0xF1_u8; 32];
+        let event_id = uuid::Uuid::new_v4();
+        let corr_id = uuid::Uuid::new_v4();
+        let attempt_id = uuid::Uuid::new_v4();
+
+        let mut conn = pool
+            .acquire()
+            .await
+            .expect("acquire connection for positive case");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin positive transaction");
+
+        // History first: the receipt_history_cardinality AFTER INSERT trigger
+        // on authorization_operation_receipts is DEFERRED and checks at COMMIT
+        // time, but inserting history before receipt is idiomatic.
+        // successor_binding_version = 1 because binding_version is an identity
+        // sequence starting at 1 per community; this is the first binding.
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id, history_id, transition_kind, outcome_code, \
+              successor_binding_id, successor_binding_version, \
+              successor_lifecycle_revision, successor_state, \
+              operation_id, request_fingerprint, transition_digest) \
+             VALUES ($1, $2, 1, 1, $3, 1, 1, 1, $4, $5, $6)",
+        )
+        .bind(community_id)
+        .bind(history_id)
+        .bind(binding_id)
+        .bind(op_id)
+        .bind(&fp)
+        .bind(vec![0xF2_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert lifecycle history");
+
+        // Applied enroll receipt (operation_kind = 1, outcome_code = 1).
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op_id)
+        .bind(&fp)
+        .bind(vec![0xF3_u8; 32])
+        .bind(vec![0xF4_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert applied enroll receipt");
+
+        // Binding — birth_history_id FK is deferred; binding_version is generated.
+        sqlx::query(
+            "INSERT INTO identity_bindings \
+             (community_id, binding_id, issuer, subject, \
+              principal_fingerprint, event_author_pubkey, \
+              binding_state, lifecycle_revision, binding_provenance, \
+              policy_revision, enrollment_evidence_digest, \
+              birth_history_id, creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1, $2, 'https://issuer.example', 'sub-applied', \
+                     $3, $4, 1, 1, 1, $5, $6, $7, $8, $9)",
+        )
+        .bind(community_id)
+        .bind(binding_id)
+        .bind(vec![0xF5_u8; 32]) // principal_fingerprint
+        .bind(vec![0xF6_u8; 32]) // event_author_pubkey
+        .bind(policy_revision)
+        .bind(vec![0xF7_u8; 32]) // enrollment_evidence_digest
+        .bind(history_id)
+        .bind(op_id)
+        .bind(&fp)
+        .execute(&mut *conn)
+        .await
+        .expect("insert identity binding");
+
+        // Mapped success-transition event (event_kind = 1, enrolled).
+        // actor_kind = 1 requires non-null actor_fingerprint and matching receipt FK.
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, actor_fingerprint, operation_id, request_fingerprint, \
+              correlation_id, attempt_id, semantic_fingerprint, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 1, 1, 4, 1, $3, $4, $5, $6, $7, NULL, \
+                     '2026-01-01T00:00:00Z', $8, $9)",
+        )
+        .bind(community_id)
+        .bind(event_id)
+        .bind(vec![0xF8_u8; 32]) // actor_fingerprint
+        .bind(op_id)
+        .bind(&fp)
+        .bind(corr_id)
+        .bind(attempt_id)
+        .bind(vec![0xF9_u8; 64]) // canonical_envelope
+        .bind(vec![0xFA_u8; 32]) // envelope_digest
+        .execute(&mut *conn)
+        .await
+        .expect("insert mapped success-transition event");
+
+        sqlx::query("COMMIT").execute(&mut *conn).await.expect(
+            "applied enroll receipt + exactly one mapped event must commit — \
+                 authorization_operation_receipt_event_guard_v1 applied/no-op branch",
+        );
+
+        // Confirm exactly one event committed for this operation.
+        let event_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_events \
+             WHERE community_id = $1 AND operation_id = $2",
+        )
+        .bind(community_id)
+        .bind(op_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count events for applied receipt");
+        assert_eq!(
+            event_count, 1,
+            "exactly one audit event must be present for an applied enroll receipt"
+        );
+
+        // --- Negative: applied enroll receipt without a mapped event must reject ---
+        //
+        // A second applied enroll transaction that commits receipt + history + binding
+        // but no event must be rejected with authorization_operation_receipt_event_cardinality.
+        let op_neg = uuid::Uuid::new_v4();
+        let binding_neg = uuid::Uuid::new_v4();
+        let history_neg = uuid::Uuid::new_v4();
+        let fp_neg = vec![0xFB_u8; 32];
+
+        let mut conn_neg = pool
+            .acquire()
+            .await
+            .expect("acquire connection for negative case");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_neg)
+            .await
+            .expect("begin negative transaction");
+
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id, history_id, transition_kind, outcome_code, \
+              successor_binding_id, successor_binding_version, \
+              successor_lifecycle_revision, successor_state, \
+              operation_id, request_fingerprint, transition_digest) \
+             VALUES ($1, $2, 1, 1, $3, 2, 1, 1, $4, $5, $6)",
+            // successor_binding_version = 2: second binding in this community
+        )
+        .bind(community_id)
+        .bind(history_neg)
+        .bind(binding_neg)
+        .bind(op_neg)
+        .bind(&fp_neg)
+        .bind(vec![0xFC_u8; 32])
+        .execute(&mut *conn_neg)
+        .await
+        .expect("insert negative lifecycle history");
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(op_neg)
+        .bind(&fp_neg)
+        .bind(vec![0xFD_u8; 32])
+        .bind(vec![0xFE_u8; 32])
+        .execute(&mut *conn_neg)
+        .await
+        .expect("insert negative applied receipt");
+
+        sqlx::query(
+            "INSERT INTO identity_bindings \
+             (community_id, binding_id, issuer, subject, \
+              principal_fingerprint, event_author_pubkey, \
+              binding_state, lifecycle_revision, binding_provenance, \
+              policy_revision, enrollment_evidence_digest, \
+              birth_history_id, creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1, $2, 'https://issuer.example', 'sub-applied-neg', \
+                     $3, $4, 1, 1, 1, $5, $6, $7, $8, $9)",
+        )
+        .bind(community_id)
+        .bind(binding_neg)
+        .bind(vec![0xE7_u8; 32]) // principal_fingerprint (distinct from positive)
+        .bind(vec![0xE8_u8; 32]) // event_author_pubkey (distinct from positive)
+        .bind(policy_revision)
+        .bind(vec![0xE9_u8; 32])
+        .bind(history_neg)
+        .bind(op_neg)
+        .bind(&fp_neg)
+        .execute(&mut *conn_neg)
+        .await
+        .expect("insert negative binding — no event inserted");
+
+        // Commit without the mapped event — guard must reject.
+        let absent_event_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_neg)
+            .await
+            .expect_err(
+                "applied enroll receipt without a mapped success-transition event \
+                 must be rejected at COMMIT",
+            );
+        assert_eq!(
+            absent_event_err
+                .as_database_error()
+                .and_then(|e| e.constraint()),
+            Some("authorization_operation_receipt_event_cardinality"),
+            "expected authorization_operation_receipt_event_cardinality rejection \
+             for applied receipt without event, got: {absent_event_err}"
         );
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -690,7 +690,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 40);
+        assert_eq!(migrations.len(), 42);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -1231,6 +1231,45 @@ mod tests {
         assert!(
             operator_audit.contains("_operator_global_tables"),
             "migration 39 must register relay_operator_audit in _operator_global_tables"
+        );
+
+        // NIP-FI core identity + base-lifecycle foundation (migration 0041) and
+        // final-admission foundation (0042). Both widen the single SQL source of
+        // truth `community_write_fence_excluded_table` so their durable,
+        // immutable ledger relations are never fence-attached, purged, or
+        // counted as tenant-scoped drift. schema.sql keeps one consolidated
+        // definition of that function whose body must match 0042's exactly.
+        assert_eq!(migrations[40].version, 41);
+        let identity_foundation = migrations[40].sql.as_str();
+        assert!(identity_foundation.contains("CREATE TABLE identity_bindings"));
+        assert!(identity_foundation.contains("CREATE TABLE identity_lifecycle_history"));
+        assert!(identity_foundation
+            .contains("CREATE OR REPLACE FUNCTION community_write_fence_excluded_table"));
+        assert!(identity_foundation.contains("'identity_bindings'"));
+
+        assert_eq!(migrations[41].version, 42);
+        let authorization_foundation = migrations[41].sql.as_str();
+        assert!(authorization_foundation.contains("CREATE TABLE authorization_events"));
+        assert!(authorization_foundation.contains("CREATE TABLE protected_object_authority"));
+        assert!(authorization_foundation.contains("CREATE TABLE authorization_admission_results"));
+
+        // The consolidated desired-state exclusion function must byte-match
+        // migration 0042's CREATE OR REPLACE body, or a future schema
+        // consolidation would silently drop NIP-FI relations from the ledger.
+        fn extract_excluded_table_array(sql: &str) -> &str {
+            let anchor = "community_write_fence_excluded_table(target NAME) RETURNS BOOLEAN";
+            let start = sql.find(anchor).expect("exclusion function definition");
+            let array_start = sql[start..].find("ARRAY[").expect("exclusion array") + start;
+            let array_end = sql[array_start..]
+                .find("]::TEXT[]")
+                .expect("exclusion array end")
+                + array_start;
+            &sql[array_start..array_end]
+        }
+        assert_eq!(
+            extract_excluded_table_array(authorization_foundation),
+            extract_excluded_table_array(desired_schema),
+            "schema.sql exclusion list drifted from migration 0042"
         );
     }
 
@@ -2608,5 +2647,195 @@ mod tests {
             .execute(&pool)
             .await
             .expect("drop late-table fixtures");
+    }
+
+    /// NIP-FI intermediate state: migration 0041 (identity + base lifecycle)
+    /// alone must present a coherent catalog. Its five community-scoped ledger
+    /// relations are immutable and durable, so they are registered in the
+    /// write-fence exclusion — never counted as tenant-scoped drift, never
+    /// fence-attached — and the exact deletion catalog must still validate.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn migration_0041_identity_foundation_is_durable_ledger_after_migration_a() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(41, &pool)
+            .await
+            .expect("apply migrations 1-41");
+
+        // The five identity relations exist.
+        let identity_tables = [
+            "authorization_operation_receipts",
+            "identity_enrollment_policies",
+            "identity_bindings",
+            "identity_lifecycle_history",
+            "identity_lifecycle_selectors",
+        ];
+        for table in identity_tables {
+            let exists = sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+                 WHERE table_schema = 'public' AND table_name = $1)",
+            )
+            .bind(table)
+            .fetch_one(&pool)
+            .await
+            .unwrap_or_else(|err| panic!("check table {table}: {err}"));
+            assert!(exists, "migration 0041 must create {table}");
+        }
+
+        // Migration B's relations must NOT exist yet.
+        for table in ["authorization_events", "protected_object_authority"] {
+            let exists = sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+                 WHERE table_schema = 'public' AND table_name = $1)",
+            )
+            .bind(table)
+            .fetch_one(&pool)
+            .await
+            .unwrap_or_else(|err| panic!("check table {table}: {err}"));
+            assert!(!exists, "{table} belongs to migration 0042, not 0041");
+        }
+
+        // Every identity relation is excluded from the write fence: none may
+        // appear as tenant-scoped drift or carry the fence trigger.
+        let scoped_or_fenced: Vec<String> = sqlx::query_scalar(
+            "WITH scoped AS ( \
+                 SELECT c.relname FROM pg_class c \
+                 JOIN pg_namespace n ON n.oid = c.relnamespace \
+                 JOIN pg_attribute a ON a.attrelid = c.oid \
+                 WHERE n.nspname = 'public' AND c.relkind IN ('r','p') \
+                   AND NOT c.relispartition AND a.attname = 'community_id' \
+                   AND NOT a.attisdropped \
+                   AND NOT community_write_fence_excluded_table(c.relname) \
+             ) \
+             SELECT relname FROM scoped \
+             WHERE relname = ANY($1) ORDER BY relname",
+        )
+        .bind(&identity_tables[..])
+        .fetch_all(&pool)
+        .await
+        .expect("read scoped identity relations");
+        assert!(
+            scoped_or_fenced.is_empty(),
+            "identity ledger relations must be write-fence excluded, not scoped: {scoped_or_fenced:?}"
+        );
+
+        // The exact deletion catalog validates: the excluded ledger relations
+        // do not perturb the scoped-table/fence equality check.
+        crate::deletion::DeletionStore::new(pool.clone())
+            .validate_catalog()
+            .await
+            .expect("deletion catalog validates after migration 0041");
+
+        // The immutability contract is enforced, not merely declared. TRUNCATE
+        // fires the statement-level guard unconditionally, so this proves the
+        // rejection without constructing a fully valid ledger row.
+        let rejected = sqlx::query("TRUNCATE identity_lifecycle_selectors")
+            .execute(&pool)
+            .await
+            .expect_err("identity_lifecycle_selectors truncation must be rejected");
+        assert!(
+            rejected.to_string().contains("cannot be truncated"),
+            "expected immutability rejection, got: {rejected}"
+        );
+    }
+
+    /// NIP-FI full state: migrations 0041 + 0042 together must present a
+    /// coherent 15-relation catalog with zero dangling foreign keys, all
+    /// relations write-fence excluded, and an intact exact deletion catalog.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn nip_fi_foundation_is_a_closed_durable_ledger_after_migrations_a_and_b() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let nip_fi_tables = [
+            "authorization_admission_results",
+            "authorization_authentication_denial_attempts",
+            "authorization_authority_epochs",
+            "authorization_event_capacity",
+            "authorization_events",
+            "authorization_invalidation_domains",
+            "authorization_invalidation_floors",
+            "authorization_operation_receipts",
+            "authorization_operation_version_delta_manifests",
+            "authorization_operation_version_deltas",
+            "identity_bindings",
+            "identity_enrollment_policies",
+            "identity_lifecycle_history",
+            "identity_lifecycle_selectors",
+            "protected_object_authority",
+        ];
+
+        // All fifteen relations exist.
+        let present: Vec<String> = sqlx::query_scalar(
+            "SELECT table_name FROM information_schema.tables \
+             WHERE table_schema = 'public' AND table_name = ANY($1) ORDER BY table_name",
+        )
+        .bind(&nip_fi_tables[..])
+        .fetch_all(&pool)
+        .await
+        .expect("read NIP-FI table catalog");
+        let mut expected: Vec<String> = nip_fi_tables.iter().map(|t| t.to_string()).collect();
+        expected.sort();
+        assert_eq!(
+            present, expected,
+            "all NIP-FI relations must exist after 0042"
+        );
+
+        // Zero dangling foreign keys: every FK target is a live relation.
+        let invalid_fks: i64 = sqlx::query_scalar(
+            "SELECT count(*)::BIGINT FROM pg_constraint \
+             WHERE contype = 'f' AND NOT convalidated",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("read FK validity");
+        assert_eq!(
+            invalid_fks, 0,
+            "no NIP-FI foreign key may be left unvalidated"
+        );
+
+        // None of the fifteen appear as tenant-scoped drift; all are excluded.
+        let scoped: Vec<String> = sqlx::query_scalar(
+            "SELECT c.relname FROM pg_class c \
+             JOIN pg_namespace n ON n.oid = c.relnamespace \
+             JOIN pg_attribute a ON a.attrelid = c.oid \
+             WHERE n.nspname = 'public' AND c.relkind IN ('r','p') \
+               AND NOT c.relispartition AND a.attname = 'community_id' \
+               AND NOT a.attisdropped \
+               AND NOT community_write_fence_excluded_table(c.relname) \
+               AND c.relname = ANY($1) ORDER BY c.relname",
+        )
+        .bind(&nip_fi_tables[..])
+        .fetch_all(&pool)
+        .await
+        .expect("read scoped NIP-FI relations");
+        assert!(
+            scoped.is_empty(),
+            "all NIP-FI ledger relations must be write-fence excluded: {scoped:?}"
+        );
+
+        // The exact deletion catalog validates with the full ledger present.
+        crate::deletion::DeletionStore::new(pool.clone())
+            .validate_catalog()
+            .await
+            .expect("deletion catalog validates after migrations 0041 + 0042");
+
+        // A migration-B relation is immutable too. TRUNCATE fires the
+        // statement-level guard unconditionally.
+        let rejected = sqlx::query("TRUNCATE authorization_admission_results")
+            .execute(&pool)
+            .await
+            .expect_err("authorization_admission_results truncation must be rejected");
+        assert!(
+            rejected.to_string().contains("cannot be truncated"),
+            "expected immutability rejection, got: {rejected}"
+        );
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -2847,4 +2847,136 @@ mod tests {
             "expected immutability rejection, got: {rejected}"
         );
     }
+
+    /// NIP-FI monotonic invalidation-floor advancement must actually run
+    /// through the `BEFORE UPDATE` guard. PL/pgSQL defers record-field
+    /// resolution to execution, so a guard that references a column absent from
+    /// its Phase-A table passes every catalog/parity test yet aborts the first
+    /// real advancement. This test exercises live UPDATEs: legitimate forward
+    /// moves on `floor_generation` and `binding_version_floor` must commit, and
+    /// equal/regressive moves must be rejected.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn authorization_invalidation_floor_advances_through_guard() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(41, &pool)
+            .await
+            .expect("apply migrations 1-41");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("floor-guard-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        // Each floor state points at an operation receipt via
+        // (community_id, operation_id, request_fingerprint). Seed one receipt
+        // per operation the test advances through.
+        let operations: [(uuid::Uuid, u8); 4] = [
+            (uuid::Uuid::new_v4(), 0x11),
+            (uuid::Uuid::new_v4(), 0x22),
+            (uuid::Uuid::new_v4(), 0x33),
+            (uuid::Uuid::new_v4(), 0x44),
+        ];
+        for (operation_id, fp_byte) in operations {
+            sqlx::query(
+                "INSERT INTO authorization_operation_receipts \
+                 (community_id, operation_id, request_fingerprint, operation_kind, \
+                  actor_fingerprint, outcome_code, result_digest) \
+                 VALUES ($1, $2, $3, 12, $4, 1, $5)",
+            )
+            .bind(community_id)
+            .bind(operation_id)
+            .bind(vec![fp_byte; 32])
+            .bind(vec![0xAA_u8; 32])
+            .bind(vec![0xBB_u8; 32])
+            .execute(&pool)
+            .await
+            .expect("seed operation receipt");
+        }
+
+        // selector_kind 3 requires binding_version_floor, so this row exercises
+        // both monotonic dimensions the guard still governs.
+        let selector_fingerprint = vec![0xCC_u8; 32];
+        sqlx::query(
+            "INSERT INTO authorization_invalidation_floors \
+             (community_id, selector_kind, selector_fingerprint, floor_generation, \
+              binding_version_floor, operation_id, request_fingerprint, updated_at) \
+             VALUES ($1, 3, $2, 1, 1, $3, $4, '2026-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(&selector_fingerprint)
+        .bind(operations[0].0)
+        .bind(vec![operations[0].1; 32])
+        .execute(&pool)
+        .await
+        .expect("insert initial invalidation floor");
+
+        let advance =
+            |generation: i64, binding_floor: i64, op_index: usize, updated_at: &'static str| {
+                sqlx::query(
+                    "UPDATE authorization_invalidation_floors \
+                 SET floor_generation = $1, binding_version_floor = $2, \
+                     operation_id = $3, request_fingerprint = $4, updated_at = $5::timestamptz \
+                 WHERE community_id = $6 AND selector_kind = 3 AND selector_fingerprint = $7",
+                )
+                .bind(generation)
+                .bind(binding_floor)
+                .bind(operations[op_index].0)
+                .bind(vec![operations[op_index].1; 32])
+                .bind(updated_at)
+                .bind(community_id)
+                .bind(selector_fingerprint.clone())
+                .execute(&pool)
+            };
+
+        // Forward generation advance commits.
+        advance(2, 1, 1, "2026-01-01T00:01:00Z")
+            .await
+            .expect("forward floor_generation advance must pass the guard");
+
+        // Forward binding_version_floor advance commits (generation unchanged).
+        advance(2, 2, 2, "2026-01-01T00:02:00Z")
+            .await
+            .expect("forward binding_version_floor advance must pass the guard");
+
+        // Regressive generation is rejected.
+        let regressive = advance(1, 2, 3, "2026-01-01T00:03:00Z")
+            .await
+            .expect_err("regressive floor_generation must be rejected");
+        assert!(
+            regressive.to_string().contains("cannot move backward"),
+            "expected monotonic rejection, got: {regressive}"
+        );
+
+        // Equal floors with only a new operation is a rejected no-op advance.
+        let no_op = advance(2, 2, 3, "2026-01-01T00:03:00Z")
+            .await
+            .expect_err("equal-floor no-op advance must be rejected");
+        assert!(
+            no_op.to_string().contains("cannot move backward"),
+            "expected no-op rejection, got: {no_op}"
+        );
+
+        // The committed state reflects only the two accepted advances.
+        let (generation, binding_floor): (i64, i64) = sqlx::query_as(
+            "SELECT floor_generation, binding_version_floor \
+             FROM authorization_invalidation_floors \
+             WHERE community_id = $1 AND selector_kind = 3 AND selector_fingerprint = $2",
+        )
+        .bind(community_id)
+        .bind(&selector_fingerprint)
+        .fetch_one(&pool)
+        .await
+        .expect("read final floor state");
+        assert_eq!(
+            (generation, binding_floor),
+            (2, 2),
+            "only the accepted forward advances may persist"
+        );
+    }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -3129,5 +3129,102 @@ mod tests {
             stored_provenance, stored_mode,
             "provenance and mode are independent: they must differ here"
         );
+
+        // --- Negative half: absent policy revision ---
+        //
+        // Two-sided mutation sensitivity requires that a FK dropped or neutered
+        // entirely is also detected.  A second otherwise-valid deferred
+        // transaction uses a nonexistent policy_revision (999) and must fail
+        // with SQLSTATE 23503 — the narrowed FK
+        // identity_bindings(community_id, policy_revision)
+        //   → identity_enrollment_policies(community_id, policy_revision)
+        // rejects the row.  This FK is not deferred, so it fires at INSERT
+        // time; a `COMMIT` is unnecessary and not reached.  If the FK were
+        // absent the INSERT would succeed and this assertion would catch the
+        // regression.
+        let absent_binding_id = uuid::Uuid::new_v4();
+        let absent_history_id = uuid::Uuid::new_v4();
+        let absent_operation_id = uuid::Uuid::new_v4();
+        let absent_fp = vec![0xC0_u8; 32];
+        let nonexistent_policy_revision: i64 = 999;
+
+        let mut conn2 = pool.acquire().await.expect("acquire second connection");
+
+        sqlx::query("BEGIN")
+            .execute(&mut *conn2)
+            .await
+            .expect("begin absent-policy transaction");
+
+        // History first (receipt_history_cardinality guard fires on receipt
+        // insert and requires the history row to already exist).
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id, history_id, transition_kind, outcome_code, \
+              successor_binding_id, successor_binding_version, \
+              successor_lifecycle_revision, successor_state, \
+              operation_id, request_fingerprint, transition_digest) \
+             VALUES ($1, $2, 1, 1, $3, 2, 1, 1, $4, $5, $6)",
+        )
+        .bind(community_id)
+        .bind(absent_history_id)
+        .bind(absent_binding_id)
+        .bind(absent_operation_id)
+        .bind(&absent_fp)
+        .bind(vec![0xC1_u8; 32])
+        .execute(&mut *conn2)
+        .await
+        .expect("insert absent-policy lifecycle history");
+
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 1, $5)",
+        )
+        .bind(community_id)
+        .bind(absent_operation_id)
+        .bind(&absent_fp)
+        .bind(vec![0xC2_u8; 32])
+        .bind(vec![0xC3_u8; 32])
+        .execute(&mut *conn2)
+        .await
+        .expect("insert absent-policy operation receipt");
+
+        // The policy FK is not deferred; it fires at INSERT, not COMMIT.
+        let absent_policy_err = sqlx::query(
+            "INSERT INTO identity_bindings \
+             (community_id, binding_id, issuer, subject, \
+              principal_fingerprint, event_author_pubkey, \
+              binding_state, lifecycle_revision, binding_provenance, \
+              policy_revision, enrollment_evidence_digest, \
+              birth_history_id, creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1, $2, 'https://issuer.example', 'sub-02', \
+                     $3, $4, 1, 1, 1, $5, $6, $7, $8, $9)",
+        )
+        .bind(community_id)
+        .bind(absent_binding_id)
+        .bind(vec![0xC4_u8; 32]) // principal_fingerprint (unique, different from first binding)
+        .bind(vec![0xC5_u8; 32]) // event_author_pubkey (unique, different from first binding)
+        .bind(nonexistent_policy_revision)
+        .bind(vec![0xC6_u8; 32]) // enrollment_evidence_digest
+        .bind(absent_history_id)
+        .bind(absent_operation_id)
+        .bind(&absent_fp)
+        .execute(&mut *conn2)
+        .await
+        .expect_err("binding with nonexistent policy_revision must be rejected by the FK");
+        assert!(
+            absent_policy_err
+                .as_database_error()
+                .map(|e| e.code().as_deref() == Some("23503"))
+                .unwrap_or(false),
+            "expected FK violation (23503) for absent policy_revision, got: {absent_policy_err}"
+        );
+
+        sqlx::query("ROLLBACK")
+            .execute(&mut *conn2)
+            .await
+            .expect("rollback absent-policy transaction");
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -4241,12 +4241,12 @@ mod tests {
     ///   positive A red: the COMMIT fails because the guard now requires a
     ///   denial-attempt row for the authenticated event and none is present.
     /// - Removing the `actor_kind <> 4` shape guard from the attempt-side
-    ///   trigger makes negative B red: the attempt binds to the authenticated
-    ///   event and COMMIT succeeds, so the `expect_err` panics. Without the
-    ///   exact constraint name check, the pre-existing
-    ///   `authorization_denial_attempt_semantic_binding` guard would fire instead
-    ///   (non-null attempt semantic_fingerprint vs. null on the event), masking
-    ///   whether the new shape guard is load-bearing.
+    ///   trigger makes negative B red: the COMMIT is rejected by the pre-existing
+    ///   `authorization_denial_attempt_semantic_binding` guard instead (non-null
+    ///   attempt `semantic_fingerprint` vs. null on the authenticated event), so
+    ///   `assert_eq!` on the constraint name fails. The exact constraint name
+    ///   assertion is therefore the load-bearing proof that the new shape guard —
+    ///   not the pre-existing semantic-binding check — is what fires.
     ///
     /// The unresolved pre-auth positive path (actor_kind 4) is exercised in
     /// `authorization_denial_attempt_requires_kind_9_event_bidirectional` and
@@ -4429,13 +4429,17 @@ mod tests {
     /// (outcome_code = 2) must commit without a paired audit event. Requiring
     /// one would falsely record that the lifecycle transition occurred.
     ///
-    /// Mutation sensitivity: removing the `outcome_code NOT IN (1, 3)` early-return
-    /// from `authorization_operation_receipt_event_guard_v1` makes the positive case
-    /// red — the denied enroll receipt cannot commit alone because the guard then
-    /// demands a paired enroll audit event (expected_event_kind = 1) that is absent.
-    /// Existing tests (`authorization_denial_attempt_requires_kind_9_event_bidirectional`
-    /// and `authorization_admission_result_requires_kind_11_receipt_bidirectional`)
-    /// already protect the applied/no-op side of the guard.
+    /// Mutation sensitivity:
+    /// - Removing the `outcome_code IN (1, 3)` branch entirely makes the positive case
+    ///   red — the denied enroll receipt cannot commit alone because the guard then
+    ///   demands a paired enroll audit event (expected_event_kind = 1) that is absent.
+    /// - The negative fixture below (denied receipt + mapped success event) covers the
+    ///   `outcome_code = 2` zero-event branch: removing that ELSIF branch makes the
+    ///   negative green, failing the expected COMMIT rejection.
+    /// Applied/no-op lifecycle cardinality is covered by the applied path exercised
+    /// in `authorization_operation_receipt_event_guard_v1`'s existing constraint
+    /// trigger, verified by the mutation above (bypass makes the positive denied path
+    /// demand an absent event, confirming the guard is active for both branches).
     #[tokio::test]
     #[ignore = "requires Postgres"]
     async fn denied_lifecycle_receipt_commits_without_audit_event() {
@@ -4496,6 +4500,97 @@ mod tests {
         assert_eq!(
             event_count, 0,
             "no audit event should be required or present for a denied lifecycle receipt"
+        );
+
+        // --- Negative: denied enroll receipt paired with its mapped success-
+        // transition event (event_kind = 1, enrolled) must be rejected at COMMIT.
+        // Both deferred trigger directions share the same
+        // authorization_operation_receipt_event_guard_v1 function, so a single
+        // transaction exercising both INSERT paths (receipt then event) covers
+        // both trigger directions.
+        //
+        // Seed event capacity; the authorization_events BEFORE INSERT trigger
+        // requires a capacity row. No lifecycle history is needed: denied receipts
+        // (outcome_code = 2) expect zero history rows per the history guard.
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        let op_neg = uuid::Uuid::new_v4();
+        let fp_neg = vec![0xD1_u8; 32];
+        let event_neg = uuid::Uuid::new_v4();
+        let corr_neg = uuid::Uuid::new_v4();
+        let attempt_neg = uuid::Uuid::new_v4();
+
+        let mut conn_neg = pool.acquire().await.expect("acquire connection neg");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn_neg)
+            .await
+            .expect("begin neg");
+
+        // Denied enroll receipt — no history row needed (outcome_code = 2).
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 2, $5)",
+        )
+        .bind(community_id)
+        .bind(op_neg)
+        .bind(&fp_neg)
+        .bind(vec![0xD2_u8; 32])
+        .bind(vec![0xD3_u8; 32])
+        .execute(&mut *conn_neg)
+        .await
+        .expect("insert denied receipt — event guard is deferred");
+
+        // Insert the mapped success-transition event (event_kind = 1, enrolled).
+        // actor_kind = 1 requires a non-null actor_fingerprint and a matching
+        // receipt FK (satisfied by the denied receipt above, which shares the
+        // same (community_id, operation_id, request_fingerprint)).
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, actor_fingerprint, operation_id, request_fingerprint, \
+              correlation_id, attempt_id, semantic_fingerprint, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 1, 1, 4, 1, $3, $4, $5, $6, $7, NULL, \
+                     '2026-01-01T00:00:00Z', $8, $9)",
+            // event_kind 1 (enrolled) — the mapped success transition for enroll
+        )
+        .bind(community_id)
+        .bind(event_neg)
+        .bind(vec![0xD4_u8; 32]) // actor_fingerprint
+        .bind(op_neg)
+        .bind(&fp_neg)
+        .bind(corr_neg)
+        .bind(attempt_neg)
+        .bind(vec![0xD5_u8; 64]) // canonical_envelope
+        .bind(vec![0xD6_u8; 32]) // envelope_digest
+        .execute(&mut *conn_neg)
+        .await
+        .expect("event INSERT must pass — deferred guard fires at COMMIT");
+
+        let contradiction_err = sqlx::query("COMMIT")
+            .execute(&mut *conn_neg)
+            .await
+            .expect_err(
+                "denied receipt + mapped success event must be rejected at COMMIT \
+                 — contradictory durable facts must not be permitted",
+            );
+        assert_eq!(
+            contradiction_err
+                .as_database_error()
+                .and_then(|e| e.constraint()),
+            Some("authorization_denied_lifecycle_receipt_no_success_event"),
+            "expected authorization_denied_lifecycle_receipt_no_success_event constraint \
+             rejection for denied receipt + success event, got: {contradiction_err}"
         );
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -3354,113 +3354,130 @@ mod tests {
              got: {replay_err}"
         );
 
-        // Concurrency regression: prove the advisory lock actually serializes
-        // concurrent writers. Two connections race to insert the SAME next revision
-        // (102) for the same community. The advisory lock must cause one writer to
-        // block, see the other's committed MAX, and then be rejected with 23514 from
-        // the named guard. Without the lock, both could pass the MAX check before
-        // either commits; only a PK collision (23505) would catch the duplicate —
-        // not the guard. Removing pg_advisory_xact_lock from the guard function and
-        // re-running must produce 23505 (PK) rather than 23514 (guard), proving the
-        // test is mutation-sensitive to the lock.
+        // Concurrency regression: prove the advisory lock is load-bearing. The
+        // test uses a controlled two-connection schedule:
         //
-        // A tokio::sync::Barrier synchronizes both connections so they both have a
-        // live transaction and are ready to INSERT before either proceeds. After the
-        // barrier both race to acquire the advisory lock; one wins, commits, and
-        // releases the lock; the other then sees the committed MAX and is rejected
-        // by the guard with 23514.
+        //   1. tx1 opens a transaction and inserts revision 102. The BEFORE INSERT
+        //      trigger acquires `pg_advisory_xact_lock(lock_key)` and completes the
+        //      INSERT — tx1 now holds the advisory lock until it commits.
+        //   2. tx2 opens a transaction on a second backend and issues INSERT for
+        //      revision 103. The trigger fires and blocks inside
+        //      `pg_advisory_xact_lock(lock_key)` waiting for tx1 to release.
+        //   3. We observe tx2's backend entering a Lock-wait state via
+        //      pg_stat_activity (wait_event_type='Lock', wait_event='advisory'),
+        //      with a bounded timeout — not a sleep. If the advisory-lock call is
+        //      removed from the guard, the trigger returns immediately; tx2 never
+        //      enters the advisory wait, and the poll times out, failing the test.
+        //      This is the mutation-sensitivity guarantee.
+        //   4. tx1 commits, releasing the advisory lock. tx2 unblocks, its trigger
+        //      reads the fresh MAX=102, and the INSERT succeeds (103 > 102).
+        //   5. tx2 commits. Both revisions 102 and 103 are present.
+        use std::time::Instant;
+
+        // tx1: open a transaction and insert revision 102. The INSERT returns after
+        // the trigger acquires the lock and succeeds; the advisory lock stays held
+        // until the transaction commits.
+        let mut conn1 = pool.acquire().await.expect("acquire conn1");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn1)
+            .await
+            .expect("begin tx1");
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+             VALUES ($1, 102, 1, $2, '2029-01-01T00:00:00Z')",
+        )
+        .bind(community_id)
+        .bind(vec![0xB1_u8; 32])
+        .execute(&mut *conn1)
+        .await
+        .expect("tx1 INSERT revision 102 must succeed");
+        // tx1 holds the advisory lock. Do NOT commit yet.
+
+        // tx2: acquire a separate backend, record its PID, then issue the INSERT.
+        // The trigger will block on the advisory lock held by tx1.
         let pool2 = pool.clone();
         let pool3 = pool.clone();
-        let community_id2 = community_id;
-        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
-        let barrier2 = barrier.clone();
+        let (pid_tx, pid_rx) = tokio::sync::oneshot::channel::<i32>();
+        let tx2_task = tokio::spawn(async move {
+            let mut conn2 = pool2.acquire().await.expect("acquire conn2");
+            // Report this backend's PID so the observer can poll pg_stat_activity.
+            let backend_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+                .fetch_one(&mut *conn2)
+                .await
+                .expect("get conn2 backend pid");
+            let _ = pid_tx.send(backend_pid);
+            sqlx::query("BEGIN")
+                .execute(&mut *conn2)
+                .await
+                .expect("begin tx2");
+            // This INSERT will block inside the trigger waiting for tx1's advisory lock.
+            let insert_r = sqlx::query(
+                "INSERT INTO identity_enrollment_policies \
+                 (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+                 VALUES ($1, 103, 1, $2, '2029-06-01T00:00:00Z')",
+            )
+            .bind(community_id)
+            .bind(vec![0xB2_u8; 32])
+            .execute(&mut *conn2)
+            .await;
+            let commit_r = sqlx::query("COMMIT").execute(&mut *conn2).await;
+            (insert_r, commit_r)
+        });
 
-        let (tx1_result, tx2_result) = tokio::join!(
-            tokio::spawn(async move {
-                let mut conn = pool.acquire().await.expect("acquire conn1");
-                sqlx::query("BEGIN")
-                    .execute(&mut *conn)
-                    .await
-                    .expect("begin1");
-                // Wait until both connections have open transactions before
-                // either races to INSERT — eliminates ordering accidents.
-                barrier.wait().await;
-                let insert_r = sqlx::query(
-                    "INSERT INTO identity_enrollment_policies \
-                     (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
-                     VALUES ($1, 102, 1, $2, '2029-01-01T00:00:00Z')",
-                )
-                .bind(community_id)
-                .bind(vec![0xB1_u8; 32])
-                .execute(&mut *conn)
-                .await;
-                let commit_r = sqlx::query("COMMIT").execute(&mut *conn).await;
-                (insert_r, commit_r)
-            }),
-            tokio::spawn(async move {
-                let mut conn = pool2.acquire().await.expect("acquire conn2");
-                sqlx::query("BEGIN")
-                    .execute(&mut *conn)
-                    .await
-                    .expect("begin2");
-                // Mirror barrier wait so both are in-flight simultaneously.
-                barrier2.wait().await;
-                let insert_r = sqlx::query(
-                    "INSERT INTO identity_enrollment_policies \
-                     (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
-                     VALUES ($1, 102, 1, $2, '2029-01-01T00:00:00Z')",
-                )
-                .bind(community_id2)
-                .bind(vec![0xB2_u8; 32])
-                .execute(&mut *conn)
-                .await;
-                let commit_r = sqlx::query("COMMIT").execute(&mut *conn).await;
-                (insert_r, commit_r)
-            }),
-        );
+        // Receive tx2's backend PID and wait until it enters an advisory-lock wait.
+        // Mutation proof: without pg_advisory_xact_lock in the guard, the trigger
+        // returns immediately; tx2 never parks on an advisory lock; the poll below
+        // times out and panics, making this test deterministically red.
+        let tx2_pid = pid_rx.await.expect("tx2 reports its backend pid");
+        let deadline = Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (\
+                     SELECT 1 FROM pg_stat_activity \
+                     WHERE pid = $1 \
+                       AND wait_event_type = 'Lock' \
+                       AND wait_event = 'advisory'\
+                 )",
+            )
+            .bind(tx2_pid)
+            .fetch_one(&pool3)
+            .await
+            .expect("poll tx2 advisory-lock wait");
+            if waiting {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "tx2 never entered advisory-lock wait — pg_advisory_xact_lock \
+                 must be present in the guard for the lock to serialize writers"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
 
-        let (insert1, commit1) = tx1_result.expect("tx1 task completed");
-        let (insert2, commit2) = tx2_result.expect("tx2 task completed");
+        // tx2 is observably blocked. Commit tx1, releasing the advisory lock.
+        sqlx::query("COMMIT")
+            .execute(&mut *conn1)
+            .await
+            .expect("tx1 COMMIT must succeed");
 
-        // The BEFORE INSERT trigger fires at statement time: the winner's INSERT
-        // succeeds (lock acquired, MAX check passes, INSERT completes), the loser's
-        // INSERT blocks waiting for the lock and then fails with 23514 when it sees
-        // the winner's committed MAX. Exactly one INSERT must succeed; exactly one
-        // must fail with 23514 from the named guard.
-        let (i1_ok, i2_ok) = (insert1.is_ok(), insert2.is_ok());
-        assert!(
-            i1_ok ^ i2_ok,
-            "exactly one of the two concurrent revision-102 inserts must succeed at INSERT; \
-             got insert1={i1_ok} insert2={i2_ok}"
-        );
-        let loser_insert = if i1_ok { insert2 } else { insert1 };
-        let loser_err = loser_insert.expect_err("loser INSERT must have failed");
-        assert!(
-            loser_err
-                .as_database_error()
-                .map(|e| e.code().as_deref() == Some("23514"))
-                .unwrap_or(false),
-            "loser must fail with check_violation (23514) from \
-             identity_enrollment_policy_revision_monotonic guard, not a PK \
-             collision — this proves the advisory lock serialized the writers; \
-             got: {loser_err}"
-        );
+        // tx2 unblocks: the trigger re-runs its SELECT MAX, sees committed 102,
+        // and INSERT 103 succeeds. Both the INSERT and COMMIT must complete.
+        let (insert2, commit2) = tx2_task.await.expect("tx2 task completed");
+        insert2.expect("tx2 INSERT revision 103 must succeed after tx1 commits");
+        commit2.expect("tx2 COMMIT must succeed");
 
-        // The winner's commit must succeed.
-        let winner_commit = if i1_ok { commit1 } else { commit2 };
-        winner_commit.expect("winner COMMIT must succeed");
-
-        // Confirm exactly 5 policy revisions are now present (1, 2, 100, 101, 102).
+        // Both revisions 102 and 103 must be present (total: 1, 2, 100, 101, 102, 103).
         let count: i64 = sqlx::query_scalar(
             "SELECT count(*) FROM identity_enrollment_policies WHERE community_id = $1",
         )
         .bind(community_id)
-        .fetch_one(&pool3)
+        .fetch_one(&pool)
         .await
         .expect("count persisted policy revisions");
         assert_eq!(
-            count, 5,
-            "exactly five revisions must persist after concurrency race"
+            count, 6,
+            "exactly six revisions must persist after the controlled concurrency sequence"
         );
     }
 

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -4429,6 +4429,13 @@ mod tests {
     /// (outcome_code = 2) must commit without a paired audit event. Requiring
     /// one would falsely record that the lifecycle transition occurred.
     ///
+    /// The denied branch forbids any event from the complete core
+    /// success-transition class (kinds 1, 2, 3, 6). This test uses the mapped
+    /// kind (kind 1 for enroll). Cross-kind rejection — a wrong success-transition
+    /// kind on a denied receipt — is exercised by
+    /// `denied_lifecycle_receipt_wrong_kind_receipt_side` (receipt-side trigger)
+    /// and `denied_lifecycle_receipt_wrong_kind_event_side` (event-side trigger).
+    ///
     /// Mutation sensitivity:
     /// - Removing the `outcome_code IN (1, 3)` branch entirely (or replacing it with a
     ///   blanket early-return) makes the positive case red — the denied enroll receipt
@@ -4604,7 +4611,9 @@ mod tests {
     /// In `denied_lifecycle_receipt_commits_without_audit_event`'s receipt-then-event
     /// negative, the receipt-side trigger (`authorization_operation_receipt_event_cardinality`)
     /// also fires. Here the committed receipt produces no deferred trigger, so rejection
-    /// can only come from the event-side trigger.
+    /// can only come from the event-side trigger. Uses the mapped kind (kind 1 for
+    /// enroll). Wrong-kind event-side isolation is in
+    /// `denied_lifecycle_receipt_wrong_kind_event_side`.
     ///
     /// Mutation sensitivity: disabling the
     /// `authorization_event_receipt_cardinality` trigger (DROP or ALTER TABLE
@@ -4994,6 +5003,232 @@ mod tests {
             Some("authorization_operation_receipt_event_cardinality"),
             "expected authorization_operation_receipt_event_cardinality rejection \
              for applied receipt without event, got: {absent_event_err}"
+        );
+    }
+
+    /// NIP-FI cross-kind denied lifecycle: a wrong success-transition kind paired
+    /// with a denied lifecycle receipt must be rejected through the receipt-side
+    /// deferred trigger. Uses a denied enroll receipt (operation_kind = 1, mapped
+    /// kind = 1) with a kind-6 (retired) event — a different success-transition
+    /// kind that is equally forbidden by the class-based guard (kinds 1, 2, 3, 6).
+    ///
+    /// Both the receipt and the wrong-kind event are inserted in the same
+    /// transaction, so the receipt-side deferred trigger
+    /// (`authorization_operation_receipt_event_cardinality`) fires at COMMIT.
+    ///
+    /// Mutation sensitivity: narrowing the denied filter back to
+    /// `event_kind = expected_event_kind` (the mapped kind, 1) removes kind 6
+    /// from the forbidden set, causing this negative to turn green — COMMIT
+    /// succeeds when it must not, failing `expect_err`.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn denied_lifecycle_receipt_wrong_kind_receipt_side() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("wrong-kind-rcpt-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        let op_id = uuid::Uuid::new_v4();
+        let fp = vec![0xA0_u8; 32];
+        let event_id = uuid::Uuid::new_v4();
+        let corr_id = uuid::Uuid::new_v4();
+        let attempt_id = uuid::Uuid::new_v4();
+
+        let mut conn = pool
+            .acquire()
+            .await
+            .expect("acquire connection for wrong-kind receipt-side test");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin");
+
+        // Denied enroll receipt (operation_kind = 1, outcome_code = 2).
+        // No history row needed: outcome_code = 2 expects zero history rows.
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 2, $5)",
+        )
+        .bind(community_id)
+        .bind(op_id)
+        .bind(&fp)
+        .bind(vec![0xA1_u8; 32])
+        .bind(vec![0xA2_u8; 32])
+        .execute(&mut *conn)
+        .await
+        .expect("insert denied enroll receipt — deferred guard");
+
+        // Wrong success-transition kind: event_kind = 6 (retired), not the mapped
+        // kind 1 (enrolled). Both are in the forbidden class (1, 2, 3, 6).
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, actor_fingerprint, operation_id, request_fingerprint, \
+              correlation_id, attempt_id, semantic_fingerprint, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 6, 1, 4, 1, $3, $4, $5, $6, $7, NULL, \
+                     '2026-01-01T00:00:00Z', $8, $9)",
+            // event_kind 6 (retired) — wrong kind for a denied enroll receipt
+        )
+        .bind(community_id)
+        .bind(event_id)
+        .bind(vec![0xA3_u8; 32]) // actor_fingerprint
+        .bind(op_id)
+        .bind(&fp)
+        .bind(corr_id)
+        .bind(attempt_id)
+        .bind(vec![0xA4_u8; 64]) // canonical_envelope
+        .bind(vec![0xA5_u8; 32]) // envelope_digest
+        .execute(&mut *conn)
+        .await
+        .expect("event INSERT must pass — deferred guard fires at COMMIT");
+
+        let wrong_kind_err = sqlx::query("COMMIT").execute(&mut *conn).await.expect_err(
+            "denied receipt + wrong success-transition kind (6) must be rejected at COMMIT \
+                 — class-based guard forbids all of kinds 1, 2, 3, 6",
+        );
+        assert_eq!(
+            wrong_kind_err
+                .as_database_error()
+                .and_then(|e| e.constraint()),
+            Some("authorization_denied_lifecycle_receipt_no_success_event"),
+            "expected authorization_denied_lifecycle_receipt_no_success_event for \
+             denied receipt + wrong kind (6), got: {wrong_kind_err}"
+        );
+    }
+
+    /// NIP-FI cross-kind denied lifecycle event-side: after a denied enroll
+    /// receipt is committed alone (auto-commit), a new transaction that inserts
+    /// only a wrong success-transition kind (kind 6, retired) must be rejected at
+    /// COMMIT by `authorization_event_receipt_cardinality` (event-side trigger).
+    ///
+    /// This isolates the event-side trigger path for the cross-kind case.
+    /// The committed receipt produces no active deferred trigger, so rejection
+    /// can only come from the event-side trigger.
+    ///
+    /// Mutation sensitivity: narrowing the denied filter to
+    /// `event_kind = expected_event_kind` (kind 1) removes kind 6 from the
+    /// forbidden set, making this negative green — COMMIT succeeds when it must
+    /// not, failing `expect_err`.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn denied_lifecycle_receipt_wrong_kind_event_side() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(42, &pool)
+            .await
+            .expect("apply migrations 1-42");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("wrong-kind-evt-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1000, 16777216, 16384)",
+        )
+        .bind(community_id)
+        .execute(&pool)
+        .await
+        .expect("insert event capacity");
+
+        // Commit a denied enroll receipt in auto-commit mode. No deferred trigger
+        // is active after this commit; the receipt-side trigger fires only within
+        // the transaction that inserts the receipt.
+        let op_id = uuid::Uuid::new_v4();
+        let fp = vec![0xB0_u8; 32];
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 1, $4, 2, $5)",
+        )
+        .bind(community_id)
+        .bind(op_id)
+        .bind(&fp)
+        .bind(vec![0xB1_u8; 32])
+        .bind(vec![0xB2_u8; 32])
+        .execute(&pool)
+        .await
+        .expect("denied receipt must commit alone in auto-commit mode");
+
+        // New transaction: insert only a kind-6 (retired) event for the same
+        // operation. The event-side trigger is the only active deferred trigger.
+        let event_id = uuid::Uuid::new_v4();
+        let corr_id = uuid::Uuid::new_v4();
+        let attempt_id = uuid::Uuid::new_v4();
+
+        let mut conn = pool
+            .acquire()
+            .await
+            .expect("acquire connection for wrong-kind event-side test");
+        sqlx::query("BEGIN")
+            .execute(&mut *conn)
+            .await
+            .expect("begin event-side wrong-kind transaction");
+
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, \
+              actor_kind, actor_fingerprint, operation_id, request_fingerprint, \
+              correlation_id, attempt_id, semantic_fingerprint, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 6, 1, 4, 1, $3, $4, $5, $6, $7, NULL, \
+                     '2026-01-01T00:00:00Z', $8, $9)",
+            // event_kind 6 (retired) — wrong kind for the denied enroll receipt
+        )
+        .bind(community_id)
+        .bind(event_id)
+        .bind(vec![0xB3_u8; 32]) // actor_fingerprint
+        .bind(op_id)
+        .bind(&fp)
+        .bind(corr_id)
+        .bind(attempt_id)
+        .bind(vec![0xB4_u8; 64]) // canonical_envelope
+        .bind(vec![0xB5_u8; 32]) // envelope_digest
+        .execute(&mut *conn)
+        .await
+        .expect("event INSERT must pass — event-side deferred guard fires at COMMIT");
+
+        let wrong_kind_evt_err = sqlx::query("COMMIT").execute(&mut *conn).await.expect_err(
+            "kind-6 event paired with a committed denied enroll receipt must be \
+                 rejected at COMMIT by the event-side trigger",
+        );
+        assert_eq!(
+            wrong_kind_evt_err
+                .as_database_error()
+                .and_then(|e| e.constraint()),
+            Some("authorization_denied_lifecycle_receipt_no_success_event"),
+            "event-side trigger must reject with authorization_denied_lifecycle_receipt_no_success_event \
+             for wrong kind (6) against denied receipt, got: {wrong_kind_evt_err}"
         );
     }
 }

--- a/migrations/0041_nip_fi_identity_foundation.sql
+++ b/migrations/0041_nip_fi_identity_foundation.sql
@@ -1,0 +1,879 @@
+-- Provider-free NIP-FI core identity and base-lifecycle foundation.
+--
+-- This is direct-final fresh-schema DDL. It intentionally does not replay a
+-- historical uid/backfill/ALTER sequence.
+--
+-- Scope is NIP-FI *core* only. Base lifecycle is exactly retire, revoke, and
+-- rotate (NIP-FI.md "Base lifecycle"). The extended NIP-FI-LIFECYCLE surface
+-- (disabled identities, pending-replacement lineage, and their provision,
+-- disable, recover, enable, and admission-loss transitions) is deferred to a
+-- later migration owned by the FI-LIFECYCLE PR, per NIP-FI-MODEL.md: "NIP-FI-
+-- LIFECYCLE adds disabled identities and pending replacement lineage." So the
+-- closed vocabularies below are the core subset:
+--   transition/operation kinds: 1 enroll, 3 retire, 5 revoke, 6 rotate;
+--   lifecycle selector kinds:   1 retired pair (P), 3 revoked key (Y).
+-- A later migration widens these vocabularies additively; nothing here presumes
+-- a single global issuer — identity is issuer-qualified (iss, sub).
+
+-- The sole idempotency/result root shared by identity base lifecycle,
+-- protected operations, and invalidation. Pre-authentication denials never
+-- write this table. ExactReplay and IntentConflict are read-time observations,
+-- not persisted outcomes.
+CREATE TABLE authorization_operation_receipts (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    -- Core operation kinds: 1 enroll, 3 retire, 5 revoke, 6 rotate,
+    -- 11 protected mutation, 12 invalidation. Extended lifecycle kinds
+    -- (2 provision, 4 disable, 7 recover, 8 enable, 9 admission loss) and
+    -- 10 operator are introduced by their owning later migrations.
+    operation_kind SMALLINT NOT NULL CHECK (
+        operation_kind IN (1, 3, 5, 6, 11, 12)
+    ),
+    actor_fingerprint BYTEA NOT NULL CHECK (octet_length(actor_fingerprint) = 32),
+    -- 1 applied, 2 denied, 3 no-op.
+    outcome_code SMALLINT NOT NULL CHECK (outcome_code IN (1, 2, 3)),
+    result_digest BYTEA NOT NULL CHECK (octet_length(result_digest) = 32),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, operation_id),
+    UNIQUE (community_id, operation_id, request_fingerprint),
+    UNIQUE (
+        community_id,
+        operation_id,
+        request_fingerprint,
+        operation_kind,
+        outcome_code
+    ),
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid)
+);
+
+-- Immutable monotonic local policy revisions. Enrollment modes are the closed
+-- provider-free V1 set: 1 attested-key, 2 provisioned, 3 risk-labelled TOFU.
+CREATE TABLE identity_enrollment_policies (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    policy_revision BIGINT NOT NULL CHECK (policy_revision > 0),
+    enrollment_mode SMALLINT NOT NULL CHECK (enrollment_mode IN (1, 2, 3)),
+    policy_digest BYTEA NOT NULL CHECK (octet_length(policy_digest) = 32),
+    effective_at TIMESTAMPTZ NOT NULL,
+    -- Optional local binding-policy expiry. Federated token `exp` MUST NOT be
+    -- copied here: token lifetime bounds an authorization lease, not this
+    -- durable binding generation.
+    expires_at TIMESTAMPTZ,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, policy_revision),
+    UNIQUE (community_id, policy_revision, enrollment_mode),
+    CHECK (expires_at IS NULL OR effective_at < expires_at)
+);
+
+-- One row is one immutable binding generation. binding_version is allocated
+-- from one non-cycling PostgreSQL identity sequence and is never changed or
+-- reused. Explicit lifecycle may only retire the generation; X/Y denial
+-- semantics live in immutable selector facts below, not alternate row states.
+CREATE TABLE identity_bindings (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    binding_id UUID NOT NULL,
+    binding_version BIGINT GENERATED ALWAYS AS IDENTITY (
+        START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1 NO CYCLE
+    ),
+    issuer TEXT COLLATE "C" NOT NULL CHECK (octet_length(issuer) BETWEEN 1 AND 2048),
+    subject TEXT COLLATE "C" NOT NULL CHECK (octet_length(subject) BETWEEN 1 AND 2048),
+    principal_fingerprint BYTEA NOT NULL CHECK (octet_length(principal_fingerprint) = 32),
+    event_author_pubkey BYTEA NOT NULL CHECK (octet_length(event_author_pubkey) = 32),
+    -- 1 active, 2 retired.
+    binding_state SMALLINT NOT NULL CHECK (binding_state IN (1, 2)),
+    lifecycle_revision BIGINT NOT NULL CHECK (lifecycle_revision IN (1, 2)),
+    -- 1 attested-key, 2 provisioned, 3 risk-labelled TOFU.
+    binding_provenance SMALLINT NOT NULL CHECK (binding_provenance IN (1, 2, 3)),
+    policy_revision BIGINT NOT NULL CHECK (policy_revision > 0),
+    -- Canonical evidence for the selected provenance. This is an assertion
+    -- digest for attested/TOFU admission and a provisioning receipt digest for
+    -- separately provisioned admission; it never stores credential bytes.
+    enrollment_evidence_digest BYTEA NOT NULL CHECK (
+        octet_length(enrollment_evidence_digest) = 32
+    ),
+    expires_at TIMESTAMPTZ,
+    birth_history_id UUID NOT NULL,
+    creation_operation_id UUID NOT NULL,
+    creation_request_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(creation_request_fingerprint) = 32
+    ),
+    retirement_history_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, binding_id),
+    UNIQUE (community_id, binding_version),
+    UNIQUE (community_id, binding_id, binding_version),
+    FOREIGN KEY (community_id, policy_revision, binding_provenance)
+        REFERENCES identity_enrollment_policies
+            (community_id, policy_revision, enrollment_mode),
+    CHECK (binding_version > 0),
+    CHECK (binding_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (birth_history_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (creation_operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (expires_at IS NULL OR created_at < expires_at),
+    CHECK (
+        (binding_state = 1 AND lifecycle_revision = 1 AND retirement_history_id IS NULL)
+        OR (binding_state = 2 AND lifecycle_revision = 2 AND retirement_history_id IS NOT NULL)
+    )
+);
+
+-- State 1 is Active. Expiry is evaluated with authoritative PostgreSQL time
+-- at read/finalization and is exclusive; it cannot appear in an index predicate.
+CREATE UNIQUE INDEX identity_bindings_active_principal
+    ON identity_bindings (community_id, issuer, subject)
+    WHERE binding_state = 1;
+CREATE INDEX identity_bindings_principal_fingerprint_lookup
+    ON identity_bindings (community_id, principal_fingerprint)
+    WHERE binding_state = 1;
+CREATE UNIQUE INDEX identity_bindings_active_event_author
+    ON identity_bindings (community_id, event_author_pubkey)
+    WHERE binding_state = 1;
+CREATE INDEX identity_bindings_current_lookup
+    ON identity_bindings (community_id, event_author_pubkey, binding_state, expires_at);
+
+-- The one canonical immutable lifecycle transition row for a successful or
+-- no-op lifecycle operation. A transition can name an old generation, a new
+-- successor generation, both (Rotate), or neither (a semantic no-op). It is not
+-- a second result/effect engine: the shared receipt remains the sole persisted
+-- operation outcome. Core transition kinds only: 1 enroll, 3 retire, 5 revoke,
+-- 6 rotate.
+CREATE TABLE identity_lifecycle_history (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    history_id UUID NOT NULL,
+    transition_kind SMALLINT NOT NULL CHECK (
+        transition_kind IN (1, 3, 5, 6)
+    ),
+    -- Matches the shared receipt: 1 applied, 3 no-op.
+    outcome_code SMALLINT NOT NULL CHECK (outcome_code IN (1, 3)),
+    old_binding_id UUID,
+    old_binding_version BIGINT CHECK (old_binding_version IS NULL OR old_binding_version > 0),
+    old_prior_lifecycle_revision BIGINT CHECK (
+        old_prior_lifecycle_revision IS NULL OR old_prior_lifecycle_revision IN (1, 2)
+    ),
+    old_prior_state SMALLINT CHECK (old_prior_state IS NULL OR old_prior_state IN (1, 2)),
+    old_resulting_lifecycle_revision BIGINT CHECK (
+        old_resulting_lifecycle_revision IS NULL OR old_resulting_lifecycle_revision IN (1, 2)
+    ),
+    old_resulting_state SMALLINT CHECK (
+        old_resulting_state IS NULL OR old_resulting_state IN (1, 2)
+    ),
+    successor_binding_id UUID,
+    successor_binding_version BIGINT CHECK (
+        successor_binding_version IS NULL OR successor_binding_version > 0
+    ),
+    successor_lifecycle_revision BIGINT CHECK (
+        successor_lifecycle_revision IS NULL OR successor_lifecycle_revision = 1
+    ),
+    successor_state SMALLINT CHECK (successor_state IS NULL OR successor_state = 1),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    transition_digest BYTEA NOT NULL CHECK (octet_length(transition_digest) = 32),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, history_id),
+    UNIQUE (community_id, operation_id),
+    UNIQUE (community_id, history_id, operation_id, request_fingerprint),
+    UNIQUE (
+        community_id,
+        history_id,
+        successor_binding_id,
+        successor_binding_version,
+        operation_id,
+        request_fingerprint
+    ),
+    UNIQUE (
+        community_id,
+        history_id,
+        old_binding_id,
+        old_binding_version,
+        old_resulting_lifecycle_revision,
+        old_resulting_state
+    ),
+    FOREIGN KEY (
+        community_id,
+        operation_id,
+        request_fingerprint,
+        transition_kind,
+        outcome_code
+    ) REFERENCES authorization_operation_receipts (
+        community_id,
+        operation_id,
+        request_fingerprint,
+        operation_kind,
+        outcome_code
+    ) DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, old_binding_id, old_binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, successor_binding_id, successor_binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (history_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (
+        (old_binding_id IS NULL
+            AND old_binding_version IS NULL
+            AND old_prior_lifecycle_revision IS NULL
+            AND old_prior_state IS NULL
+            AND old_resulting_lifecycle_revision IS NULL
+            AND old_resulting_state IS NULL)
+        OR (old_binding_id IS NOT NULL
+            AND old_binding_version IS NOT NULL
+            AND old_prior_lifecycle_revision IS NOT NULL
+            AND old_prior_state IS NOT NULL
+            AND old_resulting_lifecycle_revision IS NOT NULL
+            AND old_resulting_state IS NOT NULL)
+    ),
+    CHECK (
+        (successor_binding_id IS NULL
+            AND successor_binding_version IS NULL
+            AND successor_lifecycle_revision IS NULL
+            AND successor_state IS NULL)
+        OR (successor_binding_id IS NOT NULL
+            AND successor_binding_version IS NOT NULL
+            AND successor_lifecycle_revision = 1
+            AND successor_state = 1)
+    ),
+    CHECK (
+        old_binding_id IS NULL
+        OR successor_binding_id IS NULL
+        OR old_binding_id <> successor_binding_id
+    ),
+    CHECK (
+        old_binding_version IS NULL
+        OR successor_binding_version IS NULL
+        OR old_binding_version <> successor_binding_version
+    ),
+    -- Core lifecycle only ever moves Active/r1 to Retired/r2 for a named old
+    -- generation. Extended re-enablement (recover/enable from Retired/r2) is a
+    -- later migration's concern.
+    CHECK (
+        old_binding_id IS NULL
+        OR (old_prior_lifecycle_revision = 1
+            AND old_prior_state = 1
+            AND old_resulting_lifecycle_revision = 2
+            AND old_resulting_state = 2)
+    ),
+    CHECK (
+        (outcome_code = 3
+            AND old_binding_id IS NULL
+            AND successor_binding_id IS NULL)
+        OR (outcome_code = 1 AND (
+            (transition_kind = 1
+                AND old_binding_id IS NULL
+                AND successor_binding_id IS NOT NULL)
+            OR (transition_kind = 3
+                AND old_binding_id IS NOT NULL
+                AND successor_binding_id IS NULL)
+            OR (transition_kind = 5
+                AND successor_binding_id IS NULL)
+            OR (transition_kind = 6
+                AND old_binding_id IS NOT NULL
+                AND successor_binding_id IS NOT NULL)
+        ))
+    )
+);
+
+CREATE INDEX identity_lifecycle_history_old_binding
+    ON identity_lifecycle_history (community_id, old_binding_id, old_binding_version, recorded_at);
+CREATE INDEX identity_lifecycle_history_successor_binding
+    ON identity_lifecycle_history (
+        community_id,
+        successor_binding_id,
+        successor_binding_version,
+        recorded_at
+    );
+
+-- Circular birth/transition ordering is deliberate and fully deferred. Every
+-- generation must commit with its exact birth transition, and a retired row
+-- must commit with the exact transition that changed Active/r1 to Retired/r2.
+ALTER TABLE identity_bindings
+    ADD CONSTRAINT identity_bindings_exact_birth_history_fk
+    FOREIGN KEY (
+        community_id,
+        birth_history_id,
+        binding_id,
+        binding_version,
+        creation_operation_id,
+        creation_request_fingerprint
+    ) REFERENCES identity_lifecycle_history (
+        community_id,
+        history_id,
+        successor_binding_id,
+        successor_binding_version,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE identity_bindings
+    ADD CONSTRAINT identity_bindings_exact_retirement_history_fk
+    FOREIGN KEY (
+        community_id,
+        retirement_history_id,
+        binding_id,
+        binding_version,
+        lifecycle_revision,
+        binding_state
+    ) REFERENCES identity_lifecycle_history (
+        community_id,
+        history_id,
+        old_binding_id,
+        old_binding_version,
+        old_resulting_lifecycle_revision,
+        old_resulting_state
+    ) DEFERRABLE INITIALLY DEFERRED;
+
+-- One immutable closed-scope fact table. Core selector kinds only:
+-- 1 retired pair (P), 3 revoked key (Y). Both are permanent. The extended
+-- disabled-identity (X) and pending-replacement (Q) selectors, and their
+-- one-shot consumption, are introduced by the FI-LIFECYCLE migration.
+CREATE TABLE identity_lifecycle_selectors (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    selector_id UUID NOT NULL,
+    selector_kind SMALLINT NOT NULL CHECK (selector_kind IN (1, 3)),
+    selector_fingerprint BYTEA NOT NULL CHECK (octet_length(selector_fingerprint) = 32),
+    fact_generation BIGINT NOT NULL CHECK (fact_generation > 0),
+    principal_fingerprint BYTEA CHECK (
+        principal_fingerprint IS NULL OR octet_length(principal_fingerprint) = 32
+    ),
+    event_author_pubkey BYTEA CHECK (
+        event_author_pubkey IS NULL OR octet_length(event_author_pubkey) = 32
+    ),
+    binding_id UUID,
+    binding_version BIGINT CHECK (binding_version IS NULL OR binding_version > 0),
+    asserted_history_id UUID NOT NULL,
+    selected_by_operation_id UUID NOT NULL,
+    selected_by_request_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(selected_by_request_fingerprint) = 32
+    ),
+    selected_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, selector_id),
+    UNIQUE (community_id, selector_id, selector_kind),
+    UNIQUE (community_id, selector_kind, selector_fingerprint, fact_generation),
+    FOREIGN KEY (
+        community_id,
+        asserted_history_id,
+        selected_by_operation_id,
+        selected_by_request_fingerprint
+    ) REFERENCES identity_lifecycle_history (
+        community_id,
+        history_id,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (
+        community_id,
+        selected_by_operation_id,
+        selected_by_request_fingerprint
+    ) REFERENCES authorization_operation_receipts (
+        community_id,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, binding_id, binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (selector_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (
+        (selector_kind = 1
+            AND fact_generation = 1
+            AND principal_fingerprint IS NOT NULL
+            AND event_author_pubkey IS NOT NULL
+            AND binding_id IS NOT NULL
+            AND binding_version IS NOT NULL)
+        OR (selector_kind = 3
+            AND fact_generation = 1
+            AND principal_fingerprint IS NULL
+            AND event_author_pubkey IS NOT NULL
+            AND binding_id IS NULL
+            AND binding_version IS NULL)
+    )
+);
+
+CREATE UNIQUE INDEX identity_lifecycle_selectors_permanent_pair
+    ON identity_lifecycle_selectors (community_id, binding_id, binding_version)
+    WHERE selector_kind = 1;
+CREATE UNIQUE INDEX identity_lifecycle_selectors_permanent_principal_key
+    ON identity_lifecycle_selectors (
+        community_id,
+        principal_fingerprint,
+        event_author_pubkey
+    ) WHERE selector_kind = 1;
+CREATE UNIQUE INDEX identity_lifecycle_selectors_permanent_key
+    ON identity_lifecycle_selectors (community_id, event_author_pubkey)
+    WHERE selector_kind = 3;
+CREATE INDEX identity_lifecycle_selectors_principal_lookup
+    ON identity_lifecycle_selectors
+        (community_id, selector_kind, principal_fingerprint, fact_generation);
+CREATE INDEX identity_lifecycle_selectors_key_lookup
+    ON identity_lifecycle_selectors
+        (community_id, selector_kind, event_author_pubkey, fact_generation);
+CREATE INDEX identity_lifecycle_selectors_binding_lookup
+    ON identity_lifecycle_selectors
+        (community_id, selector_kind, binding_id, binding_version, fact_generation);
+CREATE INDEX identity_lifecycle_selectors_asserted_history
+    ON identity_lifecycle_selectors
+        (community_id, asserted_history_id, selector_kind);
+
+CREATE FUNCTION nip_fi_reject_row_mutation_v1() RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '% is immutable', TG_TABLE_NAME
+        USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION nip_fi_reject_truncate_v1() RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '% cannot be truncated', TG_TABLE_NAME
+        USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Every binding/selector path derives the same domain-scoped coordinates and
+-- takes their signed BIGINT advisory keys in numeric order. Typed transaction
+-- APIs take these locks before row mutation; the triggers are the fail-closed
+-- backstop for direct SQL.
+CREATE FUNCTION identity_lifecycle_lock_coordinates_v1(
+    locked_community_id UUID,
+    locked_principal_fingerprint BYTEA,
+    locked_event_author_pubkey BYTEA
+) RETURNS VOID AS $$
+DECLARE
+    principal_lock_key BIGINT;
+    event_author_lock_key BIGINT;
+BEGIN
+    IF locked_principal_fingerprint IS NOT NULL THEN
+        principal_lock_key := hashtextextended(
+            'buzz:identity-lifecycle-coordinate:v1:principal:'
+                || locked_community_id::text || ':'
+                || encode(locked_principal_fingerprint, 'hex'),
+            0
+        );
+    END IF;
+    IF locked_event_author_pubkey IS NOT NULL THEN
+        event_author_lock_key := hashtextextended(
+            'buzz:identity-lifecycle-coordinate:v1:key:'
+                || locked_community_id::text || ':'
+                || encode(locked_event_author_pubkey, 'hex'),
+            0
+        );
+    END IF;
+
+    IF principal_lock_key IS NOT NULL AND event_author_lock_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(LEAST(principal_lock_key, event_author_lock_key));
+        IF principal_lock_key <> event_author_lock_key THEN
+            PERFORM pg_advisory_xact_lock(GREATEST(principal_lock_key, event_author_lock_key));
+        END IF;
+    ELSIF principal_lock_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(principal_lock_key);
+    ELSIF event_author_lock_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(event_author_lock_key);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_bindings_insert_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM identity_lifecycle_lock_coordinates_v1(
+        NEW.community_id,
+        NEW.principal_fingerprint,
+        NEW.event_author_pubkey
+    );
+    IF NEW.binding_state <> 1
+        OR NEW.lifecycle_revision <> 1
+        OR NEW.retirement_history_id IS NOT NULL
+    THEN
+        RAISE EXCEPTION 'identity binding birth must be Active at lifecycle revision 1'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_birth_state';
+    END IF;
+    NEW.created_at := transaction_timestamp();
+    NEW.updated_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_bindings_transition_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    PERFORM identity_lifecycle_lock_coordinates_v1(
+        OLD.community_id,
+        OLD.principal_fingerprint,
+        OLD.event_author_pubkey
+    );
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.binding_id IS DISTINCT FROM OLD.binding_id
+        OR NEW.binding_version IS DISTINCT FROM OLD.binding_version
+        OR NEW.issuer IS DISTINCT FROM OLD.issuer
+        OR NEW.subject IS DISTINCT FROM OLD.subject
+        OR NEW.principal_fingerprint IS DISTINCT FROM OLD.principal_fingerprint
+        OR NEW.event_author_pubkey IS DISTINCT FROM OLD.event_author_pubkey
+        OR NEW.binding_provenance IS DISTINCT FROM OLD.binding_provenance
+        OR NEW.policy_revision IS DISTINCT FROM OLD.policy_revision
+        OR NEW.enrollment_evidence_digest IS DISTINCT FROM OLD.enrollment_evidence_digest
+        OR NEW.expires_at IS DISTINCT FROM OLD.expires_at
+        OR NEW.birth_history_id IS DISTINCT FROM OLD.birth_history_id
+        OR NEW.creation_operation_id IS DISTINCT FROM OLD.creation_operation_id
+        OR NEW.creation_request_fingerprint IS DISTINCT FROM OLD.creation_request_fingerprint
+        OR NEW.created_at IS DISTINCT FROM OLD.created_at
+    THEN
+        RAISE EXCEPTION 'identity binding generation coordinates are immutable'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_immutable_generation';
+    END IF;
+    IF OLD.binding_state <> 1
+        OR OLD.lifecycle_revision <> 1
+        OR OLD.retirement_history_id IS NOT NULL
+        OR NEW.binding_state <> 2
+        OR NEW.lifecycle_revision <> 2
+        OR NEW.retirement_history_id IS NULL
+        OR NEW.retirement_history_id = OLD.birth_history_id
+    THEN
+        RAISE EXCEPTION 'identity binding permits only Active/r1 to Retired/r2'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_active_to_retired';
+    END IF;
+    NEW.updated_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_history_insert_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.recorded_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_binding_history_semantics_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    retirement identity_lifecycle_history%ROWTYPE;
+BEGIN
+    IF NEW.binding_state = 2 THEN
+        SELECT * INTO STRICT retirement
+        FROM identity_lifecycle_history
+        WHERE community_id = NEW.community_id
+          AND history_id = NEW.retirement_history_id
+          AND old_binding_id = NEW.binding_id
+          AND old_binding_version = NEW.binding_version;
+        IF retirement.outcome_code <> 1
+            OR retirement.old_prior_lifecycle_revision <> 1
+            OR retirement.old_prior_state <> 1
+            OR retirement.old_resulting_lifecycle_revision <> 2
+            OR retirement.old_resulting_state <> 2
+        THEN
+            RAISE EXCEPTION 'retired binding must reference its exact Active-to-Retired transition'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'identity_bindings_retirement_history_semantics';
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_binding_birth_eligibility_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM identity_lifecycle_selectors selector
+        WHERE selector.community_id = NEW.community_id
+          AND (
+            (selector.selector_kind = 1
+                AND selector.principal_fingerprint = NEW.principal_fingerprint
+                AND selector.event_author_pubkey = NEW.event_author_pubkey)
+            OR (selector.selector_kind = 3
+                AND selector.event_author_pubkey = NEW.event_author_pubkey)
+          )
+    ) THEN
+        RAISE EXCEPTION 'binding birth conflicts with an effective lifecycle selector'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_birth_eligibility';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION authorization_operation_receipt_history_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    history_count BIGINT;
+    expected_count BIGINT;
+BEGIN
+    SELECT count(*) INTO history_count
+    FROM identity_lifecycle_history history
+    WHERE history.community_id = NEW.community_id
+      AND history.operation_id = NEW.operation_id;
+
+    -- Core lifecycle receipts (enroll, retire, revoke, rotate) each require
+    -- exactly one lifecycle-history row. Non-lifecycle receipts (protected
+    -- mutation, invalidation) require none.
+    expected_count := CASE
+        WHEN NEW.operation_kind IN (1, 3, 5, 6) AND NEW.outcome_code IN (1, 3) THEN 1
+        ELSE 0
+    END;
+    IF history_count <> expected_count THEN
+        RAISE EXCEPTION 'operation receipt requires % lifecycle history row, found %',
+            expected_count, history_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_receipt_history_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_selector_insert_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.selected_at := transaction_timestamp();
+    PERFORM identity_lifecycle_lock_coordinates_v1(
+        NEW.community_id,
+        CASE WHEN NEW.selector_kind = 1 THEN NEW.principal_fingerprint END,
+        NEW.event_author_pubkey
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_selector_history_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    history identity_lifecycle_history%ROWTYPE;
+    old_binding identity_bindings%ROWTYPE;
+BEGIN
+    SELECT * INTO STRICT history
+    FROM identity_lifecycle_history
+    WHERE community_id = NEW.community_id
+      AND history_id = NEW.asserted_history_id
+      AND operation_id = NEW.selected_by_operation_id
+      AND request_fingerprint = NEW.selected_by_request_fingerprint;
+
+    IF history.old_binding_id IS NOT NULL THEN
+        SELECT * INTO STRICT old_binding
+        FROM identity_bindings
+        WHERE community_id = history.community_id
+          AND binding_id = history.old_binding_id
+          AND binding_version = history.old_binding_version;
+    END IF;
+
+    -- A retired-pair (P) selector is asserted by retire, revoke, or rotate of a
+    -- named old generation; a revoked-key (Y) selector by revoke.
+    IF history.outcome_code <> 1
+        OR (NEW.selector_kind = 1 AND (
+            history.transition_kind NOT IN (3, 5, 6)
+            OR history.old_binding_id IS DISTINCT FROM NEW.binding_id
+            OR history.old_binding_version IS DISTINCT FROM NEW.binding_version
+            OR old_binding.principal_fingerprint IS DISTINCT FROM NEW.principal_fingerprint
+            OR old_binding.event_author_pubkey IS DISTINCT FROM NEW.event_author_pubkey
+        ))
+        OR (NEW.selector_kind = 3 AND (
+            history.transition_kind <> 5
+            OR (history.old_binding_id IS NOT NULL
+                AND old_binding.event_author_pubkey
+                    IS DISTINCT FROM NEW.event_author_pubkey)
+        ))
+    THEN
+        RAISE EXCEPTION 'selector does not match its lifecycle transition'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_lifecycle_selector_history_semantics';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_transition_integrity_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    transition identity_lifecycle_history%ROWTYPE;
+    old_binding_state SMALLINT;
+    asserted_p BIGINT;
+    asserted_y BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'identity_lifecycle_history' THEN
+        transition := NEW;
+    ELSIF TG_TABLE_NAME = 'identity_lifecycle_selectors' THEN
+        SELECT * INTO STRICT transition
+        FROM identity_lifecycle_history
+        WHERE community_id = NEW.community_id
+          AND history_id = NEW.asserted_history_id;
+    ELSE
+        SELECT * INTO STRICT transition
+        FROM identity_lifecycle_history
+        WHERE community_id = NEW.community_id
+          AND history_id = CASE
+              WHEN NEW.binding_state = 2 THEN NEW.retirement_history_id
+              ELSE NEW.birth_history_id
+          END;
+    END IF;
+
+    SELECT
+        count(*) FILTER (WHERE selector_kind = 1),
+        count(*) FILTER (WHERE selector_kind = 3)
+    INTO asserted_p, asserted_y
+    FROM identity_lifecycle_selectors
+    WHERE community_id = transition.community_id
+      AND asserted_history_id = transition.history_id;
+
+    IF transition.old_binding_id IS NOT NULL THEN
+        SELECT binding_state INTO STRICT old_binding_state
+        FROM identity_bindings
+        WHERE community_id = transition.community_id
+          AND binding_id = transition.old_binding_id
+          AND binding_version = transition.old_binding_version;
+        IF old_binding_state <> 2 THEN
+            RAISE EXCEPTION 'lifecycle transition old binding must be retired at commit'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'identity_lifecycle_transition_integrity';
+        END IF;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM identity_lifecycle_selectors selector
+        JOIN identity_bindings active
+          ON active.community_id = selector.community_id
+         AND active.binding_state = 1
+         AND (
+            (selector.selector_kind = 1
+                AND active.principal_fingerprint = selector.principal_fingerprint
+                AND active.event_author_pubkey = selector.event_author_pubkey)
+            OR (selector.selector_kind = 3
+                AND active.event_author_pubkey = selector.event_author_pubkey)
+         )
+        WHERE selector.community_id = transition.community_id
+    ) THEN
+        RAISE EXCEPTION 'effective lifecycle selector conflicts with an active binding'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_lifecycle_transition_integrity';
+    END IF;
+
+    IF transition.outcome_code = 3 THEN
+        IF asserted_p + asserted_y <> 0 THEN
+            RAISE EXCEPTION 'no-op lifecycle transition cannot create selector facts'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'identity_lifecycle_transition_integrity';
+        END IF;
+        RETURN NULL;
+    END IF;
+
+    -- Core selector companions per transition:
+    --   enroll  (1): none
+    --   retire  (3): exactly one P
+    --   revoke  (5): one Y always; one P when a named old generation is removed
+    --   rotate  (6): exactly one P (old generation retired)
+    IF (transition.transition_kind = 1
+            AND (asserted_p, asserted_y) <> (0, 0))
+        OR (transition.transition_kind = 3
+            AND (asserted_p, asserted_y) <> (1, 0))
+        OR (transition.transition_kind = 5 AND (
+            (transition.old_binding_id IS NOT NULL
+                AND (asserted_p, asserted_y) <> (1, 1))
+            OR (transition.old_binding_id IS NULL
+                AND (asserted_p, asserted_y) <> (0, 1))
+        ))
+        OR (transition.transition_kind = 6
+            AND (asserted_p, asserted_y) <> (1, 0))
+    THEN
+        RAISE EXCEPTION 'lifecycle transition has incomplete or forbidden selector companions'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_lifecycle_transition_integrity';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER identity_bindings_insert_guard
+    BEFORE INSERT ON identity_bindings
+    FOR EACH ROW EXECUTE FUNCTION identity_bindings_insert_guard_v1();
+CREATE TRIGGER identity_bindings_transition_guard
+    BEFORE UPDATE ON identity_bindings
+    FOR EACH ROW EXECUTE FUNCTION identity_bindings_transition_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_bindings_history_semantics
+    AFTER INSERT OR UPDATE ON identity_bindings
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_binding_history_semantics_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_bindings_birth_eligibility
+    AFTER INSERT ON identity_bindings
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_binding_birth_eligibility_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_bindings_transition_integrity
+    AFTER INSERT OR UPDATE ON identity_bindings
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_transition_integrity_guard_v1();
+CREATE TRIGGER identity_bindings_no_delete
+    BEFORE DELETE ON identity_bindings
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_bindings_no_truncate
+    BEFORE TRUNCATE ON identity_bindings
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_lifecycle_history_insert_guard
+    BEFORE INSERT ON identity_lifecycle_history
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_history_insert_guard_v1();
+CREATE CONSTRAINT TRIGGER authorization_operation_receipt_history_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_history_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_lifecycle_transition_integrity
+    AFTER INSERT ON identity_lifecycle_history
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_transition_integrity_guard_v1();
+
+CREATE TRIGGER identity_lifecycle_selector_insert_guard
+    BEFORE INSERT ON identity_lifecycle_selectors
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_selector_insert_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_lifecycle_selector_history_semantics
+    AFTER INSERT ON identity_lifecycle_selectors
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_selector_history_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_lifecycle_selector_transition_integrity
+    AFTER INSERT ON identity_lifecycle_selectors
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_transition_integrity_guard_v1();
+
+CREATE TRIGGER authorization_operation_receipts_immutable
+    BEFORE UPDATE OR DELETE ON authorization_operation_receipts
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_operation_receipts_no_truncate
+    BEFORE TRUNCATE ON authorization_operation_receipts
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_enrollment_policies_immutable
+    BEFORE UPDATE OR DELETE ON identity_enrollment_policies
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_enrollment_policies_no_truncate
+    BEFORE TRUNCATE ON identity_enrollment_policies
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_lifecycle_history_immutable
+    BEFORE UPDATE OR DELETE ON identity_lifecycle_history
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_lifecycle_history_no_truncate
+    BEFORE TRUNCATE ON identity_lifecycle_history
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_lifecycle_selectors_immutable
+    BEFORE UPDATE OR DELETE ON identity_lifecycle_selectors
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_lifecycle_selectors_no_truncate
+    BEFORE TRUNCATE ON identity_lifecycle_selectors
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+-- These identity relations are a durable, tamper-evident authorization ledger:
+-- FI-INV-02 (durable binding) and FI-INV-03 (tombstone monotonicity) require
+-- their denial facts to outlive any single tenant lifecycle, and the immutable
+-- no_delete/no_truncate triggers above enforce exactly that. They therefore
+-- carry community_id as provenance, not as deletable ownership — the same
+-- posture migration 0030 took for product_feedback and rate_limit_violations.
+-- Widen the single SQL source of truth so the universal write fence and the
+-- deletion catalog treat them as ledger: never fence-attached, never purged,
+-- never counted as tenant-scoped drift. community rows are permanent tombstones
+-- (never hard-deleted), so their NOT NULL community_id references never dangle.
+CREATE OR REPLACE FUNCTION community_write_fence_excluded_table(target NAME) RETURNS BOOLEAN
+LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT target::TEXT = ANY (ARRAY[
+        'community_deletion_requests', 'community_deletion_approvals',
+        'community_deletion_checkpoints', 'community_serving_write_leases',
+        'community_deletion_executor_heartbeats', 'product_feedback',
+        'rate_limit_violations',
+        'authorization_operation_receipts', 'identity_enrollment_policies',
+        'identity_bindings', 'identity_lifecycle_history',
+        'identity_lifecycle_selectors'
+    ]::TEXT[])
+$$;

--- a/migrations/0041_nip_fi_identity_foundation.sql
+++ b/migrations/0041_nip_fi_identity_foundation.sql
@@ -413,6 +413,56 @@ CREATE INDEX identity_lifecycle_selectors_asserted_history
     ON identity_lifecycle_selectors
         (community_id, asserted_history_id, selector_kind);
 
+-- Serializes policy-revision inserts per community: each new revision must
+-- strictly exceed the current maximum, and each effective_at must strictly
+-- exceed the current maximum effective_at (FI-INV-06 — stable assertion
+-- policy; a revision that moves either coordinate backward is incoherent).
+-- The per-community advisory lock prevents two concurrent writers from both
+-- passing a plain SELECT MAX() check and committing conflicting revisions.
+CREATE FUNCTION identity_enrollment_policy_revision_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    lock_key BIGINT;
+    max_revision BIGINT;
+    max_effective_at TIMESTAMPTZ;
+BEGIN
+    -- Acquire a per-community exclusive transaction-scoped advisory lock so
+    -- that concurrent insertions serialize here. The key is a stable hash of
+    -- the namespace string and the community_id bytes.
+    lock_key := hashtextextended(
+        'buzz:enrollment-policy-revision:v1:' || NEW.community_id::text,
+        0
+    );
+    PERFORM pg_advisory_xact_lock(lock_key);
+
+    SELECT MAX(policy_revision), MAX(effective_at)
+    INTO max_revision, max_effective_at
+    FROM identity_enrollment_policies
+    WHERE community_id = NEW.community_id;
+
+    IF max_revision IS NOT NULL
+        AND NEW.policy_revision <= max_revision
+    THEN
+        RAISE EXCEPTION
+            'policy_revision % does not strictly exceed current maximum % for community %',
+            NEW.policy_revision, max_revision, NEW.community_id
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
+    END IF;
+
+    IF max_effective_at IS NOT NULL
+        AND NEW.effective_at <= max_effective_at
+    THEN
+        RAISE EXCEPTION
+            'effective_at % does not strictly exceed current maximum % for community %',
+            NEW.effective_at, max_effective_at, NEW.community_id
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION nip_fi_reject_row_mutation_v1() RETURNS TRIGGER AS $$
 BEGIN
     RAISE EXCEPTION '% is immutable', TG_TABLE_NAME
@@ -833,6 +883,9 @@ CREATE TRIGGER authorization_operation_receipts_no_truncate
     BEFORE TRUNCATE ON authorization_operation_receipts
     FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
 
+CREATE TRIGGER identity_enrollment_policies_revision_guard
+    BEFORE INSERT ON identity_enrollment_policies
+    FOR EACH ROW EXECUTE FUNCTION identity_enrollment_policy_revision_guard_v1();
 CREATE TRIGGER identity_enrollment_policies_immutable
     BEFORE UPDATE OR DELETE ON identity_enrollment_policies
     FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();

--- a/migrations/0041_nip_fi_identity_foundation.sql
+++ b/migrations/0041_nip_fi_identity_foundation.sql
@@ -61,7 +61,6 @@ CREATE TABLE identity_enrollment_policies (
     expires_at TIMESTAMPTZ,
     recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
     PRIMARY KEY (community_id, policy_revision),
-    UNIQUE (community_id, policy_revision, enrollment_mode),
     CHECK (expires_at IS NULL OR effective_at < expires_at)
 );
 
@@ -103,9 +102,9 @@ CREATE TABLE identity_bindings (
     PRIMARY KEY (community_id, binding_id),
     UNIQUE (community_id, binding_version),
     UNIQUE (community_id, binding_id, binding_version),
-    FOREIGN KEY (community_id, policy_revision, binding_provenance)
+    FOREIGN KEY (community_id, policy_revision)
         REFERENCES identity_enrollment_policies
-            (community_id, policy_revision, enrollment_mode),
+            (community_id, policy_revision),
     CHECK (binding_version > 0),
     CHECK (binding_id <> '00000000-0000-0000-0000-000000000000'::uuid),
     CHECK (birth_history_id <> '00000000-0000-0000-0000-000000000000'::uuid),

--- a/migrations/0041_nip_fi_identity_foundation.sql
+++ b/migrations/0041_nip_fi_identity_foundation.sql
@@ -414,16 +414,14 @@ CREATE INDEX identity_lifecycle_selectors_asserted_history
         (community_id, asserted_history_id, selector_kind);
 
 -- Serializes policy-revision inserts per community: each new revision must
--- strictly exceed the current maximum, and each effective_at must strictly
--- exceed the current maximum effective_at (FI-INV-06 — stable assertion
--- policy; a revision that moves either coordinate backward is incoherent).
--- The per-community advisory lock prevents two concurrent writers from both
--- passing a plain SELECT MAX() check and committing conflicting revisions.
+-- strictly exceed the current maximum (FI-INV-06 — stable assertion policy
+-- anchor; a backfilled or replayed revision is incoherent). The per-community
+-- advisory lock prevents two concurrent writers from both passing a plain
+-- SELECT MAX() check and committing conflicting revisions.
 CREATE FUNCTION identity_enrollment_policy_revision_guard_v1() RETURNS TRIGGER AS $$
 DECLARE
     lock_key BIGINT;
     max_revision BIGINT;
-    max_effective_at TIMESTAMPTZ;
 BEGIN
     -- Acquire a per-community exclusive transaction-scoped advisory lock so
     -- that concurrent insertions serialize here. The key is a stable hash of
@@ -434,8 +432,8 @@ BEGIN
     );
     PERFORM pg_advisory_xact_lock(lock_key);
 
-    SELECT MAX(policy_revision), MAX(effective_at)
-    INTO max_revision, max_effective_at
+    SELECT MAX(policy_revision)
+    INTO max_revision
     FROM identity_enrollment_policies
     WHERE community_id = NEW.community_id;
 
@@ -445,16 +443,6 @@ BEGIN
         RAISE EXCEPTION
             'policy_revision % does not strictly exceed current maximum % for community %',
             NEW.policy_revision, max_revision, NEW.community_id
-            USING ERRCODE = 'check_violation',
-                  CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
-    END IF;
-
-    IF max_effective_at IS NOT NULL
-        AND NEW.effective_at <= max_effective_at
-    THEN
-        RAISE EXCEPTION
-            'effective_at % does not strictly exceed current maximum % for community %',
-            NEW.effective_at, max_effective_at, NEW.community_id
             USING ERRCODE = 'check_violation',
                   CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
     END IF;

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -4,7 +4,7 @@
 -- audio admission ledger, 30382 projection, delivery queue, exporter claim,
 -- acknowledgement, retry scheduler, or online retention/compaction workflow.
 --
--- This migration applies to migration 0040's resulting state. Its scope is the
+-- This migration applies to migration 0041's resulting state. Its scope is the
 -- NIP-FI *final-admission* surface: replay/receipt, audit events, invalidation,
 -- capacity, protected-object authority, restore version deltas, and the closed
 -- admission result. Closed vocabularies below carry only the core subset;
@@ -716,7 +716,7 @@ CREATE CONSTRAINT TRIGGER authorization_event_receipt_cardinality
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
 
--- Same ledger posture as migration 0040's identity relations: the admission,
+-- Same ledger posture as migration 0041's identity relations: the admission,
 -- replay, audit, and invalidation relations below are append-only denial and
 -- authority facts protected by immutable no_delete/no_truncate triggers, so
 -- they carry community_id as provenance rather than deletable ownership. Widen

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -381,14 +381,10 @@ BEGIN
         OR NEW.selector_fingerprint IS DISTINCT FROM OLD.selector_fingerprint
         OR NEW.floor_generation < OLD.floor_generation
         OR COALESCE(NEW.binding_version_floor, 0) < COALESCE(OLD.binding_version_floor, 0)
-        OR COALESCE(NEW.relationship_revision_floor, 0)
-            < COALESCE(OLD.relationship_revision_floor, 0)
         OR (
             NEW.floor_generation = OLD.floor_generation
             AND COALESCE(NEW.binding_version_floor, 0)
                 = COALESCE(OLD.binding_version_floor, 0)
-            AND COALESCE(NEW.relationship_revision_floor, 0)
-                = COALESCE(OLD.relationship_revision_floor, 0)
         )
         OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
         OR NEW.updated_at <= OLD.updated_at

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -240,6 +240,7 @@ CREATE TABLE authorization_authentication_denial_attempts (
     reason_code SMALLINT NOT NULL CHECK (
         reason_code IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
     ),
+    attempt_id UUID NOT NULL,
     audit_event_id UUID NOT NULL,
     audit_event_kind SMALLINT NOT NULL DEFAULT 9 CHECK (audit_event_kind = 9),
     recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
@@ -254,8 +255,12 @@ CREATE TABLE authorization_authentication_denial_attempts (
     FOREIGN KEY (community_id, audit_event_id, audit_event_kind, operation_id)
         REFERENCES authorization_events (community_id, event_id, event_kind, operation_id)
         DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, operation_id, audit_event_kind, attempt_id)
+        REFERENCES authorization_events (community_id, operation_id, event_kind, attempt_id)
+        DEFERRABLE INITIALLY DEFERRED,
     CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
-    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid)
+    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid)
 );
 
 -- Exact per-operation authority-version attribution for restore. Empty
@@ -508,12 +513,15 @@ CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
 
 -- Bidirectional deferred guard: a kind-9 (pre-authentication denial) audit
 -- event must commit with exactly one denial attempt; a denial attempt must
--- commit with its audit event present and kind-9. Both directions deferred so
+-- commit with its audit event present, kind-9, and matching semantic
+-- coordinates (correlation_id and reason_code). Both directions deferred so
 -- event and attempt may be inserted in any order inside one transaction.
 CREATE FUNCTION authorization_denial_attempt_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
     found_event_kind SMALLINT;
+    found_correlation_id UUID;
+    found_reason_code SMALLINT;
     attempt_count BIGINT;
 BEGIN
     IF TG_TABLE_NAME = 'authorization_events' THEN
@@ -534,10 +542,34 @@ BEGIN
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_event_cardinality';
         END IF;
+
+        -- Verify semantic coordinates match between event and denial attempt.
+        SELECT correlation_id, reason_code
+        INTO found_correlation_id, found_reason_code
+        FROM authorization_authentication_denial_attempts
+        WHERE community_id = NEW.community_id
+          AND audit_event_id = NEW.event_id;
+
+        IF found_correlation_id IS DISTINCT FROM NEW.correlation_id THEN
+            RAISE EXCEPTION
+                'denial attempt correlation_id % does not match event correlation_id % for event %',
+                found_correlation_id, NEW.correlation_id, NEW.event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
+
+        IF found_reason_code IS DISTINCT FROM NEW.reason_code THEN
+            RAISE EXCEPTION
+                'denial attempt reason_code % does not match event reason_code % for event %',
+                found_reason_code, NEW.reason_code, NEW.event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
     ELSE
         -- Firing from the denial-attempt side: verify the audit event is kind-9
         -- and that exactly one denial attempt references it.
-        SELECT event_kind INTO found_event_kind
+        SELECT event_kind, correlation_id, reason_code
+        INTO found_event_kind, found_correlation_id, found_reason_code
         FROM authorization_events
         WHERE community_id = NEW.community_id
           AND event_id = NEW.audit_event_id;
@@ -556,6 +588,23 @@ BEGIN
                 found_event_kind
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        -- Verify semantic coordinates match.
+        IF found_correlation_id IS DISTINCT FROM NEW.correlation_id THEN
+            RAISE EXCEPTION
+                'denial attempt correlation_id % does not match event correlation_id % for event %',
+                NEW.correlation_id, found_correlation_id, NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
+
+        IF found_reason_code IS DISTINCT FROM NEW.reason_code THEN
+            RAISE EXCEPTION
+                'denial attempt reason_code % does not match event reason_code % for event %',
+                NEW.reason_code, found_reason_code, NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;
 
         SELECT count(*) INTO attempt_count

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -506,6 +506,85 @@ CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
     BEFORE TRUNCATE ON authorization_authentication_denial_attempts
     FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
 
+-- Bidirectional deferred guard: a kind-9 (pre-authentication denial) audit
+-- event must commit with exactly one denial attempt; a denial attempt must
+-- commit with its audit event present and kind-9. Both directions deferred so
+-- event and attempt may be inserted in any order inside one transaction.
+CREATE FUNCTION authorization_denial_attempt_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    found_event_kind SMALLINT;
+    attempt_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_events' THEN
+        -- Firing from the event side: only kind-9 events require a denial row.
+        IF NEW.event_kind <> 9 THEN
+            RETURN NULL;
+        END IF;
+
+        SELECT count(*) INTO attempt_count
+        FROM authorization_authentication_denial_attempts
+        WHERE community_id = NEW.community_id
+          AND audit_event_id = NEW.event_id;
+
+        IF attempt_count <> 1 THEN
+            RAISE EXCEPTION
+                'kind-9 audit event requires exactly one denial attempt, found %',
+                attempt_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_cardinality';
+        END IF;
+    ELSE
+        -- Firing from the denial-attempt side: verify the audit event is kind-9
+        -- and that exactly one denial attempt references it.
+        SELECT event_kind INTO found_event_kind
+        FROM authorization_events
+        WHERE community_id = NEW.community_id
+          AND event_id = NEW.audit_event_id;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'denial attempt references non-existent audit event %',
+                NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        IF found_event_kind <> 9 THEN
+            RAISE EXCEPTION
+                'denial attempt audit event must be kind 9, got %',
+                found_event_kind
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        SELECT count(*) INTO attempt_count
+        FROM authorization_authentication_denial_attempts
+        WHERE community_id = NEW.community_id
+          AND audit_event_id = NEW.audit_event_id;
+
+        IF attempt_count <> 1 THEN
+            RAISE EXCEPTION
+                'exactly one denial attempt must reference audit event %, found %',
+                NEW.audit_event_id, attempt_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_cardinality';
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_denial_attempt_event_cardinality
+    AFTER INSERT ON authorization_events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_denial_attempt_guard_v1();
+
+CREATE CONSTRAINT TRIGGER authorization_denial_event_attempt_cardinality
+    AFTER INSERT ON authorization_authentication_denial_attempts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_denial_attempt_guard_v1();
+
 CREATE FUNCTION authorization_operation_version_delta_cardinality_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
@@ -643,6 +722,75 @@ CREATE TRIGGER authorization_admission_results_no_update
 CREATE TRIGGER authorization_admission_results_no_truncate
     BEFORE TRUNCATE ON authorization_admission_results
     FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+-- Bidirectional deferred cardinality guard: a kind-11 (protected-mutation)
+-- receipt must commit with exactly one admission result; an admission result
+-- must commit against a kind-11 receipt. Deferred so receipt and result may
+-- be inserted in any order inside one transaction.
+CREATE FUNCTION authorization_admission_result_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    receipt authorization_operation_receipts%ROWTYPE;
+    result_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_receipts' THEN
+        receipt := NEW;
+    ELSE
+        -- Firing from authorization_admission_results: look up the receipt.
+        SELECT * INTO receipt
+        FROM authorization_operation_receipts
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id;
+        IF NOT FOUND THEN
+            -- FK on the result table already guards the non-existent receipt
+            -- case; this path should not occur in normal operation.
+            RAISE EXCEPTION
+                'admission result references non-existent receipt for operation %',
+                NEW.operation_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_admission_result_receipt_kind';
+        END IF;
+    END IF;
+
+    -- Non-kind-11 receipts require no admission result.
+    IF receipt.operation_kind <> 11 THEN
+        -- If this fired from the result side and the receipt is not kind 11,
+        -- the result is attaching to the wrong receipt kind.
+        IF TG_TABLE_NAME = 'authorization_admission_results' THEN
+            RAISE EXCEPTION
+                'admission result may only attach to a kind-11 (protected-mutation) receipt, got kind %',
+                receipt.operation_kind
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_admission_result_receipt_kind';
+        END IF;
+        RETURN NULL;
+    END IF;
+
+    SELECT count(*) INTO result_count
+    FROM authorization_admission_results
+    WHERE community_id = receipt.community_id
+      AND operation_id = receipt.operation_id;
+
+    IF result_count <> 1 THEN
+        RAISE EXCEPTION
+            'kind-11 receipt requires exactly one admission result, found %',
+            result_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_admission_result_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_admission_result_receipt_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_admission_result_guard_v1();
+
+CREATE CONSTRAINT TRIGGER authorization_admission_result_result_cardinality
+    AFTER INSERT ON authorization_admission_results
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_admission_result_guard_v1();
 
 -- Every successful/no-op core lifecycle receipt has exactly one privacy-safe
 -- audit event with the closed transition-kind mapping. Both directions are

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -198,6 +198,12 @@ CREATE TABLE authorization_events (
     ),
     correlation_id UUID NOT NULL,
     attempt_id UUID NOT NULL,
+    -- Redaction-safe pre-authentication denial identity. Present and non-zero
+    -- for kind-9 events; NULL for all other event kinds. Binds the event to the
+    -- exact denial attempt's semantic_fingerprint (intent_digest) for exact replay.
+    semantic_fingerprint BYTEA CHECK (
+        semantic_fingerprint IS NULL OR octet_length(semantic_fingerprint) = 32
+    ),
     occurred_at TIMESTAMPTZ NOT NULL,
     accepted_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
     canonical_envelope BYTEA NOT NULL CONSTRAINT authorization_events_envelope_size CHECK (
@@ -223,6 +229,13 @@ CREATE TABLE authorization_events (
     CHECK (
         (actor_kind = 4 AND actor_fingerprint IS NULL AND subject_fingerprint IS NULL)
         OR (actor_kind IN (1, 2, 3) AND actor_fingerprint IS NOT NULL)
+    ),
+    -- Kind-9 (pre-auth denial) events must carry a non-zero semantic_fingerprint;
+    -- all other event kinds must not.
+    CHECK (
+        (event_kind = 9 AND semantic_fingerprint IS NOT NULL
+            AND semantic_fingerprint <> decode(repeat('00', 32), 'hex'))
+        OR (event_kind <> 9 AND semantic_fingerprint IS NULL)
     )
 );
 
@@ -258,6 +271,13 @@ CREATE TABLE authorization_authentication_denial_attempts (
     FOREIGN KEY (community_id, operation_id, audit_event_kind, attempt_id)
         REFERENCES authorization_events (community_id, operation_id, event_kind, attempt_id)
         DEFERRABLE INITIALLY DEFERRED,
+    -- Canonical denial_reason ↔ reason_code binding: MissingCredential(1)↔Missing(2),
+    -- InvalidCredential(2)↔Invalid(3), Unauthenticated(3)↔Unauthenticated(4).
+    CONSTRAINT authorization_denial_reason_reason_code_binding CHECK (
+        (denial_reason = 1 AND reason_code = 2)
+        OR (denial_reason = 2 AND reason_code = 3)
+        OR (denial_reason = 3 AND reason_code = 4)
+    ),
     CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
     CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
     CHECK (attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid)
@@ -514,14 +534,18 @@ CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
 -- Bidirectional deferred guard: a kind-9 (pre-authentication denial) audit
 -- event must commit with exactly one denial attempt; a denial attempt must
 -- commit with its audit event present, kind-9, and matching semantic
--- coordinates (correlation_id and reason_code). Both directions deferred so
--- event and attempt may be inserted in any order inside one transaction.
+-- coordinates (correlation_id, reason_code, and semantic_fingerprint). Both
+-- directions deferred so event and attempt may be inserted in any order inside
+-- one transaction. The static denial_reason↔reason_code mapping is enforced
+-- by an immediate CHECK on the denial attempt table; the guard enforces the
+-- matching semantic coordinates between event and attempt.
 CREATE FUNCTION authorization_denial_attempt_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
     found_event_kind SMALLINT;
     found_correlation_id UUID;
     found_reason_code SMALLINT;
+    found_semantic_fingerprint BYTEA;
     attempt_count BIGINT;
 BEGIN
     IF TG_TABLE_NAME = 'authorization_events' THEN
@@ -544,8 +568,8 @@ BEGIN
         END IF;
 
         -- Verify semantic coordinates match between event and denial attempt.
-        SELECT correlation_id, reason_code
-        INTO found_correlation_id, found_reason_code
+        SELECT correlation_id, reason_code, semantic_fingerprint
+        INTO found_correlation_id, found_reason_code, found_semantic_fingerprint
         FROM authorization_authentication_denial_attempts
         WHERE community_id = NEW.community_id
           AND audit_event_id = NEW.event_id;
@@ -565,11 +589,20 @@ BEGIN
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;
+
+        IF found_semantic_fingerprint IS DISTINCT FROM NEW.semantic_fingerprint THEN
+            RAISE EXCEPTION
+                'denial attempt semantic_fingerprint does not match event semantic_fingerprint for event %',
+                NEW.event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
     ELSE
         -- Firing from the denial-attempt side: verify the audit event is kind-9
         -- and that exactly one denial attempt references it.
-        SELECT event_kind, correlation_id, reason_code
-        INTO found_event_kind, found_correlation_id, found_reason_code
+        SELECT event_kind, correlation_id, reason_code, semantic_fingerprint
+        INTO found_event_kind, found_correlation_id, found_reason_code,
+             found_semantic_fingerprint
         FROM authorization_events
         WHERE community_id = NEW.community_id
           AND event_id = NEW.audit_event_id;
@@ -603,6 +636,14 @@ BEGIN
             RAISE EXCEPTION
                 'denial attempt reason_code % does not match event reason_code % for event %',
                 NEW.reason_code, found_reason_code, NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
+
+        IF found_semantic_fingerprint IS DISTINCT FROM NEW.semantic_fingerprint THEN
+            RAISE EXCEPTION
+                'denial attempt semantic_fingerprint does not match event semantic_fingerprint for event %',
+                NEW.audit_event_id
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -199,8 +199,10 @@ CREATE TABLE authorization_events (
     correlation_id UUID NOT NULL,
     attempt_id UUID NOT NULL,
     -- Redaction-safe pre-authentication denial identity. Present and non-zero
-    -- for kind-9 events; NULL for all other event kinds. Binds the event to the
-    -- exact denial attempt's semantic_fingerprint (intent_digest) for exact replay.
+    -- for unresolved pre-auth kind-9 events (actor_kind = 4); NULL for
+    -- authenticated kind-9 events (actor_kind 1-3) and all other event kinds.
+    -- Binds the event to the exact denial attempt's semantic_fingerprint
+    -- (intent_digest) for exact replay.
     semantic_fingerprint BYTEA CHECK (
         semantic_fingerprint IS NULL OR octet_length(semantic_fingerprint) = 32
     ),
@@ -951,28 +953,44 @@ BEGIN
     END IF;
 
     -- Only applied (outcome_code = 1) and no-op (outcome_code = 3) lifecycle
-    -- receipts require a paired audit event. A denied lifecycle receipt
-    -- (outcome_code = 2) commits without one; fabricating a transition event
-    -- would falsely record that the lifecycle change occurred.
-    IF receipt.outcome_code NOT IN (1, 3) THEN
-        RETURN NULL;
-    END IF;
+    -- receipts require exactly one paired success-transition event. A denied
+    -- lifecycle receipt (outcome_code = 2) requires zero events of the mapped
+    -- transition kind: a success-transition event would falsely record that the
+    -- denied transition occurred, creating contradictory durable ledger facts.
+    -- Other outcome codes (4, 5) are not core lifecycle outcomes; skip.
+    IF receipt.outcome_code IN (1, 3) THEN
+        SELECT
+            count(*),
+            count(*) FILTER (WHERE event_kind = expected_event_kind)
+        INTO matching_event_count, expected_event_count
+        FROM authorization_events
+        WHERE community_id = receipt.community_id
+          AND operation_id = receipt.operation_id
+          AND request_fingerprint = receipt.request_fingerprint;
 
-    SELECT
-        count(*),
-        count(*) FILTER (WHERE event_kind = expected_event_kind)
-    INTO matching_event_count, expected_event_count
-    FROM authorization_events
-    WHERE community_id = receipt.community_id
-      AND operation_id = receipt.operation_id
-      AND request_fingerprint = receipt.request_fingerprint;
+        IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
+            RAISE EXCEPTION
+                'lifecycle receipt requires exactly one event kind %, found % total and % expected',
+                expected_event_kind, matching_event_count, expected_event_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+        END IF;
+    ELSIF receipt.outcome_code = 2 THEN
+        SELECT count(*) FILTER (WHERE event_kind = expected_event_kind)
+        INTO expected_event_count
+        FROM authorization_events
+        WHERE community_id = receipt.community_id
+          AND operation_id = receipt.operation_id
+          AND request_fingerprint = receipt.request_fingerprint;
 
-    IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
-        RAISE EXCEPTION
-            'lifecycle receipt requires exactly one event kind %, found % total and % expected',
-            expected_event_kind, matching_event_count, expected_event_count
-            USING ERRCODE = 'check_violation',
-                  CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+        IF expected_event_count <> 0 THEN
+            RAISE EXCEPTION
+                'denied lifecycle receipt must not have a mapped success-transition event '
+                '(kind %); found % — contradictory durable facts are not permitted',
+                expected_event_kind, expected_event_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denied_lifecycle_receipt_no_success_event';
+        END IF;
     END IF;
     RETURN NULL;
 END;

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -1,0 +1,749 @@
+-- Provider-free NIP-FI authorization, audit, fencing, and restore foundation.
+--
+-- There is no provider registry/SPI/profile/evidence table, durable lease or
+-- audio admission ledger, 30382 projection, delivery queue, exporter claim,
+-- acknowledgement, retry scheduler, or online retention/compaction workflow.
+--
+-- This migration applies to migration 0040's resulting state. Its scope is the
+-- NIP-FI *final-admission* surface: replay/receipt, audit events, invalidation,
+-- capacity, protected-object authority, restore version deltas, and the closed
+-- admission result. Closed vocabularies below carry only the core subset;
+-- delegation coordinates (owner/relationship columns, invalidation selector 7,
+-- version-delta component kind 6) are deferred to the FI-DELEG migration and
+-- extended-lifecycle audit kinds (recover, enable, disable, admission-loss;
+-- version-delta component kind 7) to the FI-LIFECYCLE migration, matching
+-- 0040's carve. A later migration widens these additively; nothing here
+-- presumes a single global issuer.
+
+-- Durable one-way activation marker and current domain invalidation generation.
+CREATE TABLE authorization_invalidation_domains (
+    community_id UUID NOT NULL PRIMARY KEY REFERENCES communities(id),
+    current_generation BIGINT NOT NULL CHECK (current_generation >= 0),
+    activated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp()
+);
+
+-- Closed selectors: 1 principal, 2 Nostr key, 3 binding, 4 session, 5 domain,
+-- 6 configuration revision. Selector 7 (delegated relationship) and its
+-- relationship-revision floor are deferred to the FI-DELEG migration.
+CREATE TABLE authorization_invalidation_floors (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    selector_kind SMALLINT NOT NULL CHECK (selector_kind IN (1, 2, 3, 4, 5, 6)),
+    selector_fingerprint BYTEA NOT NULL CHECK (octet_length(selector_fingerprint) = 32),
+    floor_generation BIGINT NOT NULL CHECK (floor_generation > 0),
+    binding_version_floor BIGINT CHECK (binding_version_floor IS NULL OR binding_version_floor > 0),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, selector_kind, selector_fingerprint),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (
+        (selector_kind = 3 AND binding_version_floor IS NOT NULL)
+        OR (selector_kind <> 3 AND binding_version_floor IS NULL)
+    )
+);
+
+-- Protected-object kinds: 1 domain, 2 channel, 3 repository, 4 media,
+-- 5 moderation target, 6 audio session. Kind 7 is retired: current binding
+-- status is connection-local evidence and never a durable protected object.
+CREATE TABLE authorization_authority_epochs (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    object_kind SMALLINT NOT NULL CHECK (object_kind IN (1, 2, 3, 4, 5, 6)),
+    object_key BYTEA NOT NULL CHECK (octet_length(object_key) = 32),
+    authority_epoch BIGINT NOT NULL CHECK (authority_epoch > 0),
+    fence BYTEA NOT NULL CHECK (
+        octet_length(fence) = 32 AND fence <> decode(repeat('00', 32), 'hex')
+    ),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, object_kind, object_key),
+    UNIQUE (
+        community_id,
+        object_kind,
+        object_key,
+        authority_epoch,
+        fence,
+        operation_id,
+        request_fingerprint
+    ),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+-- Direct-final current authority for a protected object. The authorization
+-- lease itself is sealed in memory and dies on restart; this durable row is the
+-- exact source re-fenced immediately before a protected mutation or emission.
+CREATE TABLE protected_object_authority (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    object_kind SMALLINT NOT NULL CHECK (object_kind IN (1, 2, 3, 4, 5, 6)),
+    object_key BYTEA NOT NULL CHECK (octet_length(object_key) = 32),
+    capability SMALLINT NOT NULL CHECK (
+        capability IN (
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+            28, 29
+        )
+    ),
+    actor_pubkey BYTEA NOT NULL CHECK (octet_length(actor_pubkey) = 32),
+    binding_id UUID NOT NULL,
+    binding_version BIGINT NOT NULL CHECK (binding_version > 0),
+    policy_revision BIGINT NOT NULL CHECK (policy_revision > 0),
+    invalidation_generation BIGINT NOT NULL CHECK (invalidation_generation >= 0),
+    authority_epoch BIGINT NOT NULL CHECK (authority_epoch > 0),
+    fence BYTEA NOT NULL CHECK (
+        octet_length(fence) = 32 AND fence <> decode(repeat('00', 32), 'hex')
+    ),
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    PRIMARY KEY (community_id, object_kind, object_key),
+    FOREIGN KEY (community_id, binding_id, binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (
+        community_id,
+        object_kind,
+        object_key,
+        authority_epoch,
+        fence,
+        operation_id,
+        request_fingerprint
+    ) REFERENCES authorization_authority_epochs (
+        community_id,
+        object_kind,
+        object_key,
+        authority_epoch,
+        fence,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED,
+    CHECK (issued_at < expires_at)
+);
+
+-- Explicit immutable-capacity policy required by Enforce mode. Hard ceilings
+-- match buzz-auth; installation limits must be sized explicitly below them.
+-- V1 has no online pruning/export/reset workflow.
+CREATE TABLE authorization_event_capacity (
+    community_id UUID NOT NULL PRIMARY KEY REFERENCES communities(id),
+    max_events_per_domain BIGINT NOT NULL CONSTRAINT authorization_event_capacity_max_events CHECK (
+        max_events_per_domain BETWEEN 1 AND 10000
+    ),
+    max_bytes_per_domain BIGINT NOT NULL CONSTRAINT authorization_event_capacity_max_bytes CHECK (
+        max_bytes_per_domain BETWEEN 1 AND 16777216
+    ),
+    max_envelope_bytes INTEGER NOT NULL CONSTRAINT authorization_event_capacity_max_envelope CHECK (
+        max_envelope_bytes BETWEEN 1 AND 16384
+    ),
+    retained_event_count BIGINT NOT NULL DEFAULT 0 CHECK (retained_event_count >= 0),
+    retained_envelope_bytes BIGINT NOT NULL DEFAULT 0 CHECK (retained_envelope_bytes >= 0),
+    -- 1 healthy, 2 audit unavailable/exhausted. Recovery/reset is not a V1
+    -- online workflow; enabled runtime latches failure when insertion aborts.
+    health_state SMALLINT NOT NULL DEFAULT 1 CHECK (health_state IN (1, 2)),
+    failure_code SMALLINT CHECK (failure_code IS NULL OR failure_code IN (1, 2, 3)),
+    failure_observed_at TIMESTAMPTZ,
+    configured_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    CHECK (max_envelope_bytes <= max_bytes_per_domain),
+    CHECK (retained_event_count <= max_events_per_domain),
+    CHECK (retained_envelope_bytes <= max_bytes_per_domain),
+    CHECK (
+        (health_state = 1 AND failure_code IS NULL AND failure_observed_at IS NULL)
+        OR (health_state = 2 AND failure_code IS NOT NULL AND failure_observed_at IS NOT NULL)
+    )
+);
+
+-- Durable versioned pseudonymous authorization envelope. event_kind:
+-- 1 enrolled, 2 revoked, 3 rotated, 6 retired, 9 operator denied,
+-- 10 protected allowed, 11 protected denied, 14 invalidation advanced.
+-- The extended-lifecycle audit kinds (4 recovered, 5 principal enabled,
+-- 7 principal disabled, 8 admission lost) are deferred to the FI-LIFECYCLE
+-- migration, matching 0040's core lifecycle carve. Kinds 12 and 13 are
+-- retired: kind 24244 publication/withdrawal is ephemeral connection state and
+-- never a durable authorization event.
+CREATE TABLE authorization_events (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    event_id UUID NOT NULL,
+    schema_version SMALLINT NOT NULL DEFAULT 1 CHECK (schema_version = 1),
+    event_kind SMALLINT NOT NULL CHECK (
+        event_kind IN (1, 2, 3, 6, 9, 10, 11, 14)
+    ),
+    outcome_code SMALLINT NOT NULL CHECK (outcome_code IN (1, 2, 3, 4, 5)),
+    reason_code SMALLINT NOT NULL CHECK (
+        reason_code IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+    ),
+    actor_kind SMALLINT NOT NULL CHECK (actor_kind IN (1, 2, 3, 4)),
+    actor_fingerprint BYTEA CHECK (
+        actor_fingerprint IS NULL OR octet_length(actor_fingerprint) = 32
+    ),
+    subject_fingerprint BYTEA CHECK (
+        subject_fingerprint IS NULL OR octet_length(subject_fingerprint) = 32
+    ),
+    -- Always retains attempted operation identity. Only unresolved pre-auth
+    -- event kind 9 omits the canonical receipt fingerprint; authenticated
+    -- OperatorDenied events remain linked to their exact canonical receipt.
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA CHECK (
+        request_fingerprint IS NULL OR octet_length(request_fingerprint) = 32
+    ),
+    correlation_id UUID NOT NULL,
+    attempt_id UUID NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    accepted_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    canonical_envelope BYTEA NOT NULL CONSTRAINT authorization_events_envelope_size CHECK (
+        octet_length(canonical_envelope) BETWEEN 1 AND 16384
+    ),
+    envelope_digest BYTEA NOT NULL CHECK (octet_length(envelope_digest) = 32),
+    PRIMARY KEY (community_id, event_id),
+    UNIQUE (community_id, event_id, operation_id),
+    UNIQUE (community_id, event_id, event_kind, operation_id),
+    UNIQUE (community_id, operation_id, event_kind, attempt_id),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (event_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (
+        (actor_kind = 4 AND event_kind = 9 AND request_fingerprint IS NULL)
+        OR (actor_kind IN (1, 2, 3) AND request_fingerprint IS NOT NULL)
+    ),
+    CHECK (
+        (actor_kind = 4 AND actor_fingerprint IS NULL AND subject_fingerprint IS NULL)
+        OR (actor_kind IN (1, 2, 3) AND actor_fingerprint IS NOT NULL)
+    )
+);
+
+-- Credential-free pre-authentication denial attempts. The five-column key is
+-- exact replay identity; no row or FK occupies canonical operation/result,
+-- effect, authority, approval, or consumption state.
+CREATE TABLE authorization_authentication_denial_attempts (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    correlation_id UUID NOT NULL,
+    semantic_fingerprint BYTEA NOT NULL CHECK (octet_length(semantic_fingerprint) = 32),
+    denial_reason SMALLINT NOT NULL CHECK (denial_reason IN (1, 2, 3)),
+    expected_revision BIGINT NOT NULL CHECK (expected_revision > 0),
+    action SMALLINT NOT NULL CHECK (action IN (1, 2, 3, 4, 5, 6, 7, 8)),
+    reason_code SMALLINT NOT NULL CHECK (
+        reason_code IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+    ),
+    audit_event_id UUID NOT NULL,
+    audit_event_kind SMALLINT NOT NULL DEFAULT 9 CHECK (audit_event_kind = 9),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (
+        community_id,
+        operation_id,
+        correlation_id,
+        semantic_fingerprint,
+        denial_reason
+    ),
+    UNIQUE (community_id, audit_event_id),
+    FOREIGN KEY (community_id, audit_event_id, audit_event_kind, operation_id)
+        REFERENCES authorization_events (community_id, event_id, event_kind, operation_id)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid)
+);
+
+-- Exact per-operation authority-version attribution for restore. Empty
+-- manifests are valid; every stored component must advance strictly.
+CREATE TABLE authorization_operation_version_delta_manifests (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    component_count INTEGER NOT NULL CHECK (component_count BETWEEN 0 AND 1024),
+    before_digest BYTEA NOT NULL CHECK (octet_length(before_digest) = 32),
+    after_digest BYTEA NOT NULL CHECK (octet_length(after_digest) = 32),
+    manifest_digest BYTEA NOT NULL CHECK (octet_length(manifest_digest) = 32),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, operation_id),
+    UNIQUE (community_id, operation_id, request_fingerprint),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+-- component_kind: 1 binding version, 2 policy revision,
+-- 3 invalidation generation, 4 authority epoch. Kind 6 (delegated-relationship
+-- revision) is deferred to the FI-DELEG migration and kind 7 (lifecycle-selector
+-- generation) to the FI-LIFECYCLE migration. Kind 5 is retired with durable
+-- client-status revisions; retained kinds keep their original identities.
+CREATE TABLE authorization_operation_version_deltas (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    component_kind SMALLINT NOT NULL CHECK (component_kind IN (1, 2, 3, 4)),
+    component_key BYTEA NOT NULL CHECK (octet_length(component_key) = 32),
+    before_version BIGINT NOT NULL CHECK (before_version >= 0),
+    after_version BIGINT NOT NULL,
+    component_digest BYTEA NOT NULL CHECK (octet_length(component_digest) = 32),
+    PRIMARY KEY (community_id, operation_id, component_kind, component_key),
+    FOREIGN KEY (community_id, operation_id)
+        REFERENCES authorization_operation_version_delta_manifests
+            (community_id, operation_id),
+    CHECK (after_version > before_version)
+);
+
+CREATE FUNCTION authorization_event_capacity_before_insert_v1() RETURNS TRIGGER AS $$
+DECLARE
+    policy authorization_event_capacity%ROWTYPE;
+    envelope_bytes BIGINT;
+BEGIN
+    SELECT * INTO policy
+    FROM authorization_event_capacity
+    WHERE community_id = NEW.community_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'authorization event capacity policy missing'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_policy_required';
+    END IF;
+    IF policy.health_state <> 1 THEN
+        RAISE EXCEPTION 'authorization audit is unavailable'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_health';
+    END IF;
+
+    envelope_bytes := octet_length(NEW.canonical_envelope);
+    IF envelope_bytes > policy.max_envelope_bytes
+        OR policy.retained_event_count + 1 > policy.max_events_per_domain
+        OR policy.retained_envelope_bytes + envelope_bytes > policy.max_bytes_per_domain
+    THEN
+        -- The INSERT and protected mutation abort together. The runtime maps
+        -- this stable constraint to typed CapacityExhausted and latches audit
+        -- health outside the rolled-back transaction.
+        RAISE EXCEPTION 'authorization event capacity exhausted'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_exhausted';
+    END IF;
+
+    UPDATE authorization_event_capacity
+    SET retained_event_count = retained_event_count + 1,
+        retained_envelope_bytes = retained_envelope_bytes + envelope_bytes,
+        updated_at = transaction_timestamp()
+    WHERE community_id = NEW.community_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_events_capacity
+    BEFORE INSERT ON authorization_events
+    FOR EACH ROW EXECUTE FUNCTION authorization_event_capacity_before_insert_v1();
+
+CREATE FUNCTION authorization_invalidation_domain_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.activated_at IS DISTINCT FROM OLD.activated_at
+        OR NEW.current_generation <= OLD.current_generation
+        OR NEW.updated_at <= OLD.updated_at
+    THEN
+        RAISE EXCEPTION 'authorization invalidation activation/generation cannot move backward'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_invalidation_domains_monotonic
+    BEFORE UPDATE ON authorization_invalidation_domains
+    FOR EACH ROW EXECUTE FUNCTION authorization_invalidation_domain_guard_v1();
+CREATE TRIGGER authorization_invalidation_domains_no_delete
+    BEFORE DELETE ON authorization_invalidation_domains
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_invalidation_domains_no_truncate
+    BEFORE TRUNCATE ON authorization_invalidation_domains
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_invalidation_floor_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.selector_kind IS DISTINCT FROM OLD.selector_kind
+        OR NEW.selector_fingerprint IS DISTINCT FROM OLD.selector_fingerprint
+        OR NEW.floor_generation < OLD.floor_generation
+        OR COALESCE(NEW.binding_version_floor, 0) < COALESCE(OLD.binding_version_floor, 0)
+        OR COALESCE(NEW.relationship_revision_floor, 0)
+            < COALESCE(OLD.relationship_revision_floor, 0)
+        OR (
+            NEW.floor_generation = OLD.floor_generation
+            AND COALESCE(NEW.binding_version_floor, 0)
+                = COALESCE(OLD.binding_version_floor, 0)
+            AND COALESCE(NEW.relationship_revision_floor, 0)
+                = COALESCE(OLD.relationship_revision_floor, 0)
+        )
+        OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
+        OR NEW.updated_at <= OLD.updated_at
+    THEN
+        RAISE EXCEPTION 'authorization invalidation floor cannot move backward'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_invalidation_floors_monotonic
+    BEFORE UPDATE ON authorization_invalidation_floors
+    FOR EACH ROW EXECUTE FUNCTION authorization_invalidation_floor_guard_v1();
+CREATE TRIGGER authorization_invalidation_floors_no_delete
+    BEFORE DELETE ON authorization_invalidation_floors
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_invalidation_floors_no_truncate
+    BEFORE TRUNCATE ON authorization_invalidation_floors
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_authority_epoch_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.object_kind IS DISTINCT FROM OLD.object_kind
+        OR NEW.object_key IS DISTINCT FROM OLD.object_key
+        OR NEW.authority_epoch <= OLD.authority_epoch
+        OR NEW.fence IS NOT DISTINCT FROM OLD.fence
+        OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
+        OR NEW.updated_at <= OLD.updated_at
+    THEN
+        RAISE EXCEPTION 'authorization authority epoch cannot move backward'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_authority_epochs_monotonic
+    BEFORE UPDATE ON authorization_authority_epochs
+    FOR EACH ROW EXECUTE FUNCTION authorization_authority_epoch_guard_v1();
+CREATE TRIGGER authorization_authority_epochs_no_delete
+    BEFORE DELETE ON authorization_authority_epochs
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_authority_epochs_no_truncate
+    BEFORE TRUNCATE ON authorization_authority_epochs
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_event_capacity_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.max_events_per_domain IS DISTINCT FROM OLD.max_events_per_domain
+        OR NEW.max_bytes_per_domain IS DISTINCT FROM OLD.max_bytes_per_domain
+        OR NEW.max_envelope_bytes IS DISTINCT FROM OLD.max_envelope_bytes
+        OR NEW.configured_at IS DISTINCT FROM OLD.configured_at
+        OR NEW.retained_event_count < OLD.retained_event_count
+        OR NEW.retained_envelope_bytes < OLD.retained_envelope_bytes
+        OR NEW.updated_at < OLD.updated_at
+        OR (OLD.health_state = 2 AND (
+            NEW.health_state <> 2
+            OR NEW.failure_code IS DISTINCT FROM OLD.failure_code
+            OR NEW.failure_observed_at IS DISTINCT FROM OLD.failure_observed_at
+        ))
+        OR (OLD.health_state = 1 AND NEW.health_state = 1 AND (
+            NEW.failure_code IS NOT NULL OR NEW.failure_observed_at IS NOT NULL
+        ))
+    THEN
+        RAISE EXCEPTION 'authorization event capacity cannot be reset online'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION protected_object_authority_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.object_kind IS DISTINCT FROM OLD.object_kind
+        OR NEW.object_key IS DISTINCT FROM OLD.object_key
+        OR NEW.authority_epoch <= OLD.authority_epoch
+        OR NEW.fence IS NOT DISTINCT FROM OLD.fence
+        OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
+        OR NEW.issued_at <= OLD.issued_at
+    THEN
+        RAISE EXCEPTION 'protected authority replacement requires a new operation and epoch'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_event_capacity_monotonic
+    BEFORE UPDATE ON authorization_event_capacity
+    FOR EACH ROW EXECUTE FUNCTION authorization_event_capacity_guard_v1();
+CREATE TRIGGER authorization_event_capacity_no_delete
+    BEFORE DELETE ON authorization_event_capacity
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_event_capacity_no_truncate
+    BEFORE TRUNCATE ON authorization_event_capacity
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER authorization_events_immutable
+    BEFORE UPDATE OR DELETE ON authorization_events
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_events_no_truncate
+    BEFORE TRUNCATE ON authorization_events
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER authorization_authentication_denial_attempts_immutable
+    BEFORE UPDATE OR DELETE ON authorization_authentication_denial_attempts
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
+    BEFORE TRUNCATE ON authorization_authentication_denial_attempts
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_operation_version_delta_cardinality_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    manifest authorization_operation_version_delta_manifests%ROWTYPE;
+    actual_component_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_version_delta_manifests' THEN
+        manifest := NEW;
+    ELSE
+        SELECT * INTO STRICT manifest
+        FROM authorization_operation_version_delta_manifests
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id
+        FOR NO KEY UPDATE;
+    END IF;
+
+    SELECT count(*) INTO actual_component_count
+    FROM authorization_operation_version_deltas
+    WHERE community_id = manifest.community_id
+      AND operation_id = manifest.operation_id;
+
+    IF actual_component_count <> manifest.component_count THEN
+        RAISE EXCEPTION 'operation version manifest declares % components, found %',
+            manifest.component_count, actual_component_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_version_delta_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_operation_version_delta_manifest_cardinality
+    AFTER INSERT ON authorization_operation_version_delta_manifests
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_version_delta_cardinality_guard_v1();
+CREATE CONSTRAINT TRIGGER authorization_operation_version_delta_component_cardinality
+    AFTER INSERT ON authorization_operation_version_deltas
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_version_delta_cardinality_guard_v1();
+
+CREATE TRIGGER authorization_operation_version_delta_manifests_immutable
+    BEFORE UPDATE OR DELETE ON authorization_operation_version_delta_manifests
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_operation_version_delta_manifests_no_truncate
+    BEFORE TRUNCATE ON authorization_operation_version_delta_manifests
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER authorization_operation_version_deltas_immutable
+    BEFORE UPDATE OR DELETE ON authorization_operation_version_deltas
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_operation_version_deltas_no_truncate
+    BEFORE TRUNCATE ON authorization_operation_version_deltas
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER protected_object_authority_no_delete
+    BEFORE DELETE ON protected_object_authority
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER protected_object_authority_no_truncate
+    BEFORE TRUNCATE ON protected_object_authority
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+CREATE TRIGGER protected_object_authority_strict_replacement
+    BEFORE UPDATE ON protected_object_authority
+    FOR EACH ROW EXECUTE FUNCTION protected_object_authority_guard_v1();
+
+-- Canonical admission keeps its complete logical intent and the closed,
+-- credential-free application result beside the immutable receipt. This is
+-- what lets an identical request replay reconstruct the same typed result
+-- without repeating membership or other application DML. Object kinds match
+-- protected_object_authority: 1 domain, 2 channel, 3 repository, 4 media,
+-- 5 moderation target, 6 audio session.
+CREATE TABLE authorization_admission_results (
+    community_id UUID NOT NULL,
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    semantic_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(semantic_fingerprint) = 32
+        AND semantic_fingerprint <> decode(repeat('00', 32), 'hex')
+    ),
+    object_kind SMALLINT NOT NULL CHECK (object_kind BETWEEN 1 AND 6),
+    object_key BYTEA NOT NULL CHECK (
+        octet_length(object_key) = 32
+        AND object_key <> decode(repeat('00', 32), 'hex')
+    ),
+    application_type BYTEA CHECK (
+        application_type IS NULL
+        OR (octet_length(application_type) = 32
+            AND application_type <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_version SMALLINT CHECK (application_version > 0),
+    application_code SMALLINT CHECK (application_code > 0),
+    application_payload BYTEA CHECK (
+        application_payload IS NULL OR octet_length(application_payload) <= 4096
+    ),
+    application_intent_digest BYTEA CHECK (
+        application_intent_digest IS NULL
+        OR (octet_length(application_intent_digest) = 32
+            AND application_intent_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_effect_digest BYTEA CHECK (
+        application_effect_digest IS NULL
+        OR (octet_length(application_effect_digest) = 32
+            AND application_effect_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_result_digest BYTEA CHECK (
+        application_result_digest IS NULL
+        OR (octet_length(application_result_digest) = 32
+            AND application_result_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, operation_id),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint),
+    CHECK (
+        (application_type IS NULL
+            AND application_version IS NULL
+            AND application_code IS NULL
+            AND application_payload IS NULL
+            AND application_intent_digest IS NULL
+            AND application_effect_digest IS NULL
+            AND application_result_digest IS NULL)
+        OR (application_type IS NOT NULL
+            AND application_version IS NOT NULL
+            AND application_code IS NOT NULL
+            AND application_payload IS NOT NULL
+            AND application_intent_digest IS NOT NULL
+            AND application_effect_digest IS NOT NULL
+            AND application_result_digest IS NOT NULL)
+    )
+);
+
+CREATE TRIGGER authorization_admission_results_no_update
+    BEFORE UPDATE OR DELETE ON authorization_admission_results
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_admission_results_no_truncate
+    BEFORE TRUNCATE ON authorization_admission_results
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+-- Every successful/no-op core lifecycle receipt has exactly one privacy-safe
+-- audit event with the closed transition-kind mapping. Both directions are
+-- deferred so receipt, history, event, selectors, and binding may be inserted
+-- in any order inside one transaction but can never commit partially. The
+-- extended-lifecycle operation kinds (2 provision, 4 disable, 7 recover,
+-- 8 enable, 9 admission loss) and their event kinds arrive with the
+-- FI-LIFECYCLE migration; here the mapping covers only enroll/retire/revoke/
+-- rotate. Non-lifecycle receipts (protected mutation, invalidation) carry no
+-- audit-event cardinality requirement.
+CREATE FUNCTION authorization_operation_receipt_event_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    receipt authorization_operation_receipts%ROWTYPE;
+    expected_event_kind SMALLINT;
+    matching_event_count BIGINT;
+    expected_event_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_receipts' THEN
+        receipt := NEW;
+    ELSE
+        SELECT * INTO receipt
+        FROM authorization_operation_receipts
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id;
+        IF NOT FOUND THEN
+            -- Credential-free pre-authentication denials intentionally have no
+            -- canonical receipt. Their separate FK/shape guards still run.
+            RETURN NULL;
+        END IF;
+    END IF;
+
+    expected_event_kind := CASE receipt.operation_kind
+        WHEN 1 THEN 1  -- enroll
+        WHEN 3 THEN 6  -- retire
+        WHEN 5 THEN 2  -- revoke
+        WHEN 6 THEN 3  -- rotate
+        ELSE NULL
+    END;
+    IF expected_event_kind IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT
+        count(*),
+        count(*) FILTER (WHERE event_kind = expected_event_kind)
+    INTO matching_event_count, expected_event_count
+    FROM authorization_events
+    WHERE community_id = receipt.community_id
+      AND operation_id = receipt.operation_id
+      AND request_fingerprint = receipt.request_fingerprint;
+
+    IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
+        RAISE EXCEPTION
+            'lifecycle receipt requires exactly one event kind %, found % total and % expected',
+            expected_event_kind, matching_event_count, expected_event_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_operation_receipt_event_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
+
+CREATE CONSTRAINT TRIGGER authorization_event_receipt_cardinality
+    AFTER INSERT ON authorization_events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
+
+-- Same ledger posture as migration 0040's identity relations: the admission,
+-- replay, audit, and invalidation relations below are append-only denial and
+-- authority facts protected by immutable no_delete/no_truncate triggers, so
+-- they carry community_id as provenance rather than deletable ownership. Widen
+-- the single SQL source of truth so the universal write fence and the deletion
+-- catalog treat all NIP-FI relations as ledger — never fence-attached, never
+-- purged, never counted as tenant-scoped drift. This re-declares the full set
+-- (0040's identity relations plus these) because CREATE OR REPLACE FUNCTION
+-- replaces the whole body.
+CREATE OR REPLACE FUNCTION community_write_fence_excluded_table(target NAME) RETURNS BOOLEAN
+LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT target::TEXT = ANY (ARRAY[
+        'community_deletion_requests', 'community_deletion_approvals',
+        'community_deletion_checkpoints', 'community_serving_write_leases',
+        'community_deletion_executor_heartbeats', 'product_feedback',
+        'rate_limit_violations',
+        'authorization_operation_receipts', 'identity_enrollment_policies',
+        'identity_bindings', 'identity_lifecycle_history',
+        'identity_lifecycle_selectors',
+        'authorization_invalidation_domains', 'authorization_invalidation_floors',
+        'authorization_authority_epochs', 'protected_object_authority',
+        'authorization_event_capacity', 'authorization_events',
+        'authorization_authentication_denial_attempts',
+        'authorization_operation_version_delta_manifests',
+        'authorization_operation_version_deltas', 'authorization_admission_results'
+    ]::TEXT[])
+$$;

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -12,7 +12,7 @@
 -- version-delta component kind 6) are deferred to the FI-DELEG migration and
 -- extended-lifecycle audit kinds (recover, enable, disable, admission-loss;
 -- version-delta component kind 7) to the FI-LIFECYCLE migration, matching
--- 0040's carve. A later migration widens these additively; nothing here
+-- 0041's carve. A later migration widens these additively; nothing here
 -- presumes a single global issuer.
 
 -- Durable one-way activation marker and current domain invalidation generation.
@@ -168,7 +168,7 @@ CREATE TABLE authorization_event_capacity (
 -- 10 protected allowed, 11 protected denied, 14 invalidation advanced.
 -- The extended-lifecycle audit kinds (4 recovered, 5 principal enabled,
 -- 7 principal disabled, 8 admission lost) are deferred to the FI-LIFECYCLE
--- migration, matching 0040's core lifecycle carve. Kinds 12 and 13 are
+-- migration, matching 0041's core lifecycle carve. Kinds 12 and 13 are
 -- retired: kind 24244 publication/withdrawal is ephemeral connection state and
 -- never a durable authorization event.
 CREATE TABLE authorization_events (
@@ -230,11 +230,13 @@ CREATE TABLE authorization_events (
         (actor_kind = 4 AND actor_fingerprint IS NULL AND subject_fingerprint IS NULL)
         OR (actor_kind IN (1, 2, 3) AND actor_fingerprint IS NOT NULL)
     ),
-    -- Kind-9 (pre-auth denial) events must carry a non-zero semantic_fingerprint;
+    -- Unresolved pre-auth kind-9 events (actor_kind = 4) carry a non-zero
+    -- semantic_fingerprint; authenticated kind-9 events (actor_kind 1-3) and
     -- all other event kinds must not.
     CHECK (
-        (event_kind = 9 AND semantic_fingerprint IS NOT NULL
+        (event_kind = 9 AND actor_kind = 4 AND semantic_fingerprint IS NOT NULL
             AND semantic_fingerprint <> decode(repeat('00', 32), 'hex'))
+        OR (event_kind = 9 AND actor_kind IN (1, 2, 3) AND semantic_fingerprint IS NULL)
         OR (event_kind <> 9 AND semantic_fingerprint IS NULL)
     )
 );
@@ -543,14 +545,19 @@ CREATE FUNCTION authorization_denial_attempt_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
     found_event_kind SMALLINT;
+    found_actor_kind SMALLINT;
+    found_request_fingerprint BYTEA;
     found_correlation_id UUID;
     found_reason_code SMALLINT;
     found_semantic_fingerprint BYTEA;
     attempt_count BIGINT;
 BEGIN
     IF TG_TABLE_NAME = 'authorization_events' THEN
-        -- Firing from the event side: only kind-9 events require a denial row.
-        IF NEW.event_kind <> 9 THEN
+        -- Firing from the event side: only unresolved pre-auth kind-9 events
+        -- (actor_kind = 4) require a denial attempt row. Authenticated
+        -- OperatorDenied events (actor_kind 1-3) have a canonical receipt and
+        -- no denial attempt.
+        IF NEW.event_kind <> 9 OR NEW.actor_kind <> 4 THEN
             RETURN NULL;
         END IF;
 
@@ -598,10 +605,13 @@ BEGIN
                       CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;
     ELSE
-        -- Firing from the denial-attempt side: verify the audit event is kind-9
-        -- and that exactly one denial attempt references it.
-        SELECT event_kind, correlation_id, reason_code, semantic_fingerprint
-        INTO found_event_kind, found_correlation_id, found_reason_code,
+        -- Firing from the denial-attempt side: verify the audit event is the
+        -- unresolved pre-auth kind-9 shape (actor_kind = 4, null receipt
+        -- fingerprint) and that exactly one denial attempt references it.
+        SELECT event_kind, actor_kind, request_fingerprint,
+               correlation_id, reason_code, semantic_fingerprint
+        INTO found_event_kind, found_actor_kind, found_request_fingerprint,
+             found_correlation_id, found_reason_code,
              found_semantic_fingerprint
         FROM authorization_events
         WHERE community_id = NEW.community_id
@@ -619,6 +629,22 @@ BEGIN
             RAISE EXCEPTION
                 'denial attempt audit event must be kind 9, got %',
                 found_event_kind
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        -- The referenced event must be the unresolved pre-auth shape: actor_kind
+        -- 4 with a null receipt fingerprint. Attaching a denial attempt to an
+        -- authenticated OperatorDenied (actor_kind 1-3) would violate the
+        -- credential-free pre-authentication contract.
+        IF found_actor_kind <> 4 OR found_request_fingerprint IS NOT NULL THEN
+            RAISE EXCEPTION
+                'denial attempt must reference an unresolved pre-auth kind-9 event '
+                '(actor_kind 4, null request_fingerprint); got actor_kind % '
+                'and request_fingerprint % for event %',
+                found_actor_kind,
+                CASE WHEN found_request_fingerprint IS NULL THEN 'null' ELSE 'non-null' END,
+                NEW.audit_event_id
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_event_kind';
         END IF;
@@ -924,6 +950,14 @@ BEGIN
         RETURN NULL;
     END IF;
 
+    -- Only applied (outcome_code = 1) and no-op (outcome_code = 3) lifecycle
+    -- receipts require a paired audit event. A denied lifecycle receipt
+    -- (outcome_code = 2) commits without one; fabricating a transition event
+    -- would falsely record that the lifecycle change occurred.
+    IF receipt.outcome_code NOT IN (1, 3) THEN
+        RETURN NULL;
+    END IF;
+
     SELECT
         count(*),
         count(*) FILTER (WHERE event_kind = expected_event_kind)
@@ -961,7 +995,7 @@ CREATE CONSTRAINT TRIGGER authorization_event_receipt_cardinality
 -- the single SQL source of truth so the universal write fence and the deletion
 -- catalog treat all NIP-FI relations as ledger — never fence-attached, never
 -- purged, never counted as tenant-scoped drift. This re-declares the full set
--- (0040's identity relations plus these) because CREATE OR REPLACE FUNCTION
+-- (0041's identity relations plus these) because CREATE OR REPLACE FUNCTION
 -- replaces the whole body.
 CREATE OR REPLACE FUNCTION community_write_fence_excluded_table(target NAME) RETURNS BOOLEAN
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$

--- a/migrations/0042_nip_fi_authorization_foundation.sql
+++ b/migrations/0042_nip_fi_authorization_foundation.sql
@@ -954,9 +954,12 @@ BEGIN
 
     -- Only applied (outcome_code = 1) and no-op (outcome_code = 3) lifecycle
     -- receipts require exactly one paired success-transition event. A denied
-    -- lifecycle receipt (outcome_code = 2) requires zero events of the mapped
-    -- transition kind: a success-transition event would falsely record that the
-    -- denied transition occurred, creating contradictory durable ledger facts.
+    -- lifecycle receipt (outcome_code = 2) requires zero events from the
+    -- complete core lifecycle success-transition class (kinds 1, 2, 3, 6:
+    -- enrolled, revoked, rotated, retired). Forbidding only the mapped kind
+    -- would allow a wrong-kind transition event to attach to the denied receipt,
+    -- which is equally a contradictory durable fact. Legitimate audit/denial
+    -- events of other kinds (e.g., authenticated kind 9) remain allowed.
     -- Other outcome codes (4, 5) are not core lifecycle outcomes; skip.
     IF receipt.outcome_code IN (1, 3) THEN
         SELECT
@@ -976,7 +979,7 @@ BEGIN
                       CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
         END IF;
     ELSIF receipt.outcome_code = 2 THEN
-        SELECT count(*) FILTER (WHERE event_kind = expected_event_kind)
+        SELECT count(*) FILTER (WHERE event_kind IN (1, 2, 3, 6))
         INTO expected_event_count
         FROM authorization_events
         WHERE community_id = receipt.community_id
@@ -985,9 +988,9 @@ BEGIN
 
         IF expected_event_count <> 0 THEN
             RAISE EXCEPTION
-                'denied lifecycle receipt must not have a mapped success-transition event '
-                '(kind %); found % — contradictory durable facts are not permitted',
-                expected_event_kind, expected_event_count
+                'denied lifecycle receipt must not have any core success-transition event '
+                '(kinds 1/2/3/6); found % — contradictory durable facts are not permitted',
+                expected_event_count
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denied_lifecycle_receipt_no_success_event';
         END IF;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1485,13 +1485,19 @@ $$;
 CREATE FUNCTION community_write_fence_excluded_table(target NAME) RETURNS BOOLEAN
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT target::TEXT = ANY (ARRAY[
-        'community_deletion_requests',
-        'community_deletion_approvals',
-        'community_deletion_checkpoints',
-        'community_serving_write_leases',
-        'community_deletion_executor_heartbeats',
-        'product_feedback',
-        'rate_limit_violations'
+        'community_deletion_requests', 'community_deletion_approvals',
+        'community_deletion_checkpoints', 'community_serving_write_leases',
+        'community_deletion_executor_heartbeats', 'product_feedback',
+        'rate_limit_violations',
+        'authorization_operation_receipts', 'identity_enrollment_policies',
+        'identity_bindings', 'identity_lifecycle_history',
+        'identity_lifecycle_selectors',
+        'authorization_invalidation_domains', 'authorization_invalidation_floors',
+        'authorization_authority_epochs', 'protected_object_authority',
+        'authorization_event_capacity', 'authorization_events',
+        'authorization_authentication_denial_attempts',
+        'authorization_operation_version_delta_manifests',
+        'authorization_operation_version_deltas', 'authorization_admission_results'
     ]::TEXT[])
 $$;
 
@@ -1895,3 +1901,1561 @@ CREATE INDEX idx_relay_operator_audit_target
 
 INSERT INTO _operator_global_tables (table_name, reason) VALUES
     ('relay_operator_audit', 'deployment-global append-only roster mutation audit trail; no community_id intentionally');
+
+
+-- ============================================================================
+-- NIP-FI core identity + base-lifecycle foundation (mirror of migration 0040).
+-- The community_write_fence_excluded_table definition above already folds in
+-- the NIP-FI ledger relations; the per-migration CREATE OR REPLACE bodies are
+-- intentionally omitted here (desired state keeps one consolidated definition).
+-- ============================================================================
+
+-- The sole idempotency/result root shared by identity base lifecycle,
+-- protected operations, and invalidation. Pre-authentication denials never
+-- write this table. ExactReplay and IntentConflict are read-time observations,
+-- not persisted outcomes.
+CREATE TABLE authorization_operation_receipts (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    -- Core operation kinds: 1 enroll, 3 retire, 5 revoke, 6 rotate,
+    -- 11 protected mutation, 12 invalidation. Extended lifecycle kinds
+    -- (2 provision, 4 disable, 7 recover, 8 enable, 9 admission loss) and
+    -- 10 operator are introduced by their owning later migrations.
+    operation_kind SMALLINT NOT NULL CHECK (
+        operation_kind IN (1, 3, 5, 6, 11, 12)
+    ),
+    actor_fingerprint BYTEA NOT NULL CHECK (octet_length(actor_fingerprint) = 32),
+    -- 1 applied, 2 denied, 3 no-op.
+    outcome_code SMALLINT NOT NULL CHECK (outcome_code IN (1, 2, 3)),
+    result_digest BYTEA NOT NULL CHECK (octet_length(result_digest) = 32),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, operation_id),
+    UNIQUE (community_id, operation_id, request_fingerprint),
+    UNIQUE (
+        community_id,
+        operation_id,
+        request_fingerprint,
+        operation_kind,
+        outcome_code
+    ),
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid)
+);
+
+-- Immutable monotonic local policy revisions. Enrollment modes are the closed
+-- provider-free V1 set: 1 attested-key, 2 provisioned, 3 risk-labelled TOFU.
+CREATE TABLE identity_enrollment_policies (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    policy_revision BIGINT NOT NULL CHECK (policy_revision > 0),
+    enrollment_mode SMALLINT NOT NULL CHECK (enrollment_mode IN (1, 2, 3)),
+    policy_digest BYTEA NOT NULL CHECK (octet_length(policy_digest) = 32),
+    effective_at TIMESTAMPTZ NOT NULL,
+    -- Optional local binding-policy expiry. Federated token `exp` MUST NOT be
+    -- copied here: token lifetime bounds an authorization lease, not this
+    -- durable binding generation.
+    expires_at TIMESTAMPTZ,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, policy_revision),
+    UNIQUE (community_id, policy_revision, enrollment_mode),
+    CHECK (expires_at IS NULL OR effective_at < expires_at)
+);
+
+-- One row is one immutable binding generation. binding_version is allocated
+-- from one non-cycling PostgreSQL identity sequence and is never changed or
+-- reused. Explicit lifecycle may only retire the generation; X/Y denial
+-- semantics live in immutable selector facts below, not alternate row states.
+CREATE TABLE identity_bindings (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    binding_id UUID NOT NULL,
+    binding_version BIGINT GENERATED ALWAYS AS IDENTITY (
+        START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1 NO CYCLE
+    ),
+    issuer TEXT COLLATE "C" NOT NULL CHECK (octet_length(issuer) BETWEEN 1 AND 2048),
+    subject TEXT COLLATE "C" NOT NULL CHECK (octet_length(subject) BETWEEN 1 AND 2048),
+    principal_fingerprint BYTEA NOT NULL CHECK (octet_length(principal_fingerprint) = 32),
+    event_author_pubkey BYTEA NOT NULL CHECK (octet_length(event_author_pubkey) = 32),
+    -- 1 active, 2 retired.
+    binding_state SMALLINT NOT NULL CHECK (binding_state IN (1, 2)),
+    lifecycle_revision BIGINT NOT NULL CHECK (lifecycle_revision IN (1, 2)),
+    -- 1 attested-key, 2 provisioned, 3 risk-labelled TOFU.
+    binding_provenance SMALLINT NOT NULL CHECK (binding_provenance IN (1, 2, 3)),
+    policy_revision BIGINT NOT NULL CHECK (policy_revision > 0),
+    -- Canonical evidence for the selected provenance. This is an assertion
+    -- digest for attested/TOFU admission and a provisioning receipt digest for
+    -- separately provisioned admission; it never stores credential bytes.
+    enrollment_evidence_digest BYTEA NOT NULL CHECK (
+        octet_length(enrollment_evidence_digest) = 32
+    ),
+    expires_at TIMESTAMPTZ,
+    birth_history_id UUID NOT NULL,
+    creation_operation_id UUID NOT NULL,
+    creation_request_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(creation_request_fingerprint) = 32
+    ),
+    retirement_history_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, binding_id),
+    UNIQUE (community_id, binding_version),
+    UNIQUE (community_id, binding_id, binding_version),
+    FOREIGN KEY (community_id, policy_revision, binding_provenance)
+        REFERENCES identity_enrollment_policies
+            (community_id, policy_revision, enrollment_mode),
+    CHECK (binding_version > 0),
+    CHECK (binding_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (birth_history_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (creation_operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (expires_at IS NULL OR created_at < expires_at),
+    CHECK (
+        (binding_state = 1 AND lifecycle_revision = 1 AND retirement_history_id IS NULL)
+        OR (binding_state = 2 AND lifecycle_revision = 2 AND retirement_history_id IS NOT NULL)
+    )
+);
+
+-- State 1 is Active. Expiry is evaluated with authoritative PostgreSQL time
+-- at read/finalization and is exclusive; it cannot appear in an index predicate.
+CREATE UNIQUE INDEX identity_bindings_active_principal
+    ON identity_bindings (community_id, issuer, subject)
+    WHERE binding_state = 1;
+CREATE INDEX identity_bindings_principal_fingerprint_lookup
+    ON identity_bindings (community_id, principal_fingerprint)
+    WHERE binding_state = 1;
+CREATE UNIQUE INDEX identity_bindings_active_event_author
+    ON identity_bindings (community_id, event_author_pubkey)
+    WHERE binding_state = 1;
+CREATE INDEX identity_bindings_current_lookup
+    ON identity_bindings (community_id, event_author_pubkey, binding_state, expires_at);
+
+-- The one canonical immutable lifecycle transition row for a successful or
+-- no-op lifecycle operation. A transition can name an old generation, a new
+-- successor generation, both (Rotate), or neither (a semantic no-op). It is not
+-- a second result/effect engine: the shared receipt remains the sole persisted
+-- operation outcome. Core transition kinds only: 1 enroll, 3 retire, 5 revoke,
+-- 6 rotate.
+CREATE TABLE identity_lifecycle_history (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    history_id UUID NOT NULL,
+    transition_kind SMALLINT NOT NULL CHECK (
+        transition_kind IN (1, 3, 5, 6)
+    ),
+    -- Matches the shared receipt: 1 applied, 3 no-op.
+    outcome_code SMALLINT NOT NULL CHECK (outcome_code IN (1, 3)),
+    old_binding_id UUID,
+    old_binding_version BIGINT CHECK (old_binding_version IS NULL OR old_binding_version > 0),
+    old_prior_lifecycle_revision BIGINT CHECK (
+        old_prior_lifecycle_revision IS NULL OR old_prior_lifecycle_revision IN (1, 2)
+    ),
+    old_prior_state SMALLINT CHECK (old_prior_state IS NULL OR old_prior_state IN (1, 2)),
+    old_resulting_lifecycle_revision BIGINT CHECK (
+        old_resulting_lifecycle_revision IS NULL OR old_resulting_lifecycle_revision IN (1, 2)
+    ),
+    old_resulting_state SMALLINT CHECK (
+        old_resulting_state IS NULL OR old_resulting_state IN (1, 2)
+    ),
+    successor_binding_id UUID,
+    successor_binding_version BIGINT CHECK (
+        successor_binding_version IS NULL OR successor_binding_version > 0
+    ),
+    successor_lifecycle_revision BIGINT CHECK (
+        successor_lifecycle_revision IS NULL OR successor_lifecycle_revision = 1
+    ),
+    successor_state SMALLINT CHECK (successor_state IS NULL OR successor_state = 1),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    transition_digest BYTEA NOT NULL CHECK (octet_length(transition_digest) = 32),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, history_id),
+    UNIQUE (community_id, operation_id),
+    UNIQUE (community_id, history_id, operation_id, request_fingerprint),
+    UNIQUE (
+        community_id,
+        history_id,
+        successor_binding_id,
+        successor_binding_version,
+        operation_id,
+        request_fingerprint
+    ),
+    UNIQUE (
+        community_id,
+        history_id,
+        old_binding_id,
+        old_binding_version,
+        old_resulting_lifecycle_revision,
+        old_resulting_state
+    ),
+    FOREIGN KEY (
+        community_id,
+        operation_id,
+        request_fingerprint,
+        transition_kind,
+        outcome_code
+    ) REFERENCES authorization_operation_receipts (
+        community_id,
+        operation_id,
+        request_fingerprint,
+        operation_kind,
+        outcome_code
+    ) DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, old_binding_id, old_binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, successor_binding_id, successor_binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (history_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (
+        (old_binding_id IS NULL
+            AND old_binding_version IS NULL
+            AND old_prior_lifecycle_revision IS NULL
+            AND old_prior_state IS NULL
+            AND old_resulting_lifecycle_revision IS NULL
+            AND old_resulting_state IS NULL)
+        OR (old_binding_id IS NOT NULL
+            AND old_binding_version IS NOT NULL
+            AND old_prior_lifecycle_revision IS NOT NULL
+            AND old_prior_state IS NOT NULL
+            AND old_resulting_lifecycle_revision IS NOT NULL
+            AND old_resulting_state IS NOT NULL)
+    ),
+    CHECK (
+        (successor_binding_id IS NULL
+            AND successor_binding_version IS NULL
+            AND successor_lifecycle_revision IS NULL
+            AND successor_state IS NULL)
+        OR (successor_binding_id IS NOT NULL
+            AND successor_binding_version IS NOT NULL
+            AND successor_lifecycle_revision = 1
+            AND successor_state = 1)
+    ),
+    CHECK (
+        old_binding_id IS NULL
+        OR successor_binding_id IS NULL
+        OR old_binding_id <> successor_binding_id
+    ),
+    CHECK (
+        old_binding_version IS NULL
+        OR successor_binding_version IS NULL
+        OR old_binding_version <> successor_binding_version
+    ),
+    -- Core lifecycle only ever moves Active/r1 to Retired/r2 for a named old
+    -- generation. Extended re-enablement (recover/enable from Retired/r2) is a
+    -- later migration's concern.
+    CHECK (
+        old_binding_id IS NULL
+        OR (old_prior_lifecycle_revision = 1
+            AND old_prior_state = 1
+            AND old_resulting_lifecycle_revision = 2
+            AND old_resulting_state = 2)
+    ),
+    CHECK (
+        (outcome_code = 3
+            AND old_binding_id IS NULL
+            AND successor_binding_id IS NULL)
+        OR (outcome_code = 1 AND (
+            (transition_kind = 1
+                AND old_binding_id IS NULL
+                AND successor_binding_id IS NOT NULL)
+            OR (transition_kind = 3
+                AND old_binding_id IS NOT NULL
+                AND successor_binding_id IS NULL)
+            OR (transition_kind = 5
+                AND successor_binding_id IS NULL)
+            OR (transition_kind = 6
+                AND old_binding_id IS NOT NULL
+                AND successor_binding_id IS NOT NULL)
+        ))
+    )
+);
+
+CREATE INDEX identity_lifecycle_history_old_binding
+    ON identity_lifecycle_history (community_id, old_binding_id, old_binding_version, recorded_at);
+CREATE INDEX identity_lifecycle_history_successor_binding
+    ON identity_lifecycle_history (
+        community_id,
+        successor_binding_id,
+        successor_binding_version,
+        recorded_at
+    );
+
+-- Circular birth/transition ordering is deliberate and fully deferred. Every
+-- generation must commit with its exact birth transition, and a retired row
+-- must commit with the exact transition that changed Active/r1 to Retired/r2.
+ALTER TABLE identity_bindings
+    ADD CONSTRAINT identity_bindings_exact_birth_history_fk
+    FOREIGN KEY (
+        community_id,
+        birth_history_id,
+        binding_id,
+        binding_version,
+        creation_operation_id,
+        creation_request_fingerprint
+    ) REFERENCES identity_lifecycle_history (
+        community_id,
+        history_id,
+        successor_binding_id,
+        successor_binding_version,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE identity_bindings
+    ADD CONSTRAINT identity_bindings_exact_retirement_history_fk
+    FOREIGN KEY (
+        community_id,
+        retirement_history_id,
+        binding_id,
+        binding_version,
+        lifecycle_revision,
+        binding_state
+    ) REFERENCES identity_lifecycle_history (
+        community_id,
+        history_id,
+        old_binding_id,
+        old_binding_version,
+        old_resulting_lifecycle_revision,
+        old_resulting_state
+    ) DEFERRABLE INITIALLY DEFERRED;
+
+-- One immutable closed-scope fact table. Core selector kinds only:
+-- 1 retired pair (P), 3 revoked key (Y). Both are permanent. The extended
+-- disabled-identity (X) and pending-replacement (Q) selectors, and their
+-- one-shot consumption, are introduced by the FI-LIFECYCLE migration.
+CREATE TABLE identity_lifecycle_selectors (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    selector_id UUID NOT NULL,
+    selector_kind SMALLINT NOT NULL CHECK (selector_kind IN (1, 3)),
+    selector_fingerprint BYTEA NOT NULL CHECK (octet_length(selector_fingerprint) = 32),
+    fact_generation BIGINT NOT NULL CHECK (fact_generation > 0),
+    principal_fingerprint BYTEA CHECK (
+        principal_fingerprint IS NULL OR octet_length(principal_fingerprint) = 32
+    ),
+    event_author_pubkey BYTEA CHECK (
+        event_author_pubkey IS NULL OR octet_length(event_author_pubkey) = 32
+    ),
+    binding_id UUID,
+    binding_version BIGINT CHECK (binding_version IS NULL OR binding_version > 0),
+    asserted_history_id UUID NOT NULL,
+    selected_by_operation_id UUID NOT NULL,
+    selected_by_request_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(selected_by_request_fingerprint) = 32
+    ),
+    selected_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, selector_id),
+    UNIQUE (community_id, selector_id, selector_kind),
+    UNIQUE (community_id, selector_kind, selector_fingerprint, fact_generation),
+    FOREIGN KEY (
+        community_id,
+        asserted_history_id,
+        selected_by_operation_id,
+        selected_by_request_fingerprint
+    ) REFERENCES identity_lifecycle_history (
+        community_id,
+        history_id,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (
+        community_id,
+        selected_by_operation_id,
+        selected_by_request_fingerprint
+    ) REFERENCES authorization_operation_receipts (
+        community_id,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, binding_id, binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (selector_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (
+        (selector_kind = 1
+            AND fact_generation = 1
+            AND principal_fingerprint IS NOT NULL
+            AND event_author_pubkey IS NOT NULL
+            AND binding_id IS NOT NULL
+            AND binding_version IS NOT NULL)
+        OR (selector_kind = 3
+            AND fact_generation = 1
+            AND principal_fingerprint IS NULL
+            AND event_author_pubkey IS NOT NULL
+            AND binding_id IS NULL
+            AND binding_version IS NULL)
+    )
+);
+
+CREATE UNIQUE INDEX identity_lifecycle_selectors_permanent_pair
+    ON identity_lifecycle_selectors (community_id, binding_id, binding_version)
+    WHERE selector_kind = 1;
+CREATE UNIQUE INDEX identity_lifecycle_selectors_permanent_principal_key
+    ON identity_lifecycle_selectors (
+        community_id,
+        principal_fingerprint,
+        event_author_pubkey
+    ) WHERE selector_kind = 1;
+CREATE UNIQUE INDEX identity_lifecycle_selectors_permanent_key
+    ON identity_lifecycle_selectors (community_id, event_author_pubkey)
+    WHERE selector_kind = 3;
+CREATE INDEX identity_lifecycle_selectors_principal_lookup
+    ON identity_lifecycle_selectors
+        (community_id, selector_kind, principal_fingerprint, fact_generation);
+CREATE INDEX identity_lifecycle_selectors_key_lookup
+    ON identity_lifecycle_selectors
+        (community_id, selector_kind, event_author_pubkey, fact_generation);
+CREATE INDEX identity_lifecycle_selectors_binding_lookup
+    ON identity_lifecycle_selectors
+        (community_id, selector_kind, binding_id, binding_version, fact_generation);
+CREATE INDEX identity_lifecycle_selectors_asserted_history
+    ON identity_lifecycle_selectors
+        (community_id, asserted_history_id, selector_kind);
+
+CREATE FUNCTION nip_fi_reject_row_mutation_v1() RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '% is immutable', TG_TABLE_NAME
+        USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION nip_fi_reject_truncate_v1() RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '% cannot be truncated', TG_TABLE_NAME
+        USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Every binding/selector path derives the same domain-scoped coordinates and
+-- takes their signed BIGINT advisory keys in numeric order. Typed transaction
+-- APIs take these locks before row mutation; the triggers are the fail-closed
+-- backstop for direct SQL.
+CREATE FUNCTION identity_lifecycle_lock_coordinates_v1(
+    locked_community_id UUID,
+    locked_principal_fingerprint BYTEA,
+    locked_event_author_pubkey BYTEA
+) RETURNS VOID AS $$
+DECLARE
+    principal_lock_key BIGINT;
+    event_author_lock_key BIGINT;
+BEGIN
+    IF locked_principal_fingerprint IS NOT NULL THEN
+        principal_lock_key := hashtextextended(
+            'buzz:identity-lifecycle-coordinate:v1:principal:'
+                || locked_community_id::text || ':'
+                || encode(locked_principal_fingerprint, 'hex'),
+            0
+        );
+    END IF;
+    IF locked_event_author_pubkey IS NOT NULL THEN
+        event_author_lock_key := hashtextextended(
+            'buzz:identity-lifecycle-coordinate:v1:key:'
+                || locked_community_id::text || ':'
+                || encode(locked_event_author_pubkey, 'hex'),
+            0
+        );
+    END IF;
+
+    IF principal_lock_key IS NOT NULL AND event_author_lock_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(LEAST(principal_lock_key, event_author_lock_key));
+        IF principal_lock_key <> event_author_lock_key THEN
+            PERFORM pg_advisory_xact_lock(GREATEST(principal_lock_key, event_author_lock_key));
+        END IF;
+    ELSIF principal_lock_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(principal_lock_key);
+    ELSIF event_author_lock_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(event_author_lock_key);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_bindings_insert_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM identity_lifecycle_lock_coordinates_v1(
+        NEW.community_id,
+        NEW.principal_fingerprint,
+        NEW.event_author_pubkey
+    );
+    IF NEW.binding_state <> 1
+        OR NEW.lifecycle_revision <> 1
+        OR NEW.retirement_history_id IS NOT NULL
+    THEN
+        RAISE EXCEPTION 'identity binding birth must be Active at lifecycle revision 1'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_birth_state';
+    END IF;
+    NEW.created_at := transaction_timestamp();
+    NEW.updated_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_bindings_transition_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    PERFORM identity_lifecycle_lock_coordinates_v1(
+        OLD.community_id,
+        OLD.principal_fingerprint,
+        OLD.event_author_pubkey
+    );
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.binding_id IS DISTINCT FROM OLD.binding_id
+        OR NEW.binding_version IS DISTINCT FROM OLD.binding_version
+        OR NEW.issuer IS DISTINCT FROM OLD.issuer
+        OR NEW.subject IS DISTINCT FROM OLD.subject
+        OR NEW.principal_fingerprint IS DISTINCT FROM OLD.principal_fingerprint
+        OR NEW.event_author_pubkey IS DISTINCT FROM OLD.event_author_pubkey
+        OR NEW.binding_provenance IS DISTINCT FROM OLD.binding_provenance
+        OR NEW.policy_revision IS DISTINCT FROM OLD.policy_revision
+        OR NEW.enrollment_evidence_digest IS DISTINCT FROM OLD.enrollment_evidence_digest
+        OR NEW.expires_at IS DISTINCT FROM OLD.expires_at
+        OR NEW.birth_history_id IS DISTINCT FROM OLD.birth_history_id
+        OR NEW.creation_operation_id IS DISTINCT FROM OLD.creation_operation_id
+        OR NEW.creation_request_fingerprint IS DISTINCT FROM OLD.creation_request_fingerprint
+        OR NEW.created_at IS DISTINCT FROM OLD.created_at
+    THEN
+        RAISE EXCEPTION 'identity binding generation coordinates are immutable'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_immutable_generation';
+    END IF;
+    IF OLD.binding_state <> 1
+        OR OLD.lifecycle_revision <> 1
+        OR OLD.retirement_history_id IS NOT NULL
+        OR NEW.binding_state <> 2
+        OR NEW.lifecycle_revision <> 2
+        OR NEW.retirement_history_id IS NULL
+        OR NEW.retirement_history_id = OLD.birth_history_id
+    THEN
+        RAISE EXCEPTION 'identity binding permits only Active/r1 to Retired/r2'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_active_to_retired';
+    END IF;
+    NEW.updated_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_history_insert_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.recorded_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_binding_history_semantics_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    retirement identity_lifecycle_history%ROWTYPE;
+BEGIN
+    IF NEW.binding_state = 2 THEN
+        SELECT * INTO STRICT retirement
+        FROM identity_lifecycle_history
+        WHERE community_id = NEW.community_id
+          AND history_id = NEW.retirement_history_id
+          AND old_binding_id = NEW.binding_id
+          AND old_binding_version = NEW.binding_version;
+        IF retirement.outcome_code <> 1
+            OR retirement.old_prior_lifecycle_revision <> 1
+            OR retirement.old_prior_state <> 1
+            OR retirement.old_resulting_lifecycle_revision <> 2
+            OR retirement.old_resulting_state <> 2
+        THEN
+            RAISE EXCEPTION 'retired binding must reference its exact Active-to-Retired transition'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'identity_bindings_retirement_history_semantics';
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_binding_birth_eligibility_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM identity_lifecycle_selectors selector
+        WHERE selector.community_id = NEW.community_id
+          AND (
+            (selector.selector_kind = 1
+                AND selector.principal_fingerprint = NEW.principal_fingerprint
+                AND selector.event_author_pubkey = NEW.event_author_pubkey)
+            OR (selector.selector_kind = 3
+                AND selector.event_author_pubkey = NEW.event_author_pubkey)
+          )
+    ) THEN
+        RAISE EXCEPTION 'binding birth conflicts with an effective lifecycle selector'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_bindings_birth_eligibility';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION authorization_operation_receipt_history_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    history_count BIGINT;
+    expected_count BIGINT;
+BEGIN
+    SELECT count(*) INTO history_count
+    FROM identity_lifecycle_history history
+    WHERE history.community_id = NEW.community_id
+      AND history.operation_id = NEW.operation_id;
+
+    -- Core lifecycle receipts (enroll, retire, revoke, rotate) each require
+    -- exactly one lifecycle-history row. Non-lifecycle receipts (protected
+    -- mutation, invalidation) require none.
+    expected_count := CASE
+        WHEN NEW.operation_kind IN (1, 3, 5, 6) AND NEW.outcome_code IN (1, 3) THEN 1
+        ELSE 0
+    END;
+    IF history_count <> expected_count THEN
+        RAISE EXCEPTION 'operation receipt requires % lifecycle history row, found %',
+            expected_count, history_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_receipt_history_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_selector_insert_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.selected_at := transaction_timestamp();
+    PERFORM identity_lifecycle_lock_coordinates_v1(
+        NEW.community_id,
+        CASE WHEN NEW.selector_kind = 1 THEN NEW.principal_fingerprint END,
+        NEW.event_author_pubkey
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_selector_history_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    history identity_lifecycle_history%ROWTYPE;
+    old_binding identity_bindings%ROWTYPE;
+BEGIN
+    SELECT * INTO STRICT history
+    FROM identity_lifecycle_history
+    WHERE community_id = NEW.community_id
+      AND history_id = NEW.asserted_history_id
+      AND operation_id = NEW.selected_by_operation_id
+      AND request_fingerprint = NEW.selected_by_request_fingerprint;
+
+    IF history.old_binding_id IS NOT NULL THEN
+        SELECT * INTO STRICT old_binding
+        FROM identity_bindings
+        WHERE community_id = history.community_id
+          AND binding_id = history.old_binding_id
+          AND binding_version = history.old_binding_version;
+    END IF;
+
+    -- A retired-pair (P) selector is asserted by retire, revoke, or rotate of a
+    -- named old generation; a revoked-key (Y) selector by revoke.
+    IF history.outcome_code <> 1
+        OR (NEW.selector_kind = 1 AND (
+            history.transition_kind NOT IN (3, 5, 6)
+            OR history.old_binding_id IS DISTINCT FROM NEW.binding_id
+            OR history.old_binding_version IS DISTINCT FROM NEW.binding_version
+            OR old_binding.principal_fingerprint IS DISTINCT FROM NEW.principal_fingerprint
+            OR old_binding.event_author_pubkey IS DISTINCT FROM NEW.event_author_pubkey
+        ))
+        OR (NEW.selector_kind = 3 AND (
+            history.transition_kind <> 5
+            OR (history.old_binding_id IS NOT NULL
+                AND old_binding.event_author_pubkey
+                    IS DISTINCT FROM NEW.event_author_pubkey)
+        ))
+    THEN
+        RAISE EXCEPTION 'selector does not match its lifecycle transition'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_lifecycle_selector_history_semantics';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION identity_lifecycle_transition_integrity_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    transition identity_lifecycle_history%ROWTYPE;
+    old_binding_state SMALLINT;
+    asserted_p BIGINT;
+    asserted_y BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'identity_lifecycle_history' THEN
+        transition := NEW;
+    ELSIF TG_TABLE_NAME = 'identity_lifecycle_selectors' THEN
+        SELECT * INTO STRICT transition
+        FROM identity_lifecycle_history
+        WHERE community_id = NEW.community_id
+          AND history_id = NEW.asserted_history_id;
+    ELSE
+        SELECT * INTO STRICT transition
+        FROM identity_lifecycle_history
+        WHERE community_id = NEW.community_id
+          AND history_id = CASE
+              WHEN NEW.binding_state = 2 THEN NEW.retirement_history_id
+              ELSE NEW.birth_history_id
+          END;
+    END IF;
+
+    SELECT
+        count(*) FILTER (WHERE selector_kind = 1),
+        count(*) FILTER (WHERE selector_kind = 3)
+    INTO asserted_p, asserted_y
+    FROM identity_lifecycle_selectors
+    WHERE community_id = transition.community_id
+      AND asserted_history_id = transition.history_id;
+
+    IF transition.old_binding_id IS NOT NULL THEN
+        SELECT binding_state INTO STRICT old_binding_state
+        FROM identity_bindings
+        WHERE community_id = transition.community_id
+          AND binding_id = transition.old_binding_id
+          AND binding_version = transition.old_binding_version;
+        IF old_binding_state <> 2 THEN
+            RAISE EXCEPTION 'lifecycle transition old binding must be retired at commit'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'identity_lifecycle_transition_integrity';
+        END IF;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM identity_lifecycle_selectors selector
+        JOIN identity_bindings active
+          ON active.community_id = selector.community_id
+         AND active.binding_state = 1
+         AND (
+            (selector.selector_kind = 1
+                AND active.principal_fingerprint = selector.principal_fingerprint
+                AND active.event_author_pubkey = selector.event_author_pubkey)
+            OR (selector.selector_kind = 3
+                AND active.event_author_pubkey = selector.event_author_pubkey)
+         )
+        WHERE selector.community_id = transition.community_id
+    ) THEN
+        RAISE EXCEPTION 'effective lifecycle selector conflicts with an active binding'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_lifecycle_transition_integrity';
+    END IF;
+
+    IF transition.outcome_code = 3 THEN
+        IF asserted_p + asserted_y <> 0 THEN
+            RAISE EXCEPTION 'no-op lifecycle transition cannot create selector facts'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'identity_lifecycle_transition_integrity';
+        END IF;
+        RETURN NULL;
+    END IF;
+
+    -- Core selector companions per transition:
+    --   enroll  (1): none
+    --   retire  (3): exactly one P
+    --   revoke  (5): one Y always; one P when a named old generation is removed
+    --   rotate  (6): exactly one P (old generation retired)
+    IF (transition.transition_kind = 1
+            AND (asserted_p, asserted_y) <> (0, 0))
+        OR (transition.transition_kind = 3
+            AND (asserted_p, asserted_y) <> (1, 0))
+        OR (transition.transition_kind = 5 AND (
+            (transition.old_binding_id IS NOT NULL
+                AND (asserted_p, asserted_y) <> (1, 1))
+            OR (transition.old_binding_id IS NULL
+                AND (asserted_p, asserted_y) <> (0, 1))
+        ))
+        OR (transition.transition_kind = 6
+            AND (asserted_p, asserted_y) <> (1, 0))
+    THEN
+        RAISE EXCEPTION 'lifecycle transition has incomplete or forbidden selector companions'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_lifecycle_transition_integrity';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER identity_bindings_insert_guard
+    BEFORE INSERT ON identity_bindings
+    FOR EACH ROW EXECUTE FUNCTION identity_bindings_insert_guard_v1();
+CREATE TRIGGER identity_bindings_transition_guard
+    BEFORE UPDATE ON identity_bindings
+    FOR EACH ROW EXECUTE FUNCTION identity_bindings_transition_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_bindings_history_semantics
+    AFTER INSERT OR UPDATE ON identity_bindings
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_binding_history_semantics_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_bindings_birth_eligibility
+    AFTER INSERT ON identity_bindings
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_binding_birth_eligibility_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_bindings_transition_integrity
+    AFTER INSERT OR UPDATE ON identity_bindings
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_transition_integrity_guard_v1();
+CREATE TRIGGER identity_bindings_no_delete
+    BEFORE DELETE ON identity_bindings
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_bindings_no_truncate
+    BEFORE TRUNCATE ON identity_bindings
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_lifecycle_history_insert_guard
+    BEFORE INSERT ON identity_lifecycle_history
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_history_insert_guard_v1();
+CREATE CONSTRAINT TRIGGER authorization_operation_receipt_history_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_history_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_lifecycle_transition_integrity
+    AFTER INSERT ON identity_lifecycle_history
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_transition_integrity_guard_v1();
+
+CREATE TRIGGER identity_lifecycle_selector_insert_guard
+    BEFORE INSERT ON identity_lifecycle_selectors
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_selector_insert_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_lifecycle_selector_history_semantics
+    AFTER INSERT ON identity_lifecycle_selectors
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_selector_history_guard_v1();
+CREATE CONSTRAINT TRIGGER identity_lifecycle_selector_transition_integrity
+    AFTER INSERT ON identity_lifecycle_selectors
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION identity_lifecycle_transition_integrity_guard_v1();
+
+CREATE TRIGGER authorization_operation_receipts_immutable
+    BEFORE UPDATE OR DELETE ON authorization_operation_receipts
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_operation_receipts_no_truncate
+    BEFORE TRUNCATE ON authorization_operation_receipts
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_enrollment_policies_immutable
+    BEFORE UPDATE OR DELETE ON identity_enrollment_policies
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_enrollment_policies_no_truncate
+    BEFORE TRUNCATE ON identity_enrollment_policies
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_lifecycle_history_immutable
+    BEFORE UPDATE OR DELETE ON identity_lifecycle_history
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_lifecycle_history_no_truncate
+    BEFORE TRUNCATE ON identity_lifecycle_history
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER identity_lifecycle_selectors_immutable
+    BEFORE UPDATE OR DELETE ON identity_lifecycle_selectors
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER identity_lifecycle_selectors_no_truncate
+    BEFORE TRUNCATE ON identity_lifecycle_selectors
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+
+-- ============================================================================
+-- NIP-FI final-admission foundation (mirror of migration 0041).
+-- ============================================================================
+
+CREATE TABLE authorization_invalidation_domains (
+    community_id UUID NOT NULL PRIMARY KEY REFERENCES communities(id),
+    current_generation BIGINT NOT NULL CHECK (current_generation >= 0),
+    activated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp()
+);
+
+-- Closed selectors: 1 principal, 2 Nostr key, 3 binding, 4 session, 5 domain,
+-- 6 configuration revision. Selector 7 (delegated relationship) and its
+-- relationship-revision floor are deferred to the FI-DELEG migration.
+CREATE TABLE authorization_invalidation_floors (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    selector_kind SMALLINT NOT NULL CHECK (selector_kind IN (1, 2, 3, 4, 5, 6)),
+    selector_fingerprint BYTEA NOT NULL CHECK (octet_length(selector_fingerprint) = 32),
+    floor_generation BIGINT NOT NULL CHECK (floor_generation > 0),
+    binding_version_floor BIGINT CHECK (binding_version_floor IS NULL OR binding_version_floor > 0),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, selector_kind, selector_fingerprint),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (
+        (selector_kind = 3 AND binding_version_floor IS NOT NULL)
+        OR (selector_kind <> 3 AND binding_version_floor IS NULL)
+    )
+);
+
+-- Protected-object kinds: 1 domain, 2 channel, 3 repository, 4 media,
+-- 5 moderation target, 6 audio session. Kind 7 is retired: current binding
+-- status is connection-local evidence and never a durable protected object.
+CREATE TABLE authorization_authority_epochs (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    object_kind SMALLINT NOT NULL CHECK (object_kind IN (1, 2, 3, 4, 5, 6)),
+    object_key BYTEA NOT NULL CHECK (octet_length(object_key) = 32),
+    authority_epoch BIGINT NOT NULL CHECK (authority_epoch > 0),
+    fence BYTEA NOT NULL CHECK (
+        octet_length(fence) = 32 AND fence <> decode(repeat('00', 32), 'hex')
+    ),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, object_kind, object_key),
+    UNIQUE (
+        community_id,
+        object_kind,
+        object_key,
+        authority_epoch,
+        fence,
+        operation_id,
+        request_fingerprint
+    ),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+-- Direct-final current authority for a protected object. The authorization
+-- lease itself is sealed in memory and dies on restart; this durable row is the
+-- exact source re-fenced immediately before a protected mutation or emission.
+CREATE TABLE protected_object_authority (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    object_kind SMALLINT NOT NULL CHECK (object_kind IN (1, 2, 3, 4, 5, 6)),
+    object_key BYTEA NOT NULL CHECK (octet_length(object_key) = 32),
+    capability SMALLINT NOT NULL CHECK (
+        capability IN (
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+            28, 29
+        )
+    ),
+    actor_pubkey BYTEA NOT NULL CHECK (octet_length(actor_pubkey) = 32),
+    binding_id UUID NOT NULL,
+    binding_version BIGINT NOT NULL CHECK (binding_version > 0),
+    policy_revision BIGINT NOT NULL CHECK (policy_revision > 0),
+    invalidation_generation BIGINT NOT NULL CHECK (invalidation_generation >= 0),
+    authority_epoch BIGINT NOT NULL CHECK (authority_epoch > 0),
+    fence BYTEA NOT NULL CHECK (
+        octet_length(fence) = 32 AND fence <> decode(repeat('00', 32), 'hex')
+    ),
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    PRIMARY KEY (community_id, object_kind, object_key),
+    FOREIGN KEY (community_id, binding_id, binding_version)
+        REFERENCES identity_bindings (community_id, binding_id, binding_version)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (
+        community_id,
+        object_kind,
+        object_key,
+        authority_epoch,
+        fence,
+        operation_id,
+        request_fingerprint
+    ) REFERENCES authorization_authority_epochs (
+        community_id,
+        object_kind,
+        object_key,
+        authority_epoch,
+        fence,
+        operation_id,
+        request_fingerprint
+    ) DEFERRABLE INITIALLY DEFERRED,
+    CHECK (issued_at < expires_at)
+);
+
+-- Explicit immutable-capacity policy required by Enforce mode. Hard ceilings
+-- match buzz-auth; installation limits must be sized explicitly below them.
+-- V1 has no online pruning/export/reset workflow.
+CREATE TABLE authorization_event_capacity (
+    community_id UUID NOT NULL PRIMARY KEY REFERENCES communities(id),
+    max_events_per_domain BIGINT NOT NULL CONSTRAINT authorization_event_capacity_max_events CHECK (
+        max_events_per_domain BETWEEN 1 AND 10000
+    ),
+    max_bytes_per_domain BIGINT NOT NULL CONSTRAINT authorization_event_capacity_max_bytes CHECK (
+        max_bytes_per_domain BETWEEN 1 AND 16777216
+    ),
+    max_envelope_bytes INTEGER NOT NULL CONSTRAINT authorization_event_capacity_max_envelope CHECK (
+        max_envelope_bytes BETWEEN 1 AND 16384
+    ),
+    retained_event_count BIGINT NOT NULL DEFAULT 0 CHECK (retained_event_count >= 0),
+    retained_envelope_bytes BIGINT NOT NULL DEFAULT 0 CHECK (retained_envelope_bytes >= 0),
+    -- 1 healthy, 2 audit unavailable/exhausted. Recovery/reset is not a V1
+    -- online workflow; enabled runtime latches failure when insertion aborts.
+    health_state SMALLINT NOT NULL DEFAULT 1 CHECK (health_state IN (1, 2)),
+    failure_code SMALLINT CHECK (failure_code IS NULL OR failure_code IN (1, 2, 3)),
+    failure_observed_at TIMESTAMPTZ,
+    configured_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    CHECK (max_envelope_bytes <= max_bytes_per_domain),
+    CHECK (retained_event_count <= max_events_per_domain),
+    CHECK (retained_envelope_bytes <= max_bytes_per_domain),
+    CHECK (
+        (health_state = 1 AND failure_code IS NULL AND failure_observed_at IS NULL)
+        OR (health_state = 2 AND failure_code IS NOT NULL AND failure_observed_at IS NOT NULL)
+    )
+);
+
+-- Durable versioned pseudonymous authorization envelope. event_kind:
+-- 1 enrolled, 2 revoked, 3 rotated, 6 retired, 9 operator denied,
+-- 10 protected allowed, 11 protected denied, 14 invalidation advanced.
+-- The extended-lifecycle audit kinds (4 recovered, 5 principal enabled,
+-- 7 principal disabled, 8 admission lost) are deferred to the FI-LIFECYCLE
+-- migration, matching 0040's core lifecycle carve. Kinds 12 and 13 are
+-- retired: kind 24244 publication/withdrawal is ephemeral connection state and
+-- never a durable authorization event.
+CREATE TABLE authorization_events (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    event_id UUID NOT NULL,
+    schema_version SMALLINT NOT NULL DEFAULT 1 CHECK (schema_version = 1),
+    event_kind SMALLINT NOT NULL CHECK (
+        event_kind IN (1, 2, 3, 6, 9, 10, 11, 14)
+    ),
+    outcome_code SMALLINT NOT NULL CHECK (outcome_code IN (1, 2, 3, 4, 5)),
+    reason_code SMALLINT NOT NULL CHECK (
+        reason_code IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+    ),
+    actor_kind SMALLINT NOT NULL CHECK (actor_kind IN (1, 2, 3, 4)),
+    actor_fingerprint BYTEA CHECK (
+        actor_fingerprint IS NULL OR octet_length(actor_fingerprint) = 32
+    ),
+    subject_fingerprint BYTEA CHECK (
+        subject_fingerprint IS NULL OR octet_length(subject_fingerprint) = 32
+    ),
+    -- Always retains attempted operation identity. Only unresolved pre-auth
+    -- event kind 9 omits the canonical receipt fingerprint; authenticated
+    -- OperatorDenied events remain linked to their exact canonical receipt.
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA CHECK (
+        request_fingerprint IS NULL OR octet_length(request_fingerprint) = 32
+    ),
+    correlation_id UUID NOT NULL,
+    attempt_id UUID NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    accepted_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    canonical_envelope BYTEA NOT NULL CONSTRAINT authorization_events_envelope_size CHECK (
+        octet_length(canonical_envelope) BETWEEN 1 AND 16384
+    ),
+    envelope_digest BYTEA NOT NULL CHECK (octet_length(envelope_digest) = 32),
+    PRIMARY KEY (community_id, event_id),
+    UNIQUE (community_id, event_id, operation_id),
+    UNIQUE (community_id, event_id, event_kind, operation_id),
+    UNIQUE (community_id, operation_id, event_kind, attempt_id),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (event_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (
+        (actor_kind = 4 AND event_kind = 9 AND request_fingerprint IS NULL)
+        OR (actor_kind IN (1, 2, 3) AND request_fingerprint IS NOT NULL)
+    ),
+    CHECK (
+        (actor_kind = 4 AND actor_fingerprint IS NULL AND subject_fingerprint IS NULL)
+        OR (actor_kind IN (1, 2, 3) AND actor_fingerprint IS NOT NULL)
+    )
+);
+
+-- Credential-free pre-authentication denial attempts. The five-column key is
+-- exact replay identity; no row or FK occupies canonical operation/result,
+-- effect, authority, approval, or consumption state.
+CREATE TABLE authorization_authentication_denial_attempts (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    correlation_id UUID NOT NULL,
+    semantic_fingerprint BYTEA NOT NULL CHECK (octet_length(semantic_fingerprint) = 32),
+    denial_reason SMALLINT NOT NULL CHECK (denial_reason IN (1, 2, 3)),
+    expected_revision BIGINT NOT NULL CHECK (expected_revision > 0),
+    action SMALLINT NOT NULL CHECK (action IN (1, 2, 3, 4, 5, 6, 7, 8)),
+    reason_code SMALLINT NOT NULL CHECK (
+        reason_code IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+    ),
+    audit_event_id UUID NOT NULL,
+    audit_event_kind SMALLINT NOT NULL DEFAULT 9 CHECK (audit_event_kind = 9),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (
+        community_id,
+        operation_id,
+        correlation_id,
+        semantic_fingerprint,
+        denial_reason
+    ),
+    UNIQUE (community_id, audit_event_id),
+    FOREIGN KEY (community_id, audit_event_id, audit_event_kind, operation_id)
+        REFERENCES authorization_events (community_id, event_id, event_kind, operation_id)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid)
+);
+
+-- Exact per-operation authority-version attribution for restore. Empty
+-- manifests are valid; every stored component must advance strictly.
+CREATE TABLE authorization_operation_version_delta_manifests (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    component_count INTEGER NOT NULL CHECK (component_count BETWEEN 0 AND 1024),
+    before_digest BYTEA NOT NULL CHECK (octet_length(before_digest) = 32),
+    after_digest BYTEA NOT NULL CHECK (octet_length(after_digest) = 32),
+    manifest_digest BYTEA NOT NULL CHECK (octet_length(manifest_digest) = 32),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, operation_id),
+    UNIQUE (community_id, operation_id, request_fingerprint),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+-- component_kind: 1 binding version, 2 policy revision,
+-- 3 invalidation generation, 4 authority epoch. Kind 6 (delegated-relationship
+-- revision) is deferred to the FI-DELEG migration and kind 7 (lifecycle-selector
+-- generation) to the FI-LIFECYCLE migration. Kind 5 is retired with durable
+-- client-status revisions; retained kinds keep their original identities.
+CREATE TABLE authorization_operation_version_deltas (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    component_kind SMALLINT NOT NULL CHECK (component_kind IN (1, 2, 3, 4)),
+    component_key BYTEA NOT NULL CHECK (octet_length(component_key) = 32),
+    before_version BIGINT NOT NULL CHECK (before_version >= 0),
+    after_version BIGINT NOT NULL,
+    component_digest BYTEA NOT NULL CHECK (octet_length(component_digest) = 32),
+    PRIMARY KEY (community_id, operation_id, component_kind, component_key),
+    FOREIGN KEY (community_id, operation_id)
+        REFERENCES authorization_operation_version_delta_manifests
+            (community_id, operation_id),
+    CHECK (after_version > before_version)
+);
+
+CREATE FUNCTION authorization_event_capacity_before_insert_v1() RETURNS TRIGGER AS $$
+DECLARE
+    policy authorization_event_capacity%ROWTYPE;
+    envelope_bytes BIGINT;
+BEGIN
+    SELECT * INTO policy
+    FROM authorization_event_capacity
+    WHERE community_id = NEW.community_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'authorization event capacity policy missing'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_policy_required';
+    END IF;
+    IF policy.health_state <> 1 THEN
+        RAISE EXCEPTION 'authorization audit is unavailable'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_health';
+    END IF;
+
+    envelope_bytes := octet_length(NEW.canonical_envelope);
+    IF envelope_bytes > policy.max_envelope_bytes
+        OR policy.retained_event_count + 1 > policy.max_events_per_domain
+        OR policy.retained_envelope_bytes + envelope_bytes > policy.max_bytes_per_domain
+    THEN
+        -- The INSERT and protected mutation abort together. The runtime maps
+        -- this stable constraint to typed CapacityExhausted and latches audit
+        -- health outside the rolled-back transaction.
+        RAISE EXCEPTION 'authorization event capacity exhausted'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_exhausted';
+    END IF;
+
+    UPDATE authorization_event_capacity
+    SET retained_event_count = retained_event_count + 1,
+        retained_envelope_bytes = retained_envelope_bytes + envelope_bytes,
+        updated_at = transaction_timestamp()
+    WHERE community_id = NEW.community_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_events_capacity
+    BEFORE INSERT ON authorization_events
+    FOR EACH ROW EXECUTE FUNCTION authorization_event_capacity_before_insert_v1();
+
+CREATE FUNCTION authorization_invalidation_domain_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.activated_at IS DISTINCT FROM OLD.activated_at
+        OR NEW.current_generation <= OLD.current_generation
+        OR NEW.updated_at <= OLD.updated_at
+    THEN
+        RAISE EXCEPTION 'authorization invalidation activation/generation cannot move backward'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_invalidation_domains_monotonic
+    BEFORE UPDATE ON authorization_invalidation_domains
+    FOR EACH ROW EXECUTE FUNCTION authorization_invalidation_domain_guard_v1();
+CREATE TRIGGER authorization_invalidation_domains_no_delete
+    BEFORE DELETE ON authorization_invalidation_domains
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_invalidation_domains_no_truncate
+    BEFORE TRUNCATE ON authorization_invalidation_domains
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_invalidation_floor_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.selector_kind IS DISTINCT FROM OLD.selector_kind
+        OR NEW.selector_fingerprint IS DISTINCT FROM OLD.selector_fingerprint
+        OR NEW.floor_generation < OLD.floor_generation
+        OR COALESCE(NEW.binding_version_floor, 0) < COALESCE(OLD.binding_version_floor, 0)
+        OR COALESCE(NEW.relationship_revision_floor, 0)
+            < COALESCE(OLD.relationship_revision_floor, 0)
+        OR (
+            NEW.floor_generation = OLD.floor_generation
+            AND COALESCE(NEW.binding_version_floor, 0)
+                = COALESCE(OLD.binding_version_floor, 0)
+            AND COALESCE(NEW.relationship_revision_floor, 0)
+                = COALESCE(OLD.relationship_revision_floor, 0)
+        )
+        OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
+        OR NEW.updated_at <= OLD.updated_at
+    THEN
+        RAISE EXCEPTION 'authorization invalidation floor cannot move backward'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_invalidation_floors_monotonic
+    BEFORE UPDATE ON authorization_invalidation_floors
+    FOR EACH ROW EXECUTE FUNCTION authorization_invalidation_floor_guard_v1();
+CREATE TRIGGER authorization_invalidation_floors_no_delete
+    BEFORE DELETE ON authorization_invalidation_floors
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_invalidation_floors_no_truncate
+    BEFORE TRUNCATE ON authorization_invalidation_floors
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_authority_epoch_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.object_kind IS DISTINCT FROM OLD.object_kind
+        OR NEW.object_key IS DISTINCT FROM OLD.object_key
+        OR NEW.authority_epoch <= OLD.authority_epoch
+        OR NEW.fence IS NOT DISTINCT FROM OLD.fence
+        OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
+        OR NEW.updated_at <= OLD.updated_at
+    THEN
+        RAISE EXCEPTION 'authorization authority epoch cannot move backward'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_authority_epochs_monotonic
+    BEFORE UPDATE ON authorization_authority_epochs
+    FOR EACH ROW EXECUTE FUNCTION authorization_authority_epoch_guard_v1();
+CREATE TRIGGER authorization_authority_epochs_no_delete
+    BEFORE DELETE ON authorization_authority_epochs
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_authority_epochs_no_truncate
+    BEFORE TRUNCATE ON authorization_authority_epochs
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_event_capacity_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.max_events_per_domain IS DISTINCT FROM OLD.max_events_per_domain
+        OR NEW.max_bytes_per_domain IS DISTINCT FROM OLD.max_bytes_per_domain
+        OR NEW.max_envelope_bytes IS DISTINCT FROM OLD.max_envelope_bytes
+        OR NEW.configured_at IS DISTINCT FROM OLD.configured_at
+        OR NEW.retained_event_count < OLD.retained_event_count
+        OR NEW.retained_envelope_bytes < OLD.retained_envelope_bytes
+        OR NEW.updated_at < OLD.updated_at
+        OR (OLD.health_state = 2 AND (
+            NEW.health_state <> 2
+            OR NEW.failure_code IS DISTINCT FROM OLD.failure_code
+            OR NEW.failure_observed_at IS DISTINCT FROM OLD.failure_observed_at
+        ))
+        OR (OLD.health_state = 1 AND NEW.health_state = 1 AND (
+            NEW.failure_code IS NOT NULL OR NEW.failure_observed_at IS NOT NULL
+        ))
+    THEN
+        RAISE EXCEPTION 'authorization event capacity cannot be reset online'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION protected_object_authority_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.object_kind IS DISTINCT FROM OLD.object_kind
+        OR NEW.object_key IS DISTINCT FROM OLD.object_key
+        OR NEW.authority_epoch <= OLD.authority_epoch
+        OR NEW.fence IS NOT DISTINCT FROM OLD.fence
+        OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
+        OR NEW.issued_at <= OLD.issued_at
+    THEN
+        RAISE EXCEPTION 'protected authority replacement requires a new operation and epoch'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_event_capacity_monotonic
+    BEFORE UPDATE ON authorization_event_capacity
+    FOR EACH ROW EXECUTE FUNCTION authorization_event_capacity_guard_v1();
+CREATE TRIGGER authorization_event_capacity_no_delete
+    BEFORE DELETE ON authorization_event_capacity
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_event_capacity_no_truncate
+    BEFORE TRUNCATE ON authorization_event_capacity
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER authorization_events_immutable
+    BEFORE UPDATE OR DELETE ON authorization_events
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_events_no_truncate
+    BEFORE TRUNCATE ON authorization_events
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER authorization_authentication_denial_attempts_immutable
+    BEFORE UPDATE OR DELETE ON authorization_authentication_denial_attempts
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
+    BEFORE TRUNCATE ON authorization_authentication_denial_attempts
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE FUNCTION authorization_operation_version_delta_cardinality_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    manifest authorization_operation_version_delta_manifests%ROWTYPE;
+    actual_component_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_version_delta_manifests' THEN
+        manifest := NEW;
+    ELSE
+        SELECT * INTO STRICT manifest
+        FROM authorization_operation_version_delta_manifests
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id
+        FOR NO KEY UPDATE;
+    END IF;
+
+    SELECT count(*) INTO actual_component_count
+    FROM authorization_operation_version_deltas
+    WHERE community_id = manifest.community_id
+      AND operation_id = manifest.operation_id;
+
+    IF actual_component_count <> manifest.component_count THEN
+        RAISE EXCEPTION 'operation version manifest declares % components, found %',
+            manifest.component_count, actual_component_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_version_delta_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_operation_version_delta_manifest_cardinality
+    AFTER INSERT ON authorization_operation_version_delta_manifests
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_version_delta_cardinality_guard_v1();
+CREATE CONSTRAINT TRIGGER authorization_operation_version_delta_component_cardinality
+    AFTER INSERT ON authorization_operation_version_deltas
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_version_delta_cardinality_guard_v1();
+
+CREATE TRIGGER authorization_operation_version_delta_manifests_immutable
+    BEFORE UPDATE OR DELETE ON authorization_operation_version_delta_manifests
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_operation_version_delta_manifests_no_truncate
+    BEFORE TRUNCATE ON authorization_operation_version_delta_manifests
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER authorization_operation_version_deltas_immutable
+    BEFORE UPDATE OR DELETE ON authorization_operation_version_deltas
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_operation_version_deltas_no_truncate
+    BEFORE TRUNCATE ON authorization_operation_version_deltas
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+CREATE TRIGGER protected_object_authority_no_delete
+    BEFORE DELETE ON protected_object_authority
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER protected_object_authority_no_truncate
+    BEFORE TRUNCATE ON protected_object_authority
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+CREATE TRIGGER protected_object_authority_strict_replacement
+    BEFORE UPDATE ON protected_object_authority
+    FOR EACH ROW EXECUTE FUNCTION protected_object_authority_guard_v1();
+
+-- Canonical admission keeps its complete logical intent and the closed,
+-- credential-free application result beside the immutable receipt. This is
+-- what lets an identical request replay reconstruct the same typed result
+-- without repeating membership or other application DML. Object kinds match
+-- protected_object_authority: 1 domain, 2 channel, 3 repository, 4 media,
+-- 5 moderation target, 6 audio session.
+CREATE TABLE authorization_admission_results (
+    community_id UUID NOT NULL,
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    semantic_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(semantic_fingerprint) = 32
+        AND semantic_fingerprint <> decode(repeat('00', 32), 'hex')
+    ),
+    object_kind SMALLINT NOT NULL CHECK (object_kind BETWEEN 1 AND 6),
+    object_key BYTEA NOT NULL CHECK (
+        octet_length(object_key) = 32
+        AND object_key <> decode(repeat('00', 32), 'hex')
+    ),
+    application_type BYTEA CHECK (
+        application_type IS NULL
+        OR (octet_length(application_type) = 32
+            AND application_type <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_version SMALLINT CHECK (application_version > 0),
+    application_code SMALLINT CHECK (application_code > 0),
+    application_payload BYTEA CHECK (
+        application_payload IS NULL OR octet_length(application_payload) <= 4096
+    ),
+    application_intent_digest BYTEA CHECK (
+        application_intent_digest IS NULL
+        OR (octet_length(application_intent_digest) = 32
+            AND application_intent_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_effect_digest BYTEA CHECK (
+        application_effect_digest IS NULL
+        OR (octet_length(application_effect_digest) = 32
+            AND application_effect_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_result_digest BYTEA CHECK (
+        application_result_digest IS NULL
+        OR (octet_length(application_result_digest) = 32
+            AND application_result_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, operation_id),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint),
+    CHECK (
+        (application_type IS NULL
+            AND application_version IS NULL
+            AND application_code IS NULL
+            AND application_payload IS NULL
+            AND application_intent_digest IS NULL
+            AND application_effect_digest IS NULL
+            AND application_result_digest IS NULL)
+        OR (application_type IS NOT NULL
+            AND application_version IS NOT NULL
+            AND application_code IS NOT NULL
+            AND application_payload IS NOT NULL
+            AND application_intent_digest IS NOT NULL
+            AND application_effect_digest IS NOT NULL
+            AND application_result_digest IS NOT NULL)
+    )
+);
+
+CREATE TRIGGER authorization_admission_results_no_update
+    BEFORE UPDATE OR DELETE ON authorization_admission_results
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_admission_results_no_truncate
+    BEFORE TRUNCATE ON authorization_admission_results
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+-- Every successful/no-op core lifecycle receipt has exactly one privacy-safe
+-- audit event with the closed transition-kind mapping. Both directions are
+-- deferred so receipt, history, event, selectors, and binding may be inserted
+-- in any order inside one transaction but can never commit partially. The
+-- extended-lifecycle operation kinds (2 provision, 4 disable, 7 recover,
+-- 8 enable, 9 admission loss) and their event kinds arrive with the
+-- FI-LIFECYCLE migration; here the mapping covers only enroll/retire/revoke/
+-- rotate. Non-lifecycle receipts (protected mutation, invalidation) carry no
+-- audit-event cardinality requirement.
+CREATE FUNCTION authorization_operation_receipt_event_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    receipt authorization_operation_receipts%ROWTYPE;
+    expected_event_kind SMALLINT;
+    matching_event_count BIGINT;
+    expected_event_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_receipts' THEN
+        receipt := NEW;
+    ELSE
+        SELECT * INTO receipt
+        FROM authorization_operation_receipts
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id;
+        IF NOT FOUND THEN
+            -- Credential-free pre-authentication denials intentionally have no
+            -- canonical receipt. Their separate FK/shape guards still run.
+            RETURN NULL;
+        END IF;
+    END IF;
+
+    expected_event_kind := CASE receipt.operation_kind
+        WHEN 1 THEN 1  -- enroll
+        WHEN 3 THEN 6  -- retire
+        WHEN 5 THEN 2  -- revoke
+        WHEN 6 THEN 3  -- rotate
+        ELSE NULL
+    END;
+    IF expected_event_kind IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT
+        count(*),
+        count(*) FILTER (WHERE event_kind = expected_event_kind)
+    INTO matching_event_count, expected_event_count
+    FROM authorization_events
+    WHERE community_id = receipt.community_id
+      AND operation_id = receipt.operation_id
+      AND request_fingerprint = receipt.request_fingerprint;
+
+    IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
+        RAISE EXCEPTION
+            'lifecycle receipt requires exactly one event kind %, found % total and % expected',
+            expected_event_kind, matching_event_count, expected_event_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_operation_receipt_event_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
+
+CREATE CONSTRAINT TRIGGER authorization_event_receipt_cardinality
+    AFTER INSERT ON authorization_events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
+

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -3009,11 +3009,13 @@ CREATE TABLE authorization_events (
         (actor_kind = 4 AND actor_fingerprint IS NULL AND subject_fingerprint IS NULL)
         OR (actor_kind IN (1, 2, 3) AND actor_fingerprint IS NOT NULL)
     ),
-    -- Kind-9 (pre-auth denial) events must carry a non-zero semantic_fingerprint;
+    -- Unresolved pre-auth kind-9 events (actor_kind = 4) carry a non-zero
+    -- semantic_fingerprint; authenticated kind-9 events (actor_kind 1-3) and
     -- all other event kinds must not.
     CHECK (
-        (event_kind = 9 AND semantic_fingerprint IS NOT NULL
+        (event_kind = 9 AND actor_kind = 4 AND semantic_fingerprint IS NOT NULL
             AND semantic_fingerprint <> decode(repeat('00', 32), 'hex'))
+        OR (event_kind = 9 AND actor_kind IN (1, 2, 3) AND semantic_fingerprint IS NULL)
         OR (event_kind <> 9 AND semantic_fingerprint IS NULL)
     )
 );
@@ -3322,14 +3324,19 @@ CREATE FUNCTION authorization_denial_attempt_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
     found_event_kind SMALLINT;
+    found_actor_kind SMALLINT;
+    found_request_fingerprint BYTEA;
     found_correlation_id UUID;
     found_reason_code SMALLINT;
     found_semantic_fingerprint BYTEA;
     attempt_count BIGINT;
 BEGIN
     IF TG_TABLE_NAME = 'authorization_events' THEN
-        -- Firing from the event side: only kind-9 events require a denial row.
-        IF NEW.event_kind <> 9 THEN
+        -- Firing from the event side: only unresolved pre-auth kind-9 events
+        -- (actor_kind = 4) require a denial attempt row. Authenticated
+        -- OperatorDenied events (actor_kind 1-3) have a canonical receipt and
+        -- no denial attempt.
+        IF NEW.event_kind <> 9 OR NEW.actor_kind <> 4 THEN
             RETURN NULL;
         END IF;
 
@@ -3377,10 +3384,13 @@ BEGIN
                       CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;
     ELSE
-        -- Firing from the denial-attempt side: verify the audit event is kind-9
-        -- and that exactly one denial attempt references it.
-        SELECT event_kind, correlation_id, reason_code, semantic_fingerprint
-        INTO found_event_kind, found_correlation_id, found_reason_code,
+        -- Firing from the denial-attempt side: verify the audit event is the
+        -- unresolved pre-auth kind-9 shape (actor_kind = 4, null receipt
+        -- fingerprint) and that exactly one denial attempt references it.
+        SELECT event_kind, actor_kind, request_fingerprint,
+               correlation_id, reason_code, semantic_fingerprint
+        INTO found_event_kind, found_actor_kind, found_request_fingerprint,
+             found_correlation_id, found_reason_code,
              found_semantic_fingerprint
         FROM authorization_events
         WHERE community_id = NEW.community_id
@@ -3398,6 +3408,22 @@ BEGIN
             RAISE EXCEPTION
                 'denial attempt audit event must be kind 9, got %',
                 found_event_kind
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        -- The referenced event must be the unresolved pre-auth shape: actor_kind
+        -- 4 with a null receipt fingerprint. Attaching a denial attempt to an
+        -- authenticated OperatorDenied (actor_kind 1-3) would violate the
+        -- credential-free pre-authentication contract.
+        IF found_actor_kind <> 4 OR found_request_fingerprint IS NOT NULL THEN
+            RAISE EXCEPTION
+                'denial attempt must reference an unresolved pre-auth kind-9 event '
+                '(actor_kind 4, null request_fingerprint); got actor_kind % '
+                'and request_fingerprint % for event %',
+                found_actor_kind,
+                CASE WHEN found_request_fingerprint IS NULL THEN 'null' ELSE 'non-null' END,
+                NEW.audit_event_id
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_event_kind';
         END IF;
@@ -3703,6 +3729,14 @@ BEGIN
         RETURN NULL;
     END IF;
 
+    -- Only applied (outcome_code = 1) and no-op (outcome_code = 3) lifecycle
+    -- receipts require a paired audit event. A denied lifecycle receipt
+    -- (outcome_code = 2) commits without one; fabricating a transition event
+    -- would falsely record that the lifecycle change occurred.
+    IF receipt.outcome_code NOT IN (1, 3) THEN
+        RETURN NULL;
+    END IF;
+
     SELECT
         count(*),
         count(*) FILTER (WHERE event_kind = expected_event_kind)
@@ -3732,4 +3766,3 @@ CREATE CONSTRAINT TRIGGER authorization_event_receipt_cardinality
     AFTER INSERT ON authorization_events
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
-

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -2977,6 +2977,12 @@ CREATE TABLE authorization_events (
     ),
     correlation_id UUID NOT NULL,
     attempt_id UUID NOT NULL,
+    -- Redaction-safe pre-authentication denial identity. Present and non-zero
+    -- for kind-9 events; NULL for all other event kinds. Binds the event to the
+    -- exact denial attempt's semantic_fingerprint (intent_digest) for exact replay.
+    semantic_fingerprint BYTEA CHECK (
+        semantic_fingerprint IS NULL OR octet_length(semantic_fingerprint) = 32
+    ),
     occurred_at TIMESTAMPTZ NOT NULL,
     accepted_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
     canonical_envelope BYTEA NOT NULL CONSTRAINT authorization_events_envelope_size CHECK (
@@ -3002,6 +3008,13 @@ CREATE TABLE authorization_events (
     CHECK (
         (actor_kind = 4 AND actor_fingerprint IS NULL AND subject_fingerprint IS NULL)
         OR (actor_kind IN (1, 2, 3) AND actor_fingerprint IS NOT NULL)
+    ),
+    -- Kind-9 (pre-auth denial) events must carry a non-zero semantic_fingerprint;
+    -- all other event kinds must not.
+    CHECK (
+        (event_kind = 9 AND semantic_fingerprint IS NOT NULL
+            AND semantic_fingerprint <> decode(repeat('00', 32), 'hex'))
+        OR (event_kind <> 9 AND semantic_fingerprint IS NULL)
     )
 );
 
@@ -3037,6 +3050,13 @@ CREATE TABLE authorization_authentication_denial_attempts (
     FOREIGN KEY (community_id, operation_id, audit_event_kind, attempt_id)
         REFERENCES authorization_events (community_id, operation_id, event_kind, attempt_id)
         DEFERRABLE INITIALLY DEFERRED,
+    -- Canonical denial_reason ↔ reason_code binding: MissingCredential(1)↔Missing(2),
+    -- InvalidCredential(2)↔Invalid(3), Unauthenticated(3)↔Unauthenticated(4).
+    CONSTRAINT authorization_denial_reason_reason_code_binding CHECK (
+        (denial_reason = 1 AND reason_code = 2)
+        OR (denial_reason = 2 AND reason_code = 3)
+        OR (denial_reason = 3 AND reason_code = 4)
+    ),
     CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
     CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
     CHECK (attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid)
@@ -3293,14 +3313,18 @@ CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
 -- Bidirectional deferred guard: a kind-9 (pre-authentication denial) audit
 -- event must commit with exactly one denial attempt; a denial attempt must
 -- commit with its audit event present, kind-9, and matching semantic
--- coordinates (correlation_id and reason_code). Both directions deferred so
--- event and attempt may be inserted in any order inside one transaction.
+-- coordinates (correlation_id, reason_code, and semantic_fingerprint). Both
+-- directions deferred so event and attempt may be inserted in any order inside
+-- one transaction. The static denial_reason↔reason_code mapping is enforced
+-- by an immediate CHECK on the denial attempt table; the guard enforces the
+-- matching semantic coordinates between event and attempt.
 CREATE FUNCTION authorization_denial_attempt_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
     found_event_kind SMALLINT;
     found_correlation_id UUID;
     found_reason_code SMALLINT;
+    found_semantic_fingerprint BYTEA;
     attempt_count BIGINT;
 BEGIN
     IF TG_TABLE_NAME = 'authorization_events' THEN
@@ -3323,8 +3347,8 @@ BEGIN
         END IF;
 
         -- Verify semantic coordinates match between event and denial attempt.
-        SELECT correlation_id, reason_code
-        INTO found_correlation_id, found_reason_code
+        SELECT correlation_id, reason_code, semantic_fingerprint
+        INTO found_correlation_id, found_reason_code, found_semantic_fingerprint
         FROM authorization_authentication_denial_attempts
         WHERE community_id = NEW.community_id
           AND audit_event_id = NEW.event_id;
@@ -3344,11 +3368,20 @@ BEGIN
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;
+
+        IF found_semantic_fingerprint IS DISTINCT FROM NEW.semantic_fingerprint THEN
+            RAISE EXCEPTION
+                'denial attempt semantic_fingerprint does not match event semantic_fingerprint for event %',
+                NEW.event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
     ELSE
         -- Firing from the denial-attempt side: verify the audit event is kind-9
         -- and that exactly one denial attempt references it.
-        SELECT event_kind, correlation_id, reason_code
-        INTO found_event_kind, found_correlation_id, found_reason_code
+        SELECT event_kind, correlation_id, reason_code, semantic_fingerprint
+        INTO found_event_kind, found_correlation_id, found_reason_code,
+             found_semantic_fingerprint
         FROM authorization_events
         WHERE community_id = NEW.community_id
           AND event_id = NEW.audit_event_id;
@@ -3382,6 +3415,14 @@ BEGIN
             RAISE EXCEPTION
                 'denial attempt reason_code % does not match event reason_code % for event %',
                 NEW.reason_code, found_reason_code, NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
+
+        IF found_semantic_fingerprint IS DISTINCT FROM NEW.semantic_fingerprint THEN
+            RAISE EXCEPTION
+                'denial attempt semantic_fingerprint does not match event semantic_fingerprint for event %',
+                NEW.audit_event_id
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -3120,14 +3120,10 @@ BEGIN
         OR NEW.selector_fingerprint IS DISTINCT FROM OLD.selector_fingerprint
         OR NEW.floor_generation < OLD.floor_generation
         OR COALESCE(NEW.binding_version_floor, 0) < COALESCE(OLD.binding_version_floor, 0)
-        OR COALESCE(NEW.relationship_revision_floor, 0)
-            < COALESCE(OLD.relationship_revision_floor, 0)
         OR (
             NEW.floor_generation = OLD.floor_generation
             AND COALESCE(NEW.binding_version_floor, 0)
                 = COALESCE(OLD.binding_version_floor, 0)
-            AND COALESCE(NEW.relationship_revision_floor, 0)
-                = COALESCE(OLD.relationship_revision_floor, 0)
         )
         OR NEW.operation_id IS NOT DISTINCT FROM OLD.operation_id
         OR NEW.updated_at <= OLD.updated_at

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -2978,8 +2978,10 @@ CREATE TABLE authorization_events (
     correlation_id UUID NOT NULL,
     attempt_id UUID NOT NULL,
     -- Redaction-safe pre-authentication denial identity. Present and non-zero
-    -- for kind-9 events; NULL for all other event kinds. Binds the event to the
-    -- exact denial attempt's semantic_fingerprint (intent_digest) for exact replay.
+    -- for unresolved pre-auth kind-9 events (actor_kind = 4); NULL for
+    -- authenticated kind-9 events (actor_kind 1-3) and all other event kinds.
+    -- Binds the event to the exact denial attempt's semantic_fingerprint
+    -- (intent_digest) for exact replay.
     semantic_fingerprint BYTEA CHECK (
         semantic_fingerprint IS NULL OR octet_length(semantic_fingerprint) = 32
     ),
@@ -3730,28 +3732,44 @@ BEGIN
     END IF;
 
     -- Only applied (outcome_code = 1) and no-op (outcome_code = 3) lifecycle
-    -- receipts require a paired audit event. A denied lifecycle receipt
-    -- (outcome_code = 2) commits without one; fabricating a transition event
-    -- would falsely record that the lifecycle change occurred.
-    IF receipt.outcome_code NOT IN (1, 3) THEN
-        RETURN NULL;
-    END IF;
+    -- receipts require exactly one paired success-transition event. A denied
+    -- lifecycle receipt (outcome_code = 2) requires zero events of the mapped
+    -- transition kind: a success-transition event would falsely record that the
+    -- denied transition occurred, creating contradictory durable ledger facts.
+    -- Other outcome codes (4, 5) are not core lifecycle outcomes; skip.
+    IF receipt.outcome_code IN (1, 3) THEN
+        SELECT
+            count(*),
+            count(*) FILTER (WHERE event_kind = expected_event_kind)
+        INTO matching_event_count, expected_event_count
+        FROM authorization_events
+        WHERE community_id = receipt.community_id
+          AND operation_id = receipt.operation_id
+          AND request_fingerprint = receipt.request_fingerprint;
 
-    SELECT
-        count(*),
-        count(*) FILTER (WHERE event_kind = expected_event_kind)
-    INTO matching_event_count, expected_event_count
-    FROM authorization_events
-    WHERE community_id = receipt.community_id
-      AND operation_id = receipt.operation_id
-      AND request_fingerprint = receipt.request_fingerprint;
+        IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
+            RAISE EXCEPTION
+                'lifecycle receipt requires exactly one event kind %, found % total and % expected',
+                expected_event_kind, matching_event_count, expected_event_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+        END IF;
+    ELSIF receipt.outcome_code = 2 THEN
+        SELECT count(*) FILTER (WHERE event_kind = expected_event_kind)
+        INTO expected_event_count
+        FROM authorization_events
+        WHERE community_id = receipt.community_id
+          AND operation_id = receipt.operation_id
+          AND request_fingerprint = receipt.request_fingerprint;
 
-    IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
-        RAISE EXCEPTION
-            'lifecycle receipt requires exactly one event kind %, found % total and % expected',
-            expected_event_kind, matching_event_count, expected_event_count
-            USING ERRCODE = 'check_violation',
-                  CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+        IF expected_event_count <> 0 THEN
+            RAISE EXCEPTION
+                'denied lifecycle receipt must not have a mapped success-transition event '
+                '(kind %); found % — contradictory durable facts are not permitted',
+                expected_event_kind, expected_event_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denied_lifecycle_receipt_no_success_event';
+        END IF;
     END IF;
     RETURN NULL;
 END;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -2308,6 +2308,56 @@ CREATE INDEX identity_lifecycle_selectors_asserted_history
     ON identity_lifecycle_selectors
         (community_id, asserted_history_id, selector_kind);
 
+-- Serializes policy-revision inserts per community: each new revision must
+-- strictly exceed the current maximum, and each effective_at must strictly
+-- exceed the current maximum effective_at (FI-INV-06 — stable assertion
+-- policy; a revision that moves either coordinate backward is incoherent).
+-- The per-community advisory lock prevents two concurrent writers from both
+-- passing a plain SELECT MAX() check and committing conflicting revisions.
+CREATE FUNCTION identity_enrollment_policy_revision_guard_v1() RETURNS TRIGGER AS $$
+DECLARE
+    lock_key BIGINT;
+    max_revision BIGINT;
+    max_effective_at TIMESTAMPTZ;
+BEGIN
+    -- Acquire a per-community exclusive transaction-scoped advisory lock so
+    -- that concurrent insertions serialize here. The key is a stable hash of
+    -- the namespace string and the community_id bytes.
+    lock_key := hashtextextended(
+        'buzz:enrollment-policy-revision:v1:' || NEW.community_id::text,
+        0
+    );
+    PERFORM pg_advisory_xact_lock(lock_key);
+
+    SELECT MAX(policy_revision), MAX(effective_at)
+    INTO max_revision, max_effective_at
+    FROM identity_enrollment_policies
+    WHERE community_id = NEW.community_id;
+
+    IF max_revision IS NOT NULL
+        AND NEW.policy_revision <= max_revision
+    THEN
+        RAISE EXCEPTION
+            'policy_revision % does not strictly exceed current maximum % for community %',
+            NEW.policy_revision, max_revision, NEW.community_id
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
+    END IF;
+
+    IF max_effective_at IS NOT NULL
+        AND NEW.effective_at <= max_effective_at
+    THEN
+        RAISE EXCEPTION
+            'effective_at % does not strictly exceed current maximum % for community %',
+            NEW.effective_at, max_effective_at, NEW.community_id
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION nip_fi_reject_row_mutation_v1() RETURNS TRIGGER AS $$
 BEGIN
     RAISE EXCEPTION '% is immutable', TG_TABLE_NAME
@@ -2728,6 +2778,9 @@ CREATE TRIGGER authorization_operation_receipts_no_truncate
     BEFORE TRUNCATE ON authorization_operation_receipts
     FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
 
+CREATE TRIGGER identity_enrollment_policies_revision_guard
+    BEFORE INSERT ON identity_enrollment_policies
+    FOR EACH ROW EXECUTE FUNCTION identity_enrollment_policy_revision_guard_v1();
 CREATE TRIGGER identity_enrollment_policies_immutable
     BEFORE UPDATE OR DELETE ON identity_enrollment_policies
     FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
@@ -3244,6 +3297,85 @@ CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
     BEFORE TRUNCATE ON authorization_authentication_denial_attempts
     FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
 
+-- Bidirectional deferred guard: a kind-9 (pre-authentication denial) audit
+-- event must commit with exactly one denial attempt; a denial attempt must
+-- commit with its audit event present and kind-9. Both directions deferred so
+-- event and attempt may be inserted in any order inside one transaction.
+CREATE FUNCTION authorization_denial_attempt_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    found_event_kind SMALLINT;
+    attempt_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_events' THEN
+        -- Firing from the event side: only kind-9 events require a denial row.
+        IF NEW.event_kind <> 9 THEN
+            RETURN NULL;
+        END IF;
+
+        SELECT count(*) INTO attempt_count
+        FROM authorization_authentication_denial_attempts
+        WHERE community_id = NEW.community_id
+          AND audit_event_id = NEW.event_id;
+
+        IF attempt_count <> 1 THEN
+            RAISE EXCEPTION
+                'kind-9 audit event requires exactly one denial attempt, found %',
+                attempt_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_cardinality';
+        END IF;
+    ELSE
+        -- Firing from the denial-attempt side: verify the audit event is kind-9
+        -- and that exactly one denial attempt references it.
+        SELECT event_kind INTO found_event_kind
+        FROM authorization_events
+        WHERE community_id = NEW.community_id
+          AND event_id = NEW.audit_event_id;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'denial attempt references non-existent audit event %',
+                NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        IF found_event_kind <> 9 THEN
+            RAISE EXCEPTION
+                'denial attempt audit event must be kind 9, got %',
+                found_event_kind
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        SELECT count(*) INTO attempt_count
+        FROM authorization_authentication_denial_attempts
+        WHERE community_id = NEW.community_id
+          AND audit_event_id = NEW.audit_event_id;
+
+        IF attempt_count <> 1 THEN
+            RAISE EXCEPTION
+                'exactly one denial attempt must reference audit event %, found %',
+                NEW.audit_event_id, attempt_count
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_event_cardinality';
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_denial_attempt_event_cardinality
+    AFTER INSERT ON authorization_events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_denial_attempt_guard_v1();
+
+CREATE CONSTRAINT TRIGGER authorization_denial_event_attempt_cardinality
+    AFTER INSERT ON authorization_authentication_denial_attempts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_denial_attempt_guard_v1();
+
 CREATE FUNCTION authorization_operation_version_delta_cardinality_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
@@ -3381,6 +3513,75 @@ CREATE TRIGGER authorization_admission_results_no_update
 CREATE TRIGGER authorization_admission_results_no_truncate
     BEFORE TRUNCATE ON authorization_admission_results
     FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+-- Bidirectional deferred cardinality guard: a kind-11 (protected-mutation)
+-- receipt must commit with exactly one admission result; an admission result
+-- must commit against a kind-11 receipt. Deferred so receipt and result may
+-- be inserted in any order inside one transaction.
+CREATE FUNCTION authorization_admission_result_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    receipt authorization_operation_receipts%ROWTYPE;
+    result_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_receipts' THEN
+        receipt := NEW;
+    ELSE
+        -- Firing from authorization_admission_results: look up the receipt.
+        SELECT * INTO receipt
+        FROM authorization_operation_receipts
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id;
+        IF NOT FOUND THEN
+            -- FK on the result table already guards the non-existent receipt
+            -- case; this path should not occur in normal operation.
+            RAISE EXCEPTION
+                'admission result references non-existent receipt for operation %',
+                NEW.operation_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_admission_result_receipt_kind';
+        END IF;
+    END IF;
+
+    -- Non-kind-11 receipts require no admission result.
+    IF receipt.operation_kind <> 11 THEN
+        -- If this fired from the result side and the receipt is not kind 11,
+        -- the result is attaching to the wrong receipt kind.
+        IF TG_TABLE_NAME = 'authorization_admission_results' THEN
+            RAISE EXCEPTION
+                'admission result may only attach to a kind-11 (protected-mutation) receipt, got kind %',
+                receipt.operation_kind
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_admission_result_receipt_kind';
+        END IF;
+        RETURN NULL;
+    END IF;
+
+    SELECT count(*) INTO result_count
+    FROM authorization_admission_results
+    WHERE community_id = receipt.community_id
+      AND operation_id = receipt.operation_id;
+
+    IF result_count <> 1 THEN
+        RAISE EXCEPTION
+            'kind-11 receipt requires exactly one admission result, found %',
+            result_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_admission_result_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_admission_result_receipt_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_admission_result_guard_v1();
+
+CREATE CONSTRAINT TRIGGER authorization_admission_result_result_cardinality
+    AFTER INSERT ON authorization_admission_results
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_admission_result_guard_v1();
 
 -- Every successful/no-op core lifecycle receipt has exactly one privacy-safe
 -- audit event with the closed transition-kind mapping. Both directions are

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1904,7 +1904,7 @@ INSERT INTO _operator_global_tables (table_name, reason) VALUES
 
 
 -- ============================================================================
--- NIP-FI core identity + base-lifecycle foundation (mirror of migration 0040).
+-- NIP-FI core identity + base-lifecycle foundation (mirror of migration 0041).
 -- The community_write_fence_excluded_table definition above already folds in
 -- the NIP-FI ledger relations; the per-migration CREATE OR REPLACE bodies are
 -- intentionally omitted here (desired state keeps one consolidated definition).
@@ -2751,7 +2751,7 @@ CREATE TRIGGER identity_lifecycle_selectors_no_truncate
 
 
 -- ============================================================================
--- NIP-FI final-admission foundation (mirror of migration 0041).
+-- NIP-FI final-admission foundation (mirror of migration 0042).
 -- ============================================================================
 
 CREATE TABLE authorization_invalidation_domains (
@@ -2906,7 +2906,7 @@ CREATE TABLE authorization_event_capacity (
 -- 10 protected allowed, 11 protected denied, 14 invalidation advanced.
 -- The extended-lifecycle audit kinds (4 recovered, 5 principal enabled,
 -- 7 principal disabled, 8 admission lost) are deferred to the FI-LIFECYCLE
--- migration, matching 0040's core lifecycle carve. Kinds 12 and 13 are
+-- migration, matching 0041's core lifecycle carve. Kinds 12 and 13 are
 -- retired: kind 24244 publication/withdrawal is ephemeral connection state and
 -- never a durable authorization event.
 CREATE TABLE authorization_events (

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1956,7 +1956,6 @@ CREATE TABLE identity_enrollment_policies (
     expires_at TIMESTAMPTZ,
     recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
     PRIMARY KEY (community_id, policy_revision),
-    UNIQUE (community_id, policy_revision, enrollment_mode),
     CHECK (expires_at IS NULL OR effective_at < expires_at)
 );
 
@@ -1998,9 +1997,9 @@ CREATE TABLE identity_bindings (
     PRIMARY KEY (community_id, binding_id),
     UNIQUE (community_id, binding_version),
     UNIQUE (community_id, binding_id, binding_version),
-    FOREIGN KEY (community_id, policy_revision, binding_provenance)
+    FOREIGN KEY (community_id, policy_revision)
         REFERENCES identity_enrollment_policies
-            (community_id, policy_revision, enrollment_mode),
+            (community_id, policy_revision),
     CHECK (binding_version > 0),
     CHECK (binding_id <> '00000000-0000-0000-0000-000000000000'::uuid),
     CHECK (birth_history_id <> '00000000-0000-0000-0000-000000000000'::uuid),

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -2309,16 +2309,14 @@ CREATE INDEX identity_lifecycle_selectors_asserted_history
         (community_id, asserted_history_id, selector_kind);
 
 -- Serializes policy-revision inserts per community: each new revision must
--- strictly exceed the current maximum, and each effective_at must strictly
--- exceed the current maximum effective_at (FI-INV-06 — stable assertion
--- policy; a revision that moves either coordinate backward is incoherent).
--- The per-community advisory lock prevents two concurrent writers from both
--- passing a plain SELECT MAX() check and committing conflicting revisions.
+-- strictly exceed the current maximum (FI-INV-06 — stable assertion policy
+-- anchor; a backfilled or replayed revision is incoherent). The per-community
+-- advisory lock prevents two concurrent writers from both passing a plain
+-- SELECT MAX() check and committing conflicting revisions.
 CREATE FUNCTION identity_enrollment_policy_revision_guard_v1() RETURNS TRIGGER AS $$
 DECLARE
     lock_key BIGINT;
     max_revision BIGINT;
-    max_effective_at TIMESTAMPTZ;
 BEGIN
     -- Acquire a per-community exclusive transaction-scoped advisory lock so
     -- that concurrent insertions serialize here. The key is a stable hash of
@@ -2329,8 +2327,8 @@ BEGIN
     );
     PERFORM pg_advisory_xact_lock(lock_key);
 
-    SELECT MAX(policy_revision), MAX(effective_at)
-    INTO max_revision, max_effective_at
+    SELECT MAX(policy_revision)
+    INTO max_revision
     FROM identity_enrollment_policies
     WHERE community_id = NEW.community_id;
 
@@ -2340,16 +2338,6 @@ BEGIN
         RAISE EXCEPTION
             'policy_revision % does not strictly exceed current maximum % for community %',
             NEW.policy_revision, max_revision, NEW.community_id
-            USING ERRCODE = 'check_violation',
-                  CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
-    END IF;
-
-    IF max_effective_at IS NOT NULL
-        AND NEW.effective_at <= max_effective_at
-    THEN
-        RAISE EXCEPTION
-            'effective_at % does not strictly exceed current maximum % for community %',
-            NEW.effective_at, max_effective_at, NEW.community_id
             USING ERRCODE = 'check_violation',
                   CONSTRAINT = 'identity_enrollment_policy_revision_monotonic';
     END IF;
@@ -3031,6 +3019,7 @@ CREATE TABLE authorization_authentication_denial_attempts (
     reason_code SMALLINT NOT NULL CHECK (
         reason_code IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
     ),
+    attempt_id UUID NOT NULL,
     audit_event_id UUID NOT NULL,
     audit_event_kind SMALLINT NOT NULL DEFAULT 9 CHECK (audit_event_kind = 9),
     recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
@@ -3045,8 +3034,12 @@ CREATE TABLE authorization_authentication_denial_attempts (
     FOREIGN KEY (community_id, audit_event_id, audit_event_kind, operation_id)
         REFERENCES authorization_events (community_id, event_id, event_kind, operation_id)
         DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (community_id, operation_id, audit_event_kind, attempt_id)
+        REFERENCES authorization_events (community_id, operation_id, event_kind, attempt_id)
+        DEFERRABLE INITIALLY DEFERRED,
     CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
-    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid)
+    CHECK (correlation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid)
 );
 
 -- Exact per-operation authority-version attribution for restore. Empty
@@ -3299,12 +3292,15 @@ CREATE TRIGGER authorization_authentication_denial_attempts_no_truncate
 
 -- Bidirectional deferred guard: a kind-9 (pre-authentication denial) audit
 -- event must commit with exactly one denial attempt; a denial attempt must
--- commit with its audit event present and kind-9. Both directions deferred so
+-- commit with its audit event present, kind-9, and matching semantic
+-- coordinates (correlation_id and reason_code). Both directions deferred so
 -- event and attempt may be inserted in any order inside one transaction.
 CREATE FUNCTION authorization_denial_attempt_guard_v1()
 RETURNS TRIGGER AS $$
 DECLARE
     found_event_kind SMALLINT;
+    found_correlation_id UUID;
+    found_reason_code SMALLINT;
     attempt_count BIGINT;
 BEGIN
     IF TG_TABLE_NAME = 'authorization_events' THEN
@@ -3325,10 +3321,34 @@ BEGIN
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_event_cardinality';
         END IF;
+
+        -- Verify semantic coordinates match between event and denial attempt.
+        SELECT correlation_id, reason_code
+        INTO found_correlation_id, found_reason_code
+        FROM authorization_authentication_denial_attempts
+        WHERE community_id = NEW.community_id
+          AND audit_event_id = NEW.event_id;
+
+        IF found_correlation_id IS DISTINCT FROM NEW.correlation_id THEN
+            RAISE EXCEPTION
+                'denial attempt correlation_id % does not match event correlation_id % for event %',
+                found_correlation_id, NEW.correlation_id, NEW.event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
+
+        IF found_reason_code IS DISTINCT FROM NEW.reason_code THEN
+            RAISE EXCEPTION
+                'denial attempt reason_code % does not match event reason_code % for event %',
+                found_reason_code, NEW.reason_code, NEW.event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
     ELSE
         -- Firing from the denial-attempt side: verify the audit event is kind-9
         -- and that exactly one denial attempt references it.
-        SELECT event_kind INTO found_event_kind
+        SELECT event_kind, correlation_id, reason_code
+        INTO found_event_kind, found_correlation_id, found_reason_code
         FROM authorization_events
         WHERE community_id = NEW.community_id
           AND event_id = NEW.audit_event_id;
@@ -3347,6 +3367,23 @@ BEGIN
                 found_event_kind
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denial_attempt_event_kind';
+        END IF;
+
+        -- Verify semantic coordinates match.
+        IF found_correlation_id IS DISTINCT FROM NEW.correlation_id THEN
+            RAISE EXCEPTION
+                'denial attempt correlation_id % does not match event correlation_id % for event %',
+                NEW.correlation_id, found_correlation_id, NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
+        END IF;
+
+        IF found_reason_code IS DISTINCT FROM NEW.reason_code THEN
+            RAISE EXCEPTION
+                'denial attempt reason_code % does not match event reason_code % for event %',
+                NEW.reason_code, found_reason_code, NEW.audit_event_id
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'authorization_denial_attempt_semantic_binding';
         END IF;
 
         SELECT count(*) INTO attempt_count

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -3733,9 +3733,12 @@ BEGIN
 
     -- Only applied (outcome_code = 1) and no-op (outcome_code = 3) lifecycle
     -- receipts require exactly one paired success-transition event. A denied
-    -- lifecycle receipt (outcome_code = 2) requires zero events of the mapped
-    -- transition kind: a success-transition event would falsely record that the
-    -- denied transition occurred, creating contradictory durable ledger facts.
+    -- lifecycle receipt (outcome_code = 2) requires zero events from the
+    -- complete core lifecycle success-transition class (kinds 1, 2, 3, 6:
+    -- enrolled, revoked, rotated, retired). Forbidding only the mapped kind
+    -- would allow a wrong-kind transition event to attach to the denied receipt,
+    -- which is equally a contradictory durable fact. Legitimate audit/denial
+    -- events of other kinds (e.g., authenticated kind 9) remain allowed.
     -- Other outcome codes (4, 5) are not core lifecycle outcomes; skip.
     IF receipt.outcome_code IN (1, 3) THEN
         SELECT
@@ -3755,7 +3758,7 @@ BEGIN
                       CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
         END IF;
     ELSIF receipt.outcome_code = 2 THEN
-        SELECT count(*) FILTER (WHERE event_kind = expected_event_kind)
+        SELECT count(*) FILTER (WHERE event_kind IN (1, 2, 3, 6))
         INTO expected_event_count
         FROM authorization_events
         WHERE community_id = receipt.community_id
@@ -3764,9 +3767,9 @@ BEGIN
 
         IF expected_event_count <> 0 THEN
             RAISE EXCEPTION
-                'denied lifecycle receipt must not have a mapped success-transition event '
-                '(kind %); found % — contradictory durable facts are not permitted',
-                expected_event_kind, expected_event_count
+                'denied lifecycle receipt must not have any core success-transition event '
+                '(kinds 1/2/3/6); found % — contradictory durable facts are not permitted',
+                expected_event_count
                 USING ERRCODE = 'check_violation',
                       CONSTRAINT = 'authorization_denied_lifecycle_receipt_no_success_event';
         END IF;


### PR DESCRIPTION
PR 2 of the NIP-FI plan: the schema foundation. Establishes the durable server-side identity ledger and final-admission surface that the runtime phases build on. All of Phase A's migrations live here; later phases own their own deltas.

Depends on nothing — PR 1 (#6776, merged) owned zero migration files. This PR's relations are shaped to store exactly what PR 1's verifier produces: issuer-qualified identity and the four denial classes. They meet in a later PR that writes a verified assertion into these tables in one transaction.

## Two internally-ordered migrations

- `0041_nip_fi_identity_foundation.sql` (migration A) — core identity + base-lifecycle relations (5 tables): issuer-qualified `(iss, sub)` bindings, lifecycle history/selectors, enrollment policies, and operation receipts. Applies cleanly to current `main`.
- `0042_nip_fi_authorization_foundation.sql` (migration B) — the final-admission surface (10 tables): authorization events + capacity, admission results, replay/receipt guards, audit, invalidation domains/floors, protected-object authority, authority epochs, and restore version deltas. Applies to A's resulting state.

Fifteen NIP-FI relations total, zero dangling foreign keys. Identity is issuer-qualified throughout — no single-global-issuer assumption in any relation, no `Block`-hardcoding. A single deployment may run one issuer; that is config, not schema.

## Durable, immutable ledger posture

All 15 relations are append-only (immutable `no_delete`/`no_truncate` triggers) and carry `community_id` as provenance, not ownership. Both migrations widen the single SQL source of truth `community_write_fence_excluded_table` so the relations are never fence-attached, never purged on community deletion, and never counted as tenant-scoped drift by the deletion control plane's exact-set catalog check — the same posture main already applies to `product_feedback` and `rate_limit_violations`. `schema/schema.sql` keeps one consolidated definition of that function whose exclusion array byte-matches `0042`, guarded by a parity assertion so a future consolidation cannot silently drop NIP-FI relations from the ledger.

This makes a tenant's identity/authorization ledger survive community deletion, per the spec's `FI-INV-02` (durable binding) and `FI-INV-03` (tombstone monotonicity) and `NIP-FI.md`'s "durable server state" ruling. `communities(id)` FK never dangles: community rows become permanent tombstones, never hard-deleted.

## Authorization shape and cardinality contracts

Authenticated `OperatorDenied` events (`actor_kind` 1–3, non-null `request_fingerprint`) carry a null `semantic_fingerprint` and commit without a denial-attempt row. The denial-attempt cardinality and shape guards are scoped to unresolved pre-auth kind-9 events (`actor_kind = 4`). Applied and no-op lifecycle receipts (`outcome_code IN (1, 3)`) require exactly one mapped success-transition event; denied lifecycle receipts (`outcome_code = 2`) require zero events from the complete core lifecycle success-transition class (kinds 1, 2, 3, 6: enrolled, revoked, rotated, retired) — any such event paired with a denied receipt would record a transition that never occurred.

## Mined vs. new

Re-cut from Franco's #1476 (`0029`/`0030`) and Cea's #4772 committer schema, re-cut along FK topology and renumbered above the live `main` tip. The buzz-auth core of #1476 is Cea-authored; `Co-authored-by` reflects verified per-commit authorship of the mined schema.

Zero Rust/`deletion.rs` edits — the migration-only exclusion widening keeps `EXPECTED_SCOPED_TABLES` untouched.
