### PR TITLE
fix(desktop): deliver Pulse mentions live so they notify while unfocused

### DIFF
--- a/desktop/src/app/useLiveHomeFeedActions.test.mjs
+++ b/desktop/src/app/useLiveHomeFeedActions.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildHomeFeedLivePTagFilter } from "./useLiveHomeFeedActions.ts";
+import {
+  KIND_APPROVAL_REQUEST,
+  KIND_REMINDER,
+  KIND_TEXT_NOTE,
+} from "../shared/constants/kinds.ts";
+
+test("live p-tag filter covers Pulse mentions", () => {
+  // Regression: the home feed poll pauses while the window is unfocused, so
+  // Pulse (kind 1) mentions notify in the background only if this always-on
+  // subscription delivers them.
+  const filter = buildHomeFeedLivePTagFilter("abc123", 1_000);
+  assert.ok(filter.kinds.includes(KIND_TEXT_NOTE));
+});
+
+test("live p-tag filter keeps approval and reminder coverage", () => {
+  const filter = buildHomeFeedLivePTagFilter("abc123", 1_000);
+  assert.ok(filter.kinds.includes(KIND_APPROVAL_REQUEST));
+  assert.ok(filter.kinds.includes(KIND_REMINDER));
+});
+
+test("live p-tag filter targets the user and is live-only", () => {
+  const filter = buildHomeFeedLivePTagFilter("abc123", 1_234);
+  assert.deepEqual(filter["#p"], ["abc123"]);
+  assert.equal(filter.since, 1_234);
+});

--- a/desktop/src/app/useLiveHomeFeedActions.ts
+++ b/desktop/src/app/useLiveHomeFeedActions.ts
@@ -7,9 +7,30 @@ import {
   KIND_APPROVAL_REQUEST,
   KIND_EVENT_REMINDER,
   KIND_REMINDER,
+  KIND_TEXT_NOTE,
 } from "@/shared/constants/kinds";
 
-const HOME_FEED_ACTION_KINDS = [KIND_APPROVAL_REQUEST, KIND_REMINDER] as const;
+/**
+ * Kinds that must trigger a home-feed refresh when they arrive p-tagging the
+ * user. The home feed poll pauses while the window is unfocused, so any
+ * feed-driven alert — Pulse mentions (kind 1), approval requests, reminders —
+ * only reaches the notification pipeline in the background through this
+ * always-on subscription.
+ */
+export const HOME_FEED_LIVE_P_TAG_KINDS = [
+  KIND_TEXT_NOTE,
+  KIND_APPROVAL_REQUEST,
+  KIND_REMINDER,
+] as const;
+
+export function buildHomeFeedLivePTagFilter(pubkey: string, since: number) {
+  return {
+    kinds: [...HOME_FEED_LIVE_P_TAG_KINDS],
+    "#p": [pubkey],
+    limit: 50,
+    since,
+  };
+}
 const LIVE_HOME_FEED_RETRY_BASE_MS = 1_000;
 const LIVE_HOME_FEED_RETRY_MAX_MS = 30_000;
 
@@ -64,12 +85,7 @@ export function useLiveHomeFeedActions(
 
       void Promise.allSettled([
         relayClient.subscribeLive(
-          {
-            kinds: [...HOME_FEED_ACTION_KINDS],
-            "#p": [normalizedPubkey],
-            limit: 50,
-            since,
-          },
+          buildHomeFeedLivePTagFilter(normalizedPubkey, since),
           handleLiveHomeFeedEvent,
         ),
         relayClient.subscribeLive(


### PR DESCRIPTION
## Problem

Fixes #6276: Pulse `@mentions` produce no native desktop notification and no Home/Mention badge while the Buzz window is open but unfocused.

Mention alerts are feed-driven: `use-feed-desktop-notifications.ts` only sees a mention when the home feed query returns it. #5490 (intentionally, for CPU/power) switched the home feed to `useFocusedRefetchInterval(...)`, pausing polling on blur — so feed-driven mentions are silenced exactly when the user is working in another app. The #5490 review carved out an exception for reminders and approvals (`useLiveHomeFeedActions`: an always-on live `#p` WebSocket subscription that triggers an imperative feed refetch), but Pulse mentions (kind 1) were not included.

## How it was implemented

- Add `KIND_TEXT_NOTE` to the existing always-on live `#p` subscription in `desktop/src/app/useLiveHomeFeedActions.ts`. A Pulse note p-tagging the user now arrives over the WebSocket (which stays connected regardless of focus) and triggers the same `homeFeedQuery.refetch()` the reminder/approval exception already uses; the refetched feed flows into the existing badge and desktop-notification pipeline.
- This preserves #5490's power win: no background polling is resumed. Network work happens only when an event actually p-tags the user.
- The subscription filter is extracted into an exported `buildHomeFeedLivePTagFilter()` with regression tests documenting the constraint, so the Pulse kind can't be silently dropped later.

## How to test manually

1. In Buzz Desktop enable Desktop alerts, Home badge, and Mention alerts.
2. Keep Buzz running and connected; focus another app (do not quit or minimize-quit Buzz).
3. From another identity, publish a Pulse note (kind 1) with a `p` tag for the signed-in user.
4. Before: nothing happens until refocus (and the 5-minute focus stale-time can delay it further). After: the native notification fires and the Home/Mention badge updates within a moment of the event arriving.

No UI changes — behavior-only, so no screenshots.

## Verification

- `desktop: pnpm test` — 5,802 pass (3 new)
- `desktop: pnpm typecheck`, biome check, `pnpm build` — clean

## Related

Searched open PRs — none found addressing this. #5490 is the (intentional) origin of the regression; this follows the exception pattern its review established for reminders. Sibling PR #7123 fixes the separate active-channel suppression bug in the same notification area.
