### PR TITLE
fix(desktop): parse seconds-only video review timecodes

### DIFF
--- a/desktop/src/shared/ui/videoReviewTimecode.test.mjs
+++ b/desktop/src/shared/ui/videoReviewTimecode.test.mjs
@@ -14,6 +14,11 @@ test("parseVideoReviewTimecode extracts supported leading timecodes", () => {
     text: "Long-form note",
     timecode: "1:02:03",
   });
+  assert.deepEqual(parseVideoReviewTimecode("[42] Jump here"), {
+    seconds: 42,
+    text: "Jump here",
+    timecode: "42",
+  });
 });
 
 test("parseVideoReviewTimecode ignores ordinary bracketed markdown", () => {

--- a/desktop/src/shared/ui/videoReviewTimecode.ts
+++ b/desktop/src/shared/ui/videoReviewTimecode.ts
@@ -13,6 +13,10 @@ function parseTimecode(value: string): number | null {
     return null;
   }
 
+  if (parts.length === 1) {
+    return parts[0];
+  }
+
   if (parts.length === 2) {
     return parts[0] * 60 + parts[1];
   }


### PR DESCRIPTION
## Summary
- `TIMECODE_RE` already matched `[42]`, but `parseTimecode` only handled `MM:SS` / `HH:MM:SS`, so seconds-only review chips never appeared.
- Accept a single numeric part as seconds.

## Test plan
- [ ] `./bin/node --test desktop/src/shared/ui/videoReviewTimecode.test.mjs`
- [ ] `[42] note` produces a jump chip at 42s
