### PR TITLE
fix(desktop): unify owned-agent cloud provenance markers

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
         "**/composer-tooltip-dismiss.spec.ts",
         "**/mentions.spec.ts",
         "**/mention-spacing.spec.ts",
+        "**/cloud-provenance.spec.ts",
         "**/team-mentions.spec.ts",
         "**/persistent-agent-audience.spec.ts",
         "**/relay-reconnect.spec.ts",

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -216,6 +216,11 @@ with a TypeScript lookup table or an id comparison in a component.
    Unqueried persona siblings are unknown. No presence state grants deletion or
    Stop authority; native local stop-before-remove remains independent. See
    [the availability contract](../../../../docs/agent-availability.md).
+   The shared cloud marker means “Not managed on this device” only
+   after ownership and successful local inventory are known. It does not imply
+   hosting location, availability, or permission. Keep all identity surfaces on
+   the shared provenance context, without per-row directory subscriptions. See
+   [the provenance contract](../../../../docs/agent-management-provenance.md).
 14. **Thinking effort has two surfaces: a local-only WRITE control and a
    read-only two-facts DISPLAY.** The write control is `EffortPickerField`
    (`ui/EffortPickerField.tsx`), a self-contained section component mounted in

--- a/desktop/src/features/agents/lib/otherSetupAgent.test.mjs
+++ b/desktop/src/features/agents/lib/otherSetupAgent.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isOtherSetupAgent } from "./otherSetupAgent.ts";
+import {
+  isOtherSetupAgent,
+  isOwnedAgentNotManagedOnDevice,
+} from "./otherSetupAgent.ts";
 
 const OWNER = "a".repeat(64);
 const AGENT = "b".repeat(64);
@@ -20,7 +23,7 @@ test("fails closed while the local managed directory is unresolved", () => {
   );
 });
 
-test("labels a viewer-owned non-local identity as another setup", () => {
+test("labels a viewer-owned identity as not managed on this device", () => {
   assert.equal(
     isOtherSetupAgent({
       agentDirectoriesReady: true,
@@ -33,3 +36,38 @@ test("labels a viewer-owned non-local identity as another setup", () => {
     true,
   );
 });
+
+test("a locally managed provider is not labeled as another device", () => {
+  assert.equal(
+    isOtherSetupAgent({
+      agentDirectoriesReady: true,
+      currentPubkey: OWNER,
+      managedAgents: [{ pubkey: AGENT, backend: { type: "provider" } }],
+      profileOwnerPubkey: OWNER,
+      pubkey: AGENT,
+      relayAgents: [],
+    }),
+    false,
+  );
+});
+
+for (const [name, overrides, expected] of [
+  ["owned absent key", {}, true],
+  ["loading local inventory", { localInventoryReady: false }, false],
+  ["exact local provider record", { isLocallyManaged: true }, false],
+  ["different owner", { ownerPubkey: "b".repeat(64) }, false],
+  ["unknown ownership", { ownerPubkey: null }, false],
+]) {
+  test(`shared provenance: ${name}`, () => {
+    assert.equal(
+      isOwnedAgentNotManagedOnDevice({
+        currentPubkey: "a".repeat(64),
+        ownerPubkey: "A".repeat(64),
+        localInventoryReady: true,
+        isLocallyManaged: false,
+        ...overrides,
+      }),
+      expected,
+    );
+  });
+}

--- a/desktop/src/features/agents/lib/otherSetupAgent.ts
+++ b/desktop/src/features/agents/lib/otherSetupAgent.ts
@@ -1,6 +1,7 @@
 import type { ManagedAgent, RelayAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
+/** Owned identity absent from the loaded local inventory; not evidence of hosting location. */
 export function isOtherSetupAgent({
   agentDirectoriesReady,
   currentPubkey,
@@ -32,8 +33,31 @@ export function isOtherSetupAgent({
   )?.ownerPubkey;
   const ownerPubkey = profileOwnerPubkey ?? relayOwnerPubkey;
 
+  return isOwnedAgentNotManagedOnDevice({
+    currentPubkey,
+    ownerPubkey,
+    localInventoryReady: agentDirectoriesReady,
+    isLocallyManaged: false,
+  });
+}
+
+/** Presentation provenance only; neither hosting location nor availability. */
+export function isOwnedAgentNotManagedOnDevice({
+  currentPubkey,
+  ownerPubkey,
+  localInventoryReady,
+  isLocallyManaged,
+}: {
+  currentPubkey?: string;
+  ownerPubkey?: string | null;
+  localInventoryReady: boolean;
+  isLocallyManaged: boolean;
+}): boolean {
   return Boolean(
-    ownerPubkey &&
+    localInventoryReady &&
+      !isLocallyManaged &&
+      currentPubkey &&
+      ownerPubkey &&
       normalizePubkey(ownerPubkey) === normalizePubkey(currentPubkey),
   );
 }

--- a/desktop/src/features/agents/ui/OtherSetupAgentMarker.tsx
+++ b/desktop/src/features/agents/ui/OtherSetupAgentMarker.tsx
@@ -1,8 +1,10 @@
 import { Cloud } from "lucide-react";
 
+import { useIsOtherSetupAgent } from "../useKnownAgentPubkeys";
+
 import { cn } from "@/shared/lib/cn";
 
-const OTHER_SETUP_LABEL = "From another Buzz setup";
+const OTHER_SETUP_LABEL = "Not managed on this device";
 
 export function OtherSetupAgentMarker({
   className,
@@ -22,4 +24,22 @@ export function OtherSetupAgentMarker({
       <Cloud aria-hidden="true" className="h-3 w-3" />
     </span>
   );
+}
+
+/** Connected marker for identity details; shares the app's directory subscriptions. */
+export function AgentManagementMarker({
+  pubkey,
+  ownerPubkey,
+  className,
+  testId,
+}: {
+  pubkey?: string | null;
+  ownerPubkey?: string | null;
+  className?: string;
+  testId?: string;
+}) {
+  const show = useIsOtherSetupAgent(pubkey, ownerPubkey);
+  return show ? (
+    <OtherSetupAgentMarker className={className} testId={testId} />
+  ) : null;
 }

--- a/desktop/src/features/agents/useKnownAgentPubkeys.test.mjs
+++ b/desktop/src/features/agents/useKnownAgentPubkeys.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import { createElement } from "react";
+import { JSDOM } from "jsdom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  KnownAgentPubkeysProvider,
+  useIsOtherSetupAgent,
+} from "./useKnownAgentPubkeys.tsx";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+Object.assign(globalThis, {
+  window: dom.window,
+  document: dom.window.document,
+  HTMLElement: dom.window.HTMLElement,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+after(() => dom.window.close());
+
+test("provenance context follows exact local inventory and rejects failed cached reads", async () => {
+  const { act, renderHook, cleanup } = await import("@testing-library/react");
+  const owner = "a".repeat(64),
+    remote = "b".repeat(64),
+    local = "c".repeat(64);
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { enabled: false, retry: false, staleTime: Infinity },
+    },
+  });
+  client.setQueryData(["identity"], { pubkey: owner });
+  client.setQueryData(
+    ["managed-agents"],
+    [{ pubkey: local, status: "stopped" }],
+  );
+  client.setQueryData(
+    ["relay-agents"],
+    [{ pubkey: remote, ownerPubkey: owner }],
+  );
+  const wrapper = ({ children }) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(KnownAgentPubkeysProvider, null, children),
+    );
+  const { result } = renderHook(
+    () => [
+      useIsOtherSetupAgent(remote),
+      useIsOtherSetupAgent(local, owner),
+      useIsOtherSetupAgent("d".repeat(64), owner),
+    ],
+    { wrapper },
+  );
+  assert.deepEqual(result.current, [true, false, true]);
+  await act(async () =>
+    client.setQueryData(
+      ["managed-agents"],
+      [{ pubkey: remote, status: "deployed" }],
+    ),
+  );
+  assert.deepEqual(result.current, [false, true, true]);
+  await act(async () => {
+    client
+      .getQueryCache()
+      .find({ queryKey: ["managed-agents"] })
+      .setState({ error: new Error("inventory unavailable"), status: "error" });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  });
+  assert.deepEqual(result.current, [false, false, false]);
+  cleanup();
+  client.clear();
+});

--- a/desktop/src/features/agents/useKnownAgentPubkeys.tsx
+++ b/desktop/src/features/agents/useKnownAgentPubkeys.tsx
@@ -5,9 +5,24 @@ import {
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
 import { mergeKnownAgentPubkeys } from "@/features/agents/knownAgentPubkeys";
-import { useStableSet } from "@/shared/hooks/useStableReference";
+import { useStableMap, useStableSet } from "@/shared/hooks/useStableReference";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { isAgentDirectoryReady } from "./lib/agentAutocompleteEligibility";
+import { isOwnedAgentNotManagedOnDevice } from "./lib/otherSetupAgent";
 
 const EMPTY_KNOWN_AGENT_PUBKEYS: ReadonlySet<string> = new Set();
+
+const AgentManagementContext = React.createContext<{
+  currentPubkey?: string;
+  localInventoryReady: boolean;
+  localPubkeys: ReadonlySet<string>;
+  relayOwners: ReadonlyMap<string, string | null>;
+}>({
+  localInventoryReady: false,
+  localPubkeys: new Set(),
+  relayOwners: new Map(),
+});
 
 const KnownAgentPubkeysContext = React.createContext<ReadonlySet<string>>(
   EMPTY_KNOWN_AGENT_PUBKEYS,
@@ -39,8 +54,36 @@ export function KnownAgentPubkeysProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const managedAgents = useManagedAgentsQuery().data;
-  const relayAgents = useRelayAgentsQuery().data;
+  const managedQuery = useManagedAgentsQuery();
+  const relayQuery = useRelayAgentsQuery();
+  const currentPubkey = useIdentityQuery().data?.pubkey;
+  const managedAgents = managedQuery.data;
+  const relayAgents = relayQuery.data;
+  const localPubkeys = useStableSet(
+    new Set(
+      (managedAgents ?? []).map((agent) => normalizePubkey(agent.pubkey)),
+    ),
+  );
+  const relayOwners = useStableMap(
+    new Map(
+      isAgentDirectoryReady(relayQuery)
+        ? (relayAgents ?? []).map((agent) => [
+            normalizePubkey(agent.pubkey),
+            agent.ownerPubkey,
+          ])
+        : [],
+    ),
+  );
+  const localInventoryReady = isAgentDirectoryReady(managedQuery);
+  const management = React.useMemo(
+    () => ({
+      currentPubkey,
+      localInventoryReady,
+      localPubkeys,
+      relayOwners,
+    }),
+    [currentPubkey, localInventoryReady, localPubkeys, relayOwners],
+  );
 
   const merged = React.useMemo(
     () => mergeKnownAgentPubkeys(managedAgents, relayAgents),
@@ -50,7 +93,9 @@ export function KnownAgentPubkeysProvider({
 
   return (
     <KnownAgentPubkeysContext.Provider value={stable}>
-      {children}
+      <AgentManagementContext.Provider value={management}>
+        {children}
+      </AgentManagementContext.Provider>
     </KnownAgentPubkeysContext.Provider>
   );
 }
@@ -81,4 +126,22 @@ export function KnownAgentPubkeysProvider({
  */
 export function useKnownAgentPubkeys(): ReadonlySet<string> {
   return React.useContext(KnownAgentPubkeysContext);
+}
+
+/** Shared provenance without per-row query observers; exact keys, never personas. */
+export function useIsOtherSetupAgent(
+  pubkey?: string | null,
+  profileOwnerPubkey?: string | null,
+): boolean {
+  const state = React.useContext(AgentManagementContext);
+  const key = normalizePubkey(pubkey ?? "");
+  return (
+    Boolean(key) &&
+    isOwnedAgentNotManagedOnDevice({
+      currentPubkey: state.currentPubkey,
+      ownerPubkey: profileOwnerPubkey ?? state.relayOwners.get(key),
+      localInventoryReady: state.localInventoryReady,
+      isLocallyManaged: state.localPubkeys.has(key),
+    })
+  );
 }

--- a/desktop/src/features/channels/ui/AddMemberSearchResultRow.tsx
+++ b/desktop/src/features/channels/ui/AddMemberSearchResultRow.tsx
@@ -1,3 +1,4 @@
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { Bot } from "lucide-react";
 import type { UserSearchResult } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
@@ -60,6 +61,10 @@ export function AddMemberSearchResultRow({
                 <Bot aria-hidden="true" className="h-4 w-4" />
                 agent
               </span>
+              <AgentManagementMarker
+                pubkey={user.pubkey}
+                ownerPubkey={user.ownerPubkey}
+              />
             </div>
             <span className="block truncate font-mono text-2xs text-muted-foreground">
               {truncatePubkey(user.pubkey)}

--- a/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
@@ -14,6 +14,7 @@ import {
   ProfileAvatarWithStatus,
   scaleProfileAvatarStatusGeometry,
 } from "@/features/profile/ui/ProfileAvatarWithStatus";
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { Button } from "@/shared/ui/button";
 import type { Channel, PresenceStatus } from "@/shared/api/types";
@@ -194,9 +195,17 @@ export function ChannelScreenHeader({
         ) : undefined
       }
       statusBadge={
-        <ChannelHeaderStatusBadge
-          ephemeralDisplay={activeChannelEphemeralDisplay}
-        />
+        <>
+          <ChannelHeaderStatusBadge
+            ephemeralDisplay={activeChannelEphemeralDisplay}
+          />
+          {!isGroupDm && activeDmParticipant ? (
+            <AgentManagementMarker
+              pubkey={activeDmParticipant.pubkey}
+              testId="chat-header-agent-provenance"
+            />
+          ) : null}
+        </>
       }
       title={activeChannelTitle}
       transparentChrome={transparentChrome}

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -12,10 +12,8 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentDirectoryReady,
   isAgentIdentityInAllowedList,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
-import { isOtherSetupAgent } from "@/features/agents/lib/otherSetupAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
 import { formatMemberName } from "@/features/channels/lib/memberUtils";
@@ -184,9 +182,6 @@ export function MembersSidebar({
     managedAgentsQuery,
     relayAgentsQuery,
   } = useClassifiedMembers(rawMembers, currentPubkey);
-  const agentDirectoriesReady =
-    isAgentDirectoryReady(managedAgentsQuery) &&
-    isAgentDirectoryReady(relayAgentsQuery);
   const activeMembers = React.useMemo(
     () =>
       [...people, ...bots].sort((left, right) =>
@@ -618,16 +613,6 @@ export function MembersSidebar({
     const managedAgent = memberIsBot
       ? managedAgentByPubkey.get(normalizePubkey(member.pubkey))
       : undefined;
-    const showOtherSetupMarker =
-      memberIsBot &&
-      isOtherSetupAgent({
-        agentDirectoriesReady,
-        currentPubkey,
-        managedAgents: managedAgentsQuery.data ?? [],
-        profileOwnerPubkey: memberProfile?.ownerPubkey,
-        pubkey: member.pubkey,
-        relayAgents: relayAgentsQuery.data ?? [],
-      });
     const managedAgentRuntime =
       memberIsBot && relayUrl
         ? findManagedAgentRuntime(
@@ -685,7 +670,7 @@ export function MembersSidebar({
         pairAction={pairAction}
         presenceStatus={getAvailability(member.pubkey)}
         profileAvatarUrl={memberProfile?.avatarUrl ?? null}
-        showOtherSetupMarker={showOtherSetupMarker}
+        profileOwnerPubkey={memberProfile?.ownerPubkey}
         viewerIsOwner={viewerIsOwner}
       />
     );

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -19,7 +19,7 @@ import {
   getManagedAgentPrimaryActionLabel,
   isManagedAgentActive,
 } from "@/features/agents/lib/managedAgentControlActions";
-import { OtherSetupAgentMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 import {
@@ -75,7 +75,7 @@ type MembersSidebarMemberCardProps = {
   onViewActivity?: (pubkey: string) => void;
   presenceStatus?: PresenceStatus | null;
   profileAvatarUrl?: string | null;
-  showOtherSetupMarker?: boolean;
+  profileOwnerPubkey?: string | null;
   viewerIsOwner: boolean;
 };
 
@@ -144,7 +144,7 @@ export function MembersSidebarMemberCard({
   onViewActivity,
   presenceStatus,
   profileAvatarUrl,
-  showOtherSetupMarker = false,
+  profileOwnerPubkey,
   viewerIsOwner,
 }: MembersSidebarMemberCardProps) {
   const roleLabel = formatRoleLabel(member, memberIsBot);
@@ -199,11 +199,11 @@ export function MembersSidebarMemberCard({
                 </span>
               </span>
             </div>
-            {showOtherSetupMarker ? (
-              <OtherSetupAgentMarker
-                testId={`sidebar-member-agent-provenance-${member.pubkey}`}
-              />
-            ) : null}
+            <AgentManagementMarker
+              pubkey={member.pubkey}
+              ownerPubkey={profileOwnerPubkey}
+              testId={`sidebar-member-agent-provenance-${member.pubkey}`}
+            />
           </div>
         ) : (
           <div className="flex min-w-0 items-center gap-2">

--- a/desktop/src/features/messages/lib/buildMentionCandidates.test.mjs
+++ b/desktop/src/features/messages/lib/buildMentionCandidates.test.mjs
@@ -149,3 +149,22 @@ test("policy-only discovery stays selectable without claiming active presence", 
   assert.equal(candidate.isActiveAgent, false);
   assert.equal(candidate.ownerPubkey, MEMBER_PUBKEY);
 });
+
+for (const locallyManaged of [true, false]) {
+  test(`roster candidate preserves exact local management: ${locallyManaged}`, () => {
+    const [candidate] = buildMentionCandidates(
+      input({
+        members: [{ pubkey: AGENT_PUBKEY, displayName: "Scout", role: "bot" }],
+        managedAgentNamesByPubkey: new Map(
+          locallyManaged ? [[AGENT_PUBKEY, "Scout"]] : [],
+        ),
+        managedAgents: locallyManaged
+          ? [{ pubkey: AGENT_PUBKEY, name: "Scout", status: "deployed" }]
+          : [],
+        mentionableAgentPubkeys: new Set([AGENT_PUBKEY]),
+      }),
+    );
+    assert.equal(candidate.isMember, true);
+    assert.equal(Boolean(candidate.isManagedAgent), locallyManaged);
+  });
+}

--- a/desktop/src/features/messages/lib/buildMentionCandidates.ts
+++ b/desktop/src/features/messages/lib/buildMentionCandidates.ts
@@ -154,6 +154,7 @@ export function buildMentionCandidates({
         managedAgentNamesByPubkey.has(pubkey) ||
         relayAgentNamesByPubkey.has(pubkey),
       isActiveAgent: activeAgentPubkeys.has(pubkey),
+      isManagedAgent: managedAgentNamesByPubkey.has(pubkey),
       ownerPubkey: profile?.ownerPubkey ?? null,
       personaName: personaNameByPubkey.get(pubkey) ?? null,
       role: member.role,

--- a/desktop/src/features/messages/lib/mentionSuggestionMapping.ts
+++ b/desktop/src/features/messages/lib/mentionSuggestionMapping.ts
@@ -1,3 +1,4 @@
+import { isOwnedAgentNotManagedOnDevice } from "@/features/agents/lib/otherSetupAgent";
 import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomplete";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { formatOwnerLabel } from "@/features/profile/lib/identity";
@@ -61,10 +62,12 @@ export function mapMentionCandidateToSuggestion(opts: {
       agentProvenanceReady && candidate.kind === "identity" && candidate.isAgent
         ? candidate.isManagedAgent
           ? "managed-here"
-          : candidate.ownerPubkey &&
-              currentPubkey &&
-              normalizePubkey(candidate.ownerPubkey) ===
-                normalizePubkey(currentPubkey)
+          : isOwnedAgentNotManagedOnDevice({
+                currentPubkey: currentPubkey ?? undefined,
+                ownerPubkey: candidate.ownerPubkey,
+                localInventoryReady: agentProvenanceReady,
+                isLocallyManaged: Boolean(candidate.isManagedAgent),
+              })
             ? "managed-elsewhere"
             : undefined
         : undefined,

--- a/desktop/src/features/messages/ui/ComposerAddressControls.tsx
+++ b/desktop/src/features/messages/ui/ComposerAddressControls.tsx
@@ -1,3 +1,4 @@
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { ArrowUp, AtSign, Square, X } from "lucide-react";
 import {
   AnimatePresence,
@@ -270,7 +271,8 @@ export function ComposerMentionButton({
                       </TooltipTrigger>
                       <TooltipContent>
                         Don't automatically mention {agent.displayName} in this
-                        thread
+                        thread{" "}
+                        <AgentManagementMarker pubkey={agent.pubkey} />
                       </TooltipContent>
                     </Tooltip>
                   ))}

--- a/desktop/src/features/messages/ui/ComposerAddressControls.tsx
+++ b/desktop/src/features/messages/ui/ComposerAddressControls.tsx
@@ -271,8 +271,7 @@ export function ComposerMentionButton({
                       </TooltipTrigger>
                       <TooltipContent>
                         Don't automatically mention {agent.displayName} in this
-                        thread{" "}
-                        <AgentManagementMarker pubkey={agent.pubkey} />
+                        thread <AgentManagementMarker pubkey={agent.pubkey} />
                       </TooltipContent>
                     </Tooltip>
                   ))}

--- a/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
@@ -334,25 +334,56 @@ function suggestion(agentProvenance) {
 
 test("duplicate owned agents mark only the other setup", () => {
   assert.equal(
-    showMentionAgentProvenanceMarker(suggestion("managed-here"), true),
+    showMentionAgentProvenanceMarker(suggestion("managed-here")),
     false,
   );
   assert.equal(
-    showMentionAgentProvenanceMarker(suggestion("managed-elsewhere"), true),
+    showMentionAgentProvenanceMarker(suggestion("managed-elsewhere")),
     true,
   );
 });
 
-test("unique agents omit management provenance", () => {
+test("unique agents mark the same not-locally-managed provenance", () => {
   assert.equal(
-    showMentionAgentProvenanceMarker(suggestion("managed-here"), false),
+    showMentionAgentProvenanceMarker(suggestion("managed-elsewhere")),
+    true,
+  );
+  assert.equal(
+    showMentionAgentProvenanceMarker(suggestion("managed-here")),
     false,
   );
 });
 
 test("agents without trustworthy provenance omit management provenance", () => {
-  assert.equal(
-    showMentionAgentProvenanceMarker(suggestion(undefined), true),
-    false,
-  );
+  assert.equal(showMentionAgentProvenanceMarker(suggestion(undefined)), false);
 });
+
+for (const duplicate of [false, true]) {
+  test(`rendered provenance is truthful (${duplicate ? "duplicate" : "unique"} names)`, async () => {
+    const React = await import("react");
+    const { render } = await import("@testing-library/react");
+    const { MentionAutocomplete } = await import("./MentionAutocomplete.tsx");
+    const { TooltipProvider } = await import("@/shared/ui/tooltip");
+    const remote = suggestion("managed-elsewhere");
+    const suggestions = duplicate
+      ? [remote, { ...suggestion("managed-here"), pubkey: "2".repeat(64) }]
+      : [remote];
+    const view = render(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(MentionAutocomplete, {
+          suggestions,
+          selectedIndex: 0,
+          onSelect() {},
+        }),
+      ),
+    );
+    const markers = view.getAllByRole("img", {
+      name: "Not managed on this device",
+    });
+    assert.equal(markers.length, 1);
+    assert.equal(markers[0].title, "Not managed on this device");
+    assert.equal(view.queryByTitle("From another Buzz setup"), null);
+  });
+}

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -52,9 +52,8 @@ type MentionAutocompleteProps = {
 
 export function showMentionAgentProvenanceMarker(
   suggestion: MentionSuggestion,
-  hasNameCollision: boolean,
 ): boolean {
-  return hasNameCollision && suggestion.agentProvenance === "managed-elsewhere";
+  return suggestion.agentProvenance === "managed-elsewhere";
 }
 
 /** Focus the now-always-visible automatic-mentions switch. */
@@ -254,10 +253,8 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
               suggestion.displayName;
             const hasNameCollision =
               (nameCounts.get(suggestion.displayName.toLowerCase()) ?? 0) > 1;
-            const showAgentProvenanceMarker = showMentionAgentProvenanceMarker(
-              suggestion,
-              hasNameCollision,
-            );
+            const showAgentProvenanceMarker =
+              showMentionAgentProvenanceMarker(suggestion);
             const ownerLabel =
               hasNameCollision && suggestion.agentProvenance
                 ? null

--- a/desktop/src/features/messages/ui/MessageAgentAddressPrefix.tsx
+++ b/desktop/src/features/messages/ui/MessageAgentAddressPrefix.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
@@ -37,6 +38,10 @@ export function MessageAgentAddressPrefix({
                 interactive
               >
                 {label}
+                <AgentManagementMarker
+                  pubkey={pubkey}
+                  ownerPubkey={profile?.ownerPubkey}
+                />
               </InlineChip>
             </UserProfilePopover>{" "}
           </React.Fragment>

--- a/desktop/src/features/messages/ui/MessageHeader.tsx
+++ b/desktop/src/features/messages/ui/MessageHeader.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
 
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
+import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
+
 import { cn } from "@/shared/lib/cn";
 
 type MessageHeaderRowProps = {
@@ -102,5 +105,42 @@ export function MessageAuthorText({
     >
       {children}
     </Component>
+  );
+}
+
+/** Author navigation and provenance always refer to the same exact identity. */
+export function MessageAuthorIdentity({
+  pubkey,
+  ownerPubkey,
+  role,
+  displayName,
+  children,
+}: {
+  pubkey?: string | null;
+  ownerPubkey?: string | null;
+  role?: string;
+  displayName: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      {pubkey ? (
+        <UserProfilePopover
+          pubkey={pubkey}
+          role={role}
+          botIdenticonValue={displayName}
+        >
+          <button
+            className="truncate rounded leading-message-author focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            type="button"
+          >
+            {children}
+          </button>
+        </UserProfilePopover>
+      ) : (
+        children
+      )}
+      <AgentManagementMarker pubkey={pubkey} ownerPubkey={ownerPubkey} />
+    </>
   );
 }

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -50,6 +50,7 @@ import { toast } from "sonner";
 import { MessageAgentOwner } from "./MessageAgentOwner";
 import {
   MessageAuthorText,
+  MessageAuthorIdentity,
   MessageHeaderRow,
   MessageMetaSegments,
 } from "./MessageHeader";
@@ -646,22 +647,14 @@ export const MessageRow = React.memo(
 
     const headerNode = isDisplayedAsContinuation ? null : (
       <MessageHeaderRow>
-        {message.pubkey ? (
-          <UserProfilePopover
-            pubkey={message.pubkey}
-            role={profilePopoverRole}
-            botIdenticonValue={message.author}
-          >
-            <button
-              className="truncate rounded leading-message-author focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-              type="button"
-            >
-              {authorNode}
-            </button>
-          </UserProfilePopover>
-        ) : (
-          authorNode
-        )}
+        <MessageAuthorIdentity
+          pubkey={message.pubkey}
+          ownerPubkey={message.ownerPubkey}
+          role={profilePopoverRole}
+          displayName={message.author}
+        >
+          {authorNode}
+        </MessageAuthorIdentity>
         {/* Author is not a segment: "Alice 9:53 AM" needs no divider. */}
         <MessageMetaSegments
           segments={[

--- a/desktop/src/features/messages/ui/NewMessageResultRow.tsx
+++ b/desktop/src/features/messages/ui/NewMessageResultRow.tsx
@@ -1,3 +1,4 @@
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { Bot } from "lucide-react";
 
 import { formatOwnerLabel } from "@/features/profile/lib/identity";
@@ -133,6 +134,10 @@ export function NewMessageResultRow({
                   />
                   agent
                 </span>
+                <AgentManagementMarker
+                  pubkey={user.pubkey}
+                  ownerPubkey={user.ownerPubkey}
+                />
               </div>
               {ownerLabel ? (
                 <span className="block truncate text-xs text-muted-foreground">

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -1,3 +1,4 @@
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { SmilePlus } from "lucide-react";
 import * as React from "react";
 
@@ -285,6 +286,7 @@ function ProfileName({
       interactive={Boolean(pubkey)}
     >
       {children}
+      <AgentManagementMarker pubkey={pubkey} />
     </InlineChip>
   ) : (
     <span
@@ -295,6 +297,7 @@ function ProfileName({
       )}
     >
       {children}
+      <AgentManagementMarker pubkey={pubkey} />
     </span>
   );
 
@@ -914,6 +917,10 @@ export const SystemMessageRow = React.memo(function SystemMessageRow({
               <MessageAuthorText as="div" className="text-foreground">
                 {description.title}
               </MessageAuthorText>
+              <AgentManagementMarker
+                pubkey={displayedIdentityPubkey}
+                ownerPubkey={displayedOwnerPubkey}
+              />
               {displayedIdentityIsAgent ? (
                 <>
                   <MessageAgentOwner

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -759,6 +759,7 @@ export function UserProfilePanel({
     {
       agentSettingsMenu,
       effectivePubkey,
+      ownerPubkey: profile?.ownerPubkey,
       logCopyValue: isDiagnosticsLikeView ? managedAgentLogContent : null,
       logSubtitle: logHeaderSubtitle,
       onBack: () => setView("summary"),

--- a/desktop/src/features/profile/ui/UserProfilePanelHeaderContent.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelHeaderContent.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { CopyButton } from "@/features/agents/ui/CopyButton";
 import { MemoryRefreshButton } from "@/features/agent-memory/ui/MemorySection";
 import {
@@ -16,6 +17,7 @@ import { Button } from "@/shared/ui/button";
 export function getUserProfilePanelHeaderContent({
   agentSettingsMenu,
   effectivePubkey,
+  ownerPubkey,
   logCopyValue,
   logSubtitle,
   onBack,
@@ -25,6 +27,7 @@ export function getUserProfilePanelHeaderContent({
 }: {
   agentSettingsMenu: ReactNode;
   effectivePubkey: string | null;
+  ownerPubkey?: string | null;
   logCopyValue?: string | null;
   logSubtitle?: string | null;
   onBack: () => void;
@@ -47,6 +50,13 @@ export function getUserProfilePanelHeaderContent({
         subtitleTitle={logSubtitle ?? undefined}
         title={title}
       />
+      {view !== "summary" ? (
+        <AgentManagementMarker
+          pubkey={effectivePubkey}
+          ownerPubkey={ownerPubkey}
+          testId="user-profile-header-agent-provenance"
+        />
+      ) : null}
     </AuxiliaryPanelHeaderGroup>
   );
   const headerActions = (

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 
+import { OtherSetupAgentMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
+import { useIsOtherSetupAgent } from "@/features/agents/useKnownAgentPubkeys";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import { agentPresenceStartBlockReason } from "@/features/agents/lib/useAgentAvailability";
 import {
@@ -189,6 +191,7 @@ export function ProfileSummaryView({
   unfollowMutation,
   userStatus,
 }: ProfileSummaryViewProps) {
+  const notManagedOnDevice = useIsOtherSetupAgent(pubkey, profile?.ownerPubkey);
   const activeTurns = useAgentWorking(isBot ? pubkey : null).channels;
   const stickyLayoutRef = React.useRef<HTMLDivElement>(null);
   const [primaryActionsConcealed, setPrimaryActionsConcealed] =
@@ -398,6 +401,7 @@ export function ProfileSummaryView({
       >
         <ProfileHero
           displayName={displayName}
+          notManagedOnDevice={notManagedOnDevice}
           isBot={isBot}
           onEditAgent={canEditAgent ? handleEditAgent : undefined}
           presenceStatus={presenceStatus}
@@ -600,6 +604,7 @@ export function ProfileSummaryView({
 // ── Hero & metadata ──────────────────────────────────────────────────────────
 
 function ProfileHero({
+  notManagedOnDevice,
   displayName,
   isBot,
   onEditAgent,
@@ -608,6 +613,7 @@ function ProfileHero({
   userStatus,
 }: {
   displayName: string;
+  notManagedOnDevice?: boolean;
   isBot: boolean;
   onEditAgent?: () => void;
   presenceStatus: "online" | "away" | "offline" | undefined;
@@ -674,6 +680,7 @@ function ProfileHero({
                 {displayName}
               </span>
               {botIndicator}
+              {notManagedOnDevice ? <OtherSetupAgentMarker /> : null}
               <span
                 aria-hidden="true"
                 className="pointer-events-none absolute top-1/2 left-full ml-1 -translate-y-1/2 text-muted-foreground opacity-0 transition-[color,opacity] duration-150 ease-out group-hover:text-foreground group-hover:opacity-100 group-focus-visible:opacity-100"
@@ -690,6 +697,7 @@ function ProfileHero({
           >
             <span className="truncate">{displayName}</span>
             {botIndicator}
+            {notManagedOnDevice ? <OtherSetupAgentMarker /> : null}
           </h3>
         )}
 

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Activity, Headphones, MessageSquare } from "lucide-react";
 
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
+
 import { useChannelsQuery } from "@/features/channels/hooks";
 import {
   useUserProfileQuery,
@@ -390,6 +392,11 @@ function UserProfilePopoverBody({
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           <HoverPubkeyName displayName={displayName} pubkey={pubkey} />
+          <AgentManagementMarker
+            pubkey={pubkey}
+            ownerPubkey={ownerPubkey}
+            testId="user-profile-popover-agent-provenance"
+          />
           {isBotProfile && botIdenticonValue ? (
             <BotIdenticon
               value={botIdenticonValue}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -7,6 +7,7 @@ import {
   ContextMenuTrigger,
 } from "@/shared/ui/context-menu";
 
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
 import { ChannelContextMenuItems } from "@/features/sidebar/ui/ChannelContextMenu";
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
@@ -334,6 +335,12 @@ export function ChannelMenuButton({
           display={ephemeralDisplay}
           testId={`channel-ephemeral-${channel.name}`}
           variant="sidebar"
+        />
+      ) : null}
+      {channel.channelType === "dm" && dmParticipants?.length === 1 ? (
+        <AgentManagementMarker
+          pubkey={dmParticipants[0].pubkey}
+          testId={`channel-agent-provenance-${channel.id}`}
         />
       ) : null}
       {activeWorking ? (

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -13,7 +13,6 @@ import {
   resolveMessageLinkRenderTarget,
   type ParsedMessageLink,
 } from "@/features/messages/lib/messageLink";
-import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { renderAudioMessageAttachment } from "@/features/messages/ui/AudioMessageAttachment";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { cn } from "@/shared/lib/cn";
@@ -23,7 +22,7 @@ import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { useRelayOrigin } from "@/shared/lib/useRelayOrigin";
 import { AttachmentGroup } from "@/shared/ui/attachment";
 import { ConfigNudgeCard } from "@/shared/ui/config-nudge-attachment";
-import { InlineChip } from "@/shared/ui/InlineChip";
+import { MarkdownMention } from "./markdown/MarkdownMention";
 import { LinkPreviewList } from "@/shared/ui/link-preview-list";
 import { useSmoothCorners } from "@/shared/ui/smoothCorners";
 import {
@@ -1576,48 +1575,9 @@ export function createMarkdownComponents(
     ul: ({ children }) => (
       <ul className={cn("list-disc", listClassName)}>{children}</ul>
     ),
-    mention: function MarkdownMention({
-      children,
-    }: {
-      children?: React.ReactNode;
-    }) {
-      const { agentMentionPubkeysByName, mentionPubkeysByName } =
-        useMarkdownRuntime();
-      const mentionText = String(children ?? "");
-      const mentionName = mentionText.replace(/^@/, "").trim().toLowerCase();
-      const pubkey = mentionPubkeysByName?.[mentionName];
-      const isAgentMention =
-        pubkey !== undefined &&
-        agentMentionPubkeysByName?.[mentionName] === pubkey;
-      const mentionLabel = mentionText.replace(/^@/, "");
-      // Only chips that actually open a profile get the clickable affordance.
-      // A mention whose pubkey didn't resolve stays a plain chip — a pointer
-      // cursor there promises a click that does nothing.
-      const opensProfile = interactive && pubkey !== undefined;
-      const mentionNode = (
-        <InlineChip
-          data-mention=""
-          className={cn(isAgentMention && "agent-mention-highlight")}
-          icon={isAgentMention ? "agent" : "human"}
-          interactive={opensProfile}
-        >
-          {mentionLabel}
-        </InlineChip>
-      );
-
-      return opensProfile ? (
-        <UserProfilePopover
-          botIdenticonValue={mentionLabel}
-          pubkey={pubkey}
-          role={isAgentMention ? "bot" : undefined}
-          triggerElement="span"
-        >
-          {mentionNode}
-        </UserProfilePopover>
-      ) : (
-        mentionNode
-      );
-    },
+    mention: ({ children }: { children?: React.ReactNode }) => (
+      <MarkdownMention interactive={interactive}>{children}</MarkdownMention>
+    ),
     emoji: ({ src, alt }: { src?: string; alt?: string }) => {
       const resolvedSrc = src ? rewriteRelayUrl(src) : src;
       if (!resolvedSrc) {

--- a/desktop/src/shared/ui/markdown/MarkdownMention.tsx
+++ b/desktop/src/shared/ui/markdown/MarkdownMention.tsx
@@ -1,0 +1,52 @@
+import type * as React from "react";
+import { AgentManagementMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
+import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
+import { InlineChip } from "@/shared/ui/InlineChip";
+import { cn } from "@/shared/lib/cn";
+import { useMarkdownRuntime } from "./runtimeContext";
+
+/** Exact-identity mention chip and its shared management provenance. */
+export function MarkdownMention({
+  children,
+  interactive,
+}: {
+  children?: React.ReactNode;
+  interactive: boolean;
+}) {
+  const { agentMentionPubkeysByName, mentionPubkeysByName } =
+    useMarkdownRuntime();
+  const mentionText = String(children ?? "");
+  const mentionName = mentionText.replace(/^@/, "").trim().toLowerCase();
+  const pubkey = mentionPubkeysByName?.[mentionName];
+  const isAgentMention =
+    pubkey !== undefined && agentMentionPubkeysByName?.[mentionName] === pubkey;
+  const mentionLabel = mentionText.replace(/^@/, "");
+  // Only chips that actually open a profile get the clickable affordance.
+  // A mention whose pubkey didn't resolve stays a plain chip — a pointer
+  // cursor there promises a click that does nothing.
+  const opensProfile = interactive && pubkey !== undefined;
+  const mentionNode = (
+    <InlineChip
+      data-mention=""
+      className={cn(isAgentMention && "agent-mention-highlight")}
+      icon={isAgentMention ? "agent" : "human"}
+      interactive={opensProfile}
+    >
+      {mentionLabel}
+      {isAgentMention ? <AgentManagementMarker pubkey={pubkey} /> : null}
+    </InlineChip>
+  );
+
+  return opensProfile ? (
+    <UserProfilePopover
+      botIdenticonValue={mentionLabel}
+      pubkey={pubkey}
+      role={isAgentMention ? "bot" : undefined}
+      triggerElement="span"
+    >
+      {mentionNode}
+    </UserProfilePopover>
+  ) : (
+    mentionNode
+  );
+}

--- a/desktop/tests/e2e/cloud-provenance.spec.ts
+++ b/desktop/tests/e2e/cloud-provenance.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from "@playwright/test";
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, openNewMessagePage } from "../helpers/bridge";
+
+const OWNER = "deadbeef".repeat(8);
+const REMOTE = "ed".repeat(32);
+const GENERAL = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const LABEL = "Not managed on this device";
+
+test("existing owned member uses one cloud across picker, members, author, chip, hover, profile and DM", async ({
+  page,
+}, testInfo) => {
+  await installMockBridge(page, {
+    managedAgents: [],
+    searchProfiles: [
+      {
+        pubkey: REMOTE,
+        displayName: "Remote Scout",
+        ownerPubkey: OWNER,
+        isAgent: true,
+      },
+    ],
+    relayAgents: [
+      {
+        pubkey: REMOTE,
+        name: "Remote Scout",
+        ownerPubkey: OWNER,
+        respondTo: "owner-only",
+        channelNames: ["general"],
+        status: "offline",
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  // Fixture setup only: the UI workflow starts with membership and a DM already present.
+  const dm = await page.evaluate(
+    async ({ pubkey, channelId }) => {
+      await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("add_channel_members", {
+        channelId,
+        pubkeys: [pubkey],
+        role: "bot",
+      });
+      const dm = (await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("open_dm", {
+        pubkeys: [pubkey],
+      })) as { id: string };
+      await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+        queryKey: ["channels"],
+      });
+      return dm;
+    },
+    { pubkey: REMOTE, channelId: GENERAL },
+  );
+  await page.getByTestId("channel-general").click();
+  const input = page.getByTestId("message-input");
+  await input.fill("@Remote");
+  const suggestion = page.getByTestId(`mention-suggestion-${REMOTE}`);
+  await expect(
+    suggestion.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await page
+    .getByTestId("mention-autocomplete")
+    .screenshot({ path: testInfo.outputPath("cloud-picker.png") });
+  await input.press("Escape");
+  await input.fill("");
+
+  await page.getByTestId("channel-members-trigger").click();
+  const members = page.getByTestId("members-sidebar");
+  const memberMarker = page.getByTestId(
+    `sidebar-member-agent-provenance-${REMOTE}`,
+  );
+  await expect(memberMarker).toHaveAttribute("aria-label", LABEL);
+  await expect(memberMarker.locator("svg.lucide-cloud")).toBeVisible();
+  await waitForAnimations(page);
+  await members.screenshot({ path: testInfo.outputPath("cloud-members.png") });
+  await members.getByRole("button", { name: "Close", exact: true }).click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+          channelName: "general",
+        }),
+      ),
+    )
+    .toBe(true);
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "general",
+      content: "Cloud provenance example: @Remote Scout",
+      pubkey,
+      // A self-reference is non-notifying, but still resolves a mention chip.
+      extraTags: [["mention", pubkey]],
+      kind: 40002,
+    });
+  }, REMOTE);
+  const article = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Cloud provenance example:" });
+  await expect(
+    article.getByTestId("message-header").getByRole("img", { name: LABEL }),
+  ).toBeVisible();
+  const chip = article.locator("[data-mention]");
+  await expect(chip.locator("svg.lucide-cloud")).toBeVisible();
+  await waitForAnimations(page);
+  await article.screenshot({
+    path: testInfo.outputPath("cloud-author-chip.png"),
+  });
+  await chip.hover();
+  const hover = page.getByTestId("user-profile-popover");
+  await expect(
+    hover.getByTestId("user-profile-popover-agent-provenance"),
+  ).toHaveAttribute("title", LABEL);
+  await waitForAnimations(page);
+  await hover.screenshot({ path: testInfo.outputPath("cloud-hover.png") });
+  await chip.click();
+  const panel = page.getByTestId("user-profile-panel");
+  await expect(
+    panel.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await panel.screenshot({ path: testInfo.outputPath("cloud-profile.png") });
+  await page.getByTestId("auxiliary-panel-close").click();
+  await expect(
+    page
+      .getByTestId(`channel-agent-provenance-${dm.id}`)
+      .locator("svg.lucide-cloud"),
+  ).toBeVisible();
+  await page.locator(`[data-channel-id="${dm.id}"]`).click();
+  await expect(
+    page
+      .getByTestId("chat-header-agent-provenance")
+      .locator("svg.lucide-cloud"),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await page.screenshot({ path: testInfo.outputPath("cloud-dm.png") });
+  await openNewMessagePage(page);
+  await page.getByTestId("new-dm-search").fill("Remote Scout");
+  const recipient = page.getByTestId(`new-dm-result-${REMOTE}`);
+  await expect(
+    recipient.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await recipient.screenshot({
+    path: testInfo.outputPath("cloud-recipient.png"),
+  });
+  await page.getByTestId("channel-random").click();
+  await page.getByTestId("channel-members-trigger").click();
+  await page.getByPlaceholder("Add people and agents").fill("Remote Scout");
+  const addResult = page.getByTestId(`channel-user-search-result-${REMOTE}`);
+  await expect(
+    addResult.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await addResult.screenshot({
+    path: testInfo.outputPath("cloud-add-member-picker.png"),
+  });
+  // No invitation or local lifecycle action is exercised by this presentation test.
+  await expect(
+    page.getByRole("button", { name: "Invite", exact: true }),
+  ).toHaveCount(0);
+});

--- a/desktop/tests/e2e/cloud-provenance.spec.ts
+++ b/desktop/tests/e2e/cloud-provenance.spec.ts
@@ -7,158 +7,194 @@ const REMOTE = "ed".repeat(32);
 const GENERAL = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
 const LABEL = "Not managed on this device";
 
-test("existing owned member uses one cloud across picker, members, author, chip, hover, profile and DM", async ({
-  page,
-}, testInfo) => {
-  await installMockBridge(page, {
-    managedAgents: [],
-    searchProfiles: [
-      {
-        pubkey: REMOTE,
-        displayName: "Remote Scout",
-        ownerPubkey: OWNER,
-        isAgent: true,
-      },
-    ],
-    relayAgents: [
-      {
-        pubkey: REMOTE,
-        name: "Remote Scout",
-        ownerPubkey: OWNER,
-        respondTo: "owner-only",
-        channelNames: ["general"],
-        status: "offline",
-      },
-    ],
-  });
-  await page.goto("/");
-  await page.getByTestId("channel-general").click();
-  await expect(page.getByTestId("chat-title")).toHaveText("general");
-  // Fixture setup only: the UI workflow starts with membership and a DM already present.
-  const dm = await page.evaluate(
-    async ({ pubkey, channelId }) => {
-      await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("add_channel_members", {
-        channelId,
-        pubkeys: [pubkey],
-        role: "bot",
-      });
-      const dm = (await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("open_dm", {
-        pubkeys: [pubkey],
-      })) as { id: string };
-      await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
-        queryKey: ["channels"],
-      });
-      return dm;
-    },
-    { pubkey: REMOTE, channelId: GENERAL },
-  );
-  await page.getByTestId("channel-general").click();
-  const input = page.getByTestId("message-input");
-  await input.fill("@Remote");
-  const suggestion = page.getByTestId(`mention-suggestion-${REMOTE}`);
-  await expect(
-    suggestion.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
-  ).toBeVisible();
-  await waitForAnimations(page);
-  await page
-    .getByTestId("mention-autocomplete")
-    .screenshot({ path: testInfo.outputPath("cloud-picker.png") });
-  await input.press("Escape");
-  await input.fill("");
-
-  await page.getByTestId("channel-members-trigger").click();
-  const members = page.getByTestId("members-sidebar");
-  const memberMarker = page.getByTestId(
-    `sidebar-member-agent-provenance-${REMOTE}`,
-  );
-  await expect(memberMarker).toHaveAttribute("aria-label", LABEL);
-  await expect(memberMarker.locator("svg.lucide-cloud")).toBeVisible();
-  await waitForAnimations(page);
-  await members.screenshot({ path: testInfo.outputPath("cloud-members.png") });
-  await members.getByRole("button", { name: "Close", exact: true }).click();
-
-  await expect
-    .poll(() =>
-      page.evaluate(() =>
-        window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
-          channelName: "general",
-        }),
-      ),
-    )
-    .toBe(true);
-  await page.evaluate((pubkey) => {
-    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
-      channelName: "general",
-      content: "Cloud provenance example: @Remote Scout",
-      pubkey,
-      // A self-reference is non-notifying, but still resolves a mention chip.
-      extraTags: [["mention", pubkey]],
-      kind: 40002,
+// The delayed fixture exceeds the marker assertion's 5s deadline, proving that
+// source readiness is awaited independently of whether a cloud ever renders.
+for (const agentListDelayMs of [0, 6_000]) {
+  test(`existing owned member uses one cloud across picker, members, author, chip, hover, profile and DM (directory delay ${agentListDelayMs}ms)`, async ({
+    page,
+  }, testInfo) => {
+    await installMockBridge(page, {
+      agentListDelayMs,
+      managedAgents: [],
+      searchProfiles: [
+        {
+          pubkey: REMOTE,
+          displayName: "Remote Scout",
+          ownerPubkey: OWNER,
+          isAgent: true,
+        },
+      ],
+      relayAgents: [
+        {
+          pubkey: REMOTE,
+          name: "Remote Scout",
+          ownerPubkey: OWNER,
+          respondTo: "owner-only",
+          channelNames: ["general"],
+          status: "offline",
+        },
+      ],
     });
-  }, REMOTE);
-  const article = page
-    .getByTestId("message-row")
-    .filter({ hasText: "Cloud provenance example:" });
-  await expect(
-    article.getByTestId("message-header").getByRole("img", { name: LABEL }),
-  ).toBeVisible();
-  const chip = article.locator("[data-mention]");
-  await expect(chip.locator("svg.lucide-cloud")).toBeVisible();
-  await waitForAnimations(page);
-  await article.screenshot({
-    path: testInfo.outputPath("cloud-author-chip.png"),
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    // The channel shell can mount before the provider's directory queries settle.
+    // Wait for successful source reads, not a delay or a larger marker timeout:
+    // the assertions below must still fail if ready data renders no cloud.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const client = window.__BUZZ_E2E_QUERY_CLIENT__;
+            return Object.fromEntries(
+              ["identity", "managed-agents", "relay-agents"].map((key) => {
+                const state = client?.getQueryState([key]);
+                return [
+                  key,
+                  { status: state?.status, fetchStatus: state?.fetchStatus },
+                ];
+              }),
+            );
+          }),
+        {
+          message:
+            "Cloud provenance requires successful identity and agent directory reads",
+          timeout: 10_000,
+        },
+      )
+      .toMatchObject({
+        identity: { status: "success" },
+        "managed-agents": { status: "success" },
+        "relay-agents": { status: "success" },
+      });
+    // Fixture setup only: the UI workflow starts with membership and a DM already present.
+    const dm = await page.evaluate(
+      async ({ pubkey, channelId }) => {
+        await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("add_channel_members", {
+          channelId,
+          pubkeys: [pubkey],
+          role: "bot",
+        });
+        const dm = (await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("open_dm", {
+          pubkeys: [pubkey],
+        })) as { id: string };
+        await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+          queryKey: ["channels"],
+        });
+        return dm;
+      },
+      { pubkey: REMOTE, channelId: GENERAL },
+    );
+    await page.getByTestId("channel-general").click();
+    const input = page.getByTestId("message-input");
+    await input.fill("@Remote");
+    const suggestion = page.getByTestId(`mention-suggestion-${REMOTE}`);
+    await expect(
+      suggestion.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+    ).toBeVisible();
+    await waitForAnimations(page);
+    await page
+      .getByTestId("mention-autocomplete")
+      .screenshot({ path: testInfo.outputPath("cloud-picker.png") });
+    await input.press("Escape");
+    await input.fill("");
+
+    await page.getByTestId("channel-members-trigger").click();
+    const members = page.getByTestId("members-sidebar");
+    const memberMarker = page.getByTestId(
+      `sidebar-member-agent-provenance-${REMOTE}`,
+    );
+    await expect(memberMarker).toHaveAttribute("aria-label", LABEL);
+    await expect(memberMarker.locator("svg.lucide-cloud")).toBeVisible();
+    await waitForAnimations(page);
+    await members.screenshot({
+      path: testInfo.outputPath("cloud-members.png"),
+    });
+    await members.getByRole("button", { name: "Close", exact: true }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: "general",
+          }),
+        ),
+      )
+      .toBe(true);
+    await page.evaluate((pubkey) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: "Cloud provenance example: @Remote Scout",
+        pubkey,
+        // A self-reference is non-notifying, but still resolves a mention chip.
+        extraTags: [["mention", pubkey]],
+        kind: 40002,
+      });
+    }, REMOTE);
+    const article = page
+      .getByTestId("message-row")
+      .filter({ hasText: "Cloud provenance example:" });
+    await expect(
+      article.getByTestId("message-header").getByRole("img", { name: LABEL }),
+    ).toBeVisible();
+    const chip = article.locator("[data-mention]");
+    await expect(chip.locator("svg.lucide-cloud")).toBeVisible();
+    await waitForAnimations(page);
+    await article.screenshot({
+      path: testInfo.outputPath("cloud-author-chip.png"),
+    });
+    await chip.hover();
+    const hover = page.getByTestId("user-profile-popover");
+    await expect(
+      hover.getByTestId("user-profile-popover-agent-provenance"),
+    ).toHaveAttribute("title", LABEL);
+    await waitForAnimations(page);
+    await hover.screenshot({ path: testInfo.outputPath("cloud-hover.png") });
+    await chip.click();
+    const panel = page.getByTestId("user-profile-panel");
+    await expect(
+      panel.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+    ).toBeVisible();
+    await waitForAnimations(page);
+    await panel.screenshot({ path: testInfo.outputPath("cloud-profile.png") });
+    await page.getByTestId("auxiliary-panel-close").click();
+    await expect(
+      page
+        .getByTestId(`channel-agent-provenance-${dm.id}`)
+        .locator("svg.lucide-cloud"),
+    ).toBeVisible();
+    await page.locator(`[data-channel-id="${dm.id}"]`).click();
+    await expect(
+      page
+        .getByTestId("chat-header-agent-provenance")
+        .locator("svg.lucide-cloud"),
+    ).toBeVisible();
+    await waitForAnimations(page);
+    await page.screenshot({ path: testInfo.outputPath("cloud-dm.png") });
+    await openNewMessagePage(page);
+    await page.getByTestId("new-dm-search").fill("Remote Scout");
+    const recipient = page.getByTestId(`new-dm-result-${REMOTE}`);
+    await expect(
+      recipient.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+    ).toBeVisible();
+    await waitForAnimations(page);
+    await recipient.screenshot({
+      path: testInfo.outputPath("cloud-recipient.png"),
+    });
+    await page.getByTestId("channel-random").click();
+    await page.getByTestId("channel-members-trigger").click();
+    await page.getByPlaceholder("Add people and agents").fill("Remote Scout");
+    const addResult = page.getByTestId(`channel-user-search-result-${REMOTE}`);
+    await expect(
+      addResult.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
+    ).toBeVisible();
+    await waitForAnimations(page);
+    await addResult.screenshot({
+      path: testInfo.outputPath("cloud-add-member-picker.png"),
+    });
+    // No invitation or local lifecycle action is exercised by this presentation test.
+    await expect(
+      page.getByRole("button", { name: "Invite", exact: true }),
+    ).toHaveCount(0);
   });
-  await chip.hover();
-  const hover = page.getByTestId("user-profile-popover");
-  await expect(
-    hover.getByTestId("user-profile-popover-agent-provenance"),
-  ).toHaveAttribute("title", LABEL);
-  await waitForAnimations(page);
-  await hover.screenshot({ path: testInfo.outputPath("cloud-hover.png") });
-  await chip.click();
-  const panel = page.getByTestId("user-profile-panel");
-  await expect(
-    panel.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
-  ).toBeVisible();
-  await waitForAnimations(page);
-  await panel.screenshot({ path: testInfo.outputPath("cloud-profile.png") });
-  await page.getByTestId("auxiliary-panel-close").click();
-  await expect(
-    page
-      .getByTestId(`channel-agent-provenance-${dm.id}`)
-      .locator("svg.lucide-cloud"),
-  ).toBeVisible();
-  await page.locator(`[data-channel-id="${dm.id}"]`).click();
-  await expect(
-    page
-      .getByTestId("chat-header-agent-provenance")
-      .locator("svg.lucide-cloud"),
-  ).toBeVisible();
-  await waitForAnimations(page);
-  await page.screenshot({ path: testInfo.outputPath("cloud-dm.png") });
-  await openNewMessagePage(page);
-  await page.getByTestId("new-dm-search").fill("Remote Scout");
-  const recipient = page.getByTestId(`new-dm-result-${REMOTE}`);
-  await expect(
-    recipient.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
-  ).toBeVisible();
-  await waitForAnimations(page);
-  await recipient.screenshot({
-    path: testInfo.outputPath("cloud-recipient.png"),
-  });
-  await page.getByTestId("channel-random").click();
-  await page.getByTestId("channel-members-trigger").click();
-  await page.getByPlaceholder("Add people and agents").fill("Remote Scout");
-  const addResult = page.getByTestId(`channel-user-search-result-${REMOTE}`);
-  await expect(
-    addResult.getByRole("img", { name: LABEL }).locator("svg.lucide-cloud"),
-  ).toBeVisible();
-  await waitForAnimations(page);
-  await addResult.screenshot({
-    path: testInfo.outputPath("cloud-add-member-picker.png"),
-  });
-  // No invitation or local lifecycle action is exercised by this presentation test.
-  await expect(
-    page.getByRole("button", { name: "Invite", exact: true }),
-  ).toHaveCount(0);
-});
+}

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -386,11 +386,11 @@ test("duplicate owned agents preserve provenance and exact pubkey selection", as
   );
   await expect(relayProvenanceMarker).toHaveAttribute(
     "aria-label",
-    "From another Buzz setup",
+    "Not managed on this device",
   );
   await expect(relayProvenanceMarker).toHaveAttribute(
     "title",
-    "From another Buzz setup",
+    "Not managed on this device",
   );
   await expect(relayProvenanceMarker).toBeVisible();
   await expect(relayProvenanceMarker).toHaveText("");
@@ -465,7 +465,7 @@ test("duplicate owned agents preserve provenance and exact pubkey selection", as
   ).toHaveCount(0);
   await expect(remoteSidebarMarker).toHaveAttribute(
     "aria-label",
-    "From another Buzz setup",
+    "Not managed on this device",
   );
   await expect(remoteSidebarMarker).toHaveText("");
   await expect(remoteSidebarMarker.locator("svg")).toBeVisible();

--- a/docs/agent-management-provenance.md
+++ b/docs/agent-management-provenance.md
@@ -1,0 +1,25 @@
+# Agent management provenance
+
+The shared **Not managed on this device** cloud marker means a viewer-owned
+identity has no exact-key record in successfully loaded local managed inventory.
+The glyph is the approved visual convention, not proof of physical cloud hosting.
+Locally managed provider-backed agents, unknown/failed local inventory, unknown
+owners, and other people's identities do not get the marker. Neither lifecycle
+state nor relay presence decides management provenance.
+
+`KnownAgentPubkeysProvider` supplies stable inventory and ownership context to
+identity surfaces; rows must not create their own directory query observers.
+Picker candidates preserve exact local-management flags and use the same pure
+predicate. Profile ownership can supplement the shared directory evidence.
+
+Pickers, member cards, authors, markdown mention chips, address controls, hover
+cards, profile headers/hero/subviews, new-message recipients and DM headers/sidebar
+rows use the same glyph and accessible label. The marker grants no membership,
+mention eligibility, availability or local management capability. This change does
+not change profile navigation, presence, native discovery or invitation/routing.
+
+Regression gates: `otherSetupAgent.test.mjs`, `useKnownAgentPubkeys.test.mjs`,
+`buildMentionCandidates.test.mjs`, `MentionAutocomplete.test.mjs`, and
+`tests/e2e/cloud-provenance.spec.ts`. Browser evidence is mock-Tauri rendered UI,
+using an already eligible channel member and an existing DM, not a discovery or
+invitation acceptance test. `mentions.spec.ts` retains its marker-label assertions.

--- a/docs/agent-management-provenance.md
+++ b/docs/agent-management-provenance.md
@@ -23,3 +23,8 @@ Regression gates: `otherSetupAgent.test.mjs`, `useKnownAgentPubkeys.test.mjs`,
 `tests/e2e/cloud-provenance.spec.ts`. Browser evidence is mock-Tauri rendered UI,
 using an already eligible channel member and an existing DM, not a discovery or
 invitation acceptance test. `mentions.spec.ts` retains its marker-label assertions.
+The cloud smoke waits (at most 10 seconds, with per-query status diagnostics) for
+successful identity, local inventory and relay directory reads before opening the
+picker. Both immediate and delayed-directory fixtures exercise the same rendered
+workflow. Each cloud assertion retains its own normal deadline: successful data
+loading must not hide a missing glyph or accessible marker.


### PR DESCRIPTION
🤖

## Requested rebase published — caf5dfa6

Rebased onto fetched main **47d068e2109d077414cbf2f4f1c927f6d051037a**, published **caf5dfa6f6ab066233c609be9970d12617a64ddf** with the exact expected-old `d280d36c` force-with-lease. No merge.

Manual conflicts were additive: preserve main's exact-key identity documentation alongside the cloud provenance contract, and keep BOTH main's policy-only-discovery regression and the cloud local-management regressions. Main already contains three ownership plumbing additions, which therefore disappear as redundant branch hunks. Main's Online/Away-only active classification remains intact. Cloud marker/context, composer controls, markdown extraction and media behavior are byte-identical to the previously reviewed head; no ownership/permission or cloud design was changed. Both original authors/messages/DCO/material coauthor trailers are preserved; signing policy was not changed.

Fresh checks on the rebased candidate:
- TypeScript, Biome on 26 changed TypeScript files, differential file-size gate, and diff whitespace: pass.
- Focused provenance/candidate/autocomplete/markdown units: **146/146**.
- Fresh E2E build; eight-surface cloud workflow: **2/2** (immediate and 6000ms directory delay), no retries.
- Main exact-key profile navigation/control isolation: **4/4**, no retries.

Previously reviewed full Desktop package, cloud repetition and falsifiability evidence is reused for unchanged behavior. This is not a new full-suite/`just ci`, live-cloud, native, or accessibility certification. Existing generated artifacts, local configs and dependency links were preserved; the known all-files Biome/generated-artifact issue is not represented as passing.

The historical F1 suffix-loss evidence remains preserved. It is tracked separately as **#7253**, nonblocking for this cloud rebase; this work neither fixes it nor establishes cloud provenance as its cause. No expectations were weakened and no full-mentions pass is claimed.

Hosted observation: **MERGEABLE**, **BLOCKED / REVIEW_REQUIRED**, no new-head formal review. [CI 33699919485](https://github.com/block/buzz/actions/runs/33699919485) is queued/starting, not a completed success; DCO passed. No completed failing check or new inline feedback observed. Historical approvals are not new-head approvals. No reviewer/security authorization or merge action was performed.

---

## Feature summary and retained pre-rebase evidence

> **Historical publication status at d280d36c (superseded by the rebase status above): Publication for exact-head CI and technical review only — NOT readiness certification. F1 remains OPEN:** the full mentions run failed 2 cases (78 passed); isolated passes do not clear or waive those failures. No merge or security-review authorization is implied.

## Summary

In Buzz Desktop, an owned agent could show a cloud in one place and no marker elsewhere, leaving people to guess whether the icon meant hosted, online, or simply managed from another device. The marker now has one consistent meaning across the app: **“Not managed on this device.”** The same cloud glyph and accessible label appear in mention/member pickers, member cards, message authors and mention/address chips, hover/profile views, new-message recipients, and DM headers/sidebar rows.

The marker requires known ownership by the viewer and a successfully loaded local inventory with no management record for that exact agent. Locally managed provider-backed agents do not receive it. Unknown/failed inventory, unknown ownership and other people's agents do not receive it either. The icon is not a claim about physical hosting, availability, membership, permission or local controls.

These surfaces share the same ownership and local-management information rather than calculating conflicting answers.

### Related issue

Independent base: `main`; no stack parent or child among the replacements. Extracted from [#7114](https://github.com/block/buzz/pull/7114), retained as historical source (`98fe33ec`).

[Behavior contract](https://github.com/block/buzz/blob/d280d36c1f5b07322fedba52bf0b8f766e192cd9/docs/agent-management-provenance.md). Originating [Buzz discussion](buzz://message?channel=f7a9536a-1738-4bad-a888-b3ea25010ef1&id=7aa1f0ab23dce514bd8a0221441cf005bf428914621171472b79747c50820848) · channel `f7a9536a-1738-4bad-a888-b3ea25010ef1`.

### Historical reviewed conflict/readiness repair (d280d36c)

Exact head: `d280d36c1f5b07322fedba52bf0b8f766e192cd9`; pinned main/merge-base: `0e878664b08cdf7fb2d89d940bc2aa92cdc485f7`. Rebased cloud presentation changes preserve main's composer selection/focus, thread wording and voice-note controls, and unrelated markdown audio/image rendering.

In response to [the smoke-readiness review](https://github.com/block/buzz/pull/7129#pullrequestreview-5084829979), the test now waits on the actual identity, managed-agents and relay-agents query success states, with a **10s bound and status/fetchStatus diagnostics**. Marker assertions remain independently required with their original **5s timeout**. Immediate and 6000ms-delayed directory variants run the same eight-surface workflow. No sleeps, retries, production readiness workaround or weakened assertion was added.

### Testing — scoped evidence, not an all-green integration claim

Frozen-head local evidence (reused, not rerun during publication):

| Gate | Result |
| --- | --- |
| Desktop unit tests | **5,891 passed**, no failures/skips |
| Cloud workflow repetition | **20/20 passed: 10 immediate + 10 delayed, zero retries** |
| Typecheck; tracked-source Biome; px/pubkey guards; file-size gate | Passed |
| Production OSS/internal protected-feature build matrix; E2E build | Passed |
| Delayed readiness regression | Before repair: fails at missing picker cloud; after: 2/2 passed |
| Marker-null mutation, final frozen spec | **Fails as required** at actual missing cloud after all three queries are ready |
| Full mentions browser selection | **78 passed / 2 failed — F1 OPEN** |
| Literal `pnpm check` | **FAILED**: scans preserved generated `dist-production` (5,476 errors). Tracked-file Biome above uses unchanged rules on all 3,164 tracked desktop paths; it is not the raw command passing. |

No fresh repository-wide `just ci` pass is claimed. Old-head CI is not evidence for this head; current remote checks and fresh formal technical review are separate gates.

#### F1 — unresolved mention separator loss, before Send

`desktop/tests/e2e/mentions.spec.ts:3024` and `:3057` fail the sent human/agent chip assertions. Traces show Enter first inserts the selected `@outsider` / `@charlie` chip **and a trailing space**; typing the suffix then turns the composer into plain `Loop in @outsiderplease` / `Loop in @charlietoo` **before Send**. This is not merely a missing cloud glyph.

The same two unchanged test bodies pass **2/2 in isolation on pinned main and 2/2 against the frozen candidate**, using equivalent fixture/settings/build recipes (one worker, zero retries). Governing mention insertion/caret-settlement source is byte-identical. **No cause is proven. These isolated passes do not replace the 78/2 result, prove a pre-existing main defect, or resolve F1.** The existing #7133 mention-edit investigation is separate; this publication neither changes its trees nor asserts it fixes this symptom. Full-candidate integration approval remains withheld pending explicit maintainer disposition/evidence.

Historical old-head evidence remains historical: 5,810 frontend tests and old published CI passed; two broader old browser runs were 201/1, and one different human-separator case reproduced on that old baseline. Earlier full local `just ci` stopped at a native probe-count test; separate reruns were not one clean invocation. None of that classifies today's F1.

#### Screenshots and runtime limits

The independently reviewed final candidate has eight distinct prepared frames per run. **The five current profile/hover/member/recipient/add-member images below are byte-for-byte identical to already hosted immutable images** (SHA-256 comparison against prepared final candidate PNGs); their existing policy-compliant GitHub URLs are reused, not recaptured or newly uploaded. The old eight-frame [40844daf screenshot comment](https://github.com/block/buzz/pull/7129#issuecomment-5482268510) is minimized as outdated, not deleted; historical picker/DM examples are labeled below. Exact-head picker/DM/author-chip PNGs differ and remain in local evidence, not misrepresented by old URLs. Uploading those requires an explicit screenshot-branch exception to this assignment's no-other-branch-mutation scope.

Before (40844daf) versus after (d280d36c) intentionally has no visual difference on the five reused surfaces: this repair fixes readiness and preserves controls. Both use a **mock Tauri bridge**, an already eligible channel member and an existing DM: no invitation, live/native cloud, physical hosting or availability certification. Profile subviews/address tooltip are source-reviewed, not separately captured. No manual native/assistive-technology claim.

**Current profile hero (d280d36c, hash-matched to prepared capture):** ownership, message/follow actions and tabs remain visible.

![Current candidate profile hero](https://raw.githubusercontent.com/block/buzz/a18c2e5e9bc890afd39928f746e9a84e5df92d5f/pr-7129--cloud-profile.png)

**Current hover card (d280d36c, hash-matched):** cloud is separate from presence and local controls.

![Current candidate hover card](https://raw.githubusercontent.com/block/buzz/a18c2e5e9bc890afd39928f746e9a84e5df92d5f/pr-7129--cloud-hover.png)

<details>
<summary>Three more hash-matched current candidate surfaces</summary>

**Channel member:** separate cloud and neutral/offline presence.

![Current candidate member card](https://raw.githubusercontent.com/block/buzz/a18c2e5e9bc890afd39928f746e9a84e5df92d5f/pr-7129--cloud-members.png)

**New-message recipient:** agent and ownership labels retained.

![Current candidate recipient](https://raw.githubusercontent.com/block/buzz/a18c2e5e9bc890afd39928f746e9a84e5df92d5f/pr-7129--cloud-recipient.png)

**Add-member search:** exact identity/ownership and Add action retained; no invitation success claimed.

![Current candidate add-member picker](https://raw.githubusercontent.com/block/buzz/a18c2e5e9bc890afd39928f746e9a84e5df92d5f/pr-7129--cloud-add-member-picker.png)

</details>

**Historical picker (40844daf):** shared marker at selection time.

![Historical mention picker](https://raw.githubusercontent.com/block/buzz/a18c2e5e9bc890afd39928f746e9a84e5df92d5f/pr-7129--cloud-picker.png)

**Historical existing DM (40844daf):** header/sidebar marker, not online status.

![Historical existing DM](https://raw.githubusercontent.com/block/buzz/a18c2e5e9bc890afd39928f746e9a84e5df92d5f/pr-7129--cloud-dm.png)

Evidence directories retained in the author workspace: `WORK_LOGS/CLOUD_CANDIDATE_DE89D343` (logs/traces/PNGs), `CLOUD_REVIEW_D12DD46D/REVIEW.md` (independent review), `CLOUD_BASELINE_CE561F5E/REPORT.md` (bounded differential), and `CLOUD_PUBLICATION_69C3D7AC` (publication receipts). These are local artifact paths, not GitHub links. Candidate patch SHA-256: `2742dde8a7fc1c0d5edf4cfe8c7a63bf45ac2f684255786f67a3fd3b8a21f633`; all 544 preserved files unchanged before publication.



## Rebase for landing — 2026-09-03

Published `6dee689842cf4de29031f02f8cf2901de466aa44` onto main `d5a73b9f35feaa81ef9afb13d1ec8943e8ec6ca9` with an exact old-head lease. Only the two cloud commits were replayed. Manual conflicts were additive: keep both cloud/spacing smoke registrations and both availability/provenance contributor contracts. Auto-merged UI changes retain main's exact-key availability/lifecycle guards. The cloud behavior and directory-readiness repair are unchanged (range-diff saved).

Fresh exact-head checks: full Desktop JS **6,018/6,018**, **89/89 Chromium** across cloud provenance (0ms/6000ms), mention spacing, exact-key profiles, mentions and matched team-mentions smoke; E2E build, Desktop check/types, differential file-size gate and diff check pass. Prior independent review/mutation and screenshots remain valid for unchanged cloud code; these are mock-Tauri browser workflows, not new packaged/native or live-relay proof.

`just ci` was attempted: first stopped because pre-existing untracked production build artifacts were linted. Those files/configs were preserved outside the checkout with a hash ledger; normal Desktop checks then passed. A second full local invocation reached Desktop tests but was terminated by the command's five-minute budget. This is **not** a full-local-CI pass; fresh hosted CI remains the required landing gate.

GitHub's last-push rule requires renewed automated approval. Please review the narrow rebase integration at this head, reusing unchanged evidence rather than restarting feature review. Current hosted run: https://github.com/block/buzz/actions/runs/33706596783
