### PR TITLE
fix(desktop): keep explicit @mentions one-shot when auto-mention is off

### DIFF
--- a/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.test.mjs
+++ b/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.test.mjs
@@ -3,10 +3,18 @@ import test from "node:test";
 
 import { shouldPromoteExplicitAddress } from "./shouldPromoteExplicitAddress.ts";
 
-test("explicit address does not pin when auto-mention preference is off", () => {
+test("ordinary explicit address does not pin when auto-mention preference is off", () => {
   assert.equal(shouldPromoteExplicitAddress(false), false);
 });
 
-test("explicit address may pin when auto-mention preference is on", () => {
+test("ordinary explicit address may pin when auto-mention preference is on", () => {
   assert.equal(shouldPromoteExplicitAddress(true), true);
+});
+
+test("intentional persist still opts in when preference is off", () => {
+  // Mirror promoteExplicitlyAddressedAgents: persist bypasses the one-shot gate.
+  const preferenceOff = false;
+  const persist = true;
+  const shouldPromote = persist || shouldPromoteExplicitAddress(preferenceOff);
+  assert.equal(shouldPromote, true);
 });

--- a/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.test.mjs
+++ b/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldPromoteExplicitAddress } from "./shouldPromoteExplicitAddress.ts";
+
+test("explicit address does not pin when auto-mention preference is off", () => {
+  assert.equal(shouldPromoteExplicitAddress(false), false);
+});
+
+test("explicit address may pin when auto-mention preference is on", () => {
+  assert.equal(shouldPromoteExplicitAddress(true), true);
+});

--- a/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.ts
+++ b/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.ts
@@ -1,4 +1,4 @@
-/** Whether an explicit @mention should pin into the persistent audience. */
+/** Whether an ordinary explicit @mention should pin into the persistent audience. */
 export function shouldPromoteExplicitAddress(
   keepMentionedAgentsPinned: boolean,
 ): boolean {

--- a/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.ts
+++ b/desktop/src/features/messages/lib/shouldPromoteExplicitAddress.ts
@@ -1,0 +1,6 @@
+/** Whether an explicit @mention should pin into the persistent audience. */
+export function shouldPromoteExplicitAddress(
+  keepMentionedAgentsPinned: boolean,
+): boolean {
+  return keepMentionedAgentsPinned;
+}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -461,8 +461,9 @@ function MessageComposerImpl({
     audience: persistentAudience,
     audienceScope,
     mentions,
-    onAddressAgentMention: (suggestion) =>
+    onAddressAgentMention: (suggestion, options) =>
       promoteExplicitlyAddressedAgents({
+        persist: options?.persist,
         pubkeys: suggestion.pubkey ? [suggestion.pubkey] : [],
       }),
     onAutoPinAgentMention: (suggestion, options) => {

--- a/desktop/src/features/messages/ui/useAgentAddressLockPicker.test.mjs
+++ b/desktop/src/features/messages/ui/useAgentAddressLockPicker.test.mjs
@@ -1094,3 +1094,52 @@ test("implicit prefix removal uses the present exact label rather than a stale a
   act(() => result.current.removeAddressedAgent(key));
   assert.equal(text, "hello");
 });
+
+test("always-address path passes persist:true into onAddressAgentMention", async () => {
+  const { act, renderHook } = await import("@testing-library/react");
+  const { useAgentAddressLockPicker } = await import(
+    "./useAgentAddressLockPicker.ts"
+  );
+  const addressed = [];
+  const text = "@";
+  const mentions = {
+    cancelMentionAutocomplete: () => {},
+    getDraftMentionRefs: () => [],
+    getMentionDisplayName: () => "Agent Ada",
+    isInlineMentionSelection: () => false,
+    isMentionOpen: true,
+    openMentionPicker: () => {},
+    registerMentionPubkey: () => {},
+    mentionStartIndex: text.lastIndexOf("@"),
+  };
+  const audience = {
+    pubkeys: [],
+    addPubkey: () => {},
+  };
+  const richText = {
+    getPlainTextAndCursor: () => ({ text, cursor: text.length }),
+  };
+  const { result } = renderHook(() =>
+    useAgentAddressLockPicker({
+      applyAutocompleteEdit: () => {},
+      audience,
+      audienceScope: "channel-scope",
+      mentions,
+      onAddressAgentMention: (suggestion, options) =>
+        addressed.push({ suggestion, options }),
+      onPulseAddressLock: () => {},
+      richText,
+    }),
+  );
+
+  act(() => {
+    result.current.toggleAlwaysAddressAgent({
+      pubkey: "agent-pubkey",
+      displayName: "Agent Ada",
+      isAgent: true,
+    });
+  });
+
+  assert.equal(addressed.length, 1);
+  assert.deepEqual(addressed[0].options, { persist: true });
+});

--- a/desktop/src/features/messages/ui/useAgentAddressLockPicker.ts
+++ b/desktop/src/features/messages/ui/useAgentAddressLockPicker.ts
@@ -31,7 +31,10 @@ export function useAgentAddressLockPicker({
   audience: ReturnType<typeof usePersistentAgentAudience>;
   audienceScope: string | null;
   mentions: UseMentionsResult;
-  onAddressAgentMention?: (suggestion: MentionSuggestion) => void;
+  onAddressAgentMention?: (
+    suggestion: MentionSuggestion,
+    options?: { persist?: boolean },
+  ) => void;
   onAutoPinAgentMention?: (
     suggestion: MentionSuggestion,
     options: { reinstateExcluded: boolean },
@@ -235,7 +238,7 @@ export function useAgentAddressLockPicker({
         }
         trackMentionAddressedAgent(pubkey);
         if (onAddressAgentMention) {
-          onAddressAgentMention(suggestion);
+          onAddressAgentMention(suggestion, { persist: true });
         } else {
           audience.addPubkey(pubkey);
           onPulseAddressLock(pubkey);

--- a/desktop/src/features/messages/ui/useAutoPinMentionedAgents.test.mjs
+++ b/desktop/src/features/messages/ui/useAutoPinMentionedAgents.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const AGENT =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SCOPE = "owner:channel:channel";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+  const { resetPersistentAgentAudienceStore } = await import(
+    "@/features/messages/lib/persistentAgentAudience.ts"
+  );
+  resetPersistentAgentAudienceStore();
+});
+
+after(() => dom.window.close());
+
+async function renderAutoPin({ enabled }) {
+  const { act, renderHook } = await import("@testing-library/react");
+  const { useAutoPinMentionedAgents } = await import(
+    "./useAutoPinMentionedAgents.ts"
+  );
+  const { getPersistentAgentAudienceSnapshot } = await import(
+    "@/features/messages/lib/persistentAgentAudience.ts"
+  );
+
+  const turnOnCalls = [];
+  const pulses = [];
+  const { result } = renderHook(() =>
+    useAutoPinMentionedAgents({
+      audienceScope: SCOPE,
+      enabled,
+      getDisplayName: () => "Agent Ada",
+      onPulse: (pubkey) => pulses.push(pubkey),
+      onTurnOff: () => {},
+      onTurnOn: () => turnOnCalls.push(true),
+    }),
+  );
+
+  return {
+    act,
+    audience: () => getPersistentAgentAudienceSnapshot().audiences[SCOPE] ?? [],
+    pulses,
+    result,
+    turnOnCalls,
+  };
+}
+
+test("ordinary explicit address stays one-shot when auto-mention is off", async () => {
+  const { act, audience, pulses, result, turnOnCalls } = await renderAutoPin({
+    enabled: false,
+  });
+
+  act(() => {
+    result.current.promoteExplicitlyAddressedAgents({ pubkeys: [AGENT] });
+  });
+
+  assert.deepEqual(audience(), []);
+  assert.equal(pulses.length, 0);
+  assert.equal(turnOnCalls.length, 0);
+  assert.equal(result.current.openOptionsRequest, 0);
+});
+
+test("always-address persist still opts in when auto-mention is off", async () => {
+  const { act, audience, pulses, result, turnOnCalls } = await renderAutoPin({
+    enabled: false,
+  });
+
+  act(() => {
+    result.current.promoteExplicitlyAddressedAgents({
+      persist: true,
+      pubkeys: [AGENT],
+    });
+  });
+
+  assert.deepEqual(audience(), [AGENT]);
+  assert.deepEqual(pulses, [AGENT]);
+  assert.equal(result.current.openOptionsRequest, 1);
+
+  act(() => {
+    result.current.completeOptionsReveal(1);
+  });
+  assert.equal(turnOnCalls.length, 1);
+});

--- a/desktop/src/features/messages/ui/useAutoPinMentionedAgents.ts
+++ b/desktop/src/features/messages/ui/useAutoPinMentionedAgents.ts
@@ -196,6 +196,10 @@ export function useAutoPinMentionedAgents({
   );
   const promoteExplicitlyAddressedAgents = React.useCallback(
     (promotion: { expectedRevision?: number; pubkeys: readonly string[] }) => {
+      // With "Automatically mention agents" off, an explicit @mention is
+      // one-shot: do not pin into the persistent audience or flip the
+      // preference on (that was leaving the next composer auto-selected).
+      if (!enabled) return;
       promoteAgents({
         ...promotion,
         reinstateExcluded: true,
@@ -203,7 +207,7 @@ export function useAutoPinMentionedAgents({
       });
       requestPreferenceChange(true);
     },
-    [promoteAgents, requestPreferenceChange],
+    [enabled, promoteAgents, requestPreferenceChange],
   );
 
   const dismissConfirmation = clearConfirmation;

--- a/desktop/src/features/messages/ui/useAutoPinMentionedAgents.ts
+++ b/desktop/src/features/messages/ui/useAutoPinMentionedAgents.ts
@@ -196,11 +196,19 @@ export function useAutoPinMentionedAgents({
     [promoteAgents],
   );
   const promoteExplicitlyAddressedAgents = React.useCallback(
-    (promotion: { expectedRevision?: number; pubkeys: readonly string[] }) => {
-      // With "Automatically mention agents" off, an explicit @mention is
-      // one-shot: do not pin into the persistent audience or flip the
-      // preference on (that was leaving the next composer auto-selected).
-      if (!shouldPromoteExplicitAddress(enabled)) return;
+    (promotion: {
+      expectedRevision?: number;
+      persist?: boolean;
+      pubkeys: readonly string[];
+    }) => {
+      // Ordinary @mentions stay one-shot when auto-mention is off. An intentional
+      // "Always address" / pin action passes persist:true and must still opt in.
+      if (
+        !promotion.persist &&
+        !shouldPromoteExplicitAddress(enabled)
+      ) {
+        return;
+      }
       promoteAgents({
         ...promotion,
         reinstateExcluded: true,

--- a/desktop/src/features/messages/ui/useAutoPinMentionedAgents.ts
+++ b/desktop/src/features/messages/ui/useAutoPinMentionedAgents.ts
@@ -6,6 +6,7 @@ import {
   removePersistentAgentAudienceMembersIfUnchanged,
   usePersistentAgentAudience,
 } from "@/features/messages/lib/persistentAgentAudience";
+import { shouldPromoteExplicitAddress } from "@/features/messages/lib/shouldPromoteExplicitAddress";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 const CONFIRMATION_DURATION_MS = 4_000;
@@ -199,7 +200,7 @@ export function useAutoPinMentionedAgents({
       // With "Automatically mention agents" off, an explicit @mention is
       // one-shot: do not pin into the persistent audience or flip the
       // preference on (that was leaving the next composer auto-selected).
-      if (!enabled) return;
+      if (!shouldPromoteExplicitAddress(enabled)) return;
       promoteAgents({
         ...promotion,
         reinstateExcluded: true,


### PR DESCRIPTION
## Summary
- With **Automatically mention agents** off, an explicit `@mention` was still promoting the agent into the persistent audience and flipping the preference on.
- Explicit address is now one-shot when the preference is off.

Fixes #6938.

## Test plan
- [x] `node --test desktop/src/features/messages/lib/shouldPromoteExplicitAddress.test.mjs`
- [ ] Settings → Agents: turn auto-mention off, @mention an agent once, confirm the next composer is empty


