### PR TITLE
feat(agents): publish structured work reports

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -80,8 +80,49 @@ All replies and delegations — including task assignments to other agents — g
 
 ### General
 
+#### Result-first work reports
+
+Use `buzz messages report` for a substantive thread-level work result when its
+state becomes `completed`, `in_review`, `needs_decision`, `blocked`, or
+`failed`. The report is the thread's signed representative summary, not a
+replacement for ordinary conversation and not a progress log.
+
+- Keep pickup, progress, questions, small factual answers, and conversational
+  replies on `buzz messages send`. Do not create a report for a bare
+  acknowledgement or every intermediate update.
+- Publish the first report with the channel UUID and the exact thread root from
+  `<context>`, for example:
+
+  ```bash
+  buzz messages report --channel <UUID> --thread <ROOT_EVENT_ID> \
+    --status in-review --outcome "Implemented the change; maintainer review remains" \
+    --deliverable <PR_URL> --verification "CI passed at <SHA>" \
+    --next-action "Maintainer: review and merge"
+  ```
+
+- To update an existing representative report, pass `--prior
+  <CURRENT_REPORT_EVENT_ID>`. Reuse the event ID returned by the previous
+  publish, or retry with the current head named by a conflict response. Never
+  create a competing head deliberately.
+- Scale fields to the work. A small task needs an outcome and evidence; normal
+  work should include relevant deliverables, verification, risks, and next
+  actions; complex graph work may also include material decisions. Do not pad
+  empty sections.
+- Status meanings are strict: `completed` means no required work remains;
+  `in-review` means the deliverable exists but a review or release gate remains;
+  `needs-decision` requires a named human choice; `blocked` requires an external
+  dependency; `failed` means the attempted outcome was not achieved.
+- A report does not notify a delegator by itself. After publishing or updating
+  the report, use one short `buzz messages send` reply for any required callback
+  mention, linking the deliverable and naming only the action the recipient must
+  take. Do not repeat the full report in that message.
+- In multi-agent work, individual workers' messages are source material. Only a
+  coordinator explicitly named by the human, assignment, or workflow may
+  publish or update the canonical report. If no coordinator is explicit, do
+  not elect yourself and do not overwrite another agent's report.
+
 - Respond promptly to @mentions. Be direct — no preamble. Name what you did, what you found, or what you need.
-- **If your turn produced anything worth knowing, you MUST publish it.** Use `buzz messages send`. Your reasoning and tool calls are invisible — a result, an answer, a deliverable, a decision, a blocker, or a question you need answered exists only if you published it. Work or an answer that someone asked you for always counts. Ending that kind of turn without a message is a silent failure.
+- **If your turn produced anything worth knowing, you MUST publish it.** Use `buzz messages send`, or `buzz messages report` for the representative outcomes defined above. Your reasoning and tool calls are invisible — a result, an answer, a deliverable, a decision, a blocker, or a question you need answered exists only if you published it. Work or an answer that someone asked you for always counts. Ending that kind of turn without a message is a silent failure.
 - **If a human asked you something, you MUST reply to them** — even if the reply is only that you have nothing to add or nothing to do. Never leave a person waiting on you.
 - **Otherwise, publishing is optional and silence is usually correct.** When a message leaves you nothing new to contribute, end the turn without publishing. That is a success, not a failure.
 - **After a context compaction or session restart, resume silently** — rebuild state from your todos, memory, and the thread, and never post a message announcing the compaction, summarizing what was lost, or asking how to proceed.

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -83,7 +83,7 @@ All replies and delegations — including task assignments to other agents — g
 #### Result-first work reports
 
 Use `buzz messages report` for a substantive thread-level work result when its
-state becomes `completed`, `in_review`, `needs_decision`, `blocked`, or
+state becomes `completed`, `in-review`, `needs-decision`, `blocked`, or
 `failed`. The report is the thread's signed representative summary, not a
 replacement for ordinary conversation and not a progress log.
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4493,10 +4493,11 @@ mod agent_draft_prompt_tests {
     #[test]
     fn shared_base_prompt_teaches_result_first_reporting_without_self_elected_coordinators() {
         let prompt = include_str!("base_prompt.md");
+        let normalized = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
         assert!(prompt.contains("#### Result-first work reports"));
         assert!(prompt.contains("buzz messages report --channel <UUID> --thread <ROOT_EVENT_ID>"));
         assert!(prompt.contains("pass `--prior"));
-        assert!(prompt.contains("Only a\n  coordinator explicitly named"));
+        assert!(normalized.contains("Only a coordinator explicitly named"));
         assert!(prompt.contains("do not elect yourself"));
         assert!(prompt.contains("A report does not notify a delegator by itself"));
         assert!(prompt.contains("Use `buzz messages send`, or `buzz messages report`"));

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4491,6 +4491,18 @@ mod agent_draft_prompt_tests {
     }
 
     #[test]
+    fn shared_base_prompt_teaches_result_first_reporting_without_self_elected_coordinators() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("#### Result-first work reports"));
+        assert!(prompt.contains("buzz messages report --channel <UUID> --thread <ROOT_EVENT_ID>"));
+        assert!(prompt.contains("pass `--prior"));
+        assert!(prompt.contains("Only a\n  coordinator explicitly named"));
+        assert!(prompt.contains("do not elect yourself"));
+        assert!(prompt.contains("A report does not notify a delegator by itself"));
+        assert!(prompt.contains("Use `buzz messages send`, or `buzz messages report`"));
+    }
+
+    #[test]
     fn shared_base_prompt_teaches_repo_context_and_learning_loop() {
         let prompt = include_str!("base_prompt.md");
         assert!(prompt.contains("read its root `AGENTS.md`"));

--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -86,7 +86,7 @@ const REPLY_GUARD_SERVER: &str = "buzz-agent";
 /// Explicitly licenses silence. The base prompt tells agents that publishing is
 /// optional and "silence is usually correct"; a reminder that argued otherwise
 /// would fight that instruction and make agents chattier.
-const REPLY_GUARD_NAG: &str = "You are about to end this turn without calling `buzz messages send`. \
+const REPLY_GUARD_NAG: &str = "You are about to end this turn without calling `buzz messages send` or `buzz messages report`. \
 Your assistant text and reasoning are never shown to anyone — if you did work, found an answer, \
 or hit a blocker that someone is waiting on, it exists only if you publish it. \
 If you already posted, or if silence is genuinely correct for this turn, ignore this and end your turn.";
@@ -132,11 +132,15 @@ fn is_reply_shaped(name: &str, arguments: &serde_json::Value) -> bool {
             .get("command")
             .and_then(|v| v.as_str())
             .is_some_and(|cmd| {
-                // `messages send` also covers `messages send-diff`. `reactions
+                // `messages send` also covers `messages send-diff`. A
+                // structured `messages report` is a human-visible publish too.
+                // `reactions
                 // add` counts because the base prompt directs agents to react
                 // rather than post a bare acknowledgement, so nagging an agent
                 // that reacted would punish documented-correct behavior.
-                cmd.contains("messages send") || cmd.contains("reactions add")
+                cmd.contains("messages send")
+                    || cmd.contains("messages report")
+                    || cmd.contains("reactions add")
             })
 }
 
@@ -1448,13 +1452,14 @@ mod tests {
     /// The shapes the guard must recognize as a publish attempt. Callers apply
     /// the registry checks first; these cover the name suffix and command text.
     #[test]
-    fn reply_shape_matches_documented_send_forms() {
+    fn reply_shape_matches_documented_publish_forms() {
         for cmd in [
             "buzz messages send --channel X --content Y",
             "buzz --relay wss://r messages send --channel X --content Y",
             "/abs/path/buzz messages send",
             "printf 'hi' | buzz messages send --content -",
             "buzz messages send-diff --diff -",
+            "buzz messages report --channel X --thread E --status completed --outcome done",
             "buzz reactions add --event E --emoji +",
             // Assembled through another shell: rev 3's tokenizer missed this.
             r#"sh -c "buzz messages send --channel X""#,

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -729,6 +729,141 @@ pub async fn cmd_send_message(
     Ok(())
 }
 
+pub struct WorkReportParams {
+    pub channel_id: String,
+    pub thread_root: String,
+    pub status: crate::ReportStatus,
+    pub outcome: String,
+    pub deliverables: Vec<String>,
+    pub decisions: Vec<String>,
+    pub verification: Vec<String>,
+    pub risks: Vec<String>,
+    pub next_actions: Vec<String>,
+    pub prior: Option<String>,
+}
+
+pub async fn cmd_publish_work_report(
+    client: &BuzzClient,
+    params: WorkReportParams,
+) -> Result<(), CliError> {
+    let channel_id = parse_uuid(&params.channel_id)?;
+    let root_event = fetch_event(client, &params.thread_root).await?;
+    let root_channel = channel_id_from_event(&params.thread_root, &root_event)?;
+    if root_channel != channel_id {
+        return Err(CliError::Usage(format!(
+            "thread root {} does not belong to channel {}",
+            params.thread_root, params.channel_id
+        )));
+    }
+    let resolved_root = thread_ref_from_event(&params.thread_root, &root_event)?
+        .root_event_id
+        .to_hex();
+    if !resolved_root.eq_ignore_ascii_case(&params.thread_root) {
+        return Err(CliError::Usage(format!(
+            "--thread must reference the thread root (use {resolved_root})"
+        )));
+    }
+    let thread_root = parse_event_id(&params.thread_root)?;
+    let head_filter = serde_json::json!({
+        "kinds": [40009],
+        "#h": [params.channel_id.as_str()],
+        "#e": [params.thread_root.as_str()],
+        "limit": 100
+    });
+    let mut report_events = fetch_events(client, &head_filter)
+        .await
+        .ok_or_else(|| CliError::Other("could not load the current work-report head".into()))?;
+    report_events.retain(|event| {
+        event
+            .get("tags")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|tags| {
+                tags.iter().any(|tag| {
+                    let Some(parts) = tag.as_array() else {
+                        return false;
+                    };
+                    parts.first().and_then(serde_json::Value::as_str) == Some("e")
+                        && parts.get(1).and_then(serde_json::Value::as_str)
+                            == Some(params.thread_root.as_str())
+                        && parts.get(3).and_then(serde_json::Value::as_str) == Some("root")
+                })
+            })
+    });
+    report_events.sort_by(|left, right| {
+        left.get("created_at")
+            .and_then(serde_json::Value::as_u64)
+            .cmp(&right.get("created_at").and_then(serde_json::Value::as_u64))
+            .then_with(|| {
+                left.get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .cmp(&right.get("id").and_then(serde_json::Value::as_str))
+            })
+    });
+    let current_head = report_events
+        .last()
+        .and_then(|event| event.get("id"))
+        .and_then(serde_json::Value::as_str);
+    match (current_head, params.prior.as_deref()) {
+        (Some(head), Some(prior)) if head.eq_ignore_ascii_case(prior) => {}
+        (Some(head), _) => {
+            return Err(CliError::Conflict(format!(
+                "work report head changed; retry with --prior {head}"
+            )))
+        }
+        (None, Some(_)) => {
+            return Err(CliError::Conflict(
+                "cannot set --prior because this thread has no work report".into(),
+            ))
+        }
+        (None, None) => {}
+    }
+    let prior = match params.prior.as_deref() {
+        Some(prior_id) => {
+            let prior_event = fetch_event(client, prior_id).await?;
+            if prior_event.get("kind").and_then(serde_json::Value::as_u64) != Some(40009) {
+                return Err(CliError::Usage(
+                    "--prior must reference a work report".into(),
+                ));
+            }
+            let tags = prior_event
+                .get("tags")
+                .and_then(serde_json::Value::as_array)
+                .ok_or_else(|| CliError::Usage("prior work report has no tags".into()))?;
+            let matches_root = tags.iter().any(|tag| {
+                let Some(parts) = tag.as_array() else {
+                    return false;
+                };
+                parts.first().and_then(serde_json::Value::as_str) == Some("e")
+                    && parts.get(1).and_then(serde_json::Value::as_str)
+                        == Some(params.thread_root.as_str())
+                    && parts.get(3).and_then(serde_json::Value::as_str) == Some("root")
+            });
+            if !matches_root || channel_id_from_event(prior_id, &prior_event)? != channel_id {
+                return Err(CliError::Usage(
+                    "--prior must reference a work report for the same thread".into(),
+                ));
+            }
+            Some(parse_event_id(prior_id)?)
+        }
+        None => None,
+    };
+    let report = buzz_sdk::WorkReport {
+        status: params.status.into(),
+        outcome: params.outcome,
+        deliverables: params.deliverables,
+        decisions: params.decisions,
+        verification: params.verification,
+        risks: params.risks,
+        next_actions: params.next_actions,
+    };
+    let builder = buzz_sdk::build_work_report(channel_id, thread_root, prior, &report)
+        .map_err(|error| CliError::Usage(error.to_string()))?;
+    let event = client.sign_event(builder)?;
+    let response = client.submit_event(event).await?;
+    println!("{}", normalize_write_response(&response));
+    Ok(())
+}
+
 pub struct SendDiffParams {
     pub channel_id: String,
     pub diff: String,
@@ -961,6 +1096,35 @@ pub async fn dispatch(
                     language: lang,
                     description,
                     reply_to,
+                },
+            )
+            .await
+        }
+        MessagesCmd::Report {
+            channel,
+            thread,
+            status,
+            outcome,
+            deliverables,
+            decisions,
+            verification,
+            risks,
+            next_actions,
+            prior,
+        } => {
+            cmd_publish_work_report(
+                client,
+                WorkReportParams {
+                    channel_id: channel,
+                    thread_root: thread,
+                    status,
+                    outcome,
+                    deliverables,
+                    decisions,
+                    verification,
+                    risks,
+                    next_actions,
+                    prior,
                 },
             )
             .await

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -142,6 +142,32 @@ pub enum PresenceStatus {
     Offline,
 }
 
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum ReportStatus {
+    #[value(name = "completed")]
+    Completed,
+    #[value(name = "in-review")]
+    InReview,
+    #[value(name = "needs-decision")]
+    NeedsDecision,
+    #[value(name = "blocked")]
+    Blocked,
+    #[value(name = "failed")]
+    Failed,
+}
+
+impl From<ReportStatus> for buzz_sdk::WorkReportStatus {
+    fn from(value: ReportStatus) -> Self {
+        match value {
+            ReportStatus::Completed => Self::Completed,
+            ReportStatus::InReview => Self::InReview,
+            ReportStatus::NeedsDecision => Self::NeedsDecision,
+            ReportStatus::Blocked => Self::Blocked,
+            ReportStatus::Failed => Self::Failed,
+        }
+    }
+}
+
 #[derive(Clone, clap::ValueEnum)]
 pub enum EmojiScope {
     #[value(name = "own")]
@@ -434,6 +460,42 @@ pub enum MessagesCmd {
         /// Event ID to reply to (creates a thread)
         #[arg(long)]
         reply_to: Option<String>,
+    },
+    /// Publish or update the structured outcome report for a thread
+    #[command(
+        after_help = "Example:\n  buzz messages report --channel <UUID> --thread <EVENT_ID> --status completed --outcome \"Shipped the fix\" --deliverable <PR_URL> --verification \"CI passed\""
+    )]
+    Report {
+        /// Channel UUID containing the thread
+        #[arg(long)]
+        channel: String,
+        /// Thread root event ID
+        #[arg(long)]
+        thread: String,
+        /// Current report status
+        #[arg(long, value_enum)]
+        status: ReportStatus,
+        /// One-sentence result or required action
+        #[arg(long)]
+        outcome: String,
+        /// PR, file, document, or artifact reference (repeatable)
+        #[arg(long = "deliverable")]
+        deliverables: Vec<String>,
+        /// Material decision and rationale (repeatable)
+        #[arg(long = "decision")]
+        decisions: Vec<String>,
+        /// Test, CI, runtime check, or other evidence (repeatable)
+        #[arg(long = "verification")]
+        verification: Vec<String>,
+        /// Material risk or limitation (repeatable)
+        #[arg(long = "risk")]
+        risks: Vec<String>,
+        /// Next action with its owner (repeatable)
+        #[arg(long = "next-action")]
+        next_actions: Vec<String>,
+        /// Previous work-report event ID when updating
+        #[arg(long)]
+        prior: Option<String>,
     },
     /// Edit a previously sent message
     Edit {
@@ -2302,6 +2364,7 @@ mod tests {
                 "delete",
                 "edit",
                 "get",
+                "report",
                 "search",
                 "send",
                 "send-diff",
@@ -2430,6 +2493,46 @@ mod tests {
     }
 
     #[test]
+    fn work_report_command_accepts_structured_repeatable_fields() {
+        let channel = uuid::Uuid::new_v4().to_string();
+        let root = "ab".repeat(32);
+        assert!(Cli::try_parse_from([
+            "buzz",
+            "messages",
+            "report",
+            "--channel",
+            channel.as_str(),
+            "--thread",
+            root.as_str(),
+            "--status",
+            "in-review",
+            "--outcome",
+            "Ready for review",
+            "--deliverable",
+            "https://example.com/pr/1",
+            "--verification",
+            "CI passed",
+            "--next-action",
+            "Maintainer: review",
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from([
+            "buzz",
+            "messages",
+            "report",
+            "--channel",
+            channel.as_str(),
+            "--thread",
+            root.as_str(),
+            "--status",
+            "done",
+            "--outcome",
+            "Invalid status",
+        ])
+        .is_err());
+    }
+
+    #[test]
     fn subcommand_counts_are_stable() {
         let expected: Vec<(&str, usize)> = vec![
             ("agents", 5),
@@ -2440,7 +2543,7 @@ mod tests {
             ("feed", 1),
             ("issues", 6),
             ("media", 1),
-            ("messages", 8),
+            ("messages", 9),
             ("pack", 2),
             ("patches", 4),
             ("pr", 5),

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -491,6 +491,8 @@ pub const KIND_STREAM_MESSAGE_SCHEDULED: u32 = 40006;
 pub const KIND_STREAM_REMINDER: u32 = 40007;
 /// A diff/patch message showing file changes (unified diff format).
 pub const KIND_STREAM_MESSAGE_DIFF: u32 = 40008;
+/// A structured, signed outcome report rooted in a channel thread.
+pub const KIND_WORK_REPORT: u32 = 40009;
 /// Canvas (shared document) for a channel.
 pub const KIND_CANVAS: u32 = 40100;
 /// System message for channel state changes (join, leave, rename, etc.).
@@ -707,6 +709,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_STREAM_MESSAGE_SCHEDULED,
     KIND_STREAM_REMINDER,
     KIND_STREAM_MESSAGE_DIFF,
+    KIND_WORK_REPORT,
     KIND_CANVAS,
     KIND_SYSTEM_MESSAGE,
     KIND_CHANNEL_SUMMARY,

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -1172,6 +1172,7 @@ mod tests {
     use buzz_core::kind::{
         KIND_AGENT_OBSERVER_FRAME, KIND_CANVAS, KIND_FORUM_COMMENT, KIND_FORUM_POST,
         KIND_FORUM_VOTE, KIND_PRESENCE_UPDATE, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_DIFF,
+        KIND_WORK_REPORT,
     };
     use buzz_core::observer::{
         encrypt_observer_payload, OBSERVER_AGENT_TAG, OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG,
@@ -1223,6 +1224,7 @@ mod tests {
         for kind in [
             KIND_STREAM_MESSAGE,
             KIND_STREAM_MESSAGE_DIFF,
+            KIND_WORK_REPORT,
             KIND_CANVAS,
             KIND_FORUM_POST,
             KIND_FORUM_VOTE,

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1398,7 +1398,7 @@ fn validate_work_report_event(event: &Event) -> Result<(), String> {
     let roots = values("e");
     if roots.len() != 1
         || roots[0].len() < 4
-        || roots[0][2] != ""
+        || !roots[0][2].is_empty()
         || roots[0][3] != "root"
         || !is_hex64(&roots[0][1])
     {

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -33,7 +33,7 @@ use buzz_core::kind::{
     KIND_STREAM_MESSAGE_DIFF, KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_MESSAGE_PINNED,
     KIND_STREAM_MESSAGE_SCHEDULED, KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER, KIND_TEAM,
     KIND_TEAM_CATALOG, KIND_TEXT_NOTE, KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
-    RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE, RELAY_ADMIN_REMOVE_MEMBER,
+    KIND_WORK_REPORT, RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE, RELAY_ADMIN_REMOVE_MEMBER,
     RELAY_ADMIN_SET_WORKSPACE_PROFILE,
 };
 use buzz_core::tenant::TenantContext;
@@ -479,6 +479,7 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         | KIND_STREAM_MESSAGE_SCHEDULED
         | KIND_STREAM_REMINDER
         | KIND_STREAM_MESSAGE_DIFF
+        | KIND_WORK_REPORT
         | KIND_FORUM_POST
         | KIND_FORUM_VOTE
         | KIND_FORUM_COMMENT => Ok(Scope::MessagesWrite),
@@ -712,6 +713,7 @@ pub(crate) fn requires_h_channel_scope(kind: u32) -> bool {
             | KIND_STREAM_MESSAGE_SCHEDULED
             | KIND_STREAM_REMINDER
             | KIND_STREAM_MESSAGE_DIFF
+            | KIND_WORK_REPORT
             | KIND_CANVAS
             | KIND_FORUM_POST
             | KIND_FORUM_VOTE
@@ -1322,6 +1324,101 @@ fn validate_diff_event(event: &Event) -> Result<(), String> {
     }
     if !has_commit {
         return Err("diff event requires a commit tag".to_string());
+    }
+    Ok(())
+}
+
+/// Validate the signed envelope and structured JSON body of kind:40009.
+fn validate_work_report_event(event: &Event) -> Result<(), String> {
+    let is_hex64 = |value: &str| {
+        value.len() == 64 && value.chars().all(|character| character.is_ascii_hexdigit())
+    };
+    if event.content.len() > 32 * 1024 {
+        return Err("work report content exceeds 32KB limit".to_string());
+    }
+    let body: serde_json::Value = serde_json::from_str(&event.content)
+        .map_err(|_| "work report content must be a JSON object".to_string())?;
+    let object = body
+        .as_object()
+        .ok_or_else(|| "work report content must be a JSON object".to_string())?;
+    let status = object
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "work report requires a status".to_string())?;
+    if !matches!(
+        status,
+        "completed" | "in_review" | "needs_decision" | "blocked" | "failed"
+    ) {
+        return Err("work report status is invalid".to_string());
+    }
+    let outcome = object
+        .get("outcome")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && value.len() <= 1_024)
+        .ok_or_else(|| "work report outcome must be 1..=1024 bytes".to_string())?;
+    let _ = outcome;
+    for field in [
+        "deliverables",
+        "decisions",
+        "verification",
+        "risks",
+        "next_actions",
+    ] {
+        let Some(value) = object.get(field) else {
+            continue;
+        };
+        let values = value
+            .as_array()
+            .ok_or_else(|| format!("work report {field} must be an array"))?;
+        if values.len() > 20
+            || values.iter().any(|value| {
+                value
+                    .as_str()
+                    .map(str::trim)
+                    .is_none_or(|value| value.is_empty() || value.len() > 2_048)
+            })
+        {
+            return Err(format!(
+                "work report {field} must contain at most 20 non-empty strings of at most 2048 bytes"
+            ));
+        }
+    }
+
+    let tags: Vec<Vec<String>> = event
+        .tags
+        .iter()
+        .map(|tag| tag.as_slice().to_vec())
+        .collect();
+    let values = |name: &str| {
+        tags.iter()
+            .filter(|tag| tag.first().map(String::as_str) == Some(name))
+            .collect::<Vec<_>>()
+    };
+    let roots = values("e");
+    if roots.len() != 1
+        || roots[0].len() < 4
+        || roots[0][2] != ""
+        || roots[0][3] != "root"
+        || !is_hex64(&roots[0][1])
+    {
+        return Err("work report requires exactly one root-marked e tag".to_string());
+    }
+    let type_tags = values("t");
+    if type_tags.len() != 1 || type_tags[0].get(1).map(String::as_str) != Some("work-report") {
+        return Err("work report requires t=work-report".to_string());
+    }
+    let status_tags = values("status");
+    if status_tags.len() != 1 || status_tags[0].get(1).map(String::as_str) != Some(status) {
+        return Err("work report status tag must match content".to_string());
+    }
+    let priors = values("prior");
+    if priors.len() > 1
+        || priors
+            .first()
+            .is_some_and(|tag| tag.get(1).is_none_or(|id| !is_hex64(id)))
+    {
+        return Err("work report prior must be a single 64-char event id".to_string());
     }
     Ok(())
 }
@@ -2725,6 +2822,11 @@ async fn ingest_event_inner(
         validate_diff_event(&event).map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
     }
 
+    if kind_u32 == KIND_WORK_REPORT {
+        validate_work_report_event(&event)
+            .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
+    }
+
     if kind_u32 == KIND_AGENT_ENGRAM {
         validate_engram_envelope(&event)
             .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
@@ -3283,7 +3385,7 @@ mod tests {
     use buzz_core::kind::{
         KIND_CANVAS, KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_FORUM_VOTE, KIND_LONG_FORM,
         KIND_MANAGED_AGENT, KIND_PERSONA, KIND_PRESENCE_UPDATE, KIND_STREAM_MESSAGE,
-        KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS,
+        KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS, KIND_WORK_REPORT,
     };
     use nostr::{EventBuilder, Kind};
 
@@ -4011,6 +4113,40 @@ mod tests {
     fn unknown_kind_rejected() {
         let dummy = make_dummy_event();
         assert!(required_scope_for_kind(99999, &dummy).is_err());
+    }
+
+    fn work_report_event(status_tag: &str, content: &str) -> Event {
+        let root = "ab".repeat(32);
+        let channel_id = Uuid::new_v4().to_string();
+        EventBuilder::new(Kind::Custom(KIND_WORK_REPORT as u16), content)
+            .tags([
+                nostr::Tag::parse(["h", channel_id.as_str()]).unwrap(),
+                nostr::Tag::parse(["e", root.as_str(), "", "root"]).unwrap(),
+                nostr::Tag::parse(["t", "work-report"]).unwrap(),
+                nostr::Tag::parse(["status", status_tag]).unwrap(),
+            ])
+            .sign_with_keys(&nostr::Keys::generate())
+            .unwrap()
+    }
+
+    #[test]
+    fn work_report_is_channel_scoped_and_messages_write() {
+        let event = work_report_event("completed", r#"{"status":"completed","outcome":"Shipped"}"#);
+        assert!(requires_h_channel_scope(KIND_WORK_REPORT));
+        assert_eq!(
+            required_scope_for_kind(KIND_WORK_REPORT, &event).unwrap(),
+            Scope::MessagesWrite
+        );
+        assert!(validate_work_report_event(&event).is_ok());
+    }
+
+    #[test]
+    fn work_report_rejects_status_mismatch_and_empty_outcome() {
+        let mismatch =
+            work_report_event("completed", r#"{"status":"blocked","outcome":"Waiting"}"#);
+        assert!(validate_work_report_event(&mismatch).is_err());
+        let empty = work_report_event("completed", r#"{"status":"completed","outcome":"  "}"#);
+        assert!(validate_work_report_event(&empty).is_err());
     }
 
     #[test]

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -385,6 +385,61 @@ pub fn build_diff_message(
     Ok(EventBuilder::new(Kind::Custom(40008), content).tags(tags))
 }
 
+/// Build a structured work report rooted in a channel thread (kind 40009).
+pub fn build_work_report(
+    channel_id: Uuid,
+    thread_root: nostr::EventId,
+    prior: Option<nostr::EventId>,
+    report: &crate::WorkReport,
+) -> Result<EventBuilder, SdkError> {
+    let outcome = report.outcome.trim();
+    if outcome.is_empty() {
+        return Err(SdkError::InvalidInput(
+            "work report outcome is required".into(),
+        ));
+    }
+    if outcome.len() > 1_024 {
+        return Err(SdkError::InvalidInput(
+            "work report outcome exceeds 1024 bytes".into(),
+        ));
+    }
+    for (field, values) in [
+        ("deliverables", &report.deliverables),
+        ("decisions", &report.decisions),
+        ("verification", &report.verification),
+        ("risks", &report.risks),
+        ("next_actions", &report.next_actions),
+    ] {
+        if values.len() > 20 {
+            return Err(SdkError::InvalidInput(format!(
+                "work report {field} exceeds 20 entries"
+            )));
+        }
+        if values
+            .iter()
+            .any(|value| value.trim().is_empty() || value.len() > 2_048)
+        {
+            return Err(SdkError::InvalidInput(format!(
+                "work report {field} entries must be non-empty and at most 2048 bytes"
+            )));
+        }
+    }
+
+    let content = serde_json::to_string(report)
+        .map_err(|error| SdkError::InvalidInput(format!("invalid work report: {error}")))?;
+    check_content(&content, 32 * 1024)?;
+    let mut tags = vec![
+        tag(&["h", &channel_id.to_string()])?,
+        tag(&["e", &thread_root.to_hex(), "", "root"])?,
+        tag(&["t", "work-report"])?,
+        tag(&["status", report.status.as_str()])?,
+    ];
+    if let Some(prior) = prior {
+        tags.push(tag(&["prior", &prior.to_hex()])?);
+    }
+    Ok(EventBuilder::new(Kind::Custom(40009), content).tags(tags))
+}
+
 /// Build an edit event targeting an existing message (kind 40003).
 pub fn build_edit(
     channel_id: Uuid,
@@ -2628,6 +2683,59 @@ mod tests {
         assert!(has_tag(&ev, "repo", "https://github.com/example/repo"));
         assert!(has_tag(&ev, "commit", "abc1234"));
         assert!(has_tag(&ev, "l", "rust"));
+    }
+
+    fn completed_report() -> crate::WorkReport {
+        crate::WorkReport {
+            status: crate::WorkReportStatus::Completed,
+            outcome: "Shipped the result-first report contract".into(),
+            deliverables: vec!["https://example.com/pr/1".into()],
+            decisions: vec!["Keep raw conversation as evidence".into()],
+            verification: vec!["SDK and CLI tests passed".into()],
+            risks: vec![],
+            next_actions: vec!["Maintainer: review the PR".into()],
+        }
+    }
+
+    #[test]
+    fn work_report_has_root_status_and_prior_contract() {
+        let channel_id = uuid();
+        let root = event_id();
+        let prior = event_id();
+        let event =
+            sign(build_work_report(channel_id, root, Some(prior), &completed_report()).unwrap());
+        assert_eq!(event.kind.as_u16(), 40009);
+        assert!(has_tag(&event, "h", &channel_id.to_string()));
+        assert!(has_tag(&event, "t", "work-report"));
+        assert!(has_tag(&event, "status", "completed"));
+        assert!(has_tag(&event, "prior", &prior.to_hex()));
+        let root_tag = event
+            .tags
+            .iter()
+            .find(|tag| tag.as_slice().first().map(String::as_str) == Some("e"))
+            .expect("root tag");
+        assert_eq!(root_tag.as_slice().get(1), Some(&root.to_hex()));
+        assert_eq!(root_tag.as_slice().get(3).map(String::as_str), Some("root"));
+        let body: crate::WorkReport = serde_json::from_str(&event.content).unwrap();
+        assert_eq!(body, completed_report());
+    }
+
+    #[test]
+    fn work_report_rejects_empty_outcome_and_oversized_lists() {
+        let channel_id = uuid();
+        let root = event_id();
+        let mut report = completed_report();
+        report.outcome = "  ".into();
+        assert!(matches!(
+            build_work_report(channel_id, root, None, &report),
+            Err(SdkError::InvalidInput(_))
+        ));
+        report = completed_report();
+        report.verification = (0..21).map(|index| format!("check {index}")).collect();
+        assert!(matches!(
+            build_work_report(channel_id, root, None, &report),
+            Err(SdkError::InvalidInput(_))
+        ));
     }
 
     #[test]

--- a/crates/buzz-sdk/src/lib.rs
+++ b/crates/buzz-sdk/src/lib.rs
@@ -57,6 +57,59 @@ pub struct DiffMeta {
     pub alt_text: Option<String>,
 }
 
+/// Machine-readable status of a work report (kind 40009).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkReportStatus {
+    /// Work and verification are complete.
+    Completed,
+    /// Work is ready for review but not yet shipped.
+    InReview,
+    /// A human decision is required before progress can continue.
+    NeedsDecision,
+    /// Work cannot continue until an external dependency changes.
+    Blocked,
+    /// Work ended unsuccessfully.
+    Failed,
+}
+
+impl WorkReportStatus {
+    /// Stable wire value used in the event status tag and JSON body.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::InReview => "in_review",
+            Self::NeedsDecision => "needs_decision",
+            Self::Blocked => "blocked",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Structured outcome body for a work report (kind 40009).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkReport {
+    /// Current outcome state.
+    pub status: WorkReportStatus,
+    /// One-sentence description of what changed or what is needed.
+    pub outcome: String,
+    /// Openable PR, file, document, or artifact references.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deliverables: Vec<String>,
+    /// Material decisions and their rationale.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub decisions: Vec<String>,
+    /// Tests, CI runs, runtime checks, or other evidence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification: Vec<String>,
+    /// Risks or limitations that affect use of the result.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub risks: Vec<String>,
+    /// Action, owner, and optional timing for the next step.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<String>,
+}
+
 /// Vote direction for `build_vote`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VoteDirection {

--- a/docs/nips/NIP-WR.md
+++ b/docs/nips/NIP-WR.md
@@ -1,0 +1,66 @@
+# NIP-WR: Thread-Rooted Work Reports
+
+`kind:40009` is a signed, channel-scoped outcome report for one Buzz thread.
+It keeps the full conversation as evidence while giving clients a compact,
+machine-readable result to present first.
+
+## Event
+
+```json
+{
+  "kind": 40009,
+  "tags": [
+    ["h", "<channel-uuid>"],
+    ["e", "<thread-root-event-id>", "", "root"],
+    ["t", "work-report"],
+    ["status", "completed"],
+    ["prior", "<previous-work-report-event-id>"]
+  ],
+  "content": "{...}"
+}
+```
+
+The `prior` tag is omitted for the first report and required by the CLI when a
+head already exists. Clients reduce a thread to the newest `(created_at, id)`
+valid report and use `prior` to detect stale updates. The source events remain
+immutable and available as the revision history.
+
+## Content
+
+Content is a JSON object:
+
+```json
+{
+  "status": "completed",
+  "outcome": "Shipped the result-first report contract.",
+  "deliverables": ["https://example.com/pr/1"],
+  "decisions": ["Keep raw conversation as evidence."],
+  "verification": ["CI passed at abc1234."],
+  "risks": [],
+  "next_actions": ["Maintainer: review the PR."]
+}
+```
+
+`status` is one of `completed`, `in_review`, `needs_decision`, `blocked`, or
+`failed`. `outcome` is required and limited to 1024 bytes. The remaining arrays
+are optional; each accepts at most 20 non-empty strings of at most 2048 bytes.
+The complete serialized content is limited to 32 KiB.
+
+The `status` tag must exactly match the JSON status. This permits clients to
+filter attention states without parsing content while preventing two competing
+representations of the result.
+
+## Authorization and privacy
+
+Work reports require the same `MessagesWrite` scope and channel membership as
+other channel content. The relay requires a valid `h` tag; reports in private
+channels are readable only through the existing channel boundary. Reports are
+not an automatic LLM summary: the event signature identifies who asserted the
+result, and the root reference preserves access to the source conversation.
+
+## Presentation
+
+Clients should present the latest valid work report before the transcript and
+offer the underlying conversation and execution log through progressive
+disclosure. They must not delete or rewrite source messages when a report is
+published.


### PR DESCRIPTION
## Summary

- teach managed agents when to publish or update a signed `work-report`
- keep progress and small conversational replies on ordinary messages
- restrict canonical multi-agent reports to explicitly named coordinators
- recognize `buzz messages report` as a human-visible publish in the reply guard

## Behavior

The base prompt now distinguishes representative outcomes from progress logs. It documents strict status meanings, `prior`-based updates, scaled fields, callback notifications, and the no-self-election rule for multi-agent coordinators.

This PR is stacked on #7057, which introduces the `buzz messages report` CLI and protocol. Review scope is the single top commit `5f46ec65f` touching three agent-facing files.

## Validation

- `cargo fmt --all -- --check` passes
- `git diff --check` passes
- local package compilation is blocked before project code by missing Windows linkers (`link.exe`; gnullvm fallback also lacks `x86_64-w64-mingw32-clang`)
- fork CI is the full compile/test gate

## Follow-up boundary

This does not auto-summarize worker messages or infer a coordinator. Those behaviors require an explicit workflow/assignment authority model and are intentionally excluded.
