### PR TITLE
fix(desktop): pin relay and signer for create_channel

### DIFF
--- a/desktop/src-tauri/src/app_state_accessors.rs
+++ b/desktop/src-tauri/src/app_state_accessors.rs
@@ -67,6 +67,39 @@ impl AppState {
             .map(|k| k.clone())
     }
 
+
+    /// Capture the active signing identity and workspace relay as one coherent
+    /// scope for a multi-await command.
+    ///
+    /// `apply_workspace` mutates `relay_url_override` and `keys` under separate
+    /// mutexes. Reading them with two unlocked calls can therefore mix tenant
+    /// A's signer with tenant B's relay. Lock both in the same order
+    /// `apply_workspace` writes them (override, then keys) so the pair is
+    /// coherent for the command's submit + follow-up queries.
+    pub fn signing_and_relay_scope(&self) -> Result<(Keys, String), String> {
+        if self
+            .identity_lost
+            .load(std::sync::atomic::Ordering::Acquire)
+            || self
+                .keyring_locked
+                .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Err("identity is in recovery mode; event signing is disabled \
+                 until the identity is restored and Buzz is relaunched"
+                .to_string());
+        }
+        let override_guard = self
+            .relay_url_override
+            .lock()
+            .map_err(|e| e.to_string())?;
+        let keys_guard = self.keys.lock().map_err(|e| e.to_string())?;
+        let relay_base = match override_guard.as_ref() {
+            Some(url) => crate::relay::relay_http_base_url(url),
+            None => crate::relay::relay_api_base_url(),
+        };
+        Ok((keys_guard.clone(), relay_base))
+    }
+
     /// Emit the current huddle state to the frontend via Tauri event.
     ///
     /// Acquires both locks (app_handle + huddle_state), clones a snapshot,

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -7,8 +7,8 @@ use crate::{
     nostr_convert,
     relay::{
         assert_expected_relay_scope, assert_expected_signer, query_relay,
-        relay_api_base_url_with_override, submit_event, submit_event_at_with_keys,
-        submit_event_with_keys,
+        query_relay_at_with_keys, relay_api_base_url_with_override, submit_event,
+        submit_event_at_with_keys, submit_event_with_keys,
     },
 };
 
@@ -324,14 +324,13 @@ pub async fn create_channel(
         ttl_seconds,
     )?;
 
-    // Capture the signing identity before submission so the pending-owner
-    // mark below is bound to whoever actually signed this create — not
-    // whoever `state.keys` holds once the network round-trip completes. An
-    // in-process identity swap while the request is in flight must not be
-    // able to retarget the mark onto the new identity.
-    let creator_keys = state.signing_keys()?;
+    // Capture the signing identity AND workspace relay together before any
+    // await. `apply_workspace` mutates those under separate mutexes; two
+    // unlocked reads can mix tenant A's signer with tenant B's relay and
+    // publish the create across communities. Pin both for submit + reread.
+    let (creator_keys, relay_base) = state.signing_and_relay_scope()?;
     let creator_pubkey = creator_keys.public_key().to_hex();
-    submit_event_with_keys(builder, &state, &creator_keys, None).await?;
+    submit_event_at_with_keys(builder, &state, &relay_base, &creator_keys).await?;
 
     // Mark this channel pending-owner: we just created it, so we know we're
     // the owner, but the relay's kind:39002 membership entry (#1761) is
@@ -342,14 +341,20 @@ pub async fn create_channel(
     let channel_uuid_string = channel_uuid.to_string();
     state.mark_pending_owned_channel(&creator_pubkey, &channel_uuid_string);
 
-    // Re-fetch the canonical metadata event to return ChannelInfo.
-    let events = query_relay(
+    // Re-fetch the canonical metadata event with the same pinned identity and
+    // relay. `query_relay` / `query_relay_at` mint NIP-98 from live `state.keys`,
+    // so a mid-flight identity swap would otherwise 403 a membership-gated
+    // create that already succeeded.
+    let events = query_relay_at_with_keys(
         &state,
+        &relay_base,
         &[serde_json::json!({
             "kinds": [39000],
             "#d": [channel_uuid_string],
             "limit": 1
         })],
+        &creator_keys,
+        None,
     )
     .await?;
 

--- a/desktop/src-tauri/src/commands/channels_tests.rs
+++ b/desktop/src-tauri/src/commands/channels_tests.rs
@@ -276,6 +276,30 @@ fn pending_owner_mark_uses_signer_captured_before_identity_swap() {
     assert!(!state.is_pending_owned_channel(&post_swap_pubkey, "chan-1"));
 }
 
+
+#[test]
+fn signing_and_relay_scope_survives_interleaved_workspace_mutation() {
+    // Regression for the create_channel cross-community write Carl flagged:
+    // reading keys then relay under separate unlocked calls can mix tenants
+    // when `apply_workspace` lands between them. The helper locks both before
+    // returning either value.
+    let state = crate::app_state::build_app_state();
+    let expected_pubkey = state.signing_keys().expect("signable").public_key().to_hex();
+    let expected_relay = crate::relay::relay_api_base_url_with_override(&state);
+
+    let (keys, relay) = state.signing_and_relay_scope().expect("scope");
+    assert_eq!(keys.public_key().to_hex(), expected_pubkey);
+    assert_eq!(relay, expected_relay);
+
+    // Mutating after the snapshot must leave the captured pair unchanged.
+    *state.relay_url_override.lock().expect("lock relay") =
+        Some("wss://other.example/".to_string());
+    *state.keys.lock().expect("lock keys") = Keys::generate();
+    assert_eq!(keys.public_key().to_hex(), expected_pubkey);
+    assert_eq!(relay, expected_relay);
+}
+
+
 #[test]
 fn starter_channel_uuid_is_stable_and_scoped() {
     let first = starter_channel_uuid("https://relay-a.example", "general");

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -553,6 +553,10 @@ export function AppShell() {
       },
       onCreated?: (channelId: string) => void,
     ) => {
+      // Capture the community that initiated create. Closing the browser and
+      // switching communities while the mutation is in flight must not let the
+      // continuation applyCanvas / goChannel / agents against the new tenant.
+      const initiatingCommunityId = communitiesHook.activeCommunity?.id ?? null;
       const createdChannel = await createChannelMutation.mutateAsync({
         name,
         description,
@@ -560,13 +564,24 @@ export function AppShell() {
         visibility,
         ttlSeconds,
       });
+      if (
+        (communitiesHook.activeCommunity?.id ?? null) !== initiatingCommunityId
+      ) {
+        return;
+      }
 
       await applyCanvas(templateId, createdChannel.id, name);
       await goChannel(createdChannel.id);
       onCreated?.(createdChannel.id);
       void applyAgents(templateId, createdChannel.id);
     },
-    [applyAgents, applyCanvas, createChannelMutation, goChannel],
+    [
+      applyAgents,
+      applyCanvas,
+      communitiesHook.activeCommunity?.id,
+      createChannelMutation,
+      goChannel,
+    ],
   );
   const handleCreateForum = React.useCallback(
     async ({
@@ -582,6 +597,7 @@ export function AppShell() {
       ttlSeconds?: number;
       templateId?: string;
     }) => {
+      const initiatingCommunityId = communitiesHook.activeCommunity?.id ?? null;
       const createdForum = await createForumMutation.mutateAsync({
         name,
         description,
@@ -589,12 +605,23 @@ export function AppShell() {
         visibility,
         ttlSeconds,
       });
+      if (
+        (communitiesHook.activeCommunity?.id ?? null) !== initiatingCommunityId
+      ) {
+        return;
+      }
 
       await applyCanvas(templateId, createdForum.id, name);
       await goChannel(createdForum.id);
       void applyAgents(templateId, createdForum.id);
     },
-    [applyAgents, applyCanvas, createForumMutation, goChannel],
+    [
+      applyAgents,
+      applyCanvas,
+      communitiesHook.activeCommunity?.id,
+      createForumMutation,
+      goChannel,
+    ],
   );
 
   // The channel browser can create either a stream or a forum depending on


### PR DESCRIPTION
## Summary
- `create_channel` already captured `creator_keys`, but submit and the metadata reread still resolved the live workspace relay after awaits
- Capture the relay base with the keys and use the `*_at` helpers for the whole round-trip

Fixes #6363.

## Test plan
- [x] Diff uses `submit_event_at_with_keys` + `query_relay_at` with a pinned `relay_base`
- [ ] Community switch mid-create no longer mixes signer and relay