### PR TITLE
fix(desktop): discover Kimi Code installs

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -27,7 +27,6 @@ pub(crate) use presets::{
 };
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use runtime_metadata::KnownAcpRuntime;
-
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
@@ -55,6 +54,7 @@ fn common_binary_paths() -> &'static [PathBuf] {
                 home.join(".volta/bin"),
                 home.join(".asdf/shims"),
                 home.join(".bun/bin"),
+                home.join(".kimi-code/bin"),
             ]);
         }
         // Windows well-known dirs for npm global shims and standalone installer targets.

--- a/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
@@ -49,6 +49,24 @@ fn common_binary_paths_probes_legacy_goose_install_dir() {
     );
 }
 
+/// Kimi Code's official Unix installer places the binary in
+/// `~/.kimi-code/bin`. Its shell setup may only load in interactive shells, so
+/// the fixed probe list must include the installation directory for GUI launches.
+#[cfg(unix)]
+#[test]
+fn common_binary_paths_probes_kimi_code_install_dir() {
+    let home = dirs::home_dir().expect("home directory is available on Unix");
+    let kimi_code_bin = home.join(".kimi-code/bin");
+
+    let probed = super::super::common_binary_paths();
+
+    assert!(
+        probed.contains(&kimi_code_bin),
+        "Kimi Code install dir {} must be probed, got: {probed:?}",
+        kimi_code_bin.display()
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn resolve_command_prefers_buzz_managed_npm_shim_over_path() {


### PR DESCRIPTION
## Summary
- probe the official Kimi Code install directory, `~/.kimi-code/bin`, during managed-agent command discovery
- add a Unix regression test for the fixed binary-path list

## Validation
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml common_binary_paths_probes_kimi_code_install_dir --lib`
- file-size pre-push gate
- `just ci` is still running locally while Hermit initializes its first Flutter SDK download

Fixes the GUI-launch case where Kimi writes PATH setup only to `~/.zshrc`, which non-interactive login-shell probing does not load.