### PR TITLE
feat(acp): add opt-in Aside browser MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -212,6 +212,10 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # Binary for an optional MCP server sidecar (e.g. buzz-dev-mcp for buzz-agent).
 # BUZZ_ACP_MCP_COMMAND=
 
+# Optional Aside CLI binary. When set, buzz-acp starts `aside mcp` alongside
+# the primary MCP server so each ACP session can use Aside browser automation.
+# BUZZ_ACP_ASIDE_COMMAND=aside
+
 # Number of parallel agent subprocesses (1–32).
 # BUZZ_ACP_AGENTS=1
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -111,6 +111,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
+| `BUZZ_ACP_ASIDE_COMMAND` | no | `""` (empty) | Path to the optional Aside CLI. When set, Buzz also provides `aside mcp` as an isolated browser automation server for each agent session. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -267,6 +267,11 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_MCP_COMMAND", default_value = "")]
     pub mcp_command: String,
 
+    /// Aside CLI binary to expose as a browser automation MCP server.
+    /// When set, Buzz starts it as `aside mcp` alongside the primary MCP server.
+    #[arg(long, env = "BUZZ_ACP_ASIDE_COMMAND", default_value = "")]
+    pub aside_command: String,
+
     /// Idle timeout: max seconds of silence before killing a turn.
     /// Resets on any agent stdout activity.
     #[arg(long, env = "BUZZ_ACP_IDLE_TIMEOUT")]
@@ -521,6 +526,7 @@ pub struct Config {
     pub agent_command: String,
     pub agent_args: Vec<String>,
     pub mcp_command: String,
+    pub aside_command: String,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
     pub agents: u32,
@@ -1097,6 +1103,7 @@ impl Config {
             agent_command,
             agent_args,
             mcp_command: args.mcp_command,
+            aside_command: args.aside_command,
             idle_timeout_secs,
             max_turn_duration_secs,
             agents: args.agents,
@@ -1164,12 +1171,13 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} aside_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
             self.agent_args.join(" "),
             self.mcp_command,
+            self.aside_command,
             self.idle_timeout_secs,
             self.max_turn_duration_secs,
             self.agents,
@@ -1478,6 +1486,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "".into(),
+            aside_command: "".into(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -2247,6 +2256,22 @@ channels = "ALL"
             "300",
         ]);
         assert_eq!(configured.idle_pool_sleep, 300);
+    }
+
+    #[test]
+    fn aside_command_is_opt_in_and_accepts_cli_value() {
+        let key = "0".repeat(64);
+        let default = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert!(default.aside_command.is_empty());
+
+        let configured = CliArgs::parse_from([
+            "buzz-acp",
+            "--private-key",
+            &key,
+            "--aside-command",
+            "/usr/local/bin/aside",
+        ]);
+        assert_eq!(configured.aside_command, "/usr/local/bin/aside");
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -5067,60 +5067,71 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
 }
 
 fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
-    if config.mcp_command.is_empty() {
-        return vec![];
+    let mut servers = Vec::with_capacity(2);
+    if !config.mcp_command.is_empty() {
+        servers.push(McpServer {
+            name: std::path::Path::new(&config.mcp_command)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("mcp")
+                .to_string(),
+            command: config.mcp_command.clone(),
+            args: vec![],
+            env: buzz_mcp_env(config),
+        });
     }
-    vec![McpServer {
-        name: std::path::Path::new(&config.mcp_command)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("mcp")
-            .to_string(),
-        command: config.mcp_command.clone(),
-        args: vec![],
-        env: {
-            let mut env = vec![
-                EnvVar {
-                    name: "BUZZ_RELAY_URL".into(),
-                    value: config.relay_url.clone(),
-                },
-                EnvVar {
-                    name: "BUZZ_PRIVATE_KEY".into(),
-                    // bech32 encoding of a valid secret key is infallible.
-                    // Panic here is correct: injecting a bogus secret would cause
-                    // delayed, hard-to-diagnose agent failures downstream.
-                    value: config
-                        .keys
-                        .secret_key()
-                        .to_bech32()
-                        .expect("secret key bech32 encoding should never fail"),
-                },
-            ];
-            // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
-            // so the MCP server can attach it to every signed event.
-            if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
-                if !auth_tag.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_AUTH_TAG".into(),
-                        value: auth_tag,
-                    });
-                }
-            }
-            // Forward the agent's display name so dev-mcp can use it as the git
-            // author name instead of the raw npub. Read from the process env
-            // rather than Config: this is a pass-through of a contract owned
-            // upstream, and absent simply means dev-mcp falls back to the npub.
-            if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
-                if !display_name.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_ACP_DISPLAY_NAME".into(),
-                        value: display_name,
-                    });
-                }
-            }
-            env
+    if !config.aside_command.is_empty() {
+        servers.push(McpServer {
+            name: "aside-browser".to_string(),
+            command: config.aside_command.clone(),
+            args: vec!["mcp".to_string()],
+            env: vec![],
+        });
+    }
+    servers
+}
+
+fn buzz_mcp_env(config: &Config) -> Vec<EnvVar> {
+    let mut env = vec![
+        EnvVar {
+            name: "BUZZ_RELAY_URL".into(),
+            value: config.relay_url.clone(),
         },
-    }]
+        EnvVar {
+            name: "BUZZ_PRIVATE_KEY".into(),
+            // bech32 encoding of a valid secret key is infallible.
+            // Panic here is correct: injecting a bogus secret would cause
+            // delayed, hard-to-diagnose agent failures downstream.
+            value: config
+                .keys
+                .secret_key()
+                .to_bech32()
+                .expect("secret key bech32 encoding should never fail"),
+        },
+    ];
+    // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
+    // so the MCP server can attach it to every signed event.
+    if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
+        if !auth_tag.is_empty() {
+            env.push(EnvVar {
+                name: "BUZZ_AUTH_TAG".into(),
+                value: auth_tag,
+            });
+        }
+    }
+    // Forward the agent's display name so dev-mcp can use it as the git
+    // author name instead of the raw npub. Read from the process env
+    // rather than Config: this is a pass-through of a contract owned
+    // upstream, and absent simply means dev-mcp falls back to the npub.
+    if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
+        if !display_name.is_empty() {
+            env.push(EnvVar {
+                name: "BUZZ_ACP_DISPLAY_NAME".into(),
+                value: display_name,
+            });
+        }
+    }
+    env
 }
 
 #[cfg(test)]
@@ -6796,6 +6807,7 @@ mod build_mcp_servers_tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "test-mcp-server".into(),
+            aside_command: "".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -6952,6 +6964,44 @@ mod build_mcp_servers_tests {
     }
 
     #[test]
+    fn aside_command_adds_browser_mcp_alongside_primary_server() {
+        let mut config = test_config();
+        config.aside_command = "/Applications/Aside.app/Contents/MacOS/aside".into();
+
+        let servers = build_mcp_servers(&config);
+
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "test-mcp-server");
+        assert_eq!(servers[1].name, "aside-browser");
+        assert_eq!(servers[1].command, config.aside_command);
+        assert_eq!(servers[1].args, vec!["mcp"]);
+        assert!(servers[1].env.is_empty());
+    }
+
+    #[test]
+    fn aside_command_works_without_primary_mcp_server() {
+        let mut config = test_config();
+        config.mcp_command.clear();
+        config.aside_command = "aside".into();
+
+        let servers = build_mcp_servers(&config);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "aside-browser");
+        assert_eq!(servers[0].command, "aside");
+        assert_eq!(servers[0].args, vec!["mcp"]);
+    }
+
+    #[test]
+    fn empty_aside_command_does_not_add_browser_server() {
+        let config = test_config();
+        let servers = build_mcp_servers(&config);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "test-mcp-server");
+    }
+
+    #[test]
     fn absolute_path_mcp_command_uses_file_stem_as_name() {
         let mut config = test_config();
         config.mcp_command = "/opt/bin/my-mcp-server".into();
@@ -7020,6 +7070,7 @@ mod error_outcome_emission_tests {
             agent_command: "true".into(),
             agent_args: vec![],
             mcp_command: "test-mcp-server".into(),
+            aside_command: "".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -183,6 +183,7 @@ fn reserved_keys_include_code_execution_surface() {
         "BUZZ_ACP_AGENT_COMMAND",
         "BUZZ_ACP_AGENT_ARGS",
         "BUZZ_ACP_MCP_COMMAND",
+        "BUZZ_ACP_ASIDE_COMMAND",
     ] {
         assert!(is_reserved_env_key(key), "{key} should be reserved");
     }

--- a/desktop/src-tauri/src/managed_agents/reserved_env_keys.rs
+++ b/desktop/src-tauri/src/managed_agents/reserved_env_keys.rs
@@ -41,6 +41,7 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     "BUZZ_ACP_AGENT_COMMAND",
     "BUZZ_ACP_AGENT_ARGS",
     "BUZZ_ACP_MCP_COMMAND",
+    "BUZZ_ACP_ASIDE_COMMAND",
     // Control-plane parallelism: the Desktop resolves the effective
     // worker-pool size (applying any per-harness cap) and writes it into
     // launch.policy_env. A user-supplied BUZZ_ACP_AGENTS would bypass the


### PR DESCRIPTION
## Summary

- add an opt-in `--aside-command` / `BUZZ_ACP_ASIDE_COMMAND` setting
- expose the configured Aside CLI as a second ACP MCP server via `aside mcp`
- keep the existing primary MCP server available alongside browser automation
- document the new setting and cover opt-in, coexistence, and Aside-only configurations

## Safety

- disabled by default
- does not add Buzz relay credentials to the Aside MCP server configuration
- each ACP worker receives its own stdio MCP subprocess through the existing session lifecycle

`AcpClient::spawn` currently lets the ACP agent inherit the harness environment so its shell can use `buzz-cli`. An adapter that starts MCP children without clearing that inherited environment can therefore pass `BUZZ_PRIVATE_KEY` or `BUZZ_AUTH_TAG` through indirectly. Per-process credential isolation is follow-up hardening; this PR only guarantees that Aside receives no credentials through its explicit ACP MCP `env` list.

## Testing

- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass
- `cargo check -p buzz-acp` — blocked locally before crate compilation because Windows MSVC `link.exe` is unavailable; fork CI is the compile/test gate
- fork CI [`33315877005`](https://github.com/contentscoin/buzz/actions/runs/33315877005) — pass (Rust lint, unit tests, Windows Rust, cross-compile, Desktop Core, smoke/integration E2E, backend/relay E2E)

## Runtime validation

The current development host is Windows and does not have Aside installed. A live `aside mcp` browser smoke test therefore remains a macOS follow-up gate; automated coverage validates the exact command/argument contract passed through ACP.

The opt-in is harness-process scoped in this phase. Desktop per-agent selection and the embedded Browser Workspace are separate follow-ups.

No matching open issue or PR found during local repository inspection.
