### PR TITLE
fix(cli): reject oversized emoji import stdin instead of truncating

### DIFF
--- a/crates/buzz-cli/src/commands/emoji.rs
+++ b/crates/buzz-cli/src/commands/emoji.rs
@@ -168,9 +168,14 @@ fn read_source(file: Option<&str>) -> Result<String, CliError> {
         None => {
             let mut buf = String::new();
             std::io::stdin()
-                .take(STDIN_MAX_BYTES)
+                .take(STDIN_MAX_BYTES + 1)
                 .read_to_string(&mut buf)
                 .map_err(|e| CliError::Other(format!("stdin read failed: {e}")))?;
+            if buf.len() as u64 > STDIN_MAX_BYTES {
+                return Err(CliError::Usage(format!(
+                    "stdin exceeds {STDIN_MAX_BYTES}-byte limit"
+                )));
+            }
             if buf.is_empty() {
                 return Err(CliError::Usage(
                     "no input: provide --file or pipe JSON to stdin".into(),


### PR DESCRIPTION
## Summary
- Emoji import used `.take(STDIN_MAX_BYTES)` with no overflow check, so oversized stdin was silently truncated mid-JSON.
- Match notes/mem: take limit+1 and return a usage error when exceeded.

## Test plan
- [ ] Normal small stdin import still works
- [ ] Oversized stdin returns a clear usage error
