### PR TITLE
fix(desktop): strip .team suffix when naming snapshot cards

### DIFF
--- a/desktop/src/shared/ui/markdownFileCard.test.mjs
+++ b/desktop/src/shared/ui/markdownFileCard.test.mjs
@@ -291,6 +291,7 @@ test("resolveSnapshotCard: .team.json with sha256 returns team snapshot card", (
   assert.equal(card.filename, "my-team.team.json");
   assert.equal(card.snapshotKind, "team");
   assert.equal(card.sha256, SHA256);
+  assert.equal(card.displayName, "My Team");
 });
 
 test("resolveSnapshotCard: .team.png with image/png returns team snapshot card", () => {

--- a/desktop/src/shared/ui/markdownFileCard.ts
+++ b/desktop/src/shared/ui/markdownFileCard.ts
@@ -44,14 +44,14 @@ export type ResolvedSnapshotCard = {
 
 function snapshotDisplayName(filename: string, childText: string): string {
   const label = childText.trim();
-  const labelIsSnapshotFilename = /\.agent\.(?:json|png)$/i.test(label);
+  const labelIsSnapshotFilename = /\.(?:agent|team)\.(?:json|png)$/i.test(label);
   if (label && !labelIsSnapshotFilename) return label;
 
   const filenameStem = filename
-    .replace(/\.agent\.(?:json|png)$/i, "")
+    .replace(/\.(?:agent|team)\.(?:json|png)$/i, "")
     .replace(/[-_]+/g, " ")
     .trim();
-  if (!filenameStem) return "Agent";
+  if (!filenameStem) return /\.team\./i.test(filename) ? "Team" : "Agent";
 
   return filenameStem
     .split(/\s+/)


### PR DESCRIPTION
## Summary
- `snapshotDisplayName` only stripped `.agent.(json|png)`, so team cards kept `.team.json` in the title or fell back to "Agent".
- Strip `.team` the same way and default empty stems to "Team".

## Test plan
- [ ] `resolveSnapshotCard` for `my-team.team.json` shows displayName "My Team"
- [ ] Agent snapshot titles unchanged
