### PR TITLE
fix(desktop): derive agent availability from relay presence

### DIFF
--- a/crates/buzz-agent/tests/common/mod.rs
+++ b/crates/buzz-agent/tests/common/mod.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex, Notify};
 
 pub struct CapturingLlm {
     pub url: String,
@@ -107,11 +107,22 @@ pub struct Harness {
     stdin: tokio::process::ChildStdin,
     stdout: BufReader<tokio::process::ChildStdout>,
     stderr: Arc<StdMutex<String>>,
+    stderr_changed: Arc<Notify>,
     next_id: i64,
 }
 
 impl Harness {
     pub async fn spawn_with_env(base_url: &str, extra: &[(&str, &str)]) -> Self {
+        Self::spawn_with_stderr_gate(base_url, extra, None).await
+    }
+
+    /// Delay stderr collection until released, to exercise stdout/stderr ordering
+    /// without changing the child or relying on scheduler timing.
+    pub async fn spawn_with_stderr_gate(
+        base_url: &str,
+        extra: &[(&str, &str)],
+        stderr_gate: Option<oneshot::Receiver<()>>,
+    ) -> Self {
         let bin = env!("CARGO_BIN_EXE_buzz-agent");
         let mut cmd = tokio::process::Command::new(bin);
         cmd.env("BUZZ_AGENT_PROVIDER", "openai")
@@ -135,7 +146,14 @@ impl Harness {
         let stderr = child.stderr.take().unwrap();
         let stderr_buf = Arc::new(StdMutex::new(String::new()));
         let stderr_out = Arc::clone(&stderr_buf);
+        let stderr_changed = Arc::new(Notify::new());
+        let changed = Arc::clone(&stderr_changed);
         tokio::spawn(async move {
+            if let Some(gate) = stderr_gate {
+                // Dropping the sender (e.g. on assertion failure) also unblocks
+                // collection, rather than leaving a detached reader waiting.
+                let _ = gate.await;
+            }
             let mut reader = BufReader::new(stderr);
             let mut line = String::new();
             loop {
@@ -150,6 +168,7 @@ impl Harness {
                 if let Ok(mut out) = stderr_out.lock() {
                     out.push_str(&line);
                 }
+                changed.notify_waiters();
             }
         });
         Self {
@@ -157,6 +176,7 @@ impl Harness {
             stdin,
             stdout,
             stderr: stderr_buf,
+            stderr_changed,
             next_id: 1,
         }
     }
@@ -228,8 +248,35 @@ impl Harness {
         let _ = self.child.start_kill();
     }
 
+    /// Snapshot only: receiving a response on stdout does not drain stderr.
     pub fn stderr_text(&self) -> String {
         self.stderr.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+
+    /// Wait for a diagnostic in the independently collected stderr stream.
+    /// Returns the matching snapshot so subsequent assertions see its prefix.
+    pub async fn wait_for_stderr(&self, needle: &str, timeout: Duration) -> String {
+        tokio::time::timeout(timeout, async {
+            loop {
+                let changed = self.stderr_changed.notified();
+                tokio::pin!(changed);
+                // Register before inspecting the buffer: a line collected between
+                // the snapshot and await must not become a lost wakeup.
+                changed.as_mut().enable();
+                let stderr = self.stderr_text();
+                if stderr.contains(needle) {
+                    return stderr;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "timed out waiting for stderr diagnostic {needle:?}; stderr={}",
+                self.stderr_text()
+            )
+        })
     }
 }
 

--- a/crates/buzz-agent/tests/regressions.rs
+++ b/crates/buzz-agent/tests/regressions.rs
@@ -2706,6 +2706,30 @@ async fn ordinary_400_stays_terminal_and_triggers_no_recovery() {
 /// part of the assertion.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn context_recovery_budget_exhaustion_surfaces_the_error() {
+    assert_context_recovery_budget_exhaustion(false).await;
+}
+
+/// The same real provider/ACP scenario with stderr collection held until after
+/// the stdout response. The old immediate snapshot cannot observe the budget.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn context_recovery_budget_exhaustion_waits_for_delayed_stderr() {
+    assert_context_recovery_budget_exhaustion(true).await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "timed out waiting for stderr diagnostic")]
+async fn stderr_diagnostic_wait_is_bounded_when_absent() {
+    let llm = spawn_capturing_llm(vec![]).await;
+    let h = Harness::spawn(&llm.url).await;
+    h.wait_for_stderr(
+        "diagnostic that is never emitted",
+        Duration::from_millis(20),
+    )
+    .await;
+}
+
+async fn assert_context_recovery_budget_exhaustion(delay_stderr: bool) {
+    let (release_stderr, stderr_gate) = tokio::sync::oneshot::channel();
     // Enough canned 400s that the queue is never the thing that stops the loop;
     // the fallback response is also a 400-shaped body under this helper only if
     // queued, so keep the queue generously long.
@@ -2713,7 +2737,7 @@ async fn context_recovery_budget_exhaustion_surfaces_the_error() {
         .map(|_| (400, openai_context_length_error()))
         .collect();
     let llm = spawn_capturing_llm_with_status(responses).await;
-    let mut h = Harness::spawn_with_env(
+    let mut h = Harness::spawn_with_stderr_gate(
         &llm.url,
         &[
             ("BUZZ_AGENT_MAX_CONTEXT_TOKENS", "200000"),
@@ -2723,6 +2747,7 @@ async fn context_recovery_budget_exhaustion_surfaces_the_error() {
             ),
             ("BUZZ_AGENT_MAX_HANDOFFS", "0"),
         ],
+        delay_stderr.then_some(stderr_gate),
     )
     .await;
     let sid = init_session(&mut h, json!([])).await;
@@ -2751,8 +2776,27 @@ async fn context_recovery_budget_exhaustion_surfaces_the_error() {
     // floor produce a surfaced error, so the assertion above passes either way
     // — and the floor can fire on the first rung without the budget ever being
     // consumed, which would make this test silently exercise a different
-    // mechanism than its name claims. Pin the budget explicitly.
-    let stderr = h.stderr_text();
+    // mechanism than its name claims. Pin the budget explicitly. Stdout is not
+    // a barrier for the independent stderr collector.
+    let stderr = {
+        let wait = h.wait_for_stderr("context recovery budget spent", Duration::from_secs(5));
+        tokio::pin!(wait);
+        if delay_stderr {
+            assert!(
+                !h.stderr_text().contains("context recovery budget spent"),
+                "the old immediate snapshot must miss the held diagnostic"
+            );
+            // Prove the actual wait stays pending before releasing the collector,
+            // without a sleep or depending on how quickly either task runs.
+            std::future::poll_fn(|cx| {
+                assert!(std::future::Future::poll(wait.as_mut(), cx).is_pending());
+                std::task::Poll::Ready(())
+            })
+            .await;
+            release_stderr.send(()).expect("release stderr collection");
+        }
+        wait.await
+    };
     assert!(
         stderr.contains("context recovery budget spent"),
         "the per-run recovery BUDGET must be what stops the loop here, not the prompt floor; \
@@ -2766,6 +2810,15 @@ async fn context_recovery_budget_exhaustion_surfaces_the_error() {
         rungs, 3,
         "expected all 3 recovery rungs to be attempted before giving up, saw {rungs} — \
          stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("context recovery would shrink"),
+        "the prompt floor must not stop this fixture: {stderr}"
+    );
+    assert_eq!(
+        llm.captured.lock().await.len(),
+        4,
+        "expected the rejected completion plus exactly three failed summaries"
     );
     h.shutdown().await;
 }
@@ -2816,7 +2869,9 @@ async fn small_history_context_400_refuses_rescue_at_the_prompt_floor() {
         r0.get("error").is_some(),
         "a context 400 with no shrinkable history must surface the error, got: {r0}"
     );
-    let stderr = h.stderr_text();
+    let stderr = h
+        .wait_for_stderr("context recovery would shrink", Duration::from_secs(5))
+        .await;
     assert!(
         stderr.contains("below the") && stderr.contains("floor"),
         "the prompt-budget FLOOR must be what stops this, not the recovery budget; got: {stderr}"

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -177,6 +177,7 @@ export default defineConfig({
       name: "integration",
       testMatch: [
         "**/agents.spec.ts",
+        "**/agent-availability.spec.ts",
         "**/agent-snapshot-recipient.spec.ts",
         "**/onboarding.spec.ts",
         "**/stream.spec.ts",

--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -344,8 +344,8 @@ pub async fn get_presence(
     }
 
     // Presence is published as kind:20001 ephemeral events. Query the most
-    // recent per author. Some relays don't retain ephemeral events — we
-    // best-effort and return what we get.
+    // recent per author. Only a successful empty snapshot establishes absence;
+    // transport/auth/storage failures must reject so consumers remain unknown.
     let events = query_relay(
         &state,
         &[serde_json::json!({
@@ -353,8 +353,7 @@ pub async fn get_presence(
             "authors": pubkeys,
         })],
     )
-    .await
-    .unwrap_or_default();
+    .await?;
 
     let mut latest: HashMap<String, (u64, PresenceStatus)> = HashMap::new();
     for ev in &events {
@@ -482,3 +481,7 @@ mod tests {
         assert_eq!(filter["page"], serde_json::json!(1));
     }
 }
+
+#[cfg(test)]
+#[path = "profile_presence_tests.rs"]
+mod presence_tests;

--- a/desktop/src-tauri/src/commands/profile_presence_tests.rs
+++ b/desktop/src-tauri/src/commands/profile_presence_tests.rs
@@ -1,0 +1,103 @@
+//! Drive the actual get_presence command through its authenticated HTTP query.
+//! In particular, an error must not become a successful empty IPC snapshot.
+use super::get_presence;
+use crate::app_state::build_app_state;
+use crate::relay_admission::{reset_rate_limit_gate, TEST_SERIAL};
+use tauri::Manager;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[tokio::test]
+async fn presence_command_preserves_query_failure_and_successful_absence() {
+    let _serial = TEST_SERIAL.lock().await;
+    reset_rate_limit_gate();
+    for (status, body) in [
+        ("200 OK", "[]"),
+        ("401 Unauthorized", r#"{"error":"unauthorized"}"#),
+        ("429 Too Many Requests", r#"{"error":"retry in 1s"}"#),
+        (
+            "500 Internal Server Error",
+            r#"{"error":"storage unavailable"}"#,
+        ),
+        ("200 OK", "not json"),
+    ] {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            loop {
+                let mut buf = [0; 4096];
+                let count = stream.read(&mut buf).await.unwrap();
+                assert!(count > 0);
+                request.extend_from_slice(&buf[..count]);
+                assert!(request.len() < 16384);
+                if let Some(end) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&request[..end]).to_lowercase();
+                    let length: usize = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.strip_prefix("content-length:")
+                                .map(|v| v.trim().parse().unwrap())
+                        })
+                        .unwrap();
+                    if request.len() >= end + 4 + length {
+                        break;
+                    }
+                }
+            }
+            let request = String::from_utf8(request).unwrap();
+            assert!(request.starts_with("POST /query "));
+            assert!(request.to_lowercase().contains("authorization: nostr "));
+            assert!(request.contains("20001"));
+            let response = format!("HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len());
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        let state = build_app_state();
+        *state.relay_url_override.lock().unwrap() = Some(format!("ws://{addr}"));
+        let app = tauri::test::mock_builder()
+            .manage(state)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            get_presence(vec!["a".repeat(64)], app.state()),
+        )
+        .await
+        .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), server)
+            .await
+            .unwrap()
+            .unwrap();
+        if status == "200 OK" && body == "[]" {
+            assert_eq!(
+                serde_json::to_value(result.unwrap()).unwrap(),
+                serde_json::json!({})
+            );
+        } else {
+            assert!(
+                result.is_err(),
+                "{status} / {body} must reject, not return Offline: {result:?}"
+            );
+        }
+        reset_rate_limit_gate();
+    }
+}
+
+#[tokio::test]
+async fn presence_command_transport_failure_is_not_offline() {
+    let _serial = TEST_SERIAL.lock().await;
+    reset_rate_limit_gate();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    let state = build_app_state();
+    *state.relay_url_override.lock().unwrap() = Some(format!("ws://{addr}"));
+    let app = tauri::test::mock_builder()
+        .manage(state)
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .unwrap();
+    let result = get_presence(vec!["a".repeat(64)], app.state()).await;
+    assert!(result.is_err(), "transport failure must reject: {result:?}");
+    // Empty input does not require a relay and remains a genuine empty result.
+    assert!(get_presence(vec![], app.state()).await.unwrap().is_empty());
+}

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -207,7 +207,10 @@ with a TypeScript lookup table or an id comparison in a component.
    [the identity contract](../../../../docs/agent-profile-identity.md).
    Availability dots read relay presence, never a saved deployment
    receipt or runtime status. Failed/disconnected reads are unknown; lifecycle
-   actions retain their separate routing. See
+   actions retain their separate routing. Current exact-key Online/Away presence
+   suppresses Start for an inactive local record without granting Stop authority;
+   list/profile/member startup guards must not interpret Offline as proof of safe
+   startup. See
    [the availability contract](../../../../docs/agent-availability.md).
 14. **Thinking effort has two surfaces: a local-only WRITE control and a
    read-only two-facts DISPLAY.** The write control is `EffortPickerField`

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -205,6 +205,10 @@ with a TypeScript lookup table or an id comparison in a component.
    select a representative or offer persona Start; a relay persona link cannot
    borrow a local sibling's management controls. See
    [the identity contract](../../../../docs/agent-profile-identity.md).
+   Availability dots read relay presence, never a saved deployment
+   receipt or runtime status. Failed/disconnected reads are unknown; lifecycle
+   actions retain their separate routing. See
+   [the availability contract](../../../../docs/agent-availability.md).
 14. **Thinking effort has two surfaces: a local-only WRITE control and a
    read-only two-facts DISPLAY.** The write control is `EffortPickerField`
    (`ui/EffortPickerField.tsx`), a self-contained section component mounted in

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -210,7 +210,11 @@ with a TypeScript lookup table or an id comparison in a component.
    actions retain their separate routing. Current exact-key Online/Away presence
    suppresses Start for an inactive local record without granting Stop authority;
    list/profile/member startup guards must not interpret Offline as proof of safe
-   startup. See
+   startup. Deletion also consumes that same exact-key availability reader:
+   unknown requests shutdown when a channel exists, request failure retains the
+   record, and only established Offline keeps the intentional no-request path.
+   Unqueried persona siblings are unknown. No presence state grants deletion or
+   Stop authority; native local stop-before-remove remains independent. See
    [the availability contract](../../../../docs/agent-availability.md).
 14. **Thinking effort has two surfaces: a local-only WRITE control and a
    read-only two-facts DISPLAY.** The write control is `EffortPickerField`

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -31,6 +31,7 @@ export type ManagedAgentActionResult = {
   noticeMessage?: string;
 };
 
+/** Lifecycle action routing only; deployed is a retained receipt, not presence. */
 export function isManagedAgentActive(agent: Pick<ManagedAgent, "status">) {
   return agent.status === "running" || agent.status === "deployed";
 }
@@ -133,7 +134,8 @@ export async function stopManagedAgentWithRules({
       agent.pubkey,
     ]);
     return {
-      noticeMessage: "Shutdown command sent. Agent will stop shortly.",
+      noticeMessage:
+        "Shutdown requested. This does not confirm the agent has stopped.",
     };
   }
 

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -1,10 +1,6 @@
 import { sendChannelMessage } from "@/shared/api/tauri";
-import type {
-  Channel,
-  ManagedAgent,
-  PresenceLookup,
-  RelayAgent,
-} from "@/shared/api/types";
+import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
+import type { AgentAvailabilityReader } from "./useAgentAvailability";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 type DeleteManagedAgentInput = {
@@ -23,7 +19,7 @@ type ManagedAgentChannelContext = {
 };
 
 type ManagedAgentActionContext = ManagedAgentChannelContext & {
-  presenceLookup?: PresenceLookup | null;
+  getAvailability: AgentAvailabilityReader;
 };
 
 export type ManagedAgentActionResult = {
@@ -148,7 +144,7 @@ export async function deleteManagedAgentWithRules({
   channels,
   deleteManagedAgent,
   preferredChannelId,
-  presenceLookup,
+  getAvailability,
   relayAgents,
   skipRemoteDeleteConfirm = false,
 }: {
@@ -157,7 +153,7 @@ export async function deleteManagedAgentWithRules({
   skipRemoteDeleteConfirm?: boolean;
 } & ManagedAgentActionContext): Promise<ManagedAgentActionResult> {
   if (agent.backend.type === "provider" && agent.backendAgentId) {
-    const presence = presenceLookup?.[normalizePubkey(agent.pubkey)];
+    const availability = getAvailability(agent.pubkey);
     const channelId = resolveManagedAgentChannelId(agent, {
       channels,
       preferredChannelId,
@@ -165,14 +161,19 @@ export async function deleteManagedAgentWithRules({
     });
 
     if (channelId) {
-      if (presence === "online" || presence === "away") {
+      // Only established Offline preserves the intentional no-request path.
+      // Unknown is not evidence that shutdown can safely be skipped.
+      if (availability !== "offline") {
         await sendChannelMessage(channelId, "!shutdown", undefined, undefined, [
           agent.pubkey,
         ]);
 
         if (!skipRemoteDeleteConfirm) {
           const confirmed = window.confirm(
-            "Shutdown command sent, but the agent may still be running. " +
+            (availability === undefined
+              ? "This agent’s availability is unknown. "
+              : "") +
+              "Shutdown requested, but the agent may still be running. " +
               "Deleting now removes the local record — the remote deployment " +
               "will be orphaned if shutdown hasn't completed. Continue?",
           );
@@ -195,7 +196,7 @@ export async function deleteManagedAgentWithRules({
       if (!skipRemoteDeleteConfirm) {
         const confirmed = window.confirm(
           "This agent is deployed but not in any channel. " +
-            "Deleting will orphan the remote deployment (it will keep running). Continue?",
+            "Deleting removes the local management record; the remote deployment may still be running. Continue?",
         );
         if (!confirmed) {
           return { cancelled: true };

--- a/desktop/src/features/agents/lib/managedAgentDeletionAvailability.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentDeletionAvailability.test.mjs
@@ -1,0 +1,469 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+const PK = "a".repeat(64);
+const SIBLING = "b".repeat(64);
+const agent = {
+  pubkey: PK,
+  name: "Remote",
+  personaId: "persona",
+  status: "deployed",
+  backend: { type: "provider", id: "fixture", config: {} },
+  backendAgentId: "receipt",
+};
+const channel = { id: "channel", name: "agents", memberPubkeys: [PK] };
+const directory = [
+  { pubkey: PK, channels: ["agents"], channelIds: ["channel"] },
+];
+let act,
+  render,
+  cleanup,
+  waitFor,
+  createElement,
+  QueryClient,
+  QueryClientProvider;
+let useAgentAvailabilityLookup,
+  useManagedAgentActions,
+  useProfileAgentDeletion,
+  CommunitiesProvider;
+let deleteManagedAgentWithRules, deleteManagedAgent, relayClient, originals;
+let connection, listeners, handlers, commands, confirms, clients;
+
+before(async () => {
+  Object.assign(globalThis, {
+    window: dom.window,
+    localStorage: dom.window.localStorage,
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  dom.window.__TAURI_INTERNALS__ = {
+    invoke: async (command, args) => {
+      commands.push([command, args]);
+      if (handlers.has(command)) return handlers.get(command)(args);
+      throw new Error(`Unexpected IPC: ${command}`);
+    },
+    transformCallback: () => 1,
+  };
+  ({ act, render, cleanup, waitFor } = await import("@testing-library/react"));
+  ({ createElement } = await import("react"));
+  ({ QueryClient, QueryClientProvider } = await import(
+    "@tanstack/react-query"
+  ));
+  ({ CommunitiesProvider } = await import(
+    "../../communities/useCommunities.tsx"
+  ));
+  ({ useAgentAvailabilityLookup } = await import("./useAgentAvailability.ts"));
+  ({ useManagedAgentActions } = await import(
+    "../ui/useManagedAgentActions.ts"
+  ));
+  ({ useProfileAgentDeletion } = await import(
+    "../../profile/ui/UserProfilePanelDeletion.ts"
+  ));
+  ({ deleteManagedAgentWithRules } = await import(
+    "./managedAgentControlActions.ts"
+  ));
+  ({ deleteManagedAgent } = await import("../../../shared/api/tauri.ts"));
+  ({ relayClient } = await import("../../../shared/api/relayClient.ts"));
+  originals = {
+    getConnectionState: relayClient.getConnectionState,
+    subscribeToConnectionState: relayClient.subscribeToConnectionState,
+  };
+  relayClient.getConnectionState = () => connection;
+  relayClient.subscribeToConnectionState = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  for (const client of clients ?? []) {
+    client.cancelQueries();
+    client.clear();
+  }
+});
+after(() => {
+  Object.assign(relayClient, originals);
+  dom.window.close();
+});
+
+function setup() {
+  clients = [];
+  commands = [];
+  confirms = [];
+  connection = "connected";
+  listeners = new Set();
+  handlers = new Map([
+    ["get_presence", () => ({ [PK]: "online" })],
+    ["delete_managed_agent", () => null],
+    ["remove_channel_member", () => null],
+    ["send_channel_message", () => ({ event_id: "event", created_at: 0 })],
+    ["list_managed_agents", () => []],
+    ["get_relay_agents", () => []],
+    ["list_available_acp_runtimes", () => []],
+    ["get_channels", () => []],
+    ["plugin:event|listen", () => 1],
+    ["plugin:event|unlisten", () => null],
+  ]);
+  dom.window.confirm = (copy) => {
+    confirms.push(copy);
+    return true;
+  };
+}
+
+function mount(
+  owner,
+  { agents = [agent], keys = [PK], seedChannels = true } = {},
+) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+  clients.push(client);
+  client.setQueryData(["managed-agents"], agents);
+  client.setQueryData(["relay-agents"], directory);
+  if (seedChannels) client.setQueryData(["channels"], [channel]);
+  client.setQueryData(["globalAgentConfig"], { env_vars: {} });
+  let current;
+  function AgentsSurface() {
+    current = useManagedAgentActions();
+    return null;
+  }
+  function ProfileSurface() {
+    const availability = useAgentAvailabilityLookup(keys);
+    const deletion = useProfileAgentDeletion({
+      channels: [channel],
+      managedAgents: agents,
+      managedAgent: agents[0],
+      relayAgents: agents.map((row) => ({
+        ...directory[0],
+        pubkey: row.pubkey,
+      })),
+      getAvailability: availability.getAvailability,
+      deleteManagedAgent: ({ pubkey, forceRemoteDelete }) =>
+        deleteManagedAgent(pubkey, forceRemoteDelete),
+    });
+    current = { ...availability, ...deletion };
+    return null;
+  }
+  const Surface = owner === "agents" ? AgentsSurface : ProfileSurface;
+  render(
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(CommunitiesProvider, null, createElement(Surface)),
+    ),
+  );
+  return { client, current: () => current };
+}
+
+function effects() {
+  return commands.filter(([name]) =>
+    [
+      "send_channel_message",
+      "delete_managed_agent",
+      "remove_channel_member",
+    ].includes(name),
+  );
+}
+
+for (const owner of ["agents", "profile"]) {
+  for (const scenario of [
+    "online",
+    "away",
+    "offline",
+    "missing",
+    "pending",
+    "failed-online",
+    "failed-offline",
+    "disconnected-online",
+    "disconnected-offline",
+  ]) {
+    test(`${owner} deletion uses resolved ${scenario} at the production hook/IPC boundary`, async () => {
+      setup();
+      const warm = scenario.endsWith("-offline") ? "offline" : "online";
+      handlers.set("get_presence", () => {
+        if (scenario === "pending") return new Promise(() => {});
+        if (scenario === "missing") return {};
+        return { [PK]: scenario.includes("-") ? warm : scenario };
+      });
+      const surface = mount(owner);
+      const key = ["presence", PK];
+      if (scenario !== "pending") {
+        await waitFor(() =>
+          assert.equal(surface.client.getQueryState(key)?.status, "success"),
+        );
+      }
+      if (scenario.startsWith("failed")) {
+        handlers.set("get_presence", () =>
+          Promise.reject("relay unreachable: request timed out"),
+        );
+        await act(() =>
+          surface.client.invalidateQueries({ queryKey: key, exact: true }),
+        );
+        assert.equal(surface.client.getQueryState(key).status, "error");
+        assert.deepEqual(surface.client.getQueryData(key), { [PK]: warm });
+      }
+      if (scenario.startsWith("disconnected")) {
+        await act(async () => {
+          connection = "disconnected";
+          for (const listener of listeners) listener(connection);
+        });
+        assert.deepEqual(surface.client.getQueryData(key), { [PK]: warm });
+      }
+      const unknown = scenario.includes("-") || scenario === "pending";
+      await waitFor(() =>
+        assert.equal(
+          surface.current().getAvailability(PK),
+          unknown ? undefined : scenario === "missing" ? "offline" : scenario,
+        ),
+      );
+      commands.length = 0;
+      await act(async () => {
+        if (owner === "agents") await surface.current().handleDelete(PK);
+        else await surface.current().deleteManagedAgentRecord(agent);
+      });
+      const shouldShutdown = scenario !== "offline" && scenario !== "missing";
+      assert.deepEqual(
+        effects().map(([name]) => name),
+        [
+          ...(shouldShutdown ? ["send_channel_message"] : []),
+          "delete_managed_agent",
+          "remove_channel_member",
+        ],
+      );
+      if (shouldShutdown) {
+        assert.equal(effects()[0][1].content, "!shutdown");
+        assert.deepEqual(effects()[0][1].mentionPubkeys, [PK]);
+      }
+      assert.deepEqual(
+        effects().find(([name]) => name === "delete_managed_agent")[1],
+        {
+          pubkey: PK,
+          forceRemoteDelete: true,
+        },
+      );
+      if (owner === "agents") {
+        assert.equal(confirms.length, 1);
+        if (unknown) {
+          assert.match(confirms[0], /availability is unknown/);
+          assert.doesNotMatch(confirms[0], /offline/i);
+        } else if (!shouldShutdown) assert.match(confirms[0], /is offline/);
+      } else
+        assert.deepEqual(confirms, [], "profile already obtained confirmation");
+    });
+  }
+}
+
+test("reader retained across an await sees errors/disconnect, not cached success; unqueried siblings stay unknown", async () => {
+  setup();
+  const surface = mount("profile");
+  await waitFor(() =>
+    assert.equal(surface.current().getAvailability(PK), "online"),
+  );
+  const retainedReader = surface.current().getAvailability;
+  assert.equal(retainedReader(SIBLING), undefined);
+  handlers.set("get_presence", () => Promise.reject("failed"));
+  await act(() =>
+    surface.client.invalidateQueries({ queryKey: ["presence", PK] }),
+  );
+  assert.equal(retainedReader(PK), undefined);
+  await act(async () =>
+    surface.client.setQueryData(["presence", PK], { [PK]: "online" }),
+  );
+  connection = "reconnecting"; // even before the next React connection render
+  assert.equal(retainedReader(PK), undefined);
+});
+
+for (const owner of ["agents", "profile"]) {
+  test(`${owner} unknown shutdown failure preserves record and channel membership`, async () => {
+    setup();
+    handlers.set("get_presence", () => Promise.reject("failed"));
+    handlers.set("send_channel_message", () =>
+      Promise.reject(new Error("shutdown refused")),
+    );
+    const surface = mount(owner);
+    await waitFor(() =>
+      assert.equal(
+        surface.client.getQueryState(["presence", PK])?.status,
+        "error",
+      ),
+    );
+    await act(async () => {
+      if (owner === "agents") await surface.current().handleDelete(PK);
+      else
+        await assert.rejects(
+          surface.current().deleteManagedAgentRecord(agent),
+          /shutdown refused/,
+        );
+    });
+    assert.deepEqual(
+      effects().map(([name]) => name),
+      ["send_channel_message"],
+    );
+    assert.deepEqual(confirms, []);
+    if (owner === "agents")
+      assert.equal(surface.current().actionErrorMessage, "shutdown refused");
+  });
+}
+
+test("unknown waits for shutdown before confirmation/delete; cancellation retains record", async () => {
+  setup();
+  let release;
+  handlers.set(
+    "send_channel_message",
+    () =>
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+  );
+  dom.window.confirm = (copy) => {
+    confirms.push(copy);
+    return false;
+  };
+  const operation = deleteManagedAgentWithRules({
+    agent,
+    channels: [channel],
+    relayAgents: directory,
+    getAvailability: () => undefined,
+    deleteManagedAgent: ({ pubkey, forceRemoteDelete }) =>
+      deleteManagedAgent(pubkey, forceRemoteDelete),
+  });
+  await waitFor(() => assert.equal(typeof release, "function"));
+  assert.deepEqual(confirms, []);
+  assert.equal(effects().length, 1);
+  release({ event_id: "event" });
+  assert.deepEqual(await operation, { cancelled: true });
+  assert.match(confirms[0], /availability is unknown/);
+  assert.equal(effects().length, 1);
+});
+
+test("no channel warns without claiming process state; local deletion ignores presence", async () => {
+  setup();
+  const remove = ({ pubkey, forceRemoteDelete }) =>
+    deleteManagedAgent(pubkey, forceRemoteDelete);
+  await deleteManagedAgentWithRules({
+    agent,
+    channels: [],
+    relayAgents: [],
+    getAvailability: () => undefined,
+    deleteManagedAgent: remove,
+  });
+  assert.match(confirms[0], /may still be running/);
+  assert.doesNotMatch(confirms[0], /will keep running|offline/i);
+  assert.deepEqual(
+    effects().map(([name]) => name),
+    ["delete_managed_agent"],
+  );
+  commands.length = 0;
+  confirms.length = 0;
+  await deleteManagedAgentWithRules({
+    agent: { ...agent, backend: { type: "local" } },
+    channels: [],
+    relayAgents: [],
+    getAvailability: () => {
+      throw new Error("must not consult presence");
+    },
+    deleteManagedAgent: remove,
+  });
+  assert.deepEqual(effects(), [
+    ["delete_managed_agent", { pubkey: PK, forceRemoteDelete: null }],
+  ]);
+  assert.deepEqual(confirms, []);
+});
+
+test("Agents deletion rechecks availability after channel discovery, not the click-time snapshot", async () => {
+  setup();
+  let releaseChannels;
+  handlers.set(
+    "get_channels",
+    () =>
+      new Promise((resolve) => {
+        releaseChannels = resolve;
+      }),
+  );
+  handlers.set("get_presence", () => ({ [PK]: "offline" }));
+  const surface = mount("agents", { seedChannels: false });
+  await waitFor(() =>
+    assert.equal(surface.current().getAvailability(PK), "offline"),
+  );
+  let operation;
+  await act(async () => {
+    operation = surface.current().handleDelete(PK);
+  });
+  await waitFor(() => assert.equal(typeof releaseChannels, "function"));
+  handlers.set("get_presence", () => Promise.reject("failed"));
+  await act(() =>
+    surface.client.invalidateQueries({ queryKey: ["presence", PK] }),
+  );
+  assert.deepEqual(effects(), []);
+  await act(async () => {
+    releaseChannels({ hash: "empty", channels: [], last_messages: {} });
+    await operation;
+  });
+  assert.deepEqual(
+    effects().map(([name]) => name),
+    ["send_channel_message", "delete_managed_agent", "remove_channel_member"],
+  );
+  assert.match(confirms[0], /availability is unknown/);
+});
+
+test("profile persona deletion cannot infer Offline for an unqueried sibling", async () => {
+  setup();
+  handlers.set("get_presence", () => ({}));
+  const surface = mount("profile", {
+    agents: [agent, { ...agent, pubkey: SIBLING }],
+    keys: [PK],
+  });
+  await waitFor(() =>
+    assert.equal(surface.current().getAvailability(PK), "offline"),
+  );
+  assert.equal(surface.current().getAvailability(SIBLING), undefined);
+  await act(() =>
+    surface.current().deleteManagedAgentsForPersona({ id: "persona" }),
+  );
+  const requests = effects().filter(
+    ([name]) => name === "send_channel_message",
+  );
+  assert.equal(requests.length, 1);
+  assert.deepEqual(requests[0][1].mentionPubkeys, [SIBLING]);
+  assert.match(confirms[0], /is offline/);
+  assert.match(confirms[1], /availability is unknown/);
+});
+
+test("successful cached snapshot remains authoritative during refetch; only settled error revokes it", async () => {
+  setup();
+  const surface = mount("profile");
+  await waitFor(() =>
+    assert.equal(surface.current().getAvailability(PK), "online"),
+  );
+  let rejectRead;
+  handlers.set(
+    "get_presence",
+    () =>
+      new Promise((_, reject) => {
+        rejectRead = reject;
+      }),
+  );
+  let refresh;
+  await act(async () => {
+    refresh = surface.client.invalidateQueries({ queryKey: ["presence", PK] });
+  });
+  assert.equal(surface.current().getAvailability(PK), "online");
+  await act(async () => {
+    rejectRead("failed");
+    await refresh;
+  });
+  assert.equal(surface.current().getAvailability(PK), undefined);
+});

--- a/desktop/src/features/agents/lib/useAgentAvailability.test.mjs
+++ b/desktop/src/features/agents/lib/useAgentAvailability.test.mjs
@@ -89,7 +89,31 @@ for (const lifecycle of ["running", "stopped"]) {
         onStart() {},
       }),
     );
-    assert.equal(html.includes('data-testid="start"'), !isActive);
-    assert.equal(html.includes('data-testid="active"'), isActive);
+    assert.equal(html.includes('data-testid="start"'), false);
+    assert.equal(html.includes('data-testid="active"'), true);
+  });
+}
+
+for (const availability of ["online", "away"]) {
+  test(`stale restart and runtime error cannot hide stopped ${availability} presence`, () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentRuntimeAvatarControl, {
+        activeTestId: "active",
+        startTestId: "start",
+        errorTestId: "error",
+        isActive: false,
+        isStarting: false,
+        requiresRestart: true,
+        errorLabel: "Previous startup failed",
+        availability,
+        label: "Agent",
+        onStart() {},
+      }),
+    );
+    assert.match(html, /data-testid="active"/);
+    assert.doesNotMatch(
+      html,
+      /data-testid="start"|data-testid="error"|<button/,
+    );
   });
 }

--- a/desktop/src/features/agents/lib/useAgentAvailability.test.mjs
+++ b/desktop/src/features/agents/lib/useAgentAvailability.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { resolveAgentAvailability } from "./useAgentAvailability.ts";
+import {
+  getManagedAgentPrimaryActionLabel,
+  isManagedAgentActive,
+} from "./managedAgentControlActions.ts";
+import { AgentRuntimeAvatarControl } from "../ui/AgentRuntimeAvatarControl.tsx";
+
+const deployed = {
+  status: "deployed",
+  backend: { type: "provider", id: "fixture" },
+  backendAgentId: "retained-receipt",
+};
+
+for (const presence of ["online", "away", "offline", undefined]) {
+  test(`retained deployment receipt does not supply availability (${presence})`, () => {
+    const availability = resolveAgentAvailability(presence, true, true);
+    assert.equal(availability, presence ?? "offline");
+    // Controls retain their existing routing. Offline is not permission to
+    // spawn a second body, nor proof that a shutdown message succeeded.
+    assert.equal(isManagedAgentActive(deployed), true);
+    assert.equal(getManagedAgentPrimaryActionLabel(deployed), "Shutdown");
+    const html = renderToStaticMarkup(
+      createElement(AgentRuntimeAvatarControl, {
+        activeTestId: "active",
+        isActive: true,
+        availability,
+        isStarting: false,
+        label: "Agent",
+        startTestId: "start",
+        onStart() {},
+      }),
+    );
+    assert.doesNotMatch(html, /is running/);
+    assert.match(
+      html,
+      new RegExp(
+        `Agent: ${availability[0].toUpperCase()}${availability.slice(1)}`,
+      ),
+    );
+    assert.equal(html.includes("bg-emerald-500"), availability === "online");
+    assert.doesNotMatch(html, /data-testid="start"/);
+  });
+}
+
+for (const [loaded, connected] of [
+  [false, true],
+  [true, false],
+  [false, false],
+]) {
+  test(`unavailable presence is unknown, not cached online (${loaded}, ${connected})`, () => {
+    const availability = resolveAgentAvailability("online", loaded, connected);
+    assert.equal(availability, undefined);
+    const html = renderToStaticMarkup(
+      createElement(AgentRuntimeAvatarControl, {
+        activeTestId: "active",
+        isActive: true,
+        availability,
+        isStarting: false,
+        label: "Agent",
+        startTestId: "start",
+        onStart() {},
+      }),
+    );
+    assert.match(html, /Availability unknown/);
+    assert.doesNotMatch(html, /bg-emerald-500|is running/);
+  });
+}
+
+for (const lifecycle of ["running", "stopped"]) {
+  test(`local ${lifecycle} controls remain independent of online presence`, () => {
+    const agent = { status: lifecycle, backend: { type: "local" } };
+    const isActive = isManagedAgentActive(agent);
+    assert.equal(
+      getManagedAgentPrimaryActionLabel(agent),
+      isActive ? "Stop" : "Start agent",
+    );
+    const html = renderToStaticMarkup(
+      createElement(AgentRuntimeAvatarControl, {
+        activeTestId: "active",
+        isActive,
+        availability: "online",
+        isStarting: false,
+        label: "Local Agent",
+        startTestId: "start",
+        onStart() {},
+      }),
+    );
+    assert.equal(html.includes('data-testid="start"'), !isActive);
+    assert.equal(html.includes('data-testid="active"'), isActive);
+  });
+}

--- a/desktop/src/features/agents/lib/useAgentAvailability.ts
+++ b/desktop/src/features/agents/lib/useAgentAvailability.ts
@@ -1,0 +1,27 @@
+import { usePresenceQuery } from "@/features/presence/hooks";
+import type { PresenceStatus } from "@/shared/api/types";
+import { useRelayConnection } from "@/shared/api/useRelayConnection";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+/** Availability is relay presence, never a retained deployment receipt or PID. */
+export function resolveAgentAvailability(
+  status: PresenceStatus | undefined,
+  presenceLoaded: boolean,
+  connected: boolean,
+): PresenceStatus | undefined {
+  // Missing entries in a successful presence snapshot mean offline. Failed or
+  // disconnected reads cannot establish availability (including cached online).
+  return presenceLoaded && connected ? (status ?? "offline") : undefined;
+}
+
+/** Share the existing presence query/subscription; no separate status cache. */
+export function useAgentAvailability(pubkey: string | null | undefined) {
+  const query = usePresenceQuery(pubkey ? [pubkey] : []);
+  const connection = useRelayConnection();
+  const status = resolveAgentAvailability(
+    pubkey ? query.data?.[normalizePubkey(pubkey)] : undefined,
+    query.isSuccess,
+    connection === "connected",
+  );
+  return { query, status };
+}

--- a/desktop/src/features/agents/lib/useAgentAvailability.ts
+++ b/desktop/src/features/agents/lib/useAgentAvailability.ts
@@ -1,6 +1,8 @@
 import * as React from "react";
-import { usePresenceQuery } from "@/features/presence/hooks";
-import type { PresenceStatus } from "@/shared/api/types";
+import { useQueryClient } from "@tanstack/react-query";
+import { presenceQueryKey, usePresenceQuery } from "@/features/presence/hooks";
+import { relayClient } from "@/shared/api/relayClient";
+import type { PresenceLookup, PresenceStatus } from "@/shared/api/types";
 import { useRelayConnection } from "@/shared/api/useRelayConnection";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
@@ -39,18 +41,29 @@ export function useAgentAvailabilityLookup(
   options?: { enabled?: boolean },
 ) {
   const query = usePresenceQuery(pubkeys, options);
-  const connection = useRelayConnection();
-  const getAvailability: AgentAvailabilityReader = React.useCallback(
-    (pubkey) =>
-      pubkey
-        ? resolveAgentAvailability(
-            query.data?.[normalizePubkey(pubkey)],
-            query.isSuccess,
-            connection === "connected",
-          )
-        : undefined,
-    [query.data, query.isSuccess, connection],
-  );
+  const queryClient = useQueryClient();
+  // Subscribe for display updates; action-time reads below must also see a
+  // disconnect/error that occurred while an action awaited channel discovery.
+  const connection = useRelayConnection({ degradedAfterMs: 0 });
+  const keyId = JSON.stringify(presenceQueryKey(pubkeys));
+  // These dependencies subscribe the render to data/status changes, while the
+  // callback reads the cache at invocation time (including after an await).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Track observer changes and invalidate memoized consumers; invocation must read live state, not capture those values.
+  const getAvailability: AgentAvailabilityReader = React.useMemo(() => {
+    const key: string[] = JSON.parse(keyId);
+    const requested = new Set(key.slice(1));
+    return (pubkey) => {
+      const normalized = pubkey ? normalizePubkey(pubkey) : "";
+      // A successful subset says nothing about unqueried persona siblings.
+      if (!normalized || !requested.has(normalized)) return undefined;
+      const state = queryClient.getQueryState<PresenceLookup>(key);
+      return resolveAgentAvailability(
+        state?.data?.[normalized],
+        state?.status === "success",
+        relayClient.getConnectionState() === "connected",
+      );
+    };
+  }, [keyId, queryClient, query.data, query.isSuccess, connection]);
   return { query, getAvailability };
 }
 

--- a/desktop/src/features/agents/lib/useAgentAvailability.ts
+++ b/desktop/src/features/agents/lib/useAgentAvailability.ts
@@ -14,6 +14,19 @@ export function resolveAgentAvailability(
   return presenceLoaded && connected ? (status ?? "offline") : undefined;
 }
 
+/** Positive presence blocks another start, but never grants lifecycle control.
+ * Missing/offline presence is not proof that starting another body is safe.
+ */
+export function agentPresenceStartBlockReason(
+  isLifecycleActive: boolean,
+  availability: PresenceStatus | undefined,
+): string | undefined {
+  return !isLifecycleActive &&
+    (availability === "online" || availability === "away")
+    ? "This agent is present on the relay. Starting another instance is unavailable."
+    : undefined;
+}
+
 /** Share the existing presence query/subscription; no separate status cache. */
 export function useAgentAvailability(pubkey: string | null | undefined) {
   const query = usePresenceQuery(pubkey ? [pubkey] : []);

--- a/desktop/src/features/agents/lib/useAgentAvailability.ts
+++ b/desktop/src/features/agents/lib/useAgentAvailability.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import type { PresenceStatus } from "@/shared/api/types";
 import { useRelayConnection } from "@/shared/api/useRelayConnection";
@@ -27,14 +28,36 @@ export function agentPresenceStartBlockReason(
     : undefined;
 }
 
-/** Share the existing presence query/subscription; no separate status cache. */
-export function useAgentAvailability(pubkey: string | null | undefined) {
-  const query = usePresenceQuery(pubkey ? [pubkey] : []);
+/** Read availability from the surface-owned snapshot, not per-row polling. */
+export type AgentAvailabilityReader = (
+  pubkey: string | null | undefined,
+) => PresenceStatus | undefined;
+
+/** One query/connection observer for a surface's cards and lifecycle actions. */
+export function useAgentAvailabilityLookup(
+  pubkeys: string[],
+  options?: { enabled?: boolean },
+) {
+  const query = usePresenceQuery(pubkeys, options);
   const connection = useRelayConnection();
-  const status = resolveAgentAvailability(
-    pubkey ? query.data?.[normalizePubkey(pubkey)] : undefined,
-    query.isSuccess,
-    connection === "connected",
+  const getAvailability: AgentAvailabilityReader = React.useCallback(
+    (pubkey) =>
+      pubkey
+        ? resolveAgentAvailability(
+            query.data?.[normalizePubkey(pubkey)],
+            query.isSuccess,
+            connection === "connected",
+          )
+        : undefined,
+    [query.data, query.isSuccess, connection],
   );
-  return { query, status };
+  return { query, getAvailability };
+}
+
+/** Single-identity surfaces use the same authority as aggregate surfaces. */
+export function useAgentAvailability(pubkey: string | null | undefined) {
+  const { query, getAvailability } = useAgentAvailabilityLookup(
+    pubkey ? [pubkey] : [],
+  );
+  return { query, status: getAvailability(pubkey) };
 }

--- a/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
+++ b/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
@@ -7,6 +7,11 @@ import {
   STATUS_DOT_MASK_CURVE,
 } from "@/features/profile/ui/MaskedAvatarBadgeFrame";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import {
+  getPresenceDotClassName,
+  getPresenceLabel,
+} from "@/features/presence/lib/presence";
+import type { PresenceStatus } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Spinner } from "@/shared/ui/spinner";
 import { IdentityInitialsAvatar } from "./IdentityInitialsAvatar";
@@ -16,7 +21,9 @@ type AgentRuntimeAvatarControlProps = {
   avatarUrl?: string | null;
   errorLabel?: string | null;
   errorTestId?: string;
+  /** Lifecycle bookkeeping controls actions, not the availability dot. */
   isActive: boolean;
+  availability?: PresenceStatus;
   isRestarting?: boolean;
   isStarting: boolean;
   label: string;
@@ -128,6 +135,7 @@ const MASK_TRANSITION = {
 export function AgentRuntimeAvatarControl({
   activeTestId,
   avatarUrl,
+  availability,
   errorLabel,
   errorTestId,
   isActive,
@@ -151,32 +159,35 @@ export function AgentRuntimeAvatarControl({
         : "Start Agent";
   const actionText = isRestartAction ? "Restart" : "Start";
   const isPending = isStarting || isRestarting;
-  const showRunningDot = isActive && !isRestartAction;
+  const availabilityLabel = availability
+    ? getPresenceLabel(availability)
+    : "Availability unknown";
+  const showStatusDot = isActive && !isRestartAction;
   const hasError = !isActive && !isPending && Boolean(errorLabel);
   const errorActionLabel = `${label} has a runtime error. Open runtime details.`;
   const transition = shouldReduceMotion ? { duration: 0 } : MASK_TRANSITION;
   const actionBadge = isRestartAction
     ? RESTART_ACTION_BADGE
     : START_ACTION_BADGE;
-  const badge = showRunningDot
+  const badge = showStatusDot
     ? ACTIVE_BADGE
     : hasError
       ? ERROR_BADGE
       : actionBadge;
   const actionCutoutWidth =
-    showRunningDot || hasError ? undefined : actionBadge.cutoutWidth;
+    showStatusDot || hasError ? undefined : actionBadge.cutoutWidth;
 
   return (
     <MaskedAvatarBadgeFrame
       badge={
         <span className="grid h-full w-full place-items-center">
-          {showRunningDot ? (
+          {showStatusDot ? (
             <span
-              aria-label={`${label} is running`}
+              aria-label={`${label}: ${availabilityLabel}`}
               className="h-full w-full rounded-full"
               data-testid={activeTestId}
               role="img"
-              title={`${label} is running`}
+              title={`${label}: ${availabilityLabel}`}
             />
           ) : (
             <button
@@ -220,8 +231,10 @@ export function AgentRuntimeAvatarControl({
       badgeClassName={cn(
         "transition-colors ease-in-out",
         shouldReduceMotion ? "duration-0" : "duration-300",
-        showRunningDot
-          ? "bg-emerald-500"
+        showStatusDot
+          ? availability
+            ? getPresenceDotClassName(availability)
+            : "bg-muted-foreground/35"
           : hasError
             ? "bg-destructive"
             : isRestartAction
@@ -230,7 +243,7 @@ export function AgentRuntimeAvatarControl({
       )}
       className="h-24 w-24"
       cornerRadius={AGENT_AVATAR_SIZE * 0.3}
-      curve={showRunningDot ? STATUS_DOT_MASK_CURVE : ACTION_MASK_CURVE}
+      curve={showStatusDot ? STATUS_DOT_MASK_CURVE : ACTION_MASK_CURVE}
       cutout={badge.cutout}
       cutoutWidth={actionCutoutWidth}
       maskTransition={transition}

--- a/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
+++ b/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
@@ -14,6 +14,7 @@ import {
 import type { PresenceStatus } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Spinner } from "@/shared/ui/spinner";
+import { agentPresenceStartBlockReason } from "../lib/useAgentAvailability";
 import { IdentityInitialsAvatar } from "./IdentityInitialsAvatar";
 
 type AgentRuntimeAvatarControlProps = {
@@ -162,7 +163,14 @@ export function AgentRuntimeAvatarControl({
   const availabilityLabel = availability
     ? getPresenceLabel(availability)
     : "Availability unknown";
-  const showStatusDot = isActive && !isRestartAction;
+  const startBlockReason = agentPresenceStartBlockReason(
+    isActive,
+    availability,
+  );
+  // A present identity need not be a process this supervisor owns. Replace
+  // Start (even a stale Restart/error badge) without inventing Stop authority.
+  const showStatusDot =
+    Boolean(startBlockReason) || (isActive && !isRestartAction);
   const hasError = !isActive && !isPending && Boolean(errorLabel);
   const errorActionLabel = `${label} has a runtime error. Open runtime details.`;
   const transition = shouldReduceMotion ? { duration: 0 } : MASK_TRANSITION;
@@ -187,7 +195,7 @@ export function AgentRuntimeAvatarControl({
               className="h-full w-full rounded-full"
               data-testid={activeTestId}
               role="img"
-              title={`${label}: ${availabilityLabel}`}
+              title={startBlockReason ?? `${label}: ${availabilityLabel}`}
             />
           ) : (
             <button

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -219,6 +219,7 @@ export function AgentsView() {
           />
           <div className="flex flex-col gap-8">
             <UnifiedAgentsSection
+              getAvailability={agents.getAvailability}
               defaultModel={inheritedDefaults.model.value}
               actionErrorMessage={agents.actionErrorMessage}
               actionNoticeMessage={agents.actionNoticeMessage}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -8,7 +8,7 @@ import {
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { effectiveAgentDescription } from "@/features/agents/lib/agentDescription";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
-import { useAgentAvailability } from "@/features/agents/lib/useAgentAvailability";
+import type { AgentAvailabilityReader } from "@/features/agents/lib/useAgentAvailability";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { pickProfileAgent } from "@/features/agents/lib/pickProfileAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
@@ -30,6 +30,7 @@ import { buildUnifiedGroups } from "./unifiedAgentGroups";
 
 type UnifiedAgentsSectionProps = {
   defaultModel: string;
+  getAvailability: AgentAvailabilityReader;
   actionErrorMessage: string | null;
   actionNoticeMessage: string | null;
   agents: ManagedAgent[];
@@ -75,6 +76,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     actionErrorMessage,
     actionNoticeMessage,
     defaultModel,
+    getAvailability,
     agents,
     agentsError,
     isActionPending,
@@ -159,6 +161,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
                     />
                   )}
                   agent={profileAgent}
+                  getAvailability={getAvailability}
                   defaultModel={defaultModel}
                   isBestie={profileAgent?.pubkey.toLowerCase() === bestiePubkey}
                   key={group.persona.id}
@@ -180,6 +183,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
             <CollapsibleAgentGroup
               agents={unknown}
               collapsed={collapsed}
+              getAvailability={getAvailability}
               defaultModel={defaultModel}
               groupKey="__unknown__"
               bestiePubkey={bestiePubkey}
@@ -196,6 +200,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
             <CollapsibleAgentGroup
               agents={ungrouped}
               collapsed={collapsed}
+              getAvailability={getAvailability}
               defaultModel={defaultModel}
               groupKey="__ungrouped__"
               bestiePubkey={bestiePubkey}
@@ -234,6 +239,7 @@ function AgentPersonaCard({
   agent,
   defaultModel,
   isBestie,
+  getAvailability,
   persona,
   restartingAgentPubkey,
   startingAgentPubkey,
@@ -251,6 +257,7 @@ function AgentPersonaCard({
   agent: ManagedAgent | undefined;
   defaultModel: string;
   isBestie: boolean;
+  getAvailability: AgentAvailabilityReader;
   persona: AgentPersona;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -264,7 +271,7 @@ function AgentPersonaCard({
   onStartAgent: (pubkey: string) => void;
   onStartPersona: (persona: AgentPersona) => void;
 }) {
-  const { status: availability } = useAgentAvailability(agent?.pubkey);
+  const availability = getAvailability(agent?.pubkey);
   const title = persona.displayName;
   // Card face second line: the authored description when one exists;
   // otherwise fall back to the model label as before.
@@ -364,6 +371,7 @@ function StandaloneAgentCard({
   agent,
   isBestie,
   defaultModel,
+  getAvailability,
   restartingAgentPubkey,
   startingAgentPubkey,
   onOpenAgentProfile,
@@ -373,6 +381,7 @@ function StandaloneAgentCard({
   agent: ManagedAgent;
   isBestie: boolean;
   defaultModel: string;
+  getAvailability: AgentAvailabilityReader;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   onOpenAgentProfile: (
@@ -382,7 +391,7 @@ function StandaloneAgentCard({
   onRestartAgent: (pubkey: string) => void;
   onStartAgent: (pubkey: string) => void;
 }) {
-  const { status: availability } = useAgentAvailability(agent.pubkey);
+  const availability = getAvailability(agent.pubkey);
   const title = agent.name;
   const profileQuery = useUserProfileQuery(agent.pubkey);
   const friendlyError = friendlyAgentLastError(
@@ -478,6 +487,7 @@ function CollapsibleAgentGroup({
   bestiePubkey,
   collapsed,
   defaultModel,
+  getAvailability,
   restartingAgentPubkey,
   startingAgentPubkey,
   onToggle,
@@ -491,6 +501,7 @@ function CollapsibleAgentGroup({
   bestiePubkey: string | null;
   collapsed: ReadonlySet<string>;
   defaultModel: string;
+  getAvailability: AgentAvailabilityReader;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   onToggle: (key: string) => void;
@@ -522,6 +533,7 @@ function CollapsibleAgentGroup({
           {agents.map((agent) => (
             <StandaloneAgentCard
               agent={agent}
+              getAvailability={getAvailability}
               defaultModel={defaultModel}
               isBestie={agent.pubkey.toLowerCase() === bestiePubkey}
               key={agent.pubkey}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -8,6 +8,7 @@ import {
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { effectiveAgentDescription } from "@/features/agents/lib/agentDescription";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
+import { useAgentAvailability } from "@/features/agents/lib/useAgentAvailability";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { pickProfileAgent } from "@/features/agents/lib/pickProfileAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
@@ -263,6 +264,7 @@ function AgentPersonaCard({
   onStartAgent: (pubkey: string) => void;
   onStartPersona: (persona: AgentPersona) => void;
 }) {
+  const { status: availability } = useAgentAvailability(agent?.pubkey);
   const title = persona.displayName;
   // Card face second line: the authored description when one exists;
   // otherwise fall back to the model label as before.
@@ -298,6 +300,7 @@ function AgentPersonaCard({
             errorLabel={friendlyError}
             errorTestId={`agent-runtime-error-${agent.pubkey}`}
             isActive={isActive}
+            availability={availability}
             isRestarting={restartingAgentPubkey === agent.pubkey}
             isStarting={startingAgentPubkey === agent.pubkey}
             label={title}
@@ -379,6 +382,7 @@ function StandaloneAgentCard({
   onRestartAgent: (pubkey: string) => void;
   onStartAgent: (pubkey: string) => void;
 }) {
+  const { status: availability } = useAgentAvailability(agent.pubkey);
   const title = agent.name;
   const profileQuery = useUserProfileQuery(agent.pubkey);
   const friendlyError = friendlyAgentLastError(
@@ -398,6 +402,7 @@ function StandaloneAgentCard({
           errorLabel={friendlyError}
           errorTestId={`agent-runtime-error-${agent.pubkey}`}
           isActive={isActive}
+          availability={availability}
           isRestarting={restartingAgentPubkey === agent.pubkey}
           isStarting={startingAgentPubkey === agent.pubkey}
           label={title}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
@@ -293,3 +293,89 @@ test("errored avatar affordance still opens the explicit pubkey on the runtime t
 
   assert.deepEqual(opened, [{ pubkey: LIVE_PK, options: { tab: "runtime" } }]);
 });
+
+for (const kind of ["persona", "custom", "unknown"]) {
+  test(`${kind} stopped card uses exact-key presence without inventing lifecycle controls`, async () => {
+    installFailOpenIpc();
+    const { relayClient } = await import("../../../shared/api/relayClient.ts");
+    const originalConnection = relayClient.getConnectionState;
+    const originalSubscribe = relayClient.subscribeToConnectionState;
+    relayClient.getConnectionState = () => "connected";
+    relayClient.subscribeToConnectionState = () => () => {};
+    let snapshot = { [ARCHIVED_PK]: "online" };
+    ipcHandlers.set("get_presence", () => Promise.resolve(snapshot));
+    const starts = [];
+    const props = baseProps({
+      agents: [
+        agent({
+          personaId:
+            kind === "custom"
+              ? null
+              : kind === "unknown"
+                ? "missing"
+                : "persona-1",
+        }),
+      ],
+      personas: kind === "persona" ? [persona()] : [],
+      onStartAgent: (key) => starts.push(key),
+      onRestartAgent: () => {
+        throw new Error("presence must not cause Restart");
+      },
+    });
+    try {
+      await act(async () => renderSection(props));
+      const client = clients.at(-1);
+      const refresh = async () => {
+        await act(async () => {
+          await client.invalidateQueries({ queryKey: ["presence"] });
+        });
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        });
+      };
+      await refresh();
+      // Different-key Online must not suppress this identity's ordinary Start.
+      fireEvent.click(screen.getByTestId(`agent-runtime-start-${LIVE_PK}`));
+      assert.deepEqual(starts, [LIVE_PK]);
+      starts.length = 0;
+      for (const status of ["online", "away", "offline", "online"]) {
+        snapshot = { [LIVE_PK]: status };
+        await refresh();
+        const start = screen.queryByTestId(`agent-runtime-start-${LIVE_PK}`);
+        if (status === "offline") {
+          assert.ok(start);
+          fireEvent.click(start);
+          assert.deepEqual(starts, [LIVE_PK]);
+          starts.length = 0;
+        } else {
+          assert.equal(
+            Boolean(start),
+            false,
+            "active exact-key presence must remove Start",
+          );
+          const dot = screen.getByTestId(`agent-runtime-active-${LIVE_PK}`);
+          assert.match(
+            dot.getAttribute("aria-label"),
+            new RegExp(status === "online" ? "Online$" : "Away$"),
+          );
+          fireEvent.click(dot);
+          fireEvent.keyDown(dot, { key: "Enter" });
+          fireEvent.keyDown(dot, { key: " " });
+          assert.deepEqual(starts, []);
+          assert.equal(
+            Boolean(screen.queryByRole("button", { name: /Stop/ })),
+            false,
+          );
+        }
+      }
+      // A successful omitted entry is the existing relay expiry/missing path.
+      snapshot = {};
+      await refresh();
+      fireEvent.click(screen.getByTestId(`agent-runtime-start-${LIVE_PK}`));
+      assert.deepEqual(starts, [LIVE_PK]);
+    } finally {
+      relayClient.getConnectionState = originalConnection;
+      relayClient.subscribeToConnectionState = originalSubscribe;
+    }
+  });
+}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
@@ -41,6 +41,7 @@ let createElement;
 let QueryClient;
 let QueryClientProvider;
 let UnifiedAgentsSection;
+let useAgentAvailabilityLookup;
 
 const ipcHandlers = new Map();
 
@@ -109,16 +110,26 @@ function baseProps(overrides = {}) {
   };
 }
 
+function Surface(props) {
+  const { getAvailability } = useAgentAvailabilityLookup(
+    props.agents.map((a) => a.pubkey),
+  );
+  return createElement(UnifiedAgentsSection, { ...props, getAvailability });
+}
+
 function renderSection(props) {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { gcTime: 0 },
+    },
   });
   clients.push(client);
   return render(
     createElement(
       QueryClientProvider,
       { client },
-      createElement(UnifiedAgentsSection, props),
+      createElement(Surface, props),
     ),
   );
 }
@@ -157,6 +168,9 @@ before(async () => {
     "@tanstack/react-query"
   ));
   ({ UnifiedAgentsSection } = await import("./UnifiedAgentsSection.tsx"));
+  ({ useAgentAvailabilityLookup } = await import(
+    "../lib/useAgentAvailability.ts"
+  ));
 });
 
 afterEach(() => {
@@ -379,3 +393,214 @@ for (const kind of ["persona", "custom", "unknown"]) {
     }
   });
 }
+
+test("N cards share a snapshot, one poll, failure recovery and live subscription lifecycle", async (t) => {
+  installFailOpenIpc();
+  const { relayClient } = await import("../../../shared/api/relayClient.ts");
+  const { usePresenceSubscription, useSetPresenceMutation } = await import(
+    "../../presence/hooks.ts"
+  );
+  const original = {
+    getConnectionState: relayClient.getConnectionState,
+    subscribeToConnectionState: relayClient.subscribeToConnectionState,
+    subscribeToReconnects: relayClient.subscribeToReconnects,
+    subscribeLive: relayClient.subscribeLive,
+    sendPresence: relayClient.sendPresence,
+  };
+  const subscriptions = [];
+  const requests = [];
+  let fail = false;
+  let finishSnapshot;
+  ipcHandlers.set("get_presence", ({ pubkeys }) => {
+    requests.push(pubkeys);
+    if (fail) return Promise.reject("relay unreachable: request timed out");
+    return new Promise((resolve) => {
+      finishSnapshot = resolve;
+    });
+  });
+  relayClient.sendPresence = async () => {};
+  relayClient.getConnectionState = () => "connected";
+  relayClient.subscribeToConnectionState = () => () => {};
+  relayClient.subscribeToReconnects = () => () => {};
+  relayClient.subscribeLive = async (filter, onEvent, onReady) => {
+    const sub = { filter, onEvent, closed: false };
+    subscriptions.push(sub);
+    onReady("eose");
+    return async () => {
+      sub.closed = true;
+    };
+  };
+  Object.defineProperty(dom.window.document, "visibilityState", {
+    configurable: true,
+    value: "visible",
+  });
+  const originalFocus = dom.window.document.hasFocus;
+  dom.window.document.hasFocus = () => true;
+  t.mock.timers.enable({ apis: ["setInterval"] });
+  let setPresence;
+  function SubscribedSurface(props) {
+    setPresence = useSetPresenceMutation(SELF_PK);
+    usePresenceSubscription();
+    return createElement(Surface, props);
+  }
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { gcTime: 0 },
+    },
+  });
+  clients.push(client);
+  const props = baseProps({
+    agents: [
+      agent({ pubkey: LIVE_PK, status: "running" }),
+      agent({ pubkey: ARCHIVED_PK, personaId: null, status: "running" }),
+      agent({ pubkey: SELF_PK, personaId: "missing", status: "running" }),
+    ],
+    personas: [persona()],
+  });
+  const tree = (next) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(SubscribedSurface, next),
+    );
+  const settle = async () =>
+    act(async () => {
+      await new Promise((r) => setTimeout(r, 120));
+    });
+  try {
+    let view;
+    await act(async () => {
+      view = render(tree(props));
+    });
+    assert.equal(
+      requests.length,
+      1,
+      "one in-flight request for persona/custom/unknown rows",
+    );
+    await act(async () => {
+      view.rerender(tree({ ...props, agents: [...props.agents].reverse() }));
+    });
+    assert.equal(
+      requests.length,
+      1,
+      "reordering while the snapshot is pending does not refetch",
+    );
+    await act(async () => {
+      finishSnapshot({});
+    });
+    await settle();
+    assert.deepEqual(requests[0], [ARCHIVED_PK, LIVE_PK, SELF_PK]);
+    assert.equal(subscriptions.length, 1);
+    assert.deepEqual(subscriptions[0].filter.authors, requests[0]);
+    assert.equal(
+      client
+        .getQueryCache()
+        .find({ queryKey: ["presence", ...requests[0]] })
+        .getObserversCount(),
+      1,
+    );
+    await act(async () => {
+      subscriptions[0].onEvent({ pubkey: LIVE_PK, content: "away" });
+    });
+    await settle();
+    assert.match(
+      screen
+        .getByTestId(`agent-runtime-active-${LIVE_PK}`)
+        .getAttribute("aria-label"),
+      /Away$/,
+    );
+    assert.match(
+      screen
+        .getByTestId(`agent-runtime-active-${ARCHIVED_PK}`)
+        .getAttribute("aria-label"),
+      /Offline$/,
+    );
+    assert.equal(
+      requests.length,
+      1,
+      "live exact-key update makes no snapshot requests",
+    );
+    fail = true;
+    await act(async () => {
+      t.mock.timers.tick(60000);
+    });
+    await settle();
+    assert.equal(requests.length, 2, "one backstop poll, not one per card");
+    for (const { pubkey } of props.agents) {
+      assert.match(
+        screen
+          .getByTestId(`agent-runtime-active-${pubkey}`)
+          .getAttribute("aria-label"),
+        /Availability unknown$/,
+      );
+    }
+    await act(async () => {
+      subscriptions[0].onEvent({ pubkey: ARCHIVED_PK, content: "online" });
+    });
+    await settle();
+    for (const { pubkey } of props.agents) {
+      assert.match(
+        screen
+          .getByTestId(`agent-runtime-active-${pubkey}`)
+          .getAttribute("aria-label"),
+        /Availability unknown$/,
+        "one live author must not resurrect a failed aggregate's cached siblings",
+      );
+    }
+    await act(async () => {
+      await setPresence.mutateAsync("online");
+    });
+    await settle();
+    for (const { pubkey } of props.agents) {
+      assert.match(
+        screen
+          .getByTestId(`agent-runtime-active-${pubkey}`)
+          .getAttribute("aria-label"),
+        /Availability unknown$/,
+        "a successful self heartbeat must not heal a failed aggregate snapshot",
+      );
+    }
+    fail = false;
+    await act(async () => {
+      t.mock.timers.tick(60000);
+    });
+    await act(async () => {
+      finishSnapshot({});
+    });
+    await settle();
+    assert.equal(requests.length, 3);
+    assert.match(
+      screen
+        .getByTestId(`agent-runtime-active-${LIVE_PK}`)
+        .getAttribute("aria-label"),
+      /Offline$/,
+    );
+    await act(async () => {
+      view.rerender(tree({ ...props, agents: [props.agents[0]] }));
+    });
+    await act(async () => {
+      finishSnapshot({});
+    });
+    await settle();
+    assert.deepEqual(subscriptions[1].filter.authors, [LIVE_PK]);
+    assert.equal(subscriptions[0].closed, true);
+    await act(async () => {
+      view.unmount();
+    });
+    assert.equal(
+      subscriptions[1].closed,
+      true,
+      "last surface removes its live subscription",
+    );
+    const count = requests.length;
+    await act(async () => {
+      t.mock.timers.tick(120000);
+    });
+    assert.equal(requests.length, count, "unmounted surfaces do not poll");
+  } finally {
+    t.mock.timers.reset();
+    dom.window.document.hasFocus = originalFocus;
+    Object.assign(relayClient, original);
+  }
+});

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -16,13 +16,11 @@ import {
 } from "@/features/agents/hooks";
 import {
   agentPresenceStartBlockReason,
-  resolveAgentAvailability,
+  useAgentAvailabilityLookup,
 } from "../lib/useAgentAvailability";
-import { useRelayConnection } from "@/shared/api/useRelayConnection";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { invalidateChannelMembersRosters } from "@/features/channels/rosterFreshness";
-import { usePresenceQuery } from "@/features/presence/hooks";
 import type { AgentPersona, Channel, ManagedAgent } from "@/shared/api/types";
 import { removeChannelMember } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
@@ -106,17 +104,13 @@ export function useManagedAgentActions() {
     [managedAgents],
   );
 
-  const managedPresenceQuery = usePresenceQuery(managedPubkeyList);
-  const relayConnection = useRelayConnection();
+  const { query: managedPresenceQuery, getAvailability } =
+    useAgentAvailabilityLookup(managedPubkeyList);
 
   function assertStartNotBlockedByPresence(agent: ManagedAgent) {
     const reason = agentPresenceStartBlockReason(
       isManagedAgentActive(agent),
-      resolveAgentAvailability(
-        managedPresenceQuery.data?.[normalizePubkey(agent.pubkey)],
-        managedPresenceQuery.isSuccess,
-        relayConnection === "connected",
-      ),
+      getAvailability(agent.pubkey),
     );
     if (reason) throw new Error(reason);
   }
@@ -449,6 +443,7 @@ export function useManagedAgentActions() {
     managedAgentsQuery,
     managedAgentLogQuery,
     managedPresenceQuery,
+    getAvailability,
     managedAgents,
     managedPubkeys,
     channelIdToName,

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -14,6 +14,11 @@ import {
   useStopManagedAgentMutation,
   useDeleteManagedAgentMutation,
 } from "@/features/agents/hooks";
+import {
+  agentPresenceStartBlockReason,
+  resolveAgentAvailability,
+} from "../lib/useAgentAvailability";
+import { useRelayConnection } from "@/shared/api/useRelayConnection";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { invalidateChannelMembersRosters } from "@/features/channels/rosterFreshness";
@@ -102,6 +107,19 @@ export function useManagedAgentActions() {
   );
 
   const managedPresenceQuery = usePresenceQuery(managedPubkeyList);
+  const relayConnection = useRelayConnection();
+
+  function assertStartNotBlockedByPresence(agent: ManagedAgent) {
+    const reason = agentPresenceStartBlockReason(
+      isManagedAgentActive(agent),
+      resolveAgentAvailability(
+        managedPresenceQuery.data?.[normalizePubkey(agent.pubkey)],
+        managedPresenceQuery.isSuccess,
+        relayConnection === "connected",
+      ),
+    );
+    if (reason) throw new Error(reason);
+  }
 
   const channelsByPubkey = React.useMemo(() => {
     const map: Record<string, { id: string; name: string }[]> = {};
@@ -164,6 +182,7 @@ export function useManagedAgentActions() {
     try {
       const agent = managedAgents.find((c) => c.pubkey === pubkey);
       if (!agent) return;
+      assertStartNotBlockedByPresence(agent);
       await startManagedAgentWithRules({
         agent,
         startManagedAgent: startMutation.mutateAsync,
@@ -184,6 +203,7 @@ export function useManagedAgentActions() {
         (candidate) => candidate.pubkey === pubkey,
       );
       if (!agent) return;
+      assertStartNotBlockedByPresence(agent);
       await respawnManagedAgentWithRules({
         agent,
         startManagedAgent: startMutation.mutateAsync,

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -328,7 +328,7 @@ export function useManagedAgentActions() {
         agent,
         channels,
         deleteManagedAgent: deleteMutation.mutateAsync,
-        presenceLookup: managedPresenceQuery.data,
+        getAvailability,
         relayAgents: relayAgentsQuery.data ?? [],
       });
       if (result.cancelled) return;

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/features/profile/hooks";
 import { formatOwnerLabel } from "@/features/profile/lib/identity";
 import { rankUserCandidatesBySearch } from "@/features/profile/lib/userCandidateSearch";
-import { usePresenceQuery } from "@/features/presence/hooks";
+import { useAgentAvailabilityLookup } from "@/features/agents/lib/useAgentAvailability";
 import { VirtualizedList } from "@/shared/ui/VirtualizedList";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { changeChannelMemberRole } from "@/shared/api/tauri";
@@ -198,7 +198,7 @@ export function MembersSidebar({
     () => rawMembers.map((member) => member.pubkey),
     [rawMembers],
   );
-  const memberPresenceQuery = usePresenceQuery(allMemberPubkeys, {
+  const { getAvailability } = useAgentAvailabilityLookup(allMemberPubkeys, {
     enabled: open && rawMembers.length > 0,
   });
   const memberProfilesQuery = useUsersBatchQuery(allMemberPubkeys, {
@@ -515,6 +515,7 @@ export function MembersSidebar({
     handleRemoveMember,
     isActionPending,
   } = useMembersSidebarActions({
+    getAvailability,
     channelId,
     controllableManagedBots,
     removableManagedBots,
@@ -682,9 +683,7 @@ export function MembersSidebar({
             : undefined
         }
         pairAction={pairAction}
-        presenceStatus={
-          memberPresenceQuery.data?.[member.pubkey.toLowerCase()] ?? null
-        }
+        presenceStatus={getAvailability(member.pubkey)}
         profileAvatarUrl={memberProfile?.avatarUrl ?? null}
         showOtherSetupMarker={showOtherSetupMarker}
         viewerIsOwner={viewerIsOwner}

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -1,4 +1,8 @@
 import {
+  agentPresenceStartBlockReason,
+  useAgentAvailability,
+} from "@/features/agents/lib/useAgentAvailability";
+import {
   Activity,
   Ban,
   Bot,
@@ -347,6 +351,14 @@ function MemberActionsMenu({
   const isBanned = moderationState?.banned ?? false;
   const isTimedOut = moderationState?.timedOut ?? false;
 
+  const { status: availability } = useAgentAvailability(managedAgent?.pubkey);
+  const startBlockReason = managedAgent
+    ? agentPresenceStartBlockReason(
+        pairAction ? pairAction === "stop" : isManagedAgentActive(managedAgent),
+        availability,
+      )
+    : undefined;
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
@@ -376,8 +388,11 @@ function MemberActionsMenu({
             {canViewActivity ? <DropdownMenuSeparator /> : null}
             <DropdownMenuItem
               data-testid={`sidebar-agent-action-${member.pubkey}`}
-              disabled={disabled}
-              onClick={() => onManagedAgentAction(managedAgent)}
+              disabled={disabled || Boolean(startBlockReason)}
+              title={startBlockReason}
+              onClick={() => {
+                if (!startBlockReason) onManagedAgentAction(managedAgent);
+              }}
             >
               {pairAction
                 ? getPairActionIcon(pairAction)

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -1,7 +1,4 @@
-import {
-  agentPresenceStartBlockReason,
-  useAgentAvailability,
-} from "@/features/agents/lib/useAgentAvailability";
+import { agentPresenceStartBlockReason } from "@/features/agents/lib/useAgentAvailability";
 import {
   Activity,
   Ban,
@@ -297,6 +294,7 @@ export function MembersSidebarMemberCard({
           onUntimeout={onUntimeout}
           onViewActivity={onViewActivity}
           pairAction={pairAction}
+          availability={presenceStatus ?? undefined}
         />
       ) : null}
     </div>
@@ -306,6 +304,7 @@ export function MembersSidebarMemberCard({
 const PEOPLE_ROLES = ["admin", "member", "guest"] as const;
 
 function MemberActionsMenu({
+  availability,
   canChangeRole,
   canModerateMember,
   canRemoveMember,
@@ -327,6 +326,7 @@ function MemberActionsMenu({
   pairAction,
 }: {
   canChangeRole: boolean;
+  availability: PresenceStatus | undefined;
   canModerateMember: boolean;
   canRemoveMember: boolean;
   canViewActivity: boolean;
@@ -351,7 +351,6 @@ function MemberActionsMenu({
   const isBanned = moderationState?.banned ?? false;
   const isTimedOut = moderationState?.timedOut ?? false;
 
-  const { status: availability } = useAgentAvailability(managedAgent?.pubkey);
   const startBlockReason = managedAgent
     ? agentPresenceStartBlockReason(
         pairAction ? pairAction === "stop" : isManagedAgentActive(managedAgent),

--- a/desktop/src/features/channels/ui/useMembersSidebarActions.ts
+++ b/desktop/src/features/channels/ui/useMembersSidebarActions.ts
@@ -1,3 +1,10 @@
+import {
+  agentPresenceStartBlockReason,
+  resolveAgentAvailability,
+} from "@/features/agents/lib/useAgentAvailability";
+import { usePresenceQuery } from "@/features/presence/hooks";
+import { useRelayConnection } from "@/shared/api/useRelayConnection";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -56,6 +63,24 @@ export function useMembersSidebarActions({
   relayUrl,
 }: UseMembersSidebarActionsOptions) {
   const queryClient = useQueryClient();
+  const presenceQuery = usePresenceQuery(
+    controllableManagedBots.map((agent) => agent.pubkey),
+  );
+  const connection = useRelayConnection();
+  function assertStartNotBlockedByPresence(
+    agent: ManagedAgent,
+    lifecycleActive: boolean,
+  ) {
+    const reason = agentPresenceStartBlockReason(
+      lifecycleActive,
+      resolveAgentAvailability(
+        presenceQuery.data?.[normalizePubkey(agent.pubkey)],
+        presenceQuery.isSuccess,
+        connection === "connected",
+      ),
+    );
+    if (reason) throw new Error(reason);
+  }
   const removeMemberMutation = useRemoveChannelMemberMutation(channelId);
   const startManagedAgentMutation = useStartManagedAgentMutation();
   const stopManagedAgentMutation = useStopManagedAgentMutation();
@@ -155,6 +180,7 @@ export function useMembersSidebarActions({
       // agent-wide deploy/!shutdown flow below.
       if (agent.backend.type === "local" && relayUrl) {
         const action = managedAgentPairAction(runtime);
+        assertStartNotBlockedByPresence(agent, action === "stop");
         await runtimeActionMutation.mutateAsync({
           action,
           pubkey: agent.pubkey,
@@ -188,6 +214,7 @@ export function useMembersSidebarActions({
         return;
       }
 
+      assertStartNotBlockedByPresence(agent, false);
       await startManagedAgentWithRules({
         agent,
         startManagedAgent: startManagedAgentMutation.mutateAsync,
@@ -205,6 +232,7 @@ export function useMembersSidebarActions({
   async function handleRespawnAll() {
     await runBulkAgentAction({
       action: async (agent) => {
+        assertStartNotBlockedByPresence(agent, isManagedAgentActive(agent));
         await respawnManagedAgentWithRules({
           agent,
           startManagedAgent: startManagedAgentMutation.mutateAsync,

--- a/desktop/src/features/channels/ui/useMembersSidebarActions.ts
+++ b/desktop/src/features/channels/ui/useMembersSidebarActions.ts
@@ -1,10 +1,7 @@
 import {
   agentPresenceStartBlockReason,
-  resolveAgentAvailability,
+  type AgentAvailabilityReader,
 } from "@/features/agents/lib/useAgentAvailability";
-import { usePresenceQuery } from "@/features/presence/hooks";
-import { useRelayConnection } from "@/shared/api/useRelayConnection";
-import { normalizePubkey } from "@/shared/lib/pubkey";
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -36,6 +33,7 @@ import type {
 
 type UseMembersSidebarActionsOptions = {
   channelId: string | null;
+  getAvailability: AgentAvailabilityReader;
   controllableManagedBots: readonly ManagedAgent[];
   removableManagedBots: readonly ManagedAgent[];
   currentPubkey?: string;
@@ -56,6 +54,7 @@ const EMPTY_AGENT_CONTEXT = {
 
 export function useMembersSidebarActions({
   channelId,
+  getAvailability,
   controllableManagedBots,
   removableManagedBots,
   currentPubkey,
@@ -63,21 +62,13 @@ export function useMembersSidebarActions({
   relayUrl,
 }: UseMembersSidebarActionsOptions) {
   const queryClient = useQueryClient();
-  const presenceQuery = usePresenceQuery(
-    controllableManagedBots.map((agent) => agent.pubkey),
-  );
-  const connection = useRelayConnection();
   function assertStartNotBlockedByPresence(
     agent: ManagedAgent,
     lifecycleActive: boolean,
   ) {
     const reason = agentPresenceStartBlockReason(
       lifecycleActive,
-      resolveAgentAvailability(
-        presenceQuery.data?.[normalizePubkey(agent.pubkey)],
-        presenceQuery.isSuccess,
-        connection === "connected",
-      ),
+      getAvailability(agent.pubkey),
     );
     if (reason) throw new Error(reason);
   }

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -135,7 +135,10 @@ export function usePresenceSubscription() {
       queryClient.setQueriesData<PresenceLookup>(
         {
           queryKey: ["presence"],
+          // A single live author cannot heal a failed aggregate snapshot:
+          // setQueriesData would mark every cached sibling successful again.
           predicate: (query) =>
+            query.state.status === "success" &&
             presenceQueryWantsPubkey(query.queryKey, pubkey),
         },
         (old) => mergePresenceUpdate(old, pubkey, status),
@@ -206,7 +209,9 @@ export function useSetPresenceMutation(pubkey?: string) {
       queryClient.setQueriesData<PresenceLookup>(
         {
           queryKey: ["presence"],
+          // A successful self heartbeat is not a fresh roster snapshot.
           predicate: (query) =>
+            query.state.status === "success" &&
             presenceQueryWantsPubkey(query.queryKey, normalizedPubkey),
         },
         (old) => mergePresenceUpdate(old, normalizedPubkey, status),

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -45,7 +45,8 @@ function normalizePubkeys(pubkeys: string[]) {
     .sort();
 }
 
-function presenceQueryKey(pubkeys: string[]) {
+/** Canonical normalized key shared by observers and action-time readers. */
+export function presenceQueryKey(pubkeys: string[]) {
   return ["presence", ...normalizePubkeys(pubkeys)] as const;
 }
 

--- a/desktop/src/features/profile/ui/UserProfileAgentManagementRows.tsx
+++ b/desktop/src/features/profile/ui/UserProfileAgentManagementRows.tsx
@@ -264,7 +264,9 @@ function AgentDeleteConfirmDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Delete this agent?</AlertDialogTitle>
           <AlertDialogDescription>
-            Deleting this agent stops and removes the agent from this community.
+            {isProviderAgent
+              ? "Deleting removes this agent’s local management record, not its remote deployment."
+              : "Deleting this agent stops and removes the agent from this community."}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <ul className="list-disc space-y-1.5 pl-5 text-sm text-muted-foreground">
@@ -276,7 +278,7 @@ function AgentDeleteConfirmDialog({
           </li>
           <li>
             {isProviderAgent
-              ? "Requests remote deletion; if it is online, Buzz first sends a shutdown command when possible. If the deployment cannot be reached through a channel, the remote process may keep running without local management."
+              ? "Unless the agent is known to be Offline, Buzz first requests shutdown through a channel when available. A failed request cancels deletion. The remote process may still be running even after a successful request."
               : "Stops any local agent process before deleting the record"}
           </li>
         </ul>

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/features/agents/ui/personaDialogState";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { useIdentityArchive } from "@/features/identity-archive/hooks";
-import { useAgentAvailability } from "@/features/agents/lib/useAgentAvailability";
+import { useAgentAvailabilityLookup } from "@/features/agents/lib/useAgentAvailability";
 import {
   useContactListQuery,
   useFollowMutation,
@@ -251,8 +251,10 @@ export function UserProfilePanel({
     effectivePubkey ? [effectivePubkey] : [],
   );
   const channelsQuery = useChannelsQuery();
-  const { query: presenceQuery, status: presenceStatus } =
-    useAgentAvailability(effectivePubkey);
+  const { query: presenceQuery, getAvailability } = useAgentAvailabilityLookup(
+    effectivePubkey ? [effectivePubkey] : [],
+  );
+  const presenceStatus = getAvailability(effectivePubkey);
   const userStatusQuery = useUserStatusQuery(
     effectivePubkey ? [effectivePubkey] : [],
   );
@@ -411,7 +413,7 @@ export function UserProfilePanel({
       deleteManagedAgent: deleteAgentMutation.mutateAsync,
       managedAgent,
       managedAgents: managedAgentsQuery.data,
-      presenceLookup: presenceQuery.data,
+      getAvailability,
       relayAgents: relayAgentsQuery.data,
     });
 

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -449,6 +449,7 @@ export function UserProfilePanel({
 
   const { handleAgentPrimaryAction, handleAgentRestart } =
     useAgentLifecycleActions({
+      availability: presenceStatus,
       channels: channelsQuery.data,
       managedAgent,
       relayAgents: relayAgentsQuery.data,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/features/agents/ui/personaDialogState";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { useIdentityArchive } from "@/features/identity-archive/hooks";
-import { usePresenceQuery } from "@/features/presence/hooks";
+import { useAgentAvailability } from "@/features/agents/lib/useAgentAvailability";
 import {
   useContactListQuery,
   useFollowMutation,
@@ -251,9 +251,8 @@ export function UserProfilePanel({
     effectivePubkey ? [effectivePubkey] : [],
   );
   const channelsQuery = useChannelsQuery();
-  const presenceQuery = usePresenceQuery(
-    effectivePubkey ? [effectivePubkey] : [],
-  );
+  const { query: presenceQuery, status: presenceStatus } =
+    useAgentAvailability(effectivePubkey);
   const userStatusQuery = useUserStatusQuery(
     effectivePubkey ? [effectivePubkey] : [],
   );
@@ -269,9 +268,6 @@ export function UserProfilePanel({
   });
   const ownerPubkey = profile?.ownerPubkey ?? null;
   const ownerProfileQuery = useUserProfileQuery(ownerPubkey ?? undefined);
-  const presenceStatus = pubkeyLower
-    ? presenceQuery.data?.[pubkeyLower]
-    : undefined;
   const userStatus = pubkeyLower
     ? userStatusQuery.data?.[pubkeyLower]
     : undefined;

--- a/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
@@ -11,7 +11,6 @@ import type {
   AgentPersona,
   Channel,
   ManagedAgent,
-  PresenceLookup,
   RelayAgent,
 } from "@/shared/api/types";
 import { getRelayAgentChannelIds } from "@/features/profile/ui/UserProfilePanelUtils";
@@ -36,7 +35,7 @@ type UseProfileAgentDeletionInput = {
   deleteManagedAgent: DeleteManagedAgentRulesContext["deleteManagedAgent"];
   managedAgent?: ManagedAgent;
   managedAgents?: readonly ManagedAgent[];
-  presenceLookup?: PresenceLookup | null;
+  getAvailability: DeleteManagedAgentRulesContext["getAvailability"];
   relayAgents?: readonly RelayAgent[];
 };
 
@@ -45,7 +44,7 @@ export function useProfileAgentDeletion({
   deleteManagedAgent,
   managedAgent,
   managedAgents,
-  presenceLookup,
+  getAvailability,
   relayAgents,
 }: UseProfileAgentDeletionInput) {
   const queryClient = useQueryClient();
@@ -83,7 +82,7 @@ export function useProfileAgentDeletion({
       deleteProfileManagedAgent(agentToDelete, {
         channels: channels ?? [],
         deleteManagedAgent,
-        presenceLookup,
+        getAvailability,
         relayAgents: relayAgents ?? [],
         removeAgentFromAllChannels,
         skipRemoteDeleteConfirm: true,
@@ -91,7 +90,7 @@ export function useProfileAgentDeletion({
     [
       channels,
       deleteManagedAgent,
-      presenceLookup,
+      getAvailability,
       relayAgents,
       removeAgentFromAllChannels,
     ],
@@ -103,7 +102,7 @@ export function useProfileAgentDeletion({
         channels: channels ?? [],
         deleteManagedAgent,
         managedAgents: managedAgents ?? [],
-        presenceLookup,
+        getAvailability,
         relayAgents: relayAgents ?? [],
         removeAgentFromAllChannels,
         selectedAgent: managedAgent,
@@ -113,7 +112,7 @@ export function useProfileAgentDeletion({
       deleteManagedAgent,
       managedAgent,
       managedAgents,
-      presenceLookup,
+      getAvailability,
       relayAgents,
       removeAgentFromAllChannels,
     ],

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -2,10 +2,7 @@ import * as React from "react";
 import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
-import {
-  getManagedAgentPrimaryActionLabel,
-  isManagedAgentActive,
-} from "@/features/agents/lib/managedAgentControlActions";
+import { getManagedAgentPrimaryActionLabel } from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
 import { AgentConfigPanel } from "@/features/agents/ui/AgentConfigPanel";
 import type { IdentityArchiveActions } from "@/features/identity-archive/hooks";
@@ -189,13 +186,6 @@ export function ProfileSummaryView({
   userStatus,
 }: ProfileSummaryViewProps) {
   const activeTurns = useAgentWorking(isBot ? pubkey : null).channels;
-  const avatarStatus = isBot
-    ? managedAgent
-      ? isManagedAgentActive(managedAgent)
-        ? "online"
-        : "offline"
-      : (presenceStatus ?? "offline")
-    : presenceStatus;
   const stickyLayoutRef = React.useRef<HTMLDivElement>(null);
   const [primaryActionsConcealed, setPrimaryActionsConcealed] =
     React.useState(false);
@@ -406,7 +396,7 @@ export function ProfileSummaryView({
           displayName={displayName}
           isBot={isBot}
           onEditAgent={canEditAgent ? handleEditAgent : undefined}
-          presenceStatus={avatarStatus}
+          presenceStatus={presenceStatus}
           profile={profile}
           userStatus={userStatus}
         />

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
-import { getManagedAgentPrimaryActionLabel } from "@/features/agents/lib/managedAgentControlActions";
+import { agentPresenceStartBlockReason } from "@/features/agents/lib/useAgentAvailability";
+import {
+  getManagedAgentPrimaryActionLabel,
+  isManagedAgentActive,
+} from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
 import { AgentConfigPanel } from "@/features/agents/ui/AgentConfigPanel";
 import type { IdentityArchiveActions } from "@/features/identity-archive/hooks";
@@ -417,6 +421,14 @@ export function ProfileSummaryView({
           concealed={primaryActionsConcealed}
           followMutation={followMutation}
           agentActionDisabled={isAgentActionPending}
+          agentStartBlockReason={
+            managedAgent
+              ? agentPresenceStartBlockReason(
+                  isManagedAgentActive(managedAgent),
+                  presenceStatus,
+                )
+              : undefined
+          }
           agentActionLabel={
             isOwner === true && managedAgent
               ? getManagedAgentPrimaryActionLabel(managedAgent)

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -18,7 +18,7 @@ import {
   ownsAuthorAgent,
 } from "@/features/profile/lib/identity";
 import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
-import { usePresenceQuery } from "@/features/presence/hooks";
+import { useAgentAvailability } from "@/features/agents/lib/useAgentAvailability";
 import { useUserStatusQuery } from "@/features/user-status/hooks";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import { ProfileAvatarWithStatus } from "@/features/profile/ui/ProfileAvatarWithStatus";
@@ -262,7 +262,7 @@ function UserProfilePopoverBody({
   const usersBatchQuery = useUsersBatchQuery([pubkey]);
   const relayAgentsQuery = useRelayAgentsQuery();
   const managedAgentsQuery = useManagedAgentsQuery();
-  const presenceQuery = usePresenceQuery([pubkey]);
+  const { status: presenceStatus } = useAgentAvailability(pubkey);
   const userStatusQuery = useUserStatusQuery([pubkey]);
 
   const { canOpenAgentActivity, openAgentActivity } = useOpenAgentActivity();
@@ -331,7 +331,6 @@ function UserProfilePopoverBody({
     showHumanProfileActions || showMessageAction || showHuddleAction;
   const canViewActivity =
     isBotProfile && viewerIsOwner && canOpenAgentActivity(pubkey);
-  const presenceStatus = presenceQuery.data?.[pubkey.toLowerCase()];
   const userStatus = userStatusQuery.data?.[pubkey.toLowerCase()];
   const userStatusText = userStatus?.text.trim() ?? "";
   const hasUserStatus = Boolean(userStatusText || userStatus?.emoji);

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -382,7 +382,7 @@ function UserProfilePopoverBody({
         label={displayName}
         shape={isBotProfile ? "squircle" : "circle"}
         size={40}
-        status={presenceStatus ?? "offline"}
+        status={presenceStatus}
         statusTestId="user-profile-popover-presence-badge"
         testId="user-profile-popover-avatar"
       />

--- a/desktop/src/features/profile/ui/UserProfilePrimaryActions.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePrimaryActions.tsx
@@ -25,6 +25,7 @@ import { Spinner } from "@/shared/ui/spinner";
 export function ProfilePrimaryActions({
   actionGroupRef,
   agentActionDisabled,
+  agentStartBlockReason,
   agentActionLabel,
   agentActionLive,
   className,
@@ -44,6 +45,7 @@ export function ProfilePrimaryActions({
 }: {
   actionGroupRef?: Ref<HTMLDivElement>;
   agentActionDisabled?: boolean;
+  agentStartBlockReason?: string;
   agentActionLabel?: string;
   agentActionLive?: boolean;
   className?: string;
@@ -94,7 +96,8 @@ export function ProfilePrimaryActions({
       {onAgentPrimaryAction && agentActionLabel ? (
         <ProfileActionTile
           active
-          disabled={agentActionDisabled}
+          disabled={agentActionDisabled || Boolean(agentStartBlockReason)}
+          title={agentStartBlockReason}
           icon={agentActionLive ? Square : Play}
           label={agentActionLabel}
           onClick={onAgentPrimaryAction}
@@ -216,6 +219,7 @@ function ProfileActionTile({
   label,
   onClick,
   testId,
+  title,
 }: {
   active?: boolean;
   disabled?: boolean;
@@ -224,6 +228,7 @@ function ProfileActionTile({
   label: string;
   onClick: () => void;
   testId?: string;
+  title?: string;
 }) {
   return (
     <button
@@ -234,6 +239,7 @@ function ProfileActionTile({
         active && "bg-foreground text-background hover:bg-foreground/90",
       )}
       data-testid={testId}
+      title={title}
       disabled={disabled}
       onClick={onClick}
       type="button"

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -7,6 +7,10 @@ import {
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
+import {
+  agentPresenceStartBlockReason,
+  useAgentAvailability,
+} from "@/features/agents/lib/useAgentAvailability";
 import { clearActiveTurnsForAgentOnStop } from "@/features/agents/managedAgentRuntimeHooks";
 import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
 
@@ -23,6 +27,7 @@ export function useAgentLifecycleActions({
   startManagedAgent: (pubkey: string) => Promise<unknown>;
   stopManagedAgent: (pubkey: string) => Promise<unknown>;
 }) {
+  const { status: availability } = useAgentAvailability(managedAgent?.pubkey);
   const handleAgentPrimaryAction = React.useCallback(async () => {
     if (!managedAgent) return;
 
@@ -41,6 +46,8 @@ export function useAgentLifecycleActions({
         return;
       }
 
+      const blockReason = agentPresenceStartBlockReason(false, availability);
+      if (blockReason) throw new Error(blockReason);
       await startManagedAgentWithRules({
         agent: managedAgent,
         startManagedAgent,
@@ -56,6 +63,7 @@ export function useAgentLifecycleActions({
       );
     }
   }, [
+    availability,
     channels,
     managedAgent,
     relayAgents,
@@ -67,6 +75,11 @@ export function useAgentLifecycleActions({
     if (!managedAgent) return;
 
     try {
+      const blockReason = agentPresenceStartBlockReason(
+        isManagedAgentActive(managedAgent),
+        availability,
+      );
+      if (blockReason) throw new Error(blockReason);
       await respawnManagedAgentWithRules({
         agent: managedAgent,
         startManagedAgent,
@@ -79,7 +92,7 @@ export function useAgentLifecycleActions({
         error instanceof Error ? error.message : "Agent restart failed.",
       );
     }
-  }, [managedAgent, startManagedAgent, stopManagedAgent]);
+  }, [availability, managedAgent, startManagedAgent, stopManagedAgent]);
 
   return { handleAgentPrimaryAction, handleAgentRestart };
 }

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -7,27 +7,30 @@ import {
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
-import {
-  agentPresenceStartBlockReason,
-  useAgentAvailability,
-} from "@/features/agents/lib/useAgentAvailability";
+import { agentPresenceStartBlockReason } from "@/features/agents/lib/useAgentAvailability";
 import { clearActiveTurnsForAgentOnStop } from "@/features/agents/managedAgentRuntimeHooks";
-import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
+import type {
+  Channel,
+  ManagedAgent,
+  RelayAgent,
+  PresenceStatus,
+} from "@/shared/api/types";
 
 export function useAgentLifecycleActions({
+  availability,
   channels,
   managedAgent,
   relayAgents,
   startManagedAgent,
   stopManagedAgent,
 }: {
+  availability: PresenceStatus | undefined;
   channels: readonly Channel[] | undefined;
   managedAgent: ManagedAgent | undefined;
   relayAgents: readonly RelayAgent[] | undefined;
   startManagedAgent: (pubkey: string) => Promise<unknown>;
   stopManagedAgent: (pubkey: string) => Promise<unknown>;
 }) {
-  const { status: availability } = useAgentAvailability(managedAgent?.pubkey);
   const handleAgentPrimaryAction = React.useCallback(async () => {
     if (!managedAgent) return;
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1230,6 +1230,11 @@ declare global {
       ownerPubkey: string;
       kind: number;
     }) => boolean;
+    /** Explicit presence evidence; independent of managed-agent runtime state. */
+    __BUZZ_E2E_EMIT_MOCK_PRESENCE__?: (input: {
+      pubkey: string;
+      status: PresenceStatus;
+    }) => void;
     __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
       channelName: string;
       content: string;
@@ -9644,7 +9649,7 @@ async function handleStartManagedAgent(
   agent.updated_at = now;
   agent.last_started_at = now;
   agent.last_error = null;
-  setMockPresenceStatus(agent.pubkey, "online");
+  // Lifecycle is not presence; scenarios publish explicit relay evidence.
   agent.log_lines.push(
     agent.backend.type === "provider"
       ? `deployed mock provider harness at ${now}`
@@ -9672,7 +9677,7 @@ async function handleStopManagedAgent(args: {
       row.pid = null;
     }
   }
-  setMockPresenceStatus(agent.pubkey, "offline");
+  // A stop result alone is not an authored offline presence event.
   agent.log_lines.push(`stopped mock harness at ${now}`);
   syncMockRelayAgentsFromManagedAgents();
   return cloneManagedAgent(agent);
@@ -11443,6 +11448,11 @@ export function maybeInstallE2eTauriMocks() {
     ownerPubkey,
     kind,
   }) => hasMockOwnerKindSubscription(ownerPubkey, kind);
+  window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__ = ({ pubkey, status }) => {
+    const author = pubkey.toLowerCase();
+    setMockPresenceStatus(author, status);
+    emitMockGlobalEvent(createMockEvent(20001, status, [], author));
+  };
   window.__BUZZ_E2E_REPLACE_MOCK_TEAM_CATALOG_HEAD__ = (event) => {
     const dTag = event.tags.find((tag) => tag[0] === "d")?.[1];
     const existingIndex = mockTeamCatalogEvents.findIndex(

--- a/desktop/tests/e2e/agent-availability.spec.ts
+++ b/desktop/tests/e2e/agent-availability.spec.ts
@@ -146,7 +146,7 @@ test("missing snapshot is offline but failed reads cannot reuse cached online", 
     w.__TAURI_INTERNALS__.invoke = async (command, payload, options) => {
       if (command === "get_presence") {
         if (w.__AVAILABILITY_RESPONSE__ === "error")
-          throw new Error("Presence fixture: relay read failed");
+          throw "relay unreachable: request timed out"; // Native Result::Err IPC shape
         if (w.__AVAILABILITY_RESPONSE__ === "missing") return {};
         if (w.__AVAILABILITY_RESPONSE__ === "online") {
           return Object.fromEntries(
@@ -348,3 +348,98 @@ test("member menu cannot start a present stopped local runtime", async ({
     )
     .toBe(1);
 });
+
+for (const surface of ["agents", "members"] as const) {
+  test(`${surface}: three rows and their actions share one presence request`, async ({
+    page,
+  }) => {
+    const keys = [LOCAL, "e".repeat(64), "f".repeat(64)];
+    await installMockBridge(page, {
+      managedAgents: keys.map((pubkey, index) => ({
+        pubkey,
+        name: `Shared snapshot ${index}`,
+        status: "running" as const,
+        channelNames: ["agents"],
+      })),
+    });
+    await page.goto(surface === "agents" ? "/#/agents" : "/");
+    if (surface === "members") {
+      await page.getByTestId("channel-agents").click();
+      await page.getByTestId("channel-members-trigger").click();
+    }
+    for (const pubkey of keys) {
+      await expect(
+        page.getByTestId(
+          surface === "agents"
+            ? `managed-agent-${pubkey}`
+            : `sidebar-member-${pubkey}`,
+        ),
+      ).toBeVisible();
+    }
+    // Count requests at the actual IPC boundary. Refresh every active presence
+    // observer so a hidden per-row/action query cannot escape the assertion.
+    const calls = await page.evaluate(async (keys) => {
+      const w = window as typeof window & {
+        __TAURI_INTERNALS__: {
+          invoke: (
+            command: string,
+            payload: unknown,
+            options: unknown,
+          ) => Promise<unknown>;
+        };
+        __BUZZ_E2E_QUERY_CLIENT__: {
+          invalidateQueries: (filter: { queryKey: string[] }) => Promise<void>;
+        };
+      };
+      const calls: string[][] = [];
+      const original = w.__TAURI_INTERNALS__.invoke;
+      w.__TAURI_INTERNALS__.invoke = (command, payload, options) => {
+        if (command === "get_presence") {
+          const pubkeys = (payload as { pubkeys: string[] }).pubkeys;
+          if (pubkeys.some((key) => keys.includes(key))) calls.push(pubkeys);
+        }
+        return original(command, payload, options);
+      };
+      try {
+        await w.__BUZZ_E2E_QUERY_CLIENT__.invalidateQueries({
+          queryKey: ["presence"],
+        });
+      } finally {
+        w.__TAURI_INTERNALS__.invoke = original;
+      }
+      return calls;
+    }, keys);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(expect.arrayContaining(keys));
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: "agents",
+            kind: 20001,
+          }),
+        ),
+      )
+      .toBe(true);
+    await page.evaluate(
+      (pubkey) =>
+        window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__?.({ pubkey, status: "away" }),
+      LOCAL,
+    );
+    if (surface === "agents") {
+      await expect(
+        page.getByTestId(`agent-runtime-active-${LOCAL}`),
+      ).toHaveAttribute("aria-label", "Shared snapshot 0: Away");
+      await expect(
+        page.getByTestId(`agent-runtime-active-${keys[1]}`),
+      ).toHaveAttribute("aria-label", "Shared snapshot 1: Offline");
+    } else {
+      await expect(
+        page.getByTestId(`sidebar-member-presence-${LOCAL}`).locator("span"),
+      ).toHaveClass(/bg-amber-500/);
+      await expect(
+        page.getByTestId(`sidebar-member-presence-${keys[1]}`).locator("span"),
+      ).toHaveClass(/bg-muted-foreground/);
+    }
+  });
+}

--- a/desktop/tests/e2e/agent-availability.spec.ts
+++ b/desktop/tests/e2e/agent-availability.spec.ts
@@ -592,3 +592,153 @@ test("hover profile preserves unknown availability and announces only establishe
   await expectUnknown();
   await expect(popover).toBeVisible();
 });
+
+for (const scenario of [
+  "failed-online",
+  "disconnected-online",
+  "failed-offline",
+  "offline",
+] as const) {
+  test(`profile deletion respects ${scenario} and preserves the record on shutdown failure`, async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: LOCAL,
+          name: "Deletion fixture",
+          status: "deployed",
+          backend: { type: "provider", id: "fixture", config: {} },
+          channelNames: ["agents"],
+        },
+      ],
+    });
+    await page.goto("/#/agents");
+    await expect(
+      page.getByRole("button", { name: "Deletion fixture agent profile" }),
+    ).toBeVisible();
+    await page.evaluate(
+      async ({ pubkey, warm }) => {
+        const w = window as typeof window & {
+          __DELETE_FAIL_PRESENCE__?: boolean;
+          __DELETE_FAIL_SHUTDOWN__?: boolean;
+          __DELETE_EFFECTS__?: string[];
+          __TAURI_INTERNALS__: {
+            invoke: (
+              command: string,
+              payload: unknown,
+              options: unknown,
+            ) => Promise<unknown>;
+          };
+        };
+        const original = w.__TAURI_INTERNALS__.invoke.bind(
+          w.__TAURI_INTERNALS__,
+        );
+        w.__DELETE_EFFECTS__ = [];
+        w.__DELETE_FAIL_SHUTDOWN__ = true;
+        w.__TAURI_INTERNALS__.invoke = async (command, payload, options) => {
+          if (command === "list_managed_agents") {
+            const rows = (await original(command, payload, options)) as Array<{
+              pubkey: string;
+              backend_agent_id: string | null;
+            }>;
+            return rows.map((row) =>
+              row.pubkey === pubkey
+                ? { ...row, backend_agent_id: "fixture-receipt" }
+                : row,
+            );
+          }
+          if (command === "get_presence") {
+            if (w.__DELETE_FAIL_PRESENCE__)
+              throw "relay unreachable: request timed out";
+            return { [pubkey]: warm };
+          }
+          if (
+            command === "send_channel_message" &&
+            (payload as { content?: string })?.content === "!shutdown"
+          ) {
+            w.__DELETE_EFFECTS__?.push("shutdown");
+            if (w.__DELETE_FAIL_SHUTDOWN__) throw "shutdown refused";
+          }
+          if (command === "delete_managed_agent")
+            w.__DELETE_EFFECTS__?.push("delete");
+          if (command === "remove_channel_member")
+            w.__DELETE_EFFECTS__?.push("remove-member");
+          return original(command, payload, options);
+        };
+        await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+          queryKey: ["managed-agents"],
+        });
+        await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+          queryKey: ["presence", pubkey],
+          exact: true,
+        });
+      },
+      {
+        pubkey: LOCAL,
+        warm: scenario.endsWith("offline") ? "offline" : "online",
+      },
+    );
+    await page
+      .getByRole("button", { name: "Deletion fixture agent profile" })
+      .click();
+    await expect(
+      page.getByTestId("user-profile-presence-badge"),
+    ).toHaveAttribute(
+      "aria-label",
+      scenario.endsWith("offline") ? "Offline" : "Online",
+    );
+    if (scenario.startsWith("failed")) {
+      await page.evaluate(async (pubkey) => {
+        (
+          window as typeof window & { __DELETE_FAIL_PRESENCE__?: boolean }
+        ).__DELETE_FAIL_PRESENCE__ = true;
+        await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+          queryKey: ["presence", pubkey],
+          exact: true,
+        });
+      }, LOCAL);
+    } else if (scenario.startsWith("disconnected")) {
+      await page.evaluate(() =>
+        window.__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?.("disconnected"),
+      );
+    }
+    if (scenario !== "offline")
+      await expect(page.getByTestId("user-profile-presence-badge")).toHaveCount(
+        0,
+      );
+    await page.getByTestId("user-profile-delete-agent-row").click();
+    const dialog = page.getByTestId("agent-delete-confirm-dialog");
+    await expect(dialog).toContainText("not its remote deployment");
+    await expect(dialog).toContainText("A failed request cancels deletion");
+    await expect(dialog).not.toContainText("This agent is offline");
+    await page.getByTestId("agent-delete-confirm-action").click();
+    const effects = () =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __DELETE_EFFECTS__?: string[] })
+            .__DELETE_EFFECTS__ ?? [],
+      );
+    if (scenario === "offline") {
+      await expect.poll(effects).toEqual(["delete", "remove-member"]);
+      await expect(page.getByTestId("user-profile-panel")).toHaveCount(0);
+    } else {
+      await expect.poll(effects).toEqual(["shutdown"]);
+      await expect(page.getByTestId("user-profile-panel")).toBeVisible();
+      // Retry the same user action without healing presence. A successful
+      // request permits the explicitly confirmed local deletion, not a claim
+      // of remote termination. No membership write precedes it.
+      await page.evaluate(() => {
+        (
+          window as typeof window & { __DELETE_FAIL_SHUTDOWN__?: boolean }
+        ).__DELETE_FAIL_SHUTDOWN__ = false;
+      });
+      await page.getByTestId("user-profile-delete-agent-row").click();
+      await page.getByTestId("agent-delete-confirm-action").click();
+      await expect
+        .poll(effects)
+        .toEqual(["shutdown", "shutdown", "delete", "remove-member"]);
+      await expect(page.getByTestId("user-profile-panel")).toHaveCount(0);
+    }
+  });
+}

--- a/desktop/tests/e2e/agent-availability.spec.ts
+++ b/desktop/tests/e2e/agent-availability.spec.ts
@@ -443,3 +443,152 @@ for (const surface of ["agents", "members"] as const) {
     }
   });
 }
+
+test("hover profile preserves unknown availability and announces only established status", async ({
+  page,
+}) => {
+  const pubkey =
+    "554cef57437abac34522ac2c9f0490d685b72c80478cf9f7ed6f9570ee8624ea";
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey,
+        name: "Charlie",
+        status: "running",
+        channelNames: ["agents"],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+  // Hold the actual single-key IPC read pending before opening the lazy hover
+  // body. Do not mock the availability hook, avatar or rendered query state.
+  await page.evaluate((pubkey) => {
+    const w = window as typeof window & {
+      __POPOVER_RESPONSE__?:
+        | "pending"
+        | "missing"
+        | "offline"
+        | "online"
+        | "error";
+      __POPOVER_RELEASE__?: () => void;
+      __TAURI_INTERNALS__: {
+        invoke: (
+          command: string,
+          payload: unknown,
+          options: unknown,
+        ) => Promise<unknown>;
+      };
+    };
+    w.__POPOVER_RESPONSE__ = "pending";
+    const original = w.__TAURI_INTERNALS__.invoke.bind(w.__TAURI_INTERNALS__);
+    w.__TAURI_INTERNALS__.invoke = async (command, payload, options) => {
+      const keys = (payload as { pubkeys?: string[] } | undefined)?.pubkeys;
+      if (
+        command === "get_presence" &&
+        keys?.length === 1 &&
+        keys[0] === pubkey
+      ) {
+        if (w.__POPOVER_RESPONSE__ === "pending") {
+          await new Promise<void>((resolve) => {
+            w.__POPOVER_RELEASE__ = resolve;
+          });
+        }
+        if (w.__POPOVER_RESPONSE__ === "error") {
+          throw "relay unreachable: request timed out"; // Native Result::Err IPC shape
+        }
+        if (w.__POPOVER_RESPONSE__ === "missing") return {};
+        return { [pubkey]: w.__POPOVER_RESPONSE__ };
+      }
+      return original(command, payload, options);
+    };
+  }, pubkey);
+
+  await page
+    .getByTestId("message-row")
+    .filter({ hasText: "Indexing the channel catalog now." })
+    .getByRole("button")
+    .first()
+    .hover();
+  const popover = page.getByTestId("user-profile-popover");
+  const badge = popover.getByTestId("user-profile-popover-presence-badge");
+  await expect(popover).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          typeof (window as typeof window & { __POPOVER_RELEASE__?: unknown })
+            .__POPOVER_RELEASE__,
+      ),
+    )
+    .toBe("function");
+
+  async function expectUnknown() {
+    await expect(badge).toHaveCount(0);
+    await expect(
+      popover.getByRole("img", { name: /^(Offline|Online|Away)$/ }),
+    ).toHaveCount(0);
+    await expect(
+      popover
+        .locator(".sr-only")
+        .filter({ hasText: /^(Offline|Online|Away)$/ }),
+    ).toHaveCount(0);
+  }
+  async function expectStatus(label: string) {
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveAttribute("role", "img");
+    await expect(badge).toHaveAttribute("aria-label", label);
+    await expect(badge.locator(".sr-only")).toHaveText(label);
+  }
+  await expectUnknown();
+  await page.evaluate(() => {
+    const w = window as typeof window & {
+      __POPOVER_RESPONSE__?: string;
+      __POPOVER_RELEASE__?: () => void;
+    };
+    w.__POPOVER_RESPONSE__ = "missing";
+    w.__POPOVER_RELEASE__?.();
+  });
+  await expectStatus("Offline");
+
+  // Successful missing is distinct from explicit Offline, failure (including
+  // stale Online), and a disconnect after recovery. Keep the same popover open.
+  for (const response of [
+    "offline",
+    "online",
+    "error",
+    "missing",
+    "online",
+  ] as const) {
+    await page.evaluate(
+      async ({ response, pubkey }) => {
+        const w = window as typeof window & {
+          __POPOVER_RESPONSE__?: typeof response;
+          __BUZZ_E2E_QUERY_CLIENT__?: {
+            invalidateQueries: (filter: {
+              queryKey: string[];
+              exact: boolean;
+            }) => Promise<void>;
+          };
+        };
+        w.__POPOVER_RESPONSE__ = response;
+        if (!w.__BUZZ_E2E_QUERY_CLIENT__)
+          throw new Error("Query client unavailable");
+        await w.__BUZZ_E2E_QUERY_CLIENT__.invalidateQueries({
+          queryKey: ["presence", pubkey],
+          exact: true,
+        });
+      },
+      { response, pubkey },
+    );
+    if (response === "error") await expectUnknown();
+    else await expectStatus(response === "online" ? "Online" : "Offline");
+  }
+  await page.evaluate(() =>
+    window.__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?.("disconnected"),
+  );
+  await expectUnknown();
+  await expect(popover).toBeVisible();
+});

--- a/desktop/tests/e2e/agent-availability.spec.ts
+++ b/desktop/tests/e2e/agent-availability.spec.ts
@@ -189,3 +189,162 @@ test("missing snapshot is offline but failed reads cannot reuse cached online", 
     ).toHaveAttribute("aria-label", "Stop");
   }
 });
+
+test("stopped local with authored presence has a dot, not an invokable Start", async ({
+  page,
+}, testInfo) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: LOCAL,
+        name: "Present local",
+        status: "stopped",
+        channelNames: ["agents"],
+      },
+    ],
+  });
+  await page.goto("/#/agents");
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+          channelName: "agents",
+          kind: 20001,
+        }),
+      ),
+    )
+    .toBe(true);
+  await page.evaluate(
+    (pubkey) =>
+      window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__?.({ pubkey, status: "online" }),
+    LOCAL,
+  );
+  await expect(
+    page.getByTestId(`agent-runtime-active-${LOCAL}`),
+  ).toHaveAttribute("aria-label", "Present local: Online");
+  await expect(page.getByTestId(`agent-runtime-start-${LOCAL}`)).toHaveCount(0);
+  await page
+    .getByRole("button", { name: "Present local agent profile" })
+    .press("Enter");
+  const action = page.getByTestId("user-profile-agent-primary-action");
+  await expect(action).toHaveAttribute("aria-label", "Start agent");
+  await expect(action).toBeDisabled();
+  await action.evaluate((button: HTMLButtonElement) => button.click());
+  await action.press("Enter");
+  await action.press("Space");
+  expect(
+    await page.evaluate(() =>
+      (window.__BUZZ_E2E_COMMANDS__ ?? []).filter((command) =>
+        ["start_managed_agent", "stop_managed_agent"].includes(command),
+      ),
+    ),
+  ).toEqual([]);
+  await expect(page.getByTestId("user-profile-agent-restart")).toHaveCount(0);
+  const badge = page.getByTestId("user-profile-presence-badge");
+  await expect(badge).toHaveAttribute("aria-label", "Online");
+  await waitForAnimations(page);
+  await page
+    .getByTestId(`managed-agent-${LOCAL}`)
+    .screenshot({ path: testInfo.outputPath("stopped-online-card.png") });
+  await page
+    .getByTestId("user-profile-panel")
+    .screenshot({ path: testInfo.outputPath("stopped-online-profile.png") });
+  for (const status of ["away", "offline"] as const) {
+    await page.evaluate(
+      ({ pubkey, status }) =>
+        window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__?.({ pubkey, status }),
+      { pubkey: LOCAL, status },
+    );
+    await expect(badge).toHaveAttribute(
+      "aria-label",
+      status === "away" ? "Away" : "Offline",
+    );
+    if (status === "away") {
+      await expect(
+        page.getByTestId(`agent-runtime-active-${LOCAL}`),
+      ).toHaveAttribute("aria-label", "Present local: Away");
+      await expect(action).toBeDisabled();
+    } else {
+      await expect(action).toBeEnabled();
+      await expect(
+        page.getByTestId(`agent-runtime-start-${LOCAL}`),
+      ).toBeVisible();
+    }
+  }
+  // Keyboard activation is restored for the ordinary stopped/offline control.
+  // Runtime startup alone must still not manufacture authored availability.
+  await action.press("Enter");
+  await expect(action).toHaveAttribute("aria-label", "Stop");
+  await expect(badge).toHaveAttribute("aria-label", "Offline");
+  await expect(
+    page.getByTestId(`agent-runtime-active-${LOCAL}`),
+  ).toHaveAttribute("aria-label", "Present local: Offline");
+});
+
+test("member menu cannot start a present stopped local runtime", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: LOCAL,
+        name: "Present member",
+        status: "stopped",
+        channelNames: ["agents"],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await page.getByTestId("channel-members-trigger").click();
+  const row = page.getByTestId(`sidebar-member-${LOCAL}`);
+  await expect(row).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+          channelName: "agents",
+          kind: 20001,
+        }),
+      ),
+    )
+    .toBe(true);
+  await page.evaluate(
+    (pubkey) =>
+      window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__?.({ pubkey, status: "away" }),
+    LOCAL,
+  );
+  await row.hover();
+  const menu = page.getByTestId(`sidebar-member-menu-${LOCAL}`);
+  await menu.focus();
+  await menu.press("Enter");
+  const action = page.getByTestId(`sidebar-agent-action-${LOCAL}`);
+  await expect(action).toContainText("Start");
+  await expect(action).toHaveAttribute("aria-disabled", "true");
+  await action.press("Enter");
+  await action.evaluate((node: HTMLElement) => node.click());
+  expect(
+    await page.evaluate(() =>
+      (window.__BUZZ_E2E_COMMANDS__ ?? []).filter((command) =>
+        /^(start|stop)_managed_agent/.test(command),
+      ),
+    ),
+  ).toEqual([]);
+  await page.evaluate(
+    (pubkey) =>
+      window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__?.({ pubkey, status: "offline" }),
+    LOCAL,
+  );
+  await expect(action).not.toHaveAttribute("aria-disabled", "true");
+  await action.click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window.__BUZZ_E2E_COMMANDS__ ?? []).filter(
+            (command) => command === "start_managed_agent_runtime",
+          ).length,
+      ),
+    )
+    .toBe(1);
+});

--- a/desktop/tests/e2e/agent-availability.spec.ts
+++ b/desktop/tests/e2e/agent-availability.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test } from "@playwright/test";
+import { installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+
+const LOCAL = "d".repeat(64);
+
+test("saved deployment with offline presence is not shown as online", async ({
+  page,
+}, testInfo) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: LOCAL,
+        name: "Offline deployment",
+        status: "deployed",
+        backend: { type: "provider", id: "fixture", config: {} },
+        channelNames: ["agents"],
+      },
+    ],
+  });
+  await page.goto("/#/agents");
+  const dot = page.getByTestId(`agent-runtime-active-${LOCAL}`);
+  await expect(dot).toHaveAttribute(
+    "aria-label",
+    "Offline deployment: Offline",
+  );
+  await expect(dot.locator("xpath=../..")).not.toHaveClass(/bg-emerald-500/);
+  await page
+    .getByRole("button", { name: "Offline deployment agent profile" })
+    .click();
+  await expect(page.getByTestId("user-profile-presence-badge")).toHaveAttribute(
+    "aria-label",
+    "Offline",
+  );
+  // Preserve the existing request-only lifecycle control; no inferred redeploy.
+  await expect(
+    page.getByTestId("user-profile-agent-primary-action"),
+  ).toHaveAttribute("aria-label", "Shutdown");
+  await waitForAnimations(page);
+  await page
+    .getByTestId("user-profile-panel")
+    .screenshot({ path: testInfo.outputPath("offline-deployment.png") });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+          channelName: "agents",
+          kind: 20001,
+        }),
+      ),
+    )
+    .toBe(true);
+  for (const status of ["online", "away", "offline"] as const) {
+    await page.evaluate(
+      ({ pubkey, status }) => {
+        const emit = window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__;
+        if (!emit) throw new Error("Mock presence emitter is unavailable.");
+        emit({ pubkey, status });
+      },
+      { pubkey: LOCAL, status },
+    );
+    await expect(
+      page.getByTestId("user-profile-presence-badge"),
+    ).toHaveAttribute("aria-label", status[0].toUpperCase() + status.slice(1));
+    await expect(dot).toHaveAttribute(
+      "aria-label",
+      `Offline deployment: ${status[0].toUpperCase() + status.slice(1)}`,
+    );
+    await expect(
+      page.getByTestId("user-profile-agent-primary-action"),
+    ).toHaveAttribute("aria-label", "Shutdown");
+    if (status === "online") {
+      await waitForAnimations(page);
+      await page
+        .getByTestId("user-profile-panel")
+        .screenshot({ path: testInfo.outputPath("online-deployment.png") });
+      await page.getByTestId("user-profile-agent-primary-action").click();
+      await expect(
+        page.locator("[data-sonner-toast]").filter({
+          hasText:
+            "Shutdown requested. This does not confirm the agent has stopped.",
+        }),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId("user-profile-presence-badge"),
+      ).toHaveAttribute("aria-label", "Online");
+      await expect(
+        page.getByTestId("user-profile-agent-primary-action"),
+      ).toHaveAttribute("aria-label", "Shutdown");
+      expect(
+        await page.evaluate(() =>
+          (window.__BUZZ_E2E_COMMANDS__ ?? []).filter((command) =>
+            ["start_managed_agent", "stop_managed_agent"].includes(command),
+          ),
+        ),
+      ).toEqual([]);
+    }
+  }
+  await page.evaluate(() =>
+    window.__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?.("disconnected"),
+  );
+  await expect(page.getByTestId("user-profile-presence-badge")).toHaveCount(0);
+  await expect(dot).toHaveAttribute(
+    "aria-label",
+    "Offline deployment: Availability unknown",
+  );
+});
+
+test("missing snapshot is offline but failed reads cannot reuse cached online", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: LOCAL,
+        name: "Snapshot agent",
+        status: "running",
+        channelNames: ["agents"],
+      },
+    ],
+  });
+  await page.goto("/#/agents");
+  const dot = page.getByTestId(`agent-runtime-active-${LOCAL}`);
+  await expect(dot).toHaveAttribute("aria-label", "Snapshot agent: Offline");
+  await page
+    .getByRole("button", { name: "Snapshot agent agent profile" })
+    .click();
+  const badge = page.getByTestId("user-profile-presence-badge");
+  await expect(badge).toHaveAttribute("aria-label", "Offline");
+
+  // Override the IPC response, not rendered state or query data. Both card and
+  // profile must consume the same real query success/error boundary.
+  await page.evaluate(() => {
+    const w = window as typeof window & {
+      __AVAILABILITY_RESPONSE__?: "missing" | "online" | "error";
+      __TAURI_INTERNALS__: {
+        invoke: (
+          command: string,
+          payload: unknown,
+          options: unknown,
+        ) => Promise<unknown>;
+      };
+    };
+    const original = w.__TAURI_INTERNALS__.invoke.bind(w.__TAURI_INTERNALS__);
+    w.__TAURI_INTERNALS__.invoke = async (command, payload, options) => {
+      if (command === "get_presence") {
+        if (w.__AVAILABILITY_RESPONSE__ === "error")
+          throw new Error("Presence fixture: relay read failed");
+        if (w.__AVAILABILITY_RESPONSE__ === "missing") return {};
+        if (w.__AVAILABILITY_RESPONSE__ === "online") {
+          return Object.fromEntries(
+            (payload as { pubkeys: string[] }).pubkeys.map((key) => [
+              key,
+              "online",
+            ]),
+          );
+        }
+      }
+      return original(command, payload, options);
+    };
+  });
+  for (const response of ["online", "missing", "online", "error"] as const) {
+    await page.evaluate(async (response) => {
+      const w = window as typeof window & {
+        __AVAILABILITY_RESPONSE__?: typeof response;
+        __BUZZ_E2E_QUERY_CLIENT__?: {
+          invalidateQueries: (filter: { queryKey: string[] }) => Promise<void>;
+        };
+      };
+      w.__AVAILABILITY_RESPONSE__ = response;
+      if (!w.__BUZZ_E2E_QUERY_CLIENT__)
+        throw new Error("Query client unavailable");
+      await w.__BUZZ_E2E_QUERY_CLIENT__.invalidateQueries({
+        queryKey: ["presence"],
+      });
+    }, response);
+    const label =
+      response === "error"
+        ? "Availability unknown"
+        : response === "missing"
+          ? "Offline"
+          : "Online";
+    await expect(dot).toHaveAttribute("aria-label", `Snapshot agent: ${label}`);
+    if (response === "error") await expect(badge).toHaveCount(0);
+    else await expect(badge).toHaveAttribute("aria-label", label);
+    await expect(
+      page.getByTestId("user-profile-agent-primary-action"),
+    ).toHaveAttribute("aria-label", "Stop");
+  }
+});

--- a/desktop/tests/e2e/agent-error-state-screenshots.spec.ts
+++ b/desktop/tests/e2e/agent-error-state-screenshots.spec.ts
@@ -3,7 +3,8 @@
  *
  * Exercises the two visible surfaces where friendly error copy appears:
  *   - Agent card avatar badge (CircleAlert icon + tooltip) for stopped agents
- *     with a lastError / lastErrorCode.
+ *     with a lastError / lastErrorCode and explicit Offline presence.
+ *   - Online/Away presence taking precedence over a stopped record's error.
  *
  * ManagedAgentRow (StatusBlock text) is also exercised here even though it is
  * not yet wired into a reachable route in the main app — it will be connected
@@ -49,6 +50,33 @@ async function gotoAgentsView(page: import("@playwright/test").Page) {
   });
 }
 
+// Alice/Bob are Online/Away in the shared bridge, regardless of lifecycle.
+// Publish scenario-owned presence through the real query's live subscription.
+async function setAgentPresence(
+  page: import("@playwright/test").Page,
+  pubkeys: string[],
+  status: "online" | "away" | "offline",
+) {
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+          channelName: "agents",
+          kind: 20001,
+        }),
+      ),
+    )
+    .toBe(true);
+  await page.evaluate(
+    ({ pubkeys, status }) => {
+      const emit = window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__;
+      if (!emit) throw new Error("Mock presence emitter is unavailable.");
+      for (const pubkey of pubkeys) emit({ pubkey, status });
+    },
+    { pubkeys, status },
+  );
+}
+
 test.describe("agent error state screenshots", () => {
   test.use({ viewport: { width: 1280, height: 900 } });
 
@@ -71,12 +99,17 @@ test.describe("agent error state screenshots", () => {
     });
 
     await gotoAgentsView(page);
+    await setAgentPresence(page, [MODEL_NOT_FOUND_AGENT.pubkey], "offline");
 
     // Wait for the error badge to appear (stopped agent with error).
     const errorBadge = page.getByTestId(
       `agent-runtime-error-${MODEL_NOT_FOUND_AGENT.pubkey}`,
     );
     await expect(errorBadge).toBeVisible({ timeout: 10_000 });
+    await expect(errorBadge).toHaveAttribute(
+      "title",
+      "The configured model is not available — open agent settings and select a different one from the dropdown.",
+    );
     await waitForAnimations(page);
 
     // Capture the agent card element.
@@ -98,11 +131,16 @@ test.describe("agent error state screenshots", () => {
     });
 
     await gotoAgentsView(page);
+    await setAgentPresence(page, [GENERIC_ERROR_AGENT.pubkey], "offline");
 
     const errorBadge = page.getByTestId(
       `agent-runtime-error-${GENERIC_ERROR_AGENT.pubkey}`,
     );
     await expect(errorBadge).toBeVisible({ timeout: 10_000 });
+    await expect(errorBadge).toHaveAttribute(
+      "title",
+      GENERIC_ERROR_AGENT.lastError,
+    );
     await waitForAnimations(page);
 
     const agentCard = page.getByTestId(
@@ -121,6 +159,11 @@ test.describe("agent error state screenshots", () => {
     });
 
     await gotoAgentsView(page);
+    await setAgentPresence(
+      page,
+      [MODEL_NOT_FOUND_AGENT.pubkey, GENERIC_ERROR_AGENT.pubkey],
+      "offline",
+    );
 
     // Wait for both error badges to be present.
     await expect(
@@ -135,6 +178,38 @@ test.describe("agent error state screenshots", () => {
     const section = page.getByTestId("agents-library-personas");
     await section.screenshot({
       path: `${SHOTS}/03-agents-section-both-errors.png`,
+    });
+  });
+
+  test("04-positive-presence-supersedes-stopped-errors", async ({ page }) => {
+    await installMockBridge(page, {
+      managedAgents: [MODEL_NOT_FOUND_AGENT, GENERIC_ERROR_AGENT],
+    });
+    await gotoAgentsView(page);
+    await setAgentPresence(page, [MODEL_NOT_FOUND_AGENT.pubkey], "online");
+    await setAgentPresence(page, [GENERIC_ERROR_AGENT.pubkey], "away");
+
+    for (const [agent, label] of [
+      [MODEL_NOT_FOUND_AGENT, "Online"],
+      [GENERIC_ERROR_AGENT, "Away"],
+    ] as const) {
+      const presence = page.getByTestId(`agent-runtime-active-${agent.pubkey}`);
+      await expect(presence).toBeVisible();
+      await expect(presence).toHaveAttribute("role", "img");
+      await expect(presence).toHaveAttribute(
+        "aria-label",
+        `${agent.name}: ${label}`,
+      );
+      await expect(
+        page.getByTestId(`agent-runtime-error-${agent.pubkey}`),
+      ).toHaveCount(0);
+      await expect(
+        page.getByTestId(`agent-runtime-start-${agent.pubkey}`),
+      ).toHaveCount(0);
+    }
+    await waitForAnimations(page);
+    await page.getByTestId("agents-library-personas").screenshot({
+      path: `${SHOTS}/04-positive-presence-supersedes-stopped-errors.png`,
     });
   });
 });

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -2705,6 +2705,34 @@ test("start pill morphs into the running dot without remounting the avatar", asy
   expect(samples.at(-1)?.width).toBeCloseTo(activeDotSize, 0);
   expect(samples.at(-1)?.height).toBeCloseTo(activeDotSize, 0);
   expect(samples.at(-1)?.backgroundColor).not.toBe(samples[0]?.backgroundColor);
+  // The runtime transition must morph the badge without inventing availability.
+  const availabilityDot = page.getByTestId(`agent-runtime-active-${pubkey}`);
+  await expect(availabilityDot).toHaveAttribute(
+    "aria-label",
+    "Motion Auditor: Offline",
+  );
+  await expect(availabilityDot.locator("xpath=../..")).not.toHaveClass(
+    /bg-emerald-500/,
+  );
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+          channelName: "agents",
+          kind: 20001,
+        }),
+      ),
+    )
+    .toBe(true);
+  await page.evaluate((pubkey) => {
+    const emit = window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__;
+    if (!emit) throw new Error("Mock presence emitter is unavailable.");
+    emit({ pubkey, status: "online" });
+  }, pubkey);
+  await expect(availabilityDot).toHaveAttribute(
+    "aria-label",
+    "Motion Auditor: Online",
+  );
   await expect(
     page.getByTestId(`agent-runtime-active-${pubkey}`).locator("xpath=../.."),
   ).toHaveClass(/bg-emerald-500/);

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1035,11 +1035,10 @@ test("drops an expanded DM after the first message fails", async ({ page }) => {
   await expect(
     page.getByTestId("new-message-page").getByText(sendError, { exact: true }),
   ).toBeVisible();
-  await expect(
-    page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: `Message failed to send: ${sendError}` }),
-  ).toBeVisible();
+  const sendErrorToast = page
+    .locator("[data-sonner-toast]")
+    .filter({ hasText: `Message failed to send: ${sendError}` });
+  await expect(sendErrorToast).toBeVisible();
   await expect(input).toContainText("Fizz");
 
   const commandsAfterFailure = await readCommandPayloadLog(page);
@@ -1061,6 +1060,11 @@ test("drops an expanded DM after the first message fails", async ({ page }) => {
     "open_dm",
   );
 
+  // fill() does not move the pointer off Send, where the error toast appears.
+  // Sonner pauses dismissal on hover; move back to the editor and observe the
+  // toast's normal expiry before retrying the covered button.
+  await input.hover();
+  await expect(sendErrorToast).toHaveCount(0, { timeout: 10_000 });
   await input.fill(retryMessage);
   const retryBaseline = commandsAfterFailure.length;
   await page.getByTestId("send-message").click();

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -435,6 +435,9 @@ async function expectWelcomeView(page: Page) {
     "Create an agent",
   );
   await expect(page.getByTestId("message-composer")).toBeVisible();
+  // Measure the empty-channel intro before presence releases the live kickoff.
+  // Its message arrival can remount the timeline while bounding boxes are read.
+  await publishWelcomeTeamPresence(page);
   await expect(page.getByTestId("welcome-composer-guide-banner")).toBeVisible();
   await expect(page.getByTestId("welcome-composer-guide-banner")).toContainText(
     "Mention",
@@ -2997,7 +3000,6 @@ test("avatar step accepts an avatar URL before completing onboarding", async ({
 
   await page.getByTestId("onboarding-next").click();
   await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
-  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
 });
 
@@ -3033,7 +3035,6 @@ test("failed avatar saves can continue without saving the avatar", async ({
   await page.getByTestId("onboarding-next-without-saving").click();
 
   await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
-  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
 });
 
@@ -3132,7 +3133,6 @@ test("first-run onboarding keeps the shell hidden and lands on private Welcome a
   await page.getByTestId("onboarding-display-name").fill("Alice");
   await completeProfileOnboarding(page);
   await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
-  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
   await expectStarterChannels(page);
   await expectWelcomeGuideIntro(page);
@@ -3307,7 +3307,6 @@ test("finishing onboarding creates starter channels and focuses welcome-everyone
   await page.getByTestId("onboarding-display-name").fill("Morty QA");
   await completeProfileOnboarding(page);
 
-  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
   await expect(page.getByTestId("channel-general")).toBeVisible();
   await expectStarterChannels(page);

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -8,6 +8,11 @@ import {
   TEST_IDENTITIES,
 } from "../helpers/bridge";
 import { expectEmojiMartStylesInstalled } from "../helpers/css";
+import {
+  invokeMockCommand,
+  publishWelcomeTeamPresence,
+  waitForWelcomeTeam,
+} from "../helpers/welcomeTeam";
 import { installFakeCamera } from "../helpers/fakeCamera";
 import {
   E2E_IDENTITY_OVERRIDE_STORAGE_KEY,
@@ -517,39 +522,6 @@ async function getMockChannels(page: Page) {
     };
     return payload.channels ?? [];
   });
-}
-
-async function invokeMockCommand<T>(
-  page: Page,
-  command: string,
-  payload?: Record<string, unknown>,
-) {
-  return page.evaluate(
-    async ({ command, payload }) => {
-      const bridgeWindow = window as Window & {
-        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
-          command: string,
-          payload?: Record<string, unknown>,
-        ) => Promise<unknown>;
-        __TAURI_INTERNALS__?: {
-          invoke?: (
-            command: string,
-            payload?: Record<string, unknown>,
-          ) => Promise<unknown>;
-        };
-      };
-      const invoke =
-        bridgeWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__ ??
-        bridgeWindow.__TAURI_INTERNALS__?.invoke;
-
-      if (!invoke) {
-        throw new Error("Mock invoke bridge is unavailable.");
-      }
-
-      return (await invoke(command, payload)) as T;
-    },
-    { command, payload },
-  );
 }
 
 async function seedCurrentAvatar(page: Page, avatarUrl: string) {
@@ -3025,6 +2997,7 @@ test("avatar step accepts an avatar URL before completing onboarding", async ({
 
   await page.getByTestId("onboarding-next").click();
   await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
 });
 
@@ -3060,6 +3033,7 @@ test("failed avatar saves can continue without saving the avatar", async ({
   await page.getByTestId("onboarding-next-without-saving").click();
 
   await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
 });
 
@@ -3158,6 +3132,7 @@ test("first-run onboarding keeps the shell hidden and lands on private Welcome a
   await page.getByTestId("onboarding-display-name").fill("Alice");
   await completeProfileOnboarding(page);
   await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
   await expectStarterChannels(page);
   await expectWelcomeGuideIntro(page);
@@ -3215,6 +3190,22 @@ test("first-run onboarding posts the live Fizz kickoff", async ({ page }) => {
   await completeProfileOnboarding(page);
 
   await expectPrivateWelcomeLanding(page);
+  // Runtime start alone cannot satisfy the kickoff's relay-presence wait.
+  const team = await waitForWelcomeTeam(page);
+  const presence = await invokeMockCommand<Record<string, string>>(
+    page,
+    "get_presence",
+    { pubkeys: team.map((agent) => agent.pubkey) },
+  );
+  expect(team.map((agent) => presence[agent.pubkey])).toEqual([
+    "offline",
+    "offline",
+    "offline",
+  ]);
+  await expect(page.getByTestId("message-timeline")).not.toContainText(
+    "Hi Morty QA, I'm Fizz. Welcome to Buzz.",
+  );
+  await publishWelcomeTeamPresence(page);
   // Greeted by the name typed above — the @mention pill also files the opener
   // into the new user's Inbox mentions feed.
   await expect(page.getByTestId("message-timeline")).toContainText(
@@ -3241,6 +3232,7 @@ test("first-run onboarding lands before Welcome team bootstrap completes", async
 
   await expectPrivateWelcomeLanding(page);
   await expect(page.getByTestId("app-loading-gate")).toHaveCount(0);
+  await publishWelcomeTeamPresence(page);
   await expect(page.getByTestId("message-timeline")).toContainText(
     "Hi Morty QA, I'm Fizz. Welcome to Buzz.",
   );
@@ -3315,6 +3307,7 @@ test("finishing onboarding creates starter channels and focuses welcome-everyone
   await page.getByTestId("onboarding-display-name").fill("Morty QA");
   await completeProfileOnboarding(page);
 
+  await publishWelcomeTeamPresence(page);
   await expectWelcomeView(page);
   await expect(page.getByTestId("channel-general")).toBeVisible();
   await expectStarterChannels(page);
@@ -3331,6 +3324,7 @@ test("welcome-everywhere banner: X dismiss removes the guidance surface", async 
 
   await page.getByTestId("onboarding-display-name").fill("Morty QA");
   await completeProfileOnboarding(page);
+  await publishWelcomeTeamPresence(page);
 
   const banner = page.getByTestId("welcome-composer-guide-banner");
   const guidanceLayer = page.getByTestId("welcome-composer-guidance-layer");
@@ -3357,6 +3351,7 @@ test("welcome-everywhere banner: dismiss persists after channel re-entry", async
 
   await page.getByTestId("onboarding-display-name").fill("Morty QA");
   await completeProfileOnboarding(page);
+  await publishWelcomeTeamPresence(page);
 
   const banner = page.getByTestId("welcome-composer-guide-banner");
 

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -251,20 +251,31 @@ async function addGenericAgent(
   );
 }
 
-async function waitForMockLiveSubscription(page: Page, channelName: string) {
+async function waitForMockLiveSubscription(
+  page: Page,
+  channelName: string,
+  kind?: number,
+) {
   await expect
     .poll(async () => {
-      return page.evaluate((channelName) => {
-        return (
-          (
-            window as Window & {
-              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
-                channelName: string;
-              }) => boolean;
-            }
-          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({ channelName }) ?? false
-        );
-      }, channelName);
+      return page.evaluate(
+        ({ channelName, kind }) => {
+          return (
+            (
+              window as Window & {
+                __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                  channelName: string;
+                  kind?: number;
+                }) => boolean;
+              }
+            ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+              channelName,
+              kind,
+            }) ?? false
+          );
+        },
+        { channelName, kind },
+      );
     })
     .toBe(true);
 }
@@ -1131,6 +1142,25 @@ test("renders agent profile ingress subviews from the Playwright mock bridge", a
     "Memory Bot",
     longAgentInstruction,
   );
+  // A running process is not presence. Supply this scenario's snapshot and
+  // authored kind-20001 updates through the mock relay, not the query cache.
+  const emitAgentPresence = (status: "online" | "offline") =>
+    page.evaluate(
+      ({ pubkey, status }) => {
+        const emit = (
+          window as Window & {
+            __BUZZ_E2E_EMIT_MOCK_PRESENCE__?: (input: {
+              pubkey: string;
+              status: "online" | "offline";
+            }) => void;
+          }
+        ).__BUZZ_E2E_EMIT_MOCK_PRESENCE__;
+        if (!emit) throw new Error("Mock presence emitter is unavailable.");
+        emit({ pubkey, status });
+      },
+      { pubkey: agentPubkey, status },
+    );
+  await emitAgentPresence("online");
 
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
@@ -1232,8 +1262,11 @@ test("renders agent profile ingress subviews from the Playwright mock bridge", a
   );
   await expect(agentPrimaryAction).toHaveClass(/bg-foreground/);
   await expect(agentPrimaryAction).toHaveClass(/text-background/);
+  await waitForMockLiveSubscription(page, "general", 20001);
   await agentPrimaryAction.click();
   await expect(agentPrimaryAction).toHaveAttribute("aria-label", "Start agent");
+  await expect(agentPresenceBadge).toHaveAttribute("aria-label", "Online");
+  await emitAgentPresence("offline");
   await expect(agentPresenceBadge).toHaveAttribute("aria-label", "Offline");
   await expectHashSearchParam(page, "profile", agentPubkey);
   await expect(agentPrimaryAction).toHaveClass(/bg-foreground/);
@@ -1252,6 +1285,9 @@ test("renders agent profile ingress subviews from the Playwright mock bridge", a
   await expect(agentPrimaryAction).toBeEnabled();
   await agentPrimaryAction.click();
   await expect(agentPrimaryAction).toHaveAttribute("aria-label", "Stop");
+  await waitForMockLiveSubscription(page, "general", 20001);
+  await expect(agentPresenceBadge).toHaveAttribute("aria-label", "Offline");
+  await emitAgentPresence("online");
   await expect(agentPresenceBadge).toHaveAttribute("aria-label", "Online");
   await expect(page.getByTestId("user-profile-agent-restart")).toBeVisible();
   await expectHashSearchParam(page, "profileTab", null);

--- a/desktop/tests/helpers/welcomeTeam.ts
+++ b/desktop/tests/helpers/welcomeTeam.ts
@@ -1,0 +1,87 @@
+import { expect, type Page } from "@playwright/test";
+
+/** Invoke the mock command boundary without seeding product query caches. */
+export async function invokeMockCommand<T>(
+  page: Page,
+  command: string,
+  payload?: Record<string, unknown>,
+) {
+  return page.evaluate(
+    async ({ command, payload }) => {
+      const bridgeWindow = window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+        __TAURI_INTERNALS__?: {
+          invoke?: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<unknown>;
+        };
+      };
+      const invoke =
+        bridgeWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__ ??
+        bridgeWindow.__TAURI_INTERNALS__?.invoke;
+
+      if (!invoke) {
+        throw new Error("Mock invoke bridge is unavailable.");
+      }
+
+      return (await invoke(command, payload)) as T;
+    },
+    { command, payload },
+  );
+}
+
+type WelcomeAgent = {
+  pubkey: string;
+  persona_id: string;
+  status: string;
+};
+// Pollen retains the builtin:bumble persona identity.
+const WELCOME_PERSONAS = ["builtin:bumble", "builtin:fizz", "builtin:honey"];
+
+/** Wait for bootstrap identities so a scenario can author their relay events. */
+export async function waitForWelcomeTeam(page: Page): Promise<WelcomeAgent[]> {
+  let team: WelcomeAgent[] = [];
+  await expect
+    .poll(async () => {
+      const agents = await invokeMockCommand<WelcomeAgent[]>(
+        page,
+        "list_managed_agents",
+      );
+      const { channels } = await invokeMockCommand<{
+        channels: Array<{ id: string; name: string }>;
+      }>(page, "get_channels");
+      const welcome = channels.find((channel) => channel.name === "Welcome");
+      if (!welcome) return [];
+      const { members } = await invokeMockCommand<{
+        members: Array<{ pubkey: string }>;
+      }>(page, "get_channel_members", { channelId: welcome.id });
+      // Select the started Welcome members, not inactive seeded siblings.
+      // This only identifies the event authors; Start does not publish presence.
+      team = agents.filter(
+        (agent) =>
+          agent.status === "running" &&
+          members.some((member) => member.pubkey === agent.pubkey) &&
+          WELCOME_PERSONAS.includes(agent.persona_id),
+      );
+      return team.map((agent) => `${agent.persona_id}:${agent.status}`).sort();
+    })
+    .toEqual(WELCOME_PERSONAS.map((persona) => `${persona}:running`));
+  return team;
+}
+
+/** Author healthy Welcome-team presence explicitly, independently of Start. */
+export async function publishWelcomeTeamPresence(page: Page) {
+  const team = await waitForWelcomeTeam(page);
+  await page.evaluate(
+    (pubkeys) => {
+      const emit = window.__BUZZ_E2E_EMIT_MOCK_PRESENCE__;
+      if (!emit) throw new Error("Mock presence emitter is unavailable.");
+      for (const pubkey of pubkeys) emit({ pubkey, status: "online" });
+    },
+    team.map((agent) => agent.pubkey),
+  );
+}

--- a/docs/agent-availability.md
+++ b/docs/agent-availability.md
@@ -3,7 +3,9 @@
 Availability means conversational presence on the relay, not process health.
 A retained deployment receipt, PID, or `running` record cannot turn an agent's
 availability dot green. A successful presence snapshot with no entry means
-Offline. A pending/failed read or disconnected relay means unknown, including
+Offline **only for an identity included in that snapshot’s requested keys**.
+An unqueried identity is unknown, never implicitly Offline. An initial pending
+read, failed read, or disconnected relay means unknown, including
 when the cache previously contained Online. Online and Away require presence.
 
 Agents cards and profiles share the existing presence query and live subscription;
@@ -32,6 +34,42 @@ distributed singleton lock: missing, expired, failed or disconnected presence
 cannot certify that starting another body is safe. Existing relay query/live
 subscription freshness remains authoritative; no separate heartbeat or cache
 is introduced. Runtime details remain accessible through the card/profile.
+
+
+## Lifecycle decision authority
+
+Presence does not grant management authority. Backend type, deployment receipt,
+local/pair ownership and the existing owner gates still decide which operations
+are offered and where they route. All presence-dependent decisions use the same
+surface-owned reader, not raw query data. The reader checks the canonical query
+cache and current relay connection at invocation, including after asynchronous
+channel discovery and between persona siblings. Display observers refresh on
+query data/status and connection changes (without the warning-banner debounce).
+A successful cached snapshot remains usable during an in-flight background
+refetch under the existing query policy; a settled error revokes it even though
+TanStack retains the old data. A live single-author update cannot heal a failed
+aggregate. This is not a new freshness cache or a distributed lock.
+
+For deletion of a provider agent with a deployment receipt:
+
+| Availability / route | Before local record deletion |
+| --- | --- |
+| Online or Away, channel available | Await a shutdown request; warn it does not confirm termination. |
+| Unknown, channel available | Also await shutdown; explicitly identify unknown availability in the action confirmation, never claim Offline. |
+| Established Offline | Preserve intentional offline removal without a shutdown request; warn the remote deployment may still exist. |
+| No channel | No shutdown route; warn the remote deployment may still run, without claiming it will. |
+
+A shutdown request failure propagates and leaves the management record and
+channel memberships intact for retry; it is not silently converted into force
+removal. A successful request still requires the existing orphan confirmation
+(or the profile’s already-accepted equivalent) before forced **local record**
+deletion. The profile confirmation describes this policy without asserting the
+current availability or promising remote deletion. Cancelling after a request
+retains the record; it cannot unsend the request. Channel removal follows record
+deletion. Local deletion does not consult presence and still delegates to the
+native stop-before-remove boundary. Custom-persona native cascade continues to
+refuse provider-deployed targets; built-in persona instance removal uses these
+same per-instance rules, treating unqueried siblings as unknown.
 
 
 ## Regression evidence
@@ -72,3 +110,13 @@ availability use `__BUZZ_E2E_EMIT_MOCK_PRESENCE__` to seed the snapshot and emit
 kind 20001 with the agent as author. Updating a directory row or posting a chat
 message is not presence. Mock browser tests do not certify native relay TTL,
 provider termination, or substrate health.
+
+- `managedAgentDeletionAvailability.test.mjs`: mounted production Agents and
+  profile deletion hooks through safe mock IPC, including failed/disconnected
+  cached Online **and Offline**, pending, genuine missing/Offline, Online/Away,
+  channel-discovery suspension, unqueried persona siblings, successful in-flight
+  refetch, shutdown failure/ordering/cancel, no-channel and local delegation.
+- `agent-availability.spec.ts`: real profile Delete dialog/action with failed or
+  disconnected cached Online and failed cached Offline. A rejected shutdown
+  retains the record; retry orders shutdown → deletion → membership removal.
+  Genuine Offline preserves no-request deletion. All destructive IPC is mocked.

--- a/docs/agent-availability.md
+++ b/docs/agent-availability.md
@@ -12,12 +12,31 @@ remain separate: a deployed provider agent still offers Shutdown while offline.
 Shutdown sends a request, not a confirmed termination, and absence of presence
 is not permission to deploy a duplicate body. Local Stop/Start routing is unchanged.
 
+A locally stopped record with current exact-key Online or Away presence does
+not establish local process ownership. Its card replaces Start (including a
+stale restart/error badge) with the presence dot; its profile and member menu
+retain the lifecycle-derived Start label but disable activation with an
+explanation. No Stop is invented. Local/pair-owned running controls keep their
+existing Stop/Restart routing, even when presence is Offline. The same positive
+presence guard covers list/profile callbacks and member bulk respawn so the
+visible affordance is not the only fence. This is a UI startup guard, **not** a
+distributed singleton lock: missing, expired, failed or disconnected presence
+cannot certify that starting another body is safe. Existing relay query/live
+subscription freshness remains authoritative; no separate heartbeat or cache
+is introduced. Runtime details remain accessible through the card/profile.
+
+
 ## Regression evidence
 
 - `desktop/src/features/agents/lib/useAgentAvailability.test.mjs`: successful,
   missing, unavailable, and disconnected presence; lifecycle routing and badges.
 - `desktop/tests/e2e/agent-availability.spec.ts`: deployed/offline profile and
-  card, live presence and disconnected-state behavior.
+  card, stopped/Online and Away presence, disabled keyboard/click Start in
+  profile and member menu, restored Offline startup, running-but-Offline,
+  live updates and disconnected-state behavior.
+- `desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs`:
+  mounted persona/custom/unknown cards, exact-key versus other-key presence,
+  Online/Away/offline/missing transitions and actual Start callback activation.
 - `desktop/tests/e2e/agents.spec.ts`: Start badge animation and avatar continuity,
   runtime-only negative control, then authored Online presence.
 - `desktop/tests/e2e/profile.spec.ts`: created-agent initial Online snapshot and

--- a/docs/agent-availability.md
+++ b/docs/agent-availability.md
@@ -7,6 +7,14 @@ Offline. A pending/failed read or disconnected relay means unknown, including
 when the cache previously contained Online. Online and Away require presence.
 
 Agents cards and profiles share the existing presence query and live subscription;
+the Agents action owner queries its full managed set once and passes its reader
+to persona/custom/unknown cards. Members owns one full-roster query shared by
+rows, menus and bulk actions. The profile's actions use its existing snapshot,
+and its popover also preserves failed/disconnected reads as unknown. Native
+query errors reject the IPC call rather than fabricating an empty snapshot.
+A live update or self heartbeat cannot heal a failed aggregate snapshot by
+marking cached siblings successful; those reads remain unknown until a
+successful snapshot retry. No per-row polling is needed, and
 there is no second availability cache or substrate poller. Lifecycle controls
 remain separate: a deployed provider agent still offers Shutdown while offline.
 Shutdown sends a request, not a confirmed termination, and absence of presence
@@ -27,6 +35,15 @@ is introduced. Runtime details remain accessible through the card/profile.
 
 
 ## Regression evidence
+
+- `desktop/src-tauri/src/commands/profile_presence_tests.rs`: actual command
+  against loopback HTTP; empty success versus auth/rate-limit/storage/malformed
+  response and transport failure, with authenticated kind-20001 requests.
+- `UnifiedAgentsSectionCardTarget.test.mjs`: three card types use one request
+  and one polling observer, reordered while the snapshot is in flight; exact-key
+  live updates, failed warm-cache poll, retry, changed author set and unmount.
+- `agent-availability.spec.ts`: real Agents/Members surfaces request-count check;
+  failure uses the native string rejection shape, not a fabricated success.
 
 - `desktop/src/features/agents/lib/useAgentAvailability.test.mjs`: successful,
   missing, unavailable, and disconnected presence; lifecycle routing and badges.

--- a/docs/agent-availability.md
+++ b/docs/agent-availability.md
@@ -22,6 +22,10 @@ is not permission to deploy a duplicate body. Local Stop/Start routing is unchan
   runtime-only negative control, then authored Online presence.
 - `desktop/tests/e2e/profile.spec.ts`: created-agent initial Online snapshot and
   live Offline/Online transitions alongside independent Stop/Start controls.
+- `desktop/tests/e2e/onboarding.spec.ts`: Welcome kickoff stays pending after
+  runtime start alone, then greets the owner and addresses Honey/Pollen only
+  after the scenario publishes their explicit presence. Healthy-team scenarios
+  use `tests/helpers/welcomeTeam.ts`, without changing the product readiness wait.
 
 Mock create/start/stop only model runtime bookkeeping. Scenarios that require
 availability use `__BUZZ_E2E_EMIT_MOCK_PRESENCE__` to seed the snapshot and emit

--- a/docs/agent-availability.md
+++ b/docs/agent-availability.md
@@ -1,0 +1,30 @@
+# Agent availability and lifecycle
+
+Availability means conversational presence on the relay, not process health.
+A retained deployment receipt, PID, or `running` record cannot turn an agent's
+availability dot green. A successful presence snapshot with no entry means
+Offline. A pending/failed read or disconnected relay means unknown, including
+when the cache previously contained Online. Online and Away require presence.
+
+Agents cards and profiles share the existing presence query and live subscription;
+there is no second availability cache or substrate poller. Lifecycle controls
+remain separate: a deployed provider agent still offers Shutdown while offline.
+Shutdown sends a request, not a confirmed termination, and absence of presence
+is not permission to deploy a duplicate body. Local Stop/Start routing is unchanged.
+
+## Regression evidence
+
+- `desktop/src/features/agents/lib/useAgentAvailability.test.mjs`: successful,
+  missing, unavailable, and disconnected presence; lifecycle routing and badges.
+- `desktop/tests/e2e/agent-availability.spec.ts`: deployed/offline profile and
+  card, live presence and disconnected-state behavior.
+- `desktop/tests/e2e/agents.spec.ts`: Start badge animation and avatar continuity,
+  runtime-only negative control, then authored Online presence.
+- `desktop/tests/e2e/profile.spec.ts`: created-agent initial Online snapshot and
+  live Offline/Online transitions alongside independent Stop/Start controls.
+
+Mock create/start/stop only model runtime bookkeeping. Scenarios that require
+availability use `__BUZZ_E2E_EMIT_MOCK_PRESENCE__` to seed the snapshot and emit
+kind 20001 with the agent as author. Updating a directory row or posting a chat
+message is not presence. Mock browser tests do not certify native relay TTL,
+provider termination, or substrate health.

--- a/docs/agent-availability.md
+++ b/docs/agent-availability.md
@@ -50,7 +50,11 @@ is introduced. Runtime details remain accessible through the card/profile.
 - `desktop/tests/e2e/agent-availability.spec.ts`: deployed/offline profile and
   card, stopped/Online and Away presence, disabled keyboard/click Start in
   profile and member menu, restored Offline startup, running-but-Offline,
-  live updates and disconnected-state behavior.
+  live updates and disconnected-state behavior. Its real hover-popover journey
+  holds the single-key IPC read pending, then distinguishes successful omission
+  and explicit Offline from failed cached Online and disconnection, checking
+  visible badges plus accessible names and screen-reader status text. Restoring
+  the popover's Offline fallback must fail this regression.
 - `desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs`:
   mounted persona/custom/unknown cards, exact-key versus other-key presence,
   Online/Away/offline/missing transitions and actual Start callback activation.


### PR DESCRIPTION
🤖

## Requested rebase published — ef40744b

Rebased onto fetched main **47d068e2109d077414cbf2f4f1c927f6d051037a**, published **ef40744b3aeb4baaf8c81416e1a644fb5b315f91** with the exact expected-old `df7fad6a` force-with-lease. No merge.

Manual conflicts were additive: preserve main's exact-key identity documentation alongside the availability contract, and retain both Bestie props and the shared availability reader in `UnifiedAgentsSection`. Range-diff confirms unchanged lifecycle policy: exact-key action-time authority, Unknown versus Offline, rejected shutdown retains record/memberships, and separate local/provider/owner gates. Main's exact-key profile routing survives. Both test-only CI synchronization repairs (natural toast expiry and bounded stderr wait) are byte-identical to the prior head. All ten original authors/messages/DCO/material coauthor trailers are preserved; configured signing policy was not changed.

Fresh checks on the rebased candidate:
- TypeScript, Biome on 26 changed TypeScript files, differential file-size gate, and diff whitespace: pass.
- Focused production-hook/card/profile units: **58/58**.
- Fresh E2E build, availability/deletion browser: **11/11**, no retries.
- Main exact-key profile cases plus failed-DM send/startup retries: **6/6**, no retries.

Previously reviewed full Desktop/buzz-agent package and mutation evidence is reused for unchanged behavior; no ceremonial full suite, new native/provider test, or `just ci` pass is claimed. Local configs, dependency links, and historical artifacts are preserved.

Hosted observation: **MERGEABLE**, **BLOCKED / REVIEW_REQUIRED**, no new-head formal review. [CI 33699735990](https://github.com/block/buzz/actions/runs/33699735990) is running (including Rust and Desktop lanes), not a completed success. DCO and required Security aggregate passed at the observation; the separate Codex advisory review was skipped. No completed failing check or new inline feedback observed. Historical approvals are not new-head approvals. No reviewer/security authorization or merge action was performed.

---

## Feature summary and retained pre-rebase evidence

## Summary

In Buzz Desktop, an agent could look online just because it had been started or deployed, even when there was no current sign it was connected. Cards and profiles now show availability from the agent's relay presence rather than a saved launch record, so you can distinguish an online agent from one that was merely deployed.

Agents cards and profiles use presence reported through the shared server (the relay). A successful presence read with no online agent shows Offline; failed/disconnected evidence shows unknown, rather than retaining a misleading cached Online state.

Lifecycle actions remain separate. An offline agent may still have a Shutdown action because the deployment record exists. Shutdown reports a **request**, not proof the process stopped. Offline does not imply that starting a duplicate agent is safe, and Online does not promise a response.

### Related issue

Independent base: `main`; no stack parent or child among the replacements. Extracted from [#7114](https://github.com/block/buzz/pull/7114), retained as historical source (`98fe33ec`).

[Behavior contract](https://github.com/block/buzz/blob/f4bb2ed44e5a989d93c5f51e93c0bbd2dca941be/docs/agent-availability.md). Originating [Buzz discussion](buzz://message?channel=f7a9536a-1738-4bad-a888-b3ea25010ef1&id=7aa1f0ab23dce514bd8a0221441cf005bf428914621171472b79747c50820848) · channel `f7a9536a-1738-4bad-a888-b3ea25010ef1`.

### Testing

The same saved provider-backed agent, with only authored presence changing. These are mock-browser states, not a before/after deployment or live relay transport test; production UI is unchanged by the later fixture repairs.

**No online presence:** gray dot, existing Shutdown control retained.

![Offline presence does not remove the deployment lifecycle control](https://raw.githubusercontent.com/block/buzz/ed68b1b4597dde47118b7591b1e8ebf3702447ca/pr-7127--offline-deployment.png)

**Online presence:** green dot, same lifecycle control.

![Authored Online presence changes availability without changing the deployment](https://raw.githubusercontent.com/block/buzz/ed68b1b4597dde47118b7591b1e8ebf3702447ca/pr-7127--online-deployment.png)

[Capture details](https://github.com/block/buzz/pull/7127#issuecomment-5482264824). To check manually, compare runtime-only transitions with presence updates, then disconnect/fail the presence read and verify it does not stay Online. A Shutdown request should not immediately claim confirmed termination.

#### Historical pre-rebase evidence and limitations (df7fad6a)

Lifecycle production source remains **`f4bb2ed44e5a989d93c5f51e93c0bbd2dca941be`**. Current published head is **`df7fad6ae65dda78508317186a95522d1bb22ed9`**: the prior browser synchronization at `b78d093e` plus an additive two-file Rust test-harness synchronization described below. No production bytes, dependency/configuration files, or prior commits were changed; no rebase. Current live main `0dbd036f5bff33e7ade75e7639f3218d424a6e73` has identical failing-test/toaster/send-flow source; the causal browser comparison used latest successfully tested main `04babf02655440b4dfd37f2e2df605ead0a030d8`.

**Lifecycle/deletion correction:** both Agents and actual profile deletion now pass the shared exact-key availability reader, not raw cached data. It reads the canonical query state and connection at action time, including after awaited channel discovery. Failed/disconnected/pending evidence and unqueried persona siblings are unknown; successful missing means Offline only for a requested key. Successful background refetch cache remains usable; settled failure revokes it. No second cache or per-row polling was added.

Provider record + channel + Online/Away/**unknown** awaits shutdown submission before local removal; rejection preserves record/membership for retry. Established Offline preserves intentional no-request removal. No route preserves warned local removal. Local agents retain native stop-before-remove, independent of presence. Profile consent now describes a shutdown **request**, not remote deletion or guaranteed termination. Existing ownership and force gates are unchanged.

**Verified, reused exact-candidate validation:** the independently approved eleven-file patch (SHA-256 `2f69fe12ef0420e62dea1fd8db28cfa22cde5eecaf8080e656310a3e60d0cf86`) was committed without byte changes. Desktop **5,921 passed, 0 failed/skipped**, including **26 new mounted production hook/IPC regressions**; rebuilt availability browser suite **11/11 passed, no retries**, including four actual profile Delete journeys. Desktop check (existing 4 warnings/5 infos), typecheck, production/protected-feature artifact matrix, differential file-size/policy and diff checks passed. No blanket rerun or new full-repository `just ci` is claimed for this frontend correction.

Production regressions cover cached Online **and Offline** failure/disconnection, genuine missing/Offline, pending, successful inflight refetch versus settled error, retained reader, error during awaited channel discovery, unqueried persona sibling, shutdown rejection/order/cancel, no route and local authority. Browser fixtures use safe mock IPC and a retained provider receipt, not a real deployment. Three restored mutation controls fail: unknown → skip shutdown (**15** regressions), Agents raw-cache reader (**6**), actual profile raw-cache caller (**1 browser journey**, false removal on failed cached Offline). Independent review approved the exact frozen bytes and added **4/4 cached-empty failure/disconnection probes** across both callers. This is local independent approval, not formal GitHub/A Team clearance.

The prior native propagation/poll-count defects remain closed ([earlier response](https://github.com/block/buzz/pull/7127#issuecomment-5512278755)). The prior hover-popover correction at `b55423f6` remains covered by the full 11-journey browser run: pending/failed/disconnected means no badge or accessible status, genuine missing/Offline retains an Offline badge. Its earlier fallback-restoration mutation failed as expected (badge count 1 rather than 0); that historical witness is reused, not rerun.

**Reused unchanged native/system boundary:** local `just ci` at `c59067d8` passed workspace/Tauri fmt/clippy, static/policy checks, Rust unit recipe, native workspace **3,159 passed / 20 ignored**, Web build and **2,019 mobile tests**. No native implementation changed in this lifecycle correction. These are historical boundary results, not new-head native/live certification. [Parent CI](https://github.com/block/buzz/actions/runs/33650549130) passed with **14 retry-recovered browser flakes**, not retry-free. Old-head CI/reviews are not current-head clearance.

**Hosted gates:** [CI33662151103](https://github.com/block/buzz/actions/runs/33662151103) on `f4bb2ed4` **FAILED**: smoke shard1 had 322 pass, one failure, one retry-recovered flaky, two skipped. The failed first-DM retry test timed out on all three attempts because the error toast intercepted Send. That failure is preserved, not waived; the scoped test repair below is published as `b78d093e`. [CI33668171165](https://github.com/block/buzz/actions/runs/33668171165) on `b78d093e` subsequently **FAILED** the Rust unit budget regression described below. Both original failures remain visible; neither was retried to green. Exact `f4bb2ed4` and `b78d093e` APPROVED reviews cover unchanged reviewed bytes, not formal approval of the new head. Fresh exact-head CI and the established automated technical rereview are the next gates for `df7fad6a`. Historical deletion responses remain ([5092381800](https://github.com/block/buzz/pull/7127#issuecomment-5513759316), [5092391193](https://github.com/block/buzz/pull/7127#issuecomment-5513763497)). No formal review dismissed. The [security notice](https://github.com/block/buzz/pull/7127#issuecomment-5482231278) and latest-push maintainer/codeowner policy remain separate actionable gates: eligible Block organization members own current-range authorization. No merge/security authority exercised.

**CI causal repair (`b78d093e`, test only):** the error `Message failed to send: Mock first DM send failed.` is deliberately injected by the existing fixture. CI screenshot and retry trace show the bottom-right Sonner notification over the actual enabled Send button. `fill()` leaves the pointer parked there; Sonner pauses its 4-second lifetime while hovered. A fast run can click before animation settles (unchanged local test passed in 2.7s; two actual tested-main CI cases passed first attempt in 3.3s), which does not disprove the failure. Independent controlled browser runs on `f4bb2ed4` and tested main `04babf` both reproduced the same toast hit-test at Send `(1203,627,32,32)`, persistent hover beyond 4s, and intercepted ordinary click with no second send. Moving the real pointer to the editor allows natural expiry and successful ordinary retry, preserving all original DM-channel/recipient assertions. This same synchronization already exists in the neighboring agent-startup-failure test.

The one-file correction keeps the visible error assertion, scopes its toast locator, moves the pointer back to the editor and observes normal toast removal (bounded 10s) before retry. No forced click, direct toast dismissal, mocked clock, CSS override, skipped test, production behavior change, or new backend mock. Six focused browser executions pass (first-send/startup-failure, three repeats each, no retries); the held-toast control fails on original bytes at the Send click while the exact repaired test passes. Biome and diff checks pass. Reuse unchanged 5,921 Desktop / 11 availability browser / four independent probes above; no semantic production change warrants repeating those suites. Original failed CI attempt/retries, local fast pass, deliberate failing control and all traces remain in `WORK_LOGS/AVAILABILITY_CI_B9210A40`. Browser evidence is mock-IPC Chromium, not native/live-relay certification. The UI still temporarily overlays Send while a notification is hovered; the test exercises its real move-away/expiry recovery, not immediate click-through.

**Rust CI causal repair (`df7fad6a`, test only):** [original Rust / Unit Tests failure, job100375291370](https://github.com/block/buzz/actions/runs/33668171165/job/100375291370) tested GitHub merge `223dee91a396d8cb4ebf18b9b8559e5a54951235`. `context_recovery_budget_exhaustion_surfaces_the_error` failed at `regressions.rs:2756` in **0.091s** because its immediate stderr snapshot lacked `context recovery budget spent`. ACP context-error assertions had already passed. The captured prefix shows all three budgets **32768 → 16384 → 8192 bytes**, above the 4096-byte floor, and ends during the third attempt. This is **not evidence of floor exhaustion**. The collector is an independent Tokio task; a stdout response is not a stderr barrier. Recovery, harness and test blobs were identical across the compared base/head/merge parents; no production regression was implicated.

The shared test Harness now provides a bounded event/condition wait, registering for collector notifications before reading the buffer to avoid lost wakeups. The budget and adjacent terminal floor assertions wait for their own diagnostic and retain the matching snapshot. The budget test still requires the provider's ACP context error and exactly three recovery rungs, now corroborated by **exactly four provider calls** and no floor diagnostic. Timeout remains a real failure with captured stderr. No fixed sleep, weaker assertion, skip, provider-limit/logging change, dependency/config edit, or production change.

**Deterministic causal control:** the same real agent/HTTP-provider/ACP scenario holds only stderr collection behind a one-shot gate until after stdout responds. The old immediate snapshot fails the original budget assertion (intentional exit101); the repaired wait explicitly remains Pending while held, then passes after release. No scheduler-speed assumption or fixed sleep. This reproduces the observation race under controlled delay, **not the exact historical CI schedule**. A missing-diagnostic test proves the wait actually times out. Original failure and deliberate failing-control logs/patch remain in `WORK_LOGS/RUST_TRIAGE_06E32D2D` and `WORK_LOGS/RUST_SYNC_BC5758B9`.

**Final candidate validation:** focused recovery **9/9**, floor **1/1**, absent-diagnostic timeout **1/1** pass. One full touched-package run, `cargo test --locked -p buzz-agent`: **695 passed, 0 failed, 1 existing ignored**, including all **54 regressions**. Local nextest was unavailable, so this uses the repository-supported cargo-test fallback, not a claim of nextest reproduction. `cargo fmt --check`, package-scoped Clippy all-targets with `-D warnings`, differential file-size/policy and diff checks pass. Previously reviewed availability production and the Desktop/browser evidence above are unchanged and reused; no all-native blanket rerun. The test-only delta was self-reviewed against collector ordering, timeout and falsification evidence. Existing production approval remains valid for those bytes; exact-new-head technical/CI clearance is not assumed. The required **Security aggregate** is distinct from optional Codex advisory feedback; no security authorization, human review contact, or merge was requested.

**Remaining policy limits:** shutdown submission is not harness acceptance or process termination; confirmed Offline/no-route local removal may leave a remote process; route discovery is best effort, membership cleanup uses `Promise.allSettled`, and multi-instance deletion is sequential/non-atomic. No distributed singleton, provider-health, tenant-switch cancellation, live relay TTL or packaged WebView/VoiceOver certification is claimed. The pre-existing DM-header raw-presence fallback (`ChannelScreenHeader`/`useActiveChannelHeader`) remains outside this repair and uncertified. Screenshots above remain historical mock-browser illustrations, not new deletion or native transport evidence.

