### PR TITLE
fix(mobile): request include_aux for historical thread replies

### DIFF
--- a/mobile/lib/features/channels/thread_replies_provider.dart
+++ b/mobile/lib/features/channels/thread_replies_provider.dart
@@ -69,6 +69,7 @@ NostrFilter _threadRepliesFilter(
     limit: 200,
     extensions: {
       'depth_limit': 64,
+      'include_aux': true,
       if (cursor != null) 'thread_cursor': cursor.createdAt,
       if (cursor != null) 'thread_cursor_id': cursor.eventId,
     },


### PR DESCRIPTION
## Summary
- Channel history already sets `include_aux: true`; thread reply pagination did not.
- Cold loads / reconnects dropped kind `40003` edits on thread replies.

## Test plan
- [ ] Open a thread with an edited reply after a cold start — edited text remains
- [ ] Channel timeline aux behavior unchanged
