### PR TITLE
fix(mobile): recognize buzz://project entity links

### DIFF
--- a/mobile/lib/features/channels/message_content/link_normalizer.dart
+++ b/mobile/lib/features/channels/message_content/link_normalizer.dart
@@ -1,10 +1,10 @@
 const _markdownDelimiters = ['***', '___', '**', '__', '~~', '*', '_'];
 
 final _autolinkPattern = RegExp(
-  r'<((?:https?://|buzz://(?:message\?|join\?|channel/|(?:pr|issue|repo)\?))[^>]+)>',
+  r'<((?:https?://|buzz://(?:message\?|join\?|channel/|(?:pr|issue|repo|project)\?))[^>]+)>',
 );
 final _bareLinkPattern = RegExp(
-  r'(?<![(\]=])(?:https?://|buzz://(?:message\?|join\?|channel/|(?:pr|issue|repo)\?))[^\s)>\]]+',
+  r'(?<![(\]=])(?:https?://|buzz://(?:message\?|join\?|channel/|(?:pr|issue|repo|project)\?))[^\s)>\]]+',
 );
 final _trailingPunctuationPattern = RegExp(r'[.,!?:;]+$');
 final _backtickRunPattern = RegExp(r'`+');

--- a/mobile/lib/shared/deeplink/deep_link.dart
+++ b/mobile/lib/shared/deeplink/deep_link.dart
@@ -311,9 +311,10 @@ class EntityDeepLink extends BuzzDeepLink {
   });
 }
 
-/// Parse canonical `buzz://repo|pr|issue` permalinks for inline presentation.
+/// Parse canonical `buzz://repo|pr|issue|project` permalinks for inline presentation.
 EntityDeepLink? parseEntityDeepLink(Uri uri) {
-  if (uri.scheme != 'buzz' || !{'repo', 'pr', 'issue'}.contains(uri.host)) {
+  if (uri.scheme != 'buzz' ||
+      !{'repo', 'pr', 'issue', 'project'}.contains(uri.host)) {
     return null;
   }
   if (uri.path.isNotEmpty ||
@@ -322,12 +323,14 @@ EntityDeepLink? parseEntityDeepLink(Uri uri) {
       uri.hasPort) {
     return null;
   }
-  final allowed = uri.host == 'repo' ? {'owner', 'd'} : {'id', 'owner', 'd'};
+  final isCoordinateHost = uri.host == 'repo' || uri.host == 'project';
+  final required = isCoordinateHost ? {'owner', 'd'} : {'id', 'owner', 'd'};
+  final optional = uri.host == 'project' ? {'tab'} : <String>{};
   final queryParameters = uri.queryParametersAll;
   final parameterKeys = queryParameters.keys.toSet();
-  if (parameterKeys.difference(allowed).isNotEmpty ||
-      allowed.difference(parameterKeys).isNotEmpty ||
-      allowed.any((key) => queryParameters[key]?.length != 1)) {
+  if (parameterKeys.difference(required.union(optional)).isNotEmpty ||
+      required.difference(parameterKeys).isNotEmpty ||
+      parameterKeys.any((key) => queryParameters[key]?.length != 1)) {
     return null;
   }
   final owner = uri.queryParameters['owner'];
@@ -342,7 +345,7 @@ EntityDeepLink? parseEntityDeepLink(Uri uri) {
       repository.contains('..')) {
     return null;
   }
-  if (uri.host != 'repo' && (eventId == null || !hex.hasMatch(eventId))) {
+  if (!isCoordinateHost && (eventId == null || !hex.hasMatch(eventId))) {
     return null;
   }
   return EntityDeepLink(


### PR DESCRIPTION
## Summary
- Desktop builds/parses `buzz://project?owner=&d=` permalinks; mobile link normalization and `parseEntityDeepLink` only allowed `pr|issue|repo`.
- Treat `project` like `repo` (optional `tab`).

## Test plan
- [ ] Tap a `buzz://project?...` markdown/bare link on mobile
- [ ] Existing repo/pr/issue deep links still parse
