### PR TITLE
fix(acp): publish exact-session responses and route role forums

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -214,6 +214,11 @@ pub struct AcpClient {
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
     standard_adapter: Option<StandardAdapterKind>,
+    /// Text emitted by `agent_message_chunk` notifications during the current
+    /// prompt. ACP returns only a stop reason from `session/prompt`; adapters
+    /// such as OpenClaw deliver the human-facing final answer exclusively via
+    /// these notifications, so callers must be able to consume it.
+    turn_response_text: String,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -563,6 +568,7 @@ impl AcpClient {
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
+            turn_response_text: String::new(),
         })
     }
 
@@ -685,6 +691,44 @@ impl AcpClient {
         })
     }
 
+    /// Load an exact existing ACP session instead of creating a replacement.
+    ///
+    /// This is an explicit, fail-closed operator path. The caller supplies the
+    /// adapter-owned session ID and the adapter decides whether it can resume
+    /// it. No fallback to `session/new` is attempted when loading fails.
+    pub async fn session_load_full(
+        &mut self,
+        session_id: &str,
+        cwd: &str,
+        mcp_servers: Vec<McpServer>,
+    ) -> Result<SessionNewResponse, AcpError> {
+        let params = serde_json::json!({
+            "sessionId": session_id,
+            "cwd": cwd,
+            "mcpServers": mcp_servers,
+        });
+        let result = self.send_request("session/load", params).await?;
+        // ACP's LoadSessionResponse does not require a sessionId: the loaded
+        // session is identified by the request. Some agents echo it as an
+        // extension. When present, require exact parity; never accept a
+        // different or malformed ID.
+        if let Some(value) = result.get("sessionId") {
+            let loaded_id = value.as_str().ok_or_else(|| {
+                AcpError::Protocol("session/load returned a non-string sessionId".into())
+            })?;
+            if loaded_id != session_id {
+                return Err(AcpError::Protocol(format!(
+                    "session/load returned unexpected sessionId: expected {session_id}, got {loaded_id}"
+                )));
+            }
+        }
+        tracing::info!(target: "acp::session", "session loaded: {session_id}");
+        Ok(SessionNewResponse {
+            session_id: session_id.to_owned(),
+            raw: result,
+        })
+    }
+
     /// Send `session/new` and return only the `sessionId` string.
     ///
     /// Convenience wrapper around [`session_new_full`].
@@ -781,6 +825,7 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        self.turn_response_text.clear();
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -899,6 +944,11 @@ impl AcpClient {
     pub(crate) fn notify_session_spawned(&mut self, session_id: &str) {
         self.goose_usage.seed_zero_baseline(session_id);
         self.standard_usage.seed_zero_baseline(session_id);
+    }
+
+    /// Consume the human-facing text streamed by the most recent ACP turn.
+    pub fn take_turn_response_text(&mut self) -> String {
+        std::mem::take(&mut self.turn_response_text)
     }
 
     /// Install a per-turn steer request channel for goose-native
@@ -1755,6 +1805,7 @@ impl AcpClient {
         match update_type {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
+                    self.turn_response_text.push_str(text);
                     tracing::info!(target: "acp::stream", "{text}");
                 }
                 false
@@ -3491,6 +3542,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_load_full_uses_exact_id_and_never_calls_new() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}'
+            read -t 2 REQ
+            echo '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"81d9a95e-c9c0-4c78-b5ab-c52c5549d321","_receivedRequest":'"$REQ"'}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+
+        let resp = client
+            .session_load_full("81d9a95e-c9c0-4c78-b5ab-c52c5549d321", "/tmp", vec![])
+            .await
+            .expect("session_load_full should succeed");
+
+        assert_eq!(resp.session_id, "81d9a95e-c9c0-4c78-b5ab-c52c5549d321");
+        let received = &resp.raw["_receivedRequest"];
+        assert_eq!(received["method"], "session/load");
+        assert_eq!(
+            received["params"]["sessionId"],
+            "81d9a95e-c9c0-4c78-b5ab-c52c5549d321"
+        );
+        assert_eq!(received["params"]["cwd"], "/tmp");
+    }
+
+    #[tokio::test]
+    async fn session_load_full_accepts_standard_response_without_session_id() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}'
+            read -t 2 _load
+            echo '{"jsonrpc":"2.0","id":1,"result":{"configOptions":[]}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        let resp = client
+            .session_load_full("81d9a95e-c9c0-4c78-b5ab-c52c5549d321", "/tmp", vec![])
+            .await
+            .expect("standard load response should succeed");
+        assert_eq!(resp.session_id, "81d9a95e-c9c0-4c78-b5ab-c52c5549d321");
+    }
+
+    #[tokio::test]
+    async fn session_load_full_rejects_mismatched_echoed_session_id() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}'
+            read -t 2 _load
+            echo '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"3f3aeee9-1347-43c4-ac0d-b0cbe77dfabc"}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        let error = match client
+            .session_load_full("81d9a95e-c9c0-4c78-b5ab-c52c5549d321", "/tmp", vec![])
+            .await
+        {
+            Ok(_) => panic!("mismatched load response must fail closed"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("unexpected sessionId"));
+    }
+
+    #[tokio::test]
     async fn goose_system_prompt_request_uses_set_contract() {
         let script = r#"
             read -t 2 REQ
@@ -3720,6 +3846,28 @@ mod tests {
         AcpClient::spawn("cat", &[], &[], false)
             .await
             .expect("spawn cat as inert client")
+    }
+
+    #[tokio::test]
+    async fn agent_message_chunks_accumulate_and_take_drains_response() {
+        let mut client = spawn_inert_client().await;
+        for text in ["Morning ", "listener proof"] {
+            let msg = serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": "test-session",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": { "type": "text", "text": text }
+                    }
+                }
+            });
+            assert!(!client.handle_session_update(&msg));
+        }
+
+        assert_eq!(client.take_turn_response_text(), "Morning listener proof");
+        assert_eq!(client.take_turn_response_text(), "");
     }
 
     /// Build a `session/update` JSON-RPC notification carrying a

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -3437,8 +3437,10 @@ mod tests {
 
     #[tokio::test]
     async fn keepalive_resets_idle_past_deadline() {
-        // Keepalive session/update lines every 50ms against a 100ms idle deadline.
-        // The turn should survive well past the 100ms deadline (proves the fix).
+        // Keepalive session/update lines every 50ms against a 300ms idle deadline.
+        // The turn should survive well past the 300ms deadline (proves the fix).
+        // Keep the gap comfortably below the deadline so this remains stable
+        // under the full test suite's process-scheduling load.
         let mut client = spawn_script(
             r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"keepalive"}}}'; sleep 0.05; done; sleep 10"#,
         )
@@ -3450,16 +3452,16 @@ mod tests {
             .read_until_response_with_idle_timeout(
                 "test",
                 999,
-                std::time::Duration::from_millis(100),
+                std::time::Duration::from_millis(300),
                 hard_deadline,
                 max_dur,
             )
             .await;
         let elapsed = start.elapsed();
-        // 20 keepalives × 50ms = ~1000ms of activity, then idle fires after 100ms more.
-        // Must survive well past the 100ms deadline.
+        // 20 keepalives × 50ms = ~1000ms of activity, then idle fires after 300ms more.
+        // Must survive well past the initial 300ms deadline.
         assert!(
-            elapsed >= std::time::Duration::from_millis(500),
+            elapsed >= std::time::Duration::from_millis(800),
             "keepalive should reset idle past the deadline; elapsed only {elapsed:?}"
         );
         assert!(elapsed < std::time::Duration::from_secs(5));

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -521,6 +521,41 @@ pub struct ChannelFilter {
     pub require_mention: bool,
 }
 
+/// Operator-owned routing metadata for a Buzz channel.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChannelRoute {
+    /// Logical ACP session route. Channels with the same route may share one
+    /// continuing session while keeping their Buzz channel UUIDs distinct.
+    pub session_route: Option<String>,
+    /// Authoritative role framing rendered into each turn for this channel.
+    pub role_authority: Option<String>,
+}
+
+/// Stable key used to choose which ACP session a channel turn should reuse.
+///
+/// The default route is the concrete Buzz channel UUID. Config rules may assign
+/// several channels to the same named route so one continuing ACP session can
+/// serve several role forums while prompts, replies, and observer frames still
+/// carry the triggering channel UUID.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SessionRouteKey {
+    Channel(Uuid),
+    Named(String),
+}
+
+impl SessionRouteKey {
+    pub fn for_channel(channel_id: Uuid) -> Self {
+        Self::Channel(channel_id)
+    }
+
+    pub fn label(&self) -> String {
+        match self {
+            Self::Channel(channel_id) => channel_id.to_string(),
+            Self::Named(route) => route.clone(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Config {
     pub keys: Keys,
@@ -672,6 +707,77 @@ pub(crate) fn compose_session_title(agent: &str, channel_name: Option<&str>) -> 
     format!("{agent}{SESSION_TITLE_SEPARATOR}#{channel}")
 }
 
+fn sanitize_session_route(raw: &str) -> Option<String> {
+    let collapsed = raw
+        .split_whitespace()
+        .map(|word| word.chars().filter(|c| !c.is_control()).collect::<String>())
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    let route = collapsed
+        .trim_matches(['-', '/', '.', '_'])
+        .chars()
+        .take(128)
+        .collect::<String>();
+    if route.is_empty() {
+        None
+    } else {
+        Some(route)
+    }
+}
+
+/// Resolve the configured ACP-session route for a channel.
+///
+/// Absent `session_route` preserves the historic behavior: one ACP session key
+/// per Buzz channel. If more than one matching rule names different routes for
+/// the same channel, startup/dynamic subscription fails closed because the
+/// operator config no longer has one authoritative route for that channel.
+pub fn resolve_session_route_key(
+    channel_id: Uuid,
+    rules: &[SubscriptionRule],
+) -> Result<SessionRouteKey, ConfigError> {
+    let mut route: Option<String> = None;
+    for rule in rules {
+        if !rule.channels.matches(&channel_id) {
+            continue;
+        }
+        let Some(raw_route) = rule.session_route.as_deref() else {
+            continue;
+        };
+        let Some(normalized) = sanitize_session_route(raw_route) else {
+            return Err(ConfigError::ConfigFile(format!(
+                "subscription rule '{}' has an empty session_route",
+                rule.name
+            )));
+        };
+        match route.as_ref() {
+            Some(existing) if existing != &normalized => {
+                return Err(ConfigError::ConfigFile(format!(
+                    "channel {channel_id} matches conflicting session_route values \
+                     ('{existing}' and '{normalized}')"
+                )));
+            }
+            Some(_) => {}
+            None => route = Some(normalized),
+        }
+    }
+
+    Ok(route
+        .map(SessionRouteKey::Named)
+        .unwrap_or_else(|| SessionRouteKey::for_channel(channel_id)))
+}
+
+pub fn resolve_session_route_keys(
+    channel_ids: &[Uuid],
+    rules: &[SubscriptionRule],
+) -> Result<HashMap<Uuid, SessionRouteKey>, ConfigError> {
+    channel_ids
+        .iter()
+        .copied()
+        .map(|channel_id| resolve_session_route_key(channel_id, rules).map(|key| (channel_id, key)))
+        .collect()
+}
+
 /// Validate and deduplicate allowlist entries: each must be exactly 64 hex chars.
 fn validate_allowlist(entries: &[String]) -> Result<HashSet<String>, ConfigError> {
     let mut validated = HashSet::new();
@@ -711,6 +817,34 @@ fn validate_multiple_event_handling(
              producing incomplete merged prompts."
                 .into(),
         ));
+    }
+    Ok(())
+}
+
+fn validate_optional_rule_text(
+    rule_name: &str,
+    field_name: &str,
+    value: &Option<String>,
+) -> Result<(), ConfigError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(ConfigError::ConfigFile(format!(
+            "rule '{rule_name}': {field_name} must not be empty when set"
+        )));
+    }
+    if trimmed.chars().any(char::is_control) {
+        return Err(ConfigError::ConfigFile(format!(
+            "rule '{rule_name}': {field_name} must not contain control characters"
+        )));
+    }
+    if trimmed.len() > 4096 {
+        return Err(ConfigError::ConfigFile(format!(
+            "rule '{rule_name}': {field_name} too long ({} bytes, max 4096)",
+            trimmed.len()
+        )));
     }
     Ok(())
 }
@@ -1292,6 +1426,8 @@ pub fn load_rules(path: &std::path::Path) -> Result<Vec<SubscriptionRule>, Confi
                 )));
             }
         }
+        validate_optional_rule_text(&rule.name, "session_route", &rule.session_route)?;
+        validate_optional_rule_text(&rule.name, "role_authority", &rule.role_authority)?;
         // Deserialization leaves consecutive_timeouts at its zero default; reset explicitly.
         rule.consecutive_timeouts = Arc::new(AtomicU32::new(0));
     }
@@ -1391,6 +1527,90 @@ pub fn resolve_channel_filters(
     }
 
     result
+}
+
+/// Resolve operator-owned channel routing metadata from config rules.
+///
+/// Only fields explicitly present on matching rules participate. A channel may
+/// match several subscription rules, but its session route and role authority
+/// must each resolve to at most one distinct value. Conflicts reject startup
+/// rather than letting a Forum name or rule order become an authority boundary.
+pub fn resolve_channel_routes(
+    discovered_channels: &[Uuid],
+    rules: &[SubscriptionRule],
+) -> Result<HashMap<Uuid, ChannelRoute>, ConfigError> {
+    let mut result = HashMap::new();
+
+    for channel_id in discovered_channels {
+        let mut session_route: Option<String> = None;
+        let mut session_route_source: Option<String> = None;
+        let mut role_authority: Option<String> = None;
+        let mut role_authority_source: Option<String> = None;
+
+        for rule in rules {
+            if !rule_applies_to_channel(rule, *channel_id) {
+                continue;
+            }
+
+            if let Some(raw_route) = rule.session_route.as_deref() {
+                let Some(route) = sanitize_session_route(raw_route) else {
+                    return Err(ConfigError::ConfigFile(format!(
+                        "subscription rule '{}' has an empty session_route",
+                        rule.name
+                    )));
+                };
+                match session_route.as_deref() {
+                    Some(existing) if existing != route.as_str() => {
+                        return Err(ConfigError::ConfigFile(format!(
+                            "channel {channel_id} has conflicting session_route values: \
+                             rule '{}' set {:?}, rule '{}' set {:?}",
+                            session_route_source.as_deref().unwrap_or("<unknown>"),
+                            existing,
+                            rule.name,
+                            route
+                        )));
+                    }
+                    Some(_) => {}
+                    None => {
+                        session_route = Some(route);
+                        session_route_source = Some(rule.name.clone());
+                    }
+                }
+            }
+
+            if let Some(authority) = rule.role_authority.as_deref().map(str::trim) {
+                match role_authority.as_deref() {
+                    Some(existing) if existing != authority => {
+                        return Err(ConfigError::ConfigFile(format!(
+                            "channel {channel_id} has conflicting role_authority values: \
+                             rule '{}' set {:?}, rule '{}' set {:?}",
+                            role_authority_source.as_deref().unwrap_or("<unknown>"),
+                            existing,
+                            rule.name,
+                            authority
+                        )));
+                    }
+                    Some(_) => {}
+                    None => {
+                        role_authority = Some(authority.to_string());
+                        role_authority_source = Some(rule.name.clone());
+                    }
+                }
+            }
+        }
+
+        if session_route.is_some() || role_authority.is_some() {
+            result.insert(
+                *channel_id,
+                ChannelRoute {
+                    session_route,
+                    role_authority,
+                },
+            );
+        }
+    }
+
+    Ok(result)
 }
 
 /// Resolve the subscription filter for a single dynamically-discovered channel.
@@ -1564,6 +1784,8 @@ mod tests {
             require_mention: mention,
             filter: None,
             prompt_tag: None,
+            session_route: None,
+            role_authority: None,
             compiled_filter: None,
             consecutive_timeouts: Arc::new(AtomicU32::new(0)),
         }
@@ -2040,6 +2262,136 @@ require_mention = false
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].name, "catch-all");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_load_rules_accepts_route_metadata() {
+        let dir = std::env::temp_dir().join("buzz-acp-test-route-metadata");
+        let path = dir.join("rules.toml");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            &path,
+            r#"
+[[rules]]
+name = "platform"
+channels = "all"
+kinds = [9]
+require_mention = true
+session_route = "down-platform"
+role_authority = "You are Down acting as Platform Circle Lead."
+"#,
+        )
+        .unwrap();
+
+        let rules = load_rules(&path).unwrap();
+        assert_eq!(rules[0].session_route.as_deref(), Some("down-platform"));
+        assert_eq!(
+            rules[0].role_authority.as_deref(),
+            Some("You are Down acting as Platform Circle Lead.")
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_resolve_channel_routes_maps_shared_session_route() {
+        let ch_a = Uuid::new_v4();
+        let ch_b = Uuid::new_v4();
+        let mut rule = make_rule(
+            "down-forums",
+            ChannelScope::List(vec![ch_a.to_string(), ch_b.to_string()]),
+            vec![9],
+            true,
+        );
+        rule.session_route = Some("down-role-forums".into());
+        rule.role_authority = Some("Down owns Platform Circle authority.".into());
+
+        let routes = resolve_channel_routes(&[ch_a, ch_b], &[rule]).unwrap();
+
+        assert_eq!(
+            routes[&ch_a].session_route.as_deref(),
+            Some("down-role-forums")
+        );
+        assert_eq!(
+            routes[&ch_b].role_authority.as_deref(),
+            Some("Down owns Platform Circle authority.")
+        );
+    }
+
+    #[test]
+    fn test_resolve_channel_routes_normalizes_session_route() {
+        let ch = Uuid::new_v4();
+        let mut rule = make_rule(
+            "down-forums",
+            ChannelScope::List(vec![ch.to_string()]),
+            vec![9],
+            true,
+        );
+        rule.session_route = Some(" down role forums ".into());
+
+        let routes = resolve_channel_routes(&[ch], &[rule]).unwrap();
+
+        assert_eq!(
+            routes[&ch].session_route.as_deref(),
+            Some("down-role-forums")
+        );
+    }
+
+    #[test]
+    fn test_resolve_session_route_keys_maps_shared_route() {
+        let ch_a = Uuid::new_v4();
+        let ch_b = Uuid::new_v4();
+        let mut rule = make_rule(
+            "down-forums",
+            ChannelScope::List(vec![ch_a.to_string(), ch_b.to_string()]),
+            vec![9],
+            true,
+        );
+        rule.session_route = Some("down role forums".into());
+
+        let routes = resolve_session_route_keys(&[ch_a, ch_b], &[rule]).unwrap();
+
+        assert_eq!(
+            routes.get(&ch_a),
+            Some(&SessionRouteKey::Named("down-role-forums".into()))
+        );
+        assert_eq!(routes.get(&ch_a), routes.get(&ch_b));
+    }
+
+    #[test]
+    fn test_resolve_session_route_keys_defaults_to_channel_route() {
+        let ch = Uuid::new_v4();
+        let rule = make_rule(
+            "plain",
+            ChannelScope::List(vec![ch.to_string()]),
+            vec![9],
+            true,
+        );
+
+        let routes = resolve_session_route_keys(&[ch], &[rule]).unwrap();
+
+        assert_eq!(routes.get(&ch), Some(&SessionRouteKey::for_channel(ch)));
+    }
+
+    #[test]
+    fn test_resolve_channel_routes_rejects_conflicting_session_routes() {
+        let ch = Uuid::new_v4();
+        let mut first = make_rule(
+            "first",
+            ChannelScope::List(vec![ch.to_string()]),
+            vec![9],
+            true,
+        );
+        first.session_route = Some("down-a".into());
+        let mut second = make_rule(
+            "second",
+            ChannelScope::List(vec![ch.to_string()]),
+            vec![9],
+            true,
+        );
+        second.session_route = Some("down-b".into());
+
+        let err = resolve_channel_routes(&[ch], &[first, second]).unwrap_err();
+        assert!(err.to_string().contains("conflicting session_route"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -443,6 +443,13 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_SESSION_TITLE")]
     pub session_title: Option<String>,
 
+    /// Load one exact existing ACP session for the single configured channel.
+    /// Fails closed if the adapter cannot load that ID; never falls back to a
+    /// new session. Restricted to one agent, one channel, no heartbeat, and no
+    /// proactive session rotation.
+    #[arg(long, env = "BUZZ_ACP_LOAD_SESSION_ID")]
+    pub load_session_id: Option<String>,
+
     /// Permission mode for agents that support `session/set_config_option`
     /// with `configId: "mode"` (e.g. `claude-agent-acp`).
     ///
@@ -563,6 +570,8 @@ pub struct Config {
     /// Sanitized session title, sent as `_meta.sessionTitle` on `session/new`.
     /// `None` when unset or when the configured value sanitized to empty.
     pub session_title: Option<String>,
+    /// Exact existing ACP session ID to load for the single configured channel.
+    pub load_session_id: Option<String>,
     /// Permission mode to apply after session creation. `Default` = skip.
     pub permission_mode: PermissionMode,
     /// Inbound author gate mode.
@@ -1091,6 +1100,25 @@ impl Config {
 
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
 
+        let load_session_id = if let Some(raw) = args.load_session_id.as_deref() {
+            let parsed = Uuid::parse_str(raw.trim()).map_err(|_| {
+                ConfigError::ConfigFile("load_session_id must be a canonical UUID".into())
+            })?;
+            if args.agents != 1
+                || args.heartbeat_interval != 0
+                || args.max_turns_per_session != 0
+                || args.channels.as_ref().map(Vec::len) != Some(1)
+            {
+                return Err(ConfigError::ConfigFile(
+                    "load_session_id requires exactly one agent, one --channels value, heartbeat disabled, and session rotation disabled"
+                        .into(),
+                ));
+            }
+            Some(parsed.to_string())
+        } else {
+            None
+        };
+
         let config = Config {
             keys,
             relay_url: args.relay_url,
@@ -1130,6 +1158,7 @@ impl Config {
                 .session_title
                 .as_deref()
                 .and_then(sanitize_session_title),
+            load_session_id,
             permission_mode: args.permission_mode,
             respond_to: args.respond_to,
             respond_to_allowlist,
@@ -1503,6 +1532,7 @@ mod tests {
             model: None,
             effort_level: None,
             session_title: None,
+            load_session_id: None,
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,
             respond_to_allowlist: HashSet::new(),
@@ -2877,6 +2907,43 @@ channels = "ALL"
             result.is_ok(),
             "from_args should accept any mode when allowed list is unset: {result:?}"
         );
+    }
+
+    #[test]
+    fn load_session_full_path_accepts_exact_single_channel_scope() {
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--channels",
+            "de5e9091-05fe-4719-beaf-81ebf679ad48",
+            "--load-session-id",
+            "81d9a95e-c9c0-4c78-b5ab-c52c5549d321",
+        ])
+        .expect("clap should parse args");
+        let config = Config::from_args(args).expect("exact single-channel load should pass");
+        assert_eq!(
+            config.load_session_id.as_deref(),
+            Some("81d9a95e-c9c0-4c78-b5ab-c52c5549d321")
+        );
+    }
+
+    #[test]
+    fn load_session_full_path_rejects_multi_channel_scope() {
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--channels",
+            "de5e9091-05fe-4719-beaf-81ebf679ad48,13cd8c52-cd0b-427c-bace-8a606866a689",
+            "--load-session-id",
+            "81d9a95e-c9c0-4c78-b5ab-c52c5549d321",
+        ])
+        .expect("clap should parse args");
+        let error = Config::from_args(args).expect_err("multi-channel load must fail closed");
+        assert!(error
+            .to_string()
+            .contains("exactly one agent, one --channels"));
     }
 
     // --- max_turn_duration ceiling gate ---

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -97,6 +97,14 @@ pub struct SubscriptionRule {
     /// Tag passed to the prompt template. Falls back to `name` if absent.
     #[serde(default)]
     pub prompt_tag: Option<String>,
+    /// Optional logical session route. Rules with the same route can share one
+    /// ACP session across multiple Buzz channels.
+    #[serde(default)]
+    pub session_route: Option<String>,
+    /// Optional authoritative role framing rendered into each matched turn.
+    /// This is operator-owned config, never derived from the channel name.
+    #[serde(default)]
+    pub role_authority: Option<String>,
     /// Pre-compiled evalexpr AST for the `filter` expression.
     ///
     /// Populated by `load_rules()` at startup so `match_event` never re-parses
@@ -122,6 +130,8 @@ impl Default for SubscriptionRule {
             require_mention: false,
             filter: None,
             prompt_tag: None,
+            session_route: None,
+            role_authority: None,
             compiled_filter: None,
             consecutive_timeouts: Arc::new(AtomicU32::new(0)),
         }
@@ -137,6 +147,8 @@ impl Clone for SubscriptionRule {
             require_mention: self.require_mention,
             filter: self.filter.clone(),
             prompt_tag: self.prompt_tag.clone(),
+            session_route: self.session_route.clone(),
+            role_authority: self.role_authority.clone(),
             compiled_filter: self.compiled_filter.clone(),
             // Share the same counter across clones so all copies of a rule
             // agree on the timeout state.
@@ -503,6 +515,8 @@ mod tests {
             require_mention: mention,
             filter: filter.map(|s| s.into()),
             prompt_tag: prompt_tag.map(|s| s.into()),
+            session_route: None,
+            role_authority: None,
             compiled_filter: None,
             consecutive_timeouts: Arc::new(AtomicU32::new(0)),
         }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2201,6 +2201,7 @@ async fn tokio_main() -> Result<()> {
         dedup_mode: config.dedup_mode,
         system_prompt: config.system_prompt.clone(),
         session_title: config.session_title.clone(),
+        load_session_id: config.load_session_id.clone(),
         team_instructions: config.team_instructions.clone(),
         base_prompt: if config.no_base_prompt {
             None
@@ -6821,6 +6822,7 @@ mod build_mcp_servers_tests {
             model: None,
             effort_level: None,
             session_title: None,
+            load_session_id: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
             respond_to_allowlist: std::collections::HashSet::new(),
@@ -7045,6 +7047,7 @@ mod error_outcome_emission_tests {
             model: None,
             effort_level: None,
             session_title: None,
+            load_session_id: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
             respond_to_allowlist: HashSet::new(),

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -33,7 +33,7 @@ use buzz_core::observer::{
 use clap::Parser;
 use config::{
     AuthAgentArgs, AuthMethodsArgs, AuthenticateArgs, Config, DedupMode, ModelsArgs,
-    MultipleEventHandling, RespondTo, SubscribeMode,
+    MultipleEventHandling, RespondTo, SessionRouteKey, SubscribeMode,
 };
 use filter::SubscriptionRule;
 use futures_util::FutureExt;
@@ -1087,6 +1087,7 @@ fn handle_relay_observer_control_event(
     keys: &nostr::Keys,
     event: nostr::Event,
     pool: &mut AgentPool,
+    ctx: &PromptContext,
     observer: Option<&observer::ObserverHandle>,
     owner_pubkey_hex: &str,
     event_publisher: RelayEventPublisher,
@@ -1133,7 +1134,7 @@ fn handle_relay_observer_control_event(
             handle_cancel_turn_control(&payload, pool, observer);
         }
         Some("switch_model") => {
-            handle_switch_model_control(&payload, pool, observer);
+            handle_switch_model_control(&payload, pool, ctx, observer);
         }
         Some("publish_project_owner_announcements") => {
             handle_publish_project_owner_announcements_control(
@@ -1340,6 +1341,7 @@ fn handle_cancel_turn_control(
 fn handle_switch_model_control(
     payload: &serde_json::Value,
     pool: &mut AgentPool,
+    ctx: &PromptContext,
     observer: Option<&observer::ObserverHandle>,
 ) {
     let Some(channel_id) = payload
@@ -1388,7 +1390,8 @@ fn handle_switch_model_control(
         }
     } else {
         // Idle path: validate against the cached catalog before invalidating.
-        match pool.switch_idle_agent_model(channel_id, model_id, request_id.clone()) {
+        let route_key = ctx.session_route_key(channel_id);
+        match pool.switch_idle_agent_model(&route_key, model_id, request_id.clone()) {
             IdleSwitchResult::Switched => "switched",
             IdleSwitchResult::UnsupportedModel => "unsupported_model",
             IdleSwitchResult::NoIdleAgent => "no_active_turn",
@@ -2114,6 +2117,8 @@ async fn tokio_main() -> Result<()> {
                 }),
                 require_mention: !config.no_mention_filter,
                 filter: None,
+                session_route: None,
+                role_authority: None,
                 compiled_filter: None,
                 consecutive_timeouts: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
                 prompt_tag: Some("@mention".into()),
@@ -2126,6 +2131,8 @@ async fn tokio_main() -> Result<()> {
                 kinds: config.kinds_override.clone().unwrap_or_default(),
                 require_mention: false,
                 filter: None,
+                session_route: None,
+                role_authority: None,
                 compiled_filter: None,
                 consecutive_timeouts: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
                 prompt_tag: Some("all".into()),
@@ -2138,6 +2145,12 @@ async fn tokio_main() -> Result<()> {
     };
 
     let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let session_routes = config::resolve_session_route_keys(&channel_ids, &rules)?;
+    let channel_routes = config::resolve_channel_routes(&channel_ids, &rules)?;
+    let role_authorities: HashMap<Uuid, String> = channel_routes
+        .into_iter()
+        .filter_map(|(channel_id, route)| route.role_authority.map(|value| (channel_id, value)))
+        .collect();
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -2214,6 +2227,8 @@ async fn tokio_main() -> Result<()> {
         cwd,
         rest_client: relay.rest_client(),
         channel_info: pool::ChannelInfoResolver::new(channel_info_map, relay.rest_client()),
+        session_routes,
+        role_authorities,
         context_message_limit: config.context_message_limit,
         max_turns_per_session: config.max_turns_per_session,
         permission_mode: config.permission_mode,
@@ -2366,6 +2381,9 @@ async fn tokio_main() -> Result<()> {
     // returned to the pool, its sessions for these channels are stripped, and
     // failed/panicked batches for these channels are dropped instead of requeued.
     //
+    // Session invalidation is tracked separately by route so configured shared
+    // session routes are also stripped when any routed channel loses membership.
+    //
     // Cleared on re-add (KIND_MEMBER_ADDED_NOTIFICATION) so re-joined channels
     // regain session affinity.
     //
@@ -2379,6 +2397,7 @@ async fn tokio_main() -> Result<()> {
     // causal invalidation is needed, add a monotonic epoch counter per channel
     // and capture it in TaskMeta at dispatch time.
     let mut removed_channels: HashSet<Uuid> = HashSet::new();
+    let mut removed_session_routes: HashSet<SessionRouteKey> = HashSet::new();
 
     //
     // One SlotCircuit per agent slot. crash_times entries are pruned to the last
@@ -2611,6 +2630,7 @@ async fn tokio_main() -> Result<()> {
                                     &config.keys,
                                     event,
                                     &mut pool,
+                                    &ctx,
                                     observer.as_ref(),
                                     owner_hex,
                                     relay.event_publisher(),
@@ -2689,6 +2709,7 @@ async fn tokio_main() -> Result<()> {
                                     // Clear removal tracking so sessions are not
                                     // stripped for a legitimately re-added channel.
                                     removed_channels.remove(&ch);
+                                    removed_session_routes.remove(&ctx.session_route_key(ch));
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
@@ -2712,15 +2733,17 @@ async fn tokio_main() -> Result<()> {
                                     // removed channel. Events already in-flight will
                                     // complete normally (the relay may reject actions if
                                     // the agent lost access).
+                                    let route_key = ctx.session_route_key(ch);
                                     let drained_ids = queue.drain_channel(ch);
                                     let invalidated = if pool_ready {
-                                        pool.invalidate_channel_sessions(ch)
+                                        pool.invalidate_route_sessions(&route_key)
                                     } else {
                                         0
                                     };
                                     // Track removed channels so checked-out agents get
-                                    // their sessions stripped when they return to the pool.
+                                    // their routed sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
+                                    removed_session_routes.insert(route_key.clone());
                                     typing_channels.remove(&ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
@@ -2844,9 +2867,13 @@ async fn tokio_main() -> Result<()> {
                                                 "!rotate received — cancelling in-flight turn and rotating session"
                                             );
                                         } else {
-                                            let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id);
+                                            let route_key =
+                                                ctx.session_route_key(buzz_event.channel_id);
+                                            let invalidated =
+                                                pool.invalidate_route_sessions(&route_key);
                                             tracing::info!(
                                                 channel_id = %buzz_event.channel_id,
+                                                route = %route_key.label(),
                                                 invalidated,
                                                 "!rotate received — invalidated idle channel session(s)"
                                             );
@@ -3158,6 +3185,8 @@ async fn tokio_main() -> Result<()> {
                     *result,
                     &mut heartbeat_in_flight,
                     &removed_channels,
+                    &removed_session_routes,
+                    &ctx.session_routes,
                     &mut crash_history,
                     &respawn_tx,
                     &mut respawn_tasks,
@@ -3329,8 +3358,10 @@ async fn tokio_main() -> Result<()> {
                 );
                 if let Ok(pool::SteerAck::Success { session_id }) = &ack {
                     queue.extend_in_flight_deadline(channel_id, config.max_turn_duration_secs);
+                    let route_key = ctx.session_route_key(channel_id);
                     if !pool.record_successful_steer(
                         channel_id,
+                        &route_key,
                         event_id.clone(),
                         session_id.clone(),
                     ) {
@@ -3740,13 +3771,14 @@ fn dispatch_pending(
             None => break,
         };
         let channel_id = batch.channel_id;
+        let route_key = ctx.session_route_key(channel_id);
         let typing_scope = batch
             .events
             .last()
             .map(|event| queue::parse_thread_tags(&event.event))
             .unwrap_or_default();
-        let affinity_hit = pool.has_session_for(channel_id);
-        let mut agent = match pool.try_claim(Some(channel_id)) {
+        let affinity_hit = pool.has_session_for(&route_key);
+        let mut agent = match pool.try_claim(Some(&route_key)) {
             Some(a) => a,
             None => {
                 let pending = queue.pending_channels();
@@ -3756,7 +3788,13 @@ fn dispatch_pending(
                 break;
             }
         };
-        tracing::debug!(agent = agent.index, channel = %channel_id, affinity_hit, "agent_claimed");
+        tracing::debug!(
+            agent = agent.index,
+            channel = %channel_id,
+            route = %route_key.label(),
+            affinity_hit,
+            "agent_claimed"
+        );
 
         let recoverable_batch = match ctx.dedup_mode {
             DedupMode::Queue => Some(batch.clone()),
@@ -3882,6 +3920,8 @@ fn handle_prompt_result(
     mut result: PromptResult,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
+    removed_session_routes: &HashSet<SessionRouteKey>,
+    session_routes: &HashMap<Uuid, SessionRouteKey>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
@@ -3900,10 +3940,14 @@ fn handle_prompt_result(
         .retain(|_, meta| meta.agent_index != agent_index);
     debug_assert_eq!(before, pool.task_map().len() + 1);
     if let PromptSource::Channel(channel_id) = &result.source {
+        let route_key = session_routes
+            .get(channel_id)
+            .cloned()
+            .unwrap_or_else(|| SessionRouteKey::for_channel(*channel_id));
         // The task may have invalidated this session before returning. Never
         // resurrect delivery state for a dead session; its replacement must
         // receive fresh standing context and history.
-        if let Some(live_session_id) = result.agent.state.sessions.get(channel_id).cloned() {
+        if let Some(live_session_id) = result.agent.state.sessions.get(&route_key).cloned() {
             let event_ids = successful_steer_deliveries
                 .into_iter()
                 .filter(|delivery| delivery.session_id == live_session_id)
@@ -4038,11 +4082,11 @@ fn handle_prompt_result(
         PromptSource::Heartbeat => *heartbeat_in_flight = false,
     }
 
-    // Strip sessions for channels the agent was removed from while this
-    // agent was checked out. This covers the gap where invalidate_channel_sessions
-    // only touches idle agents.
-    for ch in removed_channels {
-        result.agent.state.invalidate_channel(ch);
+    // Strip sessions for routes the agent was removed from while this agent
+    // was checked out. This covers the gap where idle invalidation only
+    // touches agents currently in the pool.
+    for route_key in removed_session_routes {
+        result.agent.state.invalidate_route(route_key);
     }
 
     let outcome_label = match &result.outcome {
@@ -7107,12 +7151,13 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn successful_native_steer_is_transferred_to_live_session_delivery_state() {
         let channel_id = Uuid::new_v4();
+        let route_key = SessionRouteKey::for_channel(channel_id);
         let steer_event_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(route_key, "live-session".into());
         agent
             .state
             .deliveries
@@ -7164,6 +7209,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -7180,11 +7227,12 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn in_flight_stale_native_steer_ack_cannot_update_replacement_session() {
         let channel_id = Uuid::new_v4();
+        let route_key = SessionRouteKey::for_channel(channel_id);
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "replacement-session".into());
+            .insert(route_key, "replacement-session".into());
         agent
             .state
             .deliveries
@@ -7236,6 +7284,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -7252,12 +7302,13 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn successful_native_steer_ack_after_task_return_updates_matching_live_session() {
         let channel_id = Uuid::new_v4();
+        let route_key = SessionRouteKey::for_channel(channel_id);
         let steer_event_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(route_key.clone(), "live-session".into());
         agent
             .state
             .deliveries
@@ -7266,6 +7317,7 @@ mod error_outcome_emission_tests {
 
         assert!(pool.record_successful_steer(
             channel_id,
+            &route_key,
             steer_event_id.into(),
             "live-session".into(),
         ));
@@ -7278,11 +7330,12 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn late_native_steer_ack_cannot_update_replacement_session() {
         let channel_id = Uuid::new_v4();
+        let route_key = SessionRouteKey::for_channel(channel_id);
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "replacement-session".into());
+            .insert(route_key.clone(), "replacement-session".into());
         agent
             .state
             .deliveries
@@ -7291,6 +7344,7 @@ mod error_outcome_emission_tests {
 
         assert!(!pool.record_successful_steer(
             channel_id,
+            &route_key,
             "stale-event".into(),
             "old-session".into(),
         ));
@@ -7350,6 +7404,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -7413,6 +7469,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -7580,6 +7638,8 @@ mod error_outcome_emission_tests {
                 result,
                 &mut heartbeat_in_flight,
                 &removed_channels,
+                &HashSet::new(),
+                &HashMap::new(),
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
@@ -7671,6 +7731,8 @@ mod error_outcome_emission_tests {
                 result,
                 &mut heartbeat_in_flight,
                 &removed_channels,
+                &HashSet::new(),
+                &HashMap::new(),
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
@@ -7777,6 +7839,8 @@ mod error_outcome_emission_tests {
                 result,
                 &mut heartbeat_in_flight,
                 &removed_channels,
+                &HashSet::new(),
+                &HashMap::new(),
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
@@ -7869,6 +7933,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -7963,6 +8029,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8079,6 +8147,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8212,6 +8282,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8291,10 +8363,11 @@ mod error_outcome_emission_tests {
         };
 
         let mut agent = dummy_agent(0).await;
+        let route_key = SessionRouteKey::for_channel(channel_id);
         agent
             .state
             .sessions
-            .insert(channel_id, "healthy-session".into());
+            .insert(route_key.clone(), "healthy-session".into());
         let mut pool = AgentPool::from_slots(vec![None]);
         let task_id = pool.join_set.spawn(async {}).id();
         pool.task_map_mut().insert(
@@ -8338,6 +8411,8 @@ mod error_outcome_emission_tests {
                 result,
                 &mut heartbeat_in_flight,
                 &removed_channels,
+                &HashSet::new(),
+                &HashMap::new(),
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
@@ -8351,7 +8426,7 @@ mod error_outcome_emission_tests {
             .as_ref()
             .expect("healthy agent returns to its slot");
         assert_eq!(
-            returned.state.sessions.get(&channel_id).map(String::as_str),
+            returned.state.sessions.get(&route_key).map(String::as_str),
             Some("healthy-session")
         );
         assert_eq!(queue.queued_event_count(&channel_id), 1);
@@ -8483,6 +8558,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
@@ -8569,6 +8646,8 @@ mod error_outcome_emission_tests {
             result,
             &mut heartbeat_in_flight,
             &removed_channels,
+            &HashSet::new(),
+            &HashMap::new(),
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -38,8 +38,8 @@ use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
 use crate::prompt_project::{pick_authoritative_project_home, PromptProjectInfo};
 use crate::queue::{
-    CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
-    PromptProfile, PromptProfileLookup, ThreadTags,
+    parse_thread_tags, CancelReason, ContextMessage, ConversationContext, FlushBatch,
+    PromptChannelInfo, PromptProfile, PromptProfileLookup, ThreadTags,
 };
 use crate::relay::{ChannelInfo, RestClient};
 
@@ -703,6 +703,8 @@ pub struct PromptContext {
     /// Sanitized title for each new ACP session, sent as `_meta.sessionTitle`
     /// on `session/new`. Never part of the prompt.
     pub session_title: Option<String>,
+    /// Exact existing session to load for the single configured channel.
+    pub load_session_id: Option<String>,
     pub team_instructions: Option<String>,
     pub heartbeat_prompt: Option<String>,
     /// Base prompt content, or `None` if `--no-base-prompt` was passed.
@@ -1142,20 +1144,27 @@ async fn create_session_and_apply_model(
         ctx.session_title.as_deref(),
     );
 
-    let resp = agent
-        .acp
-        .session_new_full(
-            &ctx.cwd,
-            mcp_servers,
-            session_new_system_prompt(
-                is_goose,
-                agent.protocol_version,
-                &agent.agent_name,
-                combined_system_prompt.as_deref(),
-            ),
-            session_title.as_deref(),
-        )
-        .await?;
+    let resp = if let Some(existing_session_id) = ctx.load_session_id.as_deref() {
+        agent
+            .acp
+            .session_load_full(existing_session_id, &ctx.cwd, mcp_servers)
+            .await?
+    } else {
+        agent
+            .acp
+            .session_new_full(
+                &ctx.cwd,
+                mcp_servers,
+                session_new_system_prompt(
+                    is_goose,
+                    agent.protocol_version,
+                    &agent.agent_name,
+                    combined_system_prompt.as_deref(),
+                ),
+                session_title.as_deref(),
+            )
+            .await?
+    };
 
     if is_goose && agent.goose_system_prompt_supported != Some(false) {
         if let Some(prompt) = combined_system_prompt.as_deref() {
@@ -1954,6 +1963,24 @@ pub async fn run_prompt_task(
         .unwrap_or_default();
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
 
+    // The reply destination is fixed from the triggering batch before any
+    // prompt work begins. A fresh root has no NIP-10 tags, so make that event
+    // both root and parent; an already-threaded event preserves its root and
+    // replies to the latest triggering event.
+    let response_thread_tags = batch.as_ref().and_then(|b| {
+        b.events.last().map(|be| {
+            let mut tags = parse_thread_tags(&be.event);
+            if tags.root_event_id.is_none() {
+                let event_id = be.event.id.to_hex();
+                tags.root_event_id = Some(event_id.clone());
+                tags.parent_event_id = Some(event_id);
+            } else {
+                tags.parent_event_id = Some(be.event.id.to_hex());
+            }
+            tags
+        })
+    });
+
     // Resolve project authority exactly once, before any ACP session creation or
     // initial-message delivery. An indeterminate result is a local relay-state
     // outcome: fail closed and preserve the batch without poisoning the healthy
@@ -2137,9 +2164,11 @@ pub async fn run_prompt_task(
                             .state
                             .deliveries
                             .insert(*cid, ChannelDeliveryState::default());
-                        // Seed a zero usage baseline: buzz-acp spawned this session
-                        // so prior usage is zero by definition — first turn is reliable.
-                        agent.acp.notify_session_spawned(&sid);
+                        if ctx.load_session_id.is_none() {
+                            // Seed a zero usage baseline: buzz-acp spawned this session
+                            // so prior usage is zero by definition — first turn is reliable.
+                            agent.acp.notify_session_spawned(&sid);
+                        }
                         // Commit canvas only after session creation succeeds (I3).
                         if let Some((pending_cid, section)) = pending_canvas.take() {
                             agent.state.canvas_sections.insert(pending_cid, section);
@@ -2199,8 +2228,10 @@ pub async fn run_prompt_task(
                             agent.index
                         );
                         agent.state.heartbeat_session = Some(sid.clone());
-                        // Seed a zero usage baseline: buzz-acp spawned this session.
-                        agent.acp.notify_session_spawned(&sid);
+                        if ctx.load_session_id.is_none() {
+                            // Seed a zero usage baseline: buzz-acp spawned this session.
+                            agent.acp.notify_session_spawned(&sid);
+                        }
                         (sid, true)
                     }
                     Err(AcpError::AgentExited) => {
@@ -2789,6 +2820,44 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+
+            // Exact-session adapters such as OpenClaw return their answer as
+            // ACP message chunks and do not execute Buzz's send-message tool.
+            // Publish that output here, and fail the turn if publication does
+            // not receive a relay acknowledgement so the batch is retried
+            // instead of being silently consumed.
+            let response_text = agent.acp.take_turn_response_text();
+            if ctx.load_session_id.is_some() && !response_text.trim().is_empty() {
+                if let (PromptSource::Channel(channel_id), Some(thread_tags)) =
+                    (&source, response_thread_tags.as_ref())
+                {
+                    if let Err(error) = post_acp_response(
+                        &ctx.rest_client,
+                        *channel_id,
+                        thread_tags,
+                        response_text.trim(),
+                    )
+                    .await
+                    {
+                        tracing::error!(
+                            channel = %channel_id,
+                            "ACP final-response publication failed: {error}"
+                        );
+                        send_prompt_result(
+                            &result_tx,
+                            &turn_id,
+                            agent,
+                            source,
+                            PromptOutcome::Error(AcpError::Protocol(format!(
+                                "ACP final-response publication failed: {error}"
+                            ))),
+                            batch,
+                        );
+                        return;
+                    }
+                    tracing::info!(channel = %channel_id, "published ACP final response");
+                }
+            }
 
             if let PromptSource::Channel(cid) = &source {
                 let standing_sent = !agent.has_system_prompt_support();
@@ -4794,6 +4863,41 @@ pub(crate) async fn post_failure_notice(
         Ok(Err(e)) => tracing::warn!(channel = %channel_id, "failure notice failed: {e}"),
         Err(_) => tracing::warn!(channel = %channel_id, "failure notice timed out"),
     }
+}
+
+/// Publish text returned through ACP's `agent_message_chunk` stream as a
+/// signed Buzz reply. This is used by exact-session adapters (notably
+/// OpenClaw), whose final answer is ACP output rather than a `buzz` tool call.
+async fn post_acp_response(
+    rest: &crate::relay::RestClient,
+    channel_id: Uuid,
+    thread_tags: &ThreadTags,
+    content: &str,
+) -> Result<(), String> {
+    let root = thread_tags
+        .root_event_id
+        .as_deref()
+        .ok_or_else(|| "ACP response has no triggering root".to_string())?;
+    let root_id = nostr::EventId::from_hex(root).map_err(|e| format!("invalid root id: {e}"))?;
+    let parent_id = thread_tags
+        .parent_event_id
+        .as_deref()
+        .and_then(|id| nostr::EventId::from_hex(id).ok())
+        .unwrap_or(root_id);
+    let thread_ref = buzz_sdk::ThreadRef {
+        root_event_id: root_id,
+        parent_event_id: parent_id,
+    };
+    let builder = buzz_sdk::build_message(channel_id, content, Some(&thread_ref), &[], false, &[])
+        .map_err(|e| format!("build failed: {e}"))?;
+    let event = builder
+        .sign_with_keys(&rest.keys)
+        .map_err(|e| format!("sign failed: {e}"))?;
+    tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event))
+        .await
+        .map_err(|_| "publication timed out".to_string())?
+        .map_err(|e| format!("publication failed: {e}"))?;
+    Ok(())
 }
 
 /// Best-effort: remove a reaction via a signed kind:5 (NIP-09) deletion event.
@@ -8209,6 +8313,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             dedup_mode: DedupMode::Drop,
             system_prompt: None,
             session_title: None,
+            load_session_id: None,
             team_instructions: None,
             heartbeat_prompt: None,
             base_prompt: None,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -34,7 +34,7 @@ use crate::acp::{
     model_in_catalog, resolve_model_switch_method, AcpClient, AcpError, EnvVar, McpServer,
     ModelSwitchMethod, StopReason, SystemPromptTransport,
 };
-use crate::config::{compose_session_title, DedupMode, PermissionMode};
+use crate::config::{compose_session_title, DedupMode, PermissionMode, SessionRouteKey};
 use crate::observer;
 use crate::prompt_project::{pick_authoritative_project_home, PromptProjectInfo};
 use crate::queue::{
@@ -107,32 +107,32 @@ pub struct ChannelDeliveryState {
     pub delivered_event_ids: HashSet<String>,
 }
 
-/// Per-channel session IDs, turn counters, and delivery state.
+/// Per-route session IDs, turn counters, and prompt state.
 ///
 /// Separated from `OwnedAgent` so the state machine is testable without
 /// spawning a real agent subprocess.
 #[derive(Default)]
 pub struct SessionState {
-    /// channel_id → session_id
-    pub sessions: HashMap<Uuid, String>,
+    /// session route key → session_id
+    pub sessions: HashMap<SessionRouteKey, String>,
     pub heartbeat_session: Option<String>,
-    /// Per-channel turn counters for proactive session rotation.
+    /// Per-route turn counters for proactive session rotation.
     /// Incremented on each successful prompt; reset when the session is rotated.
-    pub turn_counts: HashMap<Uuid, u32>,
+    pub turn_counts: HashMap<SessionRouteKey, u32>,
     /// Turn counter for the heartbeat session.
     pub heartbeat_turn_count: u32,
     /// Whether the live heartbeat session has successfully received `<base>`.
     pub heartbeat_standing_context_sent: bool,
-    /// channel_id → rendered NIP-AE core prompt section, populated once at
+    /// session route key → rendered NIP-AE core prompt section, populated once at
     /// session creation per Tyler's spec (no mid-session refresh).
-    pub core_sections: HashMap<Uuid, String>,
-    /// channel_id → rendered `<channel-canvas>` metadata section.
+    pub core_sections: HashMap<SessionRouteKey, String>,
+    /// session route key → rendered `<channel-canvas>` metadata section.
     ///
     /// Populated once before session creation (same lifecycle as `core_sections`).
     /// Absent when the channel has no canvas, the canvas content is blank, or the
     /// fetch fails — all fail open. Cleared on session invalidation alongside
     /// `core_sections` so the next session picks up any canvas change.
-    pub canvas_sections: HashMap<Uuid, String>,
+    pub canvas_sections: HashMap<SessionRouteKey, String>,
     /// Per-channel successful-delivery state. Created with the ACP session and
     /// cleared atomically with every invalidation path.
     pub deliveries: HashMap<Uuid, ChannelDeliveryState>,
@@ -143,7 +143,7 @@ impl SessionState {
     pub fn invalidate(&mut self, source: &PromptSource) {
         match source {
             PromptSource::Channel(cid) => {
-                self.invalidate_channel(cid);
+                self.invalidate_route(&SessionRouteKey::for_channel(*cid));
             }
             PromptSource::Heartbeat => {
                 self.heartbeat_session = None;
@@ -153,14 +153,14 @@ impl SessionState {
         }
     }
 
-    /// Invalidate a single channel's session and turn counter.
-    /// Returns `true` if the channel had an active session.
-    pub fn invalidate_channel(&mut self, channel_id: &Uuid) -> bool {
-        self.turn_counts.remove(channel_id);
-        self.core_sections.remove(channel_id);
-        self.canvas_sections.remove(channel_id);
-        self.deliveries.remove(channel_id);
-        self.sessions.remove(channel_id).is_some()
+    /// Invalidate a single route's session and turn counter.
+    /// Returns `true` if the route had an active session.
+    pub fn invalidate_route(&mut self, route_key: &SessionRouteKey) -> bool {
+        self.turn_counts.remove(route_key);
+        self.core_sections.remove(route_key);
+        self.canvas_sections.remove(route_key);
+        self.deliveries.clear();
+        self.sessions.remove(route_key).is_some()
     }
 
     /// Invalidate all sessions and turn counters (e.g. after agent exit).
@@ -187,11 +187,16 @@ impl SessionState {
     }
 
     #[cfg(test)]
+    fn has_route_state(&self, route_key: &SessionRouteKey) -> bool {
+        self.sessions.contains_key(route_key)
+            || self.turn_counts.contains_key(route_key)
+            || self.core_sections.contains_key(route_key)
+            || self.canvas_sections.contains_key(route_key)
+    }
+
+    #[cfg(test)]
     fn has_channel_state(&self, channel_id: &Uuid) -> bool {
-        self.sessions.contains_key(channel_id)
-            || self.turn_counts.contains_key(channel_id)
-            || self.core_sections.contains_key(channel_id)
-            || self.canvas_sections.contains_key(channel_id)
+        self.has_route_state(&SessionRouteKey::for_channel(*channel_id))
             || self.deliveries.contains_key(channel_id)
     }
 }
@@ -326,6 +331,7 @@ pub enum PromptSource {
 fn apply_completed_before_control_signal(
     state: &mut SessionState,
     source: &PromptSource,
+    route_key: Option<&SessionRouteKey>,
     control_signal: &ControlSignal,
 ) {
     // Rotate and SwitchModel both invalidate so the next turn creates a fresh
@@ -335,7 +341,27 @@ fn apply_completed_before_control_signal(
         control_signal,
         ControlSignal::Rotate | ControlSignal::SwitchModel { .. }
     ) {
-        state.invalidate(source);
+        invalidate_prompt_state(state, source, route_key);
+    }
+}
+
+fn invalidate_prompt_state(
+    state: &mut SessionState,
+    source: &PromptSource,
+    route_key: Option<&SessionRouteKey>,
+) {
+    match source {
+        PromptSource::Channel(channel_id) => {
+            let fallback;
+            let key = if let Some(route_key) = route_key {
+                route_key
+            } else {
+                fallback = SessionRouteKey::for_channel(*channel_id);
+                &fallback
+            };
+            state.invalidate_route(key);
+        }
+        PromptSource::Heartbeat => state.invalidate(source),
     }
 }
 
@@ -719,6 +745,11 @@ pub struct PromptContext {
     pub rest_client: RestClient,
     /// Shared channel metadata for startup-known and dynamically joined channels.
     pub channel_info: ChannelInfoResolver,
+    /// Channel → session route. Missing entries fall back to the channel's own
+    /// route key, preserving historic one-session-per-channel behavior.
+    pub session_routes: HashMap<Uuid, SessionRouteKey>,
+    /// Channel → operator-owned role authority rendered into every prompt turn.
+    pub role_authorities: HashMap<Uuid, String>,
     /// Max messages to include in thread/DM context. 0 = disabled.
     pub context_message_limit: u32,
     /// Max turns per session before proactive rotation. 0 = disabled.
@@ -746,6 +777,19 @@ pub struct PromptContext {
     pub relay_url: String,
 }
 
+impl PromptContext {
+    pub fn session_route_key(&self, channel_id: Uuid) -> SessionRouteKey {
+        self.session_routes
+            .get(&channel_id)
+            .cloned()
+            .unwrap_or_else(|| SessionRouteKey::for_channel(channel_id))
+    }
+
+    pub fn role_authority(&self, channel_id: Uuid) -> Option<&str> {
+        self.role_authorities.get(&channel_id).map(String::as_str)
+    }
+}
+
 impl AgentPool {
     /// Create a pool from pre-indexed slots (may contain None for failed startups).
     ///
@@ -764,18 +808,18 @@ impl AgentPool {
         }
     }
 
-    /// Try to claim an idle agent for the given channel (or heartbeat if `None`).
+    /// Try to claim an idle agent for the given route (or heartbeat if `None`).
     ///
-    /// Pass 1: prefer an agent that already has a session for `channel_id`.
+    /// Pass 1: prefer an agent that already has a session for `route_key`.
     /// Pass 2: any idle agent.
     ///
     /// Returns `None` if all agents are checked out.
-    pub fn try_claim(&mut self, channel_id: Option<Uuid>) -> Option<OwnedAgent> {
-        // Pass 1: prefer agent with existing session for this channel.
-        if let Some(cid) = channel_id {
+    pub fn try_claim(&mut self, route_key: Option<&SessionRouteKey>) -> Option<OwnedAgent> {
+        // Pass 1: prefer agent with existing session for this route.
+        if let Some(key) = route_key {
             let idx = self.agents.iter().position(|slot| {
                 slot.as_ref()
-                    .map(|a| a.state.sessions.contains_key(&cid))
+                    .map(|a| a.state.sessions.contains_key(key))
                     .unwrap_or(false)
             });
             if let Some(i) = idx {
@@ -809,12 +853,12 @@ impl AgentPool {
         self.agents.iter().any(|slot| slot.is_some())
     }
 
-    /// Whether any idle agent already has a session for `channel_id`.
+    /// Whether any idle agent already has a session for `route_key`.
     /// Used to compute `affinity_hit` before calling `try_claim`.
-    pub fn has_session_for(&self, channel_id: Uuid) -> bool {
+    pub fn has_session_for(&self, route_key: &SessionRouteKey) -> bool {
         self.agents.iter().any(|slot| {
             slot.as_ref()
-                .map(|a| a.state.sessions.contains_key(&channel_id))
+                .map(|a| a.state.sessions.contains_key(route_key))
                 .unwrap_or(false)
         })
     }
@@ -883,6 +927,7 @@ impl AgentPool {
     pub fn record_successful_steer(
         &mut self,
         channel_id: Uuid,
+        route_key: &SessionRouteKey,
         event_id: String,
         session_id: String,
     ) -> bool {
@@ -900,7 +945,7 @@ impl AgentPool {
         }
 
         let Some(agent) = self.agents.iter_mut().flatten().find(|agent| {
-            agent.state.sessions.get(&channel_id).map(String::as_str) == Some(session_id.as_str())
+            agent.state.sessions.get(route_key).map(String::as_str) == Some(session_id.as_str())
         }) else {
             return false;
         };
@@ -945,19 +990,11 @@ impl AgentPool {
         &mut self.agents
     }
 
-    /// Remove the session for `channel_id` from all idle agents.
-    ///
-    /// Called when the agent is removed from a channel — stale sessions
-    /// should not be reused. Checked-out agents (in-flight) are not
-    /// modified; their sessions will fail naturally on the next prompt
-    /// if the relay rejects the request.
-    ///
-    /// Returns the number of sessions invalidated.
-    pub fn invalidate_channel_sessions(&mut self, channel_id: Uuid) -> usize {
+    pub fn invalidate_route_sessions(&mut self, route_key: &SessionRouteKey) -> usize {
         let mut count = 0;
         for slot in &mut self.agents {
             if let Some(agent) = slot.as_mut() {
-                if agent.state.invalidate_channel(&channel_id) {
+                if agent.state.invalidate_route(route_key) {
                     count += 1;
                 }
             }
@@ -980,7 +1017,7 @@ impl AgentPool {
     /// surface an override the session has not actually applied.
     pub fn switch_idle_agent_model(
         &mut self,
-        channel_id: Uuid,
+        route_key: &SessionRouteKey,
         model_id: &str,
         request_id: Option<String>,
     ) -> IdleSwitchResult {
@@ -988,7 +1025,7 @@ impl AgentPool {
             .agents
             .iter_mut()
             .flatten()
-            .find(|a| a.state.sessions.contains_key(&channel_id))
+            .find(|a| a.state.sessions.contains_key(route_key))
         else {
             return IdleSwitchResult::NoIdleAgent;
         };
@@ -1010,7 +1047,7 @@ impl AgentPool {
         // Carry the pick's correlator so a deferred-validation miss on the next
         // turn's session creation emits a late frame the Desktop can match.
         agent.desired_model_request_id = request_id;
-        agent.state.invalidate_channel(&channel_id);
+        agent.state.invalidate_route(route_key);
         IdleSwitchResult::Switched
     }
 }
@@ -1077,10 +1114,11 @@ const UNKNOWN_CHANNEL_NAME: &str = "unknown";
 /// startup cache already refuses `channel_type == "unknown"` for the same
 /// reason.
 ///
-/// Renames do not retitle an already-live session. Prompt-turn resolution does
-/// refresh channel metadata, so a later session spawn uses the current channel
-/// name without requiring a harness restart. An agent rename lands on the next
-/// spawn (the desktop restart badge covers it — see `spawn_config_hash`).
+/// Renames do not retitle live sessions, and a **channel** rename is stickier
+/// than an agent rename: route invalidation drops the session but not the
+/// resolver's cached entry, so a renamed channel keeps its old suffix until the
+/// process restarts. An agent rename lands on the next spawn (the desktop
+/// restart badge covers it — see `spawn_config_hash`).
 async fn resolve_new_session_channel_context(
     channel_info: Option<&PromptChannelInfo>,
 ) -> (bool, Option<String>, Option<String>) {
@@ -1893,6 +1931,10 @@ pub async fn run_prompt_task(
         PromptSource::Channel(channel_id) => Some(*channel_id),
         PromptSource::Heartbeat => None,
     };
+    let route_key = match &source {
+        PromptSource::Channel(channel_id) => Some(ctx.session_route_key(*channel_id)),
+        PromptSource::Heartbeat => None,
+    };
     let turn_started_at = chrono::Utc::now().to_rfc3339();
     agent.acp.set_observer_context(observer::context_for_turn(
         observer_channel_id,
@@ -2029,16 +2071,15 @@ pub async fn run_prompt_task(
     //   * fetch exceeds CORE_FETCH_TIMEOUT → inject nothing, same reason.
     //
     // Per Tyler's locked spec: NO mid-session refreshes. Re-fetch only
-    // happens when a session is invalidated and recreated (see
-    // `SessionState::invalidate_channel`).
+    // happens when a session route is invalidated and recreated.
     //
     // Operator opt-out: `--no-memory` / `BUZZ_ACP_NO_MEMORY` skips the fetch.
     if ctx.memory_enabled {
-        if let (PromptSource::Channel(cid), Some(owner_pk)) =
-            (&source, ctx.agent_owner_pubkey.as_ref())
+        if let (PromptSource::Channel(cid), Some(owner_pk), Some(route_key)) =
+            (&source, ctx.agent_owner_pubkey.as_ref(), route_key.as_ref())
         {
-            let is_new_channel_session = !agent.state.sessions.contains_key(cid);
-            if is_new_channel_session && !agent.state.core_sections.contains_key(cid) {
+            let is_new_channel_session = !agent.state.sessions.contains_key(route_key);
+            if is_new_channel_session && !agent.state.core_sections.contains_key(route_key) {
                 // Bounded — we'd rather start the session with no core hint
                 // than block session creation on a stalled relay.
                 const CORE_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
@@ -2066,7 +2107,10 @@ pub async fn run_prompt_task(
                         section_len = rendered.len(),
                         "injected NIP-AE core section into system prompt"
                     );
-                    agent.state.core_sections.insert(*cid, rendered);
+                    agent
+                        .state
+                        .core_sections
+                        .insert(route_key.clone(), rendered);
                 }
             }
         }
@@ -2084,15 +2128,16 @@ pub async fn run_prompt_task(
     // commit it to `canvas_sections` only after session creation succeeds. This
     // prevents a stale revision A surviving a failed create and being re-used by
     // the next attempt after the canvas was cleared.
-    let mut pending_canvas: Option<(Uuid, String)> = None;
+    let mut pending_canvas: Option<(SessionRouteKey, String)> = None;
     let mut huddle_instructions: Option<String> = None;
     // Channel name for the session title, from the same single resolve the
     // canvas DM check uses — see `resolve_new_session_channel_context`.
     let mut title_channel: Option<String> = None;
     let mut origin_channel_type: Option<String> = None;
-    if let PromptSource::Channel(cid) = &source {
-        let is_new_channel_session = !agent.state.sessions.contains_key(cid);
-        let needs_canvas = is_new_channel_session && !agent.state.canvas_sections.contains_key(cid);
+    if let (PromptSource::Channel(cid), Some(route_key)) = (&source, route_key.as_ref()) {
+        let is_new_channel_session = !agent.state.sessions.contains_key(route_key);
+        let needs_canvas =
+            is_new_channel_session && !agent.state.canvas_sections.contains_key(route_key);
         if is_new_channel_session {
             let (is_dm, resolved_channel, resolved_channel_type) =
                 resolve_new_session_channel_context(resolved_channel_info.as_ref()).await;
@@ -2106,7 +2151,7 @@ pub async fn run_prompt_task(
             // channel type fails closed as a DM for the same reason.
             if needs_canvas && !is_dm {
                 if let Some(section) = fetch_canvas_section(*cid, &ctx.rest_client).await {
-                    pending_canvas = Some((*cid, section));
+                    pending_canvas = Some((route_key.clone(), section));
                 }
             }
         }
@@ -2115,25 +2160,38 @@ pub async fn run_prompt_task(
     // The core section to fold into the system prompt for this turn's session.
     // Channel-scoped; heartbeats carry no owner core.
     let agent_core: Option<String> = match &source {
-        PromptSource::Channel(cid) => agent.state.core_sections.get(cid).cloned(),
+        PromptSource::Channel(_) => route_key
+            .as_ref()
+            .and_then(|key| agent.state.core_sections.get(key).cloned()),
         PromptSource::Heartbeat => None,
     };
 
     // The canvas metadata section — channel-scoped, absent for heartbeats/DMs.
     // Prefer the committed cache; fall back to pending (for new sessions being created now).
     let agent_canvas: Option<String> = match &source {
-        PromptSource::Channel(cid) => agent
-            .state
-            .canvas_sections
-            .get(cid)
-            .cloned()
+        PromptSource::Channel(_) => route_key
+            .as_ref()
+            .and_then(|key| agent.state.canvas_sections.get(key).cloned())
             .or_else(|| pending_canvas.as_ref().map(|(_, s)| s.clone())),
         PromptSource::Heartbeat => None,
     };
 
     let (session_id, is_new_session) = match &source {
         PromptSource::Channel(cid) => {
-            if let Some(sid) = agent.state.sessions.get(cid) {
+            let Some(route_key) = route_key.as_ref() else {
+                send_prompt_result(
+                    &result_tx,
+                    &turn_id,
+                    agent,
+                    source,
+                    PromptOutcome::Error(AcpError::Protocol(
+                        "missing channel session route".into(),
+                    )),
+                    requeue_batch_if_queue(&ctx, batch),
+                );
+                return;
+            };
+            if let Some(sid) = agent.state.sessions.get(route_key) {
                 (sid.clone(), false)
             } else {
                 // The title is channel-qualified (`Agent · #channel`) so one
@@ -2157,9 +2215,10 @@ pub async fn run_prompt_task(
                     Ok(sid) => {
                         tracing::info!(
                             target: "pool::session",
+                            route = %route_key.label(),
                             "created session {sid} for channel {cid}"
                         );
-                        agent.state.sessions.insert(*cid, sid.clone());
+                        agent.state.sessions.insert(route_key.clone(), sid.clone());
                         agent
                             .state
                             .deliveries
@@ -2170,8 +2229,8 @@ pub async fn run_prompt_task(
                             agent.acp.notify_session_spawned(&sid);
                         }
                         // Commit canvas only after session creation succeeds (I3).
-                        if let Some((pending_cid, section)) = pending_canvas.take() {
-                            agent.state.canvas_sections.insert(pending_cid, section);
+                        if let Some((pending_route, section)) = pending_canvas.take() {
+                            agent.state.canvas_sections.insert(pending_route, section);
                         }
                         (sid, true)
                     }
@@ -2388,7 +2447,7 @@ pub async fn run_prompt_task(
                                 Some(acp_stop_to_core(&stop_reason)),
                             )
                             .await;
-                            agent.state.invalidate(&source);
+                            invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
                         }
                         Err(AcpError::AgentExited) => {
                             agent.state.invalidate_all();
@@ -2407,7 +2466,7 @@ pub async fn run_prompt_task(
                                 target: "pool::session",
                                 "cancel_with_cleanup failed during initial_message timeout: {e}"
                             );
-                            agent.state.invalidate(&source);
+                            invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
                         }
                     }
                     send_prompt_result(
@@ -2443,7 +2502,7 @@ pub async fn run_prompt_task(
                         target: "pool::session",
                         "initial_message failed for channel {cid}: {e} — invalidating session"
                     );
-                    agent.state.invalidate(&source);
+                    invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
                     send_prompt_result(
                         &result_tx,
                         &turn_id,
@@ -2559,6 +2618,7 @@ pub async fn run_prompt_task(
                 system_prompt: standing.system_prompt,
                 team_instructions: standing.team_instructions,
                 agent_canvas: standing.agent_canvas,
+                role_authority: ctx.role_authority(b.channel_id),
                 standing_context_sent,
             },
         )
@@ -2687,7 +2747,7 @@ pub async fn run_prompt_task(
                         {
                             Ok(stop_reason) => {
                                 log_stop_reason(&source, &stop_reason);
-                                agent.state.invalidate(&source);
+                                invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
                                 let retry_batch =
                                     requeue_cancelled_batch(&ctx, control_signal, batch);
 
@@ -2724,7 +2784,7 @@ pub async fn run_prompt_task(
                                 if failure.invalidate_all {
                                     agent.state.invalidate_all();
                                 } else {
-                                    agent.state.invalidate(&source);
+                                    invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
                                 }
 
                                 let usage = agent.acp.take_turn_usage();
@@ -2790,6 +2850,7 @@ pub async fn run_prompt_task(
                         apply_completed_before_control_signal(
                             &mut agent.state,
                             &source,
+                            route_key.as_ref(),
                             &control_signal,
                         );
                         let usage = agent.acp.take_turn_usage();
@@ -2881,7 +2942,11 @@ pub async fn run_prompt_task(
                 if limit > 0 {
                     match &source {
                         PromptSource::Channel(cid) => {
-                            let count = agent.state.turn_counts.entry(*cid).or_insert(0);
+                            let route_key = route_key
+                                .as_ref()
+                                .cloned()
+                                .unwrap_or_else(|| SessionRouteKey::for_channel(*cid));
+                            let count = agent.state.turn_counts.entry(route_key).or_insert(0);
                             *count += 1;
                             *count >= limit
                         }
@@ -2900,7 +2965,7 @@ pub async fn run_prompt_task(
                     target: "pool::session",
                     "rotating session for {source:?} after {stop_reason:?}",
                 );
-                agent.state.invalidate(&source);
+                invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
             }
 
             let core_stop = acp_stop_to_core(&stop_reason);
@@ -3011,7 +3076,7 @@ pub async fn run_prompt_task(
                         target: "pool::prompt",
                         "cancel_with_cleanup error: {e} — invalidating session"
                     );
-                    agent.state.invalidate(&source);
+                    invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
                     let usage = agent.acp.take_turn_usage();
                     publish_agent_turn_metric(
                         &ctx,
@@ -3066,7 +3131,7 @@ pub async fn run_prompt_task(
             // session state (e.g. bad LLM response). The session is healthy —
             // don't invalidate it. Other errors may have corrupted state.
             if !matches!(e, AcpError::AgentError { .. }) {
-                agent.state.invalidate(&source);
+                invalidate_prompt_state(&mut agent.state, &source, route_key.as_ref());
             }
             let usage = agent.acp.take_turn_usage();
             publish_agent_turn_metric(
@@ -6464,10 +6529,11 @@ done"#
             goose_system_prompt_supported: None,
             protocol_version: 1,
         };
+        let route_key = SessionRouteKey::for_channel(channel_id);
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(route_key.clone(), "live-session".into());
         agent
             .state
             .deliveries
@@ -6625,6 +6691,7 @@ done"#
         let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
             .await
             .expect("spawn wire-capture ACP");
+        let route_key = SessionRouteKey::for_channel(channel_id);
         let mut agent = OwnedAgent {
             index: 0,
             acp,
@@ -6642,7 +6709,7 @@ done"#
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(route_key.clone(), "live-session".into());
         agent
             .state
             .deliveries
@@ -6778,6 +6845,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
             .await
             .expect("spawn wire-capture ACP");
+        let route_key = SessionRouteKey::for_channel(channel_id);
         let mut agent = OwnedAgent {
             index: 0,
             acp,
@@ -6795,7 +6863,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(route_key.clone(), "live-session".into());
         agent
             .state
             .deliveries
@@ -6806,11 +6874,12 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         let mut pool = AgentPool::from_slots(vec![Some(agent)]);
         assert!(pool.record_successful_steer(
             channel_id,
+            &route_key,
             steered_event_id.clone(),
             "live-session".into(),
         ));
         let agent = pool
-            .try_claim(Some(channel_id))
+            .try_claim(Some(&route_key))
             .expect("claim returned agent");
 
         let mut ctx = make_prompt_context_no_owner();
@@ -6893,14 +6962,17 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn delivery_state_is_cleared_on_rotation_and_restarts_empty() {
         let channel = Uuid::new_v4();
+        let route_key = SessionRouteKey::for_channel(channel);
         let mut state = SessionState::default();
-        state.sessions.insert(channel, "old-session".into());
+        state
+            .sessions
+            .insert(route_key.clone(), "old-session".into());
         state.mark_channel_delivery_success(channel, true, ["old-event".to_string()]);
 
-        assert!(state.invalidate_channel(&channel));
+        assert!(state.invalidate_route(&route_key));
         assert!(!state.deliveries.contains_key(&channel));
 
-        state.sessions.insert(channel, "new-session".into());
+        state.sessions.insert(route_key, "new-session".into());
         state
             .deliveries
             .insert(channel, ChannelDeliveryState::default());
@@ -7013,13 +7085,15 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     fn make_state() -> (SessionState, Uuid, Uuid) {
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
         let mut s = SessionState::default();
-        s.sessions.insert(ch_a, "sess-a".into());
-        s.sessions.insert(ch_b, "sess-b".into());
-        s.turn_counts.insert(ch_a, 5);
-        s.turn_counts.insert(ch_b, 3);
-        s.core_sections.insert(ch_a, "core-a".into());
-        s.core_sections.insert(ch_b, "core-b".into());
+        s.sessions.insert(route_a.clone(), "sess-a".into());
+        s.sessions.insert(route_b.clone(), "sess-b".into());
+        s.turn_counts.insert(route_a.clone(), 5);
+        s.turn_counts.insert(route_b.clone(), 3);
+        s.core_sections.insert(route_a, "core-a".into());
+        s.core_sections.insert(route_b, "core-b".into());
         s.deliveries.insert(
             ch_a,
             ChannelDeliveryState {
@@ -7043,20 +7117,23 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn test_rotate_after_natural_completion_invalidates_channel_state() {
         let (mut s, ch_a, ch_b) = make_state();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
 
         apply_completed_before_control_signal(
             &mut s,
             &PromptSource::Channel(ch_a),
+            Some(&route_a),
             &ControlSignal::Rotate,
         );
 
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
+        assert!(!s.sessions.contains_key(&route_a));
+        assert!(!s.turn_counts.contains_key(&route_a));
+        assert!(!s.core_sections.contains_key(&route_a));
         assert!(!s.has_channel_state(&ch_a));
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.sessions.get(&route_b).unwrap(), "sess-b");
+        assert_eq!(*s.turn_counts.get(&route_b).unwrap(), 3);
+        assert_eq!(s.core_sections.get(&route_b).unwrap(), "core-b");
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
         assert_eq!(s.heartbeat_turn_count, 7);
     }
@@ -7064,32 +7141,37 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn test_cancel_after_natural_completion_preserves_channel_state() {
         let (mut s, ch_a, ch_b) = make_state();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
 
         apply_completed_before_control_signal(
             &mut s,
             &PromptSource::Channel(ch_a),
+            Some(&route_a),
             &ControlSignal::Cancel,
         );
 
-        assert_eq!(s.sessions.get(&ch_a).unwrap(), "sess-a");
-        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
-        assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
+        assert_eq!(s.sessions.get(&route_a).unwrap(), "sess-a");
+        assert_eq!(*s.turn_counts.get(&route_a).unwrap(), 5);
+        assert_eq!(s.core_sections.get(&route_a).unwrap(), "core-a");
+        assert_eq!(s.sessions.get(&route_b).unwrap(), "sess-b");
     }
 
     #[test]
-    fn test_invalidate_channel_clears_session_and_turn_count() {
+    fn test_invalidate_prompt_source_clears_session_and_turn_count() {
         let (mut s, ch_a, ch_b) = make_state();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
         s.invalidate(&PromptSource::Channel(ch_a));
 
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
+        assert!(!s.sessions.contains_key(&route_a));
+        assert!(!s.turn_counts.contains_key(&route_a));
+        assert!(!s.core_sections.contains_key(&route_a));
         assert!(!s.has_channel_state(&ch_a));
         // ch_b untouched
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.sessions.get(&route_b).unwrap(), "sess-b");
+        assert_eq!(*s.turn_counts.get(&route_b).unwrap(), 3);
+        assert_eq!(s.core_sections.get(&route_b).unwrap(), "core-b");
         // heartbeat untouched
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
         assert_eq!(s.heartbeat_turn_count, 7);
@@ -7098,6 +7180,8 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn test_invalidate_heartbeat_clears_session_and_turn_count() {
         let (mut s, ch_a, ch_b) = make_state();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
         s.invalidate(&PromptSource::Heartbeat);
 
         assert!(s.heartbeat_session.is_none());
@@ -7105,10 +7189,10 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         assert!(!s.heartbeat_standing_context_sent);
         // channels untouched
         assert_eq!(s.sessions.len(), 2);
-        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(*s.turn_counts.get(&route_a).unwrap(), 5);
+        assert_eq!(*s.turn_counts.get(&route_b).unwrap(), 3);
+        assert_eq!(s.core_sections.get(&route_a).unwrap(), "core-a");
+        assert_eq!(s.core_sections.get(&route_b).unwrap(), "core-b");
     }
 
     #[test]
@@ -7127,16 +7211,18 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn test_invalidate_nonexistent_channel_is_noop() {
         let (mut s, ch_a, ch_b) = make_state();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
         let ghost = Uuid::new_v4();
         s.invalidate(&PromptSource::Channel(ghost));
 
         // Everything still intact.
         assert_eq!(s.sessions.len(), 2);
         assert_eq!(s.turn_counts.len(), 2);
-        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(*s.turn_counts.get(&route_a).unwrap(), 5);
+        assert_eq!(*s.turn_counts.get(&route_b).unwrap(), 3);
+        assert_eq!(s.core_sections.get(&route_a).unwrap(), "core-a");
+        assert_eq!(s.core_sections.get(&route_b).unwrap(), "core-b");
     }
 
     #[test]
@@ -7149,48 +7235,74 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     }
 
     #[test]
-    fn test_invalidate_channel_returns_true_when_session_existed() {
+    fn test_invalidate_route_returns_true_when_session_existed() {
         let (mut s, ch_a, ch_b) = make_state();
-        assert!(s.invalidate_channel(&ch_a));
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
+        assert!(s.invalidate_route(&route_a));
+        assert!(!s.sessions.contains_key(&route_a));
+        assert!(!s.turn_counts.contains_key(&route_a));
+        assert!(!s.core_sections.contains_key(&route_a));
         assert!(!s.has_channel_state(&ch_a));
         // ch_b untouched
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.sessions.get(&route_b).unwrap(), "sess-b");
+        assert_eq!(*s.turn_counts.get(&route_b).unwrap(), 3);
+        assert_eq!(s.core_sections.get(&route_b).unwrap(), "core-b");
         // heartbeat untouched
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
         assert_eq!(s.heartbeat_turn_count, 7);
     }
 
     #[test]
-    fn test_invalidate_channel_returns_false_when_no_session() {
+    fn test_invalidate_route_returns_false_when_no_session() {
         let (mut s, _ch_a, _ch_b) = make_state();
         let ghost = Uuid::new_v4();
-        assert!(!s.invalidate_channel(&ghost));
+        assert!(!s.invalidate_route(&SessionRouteKey::for_channel(ghost)));
         // Nothing changed.
         assert_eq!(s.sessions.len(), 2);
         assert_eq!(s.turn_counts.len(), 2);
     }
 
     #[test]
-    fn test_removed_channels_cleaned_via_invalidate_channel() {
+    fn test_removed_channels_cleaned_via_invalidate_route() {
         // Simulates handle_prompt_result: channels removed while agent
         // was checked out should have both sessions and turn_counts stripped.
         let (mut s, ch_a, ch_b) = make_state();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
         let removed = vec![ch_a];
         for ch in &removed {
-            s.invalidate_channel(ch);
+            s.invalidate_route(&SessionRouteKey::for_channel(*ch));
         }
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
+        assert!(!s.sessions.contains_key(&route_a));
+        assert!(!s.turn_counts.contains_key(&route_a));
+        assert!(!s.core_sections.contains_key(&route_a));
         assert!(!s.has_channel_state(&ch_a));
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.sessions.get(&route_b).unwrap(), "sess-b");
+        assert_eq!(*s.turn_counts.get(&route_b).unwrap(), 3);
+        assert_eq!(s.core_sections.get(&route_b).unwrap(), "core-b");
+    }
+
+    #[test]
+    fn test_removed_shared_route_cleaned_via_invalidate_route() {
+        let ch = Uuid::new_v4();
+        let route = SessionRouteKey::Named("down-role-forums".into());
+        let mut s = SessionState::default();
+        s.sessions.insert(route.clone(), "sess-shared".into());
+        s.turn_counts.insert(route.clone(), 4);
+        s.core_sections.insert(route.clone(), "core-shared".into());
+        s.canvas_sections
+            .insert(route.clone(), "canvas-shared".into());
+        s.sessions
+            .insert(SessionRouteKey::for_channel(ch), "sess-channel".into());
+
+        assert!(s.invalidate_route(&route));
+
+        assert!(!s.has_route_state(&route));
+        assert_eq!(
+            s.sessions.get(&SessionRouteKey::for_channel(ch)).unwrap(),
+            "sess-channel"
+        );
     }
 
     // ── ControlSignal::SwitchModel (Phase 3a, Option ii) ─────────────────────
@@ -7198,12 +7310,15 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn test_switch_model_after_natural_completion_invalidates_channel_state() {
         let (mut s, ch_a, ch_b) = make_state();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
 
         // SwitchModel must invalidate just like Rotate so the requeued turn
         // re-creates a fresh session that re-applies the new desired_model.
         apply_completed_before_control_signal(
             &mut s,
             &PromptSource::Channel(ch_a),
+            Some(&route_a),
             &ControlSignal::SwitchModel {
                 model_id: "gpt-5".into(),
                 request_id: None,
@@ -7212,8 +7327,8 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
 
         assert!(!s.has_channel_state(&ch_a));
         // ch_b untouched — the switch is channel-scoped.
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(s.sessions.get(&route_b).unwrap(), "sess-b");
+        assert_eq!(*s.turn_counts.get(&route_b).unwrap(), 3);
     }
 
     // ── requeue_cancelled_batch ────────────────────────────────────────────
@@ -8318,6 +8433,8 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             heartbeat_prompt: None,
             base_prompt: None,
             cwd: ".".to_string(),
+            session_routes: HashMap::new(),
+            role_authorities: HashMap::new(),
             rest_client: RestClient {
                 http: reqwest::Client::new(),
                 base_url: "http://127.0.0.1:0".to_string(),
@@ -8450,27 +8567,30 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     // ── canvas_sections cache invalidation ───────────────────────────────────
 
     #[test]
-    fn test_invalidate_channel_clears_canvas_section() {
+    fn test_invalidate_route_clears_canvas_section() {
         let ch = Uuid::new_v4();
+        let route_key = SessionRouteKey::for_channel(ch);
         let mut s = SessionState::default();
-        s.sessions.insert(ch, "sess".into());
+        s.sessions.insert(route_key.clone(), "sess".into());
         s.canvas_sections
-            .insert(ch, "[Channel Canvas]\nrev abc".into());
+            .insert(route_key.clone(), "[Channel Canvas]\nrev abc".into());
 
-        s.invalidate_channel(&ch);
+        s.invalidate_route(&route_key);
 
-        assert!(!s.canvas_sections.contains_key(&ch));
-        assert!(!s.sessions.contains_key(&ch));
+        assert!(!s.canvas_sections.contains_key(&route_key));
+        assert!(!s.sessions.contains_key(&route_key));
     }
 
     #[test]
     fn test_invalidate_all_clears_canvas_sections() {
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
         let mut s = SessionState::default();
-        s.canvas_sections.insert(ch_a, "canvas-a".into());
-        s.canvas_sections.insert(ch_b, "canvas-b".into());
-        s.sessions.insert(ch_a, "sess-a".into());
+        s.canvas_sections.insert(route_a.clone(), "canvas-a".into());
+        s.canvas_sections.insert(route_b, "canvas-b".into());
+        s.sessions.insert(route_a, "sess-a".into());
 
         s.invalidate_all();
 
@@ -8479,26 +8599,29 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     }
 
     #[test]
-    fn test_invalidate_channel_leaves_other_channels_canvas_intact() {
+    fn test_invalidate_route_leaves_other_channels_canvas_intact() {
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
+        let route_a = SessionRouteKey::for_channel(ch_a);
+        let route_b = SessionRouteKey::for_channel(ch_b);
         let mut s = SessionState::default();
-        s.sessions.insert(ch_a, "sess-a".into());
-        s.sessions.insert(ch_b, "sess-b".into());
-        s.canvas_sections.insert(ch_a, "canvas-a".into());
-        s.canvas_sections.insert(ch_b, "canvas-b".into());
+        s.sessions.insert(route_a.clone(), "sess-a".into());
+        s.sessions.insert(route_b.clone(), "sess-b".into());
+        s.canvas_sections.insert(route_a.clone(), "canvas-a".into());
+        s.canvas_sections.insert(route_b.clone(), "canvas-b".into());
 
-        s.invalidate_channel(&ch_a);
+        s.invalidate_route(&route_a);
 
-        assert!(!s.canvas_sections.contains_key(&ch_a));
-        assert_eq!(s.canvas_sections.get(&ch_b).unwrap(), "canvas-b");
+        assert!(!s.canvas_sections.contains_key(&route_a));
+        assert_eq!(s.canvas_sections.get(&route_b).unwrap(), "canvas-b");
     }
 
     #[test]
     fn test_has_channel_state_true_when_only_canvas_section_present() {
         let ch = Uuid::new_v4();
+        let route_key = SessionRouteKey::for_channel(ch);
         let mut s = SessionState::default();
-        s.canvas_sections.insert(ch, "canvas".into());
+        s.canvas_sections.insert(route_key, "canvas".into());
         assert!(s.has_channel_state(&ch));
     }
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1647,6 +1647,9 @@ pub struct FormatPromptArgs<'a> {
     pub agent_core: Option<&'a str>,
     /// Owner-signed instructions for an active huddle channel.
     pub huddle_instructions: Option<&'a str>,
+    /// Operator-owned role authority for this channel/Forum. Rendered every
+    /// turn because a shared ACP session may serve multiple Forums.
+    pub role_authority: Option<&'a str>,
     pub channel_info: Option<&'a PromptChannelInfo>,
     pub conversation_context: Option<&'a ConversationContext>,
     /// True when delivery-delta filtering removed at least one event that this
@@ -1756,6 +1759,18 @@ pub(crate) fn base_section(base_prompt: &str) -> String {
     crate::prompt_framing::semantic_section("base", base_prompt.trim_end())
 }
 
+fn role_authority_section(role_authority: &str) -> Option<String> {
+    let trimmed = role_authority.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(crate::prompt_framing::semantic_section(
+            "role-authority",
+            trimmed,
+        ))
+    }
+}
+
 /// Format a [`FlushBatch`] into the per-section prompt blocks for the agent.
 ///
 /// Produces a stable prompt with these sections (in order):
@@ -1813,6 +1828,10 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
             }
             .sections(),
         );
+    }
+
+    if let Some(section) = args.role_authority.and_then(role_authority_section) {
+        sections.push(section);
     }
 
     // 2. Context hints (with a human-aware reply anchor).
@@ -5370,6 +5389,35 @@ mod tests {
             !prompt.contains("[Channel Canvas]"),
             "no canvas section expected when agent_canvas is None; got: {prompt}"
         );
+    }
+
+    #[test]
+    fn test_format_prompt_includes_role_authority_every_turn() {
+        let ch = Uuid::new_v4();
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event: make_event("hi"),
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                role_authority: Some("You are Down acting as Platform Circle Lead."),
+                has_system_prompt_support: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("<role-authority>\nYou are Down acting as Platform Circle Lead.\n</role-authority>"),
+            "role authority must be repeated in each user prompt for shared sessions; got: {prompt}"
+        );
+        assert!(prompt.contains("<context>"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -550,6 +550,8 @@ fn mentions_rule(kinds: Vec<u32>) -> filter::SubscriptionRule {
         kinds,
         require_mention: true,
         filter: None,
+        session_route: None,
+        role_authority: None,
         compiled_filter: None,
         consecutive_timeouts: Arc::new(AtomicU32::new(0)),
         prompt_tag: Some("@mention".into()),


### PR DESCRIPTION
## Summary

This PR adds the ACP response and routing seam needed for exact-session adapters, especially OpenClaw:

- publish final ACP text responses back into Buzz when the adapter session returns output without an explicit `buzz messages send` tool call
- add config-driven `session_route` and `role_authority` routing for role/forum lanes
- keep routed role forums sharing the intended persistent session while preserving per-root/thread reply anchoring
- fail closed on conflicting route/session configuration
- clean up obsolete route invalidation helpers so the shared invalidation path is the only active path

## Scope

Changed files are limited to `crates/buzz-acp`:

- `src/acp.rs`
- `src/config.rs`
- `src/filter.rs`
- `src/lib.rs`
- `src/pool.rs`
- `src/queue.rs`
- `src/setup_mode.rs`

## Verification

Local verification on the rebased branch:

- `bin/cargo fmt --all -- --check`
- `bin/cargo test -p buzz-acp`
  - 844 unit tests
  - 9 lifecycle tests
- `bin/cargo clippy -p buzz-acp --all-targets -- -D warnings`

## Live Canary

Ran an Air-only local adapter canary using the rebased `target/debug/buzz-acp` binary against the existing Buzz relay. This did not update Buzz Desktop, mobile, relay, migrations, signer custody, or production services.

Platform Circle route:

- channel: `Platform Circle (Down)`
- verified top-level root pickup
- verified threaded follow-up pickup
- verified exact Down session reuse
- verified final ACP response publication
- verified root/reply tags for threaded continuation
- verified role-authority boundary prompt framing

Engine Room route:

- channel: `Engine Room (Down)`
- verified top-level root pickup
- verified exact Down session reuse
- verified final ACP response publication
- verified no-mutation boundary framing

Canary listeners were stopped after proof capture.

## Boundaries

This PR only changes the ACP adapter code path. It does not:

- treat Buzz membership, channel placement, mentions, labels, or ACLs as authority
- connect Hub governed exports as a live authority source
- change relay behavior
- change desktop or mobile release artifacts
- apply migrations
- mutate production configuration
