### PR TITLE
fix: preserve reply obligations and reject empty messages

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2867,13 +2867,13 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            let is_dm =
+                                is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
@@ -2970,6 +2970,7 @@ async fn tokio_main() -> Result<()> {
                                             buzz_event.channel_id,
                                             event_for_steer,
                                             prompt_tag_for_steer,
+                                            is_dm,
                                             &steer_ack_tx,
                                         );
                                     if !native_attempted {
@@ -3640,6 +3641,7 @@ fn try_native_steer(
     channel_id: uuid::Uuid,
     event: nostr::Event,
     prompt_tag: String,
+    is_dm: bool,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
     // Build the steer body: framing strings come from
@@ -3662,7 +3664,7 @@ fn try_native_steer(
         prompt_tag: prompt_tag.clone(),
         received_at: std::time::Instant::now(),
     };
-    let event_block = queue::format_event_block(channel_id, None, &be, None);
+    let event_block = queue::format_routed_event_block(channel_id, None, &be, None, is_dm);
     let new_message = prompt_framing::semantic_section(tag, "");
     let event_section = prompt_framing::semantic_section_with_attributes(
         "buzz-event",

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1181,6 +1181,42 @@ pub(crate) fn format_event_block(
     block
 }
 
+/// Format an event and retain the reply destination that belongs to it.
+///
+/// A batch or mid-turn steer can contain several unrelated human messages.
+/// The turn-level `<context>` only describes the last event, so without this
+/// per-event route an agent can answer the newest thread and silently absorb
+/// earlier reply obligations. DMs deliberately keep their existing linear
+/// routing semantics and therefore do not get an event-level `--reply-to`.
+pub(crate) fn format_routed_event_block(
+    channel_id: Uuid,
+    channel_info: Option<&PromptChannelInfo>,
+    be: &BatchEvent,
+    profile_lookup: Option<&PromptProfileLookup>,
+    is_dm: bool,
+) -> String {
+    let mut block = format_event_block(channel_id, channel_info, be, profile_lookup);
+    if is_dm {
+        return block;
+    }
+
+    let sender_pubkey = be.event.pubkey.to_hex();
+    let thread_tags = parse_thread_tags(&be.event);
+    if let Some(anchor) = resolve_reply_anchor(
+        &sender_pubkey,
+        &thread_tags,
+        &be.event.id.to_hex(),
+        profile_lookup,
+    ) {
+        block.push_str(&format!(
+            "\nReply routing: If this human event requires a response, send it with \
+             `--reply-to {anchor}`. This destination belongs to this event; a reply \
+             sent only under another event does not close it."
+        ));
+    }
+    block
+}
+
 /// Append a reply instruction when the agent is responding to a thread event.
 ///
 /// Tells the agent to default to `--reply-to <event_id>` for ordinary replies
@@ -1874,7 +1910,13 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
                 "--- Event {} ({}) ---\n{}",
                 i + 1,
                 be.prompt_tag,
-                format_event_block(batch.channel_id, args.channel_info, be, args.profile_lookup)
+                format_routed_event_block(
+                    batch.channel_id,
+                    args.channel_info,
+                    be,
+                    args.profile_lookup,
+                    is_dm,
+                )
             ));
         }
         sections.push(crate::prompt_framing::semantic_section(
@@ -1892,11 +1934,12 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
                 &format!(
                     "--- Event 1 ({}) ---\n{}",
                     be.prompt_tag,
-                    format_event_block(
+                    format_routed_event_block(
                         batch.channel_id,
                         args.channel_info,
                         be,
-                        args.profile_lookup
+                        args.profile_lookup,
+                        is_dm,
                     )
                 ),
             )
@@ -1904,7 +1947,13 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
             crate::prompt_framing::semantic_section_with_attributes(
                 "buzz-event",
                 &[("type", be.prompt_tag.as_str())],
-                &format_event_block(batch.channel_id, args.channel_info, be, args.profile_lookup),
+                &format_routed_event_block(
+                    batch.channel_id,
+                    args.channel_info,
+                    be,
+                    args.profile_lookup,
+                    is_dm,
+                ),
             )
         }
     } else {
@@ -1917,7 +1966,13 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
                 "--- Event {} ({}) ---\n{}",
                 i + 1,
                 be.prompt_tag,
-                format_event_block(batch.channel_id, args.channel_info, be, args.profile_lookup)
+                format_routed_event_block(
+                    batch.channel_id,
+                    args.channel_info,
+                    be,
+                    args.profile_lookup,
+                    is_dm,
+                )
             ));
         }
         let count = batch.events.len().to_string();
@@ -2429,10 +2484,10 @@ mod tests {
     }
 
     /// Cross-thread steering: original work in thread A (cancelled), steering
-    /// message in thread B (new). Pins Perci's edge — the reply instruction
-    /// targets the *steering* message (the one the agent is responding to, where
-    /// the mentioner is waiting), while the steer framing still says "continue
-    /// your in-progress work." This is intended behavior, not a mismatch.
+    /// message in thread B (new). The turn-level reply instruction targets the
+    /// steering message, while each human event retains its own reply route in
+    /// the event block. This keeps the active turn in thread B without silently
+    /// absorbing the outstanding reply obligation in thread A.
     #[test]
     fn test_steer_cross_thread_reply_targets_steering_message() {
         let ch = Uuid::new_v4();
@@ -2476,18 +2531,27 @@ mod tests {
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
 
-        // Reply instruction points at the thread root of the steering message
-        // (thread_b), not the steering event's own id — this matches the
-        // human-aware reply anchoring from PR #1281: for human-facing turns in
-        // a thread, the anchor is always the thread root.
+        // The turn-level context points at the thread root of the steering
+        // message (thread_b), not the steering event's own id — this matches
+        // the human-aware reply anchoring from PR #1281: for human-facing turns
+        // in a thread, the anchor is always the thread root.
+        let turn_context = prompt
+            .split_once("</context>")
+            .map(|(context, _)| context)
+            .expect("steer prompt should contain a context section");
         assert!(
-            prompt.contains(&format!("--reply-to {thread_b}")),
+            turn_context.contains(&format!("--reply-to {thread_b}")),
             "reply instruction should target the steering thread root: {prompt}"
         );
         assert!(
-            !prompt.contains(&format!("--reply-to {thread_a}")),
-            "reply instruction must NOT target the original thread: {prompt}"
+            !turn_context.contains(&format!("--reply-to {thread_a}")),
+            "turn-level reply instruction must not target the original thread: {prompt}"
         );
+        // Both human events retain their own event-level routes so neither
+        // reply obligation is lost when the messages came from different
+        // threads.
+        assert!(prompt.contains(&format!("`--reply-to {thread_a}`")));
+        assert!(prompt.contains(&format!("`--reply-to {thread_b}`")));
         // Steer framing still frames the original as in-progress work to continue.
         assert!(prompt.contains("<what-you-were-working-on>"));
         assert!(prompt.contains("arrived while you were working"));
@@ -4254,6 +4318,117 @@ mod tests {
             prompt.contains(&format!("Event ID: {event_id}")),
             "prompt should contain the event ID"
         );
+    }
+
+    #[test]
+    fn test_batch_retains_each_human_events_reply_destination() {
+        let ch = Uuid::new_v4();
+        let first = make_event("first question");
+        let second = make_event("second question");
+        let first_id = first.id.to_hex();
+        let second_id = second.id.to_hex();
+        let profiles = HashMap::from([
+            (first.pubkey.to_hex(), profile(false)),
+            (second.pubkey.to_hex(), profile(false)),
+        ]);
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![
+                BatchEvent {
+                    event: first,
+                    prompt_tag: "mention".into(),
+                    received_at: Instant::now(),
+                },
+                BatchEvent {
+                    event: second,
+                    prompt_tag: "mention".into(),
+                    received_at: Instant::now(),
+                },
+            ],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                profile_lookup: Some(&profiles),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+
+        for event_id in [&first_id, &second_id] {
+            assert!(
+                prompt.contains(&format!(
+                    "Reply routing: If this human event requires a response, send it with \
+                     `--reply-to {event_id}`"
+                )),
+                "every batched human event must retain its own reply destination"
+            );
+        }
+    }
+
+    #[test]
+    fn test_routed_event_block_uses_thread_root() {
+        let ch = Uuid::new_v4();
+        let root = "a".repeat(64);
+        let parent = "b".repeat(64);
+        let event = make_event_with_tags(
+            "thread question",
+            vec![
+                vec!["e".into(), root.clone(), "".into(), "root".into()],
+                vec!["e".into(), parent, "".into(), "reply".into()],
+            ],
+        );
+        let profiles = HashMap::from([(event.pubkey.to_hex(), profile(false))]);
+        let block = format_routed_event_block(
+            ch,
+            None,
+            &BatchEvent {
+                event,
+                prompt_tag: "mention".into(),
+                received_at: Instant::now(),
+            },
+            Some(&profiles),
+            false,
+        );
+
+        assert!(block.contains(&format!("`--reply-to {root}`")));
+    }
+
+    #[test]
+    fn test_routed_event_block_skips_agent_only_and_dm_events() {
+        let ch = Uuid::new_v4();
+        let agent_event = make_event("agent coordination");
+        let profiles = HashMap::from([(agent_event.pubkey.to_hex(), profile(true))]);
+        let agent_block = format_routed_event_block(
+            ch,
+            None,
+            &BatchEvent {
+                event: agent_event,
+                prompt_tag: "mention".into(),
+                received_at: Instant::now(),
+            },
+            Some(&profiles),
+            false,
+        );
+        assert!(!agent_block.contains("Reply routing:"));
+
+        let dm_event = make_event("dm question");
+        let dm_profiles = HashMap::from([(dm_event.pubkey.to_hex(), profile(false))]);
+        let dm_block = format_routed_event_block(
+            ch,
+            None,
+            &BatchEvent {
+                event: dm_event,
+                prompt_tag: "dm".into(),
+                received_at: Instant::now(),
+            },
+            Some(&dm_profiles),
+            true,
+        );
+        assert!(!dm_block.contains("Reply routing:"));
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -608,6 +608,17 @@ pub struct SendMessageParams {
     pub mentions: Vec<String>,
 }
 
+fn validate_message_payload(content: &str, has_files: bool) -> Result<(), CliError> {
+    if content.trim().is_empty() && !has_files {
+        return Err(CliError::Usage(
+            "message content is empty; provide non-whitespace --content or attach a file \
+             (when using --content -, ensure stdin is connected)"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 pub async fn cmd_send_message(
     client: &BuzzClient,
     mut p: SendMessageParams,
@@ -617,6 +628,7 @@ pub async fn cmd_send_message(
     // quoting — the source of countless self-inflicted command-substitution
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
+    validate_message_payload(&p.content, !p.files.is_empty())?;
     validate_content_size(&p.content)?;
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
@@ -855,6 +867,7 @@ pub async fn cmd_edit_message(
     content: &str,
 ) -> Result<(), CliError> {
     validate_hex64(event_id)?;
+    validate_message_payload(content, false)?;
     validate_content_size(content)?;
 
     // Resolve channel_id from the event's h-tag
@@ -1059,8 +1072,8 @@ mod tests {
         channel_id_from_event, cmd_get_thread, event_mention_pubkeys, find_root_from_tags,
         format_events, match_profiles_by_name, merge_message_mentions, missing_members,
         normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
-        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
-        CliError, Uuid,
+        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags,
+        validate_message_payload, BuzzClient, CliError, Uuid,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
@@ -1077,6 +1090,21 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    #[test]
+    fn empty_message_payload_is_rejected_without_files() {
+        for content in ["", "   ", "\n\t"] {
+            let error = validate_message_payload(content, false).unwrap_err();
+            assert!(matches!(error, CliError::Usage(_)));
+            assert!(error.to_string().contains("message content is empty"));
+        }
+    }
+
+    #[test]
+    fn attachment_only_and_non_empty_message_payloads_are_allowed() {
+        assert!(validate_message_payload("", true).is_ok());
+        assert!(validate_message_payload("hello", false).is_ok());
+    }
 
     #[test]
     fn compact_event_format_remains_the_three_key_contract() {


### PR DESCRIPTION
## Summary

Prevent two ways a human mention can appear to receive no Buzz reply:

- Reject empty or whitespace-only `buzz messages send` payloads unless a file is attached. In particular, `--content -` with disconnected/empty stdin now fails before relay access instead of publishing an empty signed event.
- Preserve an event-specific `--reply-to` route for every human event rendered into a normal batch or a merged/steered turn. The newest event remains the turn-level default, but earlier human reply obligations no longer lose their destination.
- Apply the same event-specific route to native ACP steering while preserving existing DM and known agent-only routing behavior.
- Reject whitespace-only message edits as well; deletion remains the explicit way to remove a message.

### Related issue

No exact duplicate found. #3883 is adjacent: it publishes buffered assistant text when a runtime skips `buzz messages send`, while this PR prevents empty CLI publications and retains every human event's routing obligation when multiple events share a turn.

### Testing

- `cargo test -p buzz-cli -p buzz-acp`
  - 833 `buzz-acp` unit tests passed
  - 9 pool lifecycle integration tests passed
  - 415 `buzz-cli` unit tests passed
- `cargo clippy -p buzz-cli -p buzz-acp --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Built `buzz-cli` and invoked `buzz messages send --content -` with `/dev/null` as stdin and an unreachable relay. It exited 1 with `message content is empty` before relay access.
