### PR TITLE
feat: render agent avatars as squircles

### DIFF
--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -191,6 +191,7 @@ export function AddTeamToChannelDialog({
                         avatarUrl={persona.avatarUrl}
                         className="h-5 w-5 text-2xs"
                         label={persona.displayName}
+                        shape="squircle"
                       />
                       <span className="text-xs font-medium">
                         {persona.displayName}

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -3,7 +3,6 @@ import Picker from "@emoji-mart/react";
 import * as React from "react";
 import { Link2, Pencil, Plus, UploadCloud } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-
 import { MaskedAvatarBadgeFrame } from "@/features/profile/ui/MaskedAvatarBadgeFrame";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import {
@@ -44,7 +43,6 @@ import {
   type EmojiMartEmoji,
   isAvatarFileDrag,
 } from "./AgentCreationPreview.utils";
-
 export function AgentCreationPreview({
   assetLabel = "avatar",
   avatarUrl,
@@ -127,12 +125,10 @@ export function AgentCreationPreview({
     },
     processImage,
   });
-
   useEmojiMartStyles(
     emojiPickerContainerRef,
     isAvatarMenuOpen && activeTab === "emoji",
   );
-
   // Emoji Mart mounts its search input inside a shadow root. Wait for it
   // before focusing so the surrounding Radix popover cannot win the race.
   React.useEffect(() => {
@@ -728,7 +724,7 @@ export function AgentCreationPreview({
                     ? isCompact
                       ? "rounded-2xl"
                       : "rounded-[2rem]"
-                    : "rounded-full",
+                    : "rounded-[30%]",
                 )}
                 role="img"
                 style={{ backgroundColor: emojiAvatarPreview.color }}
@@ -754,6 +750,7 @@ export function AgentCreationPreview({
             ) : (
               <ProfileAvatar
                 avatarUrl={avatarUrl}
+                shape="squircle"
                 className={cn(
                   "h-full w-full",
                   isCompact ? "text-base" : "text-4xl",
@@ -927,6 +924,7 @@ export function AgentCreationPreview({
                   }
                   className={isCompact ? "h-16 w-16" : "h-36 w-36"}
                   clipTestId={`${testIdPrefix}-mask`}
+                  cornerRadius={(isCompact ? 64 : 144) * 0.3}
                   cutout={
                     isCompact
                       ? { cx: 58, cy: 58, r: 16.5 }
@@ -938,7 +936,7 @@ export function AgentCreationPreview({
                   {emojiAvatarPreview ? (
                     <div
                       aria-label={`${label} ${assetLabel}`}
-                      className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs transition-[background-color] duration-200 ease-out"
+                      className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-[30%] shadow-xs transition-[background-color] duration-200 ease-out"
                       role="img"
                       style={{
                         backgroundColor: emojiAvatarPreview.color,
@@ -964,6 +962,7 @@ export function AgentCreationPreview({
                   ) : (
                     <ProfileAvatar
                       avatarUrl={avatarUrl}
+                      shape="squircle"
                       className={cn(
                         "h-full w-full transition-shadow duration-150",
                         isCompact ? "text-base" : "text-4xl",
@@ -986,7 +985,7 @@ export function AgentCreationPreview({
                         ? isCompact
                           ? "rounded-2xl"
                           : "rounded-[2rem]"
-                        : "rounded-full",
+                        : "rounded-[30%]",
                       isDragOverAvatar &&
                         !isAvatarMenuOpen &&
                         "border-primary/70 bg-primary/5 ring-2 ring-primary/15",

--- a/desktop/src/features/agents/ui/AgentIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/AgentIdentityCard.tsx
@@ -53,6 +53,7 @@ export function AgentIdentityCard({
                 className="h-full w-full border-[3px] border-background bg-muted shadow-none"
                 iconClassName="h-8 w-8"
                 label={label}
+                shape="squircle"
               />
             ) : (
               <IdentityInitialsAvatar

--- a/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
+++ b/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
@@ -229,6 +229,7 @@ export function AgentRuntimeAvatarControl({
               : "bg-primary",
       )}
       className="h-24 w-24"
+      cornerRadius={AGENT_AVATAR_SIZE * 0.3}
       curve={showRunningDot ? STATUS_DOT_MASK_CURVE : ACTION_MASK_CURVE}
       cutout={badge.cutout}
       cutoutWidth={actionCutoutWidth}
@@ -241,6 +242,7 @@ export function AgentRuntimeAvatarControl({
           className="h-full w-full bg-muted shadow-none"
           iconClassName="h-8 w-8"
           label={label}
+          shape="squircle"
         />
       ) : (
         <IdentityInitialsAvatar

--- a/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
@@ -106,7 +106,7 @@ export function CompactMessageSummary({
             aria-label={`Open ${displayName} profile`}
             className={cn(
               avatarClassName,
-              "pointer-events-auto rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "pointer-events-auto rounded-[30%] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             )}
             onClick={(event) => {
               event.preventDefault();
@@ -119,6 +119,7 @@ export function CompactMessageSummary({
               avatarUrl={avatarUrl}
               className="size-full text-xs"
               displayName={displayName}
+              shape="squircle"
               size="sm"
               testId="transcript-agent-sent-avatar"
             />
@@ -131,6 +132,7 @@ export function CompactMessageSummary({
               isCompactPreview ? "text-3xs" : "text-xs",
             )}
             displayName={displayName}
+            shape="squircle"
             size="sm"
             testId="transcript-agent-sent-avatar"
           />

--- a/desktop/src/features/agents/ui/IdentityInitialsAvatar.tsx
+++ b/desktop/src/features/agents/ui/IdentityInitialsAvatar.tsx
@@ -39,7 +39,7 @@ export function IdentityInitialsAvatar({
   return (
     <span
       className={cn(
-        "flex h-full w-full items-center justify-center rounded-full border-[3px] border-background font-semibold shadow-sm",
+        "flex h-full w-full items-center justify-center rounded-[30%] border-[3px] border-background font-semibold shadow-sm",
         colorClassName,
         textSizeClassName,
         className,

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -419,6 +419,7 @@ function AllowlistPicker({
                       <UserAvatar
                         avatarUrl={result.avatarUrl}
                         displayName={formatSearchUserName(result)}
+                        shape={result.isAgent ? "squircle" : "circle"}
                         size="xs"
                       />
                       <div className="min-w-0">

--- a/desktop/src/features/agents/ui/TeamDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamDialog.tsx
@@ -295,6 +295,7 @@ export function TeamDialog({
                             avatarUrl={persona.avatarUrl}
                             className="h-6 w-6 text-2xs"
                             label={persona.displayName}
+                            shape="squircle"
                           />
                           <span className="text-sm">{persona.displayName}</span>
                           {persona.isBuiltIn ? (

--- a/desktop/src/features/agents/ui/TeamIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/TeamIdentityCard.tsx
@@ -120,7 +120,7 @@ function TeamAvatarRow({
   if (visiblePersonas.length === 0 && overflowCount === 0) {
     return (
       <div className="absolute inset-x-4 top-0 bottom-12 flex items-center justify-center">
-        <div className="flex h-24 w-24 items-center justify-center rounded-full border border-border/65 bg-background/80 text-muted-foreground shadow-xs">
+        <div className="flex h-24 w-24 items-center justify-center rounded-[30%] border border-border/65 bg-background/80 text-muted-foreground shadow-xs">
           <Users className="h-9 w-9" />
         </div>
       </div>
@@ -135,19 +135,14 @@ function TeamAvatarRow({
         role="img"
       >
         {visiblePersonas.map((persona, index) => (
-          <TeamAvatarItem
-            index={index}
-            isFollowedByAnother={index < stackItemCount - 1}
-            key={persona.id}
-            persona={persona}
-          />
+          <TeamAvatarItem index={index} key={persona.id} persona={persona} />
         ))}
         {overflowCount > 0 ? (
           <div
             className={visiblePersonas.length > 0 ? "-ml-5" : ""}
             style={{ zIndex: stackItemCount }}
           >
-            <span className="flex h-14 w-14 items-center justify-center rounded-full bg-card text-sm font-semibold text-muted-foreground">
+            <span className="flex h-14 w-14 items-center justify-center rounded-[30%] bg-card text-sm font-semibold text-muted-foreground ring-2 ring-card">
               +{overflowCount}
             </span>
           </div>
@@ -159,44 +154,40 @@ function TeamAvatarRow({
 
 function TeamAvatarItem({
   index,
-  isFollowedByAnother,
   persona,
 }: {
   index: number;
-  isFollowedByAnother: boolean;
   persona: AgentPersona;
 }) {
   const avatarUrl = persona.avatarUrl?.trim() ?? null;
 
   return (
     <div
-      className={`h-14 w-14 ${index > 0 ? "-ml-5" : ""}`}
+      className={`relative h-14 w-14 before:absolute before:-inset-0.5 before:rounded-[calc(30%+2px)] before:bg-card before:content-[''] ${index > 0 ? "-ml-5" : ""}`}
       data-team-member-avatar="avatar"
       style={{
         zIndex: index + 1,
-        ...(isFollowedByAnother && {
-          mask: "radial-gradient(circle 32px at calc(100% + 8px) 50%, transparent 99%, #fff 100%)",
-          WebkitMask:
-            "radial-gradient(circle 32px at calc(100% + 8px) 50%, transparent 99%, #fff 100%)",
-        }),
       }}
     >
-      {avatarUrl ? (
-        <ProfileAvatar
-          avatarUrl={avatarUrl}
-          className="h-full w-full bg-muted shadow-none"
-          iconClassName="h-6 w-6"
-          label={persona.displayName}
-          testId={`team-member-avatar-${persona.id}`}
-        />
-      ) : (
-        <IdentityInitialsAvatar
-          className="border-0 shadow-none"
-          colorIndex={index}
-          label={persona.displayName}
-          size={56}
-        />
-      )}
+      <div className="relative z-10 h-full w-full">
+        {avatarUrl ? (
+          <ProfileAvatar
+            avatarUrl={avatarUrl}
+            className="h-full w-full bg-muted shadow-none"
+            iconClassName="h-6 w-6"
+            label={persona.displayName}
+            shape="squircle"
+            testId={`team-member-avatar-${persona.id}`}
+          />
+        ) : (
+          <IdentityInitialsAvatar
+            className="border-0 shadow-none"
+            colorIndex={index}
+            label={persona.displayName}
+            size={56}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
@@ -101,7 +101,10 @@ export function UserMessageBubble({
       {isCompactPreview ? null : item.authorPubkey && openProfilePanel ? (
         <button
           aria-label={`Open ${authorLabel} profile`}
-          className="pointer-events-auto order-last ml-2 mt-1 size-7 shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={cn(
+            "pointer-events-auto order-last ml-2 mt-1 size-7 shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            authorProfile?.isAgent ? "rounded-[30%]" : "rounded-full",
+          )}
           onClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
@@ -115,6 +118,7 @@ export function UserMessageBubble({
             avatarUrl={authorProfile?.avatarUrl ?? null}
             className="size-full text-xs"
             displayName={authorLabel}
+            shape={authorProfile?.isAgent ? "squircle" : "circle"}
             size="sm"
           />
         </button>
@@ -123,6 +127,7 @@ export function UserMessageBubble({
           avatarUrl={authorProfile?.avatarUrl ?? null}
           className="order-last ml-2 mt-1 size-7 shrink-0 text-xs"
           displayName={authorLabel}
+          shape={authorProfile?.isAgent ? "squircle" : "circle"}
           size="sm"
         />
       )}

--- a/desktop/src/features/channels/lib/dmParticipantDisplay.ts
+++ b/desktop/src/features/channels/lib/dmParticipantDisplay.ts
@@ -14,6 +14,7 @@ export type DmParticipantDisplay = {
 export type DirectMessageIntroParticipant = {
   avatarUrl: string | null;
   displayName: string;
+  isAgent?: boolean;
   pubkey: string;
 };
 
@@ -95,6 +96,7 @@ export function buildDirectMessageIntro({
         profiles,
         pubkey: participant.pubkey,
       }),
+      ...(profile?.isAgent === true ? { isAgent: true } : {}),
       pubkey: participant.pubkey,
     };
   });

--- a/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
@@ -38,6 +38,7 @@ function AgentRow({
         className="h-9 w-9 shrink-0 text-xs"
         iconClassName="h-5 w-5"
         label={persona.displayName}
+        shape="squircle"
       />
       <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
         {persona.displayName}

--- a/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
@@ -161,6 +161,7 @@ export function AddChannelBotTeamsSection({
                               avatarUrl={persona.avatarUrl}
                               className="h-4 w-4 text-3xs bg-secondary-foreground/20 text-secondary-foreground"
                               label={persona.displayName}
+                              shape="squircle"
                               testId="team-tooltip-persona-avatar"
                             />
                             <span className="text-2xs text-secondary-foreground">

--- a/desktop/src/features/channels/ui/AddMemberSearchResultRow.tsx
+++ b/desktop/src/features/channels/ui/AddMemberSearchResultRow.tsx
@@ -46,6 +46,7 @@ export function AddMemberSearchResultRow({
         avatarUrl={user.avatarUrl}
         className="pointer-events-none relative z-10 h-8 w-8 text-xs shadow-none"
         displayName={formatAddCandidateName(user)}
+        shape={user.isAgent ? "squircle" : "circle"}
         size="sm"
       />
       <div className="pointer-events-none relative z-10 min-w-0 flex-1">

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -422,6 +422,7 @@ export function AgentSessionThreadPanel({
           avatarUrl={agentProfile?.avatarUrl ?? null}
           className="size-9"
           label={agentLabel}
+          shape="squircle"
           testId="agent-session-agent-avatar"
         />
         <div className="min-w-0 flex-1">

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -191,6 +191,7 @@ export function BotActivityComposerAction({
                   isInline ? "!h-4.5 !w-4.5 text-3xs" : "shrink-0",
                 )}
                 displayName={agent.name}
+                shape="squircle"
                 fallbackDelayMs={isInline ? 0 : undefined}
                 key={agent.pubkey}
                 size="xs"
@@ -259,6 +260,7 @@ export function BotActivityComposerAction({
                   avatarUrl={agentAvatarUrl(agent)}
                   className="shrink-0"
                   displayName={agent.name}
+                  shape="squircle"
                   size="sm"
                 />
                 <span className="min-w-0 flex-1 truncate">{agent.name}</span>

--- a/desktop/src/features/channels/ui/ChannelMemberAvatarStack.tsx
+++ b/desktop/src/features/channels/ui/ChannelMemberAvatarStack.tsx
@@ -56,6 +56,7 @@ export function ChannelMemberAvatarStack({
               className="!h-8 !w-8 border-2 border-background text-2xs"
               displayName={label}
               fallbackDelayMs={0}
+              shape={profile?.isAgent ? "squircle" : "circle"}
             />
           </span>
         );

--- a/desktop/src/features/channels/ui/ChannelMemberInviteCard.tsx
+++ b/desktop/src/features/channels/ui/ChannelMemberInviteCard.tsx
@@ -206,6 +206,7 @@ export function ChannelMemberInviteCard({
                   <UserAvatar
                     avatarUrl={invitee.avatarUrl ?? null}
                     displayName={formatSearchUserName(invitee)}
+                    shape={invitee.isAgent ? "squircle" : "circle"}
                     size="xs"
                   />
                   <span className="font-medium">
@@ -297,6 +298,7 @@ export function ChannelMemberInviteCard({
                         <UserAvatar
                           avatarUrl={result.avatarUrl}
                           displayName={formatSearchUserName(result)}
+                          shape={result.isAgent ? "squircle" : "circle"}
                           size="xs"
                         />
                         <p className="truncate text-sm font-medium leading-5">

--- a/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
@@ -153,6 +153,7 @@ export function ChannelScreenHeader({
           ) : activeDmParticipant ? (
             <UserProfilePopover
               pubkey={activeDmParticipant.pubkey}
+              role={activeDmParticipant.isAgent ? "bot" : undefined}
               triggerAriaLabel={`Open profile for ${activeChannelTitle}`}
               triggerElement="span"
             >
@@ -163,6 +164,7 @@ export function ChannelScreenHeader({
                 geometry={DM_HEADER_AVATAR_STATUS_GEOMETRY}
                 iconClassName="h-4 w-4"
                 label={activeChannelTitle}
+                shape={activeDmParticipant.isAgent ? "squircle" : "circle"}
                 size={DM_HEADER_AVATAR_SIZE}
                 status={activeDmPresenceStatus ?? "offline"}
                 statusTestId="chat-presence-badge"
@@ -177,6 +179,7 @@ export function ChannelScreenHeader({
               geometry={DM_HEADER_AVATAR_STATUS_GEOMETRY}
               iconClassName="h-4 w-4"
               label={activeChannelTitle}
+              shape="circle"
               size={DM_HEADER_AVATAR_SIZE}
               status={activeDmPresenceStatus ?? "offline"}
               statusTestId="chat-presence-badge"
@@ -222,23 +225,23 @@ function DmHeaderParticipantStack({
           pubkey={participant.pubkey}
           triggerAriaLabel={`Open profile for ${participant.displayName}`}
           triggerElement="span"
+          role={participant.isAgent ? "bot" : undefined}
         >
           <span
             className={index > 0 ? "-ml-2" : ""}
             data-testid="chat-header-dm-avatar-stack-participant"
-            style={{
-              zIndex: index + 1,
-              ...(index < stackItemCount - 1 && {
-                mask: "radial-gradient(circle 18px at calc(100% + 4px) 50%, transparent 99%, #fff 100%)",
-                WebkitMask:
-                  "radial-gradient(circle 18px at calc(100% + 4px) 50%, transparent 99%, #fff 100%)",
-              }),
-            }}
+            style={{ zIndex: index + 1 }}
           >
             <UserAvatar
+              accent={participant.isAgent === true}
               avatarUrl={participant.avatarUrl}
-              className="h-8 w-8 text-xs"
+              className={
+                index < stackItemCount - 1
+                  ? "h-8 w-8 text-xs ring-2 ring-background"
+                  : "h-8 w-8 text-xs"
+              }
               displayName={participant.displayName}
+              shape={participant.isAgent ? "squircle" : "circle"}
               size="sm"
             />
           </span>

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -168,6 +168,7 @@ export function MembersSidebarMemberCard({
           className="h-8 w-8 text-xs shadow-none"
           iconClassName="h-4 w-4"
           label={memberAvatarLabel}
+          shape={memberIsBot ? "squircle" : "circle"}
         />
         {presenceStatus ? (
           <span

--- a/desktop/src/features/channels/useActiveChannelHeader.ts
+++ b/desktop/src/features/channels/useActiveChannelHeader.ts
@@ -12,6 +12,7 @@ export type ActiveDmHeaderParticipant = {
   pubkey: string;
   displayName: string;
   avatarUrl: string | null;
+  isAgent?: boolean;
 };
 
 export function useActiveChannelHeader(
@@ -78,6 +79,7 @@ export function useActiveChannelHeader(
             pubkey: participant.pubkey,
           }),
           avatarUrl: profile?.avatarUrl ?? null,
+          ...(profile?.isAgent === true ? { isAgent: true } : {}),
         };
       }),
     [activeDmParticipants, activeDmProfilesQuery.data?.profiles, currentPubkey],

--- a/desktop/src/features/community-members/ui/AddMemberDialog.tsx
+++ b/desktop/src/features/community-members/ui/AddMemberDialog.tsx
@@ -441,6 +441,7 @@ function SearchResult({
         className="h-8 w-8 text-xs shadow-none"
         iconClassName="h-4 w-4"
         label={name}
+        shape={user.isAgent ? "squircle" : "circle"}
       />
       <span className="min-w-0 flex-1 truncate text-sm font-medium">
         {name}

--- a/desktop/src/features/community-members/ui/CommunityMembersSettingsCard.tsx
+++ b/desktop/src/features/community-members/ui/CommunityMembersSettingsCard.tsx
@@ -140,6 +140,7 @@ function RelayMemberRow({
           avatarUrl={profile?.avatarUrl ?? null}
           className="h-9 w-9 text-xs shadow-none"
           label={displayName}
+          shape={profile?.isAgent === true ? "squircle" : "circle"}
         />
       </UserProfilePopover>
       <div className="min-w-0 flex-1">

--- a/desktop/src/features/forum/ui/ForumPostCard.tsx
+++ b/desktop/src/features/forum/ui/ForumPostCard.tsx
@@ -45,6 +45,7 @@ export function ForumPostCard({
     preferResolvedSelfLabel: true,
   });
   const avatarUrl = profiles?.[post.pubkey.toLowerCase()]?.avatarUrl ?? null;
+  const authorIsAgent = profiles?.[post.pubkey.toLowerCase()]?.isAgent === true;
   const { mentionNames, mentionPubkeysByName } = resolveMentionProps(
     post.tags,
     profiles,
@@ -83,14 +84,19 @@ export function ForumPostCard({
       <div className="flex items-center gap-2">
         {/* biome-ignore lint/a11y/noStaticElementInteractions: presentation wrapper stops click propagation to parent card */}
         <div onClick={(e) => e.stopPropagation()} role="presentation">
-          <UserProfilePopover pubkey={post.pubkey}>
+          <UserProfilePopover
+            pubkey={post.pubkey}
+            role={authorIsAgent ? "bot" : undefined}
+          >
             <button
               className="flex items-center gap-2 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
               type="button"
             >
               <UserAvatar
+                accent={authorIsAgent}
                 avatarUrl={avatarUrl}
                 displayName={authorLabel}
+                shape={authorIsAgent ? "squircle" : "circle"}
                 size="sm"
               />
               <span className="truncate text-sm font-medium text-foreground hover:underline">

--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -76,6 +76,8 @@ function ReplyRow({
   });
   const replyAvatarUrl =
     profiles?.[reply.pubkey.toLowerCase()]?.avatarUrl ?? null;
+  const replyAuthorIsAgent =
+    profiles?.[reply.pubkey.toLowerCase()]?.isAgent === true;
   const showDelete = onDelete && canDeleteReply(reply, currentPubkey);
   const {
     mentionNames: replyMentionNames,
@@ -88,14 +90,19 @@ function ReplyRow({
       data-forum-event-id={reply.eventId}
     >
       <div className="flex items-center gap-2">
-        <UserProfilePopover pubkey={reply.pubkey}>
+        <UserProfilePopover
+          pubkey={reply.pubkey}
+          role={replyAuthorIsAgent ? "bot" : undefined}
+        >
           <button
             className="flex items-center gap-2 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             type="button"
           >
             <UserAvatar
+              accent={replyAuthorIsAgent}
               avatarUrl={replyAvatarUrl}
               displayName={replyAuthorLabel}
+              shape={replyAuthorIsAgent ? "squircle" : "circle"}
               size="sm"
             />
             <span className="text-sm font-medium text-foreground hover:underline">
@@ -211,6 +218,8 @@ export function ForumThreadPanel({
   });
   const postAvatarUrl =
     profiles?.[post.pubkey.toLowerCase()]?.avatarUrl ?? null;
+  const postAuthorIsAgent =
+    profiles?.[post.pubkey.toLowerCase()]?.isAgent === true;
 
   return (
     <div className={cn("flex h-full flex-col", channelChrome.contentPadding)}>
@@ -239,14 +248,19 @@ export function ForumThreadPanel({
           data-forum-event-id={post.eventId}
         >
           <div className="flex items-center gap-2">
-            <UserProfilePopover pubkey={post.pubkey}>
+            <UserProfilePopover
+              pubkey={post.pubkey}
+              role={postAuthorIsAgent ? "bot" : undefined}
+            >
               <button
                 className="flex items-center gap-2 rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                 type="button"
               >
                 <UserAvatar
+                  accent={postAuthorIsAgent}
                   avatarUrl={postAvatarUrl}
                   displayName={postAuthorLabel}
+                  shape={postAuthorIsAgent ? "squircle" : "circle"}
                 />
                 <span className="text-sm font-semibold text-foreground hover:underline">
                   {postAuthorLabel}

--- a/desktop/src/features/home/ui/FeedSection.tsx
+++ b/desktop/src/features/home/ui/FeedSection.tsx
@@ -206,6 +206,11 @@ export function FeedSection({
                         profiles,
                         preferResolvedSelfLabel: true,
                       })}
+                      shape={
+                        profiles?.[item.pubkey.toLowerCase()]?.isAgent === true
+                          ? "squircle"
+                          : "circle"
+                      }
                       size="xs"
                     />
                     {resolveUserLabel({

--- a/desktop/src/features/home/ui/InboxListPane.tsx
+++ b/desktop/src/features/home/ui/InboxListPane.tsx
@@ -386,13 +386,17 @@ export function InboxListPane({
                 triggerElement="span"
               >
                 <span
-                  className="inline-flex shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                  className={cn(
+                    "inline-flex shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                    isSenderAgent ? "rounded-[30%]" : "rounded-full",
+                  )}
                   data-testid={`home-inbox-avatar-${item.id}`}
                 >
                   <UserAvatar
                     avatarUrl={item.avatarUrl}
                     className="h-9 w-9"
                     displayName={item.senderLabel}
+                    shape={isSenderAgent ? "squircle" : "circle"}
                     size="md"
                   />
                 </span>

--- a/desktop/src/features/home/ui/InboxMessageRow.tsx
+++ b/desktop/src/features/home/ui/InboxMessageRow.tsx
@@ -194,11 +194,18 @@ export function InboxMessageRow({
               role={profileRole}
               triggerElement="span"
             >
-              <span className="inline-flex shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring">
+              <span
+                className={cn(
+                  "inline-flex shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                  isAuthorAgent ? "rounded-[30%]" : "rounded-full",
+                )}
+              >
                 <UserAvatar
+                  accent={isAuthorAgent}
                   avatarUrl={message.avatarUrl}
                   className="h-9 w-9 shrink-0"
                   displayName={message.authorLabel}
+                  shape={isAuthorAgent ? "squircle" : "circle"}
                   size="md"
                 />
               </span>

--- a/desktop/src/features/home/ui/ProjectInboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/ProjectInboxDetailPane.tsx
@@ -43,6 +43,8 @@ export function ProjectInboxDetailPane({
   const authorLabel = resolveUserLabel({ profiles, pubkey: authorPubkey });
   const authorAvatarUrl =
     profiles?.[normalizePubkey(authorPubkey)]?.avatarUrl ?? null;
+  const authorIsAgent =
+    profiles?.[normalizePubkey(authorPubkey)]?.isAgent === true;
   const inboxTitle = `${authorLabel} sent you ${
     workItem.type === "pull-request" ? "a review" : "a task"
   }`;
@@ -98,6 +100,7 @@ export function ProjectInboxDetailPane({
                 avatarUrl={authorAvatarUrl}
                 className="shrink-0"
                 displayName={authorLabel}
+                shape={authorIsAgent ? "squircle" : "circle"}
                 size="sm"
                 testId="project-inbox-author-avatar"
               />

--- a/desktop/src/features/home/ui/RecentNotesSection.tsx
+++ b/desktop/src/features/home/ui/RecentNotesSection.tsx
@@ -65,6 +65,7 @@ export function RecentNotesSection({
                 <UserAvatar
                   avatarUrl={profile?.avatarUrl ?? null}
                   displayName={displayName}
+                  shape={isAgent ? "squircle" : "circle"}
                   size="sm"
                 />
                 {isAgent ? (

--- a/desktop/src/features/huddle/components/AddAgentDialog.tsx
+++ b/desktop/src/features/huddle/components/AddAgentDialog.tsx
@@ -181,6 +181,7 @@ export function AddAgentDialog({
                       avatarUrl={agent.avatar_url}
                       className="h-9 w-9 shrink-0 text-xs"
                       label={agent.name}
+                      shape="squircle"
                     />
                     <span className="min-w-0 flex-1 truncate text-sm font-medium">
                       {agent.name}

--- a/desktop/src/features/huddle/components/ParticipantList.tsx
+++ b/desktop/src/features/huddle/components/ParticipantList.tsx
@@ -373,7 +373,7 @@ export function HuddleParticipantsControl({
             trigger={
               <button
                 aria-label={`Voice settings for ${participant.displayName}`}
-                className="inline-flex shrink-0 cursor-pointer rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                className="inline-flex shrink-0 cursor-pointer rounded-[30%] outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 data-testid="huddle-agent-voice-menu-trigger"
                 type="button"
               >
@@ -443,7 +443,8 @@ function ParticipantAvatar({
   return (
     <span
       className={cn(
-        "buzz-huddle-speaking-avatar relative z-0 inline-flex shrink-0 rounded-full",
+        "buzz-huddle-speaking-avatar relative z-0 inline-flex shrink-0",
+        participant.isAgent ? "rounded-[30%]" : "rounded-full",
         sizeClass,
       )}
       data-testid="huddle-participant-avatar"
@@ -452,7 +453,8 @@ function ParticipantAvatar({
       <ProfileAvatar
         avatarUrl={participant.avatarUrl}
         label={participant.displayName}
-        className="h-full w-full rounded-full border-2 border-black text-2xs"
+        className="h-full w-full border-2 border-black text-2xs"
+        shape={participant.isAgent ? "squircle" : "circle"}
       />
     </span>
   );

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -15,6 +15,7 @@ export type TimelineThreadSummaryParticipant = {
   id: string;
   author: string;
   avatarUrl: string | null;
+  isAgent?: boolean;
 };
 
 export type TimelineThreadSummary = {
@@ -152,6 +153,9 @@ export function buildDescendantStatsByMessageId(
       id: participantKey,
       author: message.author,
       avatarUrl: message.avatarUrl ?? null,
+      ...(message.isAgent === true || message.role === "bot"
+        ? { isAgent: true }
+        : {}),
     };
 
     let ancestorId = message.parentId ?? null;
@@ -233,6 +237,9 @@ function participantFromMessage(
     id: message.pubkey ?? message.id,
     author: message.author,
     avatarUrl: message.avatarUrl ?? null,
+    ...(message.isAgent === true || message.role === "bot"
+      ? { isAgent: true }
+      : {}),
   };
 }
 
@@ -403,6 +410,9 @@ function buildRelayThreadSummary(
         id: pubkey,
         author: profiles?.[pubkey.toLowerCase()]?.displayName ?? pubkey,
         avatarUrl: profiles?.[pubkey.toLowerCase()]?.avatarUrl ?? null,
+        ...(profiles?.[pubkey.toLowerCase()]?.isAgent === true
+          ? { isAgent: true }
+          : {}),
       })),
   };
 }

--- a/desktop/src/features/messages/ui/ComposerAddressControls.tsx
+++ b/desktop/src/features/messages/ui/ComposerAddressControls.tsx
@@ -69,6 +69,7 @@ function AddressedAgentAvatar({
         avatarUrl={agent.avatarUrl}
         className="h-4.5 w-4.5"
         displayName={agent.displayName}
+        shape="squircle"
         size="xs"
         testId="composer-address-lock-avatar"
       />

--- a/desktop/src/features/messages/ui/DirectMessageIntroAvatarStack.tsx
+++ b/desktop/src/features/messages/ui/DirectMessageIntroAvatarStack.tsx
@@ -5,6 +5,7 @@ import { UserAvatar } from "@/shared/ui/UserAvatar";
 export type DirectMessageIntroParticipant = {
   avatarUrl: string | null;
   displayName: string;
+  isAgent?: boolean;
   pubkey: string;
 };
 
@@ -28,23 +29,23 @@ export function DirectMessageIntroAvatarStack({
           pubkey={participant.pubkey}
           triggerAriaLabel={`Open profile for ${participant.displayName}`}
           triggerElement="span"
+          role={participant.isAgent ? "bot" : undefined}
         >
           <span
             className={index > 0 ? "-ml-5" : ""}
             data-testid="message-dm-intro-avatar-stack-participant"
-            style={{
-              zIndex: index + 1,
-              ...(index < stackItemCount - 1 && {
-                mask: "radial-gradient(circle 34px at calc(100% + 10px) 50%, transparent 99%, #fff 100%)",
-                WebkitMask:
-                  "radial-gradient(circle 34px at calc(100% + 10px) 50%, transparent 99%, #fff 100%)",
-              }),
-            }}
+            style={{ zIndex: index + 1 }}
           >
             <UserAvatar
+              accent={participant.isAgent === true}
               avatarUrl={participant.avatarUrl}
-              className="h-[60px] w-[60px] text-base"
+              className={
+                index < stackItemCount - 1
+                  ? "h-[60px] w-[60px] text-base ring-2 ring-background"
+                  : "h-[60px] w-[60px] text-base"
+              }
               displayName={participant.displayName}
+              shape={participant.isAgent ? "squircle" : "circle"}
               size="md"
             />
           </span>

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -325,6 +325,11 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
                     <UserAvatar
                       avatarUrl={suggestion.avatarUrl ?? null}
                       displayName={suggestion.displayName}
+                      shape={
+                        suggestion.isAgent || suggestion.kind === "persona"
+                          ? "squircle"
+                          : "circle"
+                      }
                       size="xs"
                       testId="mention-suggestion-avatar"
                     />

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -60,17 +60,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { getAgentAddressMentionPubkeys } from "@/features/messages/lib/agentAddressMention.mjs";
 import { getVisibleAgentAddressPubkeys } from "@/features/messages/lib/getVisibleAgentAddressPubkeys";
 import { MessageAgentAddressPrefix } from "./MessageAgentAddressPrefix";
-
 const DiffMessage = React.lazy(() => import("./DiffMessage"));
 const DiffMessageExpanded = React.lazy(() => import("./DiffMessageExpanded"));
-
 export type ThreadDepthGuideAction = {
   active?: boolean;
   depth: number;
   label: string;
   message: TimelineMessage;
 };
-
 export const MessageRow = React.memo(
   function MessageRow({
     channelId = null,
@@ -265,18 +262,18 @@ export const MessageRow = React.memo(
       (message.pubkey && isKnownAgentPubkey(message.pubkey))
         ? "bot"
         : message.role;
+    const isAuthorAgent =
+      message.isAgent === true || profilePopoverRole === "bot";
     const agentMentionPubkeysByName = React.useMemo(() => {
       if (!mentionPubkeysByName) {
         return undefined;
       }
-
       const values: Record<string, string> = {};
       for (const [name, pubkey] of Object.entries(mentionPubkeysByName)) {
         if (isKnownAgentPubkey(pubkey)) {
           values[name] = pubkey;
         }
       }
-
       return Object.keys(values).length > 0 ? values : undefined;
     }, [isKnownAgentPubkey, mentionPubkeysByName]);
     const addressedAgentPubkeys = React.useMemo(() => {
@@ -293,7 +290,6 @@ export const MessageRow = React.memo(
           pubkeys={addressedAgentPubkeys}
         />
       ) : undefined;
-
     const imetaByUrl = React.useMemo(
       () => (message.tags ? parseImetaTags(message.tags) : undefined),
       [message.tags],
@@ -464,7 +460,9 @@ export const MessageRow = React.memo(
 
     const isThreadReplyLayout = layoutVariant === "thread-reply";
     const guideBleedRem = isThreadReplyLayout ? 0.25 : 0;
-    const avatarButtonRadiusClass = "rounded-full";
+    const avatarButtonRadiusClass = isAuthorAgent
+      ? "rounded-[30%]"
+      : "rounded-full";
 
     const showRespondToIndicator =
       message.respondTo === "anyone" || message.respondTo === "allowlist";
@@ -476,6 +474,7 @@ export const MessageRow = React.memo(
           avatarUrl={message.avatarUrl ?? null}
           className="shrink-0"
           displayName={message.author}
+          shape={isAuthorAgent ? "squircle" : "circle"}
           testId="message-avatar"
         />
         {showRespondToIndicator &&

--- a/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
@@ -33,21 +33,20 @@ function ParticipantAvatar({
 }) {
   return (
     <div
-      className={index > 0 ? "-ml-1" : ""}
+      className={cn("relative", index > 0 && "-ml-1")}
       data-testid="message-thread-summary-participant"
       style={{
         zIndex: index + 1,
-        ...(index < participantCount - 1 && {
-          mask: "radial-gradient(circle 14px at calc(100% + 6px) 50%, transparent 99%, #fff 100%)",
-          WebkitMask:
-            "radial-gradient(circle 14px at calc(100% + 6px) 50%, transparent 99%, #fff 100%)",
-        }),
       }}
     >
       <UserAvatar
         avatarUrl={participant.avatarUrl}
-        className="h-6 w-6 text-2xs"
+        className={cn(
+          "h-6 w-6 text-2xs",
+          index < participantCount - 1 && "ring-2 ring-background",
+        )}
         displayName={participant.author}
+        shape={participant.isAgent ? "squircle" : "circle"}
         size="sm"
       />
     </div>

--- a/desktop/src/features/messages/ui/NewMessageResultRow.tsx
+++ b/desktop/src/features/messages/ui/NewMessageResultRow.tsx
@@ -113,6 +113,7 @@ export function NewMessageResultRow({
           className="h-8 w-8 text-xs shadow-none"
           iconClassName="h-4 w-4"
           label={name}
+          shape={user.isAgent ? "squircle" : "circle"}
         />
         <div className="min-w-0 flex-1">
           {user.isAgent ? (

--- a/desktop/src/features/messages/ui/SystemMessageAvatars.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageAvatars.tsx
@@ -68,9 +68,11 @@ export function SystemMessageAvatar({
     );
     const avatar = (
       <UserAvatar
+        accent={isSingleAgent}
         avatarUrl={resolveAvatarUrl(singlePubkey, profiles)}
         className="!h-9 !w-9 shrink-0 text-2xs"
         displayName={actorLabel}
+        shape={isSingleAgent ? "squircle" : "circle"}
         testId="system-message-avatar"
       />
     );
@@ -82,7 +84,10 @@ export function SystemMessageAvatar({
           role={isSingleAgent ? "bot" : undefined}
         >
           <button
-            className="shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            className={cn(
+              "shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+              isSingleAgent ? "rounded-[30%]" : "rounded-full",
+            )}
             data-testid="system-message-avatar"
             type="button"
           >
@@ -106,20 +111,30 @@ export function SystemMessageAvatar({
     profiles,
     preferResolvedSelfLabel: true,
   });
+  const isTargetAgent = isKnownAgentPubkey(
+    targetPubkey,
+    profiles,
+    personaLookup,
+    agentPubkeys,
+  );
   const dualAvatar = (
     <div
       className="relative h-9 w-9 shrink-0"
       data-testid="system-message-avatar"
     >
       <UserAvatar
+        accent={isActorAgent}
         avatarUrl={resolveAvatarUrl(actorPubkey, profiles)}
         className="!h-7 !w-7 border-2 border-background text-2xs"
         displayName={actorLabel}
+        shape={isActorAgent ? "squircle" : "circle"}
       />
       <UserAvatar
+        accent={isTargetAgent}
         avatarUrl={resolveAvatarUrl(targetPubkey, profiles)}
         className="!absolute !bottom-0 !right-0 !h-7 !w-7 border-2 border-background text-2xs"
         displayName={targetLabel}
+        shape={isTargetAgent ? "squircle" : "circle"}
       />
     </div>
   );
@@ -130,7 +145,10 @@ export function SystemMessageAvatar({
       role={isActorAgent ? "bot" : undefined}
     >
       <button
-        className="shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        className={cn(
+          "shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+          isActorAgent ? "rounded-[30%]" : "rounded-full",
+        )}
         type="button"
       >
         {dualAvatar}
@@ -140,11 +158,15 @@ export function SystemMessageAvatar({
 }
 
 export function MembershipAvatarStack({
+  agentPubkeys,
   currentPubkey,
+  personaLookup,
   profiles,
   pubkeys,
 }: {
+  agentPubkeys?: ReadonlySet<string>;
   currentPubkey: string | undefined;
+  personaLookup?: Map<string, string>;
   profiles: UserProfileLookup | undefined;
   pubkeys: readonly string[];
 }) {
@@ -158,6 +180,12 @@ export function MembershipAvatarStack({
       role="img"
     >
       {visiblePubkeys.map((pubkey, index) => {
+        const isAgent = isKnownAgentPubkey(
+          pubkey,
+          profiles,
+          personaLookup,
+          agentPubkeys,
+        );
         const label = resolveUserLabel({
           pubkey,
           currentPubkey,
@@ -171,20 +199,16 @@ export function MembershipAvatarStack({
             key={pubkey}
             style={{ zIndex: index + 1 }}
           >
-            <span
-              className="block"
-              style={{
-                ...(index < visiblePubkeys.length - 1 && {
-                  mask: "radial-gradient(circle 14px at calc(100% + 6px) 50%, transparent 99%, #fff 100%)",
-                  WebkitMask:
-                    "radial-gradient(circle 14px at calc(100% + 6px) 50%, transparent 99%, #fff 100%)",
-                }),
-              }}
-            >
+            <span className="block">
               <UserAvatar
+                accent={isAgent}
                 avatarUrl={resolveAvatarUrl(pubkey, profiles)}
-                className="h-6 w-6 text-2xs"
+                className={cn(
+                  "h-6 w-6 text-2xs",
+                  index < visiblePubkeys.length - 1 && "ring-2 ring-background",
+                )}
                 displayName={label}
+                shape={isAgent ? "squircle" : "circle"}
                 size="sm"
               />
             </span>

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -417,6 +417,12 @@ function MemberNamesInlineList({
                 {hiddenTargets.map((pubkey) => (
                   <div className="flex items-center gap-2" key={pubkey}>
                     <UserAvatar
+                      accent={isKnownAgentPubkey(
+                        pubkey,
+                        profiles,
+                        personaLookup,
+                        agentPubkeys,
+                      )}
                       avatarUrl={resolveAvatarUrl(pubkey, profiles)}
                       className="!h-5 !w-5 shrink-0 text-3xs"
                       displayName={resolveDisplayLabel(
@@ -424,6 +430,16 @@ function MemberNamesInlineList({
                         currentPubkey,
                         profiles,
                       )}
+                      shape={
+                        isKnownAgentPubkey(
+                          pubkey,
+                          profiles,
+                          personaLookup,
+                          agentPubkeys,
+                        )
+                          ? "squircle"
+                          : "circle"
+                      }
                     />
                     <span className="min-w-0 truncate">
                       {resolveDisplayLabel(pubkey, currentPubkey, profiles)}
@@ -865,7 +881,9 @@ export const SystemMessageRow = React.memo(function SystemMessageRow({
           <div className="flex justify-center">
             <div className="flex min-w-0 max-w-[min(40rem,80%)] items-center gap-2">
               <MembershipAvatarStack
+                agentPubkeys={agentPubkeys}
                 currentPubkey={currentPubkey}
+                personaLookup={personaLookup}
                 profiles={profiles}
                 pubkeys={membershipPubkeys}
               />

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -101,7 +101,8 @@ export function TypingIndicatorRow({
                 <div
                   key={pubkey}
                   className={cn(
-                    "relative shrink-0 rounded-lg ring-1 ring-background",
+                    "relative shrink-0 ring-1 ring-background",
+                    profile?.isAgent ? "rounded-[30%]" : "rounded-full",
                     isActivityVariant ? "h-4 w-4" : "h-5 w-5",
                     index > 0 && "-ml-1.5",
                   )}
@@ -118,6 +119,7 @@ export function TypingIndicatorRow({
                     iconClassName={
                       isActivityVariant ? "h-2.5 w-2.5" : "h-4 w-4"
                     }
+                    shape={profile?.isAgent ? "squircle" : "circle"}
                   />
                 </div>
               );

--- a/desktop/src/features/profile/ui/ProfileAvatar.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatar.tsx
@@ -27,6 +27,7 @@ type ProfileAvatarProps = {
   iconClassName?: string;
   imageClassName?: string;
   plain?: boolean;
+  shape?: "circle" | "squircle";
   testId?: string;
   /**
    * Suppress every network image request for a publisher-controlled avatar
@@ -49,6 +50,7 @@ export function ProfileAvatar({
   iconClassName,
   imageClassName,
   plain = false,
+  shape = "circle",
   testId,
   untrusted = false,
 }: ProfileAvatarProps) {
@@ -94,6 +96,7 @@ export function ProfileAvatar({
     <Avatar
       className={cn(
         "shrink-0 text-primary shadow-xs",
+        shape === "squircle" && "rounded-[30%]",
         // Animated avatars carry their own backdrop disc and transparent
         // surroundings — any container fill would flatten the pop-out.
         plain || animated ? "bg-transparent shadow-none" : "bg-primary/20",

--- a/desktop/src/features/profile/ui/ProfileAvatarWithStatus.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatarWithStatus.tsx
@@ -22,6 +22,7 @@ type ProfileAvatarWithStatusProps = {
   geometry?: ProfileAvatarStatusGeometry;
   iconClassName?: string;
   label: string;
+  shape?: "circle" | "squircle";
   size: number;
   status?: PresenceStatus;
   statusTestId?: string;
@@ -56,6 +57,7 @@ export function ProfileAvatarWithStatus({
   geometry = DEFAULT_HOVER_PROFILE_STATUS_GEOMETRY,
   iconClassName,
   label,
+  shape = "circle",
   size,
   status,
   statusTestId,
@@ -97,15 +99,17 @@ export function ProfileAvatarWithStatus({
       }
       badgeBox={badgeBox}
       className={cn("inline-flex", className)}
+      cornerRadius={shape === "squircle" ? size * 0.3 : undefined}
       curve={STATUS_DOT_MASK_CURVE}
       cutout={cutout}
       size={size}
     >
       <ProfileAvatar
         avatarUrl={avatarUrl}
-        className={cn("h-full w-full rounded-full", avatarClassName)}
+        className={cn("h-full w-full", avatarClassName)}
         iconClassName={iconClassName}
         label={label}
+        shape={shape}
         testId={testId}
       />
     </MaskedAvatarBadgeFrame>

--- a/desktop/src/features/profile/ui/SelectedRecipientChip.tsx
+++ b/desktop/src/features/profile/ui/SelectedRecipientChip.tsx
@@ -50,7 +50,8 @@ export function SelectedRecipientChip({
       <button
         aria-label={`Remove ${label}`}
         className={cn(
-          "group/remove-recipient relative h-5 w-5 shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60",
+          "group/remove-recipient relative h-5 w-5 shrink-0 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60",
+          user.isAgent ? "rounded-[30%]" : "rounded-full",
           poofOnRemove && POOF_TRIGGER_CLASS,
           poofOnRemove && POOF_ORIGIN_CLASS,
           poofOnRemove && POOF_POINTER_ORIGIN_CLASS,
@@ -75,8 +76,14 @@ export function SelectedRecipientChip({
           className="h-5 w-5 text-3xs shadow-none transition-opacity group-hover/remove-recipient:opacity-0 group-focus-visible/remove-recipient:opacity-0"
           iconClassName="h-2.5 w-2.5"
           label={label}
+          shape={user.isAgent ? "squircle" : "circle"}
         />
-        <span className="absolute inset-0 flex items-center justify-center rounded-full bg-foreground text-background opacity-0 transition-opacity group-hover/remove-recipient:opacity-100 group-focus-visible/remove-recipient:opacity-100">
+        <span
+          className={cn(
+            "absolute inset-0 flex items-center justify-center bg-foreground text-background opacity-0 transition-opacity group-hover/remove-recipient:opacity-100 group-focus-visible/remove-recipient:opacity-100",
+            user.isAgent ? "rounded-[30%]" : "rounded-full",
+          )}
+        >
           <X aria-hidden="true" className="h-3 w-3" />
         </span>
       </button>

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -642,6 +642,7 @@ function ProfileHero({
         }
         badgeBox={PROFILE_HERO_PRESENCE_BADGE.shell}
         className="h-20 w-20"
+        cornerRadius={isBot ? 24 : undefined}
         curve={STATUS_DOT_MASK_CURVE}
         cutout={PROFILE_HERO_PRESENCE_BADGE.cutout}
         size={80}
@@ -652,6 +653,7 @@ function ProfileHero({
           iconClassName="h-8 w-8"
           label={displayName}
           plain
+          shape={isBot ? "squircle" : "circle"}
           testId="user-profile-avatar"
         />
       </MaskedAvatarBadgeFrame>

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -381,6 +381,7 @@ function UserProfilePopoverBody({
         className="h-10 w-10"
         iconClassName="h-5 w-5"
         label={displayName}
+        shape={isBotProfile ? "squircle" : "circle"}
         size={40}
         status={presenceStatus ?? "offline"}
         statusTestId="user-profile-popover-presence-badge"

--- a/desktop/src/features/projects/ui/IssueAssigneesRow.tsx
+++ b/desktop/src/features/projects/ui/IssueAssigneesRow.tsx
@@ -68,7 +68,10 @@ export function IssueAssigneeFacepile({
         const label = labelForPubkey(pubkey, profiles);
         return (
           <span
-            className="inline-flex rounded-full ring-1 ring-background"
+            className={cn(
+              "inline-flex ring-1 ring-background",
+              profile?.isAgent ? "rounded-[30%]" : "rounded-full",
+            )}
             key={pubkey}
             title={`Assigned to ${label}`}
           >
@@ -76,6 +79,7 @@ export function IssueAssigneeFacepile({
               accent={profile?.isAgent === true}
               avatarUrl={profile?.avatarUrl ?? null}
               displayName={label}
+              shape={profile?.isAgent ? "squircle" : "circle"}
               size="xs"
             />
           </span>
@@ -232,6 +236,7 @@ export function IssueAssigneesRow({
             accent={profile?.isAgent === true}
             avatarUrl={profile?.avatarUrl ?? null}
             displayName={label}
+            shape={profile?.isAgent ? "squircle" : "circle"}
             size="xs"
           />
         );
@@ -241,7 +246,10 @@ export function IssueAssigneesRow({
               {canUnassign ? (
                 <button
                   aria-label={`Unassign ${label}`}
-                  className="group relative inline-flex rounded-full"
+                  className={cn(
+                    "group relative inline-flex",
+                    profile?.isAgent ? "rounded-[30%]" : "rounded-full",
+                  )}
                   data-testid={`${testIdPrefix}-unassign-${normalizePubkey(pubkey)}`}
                   disabled={unassignMutation.isPending}
                   onClick={() => {
@@ -250,7 +258,12 @@ export function IssueAssigneesRow({
                   type="button"
                 >
                   {avatar}
-                  <span className="absolute inset-0 flex items-center justify-center rounded-full bg-background/80 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+                  <span
+                    className={cn(
+                      "absolute inset-0 flex items-center justify-center bg-background/80 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100",
+                      profile?.isAgent ? "rounded-[30%]" : "rounded-full",
+                    )}
+                  >
                     <X className="h-3 w-3 text-foreground" />
                   </span>
                 </button>
@@ -361,6 +374,7 @@ export function IssueAssigneesRow({
                         accent={candidate.isAgent}
                         avatarUrl={candidate.avatarUrl}
                         displayName={label}
+                        shape={candidate.isAgent ? "squircle" : "circle"}
                         size="xs"
                       />
                       <span className="min-w-0 flex-1">

--- a/desktop/src/features/projects/ui/ProjectAuthorIdentity.tsx
+++ b/desktop/src/features/projects/ui/ProjectAuthorIdentity.tsx
@@ -40,6 +40,7 @@ export function ProjectAuthorIdentity({
                 accent={profile?.isAgent === true}
                 avatarUrl={profile?.avatarUrl ?? null}
                 displayName={label}
+                shape={profile?.isAgent ? "squircle" : "circle"}
                 fallbackDelayMs={0}
                 size="xs"
                 testId={testId ? `${testId}-avatar` : undefined}
@@ -61,6 +62,7 @@ export function ProjectAuthorIdentity({
               accent={profile?.isAgent === true}
               avatarUrl={profile?.avatarUrl ?? null}
               displayName={label}
+              shape={profile?.isAgent ? "squircle" : "circle"}
               fallbackDelayMs={0}
               size="sm"
             />

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -85,7 +85,10 @@ export function ProjectPeopleStack({
             <UserProfilePopover pubkey={pubkey} triggerElement="span">
               <button
                 aria-label={`View ${label}'s profile`}
-                className="inline-flex rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                className={cn(
+                  "inline-flex focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                  profile?.isAgent ? "rounded-[30%]" : "rounded-full",
+                )}
                 type="button"
               >
                 <UserAvatar
@@ -95,6 +98,7 @@ export function ProjectPeopleStack({
                   avatarUrl={profile?.avatarUrl ?? null}
                   className="ring-2 ring-card"
                   displayName={label}
+                  shape={profile?.isAgent ? "squircle" : "circle"}
                   size="xs"
                 />
               </button>

--- a/desktop/src/features/projects/ui/ProjectEntityListRow.tsx
+++ b/desktop/src/features/projects/ui/ProjectEntityListRow.tsx
@@ -43,8 +43,9 @@ export function ProjectEntityFacepile({
             >
               <UserAvatar
                 avatarUrl={profiles?.[pubkey]?.avatarUrl ?? null}
-                className="rounded-full ring-2 ring-background"
+                className="ring-2 ring-background"
                 displayName={label}
+                shape={profiles?.[pubkey]?.isAgent ? "squircle" : "circle"}
                 size="xs"
               />
             </span>
@@ -57,14 +58,18 @@ export function ProjectEntityFacepile({
             triggerElement="span"
           >
             <button
-              className={cn("rounded-full", index > 0 && "-ml-1.5")}
+              className={cn(
+                profiles?.[pubkey]?.isAgent ? "rounded-[30%]" : "rounded-full",
+                index > 0 && "-ml-1.5",
+              )}
               title={label}
               type="button"
             >
               <UserAvatar
                 avatarUrl={profiles?.[pubkey]?.avatarUrl ?? null}
-                className="rounded-full ring-2 ring-background"
+                className="ring-2 ring-background"
                 displayName={label}
+                shape={profiles?.[pubkey]?.isAgent ? "squircle" : "circle"}
                 size="xs"
               />
             </button>

--- a/desktop/src/features/projects/ui/ProjectIssueCommentTimeline.tsx
+++ b/desktop/src/features/projects/ui/ProjectIssueCommentTimeline.tsx
@@ -120,6 +120,11 @@ export function ProjectIssueCommentTimeline({
                 }
                 className="relative z-10 bg-background ring-1 ring-border/70"
                 displayName={authorLabel}
+                shape={
+                  profiles?.[normalizePubkey(comment.author)]?.isAgent
+                    ? "squircle"
+                    : "circle"
+                }
                 size="xs"
               />
             </div>

--- a/desktop/src/features/projects/ui/ProjectProfileIdentity.tsx
+++ b/desktop/src/features/projects/ui/ProjectProfileIdentity.tsx
@@ -45,6 +45,7 @@ export function ProfileIdentityButton({
         avatarUrl={avatarUrl}
         className={avatarClassName}
         displayName={label}
+        shape={isAgent ? "squircle" : "circle"}
         size={avatarSize}
       />
       {showLabel ? (

--- a/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
@@ -862,6 +862,9 @@ export function RepositoryFilesPanel({
                         accent={latestCommitProfile?.isAgent === true}
                         avatarUrl={latestCommitProfile?.avatarUrl ?? null}
                         displayName={latestCommitAuthorLabel}
+                        shape={
+                          latestCommitProfile?.isAgent ? "squircle" : "circle"
+                        }
                         size="sm"
                       />
                       <p className="min-w-0 flex-1 truncate text-foreground">

--- a/desktop/src/features/projects/ui/ProjectRepositoryUnavailableState.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryUnavailableState.tsx
@@ -50,6 +50,7 @@ function RepositoryOwnerReference({
             accent={ownerIsAgent}
             avatarUrl={ownerAvatarUrl ?? null}
             displayName={ownerName}
+            shape={ownerIsAgent ? "squircle" : "circle"}
             fallbackDelayMs={0}
             size="xs"
             testId="repository-owner-avatar"

--- a/desktop/src/features/projects/ui/ProjectsActivityFeed.tsx
+++ b/desktop/src/features/projects/ui/ProjectsActivityFeed.tsx
@@ -405,13 +405,17 @@ function ActivityCard({
             <UserProfilePopover pubkey={item.actorPubkey} triggerElement="span">
               <button
                 aria-label={`View ${actorLabel}'s profile`}
-                className="pointer-events-auto relative z-10 shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                className={cn(
+                  "pointer-events-auto relative z-10 shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                  profile?.isAgent ? "rounded-[30%]" : "rounded-full",
+                )}
                 type="button"
               >
                 <UserAvatar
                   accent={profile?.isAgent === true}
                   avatarUrl={profile?.avatarUrl ?? null}
                   displayName={actorLabel}
+                  shape={profile?.isAgent ? "squircle" : "circle"}
                   size={compact ? "xs" : "md"}
                 />
               </button>
@@ -422,6 +426,7 @@ function ActivityCard({
               avatarUrl={profile?.avatarUrl ?? null}
               className="relative z-10 shrink-0"
               displayName={actorLabel}
+              shape={profile?.isAgent ? "squircle" : "circle"}
               size={compact ? "xs" : "md"}
             />
           )}

--- a/desktop/src/features/projects/ui/ProjectsAgentPromptPage.tsx
+++ b/desktop/src/features/projects/ui/ProjectsAgentPromptPage.tsx
@@ -671,6 +671,7 @@ export function ProjectsAgentPromptPage({
                         avatarUrl={avatarUrlFor(selectedAgent.pubkey)}
                         className="shrink-0"
                         displayName={selectedAgent.name}
+                        shape="squircle"
                         size="xs"
                       />
                     ) : null}
@@ -697,6 +698,7 @@ export function ProjectsAgentPromptPage({
                           avatarUrl={avatarUrlFor(candidate.pubkey)}
                           className="mr-2 shrink-0"
                           displayName={candidate.name}
+                          shape="squircle"
                           size="xs"
                         />
                         <span className="min-w-0 truncate">

--- a/desktop/src/features/projects/ui/ProjectsOverviewRail.tsx
+++ b/desktop/src/features/projects/ui/ProjectsOverviewRail.tsx
@@ -58,7 +58,10 @@ function OverviewPerson({
     <Tooltip>
       <TooltipTrigger asChild>
         <span
-          className="relative inline-flex rounded-full ring-2 ring-background"
+          className={cn(
+            "relative inline-flex ring-2 ring-background",
+            profile?.isAgent ? "rounded-[30%]" : "rounded-full",
+          )}
           data-overview-person=""
           style={{ zIndex: stackSize - index }}
         >
@@ -66,6 +69,7 @@ function OverviewPerson({
             accent={profile?.isAgent === true}
             avatarUrl={profile?.avatarUrl ?? null}
             displayName={label}
+            shape={profile?.isAgent ? "squircle" : "circle"}
             size="sm"
           />
         </span>

--- a/desktop/src/features/projects/ui/PullRequestReviewersRow.tsx
+++ b/desktop/src/features/projects/ui/PullRequestReviewersRow.tsx
@@ -261,6 +261,7 @@ export function PullRequestReviewersRow({
                     accent={candidate.isAgent}
                     avatarUrl={candidate.avatarUrl}
                     displayName={label}
+                    shape={candidate.isAgent ? "squircle" : "circle"}
                     size="xs"
                   />
                   <span className="min-w-0 flex-1">

--- a/desktop/src/features/pulse/ui/AgentActivityCard.tsx
+++ b/desktop/src/features/pulse/ui/AgentActivityCard.tsx
@@ -66,7 +66,11 @@ export function AgentActivityCard({
             className="relative flex shrink-0 rounded-xl pt-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             type="button"
           >
-            <UserAvatar avatarUrl={avatarUrl} displayName={displayName} />
+            <UserAvatar
+              avatarUrl={avatarUrl}
+              displayName={displayName}
+              shape="squircle"
+            />
             <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
           </button>
         </UserProfilePopover>

--- a/desktop/src/features/pulse/ui/NoteCard.tsx
+++ b/desktop/src/features/pulse/ui/NoteCard.tsx
@@ -71,13 +71,18 @@ function ReplyParentContext({
     : null;
   const parentAvatarUrl =
     cachedProfile?.avatarUrl ?? fetchedProfile?.avatarUrl ?? null;
+  const parentIsAgent = cachedProfile?.isAgent === true;
   const parentSnippet = parentNote ? noteSnippet(parentNote.content) : null;
 
   return (
     <div className="mt-2 truncate rounded-xl border border-border/50 bg-muted/25 px-3 py-2 text-xs text-muted-foreground">
       {parentNote ? (
         <div className="flex min-w-0 items-center gap-1.5">
-          <UserProfilePopover pubkey={parentNote.pubkey} triggerElement="span">
+          <UserProfilePopover
+            pubkey={parentNote.pubkey}
+            role={parentIsAgent ? "bot" : undefined}
+            triggerElement="span"
+          >
             <button
               className="flex shrink-0 rounded-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
               type="button"
@@ -86,6 +91,7 @@ function ReplyParentContext({
                 avatarUrl={parentAvatarUrl}
                 className="!h-4 !w-4 shrink-0"
                 displayName={parentDisplayName ?? "Parent note author"}
+                shape={parentIsAgent ? "squircle" : "circle"}
               />
             </button>
           </UserProfilePopover>
@@ -170,6 +176,7 @@ export function NoteCard({
             avatarUrl={avatarUrl}
             className="!h-9 !w-9 shrink-0"
             displayName={displayName}
+            shape={isAgent ? "squircle" : "circle"}
           />
           {isAgent ? (
             <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
@@ -299,6 +306,7 @@ export function NoteCard({
                     avatarUrl={currentUserAvatarUrl}
                     className="!h-8 !w-8 shrink-0"
                     displayName={currentUserDisplayName}
+                    shape={currentUserProfile?.isAgent ? "squircle" : "circle"}
                   />
                   <span className="max-w-32 truncate text-sm font-medium text-foreground">
                     {currentUserDisplayName}

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -397,6 +397,9 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
                       avatarUrl={currentProfile?.avatarUrl ?? null}
                       className="!h-7 !w-7 shrink-0"
                       displayName={currentDisplayName}
+                      shape={
+                        currentProfile?.isAgent === true ? "squircle" : "circle"
+                      }
                     />
                     <span className="max-w-32 truncate text-sm font-medium text-foreground">
                       {currentDisplayName}

--- a/desktop/src/features/reminders/ui/RemindersPanel.tsx
+++ b/desktop/src/features/reminders/ui/RemindersPanel.tsx
@@ -37,6 +37,7 @@ export type ReminderSource = {
   avatarUrl: string | null;
   channel: Channel | null;
   channelLabel: string;
+  isAgent?: boolean;
 };
 
 export function useReminderSources(reminders: readonly Reminder[]) {
@@ -80,6 +81,9 @@ export function useReminderSources(reminders: readonly Reminder[]) {
         channelLabel: channel
           ? resolveChannelDisplayLabel(channel, currentPubkey, profiles)
           : UNKNOWN_CHANNEL_LABEL,
+        ...(profiles?.[normalizePubkey(target.authorPubkey)]?.isAgent === true
+          ? { isAgent: true }
+          : {}),
       });
     }
     return map;
@@ -194,6 +198,7 @@ function ReminderRow({
               avatarUrl={source.avatarUrl}
               className="h-4 w-4 shrink-0"
               displayName={source.authorLabel}
+              shape={source.isAgent ? "squircle" : "circle"}
               size="xs"
             />
             <span className="truncate font-medium text-foreground">
@@ -444,6 +449,7 @@ export function ReminderDetailPane({
                 avatarUrl={source.avatarUrl}
                 className="h-6 w-6"
                 displayName={source.authorLabel}
+                shape={source.isAgent ? "squircle" : "circle"}
                 size="sm"
               />
               <span className="font-medium text-foreground">

--- a/desktop/src/features/search/ui/SearchResultItem.tsx
+++ b/desktop/src/features/search/ui/SearchResultItem.tsx
@@ -233,6 +233,8 @@ export function MessageResultBody({
   });
   const avatarUrl =
     resultProfiles?.[hit.pubkey.toLowerCase()]?.avatarUrl ?? null;
+  const authorIsAgent =
+    resultProfiles?.[hit.pubkey.toLowerCase()]?.isAgent === true;
 
   return (
     <div className="min-w-0 flex-1">
@@ -245,6 +247,7 @@ export function MessageResultBody({
           <UserAvatar
             avatarUrl={avatarUrl}
             displayName={authorLabel}
+            shape={authorIsAgent ? "squircle" : "circle"}
             size="xs"
           />
           {authorLabel}

--- a/desktop/src/features/search/ui/TopbarSearch.tsx
+++ b/desktop/src/features/search/ui/TopbarSearch.tsx
@@ -1,6 +1,5 @@
 import { Search } from "lucide-react";
 import * as React from "react";
-
 import { resolveUserLabel } from "@/features/profile/lib/identity";
 import { getMinimumSearchQueryLength } from "@/features/search/hooks";
 import { parseSearchOperators } from "@/features/search/lib/parseSearchOperators";
@@ -30,7 +29,6 @@ import {
 } from "@/shared/ui/mentionChip";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
-
 type TopbarSearchProps = {
   channelLabels?: Record<string, string>;
   channels: Channel[];
@@ -48,7 +46,6 @@ type TopbarSearchProps = {
   scopeFocusRequest?: number;
   variant?: "bar" | "icon";
 };
-
 const MAX_SEARCH_SUGGESTIONS = 4;
 const SEARCH_RESULT_LIMIT = 40;
 const SEARCH_SECTION_TITLE_CLASS =
@@ -61,23 +58,18 @@ const SEARCH_RESULT_SECTION_ORDER = [
   "messages",
   "actions",
 ] as const;
-
 type SearchResultSectionKey = (typeof SEARCH_RESULT_SECTION_ORDER)[number];
-
 type SearchResultSection = {
   key: SearchResultSectionKey;
   results: SearchResult[];
   title: string;
 };
-
 type SearchHitContextLabel = {
   channelLabel: string | null;
   text: string;
 };
-
 function formatRelativeTime(unixSeconds: number) {
   const diff = Math.floor(Date.now() / 1_000) - unixSeconds;
-
   if (diff < 60) {
     return "just now";
   }
@@ -736,6 +728,12 @@ export function TopbarSearch({
               pubkey: result.hit.pubkey,
               preferResolvedSelfLabel: true,
             })}
+            shape={
+              resultProfiles?.[result.hit.pubkey.toLowerCase()]?.isAgent ===
+              true
+                ? "squircle"
+                : "circle"
+            }
             size="md"
           />
         ) : result.kind === "user" ? (
@@ -743,6 +741,7 @@ export function TopbarSearch({
             avatarUrl={result.user.avatarUrl}
             className="h-7 w-7"
             displayName={userDisplayName ?? result.user.pubkey}
+            shape={result.user.isAgent ? "squircle" : "circle"}
             size="sm"
           />
         ) : (

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -418,6 +418,7 @@ export function AppSidebar({
             accessibleLabel: participant.label,
             avatarUrl: participant.avatarUrl,
             channelId,
+            isAgent: participant.isAgent,
             label: dmChannelLabels[channelId] ?? participant.label,
           },
         ];

--- a/desktop/src/features/sidebar/ui/ChannelActivityPopover.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelActivityPopover.tsx
@@ -78,11 +78,13 @@ function RowActionButton({
 }
 
 function ThreadPreviewRow({
+  isAgent,
   item,
   onMarkRead,
   onOpen,
   onRemindLater,
 }: {
+  isAgent: boolean;
   item: InboxItem;
   onMarkRead: () => void;
   onOpen: () => void;
@@ -104,6 +106,7 @@ function ThreadPreviewRow({
           avatarUrl={item.avatarUrl}
           className="h-9 w-9 shrink-0"
           displayName={item.senderLabel}
+          shape={isAgent ? "squircle" : "circle"}
           size="md"
         />
         <div className="min-w-0 flex-1">
@@ -168,6 +171,7 @@ function WorkingAgentRow({
         avatarUrl={avatarUrl}
         className="h-9 w-9 shrink-0"
         displayName={name}
+        shape="squircle"
         size="md"
       />
       <div className="min-w-0 flex-1">
@@ -424,6 +428,10 @@ export function ChannelActivityPopover({
             {activityItems.length > 0
               ? activityItems.map((item) => (
                   <ThreadPreviewRow
+                    isAgent={
+                      profiles?.[normalizePubkey(item.item.pubkey)]?.isAgent ===
+                      true
+                    }
                     item={item}
                     key={item.conversationId}
                     onMarkRead={() => handleMarkRead(item)}

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -7,6 +7,7 @@ export type UnreadDmPreview = {
   avatarUrl: string | null;
   channelId: string;
   label: string;
+  isAgent?: boolean;
 };
 
 export function canPreviewUnreadDm(
@@ -111,6 +112,7 @@ export function MoreUnreadButton({
                       avatarUrl={preview.avatarUrl}
                       className="ring-2 ring-primary"
                       displayName={preview.label}
+                      shape={preview.isAgent ? "squircle" : "circle"}
                       fallbackDelayMs={0}
                       size="xs"
                       testId={`sidebar-unread-dm-avatar-${preview.channelId}`}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -153,6 +153,7 @@ function ChannelWorkingBadge({
 export type SidebarDmParticipant = {
   avatarUrl: string | null;
   label: string;
+  isAgent?: boolean;
   pubkey: string;
 };
 
@@ -197,6 +198,7 @@ function DmChannelIcon({
           geometry={DM_AVATAR_STATUS_GEOMETRY}
           iconClassName="h-3.5 w-3.5"
           label={primaryParticipant.label}
+          shape={primaryParticipant.isAgent ? "squircle" : "circle"}
           size={DM_AVATAR_SIZE}
           status={presenceStatus}
           statusTestId={`channel-presence-${channelName}`}

--- a/desktop/src/features/sidebar/useDmSidebarMetadata.ts
+++ b/desktop/src/features/sidebar/useDmSidebarMetadata.ts
@@ -130,6 +130,10 @@ export function useDmSidebarMetadata({
                 profiles: dmProfiles,
                 pubkey: participant.pubkey,
               }),
+              ...(dmProfiles?.[participant.pubkey.toLowerCase()]?.isAgent ===
+              true
+                ? { isAgent: true }
+                : {}),
               pubkey: participant.pubkey,
             })),
           ];

--- a/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
@@ -342,6 +342,7 @@ function AuthorOption({
       <UserAvatar
         avatarUrl={candidate.avatarUrl}
         displayName={label}
+        shape={candidate.isAgent ? "squircle" : "circle"}
         size="md"
       />
       <span className="min-w-0 max-w-full">

--- a/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
@@ -632,6 +632,7 @@ export const WorkflowFormBuilder = React.forwardRef<
     <WorkflowRichTriggerDescription
       avatarUrl={triggerPresentation.avatarUrl}
       description={compactTriggerDescription}
+      isAgent={triggerPresentation.isAgent}
       label={triggerPresentation.label}
       loading={triggerPresentation.loading}
     />

--- a/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
@@ -444,6 +444,7 @@ function MessageOption({
         <UserAvatar
           avatarUrl={profile?.avatarUrl ?? null}
           displayName={author}
+          shape={profile?.isAgent === true ? "squircle" : "circle"}
           size="sm"
         />
       ) : null}

--- a/desktop/src/features/workflows/ui/WorkflowRichTriggerDescription.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowRichTriggerDescription.tsx
@@ -6,11 +6,13 @@ import { splitWorkflowAuthorDescription } from "./workflowTriggerDescription";
 export function WorkflowRichTriggerDescription({
   avatarUrl,
   description,
+  isAgent,
   label,
   loading,
 }: {
   avatarUrl?: string | null;
   description: string;
+  isAgent?: boolean;
   label?: string | null;
   loading?: boolean;
 }) {
@@ -41,6 +43,7 @@ export function WorkflowRichTriggerDescription({
         className="h-4 w-4"
         displayName={label}
         fallbackDelayMs={0}
+        shape={isAgent ? "squircle" : "circle"}
         size="xs"
         testId="workflow-trigger-author-avatar"
       />

--- a/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
@@ -77,10 +77,12 @@ function ExclusionStrike() {
 function AuthorConditionSummary({
   avatarUrl,
   excluded,
+  isAgent,
   label,
 }: {
   avatarUrl: string | null;
   excluded: boolean;
+  isAgent?: boolean;
   label: string;
 }) {
   return (
@@ -91,6 +93,7 @@ function AuthorConditionSummary({
           className="h-6 w-6"
           displayName={label}
           fallbackDelayMs={0}
+          shape={isAgent ? "squircle" : "circle"}
           size="xs"
         />
         {excluded ? <ExclusionStrike /> : null}
@@ -326,6 +329,7 @@ export function WorkflowTriggerConditions({
                     <AuthorConditionSummary
                       avatarUrl={triggerPresentation.avatarUrl}
                       excluded={condition.operator === "not_equals"}
+                      isAgent={triggerPresentation.isAgent}
                       label={authorSummary}
                     />
                   ) : messageSummary ? (

--- a/desktop/src/features/workflows/ui/useWorkflowAuthorPresentation.ts
+++ b/desktop/src/features/workflows/ui/useWorkflowAuthorPresentation.ts
@@ -10,6 +10,7 @@ const FULL_HEX_PUBKEY = /^[0-9a-f]{64}$/i;
 export type WorkflowAuthorPresentation = {
   avatarUrl: string | null;
   description: string;
+  isAgent: boolean;
   label: string | null;
   loading: boolean;
   pubkey: string | null;
@@ -50,6 +51,7 @@ export function useWorkflowAuthorPresentation(
       authorLabel: label ?? undefined,
       authorLoading: loading,
     }),
+    isAgent: profile?.isAgent === true,
     label,
     loading,
     pubkey,

--- a/desktop/src/features/workflows/ui/useWorkflowListAuthorPresentations.ts
+++ b/desktop/src/features/workflows/ui/useWorkflowListAuthorPresentations.ts
@@ -44,6 +44,7 @@ export function useWorkflowListAuthorPresentations(
         workflowId,
         {
           avatarUrl: profile?.avatarUrl ?? null,
+          isAgent: profile?.isAgent === true,
           label: loading
             ? null
             : resolveUserLabel({

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -37,6 +37,7 @@ type UserAvatarProps = {
   displayName: string;
   size?: UserAvatarSize;
   accent?: boolean;
+  shape?: "circle" | "squircle";
   className?: string;
   fallbackDelayMs?: number;
   testId?: string;
@@ -47,6 +48,7 @@ export function UserAvatar({
   displayName,
   size = "md",
   accent = false,
+  shape,
   className,
   fallbackDelayMs = 200,
   testId,
@@ -61,12 +63,20 @@ export function UserAvatar({
     : avatarUrl
       ? rewriteRelayUrl(avatarUrl)
       : null;
+  const resolvedShape = shape ?? "circle";
+  const radiusClass =
+    resolvedShape === "squircle" ? "rounded-[30%]" : "rounded-full";
 
   return (
     <Avatar
       // Animated avatars carry their own backdrop disc and transparent
       // surroundings — any container fill would flatten the pop-out.
-      className={cn(sizeClasses[size], !animated && "shadow-xs", className)}
+      className={cn(
+        sizeClasses[size],
+        radiusClass,
+        !animated && "shadow-xs",
+        className,
+      )}
       data-testid={testId}
       onMouseEnter={animated ? () => setIsHovered(true) : undefined}
       onMouseLeave={animated ? () => setIsHovered(false) : undefined}

--- a/desktop/src/shared/ui/VideoPlayer.tsx
+++ b/desktop/src/shared/ui/VideoPlayer.tsx
@@ -43,7 +43,6 @@ import {
   saveReviewPlaybackPosition,
   setVideoReviewOpen,
 } from "./videoPlayerState";
-
 type VideoReviewReaction = {
   emoji: string;
   emojiUrl?: string;
@@ -55,11 +54,11 @@ type VideoReviewReaction = {
     avatarUrl: string | null;
   }>;
 };
-
 export type VideoReviewComment = {
   id: string;
   author: string;
   avatarUrl?: string | null;
+  isAgent?: boolean;
   body: string;
   createdAt: number;
   time: string;
@@ -67,7 +66,6 @@ export type VideoReviewComment = {
   parentId?: string | null;
   reactions?: VideoReviewReaction[];
 };
-
 export type VideoReviewContext = {
   channelId?: string | null;
   channelName?: string;
@@ -91,7 +89,6 @@ export type VideoReviewContext = {
   rootEventId?: string;
   title?: string;
 };
-
 type VideoPlayerProps = {
   src: string;
   poster?: string;
@@ -108,14 +105,12 @@ type VideoPlayerProps = {
   /** imeta `filename`, used as the save-dialog name. */
   filename?: string;
 };
-
 type TimecodedComment = {
   comment: VideoReviewComment;
   seconds: number | null;
   timecode: string | null;
   text: string;
 };
-
 const QUICK_REACTIONS = ["😂", "😍", "😮", "🙌", "👍", "👎"];
 const DEFAULT_PLAYBACK_SPEED = 1;
 const INLINE_SPEED_CONTROL_MIN_WIDTH = 220;
@@ -1813,6 +1808,9 @@ function VideoReviewDialog({
                                   avatarUrl={item.comment.avatarUrl ?? null}
                                   className="h-4 w-4 shadow-none"
                                   displayName={item.comment.author}
+                                  shape={
+                                    item.comment.isAgent ? "squircle" : "circle"
+                                  }
                                   size="xs"
                                 />
                               </button>
@@ -2143,6 +2141,7 @@ function VideoReviewCommentBody({
           avatarUrl={item.comment.avatarUrl ?? null}
           className="h-6 w-6 shadow-none"
           displayName={item.comment.author}
+          shape={item.comment.isAgent ? "squircle" : "circle"}
           size="xs"
         />
         <p className="truncate text-sm font-semibold text-foreground">

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -624,8 +624,38 @@ test("team cards use the thread-style overlapping avatar stack", async ({
   );
   expect(boxes[1]?.left).toBeLessThan(boxes[0]?.right ?? 0);
   expect(boxes[2]?.left).toBeLessThan(boxes[1]?.right ?? 0);
-  await expect(avatars.first()).not.toHaveCSS("mask-image", "none");
-  await expect(avatars.last()).toHaveCSS("mask-image", "none");
+  const overlapStyles = await avatars.evaluateAll((elements) =>
+    elements.map((element) => {
+      const styles = getComputedStyle(element);
+      const outline = getComputedStyle(element, "::before");
+      return {
+        maskImage: styles.maskImage,
+        outlineBackground: outline.backgroundColor,
+        outlineBorderRadius: outline.borderRadius,
+        outlineInset: outline.inset,
+      };
+    }),
+  );
+  expect(overlapStyles).toEqual([
+    {
+      maskImage: "none",
+      outlineBackground: "rgb(255, 255, 255)",
+      outlineBorderRadius: "calc(30% + 2px)",
+      outlineInset: "-2px",
+    },
+    {
+      maskImage: "none",
+      outlineBackground: "rgb(255, 255, 255)",
+      outlineBorderRadius: "calc(30% + 2px)",
+      outlineInset: "-2px",
+    },
+    {
+      maskImage: "none",
+      outlineBackground: "rgb(255, 255, 255)",
+      outlineBorderRadius: "calc(30% + 2px)",
+      outlineInset: "-2px",
+    },
+  ]);
   const avatarSurfaceStyles = await avatars
     .locator(":scope > *")
     .evaluateAll((elements) =>

--- a/mobile/lib/features/activity/activity_page/inbox_row.dart
+++ b/mobile/lib/features/activity/activity_page/inbox_row.dart
@@ -472,6 +472,7 @@ class _RowAvatar extends StatelessWidget {
           color: context.colors.onPrimaryContainer,
         ),
       ),
+      isAgent: profile?.ownerPubkey != null,
     );
   }
 }

--- a/mobile/lib/features/activity/activity_page/inbox_row.dart
+++ b/mobile/lib/features/activity/activity_page/inbox_row.dart
@@ -89,6 +89,9 @@ class _InboxRow extends HookConsumerWidget {
     final knownAgentPubkeys = channel == null
         ? ref.watch(knownAgentPubkeysProvider)
         : ref.watch(agentMentionPubkeysProvider(channel!.id));
+    final isAgent =
+        knownAgentPubkeys.contains(senderPubkey) ||
+        profile?.ownerPubkey != null;
     final agentMentionPubkeys = agentPubkeysWithProfileOwners(
       knownAgentPubkeys: knownAgentPubkeys,
       profileOwnedAgentPubkeys: [
@@ -223,6 +226,7 @@ class _InboxRow extends HookConsumerWidget {
                             _RowAvatar(
                               pubkey: item.item.pubkey,
                               profile: profile,
+                              isAgent: isAgent,
                             ),
                             const SizedBox(width: messageAvatarContentGap),
                             Expanded(
@@ -453,8 +457,13 @@ class _InboxSwipeAction extends StatelessWidget {
 class _RowAvatar extends StatelessWidget {
   final String pubkey;
   final UserProfile? profile;
+  final bool isAgent;
 
-  const _RowAvatar({required this.pubkey, required this.profile});
+  const _RowAvatar({
+    required this.pubkey,
+    required this.profile,
+    required this.isAgent,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -472,7 +481,7 @@ class _RowAvatar extends StatelessWidget {
           color: context.colors.onPrimaryContainer,
         ),
       ),
-      isAgent: profile?.ownerPubkey != null,
+      isAgent: isAgent,
     );
   }
 }

--- a/mobile/lib/features/channels/add_members_sheet.dart
+++ b/mobile/lib/features/channels/add_members_sheet.dart
@@ -191,6 +191,7 @@ class AddChannelMembersSheet extends HookConsumerWidget {
                                   backgroundColor:
                                       context.colors.primaryContainer,
                                   fallback: Text(user.initial),
+                                  isAgent: user.isAgent,
                                 ),
                                 title: Text(
                                   user.label,

--- a/mobile/lib/features/channels/channel_detail_page/app_bar.dart
+++ b/mobile/lib/features/channels/channel_detail_page/app_bar.dart
@@ -231,6 +231,12 @@ class _DmAppBarTitle extends ConsumerWidget {
     }
 
     final avatarUrl = profile?.avatarUrl;
+    final isAgent =
+        (otherPubkey != null &&
+            ref
+                .watch(agentMentionPubkeysProvider(channel.id))
+                .contains(otherPubkey)) ||
+        profile?.ownerPubkey != null;
     final animatedAvatar = parseAnimatedAvatarUrl(avatarUrl);
     final initial =
         profile?.initial ??
@@ -249,7 +255,10 @@ class _DmAppBarTitle extends ConsumerWidget {
           key: const ValueKey('dm-header-avatar'),
           size: _dmHeaderAvatarSize,
           geometry: AvatarBadgeMaskGeometry.presenceDot,
-          avatar: ClipOval(
+          avatar: ClipRRect(
+            borderRadius: BorderRadius.circular(
+              isAgent ? _dmHeaderAvatarSize * 0.3 : _dmHeaderAvatarSize / 2,
+            ),
             child: ColoredBox(
               color: animatedAvatar == null
                   ? context.colors.primaryContainer

--- a/mobile/lib/features/channels/channel_detail_page/huddle_call_avatar.dart
+++ b/mobile/lib/features/channels/channel_detail_page/huddle_call_avatar.dart
@@ -124,6 +124,7 @@ class _HuddleCallAvatar extends HookConsumerWidget {
       fallbackLabel: fallbackLabel,
       isSelf: isSelf,
     );
+    final isAgent = profile?.isAgent == true || fallbackLabel != null;
 
     final semanticStates = [
       label,
@@ -183,7 +184,14 @@ class _HuddleCallAvatar extends HookConsumerWidget {
                             width: speakingRingSize,
                             height: speakingRingSize,
                             decoration: BoxDecoration(
-                              shape: BoxShape.circle,
+                              shape: isAgent
+                                  ? BoxShape.rectangle
+                                  : BoxShape.circle,
+                              borderRadius: isAgent
+                                  ? BorderRadius.circular(
+                                      speakingRingSize * 0.3,
+                                    )
+                                  : null,
                               color: context.colors.primary.withValues(
                                 alpha: 0.07,
                               ),
@@ -207,7 +215,14 @@ class _HuddleCallAvatar extends HookConsumerWidget {
                                 width: avatarRadius * 2,
                                 height: avatarRadius * 2,
                                 decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
+                                  shape: isAgent
+                                      ? BoxShape.rectangle
+                                      : BoxShape.circle,
+                                  borderRadius: isAgent
+                                      ? BorderRadius.circular(
+                                          avatarRadius * 0.6,
+                                        )
+                                      : null,
                                   color: context.colors.primaryContainer,
                                 ),
                                 alignment: Alignment.center,
@@ -230,6 +245,7 @@ class _HuddleCallAvatar extends HookConsumerWidget {
                                   size: fallbackIconSize,
                                   color: context.colors.onPrimaryContainer,
                                 ),
+                                isAgent: isAgent,
                               ),
                       ),
                     ],

--- a/mobile/lib/features/channels/channel_detail_page/huddle_participant_overlay.dart
+++ b/mobile/lib/features/channels/channel_detail_page/huddle_participant_overlay.dart
@@ -170,6 +170,7 @@ class _HuddleParticipantSpotlight extends ConsumerWidget {
       fallbackLabel: fallbackLabel,
       isSelf: isSelf,
     );
+    final isAgent = profile?.isAgent == true || fallbackLabel != null;
 
     return Semantics(
       label: active ? '$label, speaking' : label,
@@ -193,7 +194,12 @@ class _HuddleParticipantSpotlight extends ConsumerWidget {
                     : const Duration(milliseconds: 180),
                 padding: EdgeInsets.all(active ? Grid.xxs : Grid.half),
                 decoration: BoxDecoration(
-                  shape: BoxShape.circle,
+                  shape: isAgent ? BoxShape.rectangle : BoxShape.circle,
+                  borderRadius: isAgent
+                      ? BorderRadius.circular(
+                          (_huddleParticipantSpotlightRadius + Grid.half) * 0.6,
+                        )
+                      : null,
                   color: context.colors.primary.withValues(
                     alpha: active ? 0.18 : 0.08,
                   ),
@@ -207,6 +213,7 @@ class _HuddleParticipantSpotlight extends ConsumerWidget {
                     size: 56,
                     color: context.colors.onPrimaryContainer,
                   ),
+                  isAgent: isAgent,
                 ),
               ),
               const SizedBox(height: Grid.twelve),
@@ -348,6 +355,9 @@ class _HuddleParticipantRoster extends ConsumerWidget {
                                       size: 22,
                                       color: context.colors.onPrimaryContainer,
                                     ),
+                                    isAgent:
+                                        profile?.isAgent == true ||
+                                        fallbackLabels[pubkey] != null,
                                   ),
                                   const SizedBox(width: Grid.twelve),
                                   Expanded(

--- a/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
@@ -34,6 +34,9 @@ class _MessageBubble extends HookConsumerWidget {
         ref.watch(userCacheProvider.select((cache) => cache[pk])) ??
         ref.read(userCacheProvider.notifier).get(pk);
     final displayName = profile?.label ?? shortPubkey(message.pubkey);
+    final isAgent =
+        ref.watch(agentMentionPubkeysProvider(currentChannelId)).contains(pk) ||
+        profile?.ownerPubkey != null;
     final canManageMessage =
         currentPubkey?.toLowerCase() == pk ||
         (profile?.ownerPubkey != null &&
@@ -148,6 +151,7 @@ class _MessageBubble extends HookConsumerWidget {
                           child: _UserAvatar(
                             profile: profile,
                             pubkey: message.pubkey,
+                            isAgent: isAgent,
                           ),
                         )
                       else
@@ -318,11 +322,13 @@ Widget _messageTimestamp(BuildContext context, int createdAt, {Key? key}) {
 class _UserAvatar extends StatelessWidget {
   final UserProfile? profile;
   final String pubkey;
+  final bool isAgent;
   final double size;
 
   const _UserAvatar({
     required this.profile,
     required this.pubkey,
+    required this.isAgent,
     this.size = messageAvatarSize,
   });
 
@@ -347,7 +353,7 @@ class _UserAvatar extends StatelessWidget {
                   fontWeight: FontWeight.w600,
                 ),
       ),
-      isAgent: profile?.ownerPubkey != null,
+      isAgent: isAgent,
     );
   }
 }

--- a/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
@@ -347,6 +347,7 @@ class _UserAvatar extends StatelessWidget {
                   fontWeight: FontWeight.w600,
                 ),
       ),
+      isAgent: profile?.ownerPubkey != null,
     );
   }
 }

--- a/mobile/lib/features/channels/channel_detail_page/system_rows.dart
+++ b/mobile/lib/features/channels/channel_detail_page/system_rows.dart
@@ -382,6 +382,8 @@ class _MessageStyleSystemMessageContent extends StatelessWidget {
           child: _UserAvatar(
             profile: userCache[displayPubkey.toLowerCase()],
             pubkey: displayPubkey,
+            isAgent:
+                userCache[displayPubkey.toLowerCase()]?.ownerPubkey != null,
             size: messageAvatarSize,
           ),
         ),

--- a/mobile/lib/features/channels/channel_details_page.dart
+++ b/mobile/lib/features/channels/channel_details_page.dart
@@ -672,6 +672,7 @@ class _ChannelMemberPreviewRow extends StatelessWidget {
         radius: 20,
         backgroundColor: context.colors.primaryContainer,
         fallback: Text(label.isEmpty ? '?' : label[0].toUpperCase()),
+        isAgent: member.isBot,
       ),
       title: Text.rich(
         TextSpan(

--- a/mobile/lib/features/channels/channel_management_provider.dart
+++ b/mobile/lib/features/channels/channel_management_provider.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../shared/auth/auth.dart';
 import '../../shared/custom_emoji/custom_emoji.dart';
 import '../../shared/custom_emoji/custom_emoji_provider.dart';
+import '../../shared/crypto/nip_oa.dart';
 import '../../shared/mentions/agent_identity_provider.dart';
 import '../../shared/relay/relay.dart';
 import '../profile/profile_provider.dart';
@@ -155,12 +156,14 @@ class DirectoryUser {
   final String? displayName;
   final String? avatarUrl;
   final String? nip05Handle;
+  final bool isAgent;
 
   const DirectoryUser({
     required this.pubkey,
     this.displayName,
     this.avatarUrl,
     this.nip05Handle,
+    this.isAgent = false,
   });
 
   String get label {
@@ -313,6 +316,7 @@ List<DirectoryUser> directoryUsersFromProfileEvents(List<NostrEvent> events) {
           displayName: profile.displayName,
           avatarUrl: profile.avatarUrl,
           nip05Handle: profile.nip05,
+          isAgent: verifiedOaOwnerPubkey(event.tags, event.pubkey) != null,
         ),
   ]..sort((a, b) {
     final labelComparison = a.label.toLowerCase().compareTo(
@@ -381,6 +385,16 @@ final relayDirectoryUsersProvider =
                   displayName: profile.displayName,
                   avatarUrl: profile.avatarUrl,
                   nip05Handle: profile.nip05,
+                  isAgent:
+                      verifiedOaOwnerPubkey(
+                        profileEvents
+                            .firstWhere(
+                              (event) => event.pubkey.toLowerCase() == pubkey,
+                            )
+                            .tags,
+                        pubkey,
+                      ) !=
+                      null,
                 )
               else
                 DirectoryUser(pubkey: pubkey),

--- a/mobile/lib/features/channels/channels_page/channel_tile.dart
+++ b/mobile/lib/features/channels/channels_page/channel_tile.dart
@@ -214,6 +214,7 @@ class _DmAvatar extends ConsumerWidget {
                 fontWeight: FontWeight.w600,
               ),
             ),
+            isAgent: profile?.isAgent == true,
           ),
           Positioned(
             right: -1,

--- a/mobile/lib/features/channels/channels_page/sheets.dart
+++ b/mobile/lib/features/channels/channels_page/sheets.dart
@@ -745,6 +745,7 @@ class _NewDirectMessageSheet extends HookConsumerWidget {
                               fontWeight: FontWeight.w600,
                             ),
                           ),
+                          isAgent: user.isAgent,
                         ),
                         title: Text(
                           user.label,
@@ -847,6 +848,7 @@ class _SelectedDmRecipientChip extends StatelessWidget {
                           fontWeight: FontWeight.w600,
                         ),
                       ),
+                      isAgent: user.isAgent,
                     ),
                     const SizedBox(width: Grid.xxs),
                     Flexible(

--- a/mobile/lib/features/channels/compose_bar/suggestions.dart
+++ b/mobile/lib/features/channels/compose_bar/suggestions.dart
@@ -53,6 +53,7 @@ class _MentionSuggestions extends StatelessWidget {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
+                isAgent: candidate.isAgent,
               ),
               title: Text(name, style: context.textTheme.titleSmall),
               subtitle: _MentionSuggestionInfo.build(

--- a/mobile/lib/features/channels/members_sheet.dart
+++ b/mobile/lib/features/channels/members_sheet.dart
@@ -227,7 +227,11 @@ class _MemberTile extends ConsumerWidget {
 
     return ListTile(
       contentPadding: EdgeInsets.zero,
-      leading: _MemberAvatar(avatarUrl: profile?.avatarUrl, initial: initial),
+      leading: _MemberAvatar(
+        avatarUrl: profile?.avatarUrl,
+        initial: initial,
+        isAgent: member.isBot || profile?.isAgent == true,
+      ),
       title: Text(label),
       subtitle: isWorking
           ? Row(
@@ -439,8 +443,13 @@ class _RoleSelector extends StatelessWidget {
 class _MemberAvatar extends StatelessWidget {
   final String? avatarUrl;
   final String initial;
+  final bool isAgent;
 
-  const _MemberAvatar({required this.avatarUrl, required this.initial});
+  const _MemberAvatar({
+    required this.avatarUrl,
+    required this.initial,
+    required this.isAgent,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -448,6 +457,7 @@ class _MemberAvatar extends StatelessWidget {
       imageUrl: avatarUrl,
       radius: 20,
       fallback: Text(initial),
+      isAgent: isAgent,
     );
   }
 }

--- a/mobile/lib/features/channels/reaction_row.dart
+++ b/mobile/lib/features/channels/reaction_row.dart
@@ -462,6 +462,7 @@ class _ReactorTile extends StatelessWidget {
         initial:
             profile?.initial ??
             (pubkey.isNotEmpty ? pubkey[0].toUpperCase() : '?'),
+        isAgent: profile?.isAgent == true,
       ),
       title: Text(
         displayName,
@@ -488,8 +489,13 @@ class _ReactorTile extends StatelessWidget {
 class _ReactorAvatar extends StatelessWidget {
   final String? avatarUrl;
   final String initial;
+  final bool isAgent;
 
-  const _ReactorAvatar({required this.avatarUrl, required this.initial});
+  const _ReactorAvatar({
+    required this.avatarUrl,
+    required this.initial,
+    required this.isAgent,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -497,6 +503,7 @@ class _ReactorAvatar extends StatelessWidget {
       imageUrl: avatarUrl,
       radius: 20,
       fallback: Text(initial),
+      isAgent: isAgent,
     );
   }
 }

--- a/mobile/lib/features/channels/small_avatar.dart
+++ b/mobile/lib/features/channels/small_avatar.dart
@@ -4,7 +4,7 @@ import '../../shared/theme/theme.dart';
 import '../../shared/widgets/avatar_image.dart';
 import '../../shared/profile/user_profile.dart';
 
-/// 20px circle avatar used in thread summary rows and other compact lists.
+/// 20px avatar used in thread summary rows and other compact lists.
 class SmallAvatar extends StatelessWidget {
   final String pubkey;
   final Map<String, UserProfile> userCache;
@@ -23,12 +23,14 @@ class SmallAvatar extends StatelessWidget {
     final avatarUrl = profile?.avatarUrl;
     final initial =
         profile?.initial ?? (pubkey.isNotEmpty ? pubkey[0].toUpperCase() : '?');
+    final isAgent = profile?.ownerPubkey != null;
 
     return Container(
       width: size,
       height: size,
       decoration: BoxDecoration(
-        shape: BoxShape.circle,
+        shape: isAgent ? BoxShape.rectangle : BoxShape.circle,
+        borderRadius: isAgent ? BorderRadius.circular(size * 0.3) : null,
         border: Border.all(color: context.colors.surface, width: 1.5),
       ),
       child: AvatarImage(
@@ -43,6 +45,7 @@ class SmallAvatar extends StatelessWidget {
             color: context.colors.onPrimaryContainer,
           ),
         ),
+        isAgent: isAgent,
       ),
     );
   }

--- a/mobile/lib/features/channels/thread_detail_page/avatar.dart
+++ b/mobile/lib/features/channels/thread_detail_page/avatar.dart
@@ -3,8 +3,13 @@ part of '../thread_detail_page.dart';
 class _Avatar extends StatelessWidget {
   final UserProfile? profile;
   final String pubkey;
+  final bool isAgent;
 
-  const _Avatar({required this.profile, required this.pubkey});
+  const _Avatar({
+    required this.profile,
+    required this.pubkey,
+    required this.isAgent,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +28,7 @@ class _Avatar extends StatelessWidget {
           fontWeight: FontWeight.w600,
         ),
       ),
-      isAgent: profile?.ownerPubkey != null,
+      isAgent: isAgent,
     );
   }
 }

--- a/mobile/lib/features/channels/thread_detail_page/avatar.dart
+++ b/mobile/lib/features/channels/thread_detail_page/avatar.dart
@@ -23,6 +23,7 @@ class _Avatar extends StatelessWidget {
           fontWeight: FontWeight.w600,
         ),
       ),
+      isAgent: profile?.ownerPubkey != null,
     );
   }
 }

--- a/mobile/lib/features/channels/thread_detail_page/thread_message.dart
+++ b/mobile/lib/features/channels/thread_detail_page/thread_message.dart
@@ -40,6 +40,9 @@ class _ThreadMessage extends HookConsumerWidget {
         ref.watch(userCacheProvider.select((cache) => cache[pk])) ??
         ref.read(userCacheProvider.notifier).get(pk);
     final displayName = profile?.label ?? shortPubkey(message.pubkey);
+    final isAgent =
+        ref.watch(agentMentionPubkeysProvider(channelId)).contains(pk) ||
+        profile?.ownerPubkey != null;
     final canManageMessage =
         currentPubkey?.toLowerCase() == pk ||
         (profile?.ownerPubkey != null &&
@@ -158,6 +161,7 @@ class _ThreadMessage extends HookConsumerWidget {
                             child: _Avatar(
                               profile: profile,
                               pubkey: message.pubkey,
+                              isAgent: isAgent,
                             ),
                           )
                         else

--- a/mobile/lib/features/forum/forum_post_card.dart
+++ b/mobile/lib/features/forum/forum_post_card.dart
@@ -54,6 +54,9 @@ class ForumPostCard extends HookConsumerWidget {
         ref.watch(userCacheProvider.select((cache) => cache[pk])) ??
         ref.read(userCacheProvider.notifier).get(pk);
     final displayName = profile?.label ?? _shortPubkey(post.pubkey);
+    final isAgent =
+        ref.watch(agentMentionPubkeysProvider(post.channelId)).contains(pk) ||
+        profile?.ownerPubkey != null;
     final profileMentionNames = ref.watch(
       userCacheProvider.select(
         (cache) => _buildMentionNames(post.mentionPubkeys, cache),
@@ -112,7 +115,11 @@ class ForumPostCard extends HookConsumerWidget {
                 GestureDetector(
                   behavior: HitTestBehavior.opaque,
                   onTap: () => showUserProfileSheet(context, post.pubkey),
-                  child: _PostAvatar(profile: profile, pubkey: post.pubkey),
+                  child: _PostAvatar(
+                    profile: profile,
+                    pubkey: post.pubkey,
+                    isAgent: isAgent,
+                  ),
                 ),
                 const SizedBox(width: Grid.xxs),
                 Expanded(
@@ -308,8 +315,13 @@ class ForumPostCard extends HookConsumerWidget {
 class _PostAvatar extends StatelessWidget {
   final UserProfile? profile;
   final String pubkey;
+  final bool isAgent;
 
-  const _PostAvatar({required this.profile, required this.pubkey});
+  const _PostAvatar({
+    required this.profile,
+    required this.pubkey,
+    required this.isAgent,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -328,7 +340,7 @@ class _PostAvatar extends StatelessWidget {
           fontWeight: FontWeight.w600,
         ),
       ),
-      isAgent: profile?.ownerPubkey != null,
+      isAgent: isAgent,
     );
   }
 }

--- a/mobile/lib/features/forum/forum_post_card.dart
+++ b/mobile/lib/features/forum/forum_post_card.dart
@@ -328,6 +328,7 @@ class _PostAvatar extends StatelessWidget {
           fontWeight: FontWeight.w600,
         ),
       ),
+      isAgent: profile?.ownerPubkey != null,
     );
   }
 }

--- a/mobile/lib/features/forum/forum_thread_page.dart
+++ b/mobile/lib/features/forum/forum_thread_page.dart
@@ -359,9 +359,11 @@ class _OriginalPost extends ConsumerWidget {
               GestureDetector(
                 onTap: () => showUserProfileSheet(context, post.pubkey),
                 child: _Avatar(
+                  key: ValueKey('forum-original-avatar-${post.eventId}'),
                   profile: profile,
                   pubkey: post.pubkey,
                   radius: 16,
+                  isAgent: agentMentionPubkeys.contains(pk),
                 ),
               ),
               const SizedBox(width: Grid.xxs),
@@ -462,9 +464,11 @@ class _ReplyRow extends ConsumerWidget {
               GestureDetector(
                 onTap: () => showUserProfileSheet(context, reply.pubkey),
                 child: _Avatar(
+                  key: ValueKey('forum-reply-avatar-${reply.eventId}'),
                   profile: profile,
                   pubkey: reply.pubkey,
                   radius: 12,
+                  isAgent: agentMentionPubkeys.contains(pk),
                 ),
               ),
               const SizedBox(width: Grid.xxs),
@@ -620,11 +624,14 @@ class _Avatar extends StatelessWidget {
   final UserProfile? profile;
   final String pubkey;
   final double radius;
+  final bool isAgent;
 
   const _Avatar({
+    super.key,
     required this.profile,
     required this.pubkey,
     required this.radius,
+    required this.isAgent,
   });
 
   @override
@@ -645,7 +652,7 @@ class _Avatar extends StatelessWidget {
           color: context.colors.onPrimaryContainer,
         ),
       ),
-      isAgent: profile?.ownerPubkey != null,
+      isAgent: isAgent,
     );
   }
 }

--- a/mobile/lib/features/forum/forum_thread_page.dart
+++ b/mobile/lib/features/forum/forum_thread_page.dart
@@ -645,6 +645,7 @@ class _Avatar extends StatelessWidget {
           color: context.colors.onPrimaryContainer,
         ),
       ),
+      isAgent: profile?.ownerPubkey != null,
     );
   }
 }

--- a/mobile/lib/features/profile/user_profile_sheet.dart
+++ b/mobile/lib/features/profile/user_profile_sheet.dart
@@ -151,6 +151,7 @@ class UserProfileSheet extends HookConsumerWidget {
                               child: _ProfileAvatar(
                                 avatarUrl: avatarUrl,
                                 initial: initial,
+                                isAgent: profile?.isAgent == true,
                               ),
                             ),
                           ),
@@ -377,8 +378,13 @@ class _ProfilePresenceChip extends StatelessWidget {
 class _ProfileAvatar extends HookWidget {
   final String? avatarUrl;
   final String initial;
+  final bool isAgent;
 
-  const _ProfileAvatar({required this.avatarUrl, required this.initial});
+  const _ProfileAvatar({
+    required this.avatarUrl,
+    required this.initial,
+    required this.isAgent,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -398,17 +404,26 @@ class _ProfileAvatar extends HookWidget {
                   stoppedAnimationUrl.value == animatedAvatar.animationUrl
                   ? null
                   : animatedAvatar.animationUrl,
-        child: ClipOval(
-          child: isPlaying
-              ? ProgressiveAnimatedAvatar(
-                  key: ValueKey(animatedAvatar.animationUrl),
-                  descriptor: animatedAvatar,
-                  fallback: _AvatarFallback(initial: initial),
-                )
-              : AvatarImageContent(
-                  imageUrl: animatedAvatar?.posterUrl ?? avatarUrl,
-                  fallback: _AvatarFallback(initial: initial),
-                ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final avatar = isPlaying
+                ? ProgressiveAnimatedAvatar(
+                    key: ValueKey(animatedAvatar.animationUrl),
+                    descriptor: animatedAvatar,
+                    fallback: _AvatarFallback(initial: initial),
+                  )
+                : AvatarImageContent(
+                    imageUrl: animatedAvatar?.posterUrl ?? avatarUrl,
+                    fallback: _AvatarFallback(initial: initial),
+                  );
+            if (!isAgent) return ClipOval(child: avatar);
+            return ClipRRect(
+              borderRadius: BorderRadius.circular(
+                constraints.biggest.shortestSide * 0.3,
+              ),
+              child: avatar,
+            );
+          },
         ),
       ),
     );

--- a/mobile/lib/features/pulse/agent_activity_card.dart
+++ b/mobile/lib/features/pulse/agent_activity_card.dart
@@ -47,6 +47,7 @@ class AgentActivityCard extends HookConsumerWidget {
                       radius: 18,
                       backgroundColor: context.colors.primaryContainer,
                       fallback: const Icon(LucideIcons.bot, size: 18),
+                      isAgent: true,
                     ),
                     Positioned(
                       right: 0,

--- a/mobile/lib/features/pulse/note_card.dart
+++ b/mobile/lib/features/pulse/note_card.dart
@@ -75,6 +75,7 @@ class NoteCard extends HookConsumerWidget {
                   color: context.colors.onPrimaryContainer,
                 ),
               ),
+              isAgent: profile?.ownerPubkey != null,
             ),
           ),
           const SizedBox(width: Grid.xs),

--- a/mobile/lib/features/search/search_page.dart
+++ b/mobile/lib/features/search/search_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
-
 import '../../shared/mentions/agent_identity_provider.dart';
 import '../../shared/mentions/mention_tags.dart';
 import '../../shared/theme/theme.dart';
@@ -730,6 +729,7 @@ class _PeopleSection extends ConsumerWidget {
               imageUrl: user.avatarUrl,
               radius: 20,
               fallback: Text(user.label.substring(0, 1).toUpperCase()),
+              isAgent: user.isAgent,
             ),
             title: Text(
               user.label,

--- a/mobile/lib/shared/profile/user_profile.dart
+++ b/mobile/lib/shared/profile/user_profile.dart
@@ -12,6 +12,8 @@ class UserProfile {
   /// means this identity is an agent (mirrors desktop's `ownerPubkey`).
   final String? ownerPubkey;
 
+  bool get isAgent => ownerPubkey != null;
+
   const UserProfile({
     required this.pubkey,
     this.displayName,

--- a/mobile/lib/shared/widgets/avatar_image.dart
+++ b/mobile/lib/shared/widgets/avatar_image.dart
@@ -13,7 +13,7 @@ import '../emoji/native_emoji_glyph.dart';
 import '../push/push_presentation_cache.dart';
 import '../relay/relay.dart';
 
-/// A circular avatar that supports both remote URLs and inline image data.
+/// An avatar that supports both remote URLs and inline image data.
 ///
 /// Flutter's [NetworkImage] only loads network URLs, while desktop browsers also
 /// accept `data:image/*` sources directly. Agent emoji avatars are inline SVGs,
@@ -23,6 +23,7 @@ class AvatarImage extends StatelessWidget {
   final double radius;
   final Color? backgroundColor;
   final Widget fallback;
+  final bool isAgent;
 
   const AvatarImage({
     super.key,
@@ -30,27 +31,32 @@ class AvatarImage extends StatelessWidget {
     required this.radius,
     required this.fallback,
     this.backgroundColor,
+    this.isAgent = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final animatedAvatar = parseAnimatedAvatarUrl(imageUrl);
-    return CircleAvatar(
-      radius: radius,
-      // Animated avatar posters carry their own backdrop disc; preserve their
-      // transparent surroundings on static/list surfaces, matching desktop.
-      backgroundColor: animatedAvatar == null
-          ? backgroundColor
-          : Colors.transparent,
-      child: ClipOval(
-        child: SizedBox.square(
-          dimension: radius * 2,
-          child: AvatarImageContent(
-            imageUrl: animatedAvatar?.posterUrl ?? imageUrl,
-            fallback: fallback,
-          ),
-        ),
+    final color = animatedAvatar == null ? backgroundColor : Colors.transparent;
+    final content = SizedBox.square(
+      dimension: radius * 2,
+      child: AvatarImageContent(
+        imageUrl: animatedAvatar?.posterUrl ?? imageUrl,
+        fallback: fallback,
       ),
+    );
+    if (!isAgent) {
+      return CircleAvatar(
+        radius: radius,
+        backgroundColor: color,
+        child: ClipOval(child: content),
+      );
+    }
+
+    final borderRadius = BorderRadius.circular(radius * 0.6);
+    return DecoratedBox(
+      decoration: BoxDecoration(color: color, borderRadius: borderRadius),
+      child: ClipRRect(borderRadius: borderRadius, child: content),
     );
   }
 }

--- a/mobile/test/features/activity/activity_page_test.dart
+++ b/mobile/test/features/activity/activity_page_test.dart
@@ -11,6 +11,7 @@ import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_detail_page.dart';
 import 'package:buzz/features/channels/message_content.dart';
 import 'package:buzz/features/channels/channels_provider.dart';
+import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 import 'package:buzz/shared/read_state/read_state_provider.dart';
 import 'package:buzz/shared/profile/user_cache_provider.dart';
 import 'package:buzz/shared/profile/user_profile.dart';
@@ -120,6 +121,7 @@ void main() {
     ValueListenable<int>? tabReselection,
     List<ComposeDraft> drafts = const [],
     List<Reminder> reminders = const [],
+    Set<String> knownAgentPubkeys = const {},
   }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -135,6 +137,7 @@ void main() {
         userCacheProvider.overrideWith(
           () => _FakeUserCacheNotifier(users ?? testUsers),
         ),
+        knownAgentPubkeysProvider.overrideWithValue(knownAgentPubkeys),
         readStateProvider.overrideWith(
           () => _FakeReadStateNotifier(readContexts),
         ),
@@ -531,6 +534,26 @@ void main() {
       ),
       isTrue,
     );
+  });
+
+  testWidgets('directory-known Activity authors use agent avatars', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      await buildTestable(knownAgentPubkeys: const {'agent_pk'}),
+    );
+    await tester.pumpAndSettle();
+
+    final agentRow = find.byKey(const ValueKey('inbox-row-ag1'));
+    final agentAvatar = tester.widget<AvatarImage>(
+      find.descendant(of: agentRow, matching: find.byType(AvatarImage)),
+    );
+    final humanRow = find.byKey(const ValueKey('inbox-row-m1'));
+    final humanAvatar = tester.widget<AvatarImage>(
+      find.descendant(of: humanRow, matching: find.byType(AvatarImage)),
+    );
+    expect(agentAvatar.isAgent, isTrue);
+    expect(humanAvatar.isAgent, isFalse);
   });
 
   testWidgets('multiple top-level messages in one DM render one row', (

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -477,6 +477,47 @@ void main() {
   });
 
   group('ChannelDetailPage', () {
+    testWidgets(
+      'bot-role author avatars stay squircles in channel and thread',
+      (tester) async {
+        final message = _textMsg(
+          id: 'bot-message',
+          pubkey: 'bot',
+          content: 'Bot message',
+        );
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: [message],
+            users: const {
+              'bot': UserProfile(pubkey: 'bot', displayName: 'Bot'),
+            },
+            loadChannelBotPubkeys: () async => const {'bot'},
+            threadReplies: const {'bot-message': []},
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        AvatarImage avatarIn(Finder row) => tester.widget<AvatarImage>(
+          find.descendant(of: row, matching: find.byType(AvatarImage)),
+        );
+        expect(
+          avatarIn(
+            find.byKey(const ValueKey('message-row-bot-message')),
+          ).isAgent,
+          isTrue,
+        );
+
+        await tester.tap(find.byKey(const ValueKey('message-row-bot-message')));
+        await tester.pumpAndSettle();
+        expect(
+          avatarIn(
+            find.byKey(const ValueKey('thread-message-row-bot-message')),
+          ).isAgent,
+          isTrue,
+        );
+      },
+    );
+
     testWidgets('uses the shared 32px masked presence avatar in DM headers', (
       tester,
     ) async {
@@ -511,6 +552,17 @@ void main() {
       expect(avatar.geometry, AvatarBadgeMaskGeometry.presenceDot);
       expect(avatar.badge, isNotNull);
       expect(
+        tester
+            .widget<ClipRRect>(
+              find.descendant(
+                of: avatarFinder,
+                matching: find.byType(ClipRRect),
+              ),
+            )
+            .borderRadius,
+        BorderRadius.circular(16),
+      );
+      expect(
         find.descendant(of: avatarFinder, matching: find.byType(ClipPath)),
         findsOneWidget,
       );
@@ -526,6 +578,61 @@ void main() {
       expect(presence.style?.fontWeight, FontWeight.w400);
       expect(find.byTooltip('View members'), findsNothing);
       expect(find.byTooltip('Start Huddle'), findsOneWidget);
+    });
+
+    testWidgets('uses a fallback squircle for bot-role DM participants', (
+      tester,
+    ) async {
+      final dmChannel = Channel(
+        id: _channelId,
+        name: 'Bot DM',
+        channelType: 'dm',
+        visibility: 'private',
+        description: 'Direct message with a bot',
+        createdBy: 'self',
+        createdAt: DateTime(2025),
+        memberCount: 2,
+        participants: const ['Self', 'Bot'],
+        participantPubkeys: const ['self', 'bot'],
+        isMember: true,
+      );
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          channel: dmChannel,
+          loadChannelBotPubkeys: () async => const {'bot'},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final avatarFinder = find.byKey(const ValueKey('dm-header-avatar'));
+      expect(
+        tester
+            .widget<ClipRRect>(
+              find.descendant(
+                of: avatarFinder,
+                matching: find.byType(ClipRRect),
+              ),
+            )
+            .borderRadius,
+        BorderRadius.circular(9.6),
+      );
+      expect(
+        tester
+            .widget<AvatarImageContent>(
+              find.descendant(
+                of: avatarFinder,
+                matching: find.byType(AvatarImageContent),
+              ),
+            )
+            .imageUrl,
+        isNull,
+      );
+      expect(
+        find.descendant(of: avatarFinder, matching: find.byType(ClipPath)),
+        findsOneWidget,
+      );
     });
 
     testWidgets('hides the Huddle action in a one-to-one agent DM', (
@@ -560,6 +667,18 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      final avatarFinder = find.byKey(const ValueKey('dm-header-avatar'));
+      expect(
+        tester
+            .widget<ClipRRect>(
+              find.descendant(
+                of: avatarFinder,
+                matching: find.byType(ClipRRect),
+              ),
+            )
+            .borderRadius,
+        BorderRadius.circular(9.6),
+      );
       expect(find.byKey(const ValueKey('channel-huddle-button')), findsNothing);
       expect(find.byTooltip('Start Huddle'), findsNothing);
     });

--- a/mobile/test/features/forum/forum_widgets_test.dart
+++ b/mobile/test/features/forum/forum_widgets_test.dart
@@ -125,11 +125,17 @@ Widget _buildThreadPage({
   bool isMember = true,
   bool isArchived = false,
   Map<String, UserProfile> users = const {},
+  Set<String> knownAgentPubkeys = const {},
+  Set<String> channelBotPubkeys = const {},
   TextScaler textScaler = TextScaler.noScaling,
 }) {
   return ProviderScope(
     overrides: [
       userCacheProvider.overrideWith(() => _FakeUserCacheNotifier(users)),
+      knownAgentPubkeysProvider.overrideWithValue(knownAgentPubkeys),
+      channelBotPubkeysProvider(
+        _channelId,
+      ).overrideWith((ref) async => channelBotPubkeys),
       profileProvider.overrideWith(() => _FakeProfileNotifier()),
       forumThreadProvider((
         channelId: _channelId,
@@ -570,6 +576,81 @@ void main() {
   });
 
   group('ForumThreadPage', () {
+    AvatarImage avatarIn(WidgetTester tester, Key key) =>
+        tester.widget<AvatarImage>(
+          find.descendant(
+            of: find.byKey(key),
+            matching: find.byType(AvatarImage),
+          ),
+        );
+
+    testWidgets(
+      'uses directory classification for an uncached original author',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildThreadPage(
+            threadResponse: ForumThreadResponse(
+              post: _makePost(pubkey: 'directory-agent'),
+              replies: const [],
+              totalReplies: 0,
+            ),
+            knownAgentPubkeys: const {'directory-agent'},
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          avatarIn(
+            tester,
+            const ValueKey('forum-original-avatar-post1'),
+          ).isAgent,
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets('uses bot-role classification for an uncached reply author', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildThreadPage(
+          threadResponse: ForumThreadResponse(
+            post: _makePost(),
+            replies: const [
+              ThreadReply(
+                eventId: 'bot-reply',
+                pubkey: 'channel-bot',
+                content: 'Automated reply',
+                kind: 45003,
+                createdAt: 2000,
+                channelId: _channelId,
+                tags: [
+                  ['h', _channelId],
+                ],
+                depth: 1,
+              ),
+            ],
+            totalReplies: 1,
+          ),
+          users: const {'alice': _aliceProfile},
+          channelBotPubkeys: const {'channel-bot'},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        avatarIn(
+          tester,
+          const ValueKey('forum-reply-avatar-bot-reply'),
+        ).isAgent,
+        isTrue,
+      );
+      expect(
+        avatarIn(tester, const ValueKey('forum-original-avatar-post1')).isAgent,
+        isFalse,
+      );
+    });
+
     testWidgets('shows original post and replies header', (tester) async {
       await tester.pumpWidget(
         _buildThreadPage(

--- a/mobile/test/features/forum/forum_widgets_test.dart
+++ b/mobile/test/features/forum/forum_widgets_test.dart
@@ -8,10 +8,12 @@ import 'package:buzz/features/forum/forum_posts_view.dart';
 import 'package:buzz/features/forum/forum_provider.dart';
 import 'package:buzz/features/forum/forum_thread_page.dart';
 import 'package:buzz/features/profile/profile_provider.dart';
+import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 import 'package:buzz/shared/profile/user_cache_provider.dart';
 import 'package:buzz/shared/profile/user_profile.dart';
 import 'package:buzz/shared/relay/relay.dart';
 import 'package:buzz/shared/theme/theme.dart';
+import 'package:buzz/shared/widgets/avatar_image.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 const _channelId = 'forum-channel';
@@ -62,10 +64,12 @@ Widget _buildPostCard({
   VoidCallback? onTap,
   void Function(String)? onDelete,
   TextScaler textScaler = TextScaler.noScaling,
+  Set<String> knownAgentPubkeys = const {},
 }) {
   return ProviderScope(
     overrides: [
       userCacheProvider.overrideWith(() => _FakeUserCacheNotifier(users)),
+      knownAgentPubkeysProvider.overrideWithValue(knownAgentPubkeys),
     ],
     child: MaterialApp(
       theme: AppTheme.light(),
@@ -205,6 +209,38 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('abcdef12\u2026'), findsOneWidget);
+    });
+
+    testWidgets('uses directory classification for uncached author avatar', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildPostCard(
+          post: _makePost(pubkey: 'directory-agent'),
+          knownAgentPubkeys: const {'directory-agent'},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<AvatarImage>(find.byType(AvatarImage)).isAgent,
+        isTrue,
+      );
+    });
+
+    testWidgets('keeps human author avatar circular', (tester) async {
+      await tester.pumpWidget(
+        _buildPostCard(
+          post: _makePost(),
+          users: const {'alice': _aliceProfile},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<AvatarImage>(find.byType(AvatarImage)).isAgent,
+        isFalse,
+      );
     });
 
     testWidgets(

--- a/mobile/test/shared/widgets/avatar_image_test.dart
+++ b/mobile/test/shared/widgets/avatar_image_test.dart
@@ -13,13 +13,18 @@ void main() {
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">'
       '<text x="16" y="24" text-anchor="middle">🦝</text></svg>';
 
-  Widget subject(String? imageUrl, {Color? backgroundColor}) => ProviderScope(
+  Widget subject(
+    String? imageUrl, {
+    Color? backgroundColor,
+    bool isAgent = false,
+  }) => ProviderScope(
     child: MaterialApp(
       home: AvatarImage(
         imageUrl: imageUrl,
         radius: 16,
         backgroundColor: backgroundColor,
         fallback: const Text('R'),
+        isAgent: isAgent,
       ),
     ),
   );
@@ -31,6 +36,14 @@ void main() {
       isFalse,
     );
     expect(isCacheablePushAvatarSource('data:image/png;base64,%%%'), isFalse);
+  });
+
+  testWidgets('clips agents to a 30 percent squircle', (tester) async {
+    await tester.pumpWidget(subject(null, isAgent: true));
+
+    expect(find.byType(CircleAvatar), findsNothing);
+    final clip = tester.widget<ClipRRect>(find.byType(ClipRRect));
+    expect(clip.borderRadius, BorderRadius.circular(9.6));
   });
 
   testWidgets('renders raccoon percent-encoded SVG data avatar', (


### PR DESCRIPTION
## Summary

- render every agent/AI identity as a 30% squircle across desktop and mobile while keeping human avatars circular
- propagate agent identity through message, thread, profile, reaction, member, DM, search, workflow, project, huddle, forum, pulse, and agent-management surfaces
- preserve squircle geometry for fallbacks, focus/status treatments, add-agent controls, and overlapping avatar outlines (`calc(30% + 2px)` for the outer background)

### Related issue

None found. This change was requested and visually reviewed in the originating Buzz thread.

### Testing

- `just desktop-test` — 5,799 passed
- `just mobile-test` — 2,008 passed
- pre-push gates passed at `0d59d77b120dcb90aac2f918e422c11c9fa5353b`: desktop check, TypeScript typecheck, desktop full test suite, mobile format/analyze and full test suite, Rust tests, Tauri checks, and differential file-size gate
- deterministic desktop visual sweep covered channel messages/thread summaries; thread, subthread, and sub-subthread depths; reactions and reactor popovers; hover/full profiles; added-to-channel activity; channel members/settings; agent library/team overlaps; agent creation; mention autocomplete; and DM header/sidebar/settings

### UI evidence

The complete labeled visual matrix is available in the originating Buzz review thread. GitHub-hosted copies will be added in a follow-up PR comment using the repository screenshot script.
