### PR TITLE
fix(desktop): keep keyring identity until a recovery path exists

### DIFF
--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -634,23 +634,23 @@ fn resolve_identity_with_store(
     })
 }
 
-/// Recover from a corrupt nsec in the keyring (parse failed). Clear the bad
-/// keyring value, then migrate a valid leftover `identity.key` if one exists.
-/// If the migration marker is present but no valid file exists, the prior
-/// identity is unrecoverable — return `Lost` recovery rather than silently
-/// generating a new identity. Generating fresh is only correct when no prior
-/// identity ever existed (no marker). The keyring delete is best-effort: a
-/// delete failure logs and continues — it must never block startup.
+/// Recover from a corrupt nsec in the keyring (parse failed). Prefer a valid
+/// leftover `identity.key` first. Only clear the keyring entry once a
+/// replacement exists, or when there was never a prior identity (no migration
+/// marker). If the marker is present but no valid file exists, return `Lost`
+/// and leave the corrupt keyring value in place for support / manual export.
 fn recover_from_keyring(
     store: &impl IdentityKeyStore,
     legacy_path: &std::path::Path,
     data_dir: &std::path::Path,
     error: &str,
 ) -> Result<ResolvedIdentity, String> {
-    eprintln!("buzz-desktop: corrupt nsec in keyring ({error}), clearing and recovering from file");
-    if let Err(e) = store.delete(IDENTITY_KEY_NAME) {
-        eprintln!("buzz-desktop: failed to clear corrupt keyring value: {e}");
-    }
+    eprintln!(
+        "buzz-desktop: corrupt nsec in keyring ({error}), looking for a recovery path before clearing"
+    );
+    // Never delete the keyring entry until a replacement exists. Steady-state
+    // installs are marker-only: clearing first would destroy the only copy of
+    // the identity even when the parse failure is transient or tool-side.
     if legacy_path.exists() {
         if let Some(keys) = migrate_identity_file(store, legacy_path, data_dir)? {
             return Ok(ResolvedIdentity {
@@ -661,13 +661,13 @@ fn recover_from_keyring(
         }
     }
     // No valid file to recover from. If the migration marker exists, a prior
-    // identity was stored in the keyring and is now corrupt AND gone — the key
-    // is unrecoverable. Enter Lost recovery instead of silently rotating.
+    // identity was stored in the keyring — keep the corrupt entry for support /
+    // manual export and enter Lost rather than silently rotating.
     if migration_marker_path(data_dir).exists() {
         let ephemeral = Keys::generate();
         eprintln!(
-            "buzz-desktop: identity lost — keyring had corrupt data and no valid identity.key \
-             backup; prior identity (migration marker present) is unrecoverable; \
+            "buzz-desktop: identity lost — keyring value failed to parse and no valid identity.key \
+             backup exists; leaving the keyring entry in place; \
              using ephemeral key {}, awaiting user re-import",
             ephemeral.public_key().to_hex()
         );
@@ -677,7 +677,11 @@ fn recover_from_keyring(
             storage: IdentityStorage::Ephemeral,
         });
     }
-    // No marker: genuine first launch with a corrupt keyring. Generate fresh.
+    // No marker: genuine first launch with a corrupt keyring. Safe to clear and
+    // generate fresh — there was never a durable identity to protect.
+    if let Err(e) = store.delete(IDENTITY_KEY_NAME) {
+        eprintln!("buzz-desktop: failed to clear corrupt keyring value: {e}");
+    }
     let (keys, storage) = generate_and_persist(store, legacy_path, data_dir)?;
     Ok(ResolvedIdentity {
         keys,
@@ -686,8 +690,6 @@ fn recover_from_keyring(
     })
 }
 
-/// Load the `0o600` identity file, quarantining corruption, else generate and
-/// save a fresh key to the file. Used when no keyring is available.
 fn load_file_or_generate(
     legacy_path: &std::path::Path,
     data_dir: &std::path::Path,

--- a/desktop/src-tauri/src/app_state_tests.rs
+++ b/desktop/src-tauri/src/app_state_tests.rs
@@ -1363,13 +1363,9 @@ fn verify_fails_store_does_not_write_marker_or_delete_file() {
     );
 }
 
-// ── I2: corrupt keyring + marker = Lost recovery ──────────────────────────
-
 #[test]
 fn corrupt_keyring_marker_present_no_file_is_lost() {
-    // I2: Present(corrupt) + migration marker + no identity.key → the prior
-    // identity was migrated into the keyring and is now unrecoverable (corrupt
-    // AND no file backup). Must enter Lost recovery, NOT generate a fresh key.
+    // I2: corrupt keyring + marker + no file → Lost (do not mint a fresh key).
     let dir = tempfile::tempdir().unwrap();
     let legacy_path = dir.path().join("identity.key");
     write_migration_marker(&migration_marker_path(dir.path())).unwrap();
@@ -1378,22 +1374,29 @@ fn corrupt_keyring_marker_present_no_file_is_lost() {
     let store = FakeIdentityStore::present_with("not-a-valid-nsec");
     let resolved = resolve_identity_with_store(&store, &legacy_path, dir.path()).unwrap();
 
-    // Must enter Lost recovery — a prior identity existed and is now unrecoverable.
-    assert_eq!(
-        resolved.recovery,
-        RecoveryState::Lost,
-        "corrupt keyring + marker + no file must return Lost recovery, not a fresh key"
-    );
-
-    // No identity.key written — the ephemeral key is in-memory only.
+    assert_eq!(resolved.recovery, RecoveryState::Lost);
+    // Lost must keep the corrupt keyring entry for support/export.
+    assert!(!store.deleted.borrow().contains(&IDENTITY_KEY_NAME.to_string()));
+    assert!(store.slot.borrow().contains_key(IDENTITY_KEY_NAME));
     assert!(!legacy_path.exists());
 }
 
 #[test]
+fn corrupt_keyring_with_valid_file_recovers_before_delete() {
+    let dir = tempfile::tempdir().unwrap();
+    let legacy_path = dir.path().join("identity.key");
+    let file_keys = Keys::generate();
+    save_key_file(&legacy_path, &file_keys).unwrap();
+    write_migration_marker(&migration_marker_path(dir.path())).unwrap();
+    let store = FakeIdentityStore::present_with("not-a-valid-nsec");
+    let resolved = resolve_identity_with_store(&store, &legacy_path, dir.path()).unwrap();
+    assert_eq!(resolved.recovery, RecoveryState::None);
+    assert_key_eq(&file_keys, &resolved.keys);
+}
+
+#[test]
 fn corrupt_keyring_no_marker_no_file_generates_fresh() {
-    // I2 (counter-case): Present(corrupt) + NO marker + no identity.key →
-    // genuine first launch with a corrupt keyring, no prior identity to
-    // protect. generate_and_persist is still the correct last resort.
+    // I2 counter-case: corrupt keyring, no marker, no file → generate fresh.
     let dir = tempfile::tempdir().unwrap();
     let legacy_path = dir.path().join("identity.key");
     assert!(!legacy_path.exists());
@@ -1402,16 +1405,9 @@ fn corrupt_keyring_no_marker_no_file_generates_fresh() {
     let store = FakeIdentityStore::present_with("not-a-valid-nsec");
     let resolved = resolve_identity_with_store(&store, &legacy_path, dir.path()).unwrap();
 
-    // No lost recovery — this is a fresh machine with no prior identity.
-    assert_eq!(
-        resolved.recovery,
-        RecoveryState::None,
-        "corrupt keyring + no marker + no file must generate a fresh key (no prior identity)"
-    );
-
-    // A fresh, valid key was stored (keyring or file).
+    assert_eq!(resolved.recovery, RecoveryState::None);
     assert!(
         store.slot.borrow().contains_key(IDENTITY_KEY_NAME) || legacy_path.exists(),
-        "a fresh key must be stored in the keyring or the file after generate_and_persist"
+        "fresh key must be stored after generate_and_persist"
     );
 }


### PR DESCRIPTION
## Summary
- `recover_from_keyring` deleted the OS keyring entry on parse failure before checking for a leftover `identity.key`
- Steady-state installs are marker-only, so that delete destroyed the only copy and forced Lost
- Probe the file first, and leave a corrupt keyring value in place when entering Lost

Fixes #6218.

## Test plan
- [x] Updated `corrupt_keyring_marker_present_no_file_is_lost` to assert the keyring entry is kept
- [x] Added `corrupt_keyring_with_valid_file_recovers_before_delete`
- [ ] `cargo test -p buzz-desktop --lib` (or hermit) for app_state recovery tests