### PR TITLE
fix(desktop): keep text selectable under the window drag strip

### DIFF
--- a/desktop/src/app/AppShell.helpers.test.mjs
+++ b/desktop/src/app/AppShell.helpers.test.mjs
@@ -1,12 +1,66 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { after, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
 
 import {
+  isWindowDragHandleEvent,
   markAllReadSources,
   activateDesktopNotificationTarget,
   createDesktopNotificationActivationQueue,
   shouldBounceForChannelNotification,
 } from "./AppShell.helpers.ts";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    Element: dom.window.Element,
+    HTMLElement: dom.window.HTMLElement,
+    document: dom.window.document,
+    window: dom.window,
+  });
+});
+
+after(() => dom.window.close());
+
+// `composedPath()` is only populated during dispatch, so the helper has to be
+// called from a live listener rather than on a synthesized event object.
+function dragHandleVerdictAt(element, clientY) {
+  let verdict;
+  const listener = (event) => {
+    verdict = isWindowDragHandleEvent(event);
+  };
+  dom.window.addEventListener("pointerdown", listener, true);
+  element.dispatchEvent(
+    new dom.window.MouseEvent("pointerdown", { bubbles: true, clientY }),
+  );
+  dom.window.removeEventListener("pointerdown", listener, true);
+  return verdict;
+}
+
+test("window drag fallback leaves content that sits under the top strip selectable", () => {
+  // Regression for #6827: the fallback was purely geometric, so any click in
+  // the top 44px — including message text scrolled up there — was swallowed as
+  // a title-bar drag and could never start a selection.
+  dom.window.document.body.innerHTML = `
+    <div data-tauri-drag-region><span id="chrome-label">Buzz</span></div>
+    <main><p id="message">selectable message text</p></main>
+  `;
+  const message = dom.window.document.getElementById("message");
+  assert.equal(dragHandleVerdictAt(message, 42), false);
+});
+
+test("window drag fallback still covers plain children of a drag region", () => {
+  dom.window.document.body.innerHTML = `
+    <div data-tauri-drag-region><span id="chrome-label">Buzz</span></div>
+    <main><p id="message">selectable message text</p></main>
+  `;
+  const label = dom.window.document.getElementById("chrome-label");
+  assert.equal(dragHandleVerdictAt(label, 42), true);
+});
 
 test("shouldBounceForChannelNotification_allowsTopLevelChannelMessages", () => {
   assert.equal(shouldBounceForChannelNotification([["h", "channel"]]), true);

--- a/desktop/src/app/AppShell.helpers.ts
+++ b/desktop/src/app/AppShell.helpers.ts
@@ -13,6 +13,7 @@ export type AppView =
 
 const WINDOW_DRAG_HANDLE_HEIGHT = 44;
 const TAURI_DRAG_REGION_ATTR = "data-tauri-drag-region";
+const WINDOW_DRAG_REGION_SELECTOR = `[${TAURI_DRAG_REGION_ATTR}]:not([${TAURI_DRAG_REGION_ATTR}="false"])`;
 const WINDOW_DRAG_INTERACTIVE_SELECTOR =
   'button, a, input, textarea, select, label, summary, [role="button"], [role="link"], [role="menuitem"], [role="tab"], [role="checkbox"], [role="radio"], [role="switch"], [role="option"], [contenteditable="true"], [tabindex]:not([tabindex="-1"])';
 
@@ -76,10 +77,20 @@ export function isWindowDragHandleEvent(event: MouseEvent | PointerEvent) {
   }
 
   const target = event.target;
-  return !(
-    target instanceof Element &&
-    target.closest(WINDOW_DRAG_INTERACTIVE_SELECTOR)
-  );
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  // The fallback exists so plain descendants of a drag region still drag —
+  // `isTauriDragRegionEvent` only matches when the marked element is itself the
+  // click target. Height alone also caught ordinary content that happened to be
+  // scrolled under the top strip and cancelled its text selection (#6827), so
+  // require the point to actually be inside a drag region.
+  if (!target.closest(WINDOW_DRAG_REGION_SELECTOR)) {
+    return false;
+  }
+
+  return !target.closest(WINDOW_DRAG_INTERACTIVE_SELECTOR);
 }
 
 export function shouldBounceForChannelNotification(tags: string[][]): boolean {


### PR DESCRIPTION
`isWindowDragHandleEvent` falls back to a purely geometric test: any left-click within `WINDOW_DRAG_HANDLE_HEIGHT` (44px) of the window top is a title-bar drag unless the target matches the interactive selector. `useTauriWindowDrag` then calls `preventDefault()` and `startDragging()`, so a selection can never begin there — message text scrolled up into that band is unselectable, and the window moves instead.

This requires the point to actually be inside a `data-tauri-drag-region` subtree before the height fallback applies.

The fallback still has a job, so it is scoped rather than deleted: `isTauriDragRegionEvent` only returns true when the marked element *is* the click target (`attr === "" || attr === "true"` → `item === directTarget`), so plain descendants inside a drag region — a `<span>` label in the chrome, for instance — need the fallback to drag. Those still work; ordinary content that merely shares the y-band no longer does.

Fixes #6827

## Test

Two cases added to the existing `desktop/src/app/AppShell.helpers.test.mjs`, driven through a real jsdom dispatch because `composedPath()` is only populated during dispatch:

- `window drag fallback leaves content that sits under the top strip selectable` — a `<p>` outside any drag region at `clientY: 42`. Fails on `main` (`actual: true, expected: false`), passes with this change.
- `window drag fallback still covers plain children of a drag region` — a `<span>` inside `[data-tauri-drag-region]` at the same `clientY`. Passes both before and after, pinning the behavior the fallback exists for.

`pnpm typecheck`, `pnpm check`, and `pnpm test` (5801 passing) are clean.


### Before / after

Settings is one of the views where `AppTopChrome` is not rendered
(`!settingsOpen && !isHuddleRoom`), so the fallback covers ordinary content with
no chrome above it. Drag-selecting from `y = 42` down across the heading and its
description:

**Before** — the gesture starts inside the 44 px band, `preventDefault()` cancels it, and nothing is selected (`getSelection()` returns 0 characters):

![before](https://raw.githubusercontent.com/PresentJay/buzz/c0f37e135fc1df7bd2f71af0c94fb27126501fc3/pr-7094--01-before.png)

**After** — the same drag selects normally (67 characters: `"Profile\nUpdate how your name, avatar, and bio appear across Buzz."`):

![after](https://raw.githubusercontent.com/PresentJay/buzz/c0f37e135fc1df7bd2f71af0c94fb27126501fc3/pr-7094--02-after.png)