### PR TITLE
fix(desktop): transcribe only the local microphone in Huddles

### DIFF
--- a/desktop/src-tauri/src/huddle/playout.rs
+++ b/desktop/src-tauri/src/huddle/playout.rs
@@ -183,23 +183,6 @@ fn same_occupancy(
         && index_to_epoch.get(&peer_idx) == Some(&epoch)
 }
 
-fn mix_remote_stt_samples(mix: &mut Vec<f32>, samples: &[f32]) {
-    if mix.len() < samples.len() {
-        mix.resize(samples.len(), 0.0);
-    }
-    for (mixed, sample) in mix.iter_mut().zip(samples) {
-        *mixed = (*mixed + *sample).clamp(-1.0, 1.0);
-    }
-}
-
-fn f32_samples_to_le_bytes(samples: &[f32]) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(std::mem::size_of_val(samples));
-    for sample in samples {
-        bytes.extend_from_slice(&sample.to_le_bytes());
-    }
-    bytes
-}
-
 /// One remote peer's slot: jitter buffer + dedicated rodio Player.
 ///
 /// Per-frame seq/timestamp come from the v2 wire header (sender-authored).
@@ -280,7 +263,6 @@ pub(crate) async fn run_playout_recv_loop(
     tts_active: Arc<AtomicBool>,
     tts_cancel: Arc<AtomicBool>,
     local_tts_publishers: super::tts::LocalTtsPublishers,
-    remote_stt_pipeline: Arc<std::sync::Mutex<Option<std::sync::Weak<super::stt::SttPipeline>>>>,
     agent_pubkeys: Arc<std::sync::Mutex<Vec<String>>>,
     human_floor: HumanFloor,
 ) {
@@ -338,7 +320,6 @@ pub(crate) async fn run_playout_recv_loop(
                 // per idle peer into rodio forever. `is_active` is a 500 ms
                 // grace past the last received packet, far longer than typical
                 // DTX comfort-noise cadence.
-                let mut remote_stt_mix = Vec::new();
                 for (peer_idx, slot) in peers.iter_mut() {
                     if !slot.is_active() {
                         // Still drain the frame to keep NetEq's internal clock
@@ -360,17 +341,10 @@ pub(crate) async fn run_playout_recv_loop(
                                 );
                                 slot.player.skip_one();
                             }
-                            if !is_locally_synthesized_peer(*peer_idx, &local_tts_publishers) {
-                                let remote_agent = {
-                                    let agents = agent_pubkeys
-                                        .lock()
-                                        .unwrap_or_else(|error| error.into_inner());
-                                    is_agent_peer(*peer_idx, &index_to_pubkey, &agents)
-                                };
-                                if !remote_agent {
-                                    mix_remote_stt_samples(&mut remote_stt_mix, &samples);
-                                }
-                            }
+                            // Remote peers are played out, never transcribed:
+                            // this device signs transcripts with the local
+                            // user's key, so another participant's speech has
+                            // no honest path into that pipeline.
                             slot.player.append(SamplesBuffer::new(channels, rate, samples));
                         }
                         Err(e) => {
@@ -378,18 +352,6 @@ pub(crate) async fn run_playout_recv_loop(
                                 "buzz-desktop: jitter get_audio peer {peer_idx}: {e}"
                             );
                         }
-                    }
-                }
-                if !remote_stt_mix.is_empty() {
-                    let pipeline = remote_stt_pipeline
-                        .lock()
-                        .unwrap_or_else(|error| error.into_inner())
-                        .as_ref()
-                        .and_then(std::sync::Weak::upgrade);
-                    if let Some(pipeline) = pipeline {
-                        let _ = pipeline.push_remote_audio(f32_samples_to_le_bytes(
-                            &remote_stt_mix,
-                        ));
                     }
                 }
             }
@@ -776,8 +738,10 @@ mod tests {
         assert!(!is_locally_synthesized_peer(9, &local_publishers));
     }
 
+    /// Agent audio plays out, but must never acquire the human floor —
+    /// otherwise one agent's speech would suppress another agent's response.
     #[test]
-    fn remote_agent_identity_is_excluded_from_human_stt() {
+    fn remote_agent_identity_is_excluded_from_the_human_floor() {
         let peers =
             std::collections::HashMap::from([(3, "human".to_owned()), (4, "AGENT".to_owned())]);
         let agents = vec!["agent".to_owned()];
@@ -811,17 +775,5 @@ mod tests {
             !is_current_occupant(9, &index_to_epoch),
             "frame for an unoccupied index is dropped"
         );
-    }
-
-    #[test]
-    fn remote_human_stt_mix_sums_and_clamps_concurrent_speakers() {
-        let mut mix = Vec::new();
-        mix_remote_stt_samples(&mut mix, &[0.4, -0.7, 0.2]);
-        mix_remote_stt_samples(&mut mix, &[0.8, -0.6, -0.1]);
-
-        assert_eq!(mix, vec![1.0, -1.0, 0.1]);
-        let bytes = f32_samples_to_le_bytes(&mix);
-        assert_eq!(bytes.len(), std::mem::size_of_val(mix.as_slice()));
-        assert_eq!(f32::from_le_bytes(bytes[0..4].try_into().unwrap()), 1.0);
     }
 }

--- a/desktop/src-tauri/src/huddle/relay_api.rs
+++ b/desktop/src-tauri/src/huddle/relay_api.rs
@@ -187,20 +187,12 @@ pub(crate) async fn connect_audio_relay(
     let keys = state.keys.lock().map_err(|e| e.to_string())?.clone();
 
     // TTS interrupt flags — recv task cancels TTS when remote humans speak.
-    let (
-        tts_cancel,
-        tts_active,
-        local_tts_publishers,
-        remote_stt_pipeline,
-        agent_pubkeys,
-        human_floor,
-    ) = {
+    let (tts_cancel, tts_active, local_tts_publishers, agent_pubkeys, human_floor) = {
         let hs = state.huddle()?;
         (
             Arc::clone(&hs.tts_cancel),
             Arc::clone(&hs.tts_active),
             Arc::clone(&hs.local_tts_publishers),
-            Arc::clone(&hs.remote_stt_pipeline),
             Arc::clone(&hs.agent_pubkeys),
             hs.human_floor.clone(),
         )
@@ -233,7 +225,6 @@ pub(crate) async fn connect_audio_relay(
             tts_cancel,
             tts_active,
             local_tts_publishers,
-            remote_stt_pipeline,
             agent_pubkeys,
             human_floor,
             output_device_name,
@@ -458,7 +449,6 @@ struct AudioRelayPipelineArgs {
     tts_cancel: Arc<AtomicBool>,
     tts_active: Arc<AtomicBool>,
     local_tts_publishers: super::tts::LocalTtsPublishers,
-    remote_stt_pipeline: Arc<std::sync::Mutex<Option<std::sync::Weak<super::stt::SttPipeline>>>>,
     agent_pubkeys: Arc<std::sync::Mutex<Vec<String>>>,
     human_floor: super::human_floor::HumanFloor,
     output_device_name: Option<String>,
@@ -475,7 +465,6 @@ async fn audio_relay_pipeline(args: AudioRelayPipelineArgs) -> Result<(), String
         tts_cancel,
         tts_active,
         local_tts_publishers,
-        remote_stt_pipeline,
         agent_pubkeys,
         human_floor,
         output_device_name,
@@ -588,7 +577,6 @@ async fn audio_relay_pipeline(args: AudioRelayPipelineArgs) -> Result<(), String
         tts_active,
         tts_cancel,
         local_tts_publishers,
-        remote_stt_pipeline,
         agent_pubkeys,
         human_floor,
     ));

--- a/desktop/src-tauri/src/huddle/state.rs
+++ b/desktop/src-tauri/src/huddle/state.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
-    Arc, Mutex, Weak,
+    Arc, Mutex,
 };
 
 use super::agent_voice::AgentVoiceSettings;
@@ -79,12 +79,6 @@ pub struct HuddleState {
     /// Active STT pipeline — not serialized, not cloned.
     #[serde(skip)]
     pub stt_pipeline: Option<Arc<stt::SttPipeline>>,
-    /// Weak STT handle shared with the audio receive loop so remote human
-    /// speech can reach transcription even when the pipeline hot-starts after
-    /// the Huddle audio socket was connected. The state-owned strong handle
-    /// above remains the sole owner and teardown clears both atomically.
-    #[serde(skip)]
-    pub remote_stt_pipeline: Arc<Mutex<Option<Weak<stt::SttPipeline>>>>,
     /// Active TTS pipeline — not serialized, not cloned.
     #[serde(skip)]
     pub tts_pipeline: Option<Arc<tts::TtsPipeline>>,
@@ -198,7 +192,6 @@ impl Clone for HuddleState {
             agent_pubkeys: Arc::new(Mutex::new(agent_pubkeys_snapshot)),
             agent_voice_settings: self.agent_voice_settings.clone(),
             stt_pipeline: None, // Never clone the pipeline handle.
-            remote_stt_pipeline: Arc::new(Mutex::new(None)),
             tts_pipeline: None, // Never clone the pipeline handle.
             local_tts_publishers: Arc::clone(&self.local_tts_publishers),
             is_creator: self.is_creator,
@@ -235,7 +228,6 @@ impl Default for HuddleState {
             agent_pubkeys: Arc::new(Mutex::new(Vec::new())),
             agent_voice_settings: BTreeMap::new(),
             stt_pipeline: None,
-            remote_stt_pipeline: Arc::new(Mutex::new(None)),
             tts_pipeline: None,
             local_tts_publishers: tts::LocalTtsPublishers::default(),
             is_creator: false,
@@ -258,19 +250,15 @@ impl Default for HuddleState {
 }
 
 impl HuddleState {
+    /// Install the STT pipeline. The state holds the only handle: the audio
+    /// receive loop must not reach it, because this pipeline's transcripts are
+    /// signed with the local user's key and it therefore accepts this device's
+    /// microphone alone.
     pub(crate) fn set_stt_pipeline(&mut self, pipeline: Arc<stt::SttPipeline>) {
-        *self
-            .remote_stt_pipeline
-            .lock()
-            .unwrap_or_else(|error| error.into_inner()) = Some(Arc::downgrade(&pipeline));
         self.stt_pipeline = Some(pipeline);
     }
 
     pub(crate) fn take_stt_pipeline(&mut self) -> Option<Arc<stt::SttPipeline>> {
-        self.remote_stt_pipeline
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .take();
         self.stt_pipeline.take()
     }
 

--- a/desktop/src-tauri/src/huddle/stt.rs
+++ b/desktop/src-tauri/src/huddle/stt.rs
@@ -17,6 +17,12 @@
 //!
 //! The worker runs on a dedicated `std::thread` (not async) because
 //! sherpa-onnx is CPU-bound and not Send-safe across await points.
+//!
+//! **Attribution invariant.** Every transcript this pipeline emits is signed
+//! with the local user's key, so only this device's own microphone may enter
+//! it. Audio from any other participant — decoded remote peers included — must
+//! never reach `push_audio`: transcribing it here would publish one person's
+//! speech as another's, on every listening desktop independently.
 
 use std::{
     collections::VecDeque,
@@ -53,24 +59,13 @@ const MAX_SPEECH_SAMPLES: usize = 16_000 * 30;
 /// task without holding a Mutex across await points.
 #[derive(Debug)]
 pub struct SttPipeline {
-    /// Send raw PCM bytes (f32 LE, 48 kHz mono) into the pipeline.
-    audio_tx: SyncSender<SttAudioInput>,
+    /// Send raw PCM bytes (f32 LE, 48 kHz mono) from the local microphone
+    /// into the pipeline. See the attribution invariant in the module docs.
+    audio_tx: SyncSender<Vec<u8>>,
     /// Signals the worker thread to stop.
     shutdown: Arc<AtomicBool>,
     /// Worker thread handle — taken on drop to join cleanly.
     thread: Option<thread::JoinHandle<()>>,
-}
-
-#[derive(Debug)]
-struct SttAudioInput {
-    pcm_bytes: Vec<u8>,
-    origin: SttAudioOrigin,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SttAudioOrigin {
-    Local,
-    RemoteHuman,
 }
 
 impl SttPipeline {
@@ -102,7 +97,7 @@ impl SttPipeline {
         human_floor: HumanFloor,
         output_device: Option<String>,
     ) -> Result<(Self, tokio_mpsc::Receiver<String>), String> {
-        let (audio_tx, audio_rx) = mpsc::sync_channel::<SttAudioInput>(AUDIO_QUEUE_DEPTH);
+        let (audio_tx, audio_rx) = mpsc::sync_channel::<Vec<u8>>(AUDIO_QUEUE_DEPTH);
         let (text_tx, text_rx) = tokio_mpsc::channel::<String>(64);
         let shutdown = Arc::new(AtomicBool::new(false));
 
@@ -144,23 +139,15 @@ impl SttPipeline {
         self.thread.as_ref().is_none_or(|h| h.is_finished())
     }
 
-    /// Feed raw PCM bytes into the pipeline.
+    /// Feed raw PCM bytes from **this device's microphone** into the pipeline.
+    ///
+    /// The only audio entry point, deliberately. Its output is signed with the
+    /// local user's key, so admitting another participant's audio here would
+    /// attribute their speech to this user — see the module docs.
     ///
     /// Non-blocking. Drops audio silently if the pipeline can't keep up —
     /// better to lose frames than to stall the UI thread.
     pub fn push_audio(&self, pcm_bytes: Vec<u8>) -> Result<(), String> {
-        self.push_audio_from(pcm_bytes, SttAudioOrigin::Local)
-    }
-
-    /// Feed decoded remote-human PCM into transcription. Unlike the desktop
-    /// microphone path, this is not gated by the desktop PTT or mute state: the
-    /// remote participant already made their transmission choice on their own
-    /// device before the relay delivered these samples.
-    pub fn push_remote_audio(&self, pcm_bytes: Vec<u8>) -> Result<(), String> {
-        self.push_audio_from(pcm_bytes, SttAudioOrigin::RemoteHuman)
-    }
-
-    fn push_audio_from(&self, pcm_bytes: Vec<u8>, origin: SttAudioOrigin) -> Result<(), String> {
         // Reject non-4-byte-aligned input — would silently truncate in bytes_to_f32.
         if !pcm_bytes.len().is_multiple_of(4) {
             return Err(format!(
@@ -169,7 +156,7 @@ impl SttPipeline {
             ));
         }
         // Drop audio if the pipeline can't keep up — better than blocking the UI.
-        let _ = self.audio_tx.try_send(SttAudioInput { pcm_bytes, origin });
+        let _ = self.audio_tx.try_send(pcm_bytes);
         Ok(())
     }
 }
@@ -405,11 +392,11 @@ impl SttStreamState {
 #[derive(Debug)]
 enum SttLoopInput {
     Tick,
-    Batch(Vec<SttAudioInput>),
+    Batch(Vec<Vec<u8>>),
 }
 
 fn run_stt_receive_loop(
-    audio_rx: Receiver<SttAudioInput>,
+    audio_rx: Receiver<Vec<u8>>,
     shutdown: &AtomicBool,
     human_floor: HumanFloor,
     mut process: impl FnMut(SttLoopInput, &mut local_barge_in::LocalBargeIn),
@@ -443,7 +430,7 @@ fn run_stt_receive_loop(
 #[allow(clippy::too_many_arguments)]
 fn stt_worker(
     model_dir: PathBuf,
-    audio_rx: Receiver<SttAudioInput>,
+    audio_rx: Receiver<Vec<u8>>,
     text_tx: tokio_mpsc::Sender<String>,
     shutdown: Arc<AtomicBool>,
     ptt_active: Option<Arc<AtomicBool>>,
@@ -488,17 +475,8 @@ fn stt_worker(
         }
     };
 
-    // ── 2. Independent local and remote processing state ─────────────────────
-    // Separate resampler/VAD state prevents simultaneous desktop and remote
-    // speech from being serialized into one artificial utterance.
+    // ── 2. Local microphone processing state ─────────────────────────────────
     let mut local_stream = match SttStreamState::new() {
-        Ok(stream) => stream,
-        Err(error) => {
-            eprintln!("buzz-desktop: {error}");
-            return;
-        }
-    };
-    let mut remote_stream = match SttStreamState::new() {
         Ok(stream) => stream,
         Err(error) => {
             eprintln!("buzz-desktop: {error}");
@@ -546,28 +524,18 @@ fn stt_worker(
                 }
             }
             SttLoopInput::Batch(batch) => {
-                for input in batch {
-                    let (stream, ptt_gate, manual_gate, track_local_floor) = match input.origin {
-                        SttAudioOrigin::Local => (
-                            &mut local_stream,
-                            ptt_active.as_ref(),
-                            manual_mic_unmuted.as_ref(),
-                            true,
-                        ),
-                        SttAudioOrigin::RemoteHuman => (&mut remote_stream, None, None, false),
-                    };
+                for pcm_bytes in batch {
                     process_stt_input(
-                        stream,
-                        &input.pcm_bytes,
+                        &mut local_stream,
+                        &pcm_bytes,
                         speculative_enabled,
                         &recognizer,
                         &text_tx,
-                        ptt_gate,
-                        manual_gate,
+                        ptt_active.as_ref(),
+                        manual_mic_unmuted.as_ref(),
                         &human_floor,
                         local_barge_in_state,
                         output_device.as_deref(),
-                        track_local_floor,
                     );
                 }
             }
@@ -591,7 +559,6 @@ fn process_stt_input(
     human_floor: &HumanFloor,
     local_barge_in_state: &mut local_barge_in::LocalBargeIn,
     output_device: Option<&str>,
-    track_local_floor: bool,
 ) {
     stream
         .input_buf_48k
@@ -614,7 +581,6 @@ fn process_stt_input(
             human_floor,
             local_barge_in_state,
             output_device,
-            track_local_floor,
         );
     }
 }
@@ -671,7 +637,6 @@ fn process_16k_samples(
     human_floor: &HumanFloor,
     local_barge_in_state: &mut local_barge_in::LocalBargeIn,
     output_device: Option<&str>,
-    track_local_floor: bool,
 ) {
     let (speculative_enabled, speculative) = speculative;
     leftover.extend_from_slice(samples);
@@ -692,20 +657,17 @@ fn process_16k_samples(
             endpoint.process_frame(frame, prob, accepts_audio, flush_allowed, flush_frames);
         // Open-mic VAD semantics also apply when a PTT-mode user manually
         // opens the mic. A held shortcut keeps its explicit key-down cancel.
-        let local_barge_in = track_local_floor
-            && local_barge_in::enabled(ptt_active.is_some(), manually_open, ptt_held);
-        if track_local_floor {
-            if local_barge_in {
-                local_barge_in_state.observe(
-                    prob,
-                    action == VadFrameAction::ConfirmedOnset,
-                    human_floor,
-                    output_device,
-                    VAD_ONSET_THRESHOLD,
-                );
-            } else {
-                local_barge_in_state.release(human_floor);
-            }
+        let local_barge_in = local_barge_in::enabled(ptt_active.is_some(), manually_open, ptt_held);
+        if local_barge_in {
+            local_barge_in_state.observe(
+                prob,
+                action == VadFrameAction::ConfirmedOnset,
+                human_floor,
+                output_device,
+                VAD_ONSET_THRESHOLD,
+            );
+        } else {
+            local_barge_in_state.release(human_floor);
         }
 
         match action {

--- a/desktop/src-tauri/src/huddle/stt_tests.rs
+++ b/desktop/src-tauri/src/huddle/stt_tests.rs
@@ -1,9 +1,9 @@
 use std::sync::{atomic::AtomicBool, mpsc, Arc, Barrier};
 
 use super::{
-    has_enough_voiced_audio, run_stt_receive_loop, vad_flush_allowed, HumanFloor, SttAudioInput,
-    SttAudioOrigin, SttLoopInput, VadEndpoint, VadFrameAction, MIN_VOICED_FRAMES,
-    SILENCE_FLUSH_FRAMES, VAD_FRAME_SAMPLES, VAD_ONSET_FRAMES, VAD_PRE_ROLL_FRAMES,
+    has_enough_voiced_audio, run_stt_receive_loop, vad_flush_allowed, HumanFloor, SttLoopInput,
+    VadEndpoint, VadFrameAction, MIN_VOICED_FRAMES, SILENCE_FLUSH_FRAMES, VAD_FRAME_SAMPLES,
+    VAD_ONSET_FRAMES, VAD_PRE_ROLL_FRAMES,
 };
 
 #[derive(Clone, Copy)]
@@ -34,12 +34,7 @@ fn assert_worker_exit_releases_floor(exit: WorkerExit) {
         );
     });
 
-    audio_tx
-        .send(SttAudioInput {
-            pcm_bytes: Vec::new(),
-            origin: SttAudioOrigin::Local,
-        })
-        .expect("worker receiver is open");
+    audio_tx.send(Vec::new()).expect("worker receiver is open");
     acquired.wait();
     assert!(human_floor.is_blocked());
     match exit {


### PR DESCRIPTION
## Related work

No open PR or issue fixes this. Closest existing work, none of which overlaps the fix itself:

- #6497 — `fix(desktop): drop punctuation-only STT transcripts in huddles` — same publish path
- #6585 — Huddles overhaul (drain-safe rooms, typed relay errors) — same subsystem, may touch neighbouring lines
- #2522 — huddle-transcript signed event kind + SDK builder — proposes a dedicated kind for transcripts

## Problem

A Huddle transcript is published as a kind:9 signed with the **local user's** key. But `playout.rs` fed *every* remote human peer's audio into the same STT pipeline: each active peer slot that wasn't a locally-synthesized TTS publisher or a known agent was summed into one mono buffer by `mix_remote_stt_samples` and pushed in via `push_remote_audio`.

The result is forged provenance. When Alice speaks, Bob's desktop transcribes her and publishes her words as a message signed by Bob — independently, on every listening desktop in the room. There is no diarization and no host election, so a three-desktop Huddle turns one sentence from Alice into a kind:9 from Bob *and* another from Carol, each claiming to be that user's own speech.

The remote path was also deliberately ungated by push-to-talk and mute, so a listener who never unmuted still published other people's speech under their own key.

## Fix

Remove the producer rather than filter at the publisher.

The alternative was to carry an origin through the text layer — `TranscriptSegment { origin, text }` — and admit only `LocalMicrophone` before publishing. But once `playout.rs` stops feeding remote audio in, that origin has exactly one possible value: `RemoteHuman` becomes an unconstructed variant, `push_remote_audio` a method with no caller, and any test would assert an unreachable branch. So the invariant is expressed by deleting the producer and documenting it on the single surviving entry point.

Secondary benefit: every listening desktop stops running Parakeet over audio it must discard.

Gone: `SttAudioOrigin` and its second VAD stream, `push_remote_audio`, `track_local_floor`, `mix_remote_stt_samples`, `f32_samples_to_le_bytes`, the mix block in the playout receive loop, and the `remote_stt_pipeline` weak handle in `HuddleState`. The STT channel now carries plain PCM. Net −152 lines across 5 files, all under `desktop/src-tauri/src/huddle/`.

No relay change. No protocol change.

## Known regression

**Legacy text-only agents lose the accidental proxy by which mobile speech reached them, and stay silent until an agent audio runtime lands.**

Mobile has no local STT, so a phone's speech reached text-driven agents only because some desktop in the room transcribed it and published it under that desktop user's key. That path is now gone, and nothing replaces it in this PR.

Speech-to-speech agents are unaffected — they receive the Opus room directly.

This is a deliberate trade: correct attribution over an undesigned capability. Publishing one participant's speech under another participant's signature is forged provenance in a signed-event system, and the lost behaviour was a side effect of every listener transcribing the room, not a designed feature.

## Verification

Automated, on this branch's base:

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Tauri fmt + clippy under `-D warnings` — clean
- `cargo test --workspace` (Tauri) — 3004 passed / 0 failed / 18 ignored
- Full `just ci` green: desktop JS 5799/0, desktop and web builds, `flutter analyze` clean, mobile 2007 tests

Manual, on real hardware — one Windows desktop as a muted listener, one phone as the speaker, against a stock `ghcr.io/block/buzz:main` relay:

| | vanilla 0.5.19 | this branch |
|---|---|---|
| Phone speaks, listener muted | 2 kind:9 events published **by the listener**, carrying the phone's words | **0 events** |
| Listener speaks | 1 event, correctly its own | 1 event, correctly its own |

The listener's own transcript is the control that makes the zero meaningful: STT was running, VAD was flushing, NIP-98 authenticated and the relay accepted, 42 seconds after the phone joined the room. It simply had nothing to say about the phone's audio.

### Why there is no new regression test

The usual shape — a test asserting that remote audio never reaches the publisher — has no code path left to exercise. Removing the producer means there is no way to construct the failing input: `push_remote_audio` has no caller, `RemoteHuman` has no constructor, and the mixing function is gone. A test could only assert that a symbol no longer exists, which the compiler already enforces at every call site.

So the guarantee is structural rather than behavioural. What the PR does instead:

- documents the invariant on `SttPipeline::push_audio`, the single surviving entry point, and in the module header
- deletes the test for the removed mixer, and renames `remote_agent_identity_is_excluded_from_the_human_stt` to `…_from_the_human_floor`, which is what it actually asserts now
- proves the behaviour end-to-end on hardware, in the before/after table above

### Not included

No UI change, so there are no screenshots.

Restoring speech input for text-only agents is deliberately out of scope. It belongs with an agent audio runtime that joins the Opus room directly, which is follow-up work.

---

The pre-fix run used the released 0.5.19 client, so the defect is reproducible in shipped code — `push_remote_audio` arrived in #6056 on 2026-08-22, three days before that tag.
