### PR TITLE
fix(ci): bootstrap the sprig-latest release on first run

### DIFF
--- a/.github/workflows/sprig.yml
+++ b/.github/workflows/sprig.yml
@@ -139,10 +139,17 @@ jobs:
           TITLE="Sprig (rolling)"
           NOTES="Rolling Linux build of Sprig (all-in-one buzz-acp + buzz-agent + buzz-dev-mcp), tracking \`main\` (\`${SHA}\`)."
 
-          gh release edit "$TAG" \
-            --prerelease \
-            --title "$TITLE" \
-            --notes "$NOTES"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --prerelease \
+              --title "$TITLE" \
+              --notes "$NOTES"
+          else
+            gh release create "$TAG" \
+              --prerelease \
+              --title "$TITLE" \
+              --notes "$NOTES"
+          fi
           gh release upload "$TAG" dist/* --clobber
 
   publish-tag:


### PR DESCRIPTION
## Summary
The rolling-release step in `sprig.yml` goes straight to `gh release edit`, which assumes the `sprig-latest` release already exists. On any repo where it hasn't been created yet (a fresh fork, or the first push to `main` after this workflow is added), every run fails with "release not found" — the build itself succeeds, only the publish step breaks, and nothing self-heals since the tag is never created for `edit` to find.

Fix: check for the release first and create it when missing — same pattern the file already uses for tagged releases (`publish-tag` job) just below.

### Related issue
Found while enabling Actions on a personal fork for the first time — `sprig-latest` had presumably been bootstrapped manually here long ago, so this never surfaced upstream.

### Testing
- `actionlint` clean.
- Confirmed the exact failure mode live on a fork: https://github.com/renatobardi/buzz/actions/runs/33380712245 ("Update rolling release" step: `release not found`, exit code 1).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>