### PR TITLE
fix(acp): grant Codex SSH agent sandbox access

### DIFF
--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -74,7 +74,7 @@ evalexpr = { workspace = true }
 # Process-group kill (safe wrapper around killpg) — Unix-only; kill_process_group
 # has a #[cfg(not(unix))] fallback in acp.rs.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal"] }
+nix = { version = "0.31", default-features = false, features = ["signal", "user"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -8,6 +8,9 @@
 //! 4. [`AcpClient::session_prompt_with_idle_timeout`] — send prompt with idle/hard deadline, return stop reason
 //! 5. [`AcpClient::session_cancel`] / [`AcpClient::cancel_with_cleanup`] — cancel in-flight turn
 
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, ChildStdout};
@@ -243,44 +246,47 @@ fn deep_merge(
 
 /// Build the merged `CODEX_CONFIG` environment-variable value for a Codex agent spawn.
 ///
-/// Returns `Some(json_string)` when `has_generated_codex_config` is true (Buzz injected a
-/// `CODEX_CONFIG` entry via `codex_network_env()`), `None` otherwise.
+/// Returns `Some(json_string)` when Buzz produced a generated `CODEX_CONFIG` via
+/// `codex_network_env()`, `None` otherwise.
 ///
-/// # Merge contract (when `has_generated_codex_config` is true)
+/// # Merge contract (when `generated_codex_config` is `Some`)
 ///
-/// 1. **Persona base** — the first `CODEX_CONFIG` value in `extra_env` is taken as
-///    the base object (all keys preserved, recursively).  When there is no persona entry,
-///    the generated entry serves as the base.
-/// 2. **Generated overlay** — all subsequent `CODEX_CONFIG` entries are deep-merged into
-///    the base so unrelated nested persona keys survive.
+/// 1. **Persona base** — the first `CODEX_CONFIG` value in `extra_env` is taken
+///    as the base object (all keys preserved, recursively). Additional persona
+///    `CODEX_CONFIG` entries are merged in order.
+/// 2. **Generated overlay** — the explicit `generated_codex_config` value is
+///    deep-merged into the base so generated defaults apply without erasing
+///    unrelated persona keys. When there is no persona entry, the generated
+///    value serves as the base.
 /// 3. **Parent-env precedence** — if `parent_codex_config` is `Some`, its keys are
 ///    deep-merged into the result (parent wins on colliding keys at every nesting level;
 ///    unrelated keys from either side survive).
-/// 4. **Forced overlay** — generated Codex sandbox requirements are applied
-///    last: `sandbox_workspace_write.network_access = true`, plus any generated
-///    `sandbox_workspace_write.writable_roots` and `network.allow_unix_sockets`
-///    entries.
+/// 4. **Generated floor** — generated Codex sandbox requirements are applied
+///    last: `sandbox_workspace_write.network_access = true`, plus any
+///    generated `sandbox_workspace_write.writable_roots` and
+///    `network.allow_unix_sockets` entries. Parent/persona entries outside that
+///    generated floor are preserved.
 ///
-/// When `has_generated_codex_config` is false, the function returns `None` and the
-/// caller handles any persona-supplied `CODEX_CONFIG` with ordinary operator-wins
-/// semantics (no merging, no sandbox widening).
+/// When `generated_codex_config` is `None`, the function returns `None` and the
+/// caller handles any persona-supplied `CODEX_CONFIG` with ordinary
+/// operator-wins semantics.
 ///
 /// # Errors
 ///
-/// Returns `Err(AcpError::Protocol)` when `has_generated_codex_config` is true and any
-/// `CODEX_CONFIG` value is not valid JSON or is not a JSON object, or when
+/// Returns `Err(AcpError::Protocol)` when `generated_codex_config` is `Some`
+/// and any `CODEX_CONFIG` value is not valid JSON or is not a JSON object, or when
 /// `sandbox_workspace_write` is present but not an object after all merges, or
 /// when a forced string-array field has an incompatible shape.
 pub(crate) fn build_codex_config_env(
     extra_env: &[(String, String)],
     parent_codex_config: Option<&str>,
-    has_generated_codex_config: bool,
+    generated_codex_config: Option<&str>,
 ) -> Result<Option<String>, AcpError> {
-    // Without an explicit Buzz-generated overlay signal, skip the merge entirely.
+    // Without an explicit Buzz-generated overlay, skip the merge entirely.
     // Any persona CODEX_CONFIG is handled by the caller with operator-wins semantics.
-    if !has_generated_codex_config {
+    let Some(generated_raw) = generated_codex_config else {
         return Ok(None);
-    }
+    };
 
     // Collect all CODEX_CONFIG entries from extra_env in order.
     let codex_entries: Vec<&str> = extra_env
@@ -289,75 +295,40 @@ pub(crate) fn build_codex_config_env(
         .map(|(_, v)| v.as_str())
         .collect();
 
-    if codex_entries.is_empty() {
-        // has_generated_codex_config is true but no entry in extra_env — shouldn't
-        // happen in practice, but treat as no-op rather than panic.
-        return Ok(None);
-    }
-
-    // Parse all entries; first one is the persona base (or the generated entry if no
-    // persona CODEX_CONFIG was set), rest are additional generated entries.
+    // Parse persona entries independently from Buzz's generated value so the
+    // generated config cannot be confused with a positional `extra_env` entry.
     let mut parsed_entries: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
-    for (i, raw) in codex_entries.iter().enumerate() {
-        match serde_json::from_str::<serde_json::Value>(raw) {
-            Ok(serde_json::Value::Object(obj)) => parsed_entries.push(obj),
-            Ok(_) => {
-                let source = if i == 0 { "persona" } else { "generated" };
-                return Err(AcpError::Protocol(format!(
-                    "CODEX_CONFIG {source} value is valid JSON but not an object"
-                )));
-            }
-            Err(e) => {
-                let source = if i == 0 { "persona" } else { "generated" };
-                return Err(AcpError::Protocol(format!(
-                    "CODEX_CONFIG {source} value is not valid JSON: {e}"
-                )));
-            }
+    for raw in codex_entries {
+        parsed_entries.push(parse_codex_config_object(raw, "persona")?);
+    }
+    let generated = parse_codex_config_object(generated_raw, "generated")?;
+
+    let generated_writable_roots = nested_string_array(
+        &generated,
+        "sandbox_workspace_write",
+        "writable_roots",
+        "generated",
+    )?;
+    let generated_unix_sockets =
+        nested_string_array(&generated, "network", "allow_unix_sockets", "generated")?;
+
+    // Start from first persona entry when present, then merge remaining persona
+    // entries before applying the explicit generated overlay.
+    let mut base = if parsed_entries.is_empty() {
+        generated
+    } else {
+        let mut base = parsed_entries.remove(0);
+        for overlay in parsed_entries {
+            deep_merge(&mut base, overlay);
         }
-    }
-
-    let generated_start_index = if parsed_entries.len() > 1 { 1 } else { 0 };
-    let mut generated_writable_roots = Vec::new();
-    let mut generated_unix_sockets = Vec::new();
-    for generated in &parsed_entries[generated_start_index..] {
-        push_unique_strings(
-            &mut generated_writable_roots,
-            nested_string_array(
-                generated,
-                "sandbox_workspace_write",
-                "writable_roots",
-                "generated",
-            )?,
-        );
-        push_unique_strings(
-            &mut generated_unix_sockets,
-            nested_string_array(generated, "network", "allow_unix_sockets", "generated")?,
-        );
-    }
-
-    // Start from first entry, deep-merge remaining entries.
-    let mut base = parsed_entries.remove(0);
-    for overlay in parsed_entries {
-        deep_merge(&mut base, overlay);
-    }
+        deep_merge(&mut base, generated);
+        base
+    };
 
     // Deep-merge parent env (parent wins on colliding keys at every nesting level).
     if let Some(parent_raw) = parent_codex_config {
-        match serde_json::from_str::<serde_json::Value>(parent_raw) {
-            Ok(serde_json::Value::Object(parent_obj)) => {
-                deep_merge(&mut base, parent_obj);
-            }
-            Ok(_) => {
-                return Err(AcpError::Protocol(
-                    "CODEX_CONFIG in parent environment is valid JSON but not an object".into(),
-                ));
-            }
-            Err(e) => {
-                return Err(AcpError::Protocol(format!(
-                    "CODEX_CONFIG in parent environment is not valid JSON: {e}"
-                )));
-            }
-        }
+        let parent_obj = parse_codex_config_object(parent_raw, "in parent environment")?;
+        deep_merge(&mut base, parent_obj);
     }
 
     // Force sandbox_workspace_write.network_access = true (our invariant, always wins).
@@ -393,6 +364,21 @@ pub(crate) fn build_codex_config_env(
     Ok(Some(serde_json::Value::Object(base).to_string()))
 }
 
+fn parse_codex_config_object(
+    raw: &str,
+    source: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, AcpError> {
+    match serde_json::from_str::<serde_json::Value>(raw) {
+        Ok(serde_json::Value::Object(obj)) => Ok(obj),
+        Ok(_) => Err(AcpError::Protocol(format!(
+            "CODEX_CONFIG {source} value is valid JSON but not an object"
+        ))),
+        Err(e) => Err(AcpError::Protocol(format!(
+            "CODEX_CONFIG {source} value is not valid JSON: {e}"
+        ))),
+    }
+}
+
 fn nested_string_array(
     config: &serde_json::Map<String, serde_json::Value>,
     section_key: &str,
@@ -417,13 +403,14 @@ fn nested_string_array(
     };
 
     let mut out = Vec::new();
+    let mut seen = HashSet::new();
     for entry in entries {
         let Some(entry) = entry.as_str() else {
             return Err(AcpError::Protocol(format!(
                 "CODEX_CONFIG {source} {section_key}.{array_key} contains a non-string entry"
             )));
         };
-        push_unique_string(&mut out, entry.to_string());
+        push_unique_config_path(&mut out, &mut seen, entry);
     }
     Ok(out)
 }
@@ -434,7 +421,7 @@ fn force_string_array_entries(
     array_key: &str,
     entries: &[String],
 ) -> Result<(), AcpError> {
-    if entries.is_empty() {
+    if entries.is_empty() && !config.contains_key(section_key) {
         return Ok(());
     }
 
@@ -450,6 +437,9 @@ fn force_string_array_entries(
             )));
         }
     };
+    if entries.is_empty() && !section.contains_key(array_key) {
+        return Ok(());
+    }
     let array_entry = section
         .entry(array_key.to_string())
         .or_insert_with(|| serde_json::Value::Array(Vec::new()));
@@ -462,35 +452,43 @@ fn force_string_array_entries(
         }
     };
 
+    let mut merged = Vec::new();
+    let mut seen = HashSet::new();
     for entry in array.iter() {
-        if !entry.is_string() {
+        let Some(entry) = entry.as_str() else {
             return Err(AcpError::Protocol(format!(
                 "CODEX_CONFIG {section_key}.{array_key} contains a non-string entry"
             )));
-        }
+        };
+        push_unique_config_path(&mut merged, &mut seen, entry);
     }
     for entry in entries {
-        if !array
-            .iter()
-            .any(|existing| existing.as_str() == Some(entry.as_str()))
-        {
-            array.push(serde_json::Value::String(entry.clone()));
-        }
+        push_unique_config_path(&mut merged, &mut seen, entry);
     }
+    *array = merged.into_iter().map(serde_json::Value::String).collect();
 
     Ok(())
 }
 
-fn push_unique_strings(out: &mut Vec<String>, entries: Vec<String>) {
-    for entry in entries {
-        push_unique_string(out, entry);
+fn push_unique_config_path(out: &mut Vec<String>, seen: &mut HashSet<String>, entry: &str) {
+    let normalized = normalize_config_path_entry(entry);
+    if seen.insert(normalized.clone()) {
+        out.push(normalized);
     }
 }
 
-fn push_unique_string(out: &mut Vec<String>, entry: String) {
-    if !out.iter().any(|existing| existing == &entry) {
-        out.push(entry);
+fn normalize_config_path_entry(entry: &str) -> String {
+    let mut normalized = PathBuf::new();
+    for component in Path::new(entry).components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
     }
+    normalized.to_string_lossy().into_owned()
 }
 
 /// goose's non-standard mid-turn steer method. Requires `expectedRunId`, so it
@@ -580,17 +578,17 @@ impl AcpClient {
 
     /// Spawn the agent binary as a subprocess and connect to its stdio pipes.
     ///
-    /// `has_generated_codex_config` must be true when `codex_network_env()` successfully
-    /// injected a `CODEX_CONFIG` entry into `extra_env`.  The spawn path uses it to
-    /// trigger the recursive merge + forced `network_access=true` in
-    /// `build_codex_config_env`.  Pass `false` for test spawns and non-Codex agents.
+    /// `generated_codex_config` must contain the `codex_network_env()` JSON when
+    /// Buzz generated a Codex sandbox config. The spawn path uses it to trigger
+    /// the recursive merge + generated floor in `build_codex_config_env`. Pass
+    /// `None` for test spawns and non-Codex agents.
     ///
     /// After spawning, call [`initialize`](Self::initialize) before any other method.
     pub async fn spawn(
         command: &str,
         args: &[String],
         extra_env: &[(String, String)],
-        has_generated_codex_config: bool,
+        generated_codex_config: Option<&str>,
     ) -> Result<Self, AcpError> {
         use std::process::Stdio;
 
@@ -609,12 +607,11 @@ impl AcpClient {
         // in the parent environment.
         //
         // CODEX_CONFIG is handled specially via build_codex_config_env:
-        //   • has_generated_codex_config=true: merge all CODEX_CONFIG entries + parent
-        //     recursively and force network_access=true.
-        //   • has_generated_codex_config=false: return None; any persona-supplied
+        //   - generated_codex_config=Some: merge persona CODEX_CONFIG entries,
+        //     generated defaults, and parent recursively, then force the generated floor.
+        //   - generated_codex_config=None: return None; any persona-supplied
         //     CODEX_CONFIG falls through to the normal operator-wins loop below.
-        let has_codex_config = extra_env.iter().any(|(k, _)| k == "CODEX_CONFIG");
-        let parent_codex_config = if has_generated_codex_config && has_codex_config {
+        let parent_codex_config = if generated_codex_config.is_some() {
             std::env::var("CODEX_CONFIG").ok()
         } else {
             None
@@ -622,7 +619,7 @@ impl AcpClient {
         let codex_config_value = build_codex_config_env(
             extra_env,
             parent_codex_config.as_deref(),
-            has_generated_codex_config,
+            generated_codex_config,
         )?;
         // When the merge path was not taken (None returned), any persona CODEX_CONFIG
         // entry falls through to the standard operator-wins treatment below.
@@ -3159,7 +3156,7 @@ mod tests {
     }
 
     async fn spawn_script(script: &str) -> AcpClient {
-        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
+        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], None)
             .await
             .expect("failed to spawn test script")
     }
@@ -3182,7 +3179,7 @@ mod tests {
             .permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&path, permissions).expect("chmod fake adapter");
-        let client = AcpClient::spawn(path.to_str().expect("utf8 path"), &[], &[], false)
+        let client = AcpClient::spawn(path.to_str().expect("utf8 path"), &[], &[], None)
             .await
             .expect("spawn named fake adapter");
         (client, dir)
@@ -3215,7 +3212,7 @@ mod tests {
             path.to_str().expect("probe path is UTF-8"),
             &[],
             extra_env,
-            false,
+            None,
         )
         .await
         .expect("spawn env probe script");
@@ -3852,7 +3849,7 @@ mod tests {
     /// which is fine — these tests don't read from the agent, they just
     /// feed JSON into the parser.
     async fn spawn_inert_client() -> AcpClient {
-        AcpClient::spawn("cat", &[], &[], false)
+        AcpClient::spawn("cat", &[], &[], None)
             .await
             .expect("spawn cat as inert client")
     }
@@ -4941,13 +4938,13 @@ mod tests {
     }
 
     const GENERATED: &str = r#"{"sandbox_workspace_write":{"network_access":true}}"#;
-    const GENERATED_WITH_SSH_GRANTS: &str = r#"{"network":{"allow_unix_sockets":["/tmp/ssh-agent"]},"sandbox_workspace_write":{"network_access":true,"writable_roots":["/tmp/ssh-agent"]}}"#;
+    const GENERATED_WITH_SSH_SOCKET: &str = r#"{"network":{"allow_unix_sockets":["/tmp/ssh-agent"]},"sandbox_workspace_write":{"network_access":true}}"#;
 
     #[test]
-    fn build_codex_config_env_returns_none_when_no_codex_config_in_extra_env() {
-        // Non-Codex agents: extra_env has no CODEX_CONFIG → None regardless of signal.
+    fn build_codex_config_env_returns_none_when_no_generated_config() {
+        // Non-Codex agents: persona CODEX_CONFIG falls through to normal env handling.
         let extra = env(&[("GOOSE_PROVIDER", "openai")]);
-        let result = build_codex_config_env(&extra, None, false).unwrap();
+        let result = build_codex_config_env(&extra, None, None).unwrap();
         assert_eq!(
             result, None,
             "no CODEX_CONFIG in extra_env must return None"
@@ -4955,20 +4952,20 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_config_env_generated_only_single_entry_with_signal_true_merges_with_parent() {
-        // No persona: Buzz injects one CODEX_CONFIG; signal=true.
+    fn build_codex_config_env_generated_only_merges_with_parent() {
+        // No persona: Buzz supplies one generated CODEX_CONFIG.
         // Parent may have its own CODEX_CONFIG — deep_merge applies, network_access forced.
-        let extra = env(&[("CODEX_CONFIG", GENERATED)]);
+        let extra = env(&[]);
         let parent =
             r#"{"some_operator_key":"val","sandbox_workspace_write":{"operator_key":"keep"}}"#;
-        let merged = build_codex_config_env(&extra, Some(parent), true)
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED))
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
         // network_access forced true even though only one entry in extra_env.
         assert_eq!(
             v["sandbox_workspace_write"]["network_access"], true,
-            "network_access must be forced true with signal=true"
+            "network_access must be forced true with generated config"
         );
         // Operator key preserved via deep_merge.
         assert_eq!(
@@ -4982,15 +4979,15 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_config_env_persona_only_signal_false_returns_none() {
-        // Persona set CODEX_CONFIG; Buzz did not inject a generated overlay (signal=false).
-        // Must return None — no merging, no sandbox widening.
+    fn build_codex_config_env_persona_only_without_generated_config_returns_none() {
+        // Persona set CODEX_CONFIG; Buzz did not produce a generated overlay.
+        // Must return None: no special merging.
         let persona = r#"{"some_feature":"on"}"#;
         let extra = env(&[("CODEX_CONFIG", persona)]);
-        let result = build_codex_config_env(&extra, None, false).unwrap();
+        let result = build_codex_config_env(&extra, None, None).unwrap();
         assert_eq!(
             result, None,
-            "persona-only CODEX_CONFIG with signal=false must return None"
+            "persona-only CODEX_CONFIG without generated config must return None"
         );
     }
 
@@ -4999,19 +4996,21 @@ mod tests {
         // Alias: same scenario as above, confirms the old count-based path no longer exists.
         let persona = r#"{"some_feature":"on"}"#;
         let extra = env(&[("CODEX_CONFIG", persona)]);
-        let result = build_codex_config_env(&extra, None, false).unwrap();
+        let result = build_codex_config_env(&extra, None, None).unwrap();
         assert_eq!(
             result, None,
-            "persona-only CODEX_CONFIG with signal=false must return None"
+            "persona-only CODEX_CONFIG without generated config must return None"
         );
     }
 
     #[test]
     fn build_codex_config_env_sets_network_access_from_scratch() {
-        // Persona + generated overlay, signal=true: network_access is forced true.
+        // Persona + generated overlay: network_access is forced true.
         let persona = r#"{}"#;
-        let extra = env(&[("CODEX_CONFIG", persona), ("CODEX_CONFIG", GENERATED)]);
-        let merged = build_codex_config_env(&extra, None, true).unwrap().unwrap();
+        let extra = env(&[("CODEX_CONFIG", persona)]);
+        let merged = build_codex_config_env(&extra, None, Some(GENERATED))
+            .unwrap()
+            .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
         assert_eq!(v["sandbox_workspace_write"]["network_access"], true);
     }
@@ -5021,9 +5020,10 @@ mod tests {
         // Persona has CODEX_CONFIG with unrelated keys; generated overlay must
         // force network_access=true without erasing persona keys.
         let persona_cfg = r#"{"some_feature":{"enabled":true}}"#;
-        // Config::from_args appends generated AFTER persona env vars.
-        let extra = env(&[("CODEX_CONFIG", persona_cfg), ("CODEX_CONFIG", GENERATED)]);
-        let merged = build_codex_config_env(&extra, None, true).unwrap().unwrap();
+        let extra = env(&[("CODEX_CONFIG", persona_cfg)]);
+        let merged = build_codex_config_env(&extra, None, Some(GENERATED))
+            .unwrap()
+            .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
         assert_eq!(
             v["some_feature"]["enabled"], true,
@@ -5042,9 +5042,9 @@ mod tests {
         // persona_only.  deep_merge must preserve both nested keys, and
         // network_access must be forced true last.
         let persona_cfg = r#"{"sandbox_workspace_write":{"persona_only":"keep_me"}}"#;
-        let extra = env(&[("CODEX_CONFIG", persona_cfg), ("CODEX_CONFIG", GENERATED)]);
+        let extra = env(&[("CODEX_CONFIG", persona_cfg)]);
         let parent = r#"{"sandbox_workspace_write":{"parent_only":"also_here"}}"#;
-        let merged = build_codex_config_env(&extra, Some(parent), true)
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED))
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
@@ -5070,10 +5070,9 @@ mod tests {
         // Parent wins on collision; unrelated persona keys survive.
         // network_access is always forced true.
         let persona_cfg = r#"{"persona_key":"persona_val","shared_key":"persona_version"}"#;
-        // Config::from_args appends generated AFTER persona env vars.
-        let extra = env(&[("CODEX_CONFIG", persona_cfg), ("CODEX_CONFIG", GENERATED)]);
+        let extra = env(&[("CODEX_CONFIG", persona_cfg)]);
         let parent = r#"{"parent_key":"parent_val","shared_key":"parent_version"}"#;
-        let merged = build_codex_config_env(&extra, Some(parent), true)
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED))
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
@@ -5101,10 +5100,10 @@ mod tests {
         // Parent env has sandbox_workspace_write with extra keys; after merge
         // those extra keys survive alongside network_access=true.
         let persona = r#"{}"#;
-        let extra = env(&[("CODEX_CONFIG", persona), ("CODEX_CONFIG", GENERATED)]);
+        let extra = env(&[("CODEX_CONFIG", persona)]);
         let parent =
             r#"{"sandbox_workspace_write":{"network_access":false,"other_sandbox_key":"val"}}"#;
-        let merged = build_codex_config_env(&extra, Some(parent), true)
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED))
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
@@ -5115,10 +5114,10 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_config_env_preserves_generated_ssh_grants_after_parent_merge() {
-        let extra = env(&[("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS)]);
+    fn build_codex_config_env_preserves_generated_ssh_socket_after_parent_merge() {
+        let extra = env(&[]);
         let parent = r#"{"network":{"allow_unix_sockets":["/tmp/operator","/tmp/ssh-agent"]},"sandbox_workspace_write":{"network_access":false,"writable_roots":["/tmp/operator"]}}"#;
-        let merged = build_codex_config_env(&extra, Some(parent), true)
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED_WITH_SSH_SOCKET))
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
@@ -5126,7 +5125,7 @@ mod tests {
         assert_eq!(v["sandbox_workspace_write"]["network_access"], true);
         assert_eq!(
             v["sandbox_workspace_write"]["writable_roots"],
-            serde_json::json!(["/tmp/operator", "/tmp/ssh-agent"])
+            serde_json::json!(["/tmp/operator"])
         );
         assert_eq!(
             v["network"]["allow_unix_sockets"],
@@ -5135,21 +5134,18 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_config_env_forces_generated_ssh_grants_with_persona_base() {
+    fn build_codex_config_env_forces_generated_ssh_socket_with_persona_base() {
         let persona = r#"{"sandbox_workspace_write":{"writable_roots":["/tmp/persona"]},"network":{"allow_unix_sockets":["/tmp/persona"]}}"#;
-        let extra = env(&[
-            ("CODEX_CONFIG", persona),
-            ("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS),
-        ]);
+        let extra = env(&[("CODEX_CONFIG", persona)]);
         let parent = r#"{"sandbox_workspace_write":{"writable_roots":[]},"network":{"allow_unix_sockets":[]}}"#;
-        let merged = build_codex_config_env(&extra, Some(parent), true)
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED_WITH_SSH_SOCKET))
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
 
         assert_eq!(
             v["sandbox_workspace_write"]["writable_roots"],
-            serde_json::json!(["/tmp/ssh-agent"])
+            serde_json::json!([])
         );
         assert_eq!(
             v["network"]["allow_unix_sockets"],
@@ -5159,9 +5155,9 @@ mod tests {
 
     #[test]
     fn build_codex_config_env_errors_on_invalid_persona_json() {
-        // Bad persona JSON + generated overlay, signal=true → parse error before merging.
-        let extra = env(&[("CODEX_CONFIG", "not-json"), ("CODEX_CONFIG", GENERATED)]);
-        let result = build_codex_config_env(&extra, None, true);
+        // Bad persona JSON + generated overlay: parse error before merging.
+        let extra = env(&[("CODEX_CONFIG", "not-json")]);
+        let result = build_codex_config_env(&extra, None, Some(GENERATED));
         assert!(result.is_err(), "invalid persona JSON must return Err");
         let msg = format!("{}", result.unwrap_err());
         assert!(
@@ -5172,17 +5168,17 @@ mod tests {
 
     #[test]
     fn build_codex_config_env_errors_on_non_object_persona_json() {
-        // Non-object persona JSON + generated overlay, signal=true → parse error.
-        let extra = env(&[("CODEX_CONFIG", "[1,2,3]"), ("CODEX_CONFIG", GENERATED)]);
-        let result = build_codex_config_env(&extra, None, true);
+        // Non-object persona JSON + generated overlay: parse error.
+        let extra = env(&[("CODEX_CONFIG", "[1,2,3]")]);
+        let result = build_codex_config_env(&extra, None, Some(GENERATED));
         assert!(result.is_err(), "non-object persona JSON must return Err");
     }
 
     #[test]
     fn build_codex_config_env_errors_on_invalid_parent_json() {
         let persona = r#"{}"#;
-        let extra = env(&[("CODEX_CONFIG", persona), ("CODEX_CONFIG", GENERATED)]);
-        let result = build_codex_config_env(&extra, Some("bad-json"), true);
+        let extra = env(&[("CODEX_CONFIG", persona)]);
+        let result = build_codex_config_env(&extra, Some("bad-json"), Some(GENERATED));
         assert!(result.is_err(), "invalid parent env JSON must return Err");
     }
 
@@ -5192,10 +5188,10 @@ mod tests {
         // If the parent env sets it to a non-object scalar, deep_merge replaces
         // our object with the scalar, and the force step must fail clearly.
         let persona = r#"{}"#;
-        let extra = env(&[("CODEX_CONFIG", persona), ("CODEX_CONFIG", GENERATED)]);
+        let extra = env(&[("CODEX_CONFIG", persona)]);
         // Parent replaces the object with a scalar — deep_merge: scalar overlay wins.
         let parent = r#"{"sandbox_workspace_write": 42}"#;
-        let result = build_codex_config_env(&extra, Some(parent), true);
+        let result = build_codex_config_env(&extra, Some(parent), Some(GENERATED));
         assert!(
             result.is_err(),
             "non-object sandbox_workspace_write must return Err"
@@ -5209,9 +5205,9 @@ mod tests {
 
     #[test]
     fn build_codex_config_env_errors_on_non_array_writable_roots() {
-        let extra = env(&[("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS)]);
+        let extra = env(&[]);
         let parent = r#"{"sandbox_workspace_write":{"writable_roots":"bad"}}"#;
-        let result = build_codex_config_env(&extra, Some(parent), true);
+        let result = build_codex_config_env(&extra, Some(parent), Some(GENERATED));
 
         assert!(result.is_err(), "non-array writable_roots must fail");
         let msg = format!("{}", result.unwrap_err());
@@ -5223,15 +5219,47 @@ mod tests {
 
     #[test]
     fn build_codex_config_env_errors_on_non_array_unix_sockets() {
-        let extra = env(&[("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS)]);
+        let extra = env(&[]);
         let parent = r#"{"network":{"allow_unix_sockets":"bad"}}"#;
-        let result = build_codex_config_env(&extra, Some(parent), true);
+        let result = build_codex_config_env(&extra, Some(parent), Some(GENERATED));
 
         assert!(result.is_err(), "non-array allow_unix_sockets must fail");
         let msg = format!("{}", result.unwrap_err());
         assert!(
             msg.contains("allow_unix_sockets"),
             "error must mention allow_unix_sockets"
+        );
+    }
+
+    #[test]
+    fn build_codex_config_env_uses_explicit_generated_config_not_extra_env_position() {
+        let persona = r#"{"network":{"allow_unix_sockets":["/tmp/persona-one"]}}"#;
+        let persona_overlay = r#"{"network":{"allow_unix_sockets":["/tmp/persona-two"]}}"#;
+        let extra = env(&[("CODEX_CONFIG", persona), ("CODEX_CONFIG", persona_overlay)]);
+        let parent = r#"{"network":{"allow_unix_sockets":[]}}"#;
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED_WITH_SSH_SOCKET))
+            .unwrap()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+
+        assert_eq!(
+            v["network"]["allow_unix_sockets"],
+            serde_json::json!(["/tmp/ssh-agent"])
+        );
+    }
+
+    #[test]
+    fn build_codex_config_env_deduplicates_normalized_path_entries() {
+        let extra = env(&[]);
+        let parent = r#"{"network":{"allow_unix_sockets":["/tmp/ssh-agent/"]}}"#;
+        let merged = build_codex_config_env(&extra, Some(parent), Some(GENERATED_WITH_SSH_SOCKET))
+            .unwrap()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+
+        assert_eq!(
+            v["network"]["allow_unix_sockets"],
+            serde_json::json!(["/tmp/ssh-agent"])
         );
     }
 }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -256,8 +256,10 @@ fn deep_merge(
 /// 3. **Parent-env precedence** — if `parent_codex_config` is `Some`, its keys are
 ///    deep-merged into the result (parent wins on colliding keys at every nesting level;
 ///    unrelated keys from either side survive).
-/// 4. **Forced overlay** — `sandbox_workspace_write.network_access = true` is applied
-///    last so relay access is guaranteed regardless of operator / persona config.
+/// 4. **Forced overlay** — generated Codex sandbox requirements are applied
+///    last: `sandbox_workspace_write.network_access = true`, plus any generated
+///    `sandbox_workspace_write.writable_roots` and `network.allow_unix_sockets`
+///    entries.
 ///
 /// When `has_generated_codex_config` is false, the function returns `None` and the
 /// caller handles any persona-supplied `CODEX_CONFIG` with ordinary operator-wins
@@ -267,7 +269,8 @@ fn deep_merge(
 ///
 /// Returns `Err(AcpError::Protocol)` when `has_generated_codex_config` is true and any
 /// `CODEX_CONFIG` value is not valid JSON or is not a JSON object, or when
-/// `sandbox_workspace_write` is present but not an object after all merges.
+/// `sandbox_workspace_write` is present but not an object after all merges, or
+/// when a forced string-array field has an incompatible shape.
 pub(crate) fn build_codex_config_env(
     extra_env: &[(String, String)],
     parent_codex_config: Option<&str>,
@@ -313,6 +316,25 @@ pub(crate) fn build_codex_config_env(
         }
     }
 
+    let generated_start_index = if parsed_entries.len() > 1 { 1 } else { 0 };
+    let mut generated_writable_roots = Vec::new();
+    let mut generated_unix_sockets = Vec::new();
+    for generated in &parsed_entries[generated_start_index..] {
+        push_unique_strings(
+            &mut generated_writable_roots,
+            nested_string_array(
+                generated,
+                "sandbox_workspace_write",
+                "writable_roots",
+                "generated",
+            )?,
+        );
+        push_unique_strings(
+            &mut generated_unix_sockets,
+            nested_string_array(generated, "network", "allow_unix_sockets", "generated")?,
+        );
+    }
+
     // Start from first entry, deep-merge remaining entries.
     let mut base = parsed_entries.remove(0);
     for overlay in parsed_entries {
@@ -355,7 +377,120 @@ pub(crate) fn build_codex_config_env(
         }
     }
 
+    force_string_array_entries(
+        &mut base,
+        "sandbox_workspace_write",
+        "writable_roots",
+        &generated_writable_roots,
+    )?;
+    force_string_array_entries(
+        &mut base,
+        "network",
+        "allow_unix_sockets",
+        &generated_unix_sockets,
+    )?;
+
     Ok(Some(serde_json::Value::Object(base).to_string()))
+}
+
+fn nested_string_array(
+    config: &serde_json::Map<String, serde_json::Value>,
+    section_key: &str,
+    array_key: &str,
+    source: &str,
+) -> Result<Vec<String>, AcpError> {
+    let Some(section) = config.get(section_key) else {
+        return Ok(Vec::new());
+    };
+    let serde_json::Value::Object(section) = section else {
+        return Err(AcpError::Protocol(format!(
+            "CODEX_CONFIG {source} {section_key} value is valid JSON but not an object"
+        )));
+    };
+    let Some(array) = section.get(array_key) else {
+        return Ok(Vec::new());
+    };
+    let serde_json::Value::Array(entries) = array else {
+        return Err(AcpError::Protocol(format!(
+            "CODEX_CONFIG {source} {section_key}.{array_key} is not an array"
+        )));
+    };
+
+    let mut out = Vec::new();
+    for entry in entries {
+        let Some(entry) = entry.as_str() else {
+            return Err(AcpError::Protocol(format!(
+                "CODEX_CONFIG {source} {section_key}.{array_key} contains a non-string entry"
+            )));
+        };
+        push_unique_string(&mut out, entry.to_string());
+    }
+    Ok(out)
+}
+
+fn force_string_array_entries(
+    config: &mut serde_json::Map<String, serde_json::Value>,
+    section_key: &str,
+    array_key: &str,
+    entries: &[String],
+) -> Result<(), AcpError> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let section_entry = config
+        .entry(section_key.to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let section = match section_entry {
+        serde_json::Value::Object(section) => section,
+        other => {
+            return Err(AcpError::Protocol(format!(
+                "CODEX_CONFIG {section_key} is not an object (got {other}); \
+                 cannot set {array_key}"
+            )));
+        }
+    };
+    let array_entry = section
+        .entry(array_key.to_string())
+        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+    let array = match array_entry {
+        serde_json::Value::Array(array) => array,
+        other => {
+            return Err(AcpError::Protocol(format!(
+                "CODEX_CONFIG {section_key}.{array_key} is not an array (got {other})"
+            )));
+        }
+    };
+
+    for entry in array.iter() {
+        if !entry.is_string() {
+            return Err(AcpError::Protocol(format!(
+                "CODEX_CONFIG {section_key}.{array_key} contains a non-string entry"
+            )));
+        }
+    }
+    for entry in entries {
+        if !array
+            .iter()
+            .any(|existing| existing.as_str() == Some(entry.as_str()))
+        {
+            array.push(serde_json::Value::String(entry.clone()));
+        }
+    }
+
+    Ok(())
+}
+
+fn push_unique_strings(out: &mut Vec<String>, entries: Vec<String>) {
+    for entry in entries {
+        push_unique_string(out, entry);
+    }
+}
+
+fn push_unique_string(out: &mut Vec<String>, entry: String) {
+    if !out.iter().any(|existing| existing == &entry) {
+        out.push(entry);
+    }
 }
 
 /// goose's non-standard mid-turn steer method. Requires `expectedRunId`, so it
@@ -4806,6 +4941,7 @@ mod tests {
     }
 
     const GENERATED: &str = r#"{"sandbox_workspace_write":{"network_access":true}}"#;
+    const GENERATED_WITH_SSH_GRANTS: &str = r#"{"network":{"allow_unix_sockets":["/tmp/ssh-agent"]},"sandbox_workspace_write":{"network_access":true,"writable_roots":["/tmp/ssh-agent"]}}"#;
 
     #[test]
     fn build_codex_config_env_returns_none_when_no_codex_config_in_extra_env() {
@@ -4979,6 +5115,49 @@ mod tests {
     }
 
     #[test]
+    fn build_codex_config_env_preserves_generated_ssh_grants_after_parent_merge() {
+        let extra = env(&[("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS)]);
+        let parent = r#"{"network":{"allow_unix_sockets":["/tmp/operator","/tmp/ssh-agent"]},"sandbox_workspace_write":{"network_access":false,"writable_roots":["/tmp/operator"]}}"#;
+        let merged = build_codex_config_env(&extra, Some(parent), true)
+            .unwrap()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+
+        assert_eq!(v["sandbox_workspace_write"]["network_access"], true);
+        assert_eq!(
+            v["sandbox_workspace_write"]["writable_roots"],
+            serde_json::json!(["/tmp/operator", "/tmp/ssh-agent"])
+        );
+        assert_eq!(
+            v["network"]["allow_unix_sockets"],
+            serde_json::json!(["/tmp/operator", "/tmp/ssh-agent"])
+        );
+    }
+
+    #[test]
+    fn build_codex_config_env_forces_generated_ssh_grants_with_persona_base() {
+        let persona = r#"{"sandbox_workspace_write":{"writable_roots":["/tmp/persona"]},"network":{"allow_unix_sockets":["/tmp/persona"]}}"#;
+        let extra = env(&[
+            ("CODEX_CONFIG", persona),
+            ("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS),
+        ]);
+        let parent = r#"{"sandbox_workspace_write":{"writable_roots":[]},"network":{"allow_unix_sockets":[]}}"#;
+        let merged = build_codex_config_env(&extra, Some(parent), true)
+            .unwrap()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+
+        assert_eq!(
+            v["sandbox_workspace_write"]["writable_roots"],
+            serde_json::json!(["/tmp/ssh-agent"])
+        );
+        assert_eq!(
+            v["network"]["allow_unix_sockets"],
+            serde_json::json!(["/tmp/ssh-agent"])
+        );
+    }
+
+    #[test]
     fn build_codex_config_env_errors_on_invalid_persona_json() {
         // Bad persona JSON + generated overlay, signal=true → parse error before merging.
         let extra = env(&[("CODEX_CONFIG", "not-json"), ("CODEX_CONFIG", GENERATED)]);
@@ -5025,6 +5204,34 @@ mod tests {
         assert!(
             msg.contains("sandbox_workspace_write"),
             "error must mention sandbox_workspace_write"
+        );
+    }
+
+    #[test]
+    fn build_codex_config_env_errors_on_non_array_writable_roots() {
+        let extra = env(&[("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS)]);
+        let parent = r#"{"sandbox_workspace_write":{"writable_roots":"bad"}}"#;
+        let result = build_codex_config_env(&extra, Some(parent), true);
+
+        assert!(result.is_err(), "non-array writable_roots must fail");
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("writable_roots"),
+            "error must mention writable_roots"
+        );
+    }
+
+    #[test]
+    fn build_codex_config_env_errors_on_non_array_unix_sockets() {
+        let extra = env(&[("CODEX_CONFIG", GENERATED_WITH_SSH_GRANTS)]);
+        let parent = r#"{"network":{"allow_unix_sockets":"bad"}}"#;
+        let result = build_codex_config_env(&extra, Some(parent), true);
+
+        assert!(result.is_err(), "non-array allow_unix_sockets must fail");
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("allow_unix_sockets"),
+            "error must mention allow_unix_sockets"
         );
     }
 }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -9,7 +9,7 @@
 //! 5. [`AcpClient::session_cancel`] / [`AcpClient::cancel_with_cleanup`] — cancel in-flight turn
 
 use std::collections::HashSet;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
@@ -17,6 +17,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
 
 use crate::observer::{ObserverContext, ObserverHandle};
+use crate::ssh_auth_sock::normalize_path_lexically;
 use crate::usage::{
     PromptResponseUsage, StandardAdapterKind, StandardUsageTracker, TurnUsage, UsageTracker,
 };
@@ -262,10 +263,9 @@ fn deep_merge(
 ///    deep-merged into the result (parent wins on colliding keys at every nesting level;
 ///    unrelated keys from either side survive).
 /// 4. **Generated floor** — generated Codex sandbox requirements are applied
-///    last: `sandbox_workspace_write.network_access = true`, plus any
-///    generated `sandbox_workspace_write.writable_roots` and
+///    last: `sandbox_workspace_write.network_access = true`, plus any generated
 ///    `network.allow_unix_sockets` entries. Parent/persona entries outside that
-///    generated floor are preserved.
+///    floor are preserved.
 ///
 /// When `generated_codex_config` is `None`, the function returns `None` and the
 /// caller handles any persona-supplied `CODEX_CONFIG` with ordinary
@@ -274,9 +274,9 @@ fn deep_merge(
 /// # Errors
 ///
 /// Returns `Err(AcpError::Protocol)` when `generated_codex_config` is `Some`
-/// and any `CODEX_CONFIG` value is not valid JSON or is not a JSON object, or when
-/// `sandbox_workspace_write` is present but not an object after all merges, or
-/// when a forced string-array field has an incompatible shape.
+/// and any `CODEX_CONFIG` value is not valid JSON or is not a JSON object, or
+/// when `sandbox_workspace_write` or `network.allow_unix_sockets` has an
+/// incompatible shape.
 pub(crate) fn build_codex_config_env(
     extra_env: &[(String, String)],
     parent_codex_config: Option<&str>,
@@ -301,16 +301,8 @@ pub(crate) fn build_codex_config_env(
     for raw in codex_entries {
         parsed_entries.push(parse_codex_config_object(raw, "persona")?);
     }
-    let generated = parse_codex_config_object(generated_raw, "generated")?;
-
-    let generated_writable_roots = nested_string_array(
-        &generated,
-        "sandbox_workspace_write",
-        "writable_roots",
-        "generated",
-    )?;
-    let generated_unix_sockets =
-        nested_string_array(&generated, "network", "allow_unix_sockets", "generated")?;
+    let mut generated = parse_codex_config_object(generated_raw, "generated")?;
+    let generated_unix_sockets = take_generated_unix_sockets(&mut generated)?;
 
     // Start from first persona entry when present, then merge remaining persona
     // entries before applying the explicit generated overlay.
@@ -348,18 +340,7 @@ pub(crate) fn build_codex_config_env(
         }
     }
 
-    force_string_array_entries(
-        &mut base,
-        "sandbox_workspace_write",
-        "writable_roots",
-        &generated_writable_roots,
-    )?;
-    force_string_array_entries(
-        &mut base,
-        "network",
-        "allow_unix_sockets",
-        &generated_unix_sockets,
-    )?;
+    force_unix_socket_entries(&mut base, &generated_unix_sockets)?;
 
     Ok(Some(serde_json::Value::Object(base).to_string()))
 }
@@ -379,95 +360,92 @@ fn parse_codex_config_object(
     }
 }
 
-fn nested_string_array(
-    config: &serde_json::Map<String, serde_json::Value>,
-    section_key: &str,
-    array_key: &str,
-    source: &str,
+fn take_generated_unix_sockets(
+    config: &mut serde_json::Map<String, serde_json::Value>,
 ) -> Result<Vec<String>, AcpError> {
-    let Some(section) = config.get(section_key) else {
+    let Some(network) = config.get_mut("network") else {
         return Ok(Vec::new());
     };
-    let serde_json::Value::Object(section) = section else {
-        return Err(AcpError::Protocol(format!(
-            "CODEX_CONFIG {source} {section_key} value is valid JSON but not an object"
-        )));
+    let serde_json::Value::Object(network) = network else {
+        return Err(AcpError::Protocol(
+            "CODEX_CONFIG generated network value is valid JSON but not an object".to_string(),
+        ));
     };
-    let Some(array) = section.get(array_key) else {
+    let Some(array) = network.remove("allow_unix_sockets") else {
         return Ok(Vec::new());
     };
     let serde_json::Value::Array(entries) = array else {
-        return Err(AcpError::Protocol(format!(
-            "CODEX_CONFIG {source} {section_key}.{array_key} is not an array"
-        )));
+        return Err(AcpError::Protocol(
+            "CODEX_CONFIG generated network.allow_unix_sockets is not an array".to_string(),
+        ));
     };
 
-    let mut out = Vec::new();
-    let mut seen = HashSet::new();
-    for entry in entries {
-        let Some(entry) = entry.as_str() else {
-            return Err(AcpError::Protocol(format!(
-                "CODEX_CONFIG {source} {section_key}.{array_key} contains a non-string entry"
-            )));
-        };
-        push_unique_config_path(&mut out, &mut seen, entry);
-    }
-    Ok(out)
+    collect_string_paths(
+        &entries,
+        "CODEX_CONFIG generated network.allow_unix_sockets",
+    )
 }
 
-fn force_string_array_entries(
+fn force_unix_socket_entries(
     config: &mut serde_json::Map<String, serde_json::Value>,
-    section_key: &str,
-    array_key: &str,
     entries: &[String],
 ) -> Result<(), AcpError> {
-    if entries.is_empty() && !config.contains_key(section_key) {
+    if entries.is_empty() && !config.contains_key("network") {
         return Ok(());
     }
 
     let section_entry = config
-        .entry(section_key.to_string())
+        .entry("network".to_string())
         .or_insert_with(|| serde_json::json!({}));
     let section = match section_entry {
         serde_json::Value::Object(section) => section,
         other => {
             return Err(AcpError::Protocol(format!(
-                "CODEX_CONFIG {section_key} is not an object (got {other}); \
-                 cannot set {array_key}"
+                "CODEX_CONFIG network is not an object (got {other}); \
+                 cannot set allow_unix_sockets"
             )));
         }
     };
-    if entries.is_empty() && !section.contains_key(array_key) {
+    if entries.is_empty() && !section.contains_key("allow_unix_sockets") {
         return Ok(());
     }
     let array_entry = section
-        .entry(array_key.to_string())
+        .entry("allow_unix_sockets".to_string())
         .or_insert_with(|| serde_json::Value::Array(Vec::new()));
     let array = match array_entry {
         serde_json::Value::Array(array) => array,
         other => {
             return Err(AcpError::Protocol(format!(
-                "CODEX_CONFIG {section_key}.{array_key} is not an array (got {other})"
+                "CODEX_CONFIG network.allow_unix_sockets is not an array (got {other})"
             )));
         }
     };
 
-    let mut merged = Vec::new();
-    let mut seen = HashSet::new();
-    for entry in array.iter() {
-        let Some(entry) = entry.as_str() else {
-            return Err(AcpError::Protocol(format!(
-                "CODEX_CONFIG {section_key}.{array_key} contains a non-string entry"
-            )));
-        };
-        push_unique_config_path(&mut merged, &mut seen, entry);
-    }
+    let mut merged = collect_string_paths(array, "CODEX_CONFIG network.allow_unix_sockets")?;
+    let mut seen = merged.iter().cloned().collect::<HashSet<_>>();
     for entry in entries {
         push_unique_config_path(&mut merged, &mut seen, entry);
     }
     *array = merged.into_iter().map(serde_json::Value::String).collect();
 
     Ok(())
+}
+
+fn collect_string_paths(
+    entries: &[serde_json::Value],
+    source: &str,
+) -> Result<Vec<String>, AcpError> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for entry in entries {
+        let Some(entry) = entry.as_str() else {
+            return Err(AcpError::Protocol(format!(
+                "{source} contains a non-string entry"
+            )));
+        };
+        push_unique_config_path(&mut out, &mut seen, entry);
+    }
+    Ok(out)
 }
 
 fn push_unique_config_path(out: &mut Vec<String>, seen: &mut HashSet<String>, entry: &str) {
@@ -478,17 +456,9 @@ fn push_unique_config_path(out: &mut Vec<String>, seen: &mut HashSet<String>, en
 }
 
 fn normalize_config_path_entry(entry: &str) -> String {
-    let mut normalized = PathBuf::new();
-    for component in Path::new(entry).components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized.to_string_lossy().into_owned()
+    normalize_path_lexically(Path::new(entry))
+        .to_string_lossy()
+        .into_owned()
 }
 
 /// goose's non-standard mid-turn steer method. Requires `expectedRunId`, so it
@@ -5154,6 +5124,21 @@ mod tests {
     }
 
     #[test]
+    fn build_codex_config_env_preserves_persona_ssh_socket_without_parent_override() {
+        let persona = r#"{"network":{"allow_unix_sockets":["/tmp/persona","/tmp/ssh-agent/"]}}"#;
+        let extra = env(&[("CODEX_CONFIG", persona)]);
+        let merged = build_codex_config_env(&extra, None, Some(GENERATED_WITH_SSH_SOCKET))
+            .unwrap()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+
+        assert_eq!(
+            v["network"]["allow_unix_sockets"],
+            serde_json::json!(["/tmp/persona", "/tmp/ssh-agent"])
+        );
+    }
+
+    #[test]
     fn build_codex_config_env_errors_on_invalid_persona_json() {
         // Bad persona JSON + generated overlay: parse error before merging.
         let extra = env(&[("CODEX_CONFIG", "not-json")]);
@@ -5200,20 +5185,6 @@ mod tests {
         assert!(
             msg.contains("sandbox_workspace_write"),
             "error must mention sandbox_workspace_write"
-        );
-    }
-
-    #[test]
-    fn build_codex_config_env_errors_on_non_array_writable_roots() {
-        let extra = env(&[]);
-        let parent = r#"{"sandbox_workspace_write":{"writable_roots":"bad"}}"#;
-        let result = build_codex_config_env(&extra, Some(parent), Some(GENERATED));
-
-        assert!(result.is_err(), "non-array writable_roots must fail");
-        let msg = format!("{}", result.unwrap_err());
-        assert!(
-            msg.contains("writable_roots"),
-            "error must mention writable_roots"
         );
     }
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use clap::ValueEnum;
@@ -15,6 +15,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::filter::SubscriptionRule;
+use crate::ssh_auth_sock::safe_ssh_auth_sock_parent;
 
 /// Default idle timeout (seconds) when neither `--idle-timeout` nor the
 /// deprecated `--turn-timeout` is set.
@@ -575,12 +576,12 @@ pub struct Config {
     /// Per-persona env vars to inject at agent spawn time (e.g., GOOSE_PROVIDER, GOOSE_MODEL, BUZZ_AGENT_MODEL).
     /// Populated from persona pack resolution. Empty when no pack is configured.
     pub persona_env_vars: Vec<(String, String)>,
-    /// Whether `codex_network_env()` successfully injected a `CODEX_CONFIG` entry into
-    /// `persona_env_vars`.  When true, `AcpClient::spawn` merges all `CODEX_CONFIG` entries
-    /// and forces `sandbox_workspace_write.network_access = true` via `build_codex_config_env`.
-    /// When false (non-Codex agents or rejected relay URL), the helper returns None and
-    /// any persona-supplied `CODEX_CONFIG` is handled with ordinary operator-wins semantics.
-    pub has_generated_codex_config: bool,
+    /// Buzz-generated `CODEX_CONFIG` from `codex_network_env()`. `AcpClient::spawn`
+    /// merges this explicit generated value with persona and parent `CODEX_CONFIG`
+    /// values, then forces the generated sandbox requirements back into the result.
+    /// When `None` (non-Codex agents or rejected relay URL), any persona-supplied
+    /// `CODEX_CONFIG` is handled with ordinary operator-wins semantics.
+    pub generated_codex_config: Option<String>,
     /// Whether to publish encrypted observer frames through the relay.
     pub relay_observer: bool,
     /// Seconds without dispatched events before an idle harness exits. 0 = disabled.
@@ -772,12 +773,11 @@ pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'sta
 /// session-level config override (via `CODEX_CONFIG` → `thread/start config`), which is
 /// equivalent to the TOML overrides:
 /// - `sandbox_workspace_write.network_access = true`
-/// - `sandbox_workspace_write.writable_roots += <SSH_AUTH_SOCK parent>`
 /// - `network.allow_unix_sockets += <SSH_AUTH_SOCK parent>`
 ///
 /// The first setting allows outbound TCP/TLS for the relay. The SSH socket
-/// settings let `git push` reach the user's existing SSH agent from within the
-/// Codex sandbox without granting broader home-directory access.
+/// setting lets `git push` reach the user's existing SSH agent from within the
+/// Codex sandbox without granting write access to the socket directory.
 ///
 /// URL validation is preserved as a guard: injection is skipped when the relay URL cannot
 /// be parsed, avoiding accidental sandbox widening for malformed configs.
@@ -850,247 +850,9 @@ fn codex_sandbox_config_json(ssh_socket_parent: Option<&str>) -> String {
         },
         "sandbox_workspace_write": {
             "network_access": true,
-            "writable_roots": [socket_parent],
         },
     })
     .to_string()
-}
-
-fn safe_ssh_auth_sock_parent(socket: &Path, home: Option<&Path>) -> Option<String> {
-    let parent = socket.parent()?;
-    if !parent.is_absolute() {
-        tracing::warn!(
-            path = %parent.display(),
-            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is not absolute"
-        );
-        return None;
-    }
-    if is_forbidden_ssh_auth_sock_parent(parent, home) {
-        tracing::warn!(
-            path = %parent.display(),
-            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is too broad"
-        );
-        return None;
-    }
-
-    let canonical_parent = match parent.canonicalize() {
-        Ok(path) if path.is_dir() => path,
-        _ => {
-            tracing::warn!(
-                path = %parent.display(),
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory is missing"
-            );
-            return None;
-        }
-    };
-    if is_forbidden_ssh_auth_sock_parent(&canonical_parent, home) {
-        tracing::warn!(
-            path = %canonical_parent.display(),
-            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is too broad"
-        );
-        return None;
-    }
-    if !is_known_ssh_auth_sock_parent_shape(parent, &canonical_parent) {
-        tracing::warn!(
-            path = %parent.display(),
-            canonical_path = %canonical_parent.display(),
-            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path shape is not recognized"
-        );
-        return None;
-    }
-    if !ssh_auth_sock_parent_contains_only_socket(&canonical_parent, socket) {
-        return None;
-    }
-
-    let normalized_parent = normalize_path_lexically(parent);
-    match normalized_parent.to_str() {
-        Some(path) => Some(path.to_string()),
-        None => {
-            tracing::warn!(
-                path = %normalized_parent.display(),
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is not valid UTF-8"
-            );
-            None
-        }
-    }
-}
-
-fn is_forbidden_ssh_auth_sock_parent(path: &Path, home: Option<&Path>) -> bool {
-    is_filesystem_root_or_home_ancestor(path, home)
-        || home.is_some_and(|home| paths_equal_lexically(path, &home.join(".ssh")))
-}
-
-fn is_known_ssh_auth_sock_parent_shape(parent: &Path, canonical_parent: &Path) -> bool {
-    [parent, canonical_parent]
-        .into_iter()
-        .map(normalize_path_lexically)
-        .any(|path| is_tmp_ssh_auth_sock_parent(&path) || is_macos_ssh_auth_sock_parent(&path))
-}
-
-fn is_tmp_ssh_auth_sock_parent(path: &Path) -> bool {
-    path_has_file_name_prefix(path, "ssh-")
-        && path
-            .parent()
-            .is_some_and(|parent| is_known_temp_root(parent))
-}
-
-fn is_macos_ssh_auth_sock_parent(path: &Path) -> bool {
-    path_has_file_name_prefix(path, "com.apple.launchd.")
-        && path.parent().is_some_and(|parent| {
-            paths_equal_lexically(parent, Path::new("/var/run"))
-                || paths_equal_lexically(parent, Path::new("/private/var/run"))
-                || is_known_temp_root(parent)
-        })
-}
-
-fn path_has_file_name_prefix(path: &Path, prefix: &str) -> bool {
-    path.file_name()
-        .and_then(OsStr::to_str)
-        .is_some_and(|name| {
-            name.strip_prefix(prefix)
-                .is_some_and(|suffix| !suffix.is_empty())
-        })
-}
-
-fn is_known_temp_root(path: &Path) -> bool {
-    paths_equal_lexically(path, Path::new("/tmp"))
-        || paths_equal_lexically(path, Path::new("/private/tmp"))
-}
-
-fn ssh_auth_sock_parent_contains_only_socket(parent: &Path, socket: &Path) -> bool {
-    let Some(socket_file_name) = socket.file_name() else {
-        tracing::warn!(
-            path = %socket.display(),
-            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket file name is missing"
-        );
-        return false;
-    };
-
-    let entries = match std::fs::read_dir(parent) {
-        Ok(entries) => entries,
-        Err(error) => {
-            tracing::warn!(
-                path = %parent.display(),
-                error = %error,
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory is not readable"
-            );
-            return false;
-        }
-    };
-
-    let mut saw_socket = false;
-    for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(error) => {
-                tracing::warn!(
-                    path = %parent.display(),
-                    error = %error,
-                    "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory entry is not readable"
-                );
-                return false;
-            }
-        };
-
-        let entry_file_name = entry.file_name();
-        if entry_file_name.as_os_str() != socket_file_name {
-            tracing::warn!(
-                path = %parent.display(),
-                entry = %entry.path().display(),
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory contains another entry"
-            );
-            return false;
-        }
-        if !ssh_auth_sock_entry_is_socket(&entry) {
-            return false;
-        }
-        saw_socket = true;
-    }
-
-    if !saw_socket {
-        tracing::warn!(
-            path = %socket.display(),
-            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path is missing"
-        );
-    }
-    saw_socket
-}
-
-#[cfg(unix)]
-fn ssh_auth_sock_entry_is_socket(entry: &std::fs::DirEntry) -> bool {
-    use std::os::unix::fs::FileTypeExt;
-
-    match entry.file_type() {
-        Ok(file_type) if file_type.is_socket() => true,
-        Ok(_) => {
-            tracing::warn!(
-                path = %entry.path().display(),
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path is not a Unix socket"
-            );
-            false
-        }
-        Err(error) => {
-            tracing::warn!(
-                path = %entry.path().display(),
-                error = %error,
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket metadata is not readable"
-            );
-            false
-        }
-    }
-}
-
-#[cfg(not(unix))]
-fn ssh_auth_sock_entry_is_socket(entry: &std::fs::DirEntry) -> bool {
-    match entry.file_type() {
-        Ok(file_type) if file_type.is_file() => true,
-        Ok(_) => {
-            tracing::warn!(
-                path = %entry.path().display(),
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path is not a file"
-            );
-            false
-        }
-        Err(error) => {
-            tracing::warn!(
-                path = %entry.path().display(),
-                error = %error,
-                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket metadata is not readable"
-            );
-            false
-        }
-    }
-}
-
-fn is_filesystem_root_or_home_ancestor(path: &Path, home: Option<&Path>) -> bool {
-    let normalized = normalize_path_lexically(path);
-    if normalized.has_root() && normalized.parent().is_none() {
-        return true;
-    }
-
-    let Some(home) = home else {
-        return false;
-    };
-    let normalized_home = normalize_path_lexically(home);
-    normalized.has_root() && normalized_home.starts_with(&normalized)
-}
-
-fn paths_equal_lexically(a: &Path, b: &Path) -> bool {
-    normalize_path_lexically(a) == normalize_path_lexically(b)
-}
-
-fn normalize_path_lexically(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
 }
 
 pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
@@ -1359,19 +1121,14 @@ impl Config {
 
         // Spawned desktop agents now carry a complete instance snapshot. Team
         // instructions arrive independently so they can be layered at runtime.
-        let mut persona_env_vars = Vec::new();
+        let persona_env_vars = Vec::new();
         let model = args.model;
 
         // Inject CODEX_CONFIG so the @agentclientprotocol/codex-acp adapter (1.x)
         // opens the Seatbelt network sandbox for buzz-cli (an MCP subprocess). No-op
         // for non-Codex agents or unparseable relay URLs.
-        let has_generated_codex_config =
-            if let Some(network_env) = codex_network_env(&agent_command, &args.relay_url) {
-                persona_env_vars.push(network_env);
-                true
-            } else {
-                false
-            };
+        let generated_codex_config =
+            codex_network_env(&agent_command, &args.relay_url).map(|(_, value)| value);
 
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
 
@@ -1419,7 +1176,7 @@ impl Config {
             respond_to_allowlist,
             allowed_respond_to,
             persona_env_vars,
-            has_generated_codex_config,
+            generated_codex_config,
             relay_observer: args.relay_observer,
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
@@ -1792,7 +1549,7 @@ mod tests {
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: Vec::new(),
             persona_env_vars: vec![],
-            has_generated_codex_config: false,
+            generated_codex_config: None,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
@@ -2136,17 +1893,89 @@ mod tests {
         .expect("valid Codex runtime should receive generated config");
         let json: serde_json::Value =
             serde_json::from_str(&value).expect("generated config must be valid JSON");
-        let socket_dir = socket_dir.display().to_string();
+        let socket_dir = socket_dir.canonicalize().unwrap().display().to_string();
 
         assert_eq!(json["sandbox_workspace_write"]["network_access"], true);
-        assert_eq!(
-            json["sandbox_workspace_write"]["writable_roots"],
-            serde_json::json!([socket_dir])
-        );
+        assert!(json["sandbox_workspace_write"]
+            .get("writable_roots")
+            .is_none());
         assert_eq!(
             json["network"]["allow_unix_sockets"],
             serde_json::json!([socket_dir])
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_network_env_uses_canonical_ssh_socket_parent() {
+        let home = codex_test_dir("canonical-home");
+        let real_socket_dir = codex_test_ssh_dir("canonical-real");
+        let link_socket_dir = codex_test_ssh_dir("canonical-link");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&real_socket_dir).unwrap();
+        std::os::unix::fs::symlink(&real_socket_dir, &link_socket_dir).unwrap();
+        let socket = link_socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        let (_, value) = codex_network_env_with_env(
+            "codex-acp",
+            "wss://relay.example.com",
+            Some(socket.as_os_str()),
+            Some(&home),
+        )
+        .expect("valid Codex runtime should receive generated config");
+        let json: serde_json::Value =
+            serde_json::from_str(&value).expect("generated config must be valid JSON");
+        let real_socket_dir = real_socket_dir
+            .canonicalize()
+            .unwrap()
+            .display()
+            .to_string();
+
+        assert!(json["sandbox_workspace_write"]
+            .get("writable_roots")
+            .is_none());
+        assert_eq!(
+            json["network"]["allow_unix_sockets"],
+            serde_json::json!([real_socket_dir])
+        );
+
+        std::fs::remove_file(&link_socket_dir).ok();
+        std::fs::remove_dir_all(&real_socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_network_env_omits_ssh_socket_parent_with_unrecognized_canonical_shape() {
+        let home = codex_test_dir("canonical-shape-home");
+        let real_socket_dir = codex_test_unrecognized_socket_dir();
+        let link_socket_dir =
+            PathBuf::from("/tmp").join(format!("ssh-bacp-{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&real_socket_dir).unwrap();
+        std::os::unix::fs::symlink(&real_socket_dir, &link_socket_dir).unwrap();
+        let socket = link_socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        let (_, value) = codex_network_env_with_env(
+            "codex-acp",
+            "wss://relay.example.com",
+            Some(socket.as_os_str()),
+            Some(&home),
+        )
+        .expect("valid Codex runtime should receive generated config");
+        let json: serde_json::Value =
+            serde_json::from_str(&value).expect("generated config must be valid JSON");
+
+        assert!(json["sandbox_workspace_write"]
+            .get("writable_roots")
+            .is_none());
+        assert!(json.get("network").is_none());
+
+        std::fs::remove_file(&link_socket_dir).ok();
+        std::fs::remove_dir_all(&real_socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -890,6 +890,17 @@ fn safe_ssh_auth_sock_parent(socket: &Path, home: Option<&Path>) -> Option<Strin
         );
         return None;
     }
+    if !is_known_ssh_auth_sock_parent_shape(parent, &canonical_parent) {
+        tracing::warn!(
+            path = %parent.display(),
+            canonical_path = %canonical_parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path shape is not recognized"
+        );
+        return None;
+    }
+    if !ssh_auth_sock_parent_contains_only_socket(&canonical_parent, socket) {
+        return None;
+    }
 
     let normalized_parent = normalize_path_lexically(parent);
     match normalized_parent.to_str() {
@@ -907,6 +918,148 @@ fn safe_ssh_auth_sock_parent(socket: &Path, home: Option<&Path>) -> Option<Strin
 fn is_forbidden_ssh_auth_sock_parent(path: &Path, home: Option<&Path>) -> bool {
     is_filesystem_root_or_home_ancestor(path, home)
         || home.is_some_and(|home| paths_equal_lexically(path, &home.join(".ssh")))
+}
+
+fn is_known_ssh_auth_sock_parent_shape(parent: &Path, canonical_parent: &Path) -> bool {
+    [parent, canonical_parent]
+        .into_iter()
+        .map(normalize_path_lexically)
+        .any(|path| is_tmp_ssh_auth_sock_parent(&path) || is_macos_ssh_auth_sock_parent(&path))
+}
+
+fn is_tmp_ssh_auth_sock_parent(path: &Path) -> bool {
+    path_has_file_name_prefix(path, "ssh-")
+        && path
+            .parent()
+            .is_some_and(|parent| is_known_temp_root(parent))
+}
+
+fn is_macos_ssh_auth_sock_parent(path: &Path) -> bool {
+    path_has_file_name_prefix(path, "com.apple.launchd.")
+        && path.parent().is_some_and(|parent| {
+            paths_equal_lexically(parent, Path::new("/var/run"))
+                || paths_equal_lexically(parent, Path::new("/private/var/run"))
+                || is_known_temp_root(parent)
+        })
+}
+
+fn path_has_file_name_prefix(path: &Path, prefix: &str) -> bool {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| {
+            name.strip_prefix(prefix)
+                .is_some_and(|suffix| !suffix.is_empty())
+        })
+}
+
+fn is_known_temp_root(path: &Path) -> bool {
+    paths_equal_lexically(path, Path::new("/tmp"))
+        || paths_equal_lexically(path, Path::new("/private/tmp"))
+}
+
+fn ssh_auth_sock_parent_contains_only_socket(parent: &Path, socket: &Path) -> bool {
+    let Some(socket_file_name) = socket.file_name() else {
+        tracing::warn!(
+            path = %socket.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket file name is missing"
+        );
+        return false;
+    };
+
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::warn!(
+                path = %parent.display(),
+                error = %error,
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory is not readable"
+            );
+            return false;
+        }
+    };
+
+    let mut saw_socket = false;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                tracing::warn!(
+                    path = %parent.display(),
+                    error = %error,
+                    "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory entry is not readable"
+                );
+                return false;
+            }
+        };
+
+        let entry_file_name = entry.file_name();
+        if entry_file_name.as_os_str() != socket_file_name {
+            tracing::warn!(
+                path = %parent.display(),
+                entry = %entry.path().display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory contains another entry"
+            );
+            return false;
+        }
+        if !ssh_auth_sock_entry_is_socket(&entry) {
+            return false;
+        }
+        saw_socket = true;
+    }
+
+    if !saw_socket {
+        tracing::warn!(
+            path = %socket.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path is missing"
+        );
+    }
+    saw_socket
+}
+
+#[cfg(unix)]
+fn ssh_auth_sock_entry_is_socket(entry: &std::fs::DirEntry) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+
+    match entry.file_type() {
+        Ok(file_type) if file_type.is_socket() => true,
+        Ok(_) => {
+            tracing::warn!(
+                path = %entry.path().display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path is not a Unix socket"
+            );
+            false
+        }
+        Err(error) => {
+            tracing::warn!(
+                path = %entry.path().display(),
+                error = %error,
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket metadata is not readable"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn ssh_auth_sock_entry_is_socket(entry: &std::fs::DirEntry) -> bool {
+    match entry.file_type() {
+        Ok(file_type) if file_type.is_file() => true,
+        Ok(_) => {
+            tracing::warn!(
+                path = %entry.path().display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path is not a file"
+            );
+            false
+        }
+        Err(error) => {
+            tracing::warn!(
+                path = %entry.path().display(),
+                error = %error,
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket metadata is not readable"
+            );
+            false
+        }
+    }
 }
 
 fn is_filesystem_root_or_home_ancestor(path: &Path, home: Option<&Path>) -> bool {
@@ -1857,6 +2010,29 @@ mod tests {
         ))
     }
 
+    fn codex_test_ssh_dir(name: &str) -> PathBuf {
+        PathBuf::from("/tmp").join(format!(
+            "ssh-buzz-acp-codex-config-{name}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ))
+    }
+
+    fn codex_test_unrecognized_socket_dir() -> PathBuf {
+        PathBuf::from("/tmp").join(format!("bacp-{}", Uuid::new_v4().simple()))
+    }
+
+    #[cfg(unix)]
+    fn create_test_ssh_socket(socket: &Path) {
+        let listener = std::os::unix::net::UnixListener::bind(socket).unwrap();
+        drop(listener);
+    }
+
+    #[cfg(not(unix))]
+    fn create_test_ssh_socket(socket: &Path) {
+        std::fs::write(socket, "").unwrap();
+    }
+
     #[test]
     fn codex_network_env_wss_url() {
         let result =
@@ -1945,10 +2121,11 @@ mod tests {
     #[test]
     fn codex_network_env_includes_safe_ssh_socket_parent() {
         let home = codex_test_dir("safe-home");
-        let socket_dir = codex_test_dir("ssh-agent");
+        let socket_dir = codex_test_ssh_dir("safe");
         std::fs::create_dir_all(&home).unwrap();
         std::fs::create_dir_all(&socket_dir).unwrap();
         let socket = socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
 
         let (_, value) = codex_network_env_with_env(
             "codex-acp",
@@ -2003,6 +2180,57 @@ mod tests {
             "codex-acp",
             "wss://relay.example.com",
             Some(ssh_dir.join("agent.sock").as_os_str()),
+            Some(&home),
+        )
+        .expect("valid Codex runtime should receive generated config");
+        let json: serde_json::Value =
+            serde_json::from_str(&value).expect("generated config must be valid JSON");
+
+        assert!(json["sandbox_workspace_write"]
+            .get("writable_roots")
+            .is_none());
+        assert!(json.get("network").is_none());
+    }
+
+    #[test]
+    fn codex_network_env_omits_ssh_socket_parent_with_extra_entries() {
+        let home = codex_test_dir("extra-home");
+        let socket_dir = codex_test_ssh_dir("extra");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&socket_dir).unwrap();
+        let socket = socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+        std::fs::write(socket_dir.join("other"), "").unwrap();
+
+        let (_, value) = codex_network_env_with_env(
+            "codex-acp",
+            "wss://relay.example.com",
+            Some(socket.as_os_str()),
+            Some(&home),
+        )
+        .expect("valid Codex runtime should receive generated config");
+        let json: serde_json::Value =
+            serde_json::from_str(&value).expect("generated config must be valid JSON");
+
+        assert!(json["sandbox_workspace_write"]
+            .get("writable_roots")
+            .is_none());
+        assert!(json.get("network").is_none());
+    }
+
+    #[test]
+    fn codex_network_env_omits_ssh_socket_parent_with_unrecognized_path_shape() {
+        let home = codex_test_dir("shape-home");
+        let socket_dir = codex_test_unrecognized_socket_dir();
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&socket_dir).unwrap();
+        let socket = socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        let (_, value) = codex_network_env_with_env(
+            "codex-acp",
+            "wss://relay.example.com",
+            Some(socket.as_os_str()),
             Some(&home),
         )
         .expect("valid Codex runtime should receive generated config");

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -4,7 +4,8 @@
 //! Config file (TOML) for complex subscription rules.
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 
 use clap::Parser;
 use clap::ValueEnum;
@@ -757,26 +758,48 @@ pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'sta
 }
 
 /// Build the `CODEX_CONFIG` environment variable that enables full outbound
-/// network access in Codex's macOS Seatbelt sandbox.
+/// network access in Codex's macOS Seatbelt sandbox, plus the local SSH agent
+/// socket directory when it is narrow enough to grant safely.
 ///
 /// Codex sandboxes MCP subprocesses (including `buzz-cli`) behind a Seatbelt sandbox
 /// that blocks all outbound network by default. Without this env var, `buzz-cli`
 /// requests are blocked before they can reach the relay WebSocket.
 ///
-/// Returns `Some(("CODEX_CONFIG", "{\"sandbox_workspace_write\":{\"network_access\":true}}"))` for
-/// Codex agents, or `None` for non-Codex agents or when the relay URL cannot be parsed.
+/// Returns `Some(("CODEX_CONFIG", json))` for Codex agents, or `None` for
+/// non-Codex agents or when the relay URL cannot be parsed.
 ///
 /// The env var is forwarded by the `@agentclientprotocol/codex-acp` adapter (1.x) as a
 /// session-level config override (via `CODEX_CONFIG` → `thread/start config`), which is
-/// equivalent to the TOML override `sandbox_workspace_write.network_access = true`.
-/// That sets `NetworkSandboxPolicy::Enabled`, causing the Seatbelt policy to include
-/// `(allow network-outbound)` — full outbound TCP/TLS at the OS level.
+/// equivalent to the TOML overrides:
+/// - `sandbox_workspace_write.network_access = true`
+/// - `sandbox_workspace_write.writable_roots += <SSH_AUTH_SOCK parent>`
+/// - `network.allow_unix_sockets += <SSH_AUTH_SOCK parent>`
+///
+/// The first setting allows outbound TCP/TLS for the relay. The SSH socket
+/// settings let `git push` reach the user's existing SSH agent from within the
+/// Codex sandbox without granting broader home-directory access.
 ///
 /// URL validation is preserved as a guard: injection is skipped when the relay URL cannot
 /// be parsed, avoiding accidental sandbox widening for malformed configs.
 ///
 /// Handles `ws://`, `wss://`, `http://`, and `https://` schemes.
 pub fn codex_network_env(agent_command: &str, relay_url: &str) -> Option<(String, String)> {
+    let ssh_auth_sock = std::env::var_os("SSH_AUTH_SOCK");
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    codex_network_env_with_env(
+        agent_command,
+        relay_url,
+        ssh_auth_sock.as_deref(),
+        home.as_deref(),
+    )
+}
+
+fn codex_network_env_with_env(
+    agent_command: &str,
+    relay_url: &str,
+    ssh_auth_sock: Option<&OsStr>,
+    home: Option<&Path>,
+) -> Option<(String, String)> {
     match normalize_agent_command_identity(agent_command).as_str() {
         "codex" | "codex-acp" => {}
         _ => return None,
@@ -801,12 +824,120 @@ pub fn codex_network_env(agent_command: &str, relay_url: &str) -> Option<(String
         }
     };
 
-    tracing::debug!(host, "injecting CODEX_CONFIG network_access for relay host");
+    let ssh_socket_parent =
+        ssh_auth_sock.and_then(|socket| safe_ssh_auth_sock_parent(Path::new(socket), home));
+
+    tracing::debug!(
+        host,
+        ssh_socket_parent = ?ssh_socket_parent.as_deref(),
+        "injecting CODEX_CONFIG sandbox defaults for relay host"
+    );
 
     Some((
         "CODEX_CONFIG".into(),
-        "{\"sandbox_workspace_write\":{\"network_access\":true}}".into(),
+        codex_sandbox_config_json(ssh_socket_parent.as_deref()),
     ))
+}
+
+fn codex_sandbox_config_json(ssh_socket_parent: Option<&str>) -> String {
+    let Some(socket_parent) = ssh_socket_parent else {
+        return "{\"sandbox_workspace_write\":{\"network_access\":true}}".to_string();
+    };
+
+    serde_json::json!({
+        "network": {
+            "allow_unix_sockets": [socket_parent],
+        },
+        "sandbox_workspace_write": {
+            "network_access": true,
+            "writable_roots": [socket_parent],
+        },
+    })
+    .to_string()
+}
+
+fn safe_ssh_auth_sock_parent(socket: &Path, home: Option<&Path>) -> Option<String> {
+    let parent = socket.parent()?;
+    if !parent.is_absolute() {
+        tracing::warn!(
+            path = %parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is not absolute"
+        );
+        return None;
+    }
+    if is_forbidden_ssh_auth_sock_parent(parent, home) {
+        tracing::warn!(
+            path = %parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is too broad"
+        );
+        return None;
+    }
+
+    let canonical_parent = match parent.canonicalize() {
+        Ok(path) if path.is_dir() => path,
+        _ => {
+            tracing::warn!(
+                path = %parent.display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory is missing"
+            );
+            return None;
+        }
+    };
+    if is_forbidden_ssh_auth_sock_parent(&canonical_parent, home) {
+        tracing::warn!(
+            path = %canonical_parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is too broad"
+        );
+        return None;
+    }
+
+    let normalized_parent = normalize_path_lexically(parent);
+    match normalized_parent.to_str() {
+        Some(path) => Some(path.to_string()),
+        None => {
+            tracing::warn!(
+                path = %normalized_parent.display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is not valid UTF-8"
+            );
+            None
+        }
+    }
+}
+
+fn is_forbidden_ssh_auth_sock_parent(path: &Path, home: Option<&Path>) -> bool {
+    is_filesystem_root_or_home_ancestor(path, home)
+        || home.is_some_and(|home| paths_equal_lexically(path, &home.join(".ssh")))
+}
+
+fn is_filesystem_root_or_home_ancestor(path: &Path, home: Option<&Path>) -> bool {
+    let normalized = normalize_path_lexically(path);
+    if normalized.has_root() && normalized.parent().is_none() {
+        return true;
+    }
+
+    let Some(home) = home else {
+        return false;
+    };
+    let normalized_home = normalize_path_lexically(home);
+    normalized.has_root() && normalized_home.starts_with(&normalized)
+}
+
+fn paths_equal_lexically(a: &Path, b: &Path) -> bool {
+    normalize_path_lexically(a) == normalize_path_lexically(b)
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
 }
 
 pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
@@ -1711,9 +1842,25 @@ mod tests {
 
     const CODEX_CONFIG_JSON: &str = "{\"sandbox_workspace_write\":{\"network_access\":true}}";
 
+    fn codex_network_env_without_ssh(
+        agent_command: &str,
+        relay_url: &str,
+    ) -> Option<(String, String)> {
+        codex_network_env_with_env(agent_command, relay_url, None, None)
+    }
+
+    fn codex_test_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "buzz-acp-codex-config-{name}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ))
+    }
+
     #[test]
     fn codex_network_env_wss_url() {
-        let result = codex_network_env("codex-acp", "wss://sprout-oss.stage.blox.sqprod.co");
+        let result =
+            codex_network_env_without_ssh("codex-acp", "wss://sprout-oss.stage.blox.sqprod.co");
         assert_eq!(
             result,
             Some(("CODEX_CONFIG".to_string(), CODEX_CONFIG_JSON.to_string()))
@@ -1722,7 +1869,7 @@ mod tests {
 
     #[test]
     fn codex_network_env_ws_url() {
-        let result = codex_network_env("codex-acp", "ws://localhost:3000");
+        let result = codex_network_env_without_ssh("codex-acp", "ws://localhost:3000");
         assert_eq!(
             result,
             Some(("CODEX_CONFIG".to_string(), CODEX_CONFIG_JSON.to_string()))
@@ -1731,7 +1878,7 @@ mod tests {
 
     #[test]
     fn codex_network_env_https_url() {
-        let result = codex_network_env("codex-acp", "https://relay.example.com/path");
+        let result = codex_network_env_without_ssh("codex-acp", "https://relay.example.com/path");
         assert_eq!(
             result,
             Some(("CODEX_CONFIG".to_string(), CODEX_CONFIG_JSON.to_string()))
@@ -1740,7 +1887,8 @@ mod tests {
 
     #[test]
     fn codex_network_env_http_url_with_port() {
-        let result = codex_network_env("codex-acp", "http://relay.example.com:8080/query");
+        let result =
+            codex_network_env_without_ssh("codex-acp", "http://relay.example.com:8080/query");
         assert_eq!(
             result,
             Some(("CODEX_CONFIG".to_string(), CODEX_CONFIG_JSON.to_string()))
@@ -1750,7 +1898,7 @@ mod tests {
     #[test]
     fn codex_network_env_bare_codex_command() {
         // "codex" (not "codex-acp") should also get the env var.
-        let result = codex_network_env("codex", "wss://relay.example.com");
+        let result = codex_network_env_without_ssh("codex", "wss://relay.example.com");
         assert_eq!(
             result,
             Some(("CODEX_CONFIG".to_string(), CODEX_CONFIG_JSON.to_string()))
@@ -1760,7 +1908,8 @@ mod tests {
     #[test]
     fn codex_network_env_full_path_codex_command() {
         // Full path like /usr/local/bin/codex-acp should be normalized.
-        let result = codex_network_env("/usr/local/bin/codex-acp", "wss://relay.example.com");
+        let result =
+            codex_network_env_without_ssh("/usr/local/bin/codex-acp", "wss://relay.example.com");
         assert_eq!(
             result,
             Some(("CODEX_CONFIG".to_string(), CODEX_CONFIG_JSON.to_string()))
@@ -1769,16 +1918,18 @@ mod tests {
 
     #[test]
     fn codex_network_env_non_codex_agent_returns_none() {
-        assert!(codex_network_env("goose", "wss://relay.example.com").is_none());
-        assert!(codex_network_env("claude-agent-acp", "wss://relay.example.com").is_none());
-        assert!(codex_network_env("buzz-agent", "wss://relay.example.com").is_none());
+        assert!(codex_network_env_without_ssh("goose", "wss://relay.example.com").is_none());
+        assert!(
+            codex_network_env_without_ssh("claude-agent-acp", "wss://relay.example.com").is_none()
+        );
+        assert!(codex_network_env_without_ssh("buzz-agent", "wss://relay.example.com").is_none());
     }
 
     #[test]
     fn codex_network_env_includes_sandbox_network_access() {
         // The JSON value must set sandbox_workspace_write.network_access=true — without
         // it, the Seatbelt sandbox blocks outbound connections in the 1.x adapter.
-        let result = codex_network_env("codex-acp", "wss://relay.example.com");
+        let result = codex_network_env_without_ssh("codex-acp", "wss://relay.example.com");
         let (key, val) = result.expect("expected Some for valid codex + valid url");
         assert_eq!(key, "CODEX_CONFIG");
         assert!(
@@ -1792,15 +1943,88 @@ mod tests {
     }
 
     #[test]
+    fn codex_network_env_includes_safe_ssh_socket_parent() {
+        let home = codex_test_dir("safe-home");
+        let socket_dir = codex_test_dir("ssh-agent");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&socket_dir).unwrap();
+        let socket = socket_dir.join("agent.sock");
+
+        let (_, value) = codex_network_env_with_env(
+            "codex-acp",
+            "wss://relay.example.com",
+            Some(socket.as_os_str()),
+            Some(&home),
+        )
+        .expect("valid Codex runtime should receive generated config");
+        let json: serde_json::Value =
+            serde_json::from_str(&value).expect("generated config must be valid JSON");
+        let socket_dir = socket_dir.display().to_string();
+
+        assert_eq!(json["sandbox_workspace_write"]["network_access"], true);
+        assert_eq!(
+            json["sandbox_workspace_write"]["writable_roots"],
+            serde_json::json!([socket_dir])
+        );
+        assert_eq!(
+            json["network"]["allow_unix_sockets"],
+            serde_json::json!([socket_dir])
+        );
+    }
+
+    #[test]
+    fn codex_network_env_omits_broad_ssh_socket_parent() {
+        let home = codex_test_dir("broad-home");
+        std::fs::create_dir_all(&home).unwrap();
+
+        let (_, value) = codex_network_env_with_env(
+            "codex-acp",
+            "wss://relay.example.com",
+            Some(home.join("agent.sock").as_os_str()),
+            Some(&home),
+        )
+        .expect("valid Codex runtime should receive generated config");
+        let json: serde_json::Value =
+            serde_json::from_str(&value).expect("generated config must be valid JSON");
+
+        assert!(json["sandbox_workspace_write"]
+            .get("writable_roots")
+            .is_none());
+        assert!(json.get("network").is_none());
+    }
+
+    #[test]
+    fn codex_network_env_omits_home_ssh_socket_parent() {
+        let home = codex_test_dir("ssh-home");
+        let ssh_dir = home.join(".ssh");
+        std::fs::create_dir_all(&ssh_dir).unwrap();
+
+        let (_, value) = codex_network_env_with_env(
+            "codex-acp",
+            "wss://relay.example.com",
+            Some(ssh_dir.join("agent.sock").as_os_str()),
+            Some(&home),
+        )
+        .expect("valid Codex runtime should receive generated config");
+        let json: serde_json::Value =
+            serde_json::from_str(&value).expect("generated config must be valid JSON");
+
+        assert!(json["sandbox_workspace_write"]
+            .get("writable_roots")
+            .is_none());
+        assert!(json.get("network").is_none());
+    }
+
+    #[test]
     fn codex_network_env_empty_relay_url_returns_none() {
         // Empty string fails Url::parse — graceful None return.
-        assert!(codex_network_env("codex-acp", "").is_none());
+        assert!(codex_network_env_without_ssh("codex-acp", "").is_none());
     }
 
     #[test]
     fn codex_network_env_schemeless_string_returns_none() {
         // A bare string with no scheme fails Url::parse — graceful None return.
-        assert!(codex_network_env("codex-acp", "not-a-url").is_none());
+        assert!(codex_network_env_without_ssh("codex-acp", "not-a-url").is_none());
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -576,12 +576,6 @@ pub struct Config {
     /// Per-persona env vars to inject at agent spawn time (e.g., GOOSE_PROVIDER, GOOSE_MODEL, BUZZ_AGENT_MODEL).
     /// Populated from persona pack resolution. Empty when no pack is configured.
     pub persona_env_vars: Vec<(String, String)>,
-    /// Buzz-generated `CODEX_CONFIG` from `codex_network_env()`. `AcpClient::spawn`
-    /// merges this explicit generated value with persona and parent `CODEX_CONFIG`
-    /// values, then forces the generated sandbox requirements back into the result.
-    /// When `None` (non-Codex agents or rejected relay URL), any persona-supplied
-    /// `CODEX_CONFIG` is handled with ordinary operator-wins semantics.
-    pub generated_codex_config: Option<String>,
     /// Whether to publish encrypted observer frames through the relay.
     pub relay_observer: bool,
     /// Seconds without dispatched events before an idle harness exits. 0 = disabled.
@@ -1124,12 +1118,6 @@ impl Config {
         let persona_env_vars = Vec::new();
         let model = args.model;
 
-        // Inject CODEX_CONFIG so the @agentclientprotocol/codex-acp adapter (1.x)
-        // opens the Seatbelt network sandbox for buzz-cli (an MCP subprocess). No-op
-        // for non-Codex agents or unparseable relay URLs.
-        let generated_codex_config =
-            codex_network_env(&agent_command, &args.relay_url).map(|(_, value)| value);
-
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
 
         let config = Config {
@@ -1176,7 +1164,6 @@ impl Config {
             respond_to_allowlist,
             allowed_respond_to,
             persona_env_vars,
-            generated_codex_config,
             relay_observer: args.relay_observer,
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
@@ -1549,7 +1536,6 @@ mod tests {
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: Vec::new(),
             persona_env_vars: vec![],
-            generated_codex_config: None,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
@@ -1759,37 +1745,6 @@ mod tests {
         codex_network_env_with_env(agent_command, relay_url, None, None)
     }
 
-    fn codex_test_dir(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "buzz-acp-codex-config-{name}-{}-{}",
-            std::process::id(),
-            Uuid::new_v4()
-        ))
-    }
-
-    fn codex_test_ssh_dir(name: &str) -> PathBuf {
-        PathBuf::from("/tmp").join(format!(
-            "ssh-buzz-acp-codex-config-{name}-{}-{}",
-            std::process::id(),
-            Uuid::new_v4()
-        ))
-    }
-
-    fn codex_test_unrecognized_socket_dir() -> PathBuf {
-        PathBuf::from("/tmp").join(format!("bacp-{}", Uuid::new_v4().simple()))
-    }
-
-    #[cfg(unix)]
-    fn create_test_ssh_socket(socket: &Path) {
-        let listener = std::os::unix::net::UnixListener::bind(socket).unwrap();
-        drop(listener);
-    }
-
-    #[cfg(not(unix))]
-    fn create_test_ssh_socket(socket: &Path) {
-        std::fs::write(socket, "").unwrap();
-    }
-
     #[test]
     fn codex_network_env_wss_url() {
         let result =
@@ -1873,203 +1828,6 @@ mod tests {
             val.contains("\"network_access\":true"),
             "JSON must set network_access=true"
         );
-    }
-
-    #[test]
-    fn codex_network_env_includes_safe_ssh_socket_parent() {
-        let home = codex_test_dir("safe-home");
-        let socket_dir = codex_test_ssh_dir("safe");
-        std::fs::create_dir_all(&home).unwrap();
-        std::fs::create_dir_all(&socket_dir).unwrap();
-        let socket = socket_dir.join("agent.sock");
-        create_test_ssh_socket(&socket);
-
-        let (_, value) = codex_network_env_with_env(
-            "codex-acp",
-            "wss://relay.example.com",
-            Some(socket.as_os_str()),
-            Some(&home),
-        )
-        .expect("valid Codex runtime should receive generated config");
-        let json: serde_json::Value =
-            serde_json::from_str(&value).expect("generated config must be valid JSON");
-        let socket_dir = socket_dir.canonicalize().unwrap().display().to_string();
-
-        assert_eq!(json["sandbox_workspace_write"]["network_access"], true);
-        assert!(json["sandbox_workspace_write"]
-            .get("writable_roots")
-            .is_none());
-        assert_eq!(
-            json["network"]["allow_unix_sockets"],
-            serde_json::json!([socket_dir])
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn codex_network_env_uses_canonical_ssh_socket_parent() {
-        let home = codex_test_dir("canonical-home");
-        let real_socket_dir = codex_test_ssh_dir("canonical-real");
-        let link_socket_dir = codex_test_ssh_dir("canonical-link");
-        std::fs::create_dir_all(&home).unwrap();
-        std::fs::create_dir_all(&real_socket_dir).unwrap();
-        std::os::unix::fs::symlink(&real_socket_dir, &link_socket_dir).unwrap();
-        let socket = link_socket_dir.join("agent.sock");
-        create_test_ssh_socket(&socket);
-
-        let (_, value) = codex_network_env_with_env(
-            "codex-acp",
-            "wss://relay.example.com",
-            Some(socket.as_os_str()),
-            Some(&home),
-        )
-        .expect("valid Codex runtime should receive generated config");
-        let json: serde_json::Value =
-            serde_json::from_str(&value).expect("generated config must be valid JSON");
-        let real_socket_dir = real_socket_dir
-            .canonicalize()
-            .unwrap()
-            .display()
-            .to_string();
-
-        assert!(json["sandbox_workspace_write"]
-            .get("writable_roots")
-            .is_none());
-        assert_eq!(
-            json["network"]["allow_unix_sockets"],
-            serde_json::json!([real_socket_dir])
-        );
-
-        std::fs::remove_file(&link_socket_dir).ok();
-        std::fs::remove_dir_all(&real_socket_dir).ok();
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn codex_network_env_omits_ssh_socket_parent_with_unrecognized_canonical_shape() {
-        let home = codex_test_dir("canonical-shape-home");
-        let real_socket_dir = codex_test_unrecognized_socket_dir();
-        let link_socket_dir =
-            PathBuf::from("/tmp").join(format!("ssh-bacp-{}", Uuid::new_v4().simple()));
-        std::fs::create_dir_all(&home).unwrap();
-        std::fs::create_dir_all(&real_socket_dir).unwrap();
-        std::os::unix::fs::symlink(&real_socket_dir, &link_socket_dir).unwrap();
-        let socket = link_socket_dir.join("agent.sock");
-        create_test_ssh_socket(&socket);
-
-        let (_, value) = codex_network_env_with_env(
-            "codex-acp",
-            "wss://relay.example.com",
-            Some(socket.as_os_str()),
-            Some(&home),
-        )
-        .expect("valid Codex runtime should receive generated config");
-        let json: serde_json::Value =
-            serde_json::from_str(&value).expect("generated config must be valid JSON");
-
-        assert!(json["sandbox_workspace_write"]
-            .get("writable_roots")
-            .is_none());
-        assert!(json.get("network").is_none());
-
-        std::fs::remove_file(&link_socket_dir).ok();
-        std::fs::remove_dir_all(&real_socket_dir).ok();
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    #[test]
-    fn codex_network_env_omits_broad_ssh_socket_parent() {
-        let home = codex_test_dir("broad-home");
-        std::fs::create_dir_all(&home).unwrap();
-
-        let (_, value) = codex_network_env_with_env(
-            "codex-acp",
-            "wss://relay.example.com",
-            Some(home.join("agent.sock").as_os_str()),
-            Some(&home),
-        )
-        .expect("valid Codex runtime should receive generated config");
-        let json: serde_json::Value =
-            serde_json::from_str(&value).expect("generated config must be valid JSON");
-
-        assert!(json["sandbox_workspace_write"]
-            .get("writable_roots")
-            .is_none());
-        assert!(json.get("network").is_none());
-    }
-
-    #[test]
-    fn codex_network_env_omits_home_ssh_socket_parent() {
-        let home = codex_test_dir("ssh-home");
-        let ssh_dir = home.join(".ssh");
-        std::fs::create_dir_all(&ssh_dir).unwrap();
-
-        let (_, value) = codex_network_env_with_env(
-            "codex-acp",
-            "wss://relay.example.com",
-            Some(ssh_dir.join("agent.sock").as_os_str()),
-            Some(&home),
-        )
-        .expect("valid Codex runtime should receive generated config");
-        let json: serde_json::Value =
-            serde_json::from_str(&value).expect("generated config must be valid JSON");
-
-        assert!(json["sandbox_workspace_write"]
-            .get("writable_roots")
-            .is_none());
-        assert!(json.get("network").is_none());
-    }
-
-    #[test]
-    fn codex_network_env_omits_ssh_socket_parent_with_extra_entries() {
-        let home = codex_test_dir("extra-home");
-        let socket_dir = codex_test_ssh_dir("extra");
-        std::fs::create_dir_all(&home).unwrap();
-        std::fs::create_dir_all(&socket_dir).unwrap();
-        let socket = socket_dir.join("agent.sock");
-        create_test_ssh_socket(&socket);
-        std::fs::write(socket_dir.join("other"), "").unwrap();
-
-        let (_, value) = codex_network_env_with_env(
-            "codex-acp",
-            "wss://relay.example.com",
-            Some(socket.as_os_str()),
-            Some(&home),
-        )
-        .expect("valid Codex runtime should receive generated config");
-        let json: serde_json::Value =
-            serde_json::from_str(&value).expect("generated config must be valid JSON");
-
-        assert!(json["sandbox_workspace_write"]
-            .get("writable_roots")
-            .is_none());
-        assert!(json.get("network").is_none());
-    }
-
-    #[test]
-    fn codex_network_env_omits_ssh_socket_parent_with_unrecognized_path_shape() {
-        let home = codex_test_dir("shape-home");
-        let socket_dir = codex_test_unrecognized_socket_dir();
-        std::fs::create_dir_all(&home).unwrap();
-        std::fs::create_dir_all(&socket_dir).unwrap();
-        let socket = socket_dir.join("agent.sock");
-        create_test_ssh_socket(&socket);
-
-        let (_, value) = codex_network_env_with_env(
-            "codex-acp",
-            "wss://relay.example.com",
-            Some(socket.as_os_str()),
-            Some(&home),
-        )
-        .expect("valid Codex runtime should receive generated config");
-        let json: serde_json::Value =
-            serde_json::from_str(&value).expect("generated config must be valid JSON");
-
-        assert!(json["sandbox_workspace_write"]
-            .get("writable_roots")
-            .is_none());
-        assert!(json.get("network").is_none());
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -12,6 +12,7 @@ mod prompt_project;
 mod queue;
 mod relay;
 mod setup_mode;
+mod ssh_auth_sock;
 mod usage;
 
 pub use usage::TurnUsage;
@@ -2459,11 +2460,19 @@ async fn tokio_main() -> Result<()> {
                 let cmd = config.agent_command.clone();
                 let args = config.agent_args.clone();
                 let env = config.persona_env_vars.clone();
-                let has_codex = config.has_generated_codex_config;
+                let generated_codex_config = config.generated_codex_config.clone();
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result = spawn_and_init(
+                        &cmd,
+                        &args,
+                        &env,
+                        generated_codex_config.as_deref(),
+                        idx,
+                        observer,
+                    )
+                    .await;
                     guard.send(result);
                 });
             }
@@ -4362,13 +4371,21 @@ fn recover_panicked_agent(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
-    let has_codex = config.has_generated_codex_config;
+    let generated_codex_config = config.generated_codex_config.clone();
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            generated_codex_config.as_deref(),
+            i,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 }
@@ -4589,7 +4606,7 @@ fn spawn_respawn_task(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
-    let has_codex = config.has_generated_codex_config;
+    let generated_codex_config = config.generated_codex_config.clone();
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
@@ -4601,7 +4618,15 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            generated_codex_config.as_deref(),
+            index,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 
@@ -4644,7 +4669,7 @@ struct PoolStartup {
     command: String,
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
-    has_generated_codex_config: bool,
+    generated_codex_config: Option<String>,
     model: Option<String>,
     effort_level: Option<String>,
     observer: Option<observer::ObserverHandle>,
@@ -4657,7 +4682,7 @@ impl PoolStartup {
             command: config.agent_command.clone(),
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
-            has_generated_codex_config: config.has_generated_codex_config,
+            generated_codex_config: config.generated_codex_config.clone(),
             model: config.model.clone(),
             effort_level: config.effort_level.clone(),
             observer,
@@ -4677,7 +4702,7 @@ async fn initialize_agent_pool(
             &startup.command,
             &startup.args,
             &startup.extra_env,
-            startup.has_generated_codex_config,
+            startup.generated_codex_config.as_deref(),
         )
         .await;
         match spawn_result {
@@ -4780,11 +4805,11 @@ async fn spawn_and_init(
     command: &str,
     args: &[String],
     extra_env: &[(String, String)],
-    has_generated_codex_config: bool,
+    generated_codex_config: Option<&str>,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
-    let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
+    let mut acp = AcpClient::spawn(command, args, extra_env, generated_codex_config)
         .await
         .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
@@ -4815,7 +4840,7 @@ async fn spawn_and_init(
 
 async fn spawn_auth_client(agent: &AuthAgentArgs) -> Result<AcpClient, acp::AcpError> {
     let agent_args = config::normalize_agent_args(&agent.agent_command, agent.agent_args.clone());
-    AcpClient::spawn(&agent.agent_command, &agent_args, &[], false).await
+    AcpClient::spawn(&agent.agent_command, &agent_args, &[], None).await
 }
 
 fn extract_auth_methods(init_result: &serde_json::Value) -> Vec<serde_json::Value> {
@@ -4941,14 +4966,14 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
 
     // Spawn outside the timeout so we always own the child for cleanup.
     // `models` subcommand doesn't use persona packs — no extra env, no codex config.
-    let mut client =
-        match AcpClient::spawn(&args.agent.agent_command, &agent_args, &[], false).await {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("error: failed to spawn agent: {e}");
-                std::process::exit(1);
-            }
-        };
+    let mut client = match AcpClient::spawn(&args.agent.agent_command, &agent_args, &[], None).await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to spawn agent: {e}");
+            std::process::exit(1);
+        }
+    };
 
     // Initialize + session/new under a timeout. Client is owned above,
     // so shutdown() runs on all paths (success, error, timeout).
@@ -6826,7 +6851,7 @@ mod build_mcp_servers_tests {
             respond_to_allowlist: std::collections::HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
-            has_generated_codex_config: false,
+            generated_codex_config: None,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
@@ -7050,7 +7075,7 @@ mod error_outcome_emission_tests {
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
-            has_generated_codex_config: false,
+            generated_codex_config: None,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
@@ -7083,7 +7108,7 @@ mod error_outcome_emission_tests {
     async fn dummy_agent(index: usize) -> OwnedAgent {
         OwnedAgent {
             index,
-            acp: AcpClient::spawn("cat", &[], &[], false)
+            acp: AcpClient::spawn("cat", &[], &[], None)
                 .await
                 .expect("spawn cat as inert agent"),
             state: Default::default(),

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -85,6 +85,10 @@ fn current_working_directory() -> Result<String> {
     Ok(cwd.to_string_lossy().into_owned())
 }
 
+fn generated_codex_config_for_spawn(command: &str, relay_url: &str) -> Option<String> {
+    config::codex_network_env(command, relay_url).map(|(_, value)| value)
+}
+
 /// Publish a kind:20001 presence update event via the WebSocket connection.
 ///
 /// Ephemeral kinds (20000-29999) are rejected by the HTTP bridge, so presence
@@ -2460,19 +2464,11 @@ async fn tokio_main() -> Result<()> {
                 let cmd = config.agent_command.clone();
                 let args = config.agent_args.clone();
                 let env = config.persona_env_vars.clone();
-                let generated_codex_config = config.generated_codex_config.clone();
+                let relay_url = config.relay_url.clone();
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(
-                        &cmd,
-                        &args,
-                        &env,
-                        generated_codex_config.as_deref(),
-                        idx,
-                        observer,
-                    )
-                    .await;
+                    let result = spawn_and_init(&cmd, &args, &env, &relay_url, idx, observer).await;
                     guard.send(result);
                 });
             }
@@ -4371,21 +4367,13 @@ fn recover_panicked_agent(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
-    let generated_codex_config = config.generated_codex_config.clone();
+    let relay_url = config.relay_url.clone();
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(
-            &cmd,
-            &args,
-            &env,
-            generated_codex_config.as_deref(),
-            i,
-            observer,
-        )
-        .await;
+        let result = spawn_and_init(&cmd, &args, &env, &relay_url, i, observer).await;
         guard.send(result);
     });
 }
@@ -4606,7 +4594,7 @@ fn spawn_respawn_task(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
-    let generated_codex_config = config.generated_codex_config.clone();
+    let relay_url = config.relay_url.clone();
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
@@ -4618,15 +4606,7 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(
-            &cmd,
-            &args,
-            &env,
-            generated_codex_config.as_deref(),
-            index,
-            observer,
-        )
-        .await;
+        let result = spawn_and_init(&cmd, &args, &env, &relay_url, index, observer).await;
         guard.send(result);
     });
 
@@ -4669,7 +4649,7 @@ struct PoolStartup {
     command: String,
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
-    generated_codex_config: Option<String>,
+    relay_url: String,
     model: Option<String>,
     effort_level: Option<String>,
     observer: Option<observer::ObserverHandle>,
@@ -4682,7 +4662,7 @@ impl PoolStartup {
             command: config.agent_command.clone(),
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
-            generated_codex_config: config.generated_codex_config.clone(),
+            relay_url: config.relay_url.clone(),
             model: config.model.clone(),
             effort_level: config.effort_level.clone(),
             observer,
@@ -4698,11 +4678,13 @@ async fn initialize_agent_pool(
     // Attempt each spawn under a 60-second timeout; a partial pool is valid.
     let mut agent_slots: Vec<Option<OwnedAgent>> = Vec::with_capacity(startup.agents as usize);
     for i in 0..startup.agents as usize {
+        let generated_codex_config =
+            generated_codex_config_for_spawn(&startup.command, &startup.relay_url);
         let spawn_result = AcpClient::spawn(
             &startup.command,
             &startup.args,
             &startup.extra_env,
-            startup.generated_codex_config.as_deref(),
+            generated_codex_config.as_deref(),
         )
         .await;
         match spawn_result {
@@ -4805,11 +4787,12 @@ async fn spawn_and_init(
     command: &str,
     args: &[String],
     extra_env: &[(String, String)],
-    generated_codex_config: Option<&str>,
+    relay_url: &str,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
-    let mut acp = AcpClient::spawn(command, args, extra_env, generated_codex_config)
+    let generated_codex_config = generated_codex_config_for_spawn(command, relay_url);
+    let mut acp = AcpClient::spawn(command, args, extra_env, generated_codex_config.as_deref())
         .await
         .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
@@ -6809,10 +6792,81 @@ mod observer_chunk_coalescer_tests {
 #[cfg(test)]
 mod build_mcp_servers_tests {
     use super::*;
+    use std::ffi::OsString;
     use std::sync::Mutex;
 
     /// Env-var-touching tests must run serially — env vars are process-global.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        name: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn capture(name: &'static str) -> Self {
+            Self {
+                name,
+                original: std::env::var_os(name),
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
+    fn spawn_test_dir(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "buzz-acp-spawn-codex-config-{name}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ))
+    }
+
+    fn spawn_test_ssh_dir(name: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from("/tmp").join(format!(
+            "ssh-buzz-acp-spawn-codex-config-{name}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ))
+    }
+
+    fn create_spawn_test_dir(path: &std::path::Path) {
+        std::fs::create_dir_all(path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o700);
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+    }
+
+    #[cfg(unix)]
+    fn create_spawn_test_ssh_socket(socket: &std::path::Path) {
+        let listener = std::os::unix::net::UnixListener::bind(socket).unwrap();
+        drop(listener);
+    }
+
+    #[cfg(not(unix))]
+    fn create_spawn_test_ssh_socket(socket: &std::path::Path) {
+        std::fs::write(socket, "").unwrap();
+    }
+
+    fn generated_socket_parent(config: &str) -> String {
+        let json: serde_json::Value = serde_json::from_str(config).unwrap();
+        json["network"]["allow_unix_sockets"][0]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
 
     fn test_config() -> Config {
         Config {
@@ -6851,7 +6905,6 @@ mod build_mcp_servers_tests {
             respond_to_allowlist: std::collections::HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
-            generated_codex_config: None,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
@@ -6860,6 +6913,46 @@ mod build_mcp_servers_tests {
             no_base_prompt: false,
             base_prompt_content: None,
         }
+    }
+
+    #[test]
+    fn generated_codex_config_for_spawn_reads_current_ssh_auth_sock() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _ssh_auth_sock = EnvVarGuard::capture("SSH_AUTH_SOCK");
+        let _home = EnvVarGuard::capture("HOME");
+
+        let home = spawn_test_dir("home");
+        let first_dir = spawn_test_ssh_dir("first");
+        let second_dir = spawn_test_ssh_dir("second");
+        create_spawn_test_dir(&home);
+        create_spawn_test_dir(&first_dir);
+        create_spawn_test_dir(&second_dir);
+        let first_socket = first_dir.join("agent.sock");
+        let second_socket = second_dir.join("agent.sock");
+        create_spawn_test_ssh_socket(&first_socket);
+        create_spawn_test_ssh_socket(&second_socket);
+
+        std::env::set_var("HOME", &home);
+        std::env::set_var("SSH_AUTH_SOCK", &first_socket);
+        let first = generated_codex_config_for_spawn("codex-acp", "wss://relay.example.com")
+            .expect("first spawn should receive generated config");
+
+        std::env::set_var("SSH_AUTH_SOCK", &second_socket);
+        let second = generated_codex_config_for_spawn("codex-acp", "wss://relay.example.com")
+            .expect("second spawn should receive generated config");
+
+        assert_eq!(
+            generated_socket_parent(&first),
+            first_dir.canonicalize().unwrap().display().to_string()
+        );
+        assert_eq!(
+            generated_socket_parent(&second),
+            second_dir.canonicalize().unwrap().display().to_string()
+        );
+
+        std::fs::remove_dir_all(&first_dir).ok();
+        std::fs::remove_dir_all(&second_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
@@ -7075,7 +7168,6 @@ mod error_outcome_emission_tests {
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
-            generated_codex_config: None,
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -6243,7 +6243,7 @@ while IFS= read -r line; do
   fi
 done"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], None)
             .await
             .expect("spawn lifecycle ACP script");
         let mut agent = OwnedAgent {
@@ -6342,7 +6342,7 @@ while IFS= read -r line; do
   fi
 done"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], None)
             .await
             .expect("spawn channel lifecycle ACP script");
         let channel_id = Uuid::new_v4();
@@ -6518,7 +6518,7 @@ while IFS= read -r line; do
   count=$((count + 1))
 done"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
+        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], None)
             .await
             .expect("spawn wire-capture ACP");
         let mut agent = OwnedAgent {
@@ -6671,7 +6671,7 @@ done"#
 printf '%s\n' "$line" > '{quoted_capture}'
 printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
+        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], None)
             .await
             .expect("spawn wire-capture ACP");
         let mut agent = OwnedAgent {
@@ -7673,7 +7673,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             "bash",
             &["-c".to_string(), "sleep 10".to_string()],
             &[],
-            false,
+            None,
         )
         .await
         .expect("failed to spawn test agent");
@@ -7734,7 +7734,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             "bash",
             &["-c".to_string(), "sleep 10".to_string()],
             &[],
-            false,
+            None,
         )
         .await
         .expect("failed to spawn test agent");
@@ -8850,7 +8850,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
   printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'
 done"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
+        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], None)
             .await
             .expect("spawn wire-capture ACP");
         let agent = OwnedAgent {
@@ -9281,7 +9281,7 @@ while IFS= read -r line; do
   fi
 done"#
         );
-        AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+        AcpClient::spawn("bash", &["-c".to_string(), script], &[], None)
             .await
             .expect("spawn effort ACP script")
     }
@@ -9452,7 +9452,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"sessionId":"sess-1","configO
 IFS= read -r _effort
 exit 0"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], None)
             .await
             .expect("spawn transport-exit ACP script");
         let mut agent = effort_agent(acp, Some("high"));
@@ -9541,7 +9541,7 @@ while IFS= read -r line; do
   fi
 done"#
         );
-        AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+        AcpClient::spawn("bash", &["-c".to_string(), script], &[], None)
             .await
             .expect("spawn switch ACP script")
     }
@@ -9837,7 +9837,7 @@ while IFS= read -r line; do
   fi
 done"#
         );
-        AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+        AcpClient::spawn("bash", &["-c".to_string(), script], &[], None)
             .await
             .expect("spawn switch ACP script")
     }

--- a/crates/buzz-acp/src/ssh_auth_sock.rs
+++ b/crates/buzz-acp/src/ssh_auth_sock.rs
@@ -1,0 +1,240 @@
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+
+pub(crate) fn safe_ssh_auth_sock_parent(socket: &Path, home: Option<&Path>) -> Option<String> {
+    let parent = socket.parent()?;
+    if !parent.is_absolute() {
+        tracing::warn!(
+            path = %parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is not absolute"
+        );
+        return None;
+    }
+    if !ssh_auth_sock_parent_is_narrow_enough(parent, home) {
+        tracing::warn!(
+            path = %parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is too broad"
+        );
+        return None;
+    }
+
+    let canonical_parent = match parent.canonicalize() {
+        Ok(path) if path.is_dir() => path,
+        _ => {
+            tracing::warn!(
+                path = %parent.display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory is missing"
+            );
+            return None;
+        }
+    };
+    if !ssh_auth_sock_parent_is_narrow_enough(&canonical_parent, home) {
+        tracing::warn!(
+            path = %canonical_parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is too broad"
+        );
+        return None;
+    }
+    if !ssh_auth_sock_parent_has_allowed_shape(&canonical_parent) {
+        tracing::warn!(
+            path = %parent.display(),
+            canonical_path = %canonical_parent.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path shape is not recognized"
+        );
+        return None;
+    }
+    if !ssh_auth_sock_parent_contains_only_socket(&canonical_parent, socket) {
+        return None;
+    }
+
+    let normalized_parent = normalize_path_lexically(&canonical_parent);
+    match normalized_parent.to_str() {
+        Some(path) => Some(path.to_string()),
+        None => {
+            tracing::warn!(
+                path = %normalized_parent.display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: path is not valid UTF-8"
+            );
+            None
+        }
+    }
+}
+
+fn ssh_auth_sock_parent_is_narrow_enough(path: &Path, home: Option<&Path>) -> bool {
+    !is_filesystem_root_or_home_ancestor(path, home)
+        && !home.is_some_and(|home| paths_equal_lexically(path, &home.join(".ssh")))
+}
+
+fn ssh_auth_sock_parent_has_allowed_shape(path: &Path) -> bool {
+    // Current allowlist covers OpenSSH /tmp/ssh-* and macOS launchd socket
+    // directories. Linux XDG_RUNTIME_DIR shapes fail closed until modeled.
+    let path = normalize_path_lexically(path);
+    is_tmp_ssh_auth_sock_parent(&path) || is_macos_ssh_auth_sock_parent(&path)
+}
+
+fn is_tmp_ssh_auth_sock_parent(path: &Path) -> bool {
+    // OpenSSH creates /tmp/ssh-* directories with mkdtemp, whose exclusive
+    // create gives the user-owned directory a race-free name under /tmp. The
+    // later one-entry socket check still rejects reused or populated dirs.
+    path_has_file_name_prefix(path, "ssh-")
+        && path
+            .parent()
+            .is_some_and(|parent| is_known_temp_root(parent))
+}
+
+fn is_macos_ssh_auth_sock_parent(path: &Path) -> bool {
+    path_has_file_name_prefix(path, "com.apple.launchd.")
+        && path.parent().is_some_and(|parent| {
+            paths_equal_lexically(parent, Path::new("/var/run"))
+                || paths_equal_lexically(parent, Path::new("/private/var/run"))
+                || is_known_temp_root(parent)
+        })
+}
+
+fn path_has_file_name_prefix(path: &Path, prefix: &str) -> bool {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| {
+            name.strip_prefix(prefix)
+                .is_some_and(|suffix| !suffix.is_empty())
+        })
+}
+
+fn is_known_temp_root(path: &Path) -> bool {
+    paths_equal_lexically(path, Path::new("/tmp"))
+        || paths_equal_lexically(path, Path::new("/private/tmp"))
+}
+
+fn ssh_auth_sock_parent_contains_only_socket(parent: &Path, socket: &Path) -> bool {
+    let Some(socket_file_name) = socket.file_name() else {
+        tracing::warn!(
+            path = %socket.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket file name is missing"
+        );
+        return false;
+    };
+
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::warn!(
+                path = %parent.display(),
+                error = %error,
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory is not readable"
+            );
+            return false;
+        }
+    };
+
+    let mut saw_socket = false;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                tracing::warn!(
+                    path = %parent.display(),
+                    error = %error,
+                    "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory entry is not readable"
+                );
+                return false;
+            }
+        };
+
+        let entry_file_name = entry.file_name();
+        if entry_file_name.as_os_str() != socket_file_name {
+            tracing::warn!(
+                path = %parent.display(),
+                entry = %entry.path().display(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent directory contains another entry"
+            );
+            return false;
+        }
+        if !ssh_auth_sock_entry_is_socket(&entry) {
+            return false;
+        }
+        saw_socket = true;
+    }
+
+    if !saw_socket {
+        tracing::warn!(
+            path = %socket.display(),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path is missing"
+        );
+    }
+    saw_socket
+}
+
+fn ssh_auth_sock_entry_is_socket(entry: &std::fs::DirEntry) -> bool {
+    match entry.file_type() {
+        Ok(file_type) if ssh_auth_sock_file_type_matches(&file_type) => true,
+        Ok(_) => {
+            tracing::warn!(
+                path = %entry.path().display(),
+                expected = ssh_auth_sock_file_type_name(),
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket path has unexpected type"
+            );
+            false
+        }
+        Err(error) => {
+            tracing::warn!(
+                path = %entry.path().display(),
+                error = %error,
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: socket metadata is not readable"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(unix)]
+fn ssh_auth_sock_file_type_matches(file_type: &std::fs::FileType) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+
+    file_type.is_socket()
+}
+
+#[cfg(not(unix))]
+fn ssh_auth_sock_file_type_matches(file_type: &std::fs::FileType) -> bool {
+    file_type.is_file()
+}
+
+#[cfg(unix)]
+fn ssh_auth_sock_file_type_name() -> &'static str {
+    "Unix socket"
+}
+
+#[cfg(not(unix))]
+fn ssh_auth_sock_file_type_name() -> &'static str {
+    "file"
+}
+
+fn is_filesystem_root_or_home_ancestor(path: &Path, home: Option<&Path>) -> bool {
+    let normalized = normalize_path_lexically(path);
+    if normalized.has_root() && normalized.parent().is_none() {
+        return true;
+    }
+
+    let Some(home) = home else {
+        return false;
+    };
+    let normalized_home = normalize_path_lexically(home);
+    normalized.has_root() && normalized_home.starts_with(&normalized)
+}
+
+fn paths_equal_lexically(a: &Path, b: &Path) -> bool {
+    normalize_path_lexically(a) == normalize_path_lexically(b)
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}

--- a/crates/buzz-acp/src/ssh_auth_sock.rs
+++ b/crates/buzz-acp/src/ssh_auth_sock.rs
@@ -76,10 +76,7 @@ fn is_tmp_ssh_auth_sock_parent(path: &Path) -> bool {
     // OpenSSH creates /tmp/ssh-* directories with mkdtemp, whose exclusive
     // create gives the user-owned directory a race-free name under /tmp. The
     // later one-entry socket check still rejects reused or populated dirs.
-    path_has_file_name_prefix(path, "ssh-")
-        && path
-            .parent()
-            .is_some_and(|parent| is_known_temp_root(parent))
+    path_has_file_name_prefix(path, "ssh-") && path.parent().is_some_and(is_known_temp_root)
 }
 
 fn is_macos_ssh_auth_sock_parent(path: &Path) -> bool {

--- a/crates/buzz-acp/src/ssh_auth_sock.rs
+++ b/crates/buzz-acp/src/ssh_auth_sock.rs
@@ -43,6 +43,9 @@ pub(crate) fn safe_ssh_auth_sock_parent(socket: &Path, home: Option<&Path>) -> O
         );
         return None;
     }
+    if !ssh_auth_sock_parent_metadata_is_safe(&canonical_parent) {
+        return None;
+    }
     if !ssh_auth_sock_parent_contains_only_socket(&canonical_parent, socket) {
         return None;
     }
@@ -161,6 +164,51 @@ fn ssh_auth_sock_parent_contains_only_socket(parent: &Path, socket: &Path) -> bo
     saw_socket
 }
 
+#[cfg(unix)]
+fn ssh_auth_sock_parent_metadata_is_safe(parent: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = match std::fs::metadata(parent) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            tracing::warn!(
+                path = %parent.display(),
+                error = %error,
+                "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent metadata is not readable"
+            );
+            return false;
+        }
+    };
+
+    let current_uid = nix::unistd::Uid::current().as_raw();
+    if metadata.uid() != current_uid {
+        tracing::warn!(
+            path = %parent.display(),
+            owner_uid = metadata.uid(),
+            current_uid,
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent owner is not current user"
+        );
+        return false;
+    }
+
+    let mode = metadata.mode() & 0o777;
+    if mode & 0o022 != 0 {
+        tracing::warn!(
+            path = %parent.display(),
+            mode = format_args!("{mode:o}"),
+            "dropping SSH_AUTH_SOCK parent from Codex sandbox config: parent is group- or world-writable"
+        );
+        return false;
+    }
+
+    true
+}
+
+#[cfg(not(unix))]
+fn ssh_auth_sock_parent_metadata_is_safe(_parent: &Path) -> bool {
+    true
+}
+
 fn ssh_auth_sock_entry_is_socket(entry: &std::fs::DirEntry) -> bool {
     match entry.file_type() {
         Ok(file_type) if ssh_auth_sock_file_type_matches(&file_type) => true,
@@ -222,7 +270,7 @@ fn paths_equal_lexically(a: &Path, b: &Path) -> bool {
     normalize_path_lexically(a) == normalize_path_lexically(b)
 }
 
-fn normalize_path_lexically(path: &Path) -> PathBuf {
+pub(crate) fn normalize_path_lexically(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
     for component in path.components() {
         match component {
@@ -234,4 +282,197 @@ fn normalize_path_lexically(path: &Path) -> PathBuf {
         }
     }
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn test_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "buzz-acp-ssh-auth-sock-{name}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ))
+    }
+
+    fn test_ssh_dir(name: &str) -> PathBuf {
+        PathBuf::from("/tmp").join(format!(
+            "ssh-buzz-acp-ssh-auth-sock-{name}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ))
+    }
+
+    fn test_unrecognized_socket_dir() -> PathBuf {
+        PathBuf::from("/tmp").join(format!("bacp-{}", Uuid::new_v4().simple()))
+    }
+
+    fn create_test_dir(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o700);
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+    }
+
+    #[cfg(unix)]
+    fn create_test_ssh_socket(socket: &Path) {
+        let listener = std::os::unix::net::UnixListener::bind(socket).unwrap();
+        drop(listener);
+    }
+
+    #[cfg(not(unix))]
+    fn create_test_ssh_socket(socket: &Path) {
+        std::fs::write(socket, "").unwrap();
+    }
+
+    #[test]
+    fn includes_safe_ssh_socket_parent() {
+        let home = test_dir("safe-home");
+        let socket_dir = test_ssh_dir("safe");
+        create_test_dir(&home);
+        create_test_dir(&socket_dir);
+        let socket = socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        let parent = safe_ssh_auth_sock_parent(&socket, Some(&home))
+            .expect("safe socket parent should be allowed");
+        let expected = socket_dir.canonicalize().unwrap().display().to_string();
+        assert_eq!(parent, expected);
+
+        std::fs::remove_dir_all(&socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uses_canonical_ssh_socket_parent() {
+        let home = test_dir("canonical-home");
+        let real_socket_dir = test_ssh_dir("canonical-real");
+        let link_socket_dir = test_ssh_dir("canonical-link");
+        create_test_dir(&home);
+        create_test_dir(&real_socket_dir);
+        std::os::unix::fs::symlink(&real_socket_dir, &link_socket_dir).unwrap();
+        let socket = link_socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        let parent = safe_ssh_auth_sock_parent(&socket, Some(&home))
+            .expect("safe symlinked socket parent should be allowed");
+        let expected = real_socket_dir
+            .canonicalize()
+            .unwrap()
+            .display()
+            .to_string();
+        assert_eq!(parent, expected);
+
+        std::fs::remove_file(&link_socket_dir).ok();
+        std::fs::remove_dir_all(&real_socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn omits_ssh_socket_parent_with_unrecognized_canonical_shape() {
+        let home = test_dir("canonical-shape-home");
+        let real_socket_dir = test_unrecognized_socket_dir();
+        let link_socket_dir =
+            PathBuf::from("/tmp").join(format!("ssh-bacp-{}", Uuid::new_v4().simple()));
+        create_test_dir(&home);
+        create_test_dir(&real_socket_dir);
+        std::os::unix::fs::symlink(&real_socket_dir, &link_socket_dir).unwrap();
+        let socket = link_socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        assert_eq!(safe_ssh_auth_sock_parent(&socket, Some(&home)), None);
+
+        std::fs::remove_file(&link_socket_dir).ok();
+        std::fs::remove_dir_all(&real_socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn omits_broad_ssh_socket_parent() {
+        let home = test_dir("broad-home");
+        create_test_dir(&home);
+
+        assert_eq!(
+            safe_ssh_auth_sock_parent(&home.join("agent.sock"), Some(&home)),
+            None
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn omits_home_ssh_socket_parent() {
+        let home = test_dir("ssh-home");
+        let ssh_dir = home.join(".ssh");
+        create_test_dir(&ssh_dir);
+
+        assert_eq!(
+            safe_ssh_auth_sock_parent(&ssh_dir.join("agent.sock"), Some(&home)),
+            None
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn omits_ssh_socket_parent_with_extra_entries() {
+        let home = test_dir("extra-home");
+        let socket_dir = test_ssh_dir("extra");
+        create_test_dir(&home);
+        create_test_dir(&socket_dir);
+        let socket = socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+        std::fs::write(socket_dir.join("other"), "").unwrap();
+
+        assert_eq!(safe_ssh_auth_sock_parent(&socket, Some(&home)), None);
+
+        std::fs::remove_dir_all(&socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn omits_ssh_socket_parent_with_unrecognized_path_shape() {
+        let home = test_dir("shape-home");
+        let socket_dir = test_unrecognized_socket_dir();
+        create_test_dir(&home);
+        create_test_dir(&socket_dir);
+        let socket = socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        assert_eq!(safe_ssh_auth_sock_parent(&socket, Some(&home)), None);
+
+        std::fs::remove_dir_all(&socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn omits_group_writable_ssh_socket_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = test_dir("mode-home");
+        let socket_dir = test_ssh_dir("mode");
+        create_test_dir(&home);
+        create_test_dir(&socket_dir);
+        let socket = socket_dir.join("agent.sock");
+        create_test_ssh_socket(&socket);
+
+        let mut permissions = std::fs::metadata(&socket_dir).unwrap().permissions();
+        permissions.set_mode(0o770);
+        std::fs::set_permissions(&socket_dir, permissions).unwrap();
+
+        assert_eq!(safe_ssh_auth_sock_parent(&socket, Some(&home)), None);
+
+        std::fs::remove_dir_all(&socket_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
## Why I am doing this
[NEXUS-1471](https://linear.app/squareup/issue/NEXUS-1471/default-sandbox-toolchain-allowlist-for-new-agents)

## What I am doing
This only affects Codex-backed managed agents, the ones that run under macOS sandboxing (Seatbelt) by default. Claude-backed agents are not sandboxed today and are unaffected either way.

- Detects the real `SSH_AUTH_SOCK` location when a Codex agent starts and grants sandbox access to just that one socket, automatically, no manual config needed.
- Only grants access when the socket's location looks safe: a standard OS temp or launchd path, never the filesystem root, never someone's home directory, and never a directory holding anything besides the socket itself.
- Extracts the SSH socket validation logic into its own module (`ssh_auth_sock.rs`).

## How to test
1. `cargo fmt --package buzz-acp`
2. `cargo check -p buzz-acp --lib --tests`
3. `env -u BUZZ_ACP_LAZY_POOL cargo test -p buzz-acp --lib -- --test-threads=1`

## Risks
Low. The generated sandbox config only ever adds a connect-only grant for the one detected SSH socket; it never widens access to anything else, and the safety checks fail closed (no grant) on anything that doesn't match a known-safe shape.

AI-assisted by Turbo Chook and Tech Duck.
