### PR TITLE
fix(desktop): notify for the selected channel when the window is unfocused

### DIFF
--- a/desktop/src/features/channels/activeChannelSuppression.test.mjs
+++ b/desktop/src/features/channels/activeChannelSuppression.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSuppressedAsActiveChannel } from "./activeChannelSuppression.ts";
+
+test("suppresses the active channel while the app is focused", () => {
+  assert.equal(isSuppressedAsActiveChannel("ch1", "ch1", true, false), true);
+});
+
+test("does not suppress the active channel while the app is unfocused", () => {
+  // Regression: a DM channel left selected in a minimized/backgrounded
+  // window must still notify — the user isn't reading it.
+  assert.equal(isSuppressedAsActiveChannel("ch1", "ch1", false, false), false);
+});
+
+test("does not suppress other channels regardless of focus", () => {
+  assert.equal(isSuppressedAsActiveChannel("ch2", "ch1", true, false), false);
+  assert.equal(isSuppressedAsActiveChannel("ch2", "ch1", false, false), false);
+});
+
+test("does not suppress when no channel is active", () => {
+  assert.equal(isSuppressedAsActiveChannel("ch1", null, true, false), false);
+});
+
+test("notifyForActiveChannel opt-in disables suppression entirely", () => {
+  assert.equal(isSuppressedAsActiveChannel("ch1", "ch1", true, true), false);
+  assert.equal(isSuppressedAsActiveChannel("ch1", "ch1", false, true), false);
+});

--- a/desktop/src/features/channels/activeChannelSuppression.ts
+++ b/desktop/src/features/channels/activeChannelSuppression.ts
@@ -1,0 +1,20 @@
+/**
+ * Decides whether a notification for `channelId` is suppressed because the
+ * user is actively viewing that channel.
+ *
+ * "Viewing" requires the app window to be focused: a channel that is merely
+ * selected in a minimized or backgrounded window is not being read, so
+ * notifications for it must still fire. `notifyForActiveChannel` opts out of
+ * suppression entirely.
+ */
+export function isSuppressedAsActiveChannel(
+  channelId: string,
+  activeChannelId: string | null,
+  appFocused: boolean,
+  notifyForActiveChannel: boolean,
+): boolean {
+  if (notifyForActiveChannel) {
+    return false;
+  }
+  return channelId === activeChannelId && appFocused;
+}

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -11,6 +11,7 @@ import {
 } from "@/features/messages/lib/threading";
 import { shouldNotifyForEvent } from "@/features/notifications/lib/shouldNotify";
 import { relayClient } from "@/shared/api/relayClient";
+import { isAppFocused } from "@/shared/lib/useDocumentVisible";
 import {
   CHANNEL_EVENT_KINDS,
   CHANNEL_MESSAGE_EVENT_KINDS,
@@ -21,6 +22,7 @@ import {
   type TrailingDebounce,
 } from "@/shared/lib/trailingDebounce";
 
+import { isSuppressedAsActiveChannel } from "./activeChannelSuppression";
 import { isDmNotifiableKind } from "./isDmNotifiableKind";
 import { refreshChannelsWhenIdle } from "./refreshChannelsWhenIdle";
 
@@ -28,7 +30,7 @@ export type UseLiveChannelUpdatesOptions = {
   currentPubkey?: string;
   /**
    * When true, DM notifications also fire for the channel the user is
-   * currently viewing (normally suppressed).
+   * currently viewing (normally suppressed while the app window is focused).
    */
   notifyForActiveChannel?: boolean;
   onDmMessage?: (event: RelayEvent, channel: Channel) => void;
@@ -54,8 +56,8 @@ export type UseLiveChannelUpdatesOptions = {
   /**
    * Fired for replies in threads the user authored, participated in, or
    * follows (non-DM channels only — the DM path owns those). Follows the DM
-   * active-channel rule: suppressed for the channel being viewed unless
-   * notifyForActiveChannel opts in.
+   * active-channel rule: suppressed for the channel being viewed in a focused
+   * window unless notifyForActiveChannel opts in.
    */
   onThreadReplyDesktopNotification?: (
     channelId: string,
@@ -220,8 +222,16 @@ export function useLiveChannelUpdates(
       }
 
       // Don't fire a notification for the channel the user is already viewing,
-      // unless the notify-while-viewing setting opts in.
-      if (channelId === activeChannelId && !options.notifyForActiveChannel) {
+      // unless the notify-while-viewing setting opts in. A selected channel in
+      // an unfocused window doesn't count as viewed.
+      if (
+        isSuppressedAsActiveChannel(
+          channelId,
+          activeChannelId,
+          isAppFocused(),
+          options.notifyForActiveChannel ?? false,
+        )
+      ) {
         return;
       }
 
@@ -315,7 +325,12 @@ export function useLiveChannelUpdates(
       if (shouldNotify && isThreadedReply) {
         if (
           !dmChannelMap.has(channelId) &&
-          (channelId !== activeChannelId || options.notifyForActiveChannel)
+          !isSuppressedAsActiveChannel(
+            channelId,
+            activeChannelId,
+            isAppFocused(),
+            options.notifyForActiveChannel ?? false,
+          )
         ) {
           options.onThreadReplyDesktopNotification?.(channelId, event);
         }


### PR DESCRIPTION
## Problem

DM and thread-reply desktop notifications are suppressed for the currently selected channel, but the check only compares channel ids — it never asks whether the app window is actually focused. Leaving a DM conversation selected and minimizing (or backgrounding) the app silently drops every notification for that conversation — the one the user is most likely waiting on. `useLiveChannelUpdates.ts` previously:

```ts
if (channelId === activeChannelId && !options.notifyForActiveChannel) return;
```

## How it was implemented

- New pure predicate `isSuppressedAsActiveChannel()` in `desktop/src/features/channels/activeChannelSuppression.ts`: a channel only counts as "being viewed" when it is the active channel **and** the app window is focused, using the existing `isAppFocused()` utility from `shared/lib/useDocumentVisible.ts`.
- Both suppression sites in `useLiveChannelUpdates.ts` (the DM path and the thread-reply desktop-notification path) now share the predicate, evaluated at event-delivery time.
- The `notifyForActiveChannel` (notify-while-viewing) opt-in still bypasses suppression entirely, and behavior while the app is focused is unchanged.
- Regression tests in `activeChannelSuppression.test.mjs`, including the minimized-window case.

## How to test manually

1. Open a DM conversation in the desktop app and keep it selected.
2. Minimize the app (or focus another application).
3. Have the other participant send a DM.
4. Before: no notification. After: OS notification + sound + dock bounce fire as they do for any non-active channel.
5. Re-focus the app with the DM still selected and receive another message: still suppressed (unchanged), unless the notify-while-viewing setting opts in.

No UI changes — behavior-only, so no screenshots.

## Verification

- `desktop: pnpm test` — 5,804 pass (5 new)
- `desktop: pnpm typecheck`, `pnpm check`, `pnpm build` — clean

## Related

Searched open PRs and issues for duplicates — none found for this specific bug. Closest neighbors: #6276 (mentions don't notify while unfocused — different mechanism, the home-feed poll pausing) and the notify-while-viewing setting added in #753. Follow-up candidate deferred to a future PR: fixing #6276 itself.
