### PR TITLE
fix(dev-mcp): pin UTF-8 for PowerShell shell commands

### DIFF
--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -164,7 +164,8 @@ pub async fn run(
     };
     let shell_arg = shell_flag(&bash);
     let mut cmd = Command::new(&bash);
-    cmd.arg(shell_arg).arg(&p.command);
+    cmd.arg(shell_arg)
+        .arg(shell_command_string(&bash, &p.command));
     cmd.current_dir(&workdir);
     cmd.env("PATH", &state.shim.path_env);
     // NOSTR_PRIVATE_KEY is already removed from this process's env (shim.rs).
@@ -343,6 +344,30 @@ fn shell_flag(shell: &Path) -> &'static str {
         Some("cmd") => "/C",
         Some("powershell" | "pwsh") => "-Command",
         _ => "-c",
+    }
+}
+
+/// Pins BOM-less UTF-8 on a PowerShell session's pipes to a native process.
+const POWERSHELL_UTF8_PREAMBLE: &str =
+    "$OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new(); ";
+
+/// Build the command string handed to the shell.
+///
+/// Windows PowerShell 5.1 encodes what it writes to a native process with the
+/// legacy console codepage, substituting `?` for every character that codepage
+/// cannot represent. Text piped into `buzz messages send --content -` is
+/// corrupted before the event is built, and the command still reports success,
+/// so the damage is permanent and silent. Pin UTF-8 for the session rather than
+/// relying on each caller to set it (#6527).
+fn shell_command_string(shell: &Path, command: &str) -> String {
+    match shell
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("powershell" | "pwsh") => format!("{POWERSHELL_UTF8_PREAMBLE}{command}"),
+        _ => command.to_string(),
     }
 }
 
@@ -991,6 +1016,33 @@ mod tests {
     fn make_state(cwd: &std::path::Path) -> SharedState {
         let shim = Shim::install().expect("shim install");
         SharedState::new(cwd.to_path_buf(), shim).expect("state new")
+    }
+
+    /// Windows PowerShell 5.1 encodes a native process's pipes with the legacy
+    /// console codepage, which substitutes `?` for anything it cannot represent
+    /// — the command still succeeds and the corrupted text is signed as-is.
+    #[test]
+    fn powershell_command_pins_utf8_before_the_callers_command() {
+        let unicode = "buzz messages send --content 'em dash — café 測試 🐝'";
+        for shell in ["powershell.exe", "pwsh.exe", "pwsh"] {
+            let built = shell_command_string(Path::new(shell), unicode);
+            assert!(
+                built.starts_with(POWERSHELL_UTF8_PREAMBLE),
+                "{shell} should pin UTF-8 first, got: {built}"
+            );
+            assert!(built.ends_with(unicode), "{shell} must keep the command");
+        }
+    }
+
+    /// Shells without the codepage boundary must be handed the command verbatim.
+    #[test]
+    fn other_shells_receive_the_command_unchanged() {
+        for shell in ["bash", "/bin/zsh", "sh", "cmd.exe"] {
+            assert_eq!(
+                shell_command_string(Path::new(shell), "echo hello"),
+                "echo hello"
+            );
+        }
     }
 
     /// Pull the JSON body out of a CallToolResult so tests can assert on fields.


### PR DESCRIPTION
Windows PowerShell 5.1 encodes what it writes to a native process with the legacy console codepage and substitutes `?` for every character that codepage cannot represent. Prose piped into `buzz messages send --content -` loses its em dashes, curly quotes, and non-Latin text before the event is built and signed — and the command still exits 0, so the corruption is silent and permanent in message history.

`buzz-dev-mcp` spawns that shell for every `dev__shell` call, which is the path managed agents use to reach the CLI. This pins BOM-less UTF-8 on the session before the caller's command runs:

```
$OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new(); <command>
```

That is the workaround from the issue, moved from the caller into the spawn so it holds for every session. A prompt-level instruction cannot: each channel is an independent, long-running agent session, so one can comply while another keeps using the legacy encoding.

Dispatch is on the resolved shell (`powershell` / `pwsh`), not the host OS, matching how `shell_flag` right above it already picks the command flag. Every other shell is handed the command unchanged.

Fixes #6527

## Test

Two cases in `crates/buzz-dev-mcp/src/shell.rs`, over the command string that is actually handed to the shell:

- `powershell_command_pins_utf8_before_the_callers_command` — asserts the preamble comes first and the caller's command (`em dash — café 測試 🐝`) survives intact, for `powershell.exe`, `pwsh.exe`, and `pwsh`. Before the change it fails with the command returned bare.
- `other_shells_receive_the_command_unchanged` — `bash`, `/bin/zsh`, `sh`, and `cmd.exe` are untouched.

```
cargo test -p buzz-dev-mcp   101 passed / 0 failed
just fmt-check               clean
just clippy                  clean
just test-unit               9/9 lanes pass
```

Scope note: this covers how the command is constructed. The end-to-end Windows assertion the issue asks for — sending through a live harness and reading the accepted event's code points back — is not included here; it needs a Windows runner this change cannot provide.
