### PR TITLE
fix(desktop): let a provider-backed agent be restarted after shutdown

### DIFF
--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
+  isManagedAgentActive,
 } from "./managedAgentControlActions.ts";
 
 function agent(overrides = {}) {
@@ -165,4 +166,44 @@ test("test_respawn_onStopped_fires_before_start_resolves", async () => {
     ["stop", "onStopped", "start"],
     "onStopped must fire after stop resolves and before start is called",
   );
+});
+
+// --- isManagedAgentActive: backend-agnostic, on purpose --------------------
+//
+// runtime.rs's two-axis model: for a provider-backed agent, `status` is a
+// control-plane fact ("the provider was invoked") that stays "deployed"
+// forever once set — there is no v1 undeploy. It never reverts on its own
+// after `!shutdown` takes the harness offline. respawnManagedAgentWithRules
+// already knows how to redeploy a provider agent (it skips the stop step and
+// just calls start), so a caller that additionally gates Restart on
+// `backend.type === "local"` (as UserProfilePanelSections.tsx did) leaves
+// every provider-backed agent with no way back from "Shutdown" once it goes
+// offline — the primary action stays wired to `!shutdown` forever, never
+// reaching `start` again. isManagedAgentActive itself must stay
+// backend-agnostic so callers have no reason to bolt on that extra check.
+
+test("isManagedAgentActive is true for a deployed provider agent", () => {
+  const providerAgent = agent({
+    status: "deployed",
+    backend: { type: "provider", id: "lxc", config: {} },
+  });
+  assert.equal(isManagedAgentActive(providerAgent), true);
+});
+
+test("isManagedAgentActive is true for a running local agent", () => {
+  const localAgent = agent({ status: "running" });
+  assert.equal(isManagedAgentActive(localAgent), true);
+});
+
+test("isManagedAgentActive is false for a provider agent never deployed", () => {
+  const undeployedAgent = agent({
+    status: "not_deployed",
+    backend: { type: "provider", id: "lxc", config: {} },
+  });
+  assert.equal(isManagedAgentActive(undeployedAgent), false);
+});
+
+test("isManagedAgentActive is false for a stopped local agent", () => {
+  const stoppedAgent = agent({ status: "stopped" });
+  assert.equal(isManagedAgentActive(stoppedAgent), false);
 });

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -449,9 +449,8 @@ export function ProfileSummaryView({
           }
           onAgentRestart={
             isOwner === true &&
-            managedAgent?.backend.type === "local" &&
-            (managedAgent.status === "running" ||
-              managedAgent.status === "deployed")
+            managedAgent &&
+            isManagedAgentActive(managedAgent)
               ? handleAgentRestart
               : undefined
           }


### PR DESCRIPTION
## Summary
The profile panel's Restart affordance was gated to `backend.type === "local"`, but a provider agent's `status` is a control-plane fact (`runtime.rs`'s two-axis model: "the provider was invoked") that stays `"deployed"` forever once set — there is no v1 undeploy. It never reverts after `!shutdown` takes the harness offline, so once a provider-backed agent went offline it had no way back through the UI: the primary action stayed permanently wired to resend `!shutdown`, never reaching `start` again.

`respawnManagedAgentWithRules` already handles provider backends correctly (skips the stop step, calls start directly), so the local-only gate on `onAgentRestart` was just an unnecessary restriction — `isManagedAgentActive` is already backend-agnostic. Drop the extra check and use it directly.

### Related issue
None found.

### Testing
- Added unit tests pinning `isManagedAgentActive` as backend-agnostic (deployed provider agent / running local agent / never-deployed provider agent / stopped local agent).
- `pnpm exec tsc --noEmit` clean.
- `pnpm exec biome check` clean.
- Full `agents`/`profile`/`channels` feature test suites: 2025/2025 passing.
- Found while debugging a real deploy: a provider-backed agent (a third-party backend implementing the `docs/remote-agents.md` contract) shut down via `!shutdown` showed no way to restart it from the Buzz Desktop UI, even after quitting and reopening the app.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>