### PR TITLE
fix(desktop): let a community be left after the relay ends membership

### DIFF
--- a/desktop/src/features/communities/leaveCommunity.test.mjs
+++ b/desktop/src/features/communities/leaveCommunity.test.mjs
@@ -132,6 +132,56 @@ test("treats an already-absent inactive membership as successful cleanup and dis
   assert.equal(disconnected, true);
 });
 
+/** The latched session refuses to reconnect, so it never reaches the relay. */
+function terminalSession() {
+  return async () => {
+    throw new Error("Relay session is terminal; cannot reconnect.");
+  };
+}
+
+test("retries a terminal active session on a fresh connection", async () => {
+  // Membership already ended, so the relay refuses the latched session and the
+  // community can never be removed while we wait for it to accept (#7049).
+  let disconnected = false;
+  const result = await leaveCommunity(
+    "wss://active.example",
+    "wss://active.example",
+    dependencies({
+      publishActive: terminalSession(),
+      createRelayClient: () => ({
+        publishEvent: async () => {
+          throw new Error("restricted: not a relay member");
+        },
+        disconnect: () => {
+          disconnected = true;
+        },
+      }),
+    }),
+  );
+
+  assert.deepEqual(result, { status: "already-absent" });
+  assert.equal(disconnected, true);
+});
+
+test("still fails when a fresh connection has a membership to end", async () => {
+  await assert.rejects(
+    leaveCommunity(
+      "wss://active.example",
+      "wss://active.example",
+      dependencies({
+        publishActive: terminalSession(),
+        createRelayClient: () => ({
+          publishEvent: async () => {
+            throw new Error("auth-required: verification failed");
+          },
+          disconnect() {},
+        }),
+      }),
+    ),
+    /verification failed/,
+  );
+});
+
 test("preserves other relay rejections and disconnects without falling through", async () => {
   const rejection = new Error("invalid: relay owner cannot leave");
   let disconnected = false;

--- a/desktop/src/features/communities/leaveCommunity.ts
+++ b/desktop/src/features/communities/leaveCommunity.ts
@@ -35,6 +35,18 @@ function membershipIsAlreadyAbsent(error: unknown): boolean {
   );
 }
 
+/**
+ * The shared session latches terminal when the relay rejects AUTH and then
+ * refuses to reconnect, so it reports its own latch rather than the relay's
+ * answer. It cannot deliver the leave request in that state.
+ */
+function sessionIsTerminal(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.toLowerCase().includes("session is terminal")
+  );
+}
+
 export type LeaveCommunityResult =
   | { status: "left" }
   | { status: "already-absent" };
@@ -68,7 +80,15 @@ export async function leaveCommunity(
   });
 
   if (relayUrl === activeRelayUrl) {
-    return publishLeaveRequest(() => dependencies.publishActive(event));
+    try {
+      return await publishLeaveRequest(() => dependencies.publishActive(event));
+    } catch (error) {
+      // A terminal session is most often a membership the relay already ended,
+      // and then waiting for it to accept a leave request is a dead end (#7049).
+      // Fall through to a fresh connection so the relay itself answers: an ended
+      // membership resolves as already-absent, anything else still fails.
+      if (!sessionIsTerminal(error)) throw error;
+    }
   }
 
   const client = dependencies.createRelayClient(relayUrl);


### PR DESCRIPTION
When a relay ends a membership it rejects AUTH, the shared session latches terminal, and every later call gets `Relay session is terminal; cannot reconnect.` from the latch rather than an answer from the relay. `leaveCommunity` resolves only after the relay accepts the leave request (#3621), so the request is never delivered and the dead community can never be removed from the switcher.

A terminal active session now retries on a fresh connection — the same `ReadOnlyRelayClient` path already used when leaving a non-active community relay. That hands the decision back to the relay instead of guessing at the latch: a membership the relay already ended answers `not a relay member` and resolves as already-absent, and any other terminal reason still fails the leave and leaves the community in place.

#3621's behavior for transient errors is unchanged — the fresh attempt reports whatever the relay actually says, so a transient failure still keeps the community.

Fixes #7049

## Test

Two cases in the existing `desktop/src/features/communities/leaveCommunity.test.mjs`, both failing on `main`:

- `retries a terminal active session on a fresh connection` — active publish throws the terminal error, the fresh client answers `restricted: not a relay member`; asserts `already-absent` and that the fresh client was disconnected.
- `still fails when a fresh connection has a membership to end` — same terminal error, but the fresh client answers `auth-required: verification failed`; asserts the leave still rejects.

```
✖ retries a terminal active session on a fresh connection
✖ still fails when a fresh connection has a membership to end
  AssertionError: The input did not match the regular expression /verification failed/
```

The pre-existing `preserves other relay rejections and disconnects without falling through` negative control passes unchanged.

```
pnpm typecheck   ✔  tsc --noEmit
pnpm check       ✔  biome check + check:px-text + check:pubkey-truncation
pnpm test        ✔  5801 pass / 0 fail  (5799 on main + the 2 added here)
```
