### PR TITLE
fix(relay): allow signed channel message publication

### DIFF
--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -771,6 +771,20 @@ pub(crate) async fn check_channel_membership(
     }
 }
 
+fn requires_channel_write_membership(kind: u32) -> bool {
+    !matches!(
+        kind,
+        KIND_NIP29_JOIN_REQUEST
+            | KIND_NIP29_CREATE_GROUP
+            | KIND_STREAM_MESSAGE
+            | KIND_STREAM_MESSAGE_V2
+            | KIND_STREAM_MESSAGE_EDIT
+            | KIND_NIP29_EDIT_METADATA
+            | KIND_NIP29_DELETE_EVENT
+            | KIND_NIP29_DELETE_GROUP
+    )
+}
+
 fn check_token_channel_access(auth: &IngestAuth, channel_id: Uuid) -> Result<(), String> {
     if let Some(allowed) = auth.channel_ids() {
         if !allowed.contains(&channel_id) {
@@ -2483,7 +2497,22 @@ async fn ingest_event_inner(
     // it later in this request); each gate keeps its existing missing-row
     // behavior.
     let channel_row = match channel_id {
-        Some(ch_id) => state.db.get_channel(tenant.community(), ch_id).await.ok(),
+        Some(ch_id) => match state.db.get_channel(tenant.community(), ch_id).await {
+            Ok(channel) => Some(channel),
+            Err(buzz_db::DbError::ChannelNotFound(_))
+                if matches!(kind_u32, KIND_STREAM_MESSAGE | KIND_STREAM_MESSAGE_V2) =>
+            {
+                return Err(IngestError::Rejected(
+                    "restricted: not a channel member".into(),
+                ));
+            }
+            Err(error) if matches!(kind_u32, KIND_STREAM_MESSAGE | KIND_STREAM_MESSAGE_V2) => {
+                return Err(IngestError::Internal(format!(
+                    "error: database error resolving channel: {error}"
+                )));
+            }
+            Err(_) => None,
+        },
         None => None,
     };
     // E1 phase-2 (§4.8 phase-2 addendum): resolve the fan-out visibility once,
@@ -2507,20 +2536,15 @@ async fn ingest_event_inner(
         _ => None,
     };
     if let Some(ch_id) = channel_id {
-        // kind:9021 (join) doesn't require prior membership.
-        // kind:9007 (create) — channel doesn't exist yet; creator becomes owner in step 16.
+        // Signed stream messages keep their author provenance but do not require
+        // prior membership. kind:9021 (join) and kind:9007 (create) likewise do
+        // not require it; the creator becomes owner in step 16.
         // kind:40003/9002/9005/9008 — per-kind validators are the authority; they
         // individually enforce authorization and fail closed. Bypassing the generic
         // member/open gate here lets the owning human act on private agent channels
         // without being a member (OQ1 decision; see validate_edit_ownership /
         // validate_admin_event for per-kind enforcement).
-        let skip_membership = kind_u32 == KIND_NIP29_JOIN_REQUEST
-            || kind_u32 == KIND_NIP29_CREATE_GROUP
-            || kind_u32 == KIND_STREAM_MESSAGE_EDIT
-            || kind_u32 == KIND_NIP29_EDIT_METADATA
-            || kind_u32 == KIND_NIP29_DELETE_EVENT
-            || kind_u32 == KIND_NIP29_DELETE_GROUP;
-        if !skip_membership {
+        if requires_channel_write_membership(kind_u32) {
             // Spec AuthCheck (line 794): emit the verdict at the actual
             // call site. claimed_community comes from the event's h tag
             // (recorded separately to bite M2 / M8 — claim or A-host
@@ -3667,6 +3691,16 @@ mod tests {
             assert!(
                 requires_h_channel_scope(kind),
                 "kind {kind} should require h"
+            );
+        }
+    }
+
+    #[test]
+    fn channel_message_publication_does_not_require_membership() {
+        for kind in [KIND_STREAM_MESSAGE, buzz_core::kind::KIND_STREAM_MESSAGE_V2] {
+            assert!(
+                !requires_channel_write_membership(kind),
+                "signed channel message kind {kind} must not be refused for missing membership"
             );
         }
     }

--- a/crates/buzz-test-client/tests/conformance_multitenant.rs
+++ b/crates/buzz-test-client/tests/conformance_multitenant.rs
@@ -344,6 +344,10 @@ mod row_zero_host_binding {
 /// derives the community from the host — the channel lands in exactly that
 /// community and no other.
 async fn create_open_channel(base_url: &str, keys: &nostr::Keys) -> String {
+    create_channel(base_url, keys, "open").await
+}
+
+async fn create_channel(base_url: &str, keys: &nostr::Keys, visibility: &str) -> String {
     use nostr::{EventBuilder, Kind, Tag};
 
     let channel_uuid = uuid::Uuid::new_v4().to_string();
@@ -352,7 +356,7 @@ async fn create_open_channel(base_url: &str, keys: &nostr::Keys) -> String {
             Tag::parse(["h", &channel_uuid]).expect("h tag"),
             Tag::parse(["name", &format!("row-zero-{channel_uuid}")]).expect("name tag"),
             Tag::parse(["channel_type", "stream"]).expect("channel_type tag"),
-            Tag::parse(["visibility", "open"]).expect("visibility tag"),
+            Tag::parse(["visibility", visibility]).expect("visibility tag"),
         ])
         .sign_with_keys(keys)
         .expect("sign create-channel event");
@@ -386,9 +390,19 @@ async fn post_kind9(
     channel: &str,
     content: &str,
 ) -> (reqwest::StatusCode, String) {
+    post_stream_message(base_url, keys, channel, 9, content).await
+}
+
+async fn post_stream_message(
+    base_url: &str,
+    keys: &nostr::Keys,
+    channel: &str,
+    kind: u16,
+    content: &str,
+) -> (reqwest::StatusCode, String) {
     use nostr::{EventBuilder, Kind, Tag};
 
-    let event = EventBuilder::new(Kind::Custom(9), content)
+    let event = EventBuilder::new(Kind::Custom(kind), content)
         .tags(vec![Tag::parse(["h", channel]).expect("h tag")])
         .sign_with_keys(keys)
         .expect("sign kind:9 event");
@@ -405,6 +419,57 @@ async fn post_kind9(
     let status = resp.status();
     let body = resp.text().await.expect("read kind:9 body");
     (status, body)
+}
+
+#[tokio::test]
+#[ignore]
+async fn signed_nonmember_can_publish_to_an_existing_private_channel() {
+    use nostr::Keys;
+
+    let owner = Keys::generate();
+    let author = Keys::generate();
+    let channel = create_channel(&url_a(), &owner, "private").await;
+
+    for (kind, content) in [(9, "nonmember kind 9"), (40002, "nonmember kind 40002")] {
+        let (status, body) = post_stream_message(&url_a(), &author, &channel, kind, content).await;
+        assert!(
+            status.is_success() && accepted(&body),
+            "signed nonmember kind {kind} must publish to an existing private channel: \
+             status {status}, body {body}"
+        );
+    }
+
+    let filters = serde_json::json!([{
+        "kinds": [9, 40002],
+        "#h": [&channel],
+        "authors": [author.public_key().to_hex()],
+        "limit": 10,
+    }]);
+    let response = reqwest::Client::new()
+        .post(format!("{}/query", url_a()))
+        .header("X-Pubkey", owner.public_key().to_hex())
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&filters).expect("serialize query"))
+        .send()
+        .await
+        .expect("query accepted messages");
+    assert!(response.status().is_success(), "owner query must succeed");
+    let events: Vec<serde_json::Value> = response.json().await.expect("parse query response");
+    let mut contents = events
+        .iter()
+        .filter_map(|event| event["content"].as_str())
+        .collect::<Vec<_>>();
+    contents.sort_unstable();
+    assert_eq!(contents, ["nonmember kind 40002", "nonmember kind 9"]);
+
+    let missing_channel = uuid::Uuid::new_v4().to_string();
+    let (status, body) =
+        post_stream_message(&url_a(), &author, &missing_channel, 9, "orphan attempt").await;
+    assert!(
+        !status.is_success() || !accepted(&body),
+        "message to a nonexistent host-community channel must be rejected"
+    );
+    assert!(body.contains("restricted: not a channel member"));
 }
 
 /// Whether a `POST /events` JSON body reports the event as accepted.


### PR DESCRIPTION
## Summary

- allow signed kind 9 and 40002 messages to publish to an existing channel without prior channel membership
- preserve signature/authentication, channel-scoped token checks, channel existence, archived-channel checks, private reads, private fan-out, and unrelated write rules
- add a real HTTP ingest/query conformance case for a nonmember author plus an unknown-channel negative control

This is the residual real-entry fix for jmilrc/arbitrage-bot#9566. It does not deploy or change any image pin.

## Standing RED

On the unfixed predicate, the added focused test failed with:

    signed channel message kind 9 must not be refused for missing membership

After the patch, the same test passes. The real HTTP conformance test would fail at its first private-channel publication on the unfixed relay; it compiles locally but could not execute because this host has no Docker socket or Postgres/Redis Buzz test stack.

## Validation

- cargo test -p buzz-relay --lib handlers::ingest::tests:: — 175 passed, 1 ignored
- cargo test -p buzz-test-client --test conformance_multitenant --no-run — compiled
- cargo clippy -p buzz-relay --lib --tests -- -D warnings — passed
- cargo fmt --all -- --check — passed
- full relay lib run: 988 passed, 87 ignored, 7 unrelated environment/global-subscriber failures; six require a local Postgres role named buzz, one is the telemetry global-subscriber test
- live patched-relay smoke: unavailable because Docker/Postgres/Redis are absent; not claimed

## Review

Exact-head gpt-5.6-sol/high review at 0bec3f2e0ad38f4b4e95d70ee29cff33cf2404db: RED 0, INTENT-QUESTIONS 0, NOTES 1. Review job: review-20260831002610-b78116.

Coordinator-routed only. Do not merge or deploy from this lane.