### PR TITLE
fix(relay): allow longer NIP-42 AUTH window via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,10 @@ BUZZ_PUSH_ENABLED=false
 # be a positive integer.
 # BUZZ_RATE_LIMIT_HUMAN_MESSAGES_PER_MIN=60
 # BUZZ_RATE_LIMIT_GIF_SEARCHES_PER_MIN=30
+# Seconds a new WebSocket may wait to finish NIP-42 AUTH before the relay
+# closes it. Default 5. Self-host / Tailscale Desktop often needs 15–30.
+# Clamped 5–60.
+# BUZZ_NIP42_AUTH_TIMEOUT_SECS=15
 # BUZZ_RATE_LIMIT_HUMAN_API_CALLS_PER_MIN=300
 # BUZZ_RATE_LIMIT_HUMAN_WS_EVENTS_PER_SEC=10
 # BUZZ_RATE_LIMIT_AGENT_STANDARD_MESSAGES_PER_MIN=120

--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -25,8 +25,25 @@ use crate::state::{
     CommunityDisconnectReason,
 };
 
-/// Maximum time a new socket may hold a connection slot without completing NIP-42 auth.
-const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
+/// Default NIP-42 AUTH window. Override with `BUZZ_NIP42_AUTH_TIMEOUT_SECS`
+/// (clamped 5–60). Tailscale / self-host Desktop clients can miss 5s.
+const AUTH_TIMEOUT_DEFAULT_SECS: u64 = 5;
+const AUTH_TIMEOUT_MIN_SECS: u64 = 5;
+const AUTH_TIMEOUT_MAX_SECS: u64 = 60;
+
+fn parse_nip42_auth_timeout_secs(raw: Option<&str>) -> u64 {
+    raw.and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(AUTH_TIMEOUT_DEFAULT_SECS)
+        .clamp(AUTH_TIMEOUT_MIN_SECS, AUTH_TIMEOUT_MAX_SECS)
+}
+
+fn nip42_auth_timeout() -> Duration {
+    Duration::from_secs(parse_nip42_auth_timeout_secs(
+        std::env::var("BUZZ_NIP42_AUTH_TIMEOUT_SECS")
+            .ok()
+            .as_deref(),
+    ))
+}
 
 /// Shared mutable subscription map for a single WebSocket connection.
 pub(crate) type ConnectionSubscriptions = Arc<Mutex<HashMap<String, Vec<Filter>>>>;
@@ -248,11 +265,12 @@ async fn handle_active_connection(
         heartbeat_cancel,
     ));
 
+    let auth_timeout = nip42_auth_timeout();
     let auth_timeout_conn = Arc::clone(&conn);
     let auth_timeout_cancel = cancel.clone();
     let auth_timeout_task = tokio::spawn(async move {
         tokio::select! {
-            _ = tokio::time::sleep(AUTH_TIMEOUT) => {
+            _ = tokio::time::sleep(auth_timeout) => {
                 let authenticated = matches!(
                     *auth_timeout_conn.auth_state.read().await,
                     AuthState::Authenticated(_)
@@ -260,7 +278,7 @@ async fn handle_active_connection(
                 if !authenticated {
                     warn!(
                         conn_id = %auth_timeout_conn.conn_id,
-                        timeout_secs = AUTH_TIMEOUT.as_secs(),
+                        timeout_secs = auth_timeout.as_secs(),
                         "NIP-42 auth timeout — closing connection"
                     );
                     metrics::counter!("buzz_ws_auth_timeouts_total").increment(1);
@@ -1107,5 +1125,14 @@ mod tests {
             matches!(state.messages[1], WsMessage::Close(None)),
             "ordinary cancellation retains the bare Close after the reason frame"
         );
+    }
+
+    #[test]
+    fn nip42_auth_timeout_defaults_and_clamps() {
+        assert_eq!(super::parse_nip42_auth_timeout_secs(None), 5);
+        assert_eq!(super::parse_nip42_auth_timeout_secs(Some("15")), 15);
+        assert_eq!(super::parse_nip42_auth_timeout_secs(Some("1")), 5);
+        assert_eq!(super::parse_nip42_auth_timeout_secs(Some("90")), 60);
+        assert_eq!(super::parse_nip42_auth_timeout_secs(Some("nope")), 5);
     }
 }


### PR DESCRIPTION
## Summary

Self-hosted Desktop over Tailscale often misses the hardcoded 5s NIP-42 AUTH timeout, which aborts Projects enumeration (and looks like AUTH=0).

Read `BUZZ_NIP42_AUTH_TIMEOUT_SECS` (default 5, clamp 5–60) so operators can give AUTH a longer window without a rebuild.

Small relay-only slice. No Desktop extras. No Listen.

## Test plan

- [ ] Relay unit / existing AUTH tests
- [ ] Optional: self-host over Tailscale with `BUZZ_NIP42_AUTH_TIMEOUT_SECS=25` and confirm Projects catalog loads