### PR TITLE
feat(buzz-acp): pass authenticated event authors out-of-band in session/prompt _meta

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -762,6 +762,7 @@ impl AcpClient {
         self.session_prompt_blocks_with_idle_timeout(
             session_id,
             std::slice::from_ref(&prompt_text),
+            None,
             idle_timeout,
             max_duration,
         )
@@ -774,14 +775,19 @@ impl AcpClient {
     /// Used for slash-command pass-through: ACP connectors detect commands via
     /// the **first** block's text starting with `/`, so the harness sends
     /// `["/cmd args", "<buzz context>"]` instead of one wrapped block.
+    /// `prompt_meta`, when `Some`, is attached verbatim as the request's `_meta`
+    /// object — the out-of-band channel for authenticated facts (e.g. the
+    /// verified author pubkeys of the triggering Buzz events) that agents must
+    /// never have to parse out of prompt text.
     pub async fn session_prompt_blocks_with_idle_timeout(
         &mut self,
         session_id: &str,
         prompt_blocks: &[&str],
+        prompt_meta: Option<serde_json::Value>,
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
-        let params = build_prompt_params(session_id, prompt_blocks);
+        let params = build_prompt_params(session_id, prompt_blocks, prompt_meta);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
 
@@ -2041,15 +2047,23 @@ impl AcpClient {
 }
 
 /// Build `session/prompt` params from one or more text content blocks.
-fn build_prompt_params(session_id: &str, prompt_blocks: &[&str]) -> serde_json::Value {
+fn build_prompt_params(
+    session_id: &str,
+    prompt_blocks: &[&str],
+    meta: Option<serde_json::Value>,
+) -> serde_json::Value {
     let blocks: Vec<serde_json::Value> = prompt_blocks
         .iter()
         .map(|text| serde_json::json!({ "type": "text", "text": text }))
         .collect();
-    serde_json::json!({
+    let mut params = serde_json::json!({
         "sessionId": session_id,
         "prompt": blocks,
-    })
+    });
+    if let Some(meta) = meta {
+        params["_meta"] = meta;
+    }
+    params
 }
 
 /// Build `_goose/unstable/session/steer` params from one or more text
@@ -2577,6 +2591,29 @@ mod tests {
     }
 
     #[test]
+    fn build_prompt_params_attaches_meta_out_of_band() {
+        let params = build_prompt_params(
+            "sess_abc123",
+            &["[Buzz event: @mention]\nContent: hello"],
+            Some(serde_json::json!({
+                "buzz": {
+                    "channelId": "0b0e1d2c-0000-0000-0000-000000000000",
+                    "events": [
+                        { "id": "ff".repeat(32), "authorPubkey": "aa".repeat(32) }
+                    ]
+                }
+            })),
+        );
+        assert_eq!(
+            params["_meta"]["buzz"]["events"][0]["authorPubkey"].as_str(),
+            Some("aa".repeat(32).as_str())
+        );
+        // Ohne meta bleibt der Request unveraendert (kein leeres _meta).
+        let ohne = build_prompt_params("sess_abc123", &["x"], None);
+        assert!(ohne.get("_meta").is_none());
+    }
+
+    #[test]
     fn session_prompt_slash_command_two_block_format() {
         // Slash-command pass-through: bare command first, wrapped context second.
         let params = build_prompt_params(
@@ -2585,6 +2622,7 @@ mod tests {
                 "/goal ship it",
                 "[Buzz event: @mention]\nContent: @Eva /goal ship it",
             ],
+            None,
         );
         let prompt = params["prompt"].as_array().unwrap();
         assert_eq!(prompt.len(), 2);

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2562,6 +2562,24 @@ pub async fn run_prompt_task(
     // own block. Per-section blocks let the observer size trimmer elide a
     // section body in place while every `[Header]` line survives at the head
     // of its own leaf — so the "Prompt context" panel counts every section.
+    // Out-of-band author facts for the agent (ACP `_meta`): the harness already
+    // authenticated these events; agents (e.g. policy-enforcing ACP servers)
+    // must not have to parse `From:` lines out of prompt text to learn who is
+    // asking. Events only — heartbeats carry no author.
+    let prompt_meta: Option<serde_json::Value> = batch.as_ref().map(|b| {
+        let events: Vec<serde_json::Value> = b
+            .events
+            .iter()
+            .map(|be| {
+                serde_json::json!({
+                    "id": be.event.id.to_hex(),
+                    "authorPubkey": be.event.pubkey.to_hex(),
+                })
+            })
+            .collect();
+        serde_json::json!({ "buzz": { "channelId": b.channel_id, "events": events } })
+    });
+
     let prompt_blocks: Vec<&str> = match slash_command {
         Some(ref cmd) => std::iter::once(cmd.as_str())
             .chain(prompt_sections.iter().map(String::as_str))
@@ -2615,6 +2633,7 @@ pub async fn run_prompt_task(
                 result = agent.acp.session_prompt_blocks_with_idle_timeout(
                     &session_id,
                     &prompt_blocks,
+                    prompt_meta.clone(),
                     ctx.idle_timeout,
                     ctx.max_turn_duration,
                 ) => result,
@@ -2626,6 +2645,7 @@ pub async fn run_prompt_task(
                 result = agent.acp.session_prompt_blocks_with_idle_timeout(
                     &session_id,
                     &prompt_blocks,
+                    prompt_meta.clone(),
                     ctx.idle_timeout,
                     ctx.max_turn_duration,
                 ) => result,


### PR DESCRIPTION
## What

Attach the authenticated facts of a prompt turn out-of-band on `session/prompt`, following the existing `_meta` pattern (`sessionTitle`, `systemPrompt.append`):

```json
"_meta": {
  "buzz": {
    "channelId": "<uuid>",
    "events": [ { "id": "<hex>", "authorPubkey": "<hex>" } ]
  }
}
```

## Why

The harness authenticates every inbound event, but an agent only learns the sender from the `From:` line rendered into the prompt *text* — mixed with untrusted message content, where a quoted message can carry a forged `From:` line. Agents that enforce per-sender policy (e.g. ACP servers that map senders to principals/permissions before touching tools) must never have to parse identity out of prompt text.

We hit this building an ACP server that fronts a contract-gated agent runtime: the reply target and the sender→principal mapping both need verified values. With this `_meta`, the server can (a) reply deterministically into the right thread and (b) bind per-sender permissions to the pubkey the harness already verified — without trusting prompt text.

## Notes

- Heartbeat prompts are unchanged (no batch → no `_meta.buzz`).
- Requests without meta keep their exact previous wire shape (no empty `_meta` object).
- Unknown `_meta` is ignored by existing adapters (same contract as `sessionTitle`).
- New unit test `build_prompt_params_attaches_meta_out_of_band`; full `buzz-acp` suite green locally.
