### PR TITLE
feat(channels): support group profile pictures

### DIFF
--- a/NOSTR.md
+++ b/NOSTR.md
@@ -53,7 +53,7 @@ PGPASSWORD=buzz_dev psql -h localhost -U buzz -d buzz -c \
 | **Group creation (kind:9007)** | ✅ | NIP-29; include `name` tag, optional `visibility` and `channel_type` |
 | **Add user (kind:9000)** | ✅ | Open: any user, subject to target's `channel_add_policy` (`owner_only`/`nobody` can block). Private: owner/admin only. Self-add bypasses agent policy but not private-channel auth. |
 | **Remove user (kind:9001)** | ✅ | Self-remove allowed (with last-owner guard). Removing others: owner/admin only. |
-| **Edit group metadata (kind:9002)** | ✅ | `name`/`about` tags: owner/admin. `topic`/`purpose` tags: any member. |
+| **Edit group metadata (kind:9002)** | ✅ | `name`/`about`/`picture` tags: owner/admin. `topic`/`purpose` tags: any member. |
 | **Admin delete event (kind:9005)** | ✅ | Event author can always delete own. Otherwise owner/admin required. Target must be in same channel. |
 | **Group deletion (kind:9008)** | ✅ | Owner only. |
 | **Leave group (kind:9022)** | ✅ | Any member. Last-owner guard prevents orphaned groups. |

--- a/crates/buzz-core/src/channel.rs
+++ b/crates/buzz-core/src/channel.rs
@@ -17,6 +17,27 @@ pub fn canonical_channel_name(name: &str) -> &str {
         .trim_end()
 }
 
+/// Returns whether `value` is a safe, durable URL for a channel picture.
+///
+/// Channel pictures are projected into relay-signed NIP-29 metadata, so the
+/// stored value must be a public HTTPS URL without credentials, query tokens,
+/// or fragments. The byte limit matches the event-tag boundary used by Buzz
+/// clients.
+pub fn is_safe_channel_picture_url(value: &str) -> bool {
+    if value.is_empty() || value.len() > 2_048 {
+        return false;
+    }
+    let Ok(url) = url::Url::parse(value) else {
+        return false;
+    };
+    url.scheme() == "https"
+        && url.host_str().is_some()
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.query().is_none()
+        && url.fragment().is_none()
+}
+
 /// Whether a channel is publicly visible or invite-only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChannelVisibility {
@@ -180,7 +201,7 @@ impl FromStr for MemberRole {
 
 #[cfg(test)]
 mod tests {
-    use super::canonical_channel_name;
+    use super::{canonical_channel_name, is_safe_channel_picture_url};
 
     #[test]
     fn channel_names_trim_whitespace_and_drop_all_leading_hashes() {
@@ -194,5 +215,25 @@ mod tests {
         assert_eq!(canonical_channel_name("# #"), "");
         assert_eq!(canonical_channel_name("### ###"), "");
         assert_eq!(canonical_channel_name("channel#topic"), "channel#topic");
+    }
+
+    #[test]
+    fn channel_picture_urls_are_public_https_without_embedded_secrets() {
+        assert!(is_safe_channel_picture_url(
+            "https://media.example.test/groups/photo.jpg"
+        ));
+        for unsafe_url in [
+            "",
+            "http://media.example.test/groups/photo.jpg",
+            "https://user@media.example.test/groups/photo.jpg",
+            "https://media.example.test/groups/photo.jpg?token=secret",
+            "https://media.example.test/groups/photo.jpg#fragment",
+        ] {
+            assert!(!is_safe_channel_picture_url(unsafe_url), "{unsafe_url}");
+        }
+        assert!(!is_safe_channel_picture_url(&format!(
+            "https://media.example.test/{}",
+            "a".repeat(2_048)
+        )));
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -690,7 +690,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 40);
+        assert_eq!(migrations.len(), 41);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -1232,6 +1232,12 @@ mod tests {
             operator_audit.contains("_operator_global_tables"),
             "migration 39 must register relay_operator_audit in _operator_global_tables"
         );
+
+        assert_eq!(migrations[40].version, 41);
+        let channel_picture = migrations[40].sql.as_str();
+        assert!(channel_picture.contains("ADD COLUMN picture_url"));
+        assert!(channel_picture.contains("octet_length(picture_url) <= 2048"));
+        assert!(desired_schema.contains("picture_url     TEXT CHECK"));
     }
 
     #[test]

--- a/crates/buzz-db/src/store/channel.rs
+++ b/crates/buzz-db/src/store/channel.rs
@@ -42,6 +42,8 @@ pub struct ChannelRecord {
     pub visibility: String,
     /// Optional channel description.
     pub description: Option<String>,
+    /// Public HTTPS URL for the channel picture, if configured.
+    pub picture_url: Option<String>,
     /// Optional canvas (rich document) content.
     pub canvas: Option<String>,
     /// Compressed public key bytes of the channel creator.
@@ -144,7 +146,7 @@ pub async fn create_channel(
     let row = sqlx::query(
         r#"
         SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-               description, canvas,
+               description, picture_url, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
@@ -244,7 +246,7 @@ pub async fn create_channel_with_id(
     let row = sqlx::query(
         r#"
         SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-               description, canvas,
+               description, picture_url, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
@@ -272,7 +274,7 @@ pub async fn get_channel(
     let row = sqlx::query(
         r#"
         SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-               description, canvas,
+               description, picture_url, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
@@ -338,7 +340,7 @@ pub async fn list_channels(
         sqlx::query(
             r#"
             SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-                   description, canvas,
+                   description, picture_url, canvas,
                    created_by, created_at, updated_at, archived_at, deleted_at,
                    nip29_group_id, topic_required, max_members,
                    topic, topic_set_by, topic_set_at,
@@ -358,7 +360,7 @@ pub async fn list_channels(
         sqlx::query(
             r#"
             SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-                   description, canvas,
+                   description, picture_url, canvas,
                    created_by, created_at, updated_at, archived_at, deleted_at,
                    nip29_group_id, topic_required, max_members,
                    topic, topic_set_by, topic_set_at,
@@ -401,6 +403,7 @@ pub(crate) fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<Channe
     let purpose: Option<String> = row.try_get("purpose").unwrap_or(None);
     let purpose_set_by: Option<Vec<u8>> = row.try_get("purpose_set_by").unwrap_or(None);
     let purpose_set_at: Option<DateTime<Utc>> = row.try_get("purpose_set_at").unwrap_or(None);
+    let picture_url: Option<String> = row.try_get("picture_url").unwrap_or(None);
     let ttl_seconds: Option<i32> = row.try_get("ttl_seconds").unwrap_or(None);
     let ttl_deadline: Option<DateTime<Utc>> = row.try_get("ttl_deadline").unwrap_or(None);
 
@@ -410,6 +413,7 @@ pub(crate) fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<Channe
         channel_type: row.try_get("channel_type")?,
         visibility: row.try_get("visibility")?,
         description: row.try_get("description")?,
+        picture_url,
         canvas: row.try_get("canvas")?,
         created_by: row.try_get("created_by")?,
         created_at: row.try_get("created_at")?,
@@ -440,6 +444,9 @@ pub struct ChannelUpdate {
     pub description: Option<String>,
     /// New visibility (`"open"`/`"private"`), or `None` to leave unchanged.
     pub visibility: Option<String>,
+    /// Picture change: outer `None` leaves it unchanged, `Some(None)` clears
+    /// it, and `Some(Some(url))` sets a validated public HTTPS URL.
+    pub picture_url: Option<Option<String>>,
     /// TTL change: outer `None` leaves it unchanged, `Some(None)` clears the
     /// ephemeral TTL (channel becomes permanent), `Some(Some(secs))` sets it.
     /// On any change the `ttl_deadline` is reset to `NOW() + ttl_seconds`.
@@ -459,6 +466,7 @@ pub async fn update_channel(
     if updates.name.is_none()
         && updates.description.is_none()
         && updates.visibility.is_none()
+        && updates.picture_url.is_none()
         && updates.ttl_seconds.is_none()
     {
         return Err(DbError::InvalidData(
@@ -470,6 +478,13 @@ pub async fn update_channel(
         *name = buzz_core::channel::canonical_channel_name(name).to_owned();
         if name.is_empty() {
             return Err(DbError::InvalidData("channel name is required".into()));
+        }
+    }
+    if let Some(Some(picture_url)) = updates.picture_url.as_ref() {
+        if !buzz_core::channel::is_safe_channel_picture_url(picture_url) {
+            return Err(DbError::InvalidData(
+                "channel picture must be a public HTTPS URL without embedded secrets".into(),
+            ));
         }
     }
 
@@ -487,6 +502,10 @@ pub async fn update_channel(
     }
     if updates.visibility.is_some() {
         set_parts.push(format!("visibility = ${param_idx}::channel_visibility"));
+        param_idx += 1;
+    }
+    if updates.picture_url.is_some() {
+        set_parts.push(format!("picture_url = ${param_idx}"));
         param_idx += 1;
     }
     if let Some(ref ttl) = updates.ttl_seconds {
@@ -516,6 +535,9 @@ pub async fn update_channel(
     }
     if let Some(ref vis) = updates.visibility {
         q = q.bind(vis);
+    }
+    if let Some(ref picture_url) = updates.picture_url {
+        q = q.bind(picture_url.as_deref());
     }
     if let Some(ref ttl) = updates.ttl_seconds {
         q = q.bind(*ttl);

--- a/crates/buzz-db/src/store/channel_members.rs
+++ b/crates/buzz-db/src/store/channel_members.rs
@@ -886,7 +886,7 @@ async fn get_channel_tx(
     let row = sqlx::query(
         r#"
         SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-               description, canvas,
+               description, picture_url, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
@@ -977,7 +977,7 @@ pub async fn get_accessible_channels(
     let base = format!(
         r#"
         SELECT c.id, c.name, c.channel_type::text AS channel_type,
-               c.visibility::text AS visibility, c.description, c.canvas,
+               c.visibility::text AS visibility, c.description, c.picture_url, c.canvas,
                c.created_by, c.created_at, c.updated_at, c.archived_at, c.deleted_at,
                c.nip29_group_id, c.topic_required, c.max_members,
                c.topic, c.topic_set_by, c.topic_set_at,

--- a/crates/buzz-db/src/store/dm.rs
+++ b/crates/buzz-db/src/store/dm.rs
@@ -72,7 +72,7 @@ pub async fn find_dm_by_participants(
     let row = sqlx::query(
         r#"
         SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-               description, canvas,
+               description, picture_url, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
@@ -133,7 +133,7 @@ pub async fn create_dm(
     let existing = sqlx::query(
         r#"
         SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-               description, canvas,
+               description, picture_url, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
@@ -203,7 +203,7 @@ pub async fn create_dm(
     let row = sqlx::query(
         r#"
         SELECT id, name, channel_type::text AS channel_type, visibility::text AS visibility,
-               description, canvas,
+               description, picture_url, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
@@ -496,6 +496,7 @@ fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {
         channel_type: row.try_get("channel_type")?,
         visibility: row.try_get("visibility")?,
         description: row.try_get("description")?,
+        picture_url: row.try_get("picture_url").unwrap_or(None),
         canvas: row.try_get("canvas")?,
         created_by: row.try_get("created_by")?,
         created_at: row.try_get("created_at")?,

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -22,6 +22,50 @@ use crate::state::AppState;
 use buzz_core::tenant::TenantContext;
 use buzz_pubsub::EventTopic;
 
+const CHANNEL_METADATA_TAGS: &[&str] = &[
+    "name",
+    "about",
+    "archived",
+    "topic",
+    "purpose",
+    "visibility",
+    "ttl",
+    "picture",
+];
+
+const CHANNEL_PRIVILEGED_METADATA_TAGS: &[&str] =
+    &["name", "about", "archived", "visibility", "ttl", "picture"];
+
+fn validate_channel_picture_tags(event: &Event) -> anyhow::Result<()> {
+    let pictures: Vec<_> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.kind().to_string() == "picture")
+        .collect();
+    if pictures.len() > 1 {
+        return Err(anyhow::anyhow!(
+            "kind:9002 must include at most one picture tag"
+        ));
+    }
+    if let Some(tag) = pictures.first() {
+        match tag.content() {
+            Some("") => {}
+            Some(value) if buzz_core::channel::is_safe_channel_picture_url(value) => {}
+            Some(_) => {
+                return Err(anyhow::anyhow!(
+                    "picture must be a public HTTPS URL without credentials, query, or fragment"
+                ));
+            }
+            None => {
+                return Err(anyhow::anyhow!(
+                    "picture tag must have a value (URL, or empty string to clear)"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Check if a kind is an admin kind (9000-9022) that needs pre-storage validation.
 pub fn is_admin_kind(kind: u32) -> bool {
     matches!(kind, 9000..=9022)
@@ -495,24 +539,17 @@ pub async fn validate_admin_event(
         }
         9002 => {
             // EDIT_METADATA: require at least one recognized metadata tag.
-            const RECOGNIZED_TAGS: &[&str] = &[
-                "name",
-                "about",
-                "archived",
-                "topic",
-                "purpose",
-                "visibility",
-                "ttl",
-            ];
             let has_recognized = event
                 .tags
                 .iter()
-                .any(|t| RECOGNIZED_TAGS.contains(&t.kind().to_string().as_str()));
+                .any(|t| CHANNEL_METADATA_TAGS.contains(&t.kind().to_string().as_str()));
             if !has_recognized {
                 return Err(anyhow::anyhow!(
-                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose, visibility, ttl)"
+                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose, visibility, ttl, picture)"
                 ));
             }
+
+            validate_channel_picture_tags(event)?;
 
             // Validate archived values before storage.
             for t in event.tags.iter() {
@@ -589,11 +626,11 @@ pub async fn validate_admin_event(
                 }
             }
 
-            // name/about/archived/visibility/ttl require owner/admin;
+            // name/about/archived/visibility/ttl/picture require owner/admin;
             // topic/purpose allow any member.
             let has_privileged_tag = event.tags.iter().any(|t| {
                 let k = t.kind().to_string();
-                k == "name" || k == "about" || k == "archived" || k == "visibility" || k == "ttl"
+                CHANNEL_PRIVILEGED_METADATA_TAGS.contains(&k.as_str())
             });
             if has_privileged_tag {
                 let members = state.db.get_members(tenant.community(), channel_id).await?;
@@ -615,7 +652,7 @@ pub async fn validate_admin_event(
                             return Ok(());
                         }
                         Err(anyhow::anyhow!(
-                            "actor not authorized for name/about/archived/visibility/ttl changes"
+                            "actor not authorized for name/about/archived/visibility/ttl/picture changes"
                         ))
                     }
                 }
@@ -1143,6 +1180,9 @@ pub async fn emit_group_discovery_events(
                 tags.push(Tag::parse(["about", desc])?);
             }
         }
+        if let Some(ref picture_url) = channel.picture_url {
+            tags.push(Tag::parse(["picture", picture_url])?);
+        }
         if channel.visibility == "private" {
             tags.push(Tag::parse(["private"])?);
         } else {
@@ -1617,6 +1657,20 @@ async fn handle_edit_metadata(
                         chrono::Utc::now(),
                     )
                     .await?;
+                }
+                "picture" => {
+                    let picture_url = (!val.is_empty()).then(|| val.to_string());
+                    state
+                        .db
+                        .update_channel(
+                            tenant.community(),
+                            channel_id,
+                            buzz_db::channel::ChannelUpdate {
+                                picture_url: Some(picture_url),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
                 }
                 "ttl" => {
                     // Empty string clears the TTL (permanent); otherwise it is a
@@ -3683,6 +3737,38 @@ pub async fn publish_nipia_unarchived(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn channel_picture_is_recognized_and_validated_for_metadata_updates() {
+        assert!(CHANNEL_METADATA_TAGS.contains(&"picture"));
+        assert!(CHANNEL_PRIVILEGED_METADATA_TAGS.contains(&"picture"));
+        let keys = nostr::Keys::generate();
+        let channel = Uuid::new_v4().to_string();
+
+        for value in ["https://media.example.test/groups/photo.jpg", ""] {
+            let event = EventBuilder::new(Kind::Custom(9002), "")
+                .tags([
+                    Tag::parse(["h", &channel]).unwrap(),
+                    Tag::parse(["picture", value]).unwrap(),
+                ])
+                .sign_with_keys(&keys)
+                .expect("sign picture update");
+            assert!(validate_channel_picture_tags(&event).is_ok());
+        }
+
+        let unsafe_event = EventBuilder::new(Kind::Custom(9002), "")
+            .tags([
+                Tag::parse(["h", &channel]).unwrap(),
+                Tag::parse([
+                    "picture",
+                    "https://media.example.test/photo.jpg?token=secret",
+                ])
+                .unwrap(),
+            ])
+            .sign_with_keys(&keys)
+            .expect("sign unsafe picture update");
+        assert!(validate_channel_picture_tags(&unsafe_event).is_err());
+    }
 
     #[test]
     fn group_members_snapshot_keeps_members_past_one_thousand() {

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -659,6 +659,28 @@ pub fn build_update_channel(
     Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
 }
 
+/// Build a NIP-29 channel-picture update (kind 9002).
+///
+/// `Some(url)` sets a public HTTPS picture URL. `None` clears the current
+/// picture by emitting an explicit empty `picture` tag.
+pub fn build_set_channel_picture(
+    channel_id: Uuid,
+    picture: Option<&str>,
+) -> Result<EventBuilder, SdkError> {
+    let value = picture.unwrap_or("");
+    if !value.is_empty() && !buzz_core::channel::is_safe_channel_picture_url(value) {
+        return Err(SdkError::InvalidTag(
+            "channel picture must be a public HTTPS URL without credentials, query, or fragment"
+                .into(),
+        ));
+    }
+    let tags = vec![
+        tag(&["h", &channel_id.to_string()])?,
+        tag(&["picture", value])?,
+    ];
+    Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
+}
+
 /// Build a NIP-29 edit-metadata event for topic (kind 9002).
 pub fn build_set_topic(channel_id: Uuid, topic: &str) -> Result<EventBuilder, SdkError> {
     let tags = vec![
@@ -3027,6 +3049,33 @@ mod tests {
             build_update_channel(cid, None, None, None, None),
             Err(SdkError::InvalidTag(_))
         ));
+    }
+
+    #[test]
+    fn set_and_clear_channel_picture() {
+        let cid = uuid();
+        let picture = "https://media.example.test/groups/photo.jpg";
+        let set = sign(build_set_channel_picture(cid, Some(picture)).unwrap());
+        assert_eq!(set.kind.as_u16(), 9002);
+        assert!(has_tag(&set, "picture", picture));
+
+        let clear = sign(build_set_channel_picture(cid, None).unwrap());
+        assert!(has_tag(&clear, "picture", ""));
+    }
+
+    #[test]
+    fn channel_picture_rejects_unsafe_urls() {
+        for value in [
+            "http://media.example.test/photo.jpg",
+            "https://user@media.example.test/photo.jpg",
+            "https://media.example.test/photo.jpg?token=secret",
+            "https://media.example.test/photo.jpg#fragment",
+        ] {
+            assert!(matches!(
+                build_set_channel_picture(uuid(), Some(value)),
+                Err(SdkError::InvalidTag(_))
+            ));
+        }
     }
 
     #[test]

--- a/migrations/0041_channel_picture_url.sql
+++ b/migrations/0041_channel_picture_url.sql
@@ -1,0 +1,11 @@
+-- Persist the public channel-picture URL projected by relay-signed kind:39000
+-- metadata. Protocol-level URL validation remains in the kind:9002 ingest
+-- path; this storage guard keeps direct DB writers within the same coarse
+-- HTTPS and size boundary while allowing NULL to clear the picture.
+ALTER TABLE channels
+    ADD COLUMN picture_url TEXT,
+    ADD CONSTRAINT chk_channels_picture_url_safe
+        CHECK (
+            picture_url IS NULL
+            OR (octet_length(picture_url) <= 2048 AND lower(picture_url) LIKE 'https://%')
+        );

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -83,6 +83,10 @@ CREATE TABLE channels (
     channel_type    channel_type NOT NULL DEFAULT 'stream',
     visibility      channel_visibility NOT NULL DEFAULT 'open',
     description     TEXT,
+    picture_url     TEXT CHECK (
+        picture_url IS NULL
+        OR (octet_length(picture_url) <= 2048 AND lower(picture_url) LIKE 'https://%')
+    ),
     canvas          TEXT,
     created_by      BYTEA NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
## Summary
- accept and authorize NIP-29 kind 9002 picture updates for channel owners and admins
- validate, persist, clear, and expose channel picture URLs through every channel read path
- include picture in relay-signed kind 39000 group metadata and add an SDK builder
- add migration 0041 plus schema and protocol documentation updates

## Why
Haute already uploads a group image and publishes a kind 9002 picture tag. The current Buzz relay rejects that tag because it is not recognized, so the app cannot change a group profile photo. This adds the missing relay contract without introducing a Haute-side authority or workaround.

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p buzz-core channel_picture_urls_are_public_https_without_embedded_secrets
- cargo test -p buzz-sdk channel_picture
- cargo test -p buzz-relay channel_picture_is_recognized_and_validated_for_metadata_updates
- cargo test -p buzz-db embedded_migrator_contains_consolidated_initial_schema
- telemetry test rerun in isolation: pass

The repository-wide just ci reached and passed Rust fmt/clippy, then stopped during pnpm dependency installation because the local disk ran out of space (ENOSPC). GitHub CI should run the remaining unrelated frontend gates in a clean environment.