### PR TITLE
fix(desktop): enumerate project issues instead of capping at 200

### DIFF
--- a/desktop/src/features/projects/hooks.ts
+++ b/desktop/src/features/projects/hooks.ts
@@ -66,6 +66,10 @@ import {
   type Project,
   type Repository,
 } from "./projectModels";
+import {
+  enumerateProjectEvents,
+  PROJECT_ENUMERATION_PAGE_SIZE,
+} from "./projectEnumeration";
 import { fetchProjectHomeForChannel, fetchProjects } from "./projectFetch";
 import {
   markProjectCollectionAuthoritative,
@@ -85,6 +89,8 @@ export type {
   Repository,
 };
 export type ProjectPullRequestCommentDecision = "request-changes";
+
+type FetchEventsInput = Parameters<(typeof relayClient)["fetchEvents"]>[0];
 
 export type RepoState = {
   branches: Array<{ name: string; commit: string }>;
@@ -200,30 +206,40 @@ export async function fetchRepoState(
   return events.length > 0 ? eventToRepoState(events[0]) : null;
 }
 
-async function fetchProjectIssues(
+export async function fetchProjectIssues(
   project: Repository,
+  fetchEvents: (
+    filter: FetchEventsInput,
+  ) => Promise<RelayEvent[]> = relayClient.fetchEvents.bind(relayClient),
 ): Promise<ProjectIssue[]> {
-  const issuePromise = relayClient.fetchEvents({
-    kinds: [KIND_GIT_ISSUE],
-    "#a": [project.repoAddress],
-    limit: 200,
-  });
+  const repoScope = { "#a": [project.repoAddress] };
+  // Task counters reduce over the complete issue set, not the newest window a
+  // fixed `limit` happens to return: a bounded fetch made `Completed` fall as
+  // newer roots evicted older closed ones. Roots and their statuses both have
+  // to be exhaustive for the reduction to hold.
+  const issuePromise = enumerateProjectEvents(
+    fetchEvents,
+    [KIND_GIT_ISSUE],
+    PROJECT_ENUMERATION_PAGE_SIZE,
+    repoScope,
+  );
   const [issueEvents, statusEvents, commentEvents, assignmentEvents] =
     await Promise.all([
       issuePromise,
-      relayClient.fetchEvents({
-        kinds: [
+      enumerateProjectEvents(
+        fetchEvents,
+        [
           KIND_GIT_STATUS_OPEN,
           KIND_GIT_STATUS_MERGED,
           KIND_GIT_STATUS_CLOSED,
           KIND_GIT_STATUS_DRAFT,
         ],
-        "#a": [project.repoAddress],
-        limit: 500,
-      }),
-      relayClient.fetchEvents({
+        PROJECT_ENUMERATION_PAGE_SIZE,
+        repoScope,
+      ),
+      fetchEvents({
         kinds: [KIND_TEXT_NOTE],
-        "#a": [project.repoAddress],
+        ...repoScope,
         limit: 500,
       }),
       // Assignment state must reduce over the complete operation history, not
@@ -231,7 +247,10 @@ async function fetchProjectIssues(
       // (`#e`) because that is the only tag constraint the relay applies
       // before its SQL LIMIT — see fetchAssignmentOperationEvents.
       issuePromise.then((events) =>
-        fetchAssignmentOperationEvents(events.map((event) => event.id)),
+        fetchAssignmentOperationEvents(
+          events.map((event) => event.id),
+          fetchEvents,
+        ),
       ),
     ]);
 

--- a/desktop/src/features/projects/projectEnumeration.ts
+++ b/desktop/src/features/projects/projectEnumeration.ts
@@ -9,7 +9,7 @@ import { absorbStandaloneProjectRepositories } from "./lib/projectCollection";
 import { findProjectHomeByChannelId } from "./lib/projectHomeSelection";
 import { buildProjectReadModels, type Project } from "./projectModels";
 
-const PROJECT_ENUMERATION_PAGE_SIZE = 500;
+export const PROJECT_ENUMERATION_PAGE_SIZE = 500;
 
 // Relays commonly cap filter tag-value lists; chunk `#a` scoping well below
 // any such cap.

--- a/desktop/src/features/projects/projectIssueEnumeration.test.mjs
+++ b/desktop/src/features/projects/projectIssueEnumeration.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchProjectIssues } from "./hooks.ts";
+import { projectTaskActivity } from "./ui/projectRightPanelContext.ts";
+
+const OWNER = "a".repeat(64);
+const REPO_ADDRESS = `30617:${OWNER}:ralph-queue`;
+const PROJECT = { repoAddress: REPO_ADDRESS };
+
+function issueRoot(index) {
+  return {
+    id: `${index}`.padStart(64, "0"),
+    kind: 1621,
+    pubkey: OWNER,
+    // Newest-first ordering is what makes a bounded window lose the oldest
+    // roots, so index 0 has to be the oldest one.
+    created_at: 1_000 + index,
+    content: `Task ${index}`,
+    tags: [
+      ["a", REPO_ADDRESS],
+      ["subject", `Task ${index}`],
+    ],
+  };
+}
+
+/** Owner-signed kind:1632, so the root reduces to `Closed`. */
+function closedStatus(issue) {
+  return {
+    id: `${issue.created_at}`.padStart(64, "e"),
+    kind: 1632,
+    pubkey: OWNER,
+    created_at: issue.created_at + 1,
+    content: "",
+    tags: [
+      ["e", issue.id, "", "root"],
+      ["a", REPO_ADDRESS],
+    ],
+  };
+}
+
+/**
+ * Stands in for the relay: newest-first (`created_at DESC, id ASC`), honouring
+ * `limit`, `until`, and `since` the way `crates/buzz-db/src/event.rs` does.
+ */
+function makeRelay(events) {
+  return async function fetchEvents(filter) {
+    const kinds = new Set(filter.kinds);
+    return events
+      .filter(
+        (event) =>
+          kinds.has(event.kind) &&
+          (filter.until === undefined || event.created_at <= filter.until) &&
+          (filter.since === undefined || event.created_at >= filter.since),
+      )
+      .sort((a, b) => b.created_at - a.created_at || a.id.localeCompare(b.id))
+      .slice(0, filter.limit);
+  };
+}
+
+test("project issue loader returns every root past the 200-event window", async () => {
+  const roots = Array.from({ length: 201 }, (_, index) => issueRoot(index));
+  const relay = makeRelay([...roots, closedStatus(roots[0])]);
+
+  const issues = await fetchProjectIssues(PROJECT, relay);
+
+  assert.deepEqual(projectTaskActivity(issues), {
+    total: 201,
+    active: 200,
+    completed: 1,
+  });
+});
+
+test("a newer active root does not evict the oldest completed one", async () => {
+  const roots = Array.from({ length: 201 }, (_, index) => issueRoot(index));
+  const relay = makeRelay([...roots, issueRoot(201), closedStatus(roots[0])]);
+
+  const issues = await fetchProjectIssues(PROJECT, relay);
+
+  assert.deepEqual(projectTaskActivity(issues), {
+    total: 202,
+    active: 201,
+    completed: 1,
+  });
+});
+
+test("issue roots deeper than one page are drained by the cursor", async () => {
+  const roots = Array.from({ length: 501 }, (_, index) => issueRoot(index));
+  const relay = makeRelay([...roots, closedStatus(roots[0])]);
+  let issuePages = 0;
+  const counted = async (filter) => {
+    if (filter.kinds.includes(1621)) issuePages += 1;
+    return relay(filter);
+  };
+
+  const issues = await fetchProjectIssues(PROJECT, counted);
+
+  assert.ok(issuePages > 1, `expected more than one page, got ${issuePages}`);
+  assert.deepEqual(projectTaskActivity(issues), {
+    total: 501,
+    active: 500,
+    completed: 1,
+  });
+});


### PR DESCRIPTION
`fetchProjectIssues` asked the relay for at most 200 issue roots (and 500 status events) with no pagination. The relay orders newest-first, so a repository deeper than that silently lost its oldest roots. Tasks / Active / Completed in `projectTaskActivity` reduce directly over that array, so adding a new task could evict an older completed one and make **Completed decrease**.

Both queries now drain through `enumerateProjectEvents` — the boundary-bucket cursor already used for project and repository announcements — rather than raising the cap. Statuses are paginated alongside the roots because a complete root set reduced against a bounded status set still reports the wrong `Completed`.

The precedent is in the same function. Its assignment fetch already carries this rule:

> Assignment state must reduce over the complete operation history, not whatever survives the bounded comment window above.

Counters have the same property. The comment window itself is unchanged — it feeds no counter.

`enumerateProjectEvents` throws when a single second is denser than a page rather than returning a truncated set; that behavior is intentional and already pinned by `enumerateProjectEvents refuses to present a truncated boundary as complete` in `projectEnumeration.test.mjs`. It propagates here, so the panel surfaces a failure instead of a wrong number.

Fixes #6976

## Test

`desktop/src/features/projects/projectIssueEnumeration.test.mjs` drives the loader against a fake relay that reproduces the relay's `created_at DESC, id ASC` ordering and honours `limit` / `until` / `since`. `fetchProjectIssues` takes an injected page fetcher (defaulting to `relayClient.fetchEvents`) so the fixture needs no Tauri bridge.

Negative control on `main`, with 201 roots and the oldest one closed:

```
✖ project issue loader returns every root past the 200-event window
  actual:   { active: 200, completed: 0, total: 200 }
  expected: { total: 201, active: 200, completed: 1 }

✖ a newer active root does not evict the oldest completed one
  actual:   { active: 200, completed: 0, total: 200 }
  expected: { total: 202, active: 201, completed: 1 }
```

The oldest closed root is absent and `completed` is 0, exactly as reported. With this change:

```
✔ project issue loader returns every root past the 200-event window
✔ a newer active root does not evict the oldest completed one
✔ issue roots deeper than one page are drained by the cursor
```

The third case uses 501 roots and asserts more than one page was requested, so the cursor loop itself is exercised end to end rather than a single wider page.

Repository checks:

```
pnpm typecheck   ✔  tsc --noEmit
pnpm check       ✔  biome check + check:px-text + check:pubkey-truncation
pnpm test        ✔  5802 pass / 0 fail  (5799 on main + the 3 added here)
```
