### PR TITLE
fix(relay): harden community-deletion lifecycle interactions

### DIFF
--- a/crates/buzz-db/src/store/usage.rs
+++ b/crates/buzz-db/src/store/usage.rs
@@ -379,6 +379,26 @@ pub async fn community_hosts(pool: &PgPool) -> Result<Vec<CommunityHost>> {
         .collect())
 }
 
+/// Fetch id → host mappings for writable (lifecycle `active`) communities only.
+///
+/// Write paths that sweep every community (e.g. the NIP-43 membership
+/// reconciler) must use this variant: quiescing communities are read-only and
+/// fenced/tombstone communities reject writes at the database fence, so
+/// sweeping them permanently retries into `community write fenced` errors —
+/// one warning per community per sweep, forever, after any community
+/// deletion completes its fence step.
+pub async fn writable_community_hosts(pool: &PgPool) -> Result<Vec<CommunityHost>> {
+    let rows = sqlx::query_as::<_, (Uuid, String)>(
+        "SELECT id, host FROM communities WHERE deletion_state = 'active'",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(id, host)| CommunityHost { id, host })
+        .collect())
+}
+
 impl Db {
     /// Try to acquire the detached session advisory lock for relay usage metrics.
     ///
@@ -472,6 +492,13 @@ impl Db {
     #[datastore_span(name = "usage_community_hosts", system = "postgresql")]
     pub async fn usage_community_hosts(&self) -> Result<Vec<CommunityHost>> {
         community_hosts(&self.pool).await
+    }
+
+    /// Writable (lifecycle `active`) community hosts — see
+    /// [`writable_community_hosts`].
+    #[datastore_span(name = "usage_writable_community_hosts", system = "postgresql")]
+    pub async fn usage_writable_community_hosts(&self) -> Result<Vec<CommunityHost>> {
+        writable_community_hosts(&self.pool).await
     }
 }
 

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -3031,7 +3031,10 @@ async fn emit_initial_ref_state(
 /// when nothing changed. A failure in one community is logged and counted but
 /// does not prevent the remaining communities from being repaired.
 pub async fn reconcile_nip43_membership_snapshots(state: &Arc<AppState>) -> anyhow::Result<usize> {
-    let communities = state.db.usage_community_hosts().await?;
+    // Writable communities only: quiescing/fenced/tombstone communities reject
+    // membership writes at the database fence, so sweeping them turns every
+    // completed community deletion into a permanent per-sweep failure loop.
+    let communities = state.db.usage_writable_community_hosts().await?;
     let mut reconciled = 0usize;
 
     for community in communities {

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -212,10 +212,35 @@ async fn main() -> anyhow::Result<()> {
         error!("Failed to ensure partitions: {e}");
     }
 
-    db.validate_deletion_serving_catalog().await.map_err(|e| {
-        error!("Community deletion serving-fence validation failed: {e}");
-        anyhow::anyhow!("Community deletion serving fence is unsafe: {e}")
-    })?;
+    // Retry briefly before going fatal: during a rolling deploy, old and new
+    // pods briefly share the database connection budget, and a transient pool
+    // timeout here otherwise flaps a fresh pod into CrashLoopBackOff. The
+    // fail-closed contract is preserved — persistent failure still aborts boot.
+    {
+        let mut attempt = 0u32;
+        loop {
+            match db.validate_deletion_serving_catalog().await {
+                Ok(()) => break,
+                Err(e) if attempt < 3 => {
+                    attempt += 1;
+                    let backoff = std::time::Duration::from_secs(1 << attempt);
+                    warn!(
+                        %e,
+                        attempt,
+                        backoff_secs = backoff.as_secs(),
+                        "Community deletion serving-fence validation failed; retrying"
+                    );
+                    tokio::time::sleep(backoff).await;
+                }
+                Err(e) => {
+                    error!("Community deletion serving-fence validation failed: {e}");
+                    return Err(anyhow::anyhow!(
+                        "Community deletion serving fence is unsafe: {e}"
+                    ));
+                }
+            }
+        }
+    }
     info!("Community deletion serving fences verified");
 
     // Freshness fence probe: cursor pages route to the replica only for


### PR DESCRIPTION
Two production-observed issues on a deployment (~7.7k users) using the community deletion control plane. Both look benign and are permanent:

**1. The NIP-43 membership reconciler sweeps deleted communities forever.** The sweep iterates every community, including quiescing/fenced/tombstone ones — whose database write fence correctly rejects the snapshot write. After any community deletion reaches its fence step, every reconciliation cycle logs a `community write fenced` failure per retired community, indefinitely (we observed ~18 log lines/min after retiring three communities). Fix: sweep only lifecycle-`active` communities via a new `writable_community_hosts` query.

**2. Boot-time serving-fence validation flaps fresh pods under rolling deploys.** The validation is fail-closed with no retry, so a transient DB pool timeout — routine while old and new pods briefly share the connection budget — exits the pod into CrashLoopBackOff. We reproduced this repeatedly under connection pressure. Fix: retry 3x with exponential backoff before aborting; persistent failure still fails the boot, preserving the fail-closed contract.

Both fixes are running in our production deployment.