### PR TITLE
feat: support secure downloadable PDF attachments

### DIFF
--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -290,6 +290,21 @@ fn is_safe_media_path_segment(sha256_ext: &str) -> bool {
     }
 }
 
+fn is_primary_blob_path_segment(segment: &str, expected_sha256: &str) -> bool {
+    match segment.split('.').collect::<Vec<_>>().as_slice() {
+        [hash] => *hash == expected_sha256,
+        [hash, ext] => *hash == expected_sha256 && is_safe_media_ext(ext),
+        _ => false,
+    }
+}
+
+fn is_thumbnail_path_segment(segment: &str, expected_sha256: &str) -> bool {
+    matches!(
+        segment.split('.').collect::<Vec<_>>().as_slice(),
+        [hash, "thumb", "jpg"] if *hash == expected_sha256
+    )
+}
+
 fn is_lower_hex_sha256(value: &str) -> bool {
     value.len() == 64 && value.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
 }
@@ -339,7 +354,7 @@ fn media_url_from_input(relay_url: &str, input: &str) -> Result<String, CliError
                 "refusing to sign media GET for a non-relay origin".to_string(),
             ));
         }
-        return Ok(input.to_string());
+        return Ok(parsed.to_string());
     }
     if input.contains("://") {
         return Err(CliError::Usage(
@@ -366,7 +381,7 @@ fn media_url_from_input(relay_url: &str, input: &str) -> Result<String, CliError
 
 fn validate_upload_descriptor(
     relay_url: &str,
-    descriptor: BlobDescriptor,
+    mut descriptor: BlobDescriptor,
     expected_sha256: &str,
     expected_size: u64,
     expected_mime: &str,
@@ -393,21 +408,34 @@ fn validate_upload_descriptor(
         .map_err(|e| CliError::Other(format!("relay returned an invalid upload URL: {e}")))?;
     let parsed = url::Url::parse(&validated_url)
         .map_err(|e| CliError::Other(format!("relay returned an invalid upload URL: {e}")))?;
-    let path_hash = parsed
+    let path_segment = parsed
         .path()
         .strip_prefix("/media/")
-        .and_then(|segment| segment.split('.').next())
         .ok_or_else(|| CliError::Other("relay returned an invalid upload URL path".to_string()))?;
-    if path_hash != expected_sha256 {
+    if !is_primary_blob_path_segment(path_segment, expected_sha256) {
         return Err(CliError::Other(
-            "relay returned an upload URL for a different SHA-256".to_string(),
+            "relay returned an upload URL that does not identify the uploaded blob".to_string(),
         ));
     }
+    descriptor.url = validated_url;
 
-    if let Some(thumb) = descriptor.thumb.as_deref() {
-        media_url_from_input(relay_url, thumb).map_err(|e| {
+    if let Some(thumb) = descriptor.thumb.clone() {
+        let validated_thumb = media_url_from_input(relay_url, &thumb).map_err(|e| {
             CliError::Other(format!("relay returned an invalid thumbnail URL: {e}"))
         })?;
+        let parsed_thumb = url::Url::parse(&validated_thumb).map_err(|e| {
+            CliError::Other(format!("relay returned an invalid thumbnail URL: {e}"))
+        })?;
+        let thumb_segment = parsed_thumb.path().strip_prefix("/media/").ok_or_else(|| {
+            CliError::Other("relay returned an invalid thumbnail URL path".to_string())
+        })?;
+        if !is_thumbnail_path_segment(thumb_segment, expected_sha256) {
+            return Err(CliError::Other(
+                "relay returned a thumbnail URL that does not identify the uploaded blob's thumbnail"
+                    .to_string(),
+            ));
+        }
+        descriptor.thumb = Some(validated_thumb);
     }
 
     Ok(descriptor)
@@ -500,6 +528,14 @@ mod media_download_tests {
             &format!("https://relay.example/media/{hash}.jpg")
         )
         .is_ok());
+        assert_eq!(
+            media_url_from_input(
+                "https://relay.example",
+                &format!("https://relay.example:443/media/{hash}.jpg")
+            )
+            .unwrap(),
+            format!("https://relay.example/media/{hash}.jpg")
+        );
         assert!(media_url_from_input(
             "https://relay.example",
             &format!("http://relay.example/media/{hash}.jpg")
@@ -546,6 +582,13 @@ mod media_download_tests {
         )
         .is_ok());
 
+        let mut explicit_default_port = descriptor.clone();
+        explicit_default_port.url = format!("https://relay.example:443/media/{hash}.pdf");
+        let canonical =
+            validate_upload_descriptor(relay, explicit_default_port, &hash, 42, "application/pdf")
+                .unwrap();
+        assert_eq!(canonical.url, descriptor.url);
+
         let mut wrong_hash = descriptor.clone();
         wrong_hash.sha256 = "b".repeat(64);
         assert!(
@@ -564,10 +607,41 @@ mod media_download_tests {
             validate_upload_descriptor(relay, wrong_mime, &hash, 42, "application/pdf").is_err()
         );
 
-        let mut wrong_url = descriptor;
+        let mut wrong_url = descriptor.clone();
         wrong_url.url = format!("https://evil.example/media/{hash}.pdf");
         assert!(
             validate_upload_descriptor(relay, wrong_url, &hash, 42, "application/pdf").is_err()
+        );
+
+        let mut thumbnail_as_primary = descriptor.clone();
+        thumbnail_as_primary.url = format!("{relay}/media/{hash}.thumb.jpg");
+        assert!(validate_upload_descriptor(
+            relay,
+            thumbnail_as_primary,
+            &hash,
+            42,
+            "application/pdf"
+        )
+        .is_err());
+
+        let mut valid_thumb = descriptor.clone();
+        valid_thumb.thumb = Some(format!("{relay}/media/{hash}.thumb.jpg"));
+        assert!(
+            validate_upload_descriptor(relay, valid_thumb, &hash, 42, "application/pdf").is_ok()
+        );
+
+        let mut unrelated_thumb = descriptor.clone();
+        unrelated_thumb.thumb = Some(format!("{relay}/media/{}.thumb.jpg", "b".repeat(64)));
+        assert!(
+            validate_upload_descriptor(relay, unrelated_thumb, &hash, 42, "application/pdf")
+                .is_err()
+        );
+
+        let mut primary_as_thumb = descriptor;
+        primary_as_thumb.thumb = Some(format!("{relay}/media/{hash}.jpg"));
+        assert!(
+            validate_upload_descriptor(relay, primary_as_thumb, &hash, 42, "application/pdf")
+                .is_err()
         );
     }
 

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -67,6 +67,7 @@ const ALLOWED_MIMES: &[&str] = &[
     "image/gif",
     "image/webp",
     "video/mp4",
+    "application/pdf",
 ];
 
 /// Maximum file size for image uploads (50 MB).
@@ -74,6 +75,38 @@ const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum file size for video uploads (500 MB).
 const MAX_VIDEO_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Maximum file size for generic attachments (100 MB).
+const MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
+
+fn max_upload_bytes(mime: &str) -> u64 {
+    if mime.starts_with("video/") {
+        MAX_VIDEO_BYTES
+    } else if mime.starts_with("image/") {
+        MAX_IMAGE_BYTES
+    } else {
+        MAX_FILE_BYTES
+    }
+}
+
+#[cfg(test)]
+mod upload_policy_tests {
+    use super::{
+        max_upload_bytes, ALLOWED_MIMES, MAX_FILE_BYTES, MAX_IMAGE_BYTES, MAX_VIDEO_BYTES,
+    };
+
+    #[test]
+    fn pdf_is_allowed_as_a_generic_attachment() {
+        assert!(ALLOWED_MIMES.contains(&"application/pdf"));
+        assert_eq!(max_upload_bytes("application/pdf"), MAX_FILE_BYTES);
+    }
+
+    #[test]
+    fn existing_media_size_limits_are_unchanged() {
+        assert_eq!(max_upload_bytes("image/png"), MAX_IMAGE_BYTES);
+        assert_eq!(max_upload_bytes("video/mp4"), MAX_VIDEO_BYTES);
+    }
+}
 
 /// Sign a NIP-98 HTTP auth event (kind:27235) and return the Authorization header value.
 ///
@@ -1139,11 +1172,7 @@ impl BuzzClient {
         }
 
         // 3. Size check
-        let max = if mime.starts_with("video/") {
-            MAX_VIDEO_BYTES
-        } else {
-            MAX_IMAGE_BYTES
-        };
+        let max = max_upload_bytes(&mime);
         if bytes.len() as u64 > max {
             return Err(CliError::Usage(format!(
                 "file too large: {} bytes (max {})",

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -305,6 +305,15 @@ fn media_url_from_input(relay_url: &str, input: &str) -> Result<String, CliError
     if input.starts_with("http://") || input.starts_with("https://") {
         let parsed = url::Url::parse(input)
             .map_err(|e| CliError::Usage(format!("invalid media URL: {e}")))?;
+        if !parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+        {
+            return Err(CliError::Usage(
+                "media URL must not contain credentials, a query, or a fragment".to_string(),
+            ));
+        }
         if !parsed.path().starts_with("/media/") {
             return Err(CliError::Usage(
                 "media URL must point at a /media/ path".to_string(),
@@ -353,6 +362,55 @@ fn media_url_from_input(relay_url: &str, input: &str) -> Result<String, CliError
         "{}/media/{sha256_ext}",
         relay_url.trim_end_matches('/')
     ))
+}
+
+fn validate_upload_descriptor(
+    relay_url: &str,
+    descriptor: BlobDescriptor,
+    expected_sha256: &str,
+    expected_size: u64,
+    expected_mime: &str,
+) -> Result<BlobDescriptor, CliError> {
+    if descriptor.sha256 != expected_sha256 {
+        return Err(CliError::Other(
+            "relay returned an upload descriptor with a mismatched SHA-256".to_string(),
+        ));
+    }
+    if descriptor.size != expected_size {
+        return Err(CliError::Other(format!(
+            "relay returned an upload descriptor with a mismatched size ({} != {expected_size})",
+            descriptor.size
+        )));
+    }
+    if descriptor.mime_type != expected_mime {
+        return Err(CliError::Other(format!(
+            "relay returned an upload descriptor with a mismatched MIME type ({} != {expected_mime})",
+            descriptor.mime_type
+        )));
+    }
+
+    let validated_url = media_url_from_input(relay_url, &descriptor.url)
+        .map_err(|e| CliError::Other(format!("relay returned an invalid upload URL: {e}")))?;
+    let parsed = url::Url::parse(&validated_url)
+        .map_err(|e| CliError::Other(format!("relay returned an invalid upload URL: {e}")))?;
+    let path_hash = parsed
+        .path()
+        .strip_prefix("/media/")
+        .and_then(|segment| segment.split('.').next())
+        .ok_or_else(|| CliError::Other("relay returned an invalid upload URL path".to_string()))?;
+    if path_hash != expected_sha256 {
+        return Err(CliError::Other(
+            "relay returned an upload URL for a different SHA-256".to_string(),
+        ));
+    }
+
+    if let Some(thumb) = descriptor.thumb.as_deref() {
+        media_url_from_input(relay_url, thumb).map_err(|e| {
+            CliError::Other(format!("relay returned an invalid thumbnail URL: {e}"))
+        })?;
+    }
+
+    Ok(descriptor)
 }
 
 fn sign_blossom_get(keys: &Keys, media_url: &str) -> Result<String, CliError> {
@@ -462,6 +520,55 @@ mod media_download_tests {
             &format!("ftp://relay.example/media/{hash}.jpg")
         )
         .is_err());
+    }
+
+    #[test]
+    fn upload_descriptor_must_match_local_file_and_relay() {
+        let hash = "a".repeat(64);
+        let relay = "https://relay.example";
+        let descriptor = BlobDescriptor {
+            url: format!("{relay}/media/{hash}.pdf"),
+            sha256: hash.clone(),
+            size: 42,
+            mime_type: "application/pdf".to_string(),
+            uploaded: 0,
+            dim: None,
+            duration: None,
+            blurhash: None,
+            thumb: None,
+        };
+        assert!(validate_upload_descriptor(
+            relay,
+            descriptor.clone(),
+            &hash,
+            42,
+            "application/pdf"
+        )
+        .is_ok());
+
+        let mut wrong_hash = descriptor.clone();
+        wrong_hash.sha256 = "b".repeat(64);
+        assert!(
+            validate_upload_descriptor(relay, wrong_hash, &hash, 42, "application/pdf").is_err()
+        );
+
+        let mut wrong_size = descriptor.clone();
+        wrong_size.size = 41;
+        assert!(
+            validate_upload_descriptor(relay, wrong_size, &hash, 42, "application/pdf").is_err()
+        );
+
+        let mut wrong_mime = descriptor.clone();
+        wrong_mime.mime_type = "image/png".to_string();
+        assert!(
+            validate_upload_descriptor(relay, wrong_mime, &hash, 42, "application/pdf").is_err()
+        );
+
+        let mut wrong_url = descriptor;
+        wrong_url.url = format!("https://evil.example/media/{hash}.pdf");
+        assert!(
+            validate_upload_descriptor(relay, wrong_url, &hash, 42, "application/pdf").is_err()
+        );
     }
 
     #[test]
@@ -1204,6 +1311,7 @@ impl BuzzClient {
                 let mime = mime.clone();
                 let sha256 = sha256.clone();
                 async move {
+                    let expected_size = upload_body.len() as u64;
                     let auth_header =
                         sign_blossom_upload(&self.keys, &sha256, &mime, &self.relay_url)?;
                     let resp = self
@@ -1224,7 +1332,17 @@ impl BuzzClient {
                         let body = resp.text().await.unwrap_or_default();
                         return Err(CliError::Relay { status: s, body });
                     }
-                    resp.json::<BlobDescriptor>().await.map_err(CliError::from)
+                    let descriptor = resp
+                        .json::<BlobDescriptor>()
+                        .await
+                        .map_err(CliError::from)?;
+                    validate_upload_descriptor(
+                        &self.relay_url,
+                        descriptor,
+                        &sha256,
+                        expected_size,
+                        &mime,
+                    )
                 }
             })
             .await;
@@ -1251,6 +1369,7 @@ impl BuzzClient {
             let mime = mime.clone();
             let sha256 = sha256.clone();
             async move {
+                let expected_size = upload_body.len() as u64;
                 let auth_header = sign_blossom_upload(&self.keys, &sha256, &mime, &self.relay_url)?;
                 let resp = self
                     .with_auth_tag(
@@ -1269,7 +1388,17 @@ impl BuzzClient {
                     let body = resp.text().await.unwrap_or_default();
                     return Err(CliError::Relay { status, body });
                 }
-                resp.json::<BlobDescriptor>().await.map_err(CliError::from)
+                let descriptor = resp
+                    .json::<BlobDescriptor>()
+                    .await
+                    .map_err(CliError::from)?;
+                validate_upload_descriptor(
+                    &self.relay_url,
+                    descriptor,
+                    &sha256,
+                    expected_size,
+                    &mime,
+                )
             }
         })
         .await
@@ -2187,6 +2316,7 @@ mod retry_policy_tests {
         ];
         tmp.write_all(jpeg_header).unwrap();
         let file_path = tmp.path().to_str().unwrap().to_string();
+        let expected_sha = hex::encode(<sha2::Sha256 as sha2::Digest>::digest(jpeg_header));
 
         let counter = Arc::new(AtomicU32::new(0));
         let counter2 = counter.clone();
@@ -2226,7 +2356,10 @@ mod retry_policy_tests {
                     let _ = stream.write_all(partial).await;
                 } else {
                     // Valid BlobDescriptor response.
-                    let ok_body = r#"{"url":"https://relay.test/media/aabbcc.jpg","sha256":"aabbcc","size":12,"type":"image/jpeg","uploaded":0}"#;
+                    let ok_body = format!(
+                        r#"{{"url":"http://{addr}/media/{expected_sha}.jpg","sha256":"{expected_sha}","size":{},"type":"image/jpeg","uploaded":0}}"#,
+                        jpeg_header.len()
+                    );
                     let ok = format!(
                         "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
                         ok_body.len(),

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -6,7 +6,7 @@ use crate::client::{normalize_events, normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::{
     infer_language, parse_event_id, parse_uuid, read_or_stdin, truncate_diff,
-    validate_content_size, validate_hex64, validate_uuid, MAX_DIFF_BYTES,
+    validate_content_size, validate_hex64, validate_uuid, MAX_CONTENT_BYTES, MAX_DIFF_BYTES,
 };
 use buzz_sdk::mentions::{
     extract_at_mentions_with_known, extract_nostr_uris, strip_code_regions, MENTION_CAP,
@@ -613,22 +613,50 @@ fn safe_attachment_filename(file_path: &str) -> String {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("file");
-    let mut safe = String::new();
-    let mut bytes = 0;
-    for ch in basename.chars().filter(|ch| !ch.is_control()) {
-        let width = ch.len_utf8();
-        if bytes + width > 255 {
-            break;
-        }
-        safe.push(ch);
-        bytes += width;
-    }
+    let safe: String = basename.chars().filter(|ch| !ch.is_control()).collect();
     let trimmed = safe.trim();
     if trimmed.is_empty() {
+        return "file".to_string();
+    }
+
+    const MAX_FILENAME_BYTES: usize = 255;
+    if trimmed.len() <= MAX_FILENAME_BYTES {
+        return trimmed.to_string();
+    }
+
+    if let Some((stem, extension)) = trimmed.rsplit_once('.') {
+        let suffix = format!(".{extension}");
+        if !stem.is_empty() && !extension.is_empty() && suffix.len() < MAX_FILENAME_BYTES {
+            let truncated_stem = truncate_utf8_bytes(stem, MAX_FILENAME_BYTES - suffix.len());
+            let truncated_stem = truncated_stem.trim_end();
+            if !truncated_stem.is_empty() {
+                return format!("{truncated_stem}{suffix}");
+            }
+        }
+    }
+
+    let truncated = truncate_utf8_bytes(trimmed, MAX_FILENAME_BYTES);
+    let truncated = truncated.trim();
+    if truncated.is_empty() {
         "file".to_string()
     } else {
-        trimmed.to_string()
+        truncated.to_string()
     }
+}
+
+fn truncate_utf8_bytes(value: &str, max_bytes: usize) -> String {
+    value
+        .chars()
+        .scan(0usize, |bytes, ch| {
+            let next = *bytes + ch.len_utf8();
+            if next > max_bytes {
+                None
+            } else {
+                *bytes = next;
+                Some(ch)
+            }
+        })
+        .collect()
 }
 
 fn escape_markdown_label(label: &str) -> String {
@@ -640,6 +668,28 @@ fn escape_markdown_label(label: &str) -> String {
         escaped.push(ch);
     }
     escaped
+}
+
+fn validate_attachment_content_budget(
+    content: &str,
+    files: &[String],
+    relay_url: &str,
+) -> Result<(), CliError> {
+    // Upload descriptors are restricted to this relay's `/media/{sha256}[.ext]`
+    // URLs. Reserve the longest permitted URL and the generic-file markdown form
+    // before any upload so a later content-size failure cannot orphan a blob.
+    let max_url_bytes = relay_url.trim_end_matches('/').len() + "/media/".len() + 64 + 1 + 8;
+    let attachment_bytes = files.iter().try_fold(0usize, |total, file_path| {
+        let label = escape_markdown_label(&safe_attachment_filename(file_path));
+        total.checked_add(5 + label.len() + max_url_bytes)
+    });
+    let final_bytes = attachment_bytes.and_then(|bytes| content.len().checked_add(bytes));
+    if final_bytes.is_none_or(|bytes| bytes > MAX_CONTENT_BYTES) {
+        return Err(CliError::Usage(format!(
+            "content plus attachment links exceeds maximum size (max {MAX_CONTENT_BYTES} bytes)"
+        )));
+    }
+    Ok(())
 }
 
 pub async fn cmd_send_message(
@@ -681,6 +731,8 @@ pub async fn cmd_send_message(
         ));
     }
 
+    validate_attachment_content_budget(&p.content, &p.files, client.relay_url())?;
+
     // Upload files and build imeta tags
     let mut media_tags: Vec<Vec<String>> = Vec::new();
     let mut media_content = String::new();
@@ -714,6 +766,7 @@ pub async fn cmd_send_message(
     } else {
         format!("{}{media_content}", p.content)
     };
+    validate_content_size(&final_content)?;
 
     // Build thread ref if replying. `--reply-to` is the immediate parent; the
     // thread root is derived from the parent's NIP-10 tags via the relay.
@@ -1105,8 +1158,10 @@ mod tests {
         find_root_from_tags, format_events, match_profiles_by_name, merge_message_mentions,
         missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys, resolve_thread_target, safe_attachment_filename,
-        thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient, CliError, Uuid,
+        thread_ref_from_event, thread_ref_from_parent_tags, validate_attachment_content_budget,
+        BuzzClient, CliError, Uuid,
     };
+    use crate::validate::MAX_CONTENT_BYTES;
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
@@ -1243,6 +1298,27 @@ mod tests {
             "closingstatement.pdf"
         );
         assert_eq!(safe_attachment_filename("/tmp/   "), "file");
+    }
+
+    #[test]
+    fn attachment_filename_truncation_preserves_utf8_extension() {
+        let long_name = format!("{}.pdf", "é".repeat(200));
+        let safe = safe_attachment_filename(&long_name);
+        assert!(safe.len() <= 255);
+        assert!(safe.ends_with(".pdf"));
+        assert!(safe.is_char_boundary(safe.len()));
+    }
+
+    #[test]
+    fn attachment_budget_is_checked_before_upload() {
+        let files = vec!["report.pdf".to_string()];
+        assert!(validate_attachment_content_budget("ok", &files, "https://relay.example").is_ok());
+        assert!(validate_attachment_content_budget(
+            &"x".repeat(MAX_CONTENT_BYTES),
+            &files,
+            "https://relay.example"
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -676,12 +676,21 @@ fn validate_attachment_content_budget(
     relay_url: &str,
 ) -> Result<(), CliError> {
     // Upload descriptors are restricted to this relay's `/media/{sha256}[.ext]`
-    // URLs. Reserve the longest permitted URL and the generic-file markdown form
-    // before any upload so a later content-size failure cannot orphan a blob.
-    let max_url_bytes = relay_url.trim_end_matches('/').len() + "/media/".len() + 64 + 1 + 8;
+    // URLs. Reserve the longest permitted URL and the longest markdown form for
+    // each filename before any upload so a later content-size failure cannot
+    // orphan a blob. Short filenames make image/video markup longer than generic
+    // file markup, while long escaped filenames make the generic form longer.
+    let mut max_media_url = url::Url::parse(relay_url)
+        .map_err(|e| CliError::Usage(format!("invalid relay URL: {e}")))?;
+    max_media_url.set_path(&format!("/media/{}.{}", "a".repeat(64), "a".repeat(8)));
+    max_media_url.set_query(None);
+    max_media_url.set_fragment(None);
+    let max_url_bytes = max_media_url.as_str().len();
     let attachment_bytes = files.iter().try_fold(0usize, |total, file_path| {
         let label = escape_markdown_label(&safe_attachment_filename(file_path));
-        total.checked_add(5 + label.len() + max_url_bytes)
+        let generic_markdown_bytes = "\n[]()".len() + label.len();
+        let inline_media_markdown_bytes = "\n![image]()".len();
+        total.checked_add(generic_markdown_bytes.max(inline_media_markdown_bytes) + max_url_bytes)
     });
     let final_bytes = attachment_bytes.and_then(|bytes| content.len().checked_add(bytes));
     if final_bytes.is_none_or(|bytes| bytes > MAX_CONTENT_BYTES) {
@@ -1311,12 +1320,30 @@ mod tests {
 
     #[test]
     fn attachment_budget_is_checked_before_upload() {
+        let relay = "https://relay.example";
         let files = vec!["report.pdf".to_string()];
-        assert!(validate_attachment_content_budget("ok", &files, "https://relay.example").is_ok());
+        assert!(validate_attachment_content_budget("ok", &files, relay).is_ok());
+        assert!(
+            validate_attachment_content_budget(&"x".repeat(MAX_CONTENT_BYTES), &files, relay)
+                .is_err()
+        );
+
+        // A one-character filename makes inline image/video markdown longer than
+        // the generic-file form. The boundary must still be conservative so an
+        // image cannot upload and then fail the final content-size check.
+        let short_name = vec!["a".to_string()];
+        let max_url_bytes = relay.len() + "/media/".len() + 64 + 1 + 8;
+        let reserved_bytes = "\n![image]()".len() + max_url_bytes;
         assert!(validate_attachment_content_budget(
-            &"x".repeat(MAX_CONTENT_BYTES),
-            &files,
-            "https://relay.example"
+            &"x".repeat(MAX_CONTENT_BYTES - reserved_bytes),
+            &short_name,
+            relay
+        )
+        .is_ok());
+        assert!(validate_attachment_content_budget(
+            &"x".repeat(MAX_CONTENT_BYTES - reserved_bytes + 1),
+            &short_name,
+            relay
         )
         .is_err());
     }

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -608,6 +608,40 @@ pub struct SendMessageParams {
     pub mentions: Vec<String>,
 }
 
+fn safe_attachment_filename(file_path: &str) -> String {
+    let basename = std::path::Path::new(file_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file");
+    let mut safe = String::new();
+    let mut bytes = 0;
+    for ch in basename.chars().filter(|ch| !ch.is_control()) {
+        let width = ch.len_utf8();
+        if bytes + width > 255 {
+            break;
+        }
+        safe.push(ch);
+        bytes += width;
+    }
+    let trimmed = safe.trim();
+    if trimmed.is_empty() {
+        "file".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn escape_markdown_label(label: &str) -> String {
+    let mut escaped = String::with_capacity(label.len());
+    for ch in label.chars() {
+        if matches!(ch, '\\' | '[' | ']') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
 pub async fn cmd_send_message(
     client: &BuzzClient,
     mut p: SendMessageParams,
@@ -655,14 +689,25 @@ pub async fn cmd_send_message(
             .upload_file(file_path)
             .await
             .map_err(|e| CliError::Other(format!("upload failed for {file_path}: {e}")))?;
-        media_tags.push(crate::client::build_imeta_tag(&desc));
+        let filename = safe_attachment_filename(file_path);
+        let mut imeta = crate::client::build_imeta_tag(&desc);
+        imeta.push(format!("filename {filename}"));
+        media_tags.push(imeta);
         if desc.mime_type.starts_with("video/") {
             media_content.push_str("\n![video](");
-        } else {
+            media_content.push_str(&desc.url);
+            media_content.push(')');
+        } else if desc.mime_type.starts_with("image/") {
             media_content.push_str("\n![image](");
+            media_content.push_str(&desc.url);
+            media_content.push(')');
+        } else {
+            media_content.push_str("\n[");
+            media_content.push_str(&escape_markdown_label(&filename));
+            media_content.push_str("](");
+            media_content.push_str(&desc.url);
+            media_content.push(')');
         }
-        media_content.push_str(&desc.url);
-        media_content.push(')');
     }
     let final_content = if media_content.is_empty() {
         p.content.clone()
@@ -1056,11 +1101,11 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        channel_id_from_event, cmd_get_thread, event_mention_pubkeys, find_root_from_tags,
-        format_events, match_profiles_by_name, merge_message_mentions, missing_members,
-        normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
-        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
-        CliError, Uuid,
+        channel_id_from_event, cmd_get_thread, escape_markdown_label, event_mention_pubkeys,
+        find_root_from_tags, format_events, match_profiles_by_name, merge_message_mentions,
+        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        resolve_names_to_pubkeys, resolve_thread_target, safe_attachment_filename,
+        thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient, CliError, Uuid,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
@@ -1188,6 +1233,23 @@ mod tests {
             )
             .unwrap(),
             ID_A
+        );
+    }
+
+    #[test]
+    fn attachment_filename_uses_a_safe_basename() {
+        assert_eq!(
+            safe_attachment_filename("/tmp/reports/closing\nstatement.pdf"),
+            "closingstatement.pdf"
+        );
+        assert_eq!(safe_attachment_filename("/tmp/   "), "file");
+    }
+
+    #[test]
+    fn attachment_filename_is_safe_as_a_markdown_label() {
+        assert_eq!(
+            escape_markdown_label(r"report[final]\\copy.pdf"),
+            r"report\[final\]\\\\copy.pdf"
         );
     }
 


### PR DESCRIPTION
## Summary

- allow PDF uploads under the explicit generic-attachment policy
- preserve a sanitized, bounded original filename and render generic files as downloadable Markdown links
- validate final message size before upload and again after attachment assembly
- bind relay upload descriptors to locally computed SHA-256, size, MIME, and canonical same-relay media paths
- reject primary thumbnail URLs and invalid thumbnail paths returned as upload metadata

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p buzz-cli` — 420 passed
- `cargo clippy -p buzz-cli --all-targets -- -D warnings`
- `cargo build --release -p buzz-cli`
- live PDF upload/download round trip — SHA-256 matched (`b62d365c744562ecb1fb23bef22742fc082406ad57ebb0e51aa8ade8223d4ea1`)

`just ci` reaches Desktop Tauri clippy but cannot complete on this Linux host because the system `gobject-2.0`/`glib-2.0` development packages are unavailable. The workspace Rust clippy and Desktop frontend checks preceding that step pass.
