### PR TITLE
fix(cli): keep sending when an @token matches no channel member

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -134,12 +134,11 @@ fn resolve_names_to_pubkeys(
             .unwrap_or_default()
         {
             [pubkey] => resolved.push(pubkey.clone()),
-            [] if has_explicit_mentions => {}
-            [] => {
-                return Err(CliError::Usage(format!(
-                    "mention '@{name}' does not match a current channel member; retry with --mention <pubkey>"
-                )))
-            }
+            // A bare `@token` in prose is not necessarily a mention. Failing the
+            // whole send over one dropped the entire message (#7054), so leave it
+            // as the literal text it already is. Ambiguity below still hard-fails:
+            // there a real member was meant and we cannot tell which one.
+            [] => {}
             _ if has_explicit_mentions => {}
             candidates => {
                 return Err(CliError::Usage(format!(
@@ -155,8 +154,8 @@ fn resolve_names_to_pubkeys(
 /// Resolve mention text against the channel membership snapshot.
 ///
 /// Returns both the current member set and uniquely name-resolved pubkeys.
-/// Lookup failures are fatal when mention processing is requested: publishing
-/// visible mention text without its intended `p` tag is worse than not sending.
+/// Names that match no member are left as plain text; an ambiguous name is
+/// fatal unless the caller supplied an explicit identity.
 async fn resolve_content_mentions(
     client: &BuzzClient,
     channel_id: &str,
@@ -1443,7 +1442,21 @@ mod tests {
             resolve_names_to_pubkeys(&names, &profiles, true).unwrap(),
             Vec::<String>::new()
         );
-        assert!(resolve_names_to_pubkeys(&names, &profiles, false).is_err());
+    }
+
+    #[test]
+    fn unmatched_at_token_in_prose_does_not_abort_the_send() {
+        // Regression for #7054: a bare `@token` in ordinary prose used to fail
+        // the whole send, so nothing was delivered at all.
+        let profiles = std::collections::HashMap::from([("alice".into(), vec![PK_VALID_A.into()])]);
+        let names = extract_at_mentions_with_known(
+            "@alice this mentions @-mention which is not a member",
+            &["alice"],
+        );
+        assert_eq!(
+            resolve_names_to_pubkeys(&names, &profiles, false).unwrap(),
+            vec![PK_VALID_A]
+        );
     }
 
     #[test]
@@ -1470,7 +1483,6 @@ mod tests {
             resolve_names_to_pubkeys(&names, &profiles, true).unwrap(),
             vec![PK_VALID_A]
         );
-        assert!(resolve_names_to_pubkeys(&names, &profiles, false).is_err());
     }
 
     #[test]


### PR DESCRIPTION
`buzz messages send` aborts the whole message with exit 1 when the content holds a bare `@token` that matches no current channel member. Nothing is delivered — ordinary prose containing a stray `@` (the literal word `@-mention`, for instance) is unsendable.

The branch directly above already handles this correctly: when the caller supplied any explicit identity (`--mention` or an inline `nostr:npub…`), an unmatched `@Name` is passed through as presentation-only text. This change makes that unconditional, so an unmatched `@token` is left as the literal text it already is.

Ambiguous names are unchanged — they still hard-fail without an explicit identity, because there a real member was meant and the CLI cannot tell which one.

Fixes #7054

## Test

`unmatched_at_token_in_prose_does_not_abort_the_send` (`crates/buzz-cli/src/commands/messages.rs`) runs the issue's repro string through the same extract-then-resolve pipeline the send path uses. On `main` it fails with `Usage("mention '@-mention' does not match a current channel member; retry with --mention <pubkey>")`; with this change it passes and the resolvable `@alice` still produces its p-tag.

Two existing tests dropped a now-invalid assertion that an unmatched name plus no explicit identity is an error — that is the behavior this PR changes.


`cargo test -p buzz-cli` (414 passing), `cargo clippy -p buzz-cli --all-targets -- -D warnings`, and `cargo fmt -p buzz-cli -- --check` are clean locally.