### PR TITLE
Release push gateway chart 0.2.0 with Datadog metrics

### DIFF
--- a/deploy/charts/buzz-push-gateway/templates/deployment.yaml
+++ b/deploy/charts/buzz-push-gateway/templates/deployment.yaml
@@ -11,6 +11,9 @@ spec:
   template:
     metadata:
       labels: {{- include "push.runtimeLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 60

--- a/deploy/charts/buzz-push-gateway/tests/datadog-values.yaml
+++ b/deploy/charts/buzz-push-gateway/tests/datadog-values.yaml
@@ -1,0 +1,30 @@
+# Render-only fixture proving Datadog Autodiscovery can scrape the private
+# metrics listener without installing prometheus-operator CRDs. Deployment
+# repositories must replace these illustrative selectors with their agent's
+# actual namespace and pod labels.
+podAnnotations:
+  ad.datadoghq.com/gateway.checks: |
+    {
+      "openmetrics": {
+        "init_config": {},
+        "instances": [
+          {
+            "openmetrics_endpoint": "http://%%host%%:8081/metrics",
+            "service": "buzz-push-gateway",
+            "namespace": "block.buzz_push_gateway",
+            "metrics": ["push_gateway_.*"],
+            "histogram_buckets_as_distributions": true,
+            "send_distribution_buckets": true,
+            "send_monotonic_counter": true,
+            "collect_counters_with_distributions": true
+          }
+        ]
+      }
+    }
+networkPolicy:
+  monitoring:
+    enabled: true
+    namespaceSelector:
+      kubernetes.io/metadata.name: datadog
+    podSelector:
+      app.kubernetes.io/name: datadog-agent

--- a/deploy/charts/buzz-push-gateway/tests/render.sh
+++ b/deploy/charts/buzz-push-gateway/tests/render.sh
@@ -1,25 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
-out=$(mktemp); production_out=$(mktemp)
-trap 'rm -f "$out" "$production_out"' EXIT
+out=$(mktemp); production_out=$(mktemp); route_out=$(mktemp); datadog_out=$(mktemp)
+trap 'rm -f "$out" "$production_out" "$route_out" "$datadog_out" "${monitoring_out:-}"' EXIT
 
 # Defaults must lint and render without parameter injection.
 helm lint deploy/charts/buzz-push-gateway >/dev/null
 helm template push deploy/charts/buzz-push-gateway >"$out"
-# Production values must attach push.buzz.xyz to an explicit Gateway.
+# Production values support a platform-owned ingress without rendering an
+# HTTPRoute. The environment-owned inputs remain mandatory.
 production_args=(
   -f deploy/charts/buzz-push-gateway/values-production.yaml
   --set 'image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
   --set 'profiles.dogfood.appAttestAppId=REALTEAM.xyz.block.buzz.dogfood.mobile'
-  --set 'httpRoute.parentRefs[0].name=production-gateway'
-  --set 'httpRoute.parentRefs[0].namespace=gateway-system'
   --set 'networkPolicy.postgresEgressCidrs[0]=10.42.0.0/16'
 )
 helm lint deploy/charts/buzz-push-gateway "${production_args[@]}" >/dev/null
 helm template push deploy/charts/buzz-push-gateway "${production_args[@]}" >"$production_out"
 
+# Gateway API remains an explicit supported ingress mode when an operator opts
+# in and supplies the environment-owned parent.
+helm template push deploy/charts/buzz-push-gateway \
+  --set httpRoute.enabled=true \
+  --set 'httpRoute.parentRefs[0].name=production-gateway' \
+  --set 'httpRoute.parentRefs[0].namespace=gateway-system' \
+  >"$route_out"
+
 env -u GEM_HOME -u GEM_PATH -u RUBYLIB -u RUBYOPT ruby -ryaml -rset \
-  - "$out" "$production_out" <<'RUBY'
+  - "$out" "$production_out" "$route_out" <<'RUBY'
 def assert!(condition, detail = "assertion failed")
   raise detail unless condition
 end
@@ -38,6 +45,7 @@ migration = runtime.merge("app.kubernetes.io/component" => "migration")
 assert!(svc.dig("spec", "selector") == runtime)
 assert!(d.dig("spec", "selector", "matchLabels") == runtime)
 assert!(d.dig("spec", "template", "metadata", "labels") == runtime)
+assert!(d.dig("spec", "template", "metadata", "annotations").nil?)
 assert!(j.dig("spec", "template", "metadata", "labels") == migration)
 assert!(svc.dig("spec", "selector") != j.dig("spec", "template", "metadata", "labels"))
 jenv = j.dig("spec", "template", "spec", "containers", 0, "env").to_h { |entry| [entry["name"], entry] }
@@ -86,7 +94,8 @@ ingress_ports = np.dig("spec", "ingress")
   .flat_map { |rule| rule.fetch("ports", []) }.map { |port| port["port"] }.to_set
 assert!(ingress_ports == Set[8080], ingress_ports.inspect)
 production = YAML.load_stream(File.read(ARGV[1])).compact
-route = production.find { |x| x["kind"] == "HTTPRoute" }
+assert!(!production.any? { |x| x["kind"] == "HTTPRoute" })
+route = YAML.load_stream(File.read(ARGV[2])).compact.find { |x| x["kind"] == "HTTPRoute" }
 assert!(!route.dig("spec", "parentRefs").empty?)
 assert!(route.dig("spec", "hostnames").include?("push.buzz.xyz"))
 RUBY
@@ -115,7 +124,7 @@ fi
 
 # Enabling observability renders the scrape CRDs and adds a scoped 8081 ingress
 # keyed to the named monitoring source — never a blanket 8081 rule.
-monitoring_out=$(mktemp); trap 'rm -f "$out" "$production_out" "$monitoring_out"' EXIT
+monitoring_out=$(mktemp)
 helm template push deploy/charts/buzz-push-gateway \
   --set podMonitor.enabled=true \
   --set prometheusRule.enabled=true \
@@ -147,6 +156,44 @@ from = monitoring[0].fetch("from")[0]
 assert!(!from.dig("namespaceSelector", "matchLabels").empty? && !from.dig("podSelector", "matchLabels").empty?, from.inspect)
 RUBY
 
+# Datadog discovers the same private endpoint from pod annotations and needs no
+# prometheus-operator CRDs. Its agent ingress remains selector-scoped.
+helm lint deploy/charts/buzz-push-gateway \
+  -f deploy/charts/buzz-push-gateway/tests/datadog-values.yaml >/dev/null
+helm template push deploy/charts/buzz-push-gateway \
+  -f deploy/charts/buzz-push-gateway/tests/datadog-values.yaml \
+  >"$datadog_out"
+
+env -u GEM_HOME -u GEM_PATH -u RUBYLIB -u RUBYOPT ruby -rjson -ryaml -rset \
+  - "$datadog_out" <<'RUBY'
+def assert!(condition, detail = "assertion failed")
+  raise detail unless condition
+end
+
+xs = YAML.load_stream(File.read(ARGV[0])).compact
+assert!(!xs.any? { |x| %w[PodMonitor PrometheusRule].include?(x["kind"]) })
+deployment = xs.find { |x| x["kind"] == "Deployment" }
+raw_check = deployment.dig(
+  "spec", "template", "metadata", "annotations",
+  "ad.datadoghq.com/gateway.checks",
+)
+check = JSON.parse(raw_check)
+instance = check.dig("openmetrics", "instances", 0)
+assert!(instance["openmetrics_endpoint"] == "http://%%host%%:8081/metrics", instance.inspect)
+assert!(instance["metrics"] == ["push_gateway_.*"], instance.inspect)
+
+np = xs.find do |x|
+  x["kind"] == "NetworkPolicy" && x.dig("metadata", "name") == "push-buzz-push-gateway"
+end
+monitoring = np.dig("spec", "ingress").select do |rule|
+  rule.fetch("ports", []).map { |port| port["port"] }.to_set == Set[8081]
+end
+assert!(monitoring.length == 1, "exactly one scoped Datadog 8081 ingress rule")
+from = monitoring[0].fetch("from")[0]
+assert!(!from.dig("namespaceSelector", "matchLabels").empty?, from.inspect)
+assert!(!from.dig("podSelector", "matchLabels").empty?, from.inspect)
+RUBY
+
 # Negative: monitoring enabled with default empty selectors must fail (would
 # otherwise render a blanket 8081 rule matching all namespaces/pods).
 if helm template push deploy/charts/buzz-push-gateway \
@@ -156,23 +203,14 @@ if helm template push deploy/charts/buzz-push-gateway \
   exit 1
 fi
 
-# Negative: scrape flags must be coupled. PodMonitor without ingress = an
-# unreachable scraper; ingress without a PodMonitor = an open hole with no
-# scraper. Both mismatches must fail schema validation.
+# Negative: PodMonitor without ingress is an unreachable scraper and must fail.
+# Scoped ingress without PodMonitor is valid for annotation-discovered agents.
 if helm template push deploy/charts/buzz-push-gateway \
   --set podMonitor.enabled=true \
   --set 'networkPolicy.monitoring.namespaceSelector.kubernetes\.io/metadata\.name=monitoring' \
   --set 'networkPolicy.monitoring.podSelector.app\.kubernetes\.io/name=prometheus' \
   >/dev/null 2>&1; then
   echo 'expected podMonitor.enabled without monitoring ingress to fail' >&2
-  exit 1
-fi
-if helm template push deploy/charts/buzz-push-gateway \
-  --set networkPolicy.monitoring.enabled=true \
-  --set 'networkPolicy.monitoring.namespaceSelector.kubernetes\.io/metadata\.name=monitoring' \
-  --set 'networkPolicy.monitoring.podSelector.app\.kubernetes\.io/name=prometheus' \
-  >/dev/null 2>&1; then
-  echo 'expected monitoring ingress without podMonitor.enabled to fail' >&2
   exit 1
 fi
 

--- a/deploy/charts/buzz-push-gateway/values-production.yaml
+++ b/deploy/charts/buzz-push-gateway/values-production.yaml
@@ -7,7 +7,9 @@ profiles:
   dogfood:
     appAttestAppId: ""
 httpRoute:
-  enabled: true
+  # Keep disabled when the platform already routes push.buzz.xyz to this
+  # Service. Gateway API users enable it and inject an explicit parentRef.
+  enabled: false
   parentRefs: []
   hostnames:
     - push.buzz.xyz

--- a/deploy/charts/buzz-push-gateway/values.schema.json
+++ b/deploy/charts/buzz-push-gateway/values.schema.json
@@ -32,6 +32,12 @@
       }
     },
     "apnsKey": false,
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "httpRoute": {
       "type": "object",
       "required": [
@@ -313,7 +319,7 @@
   ],
   "allOf": [
     {
-      "$comment": "Scraping opt-in is coupled: a PodMonitor and its scoped 8081 ingress must be enabled together, so we never render a scraper that cannot reach the port nor an ingress hole with no scraper.",
+      "$comment": "A PodMonitor requires scoped 8081 ingress. External scrapers such as Datadog may enable that ingress without rendering a PodMonitor.",
       "if": {
         "properties": {
           "podMonitor": {
@@ -353,49 +359,6 @@
         },
         "required": [
           "networkPolicy"
-        ]
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "networkPolicy": {
-            "properties": {
-              "monitoring": {
-                "properties": {
-                  "enabled": {
-                    "const": true
-                  }
-                },
-                "required": [
-                  "enabled"
-                ]
-              }
-            },
-            "required": [
-              "monitoring"
-            ]
-          }
-        },
-        "required": [
-          "networkPolicy"
-        ]
-      },
-      "then": {
-        "properties": {
-          "podMonitor": {
-            "properties": {
-              "enabled": {
-                "const": true
-              }
-            },
-            "required": [
-              "enabled"
-            ]
-          }
-        },
-        "required": [
-          "podMonitor"
         ]
       }
     }

--- a/deploy/charts/buzz-push-gateway/values.yaml
+++ b/deploy/charts/buzz-push-gateway/values.yaml
@@ -34,9 +34,11 @@ appAttestRoot:
   secretKey: app-attest-root.pem
 service:
   port: 8080
+podAnnotations: {}
 httpRoute:
   # Disabled by default so a generic install cannot claim an unattached route.
-  # Production enables this with an explicit Gateway parentRef.
+  # Enable only when this chart owns a Gateway API route. Environments with an
+  # existing ingress or service mesh route should keep this disabled.
   enabled: false
   parentRefs: []
   hostnames: [push.buzz.xyz]
@@ -60,8 +62,9 @@ networkPolicy:
     podSelector:
       k8s-app: kube-dns
   # Scoped ingress to the private metrics port (8081). Off by default so 8081
-  # has no pod ingress at all; enable only alongside podMonitor and name the
-  # scraper's namespace/pod so reachability stays narrow.
+  # has no pod ingress at all; enable alongside podMonitor or an external
+  # annotation-discovered scraper and name its namespace/pod so reachability
+  # stays narrow.
   monitoring:
     enabled: false
     namespaceSelector: {}

--- a/docs/push-gateway-deployment.md
+++ b/docs/push-gateway-deployment.md
@@ -67,6 +67,7 @@ The gateway serves Prometheus metrics at `GET /metrics` on the **private health 
 
 | Metric | Type | Labels | Meaning |
 |---|---|---|---|
+| `push_gateway_apns_send_attempts_total` | counter | none | Entries into the concrete APNs HTTP send seam. Compare with terminal outcomes to detect work that never reached transport. |
 | `push_gateway_apns_deliveries_total` | counter | `outcome` = `accepted` \| `invalid_endpoint` \| `retry` \| `configuration_fault` \| `permanent_request_fault` | Terminal APNs send outcomes. |
 | `push_gateway_apns_delivery_seconds` | histogram | — | APNs send round-trip latency (seconds). |
 | `push_gateway_admissions_total` | counter | `result` = `admitted` \| `rejected` \| `unavailable` | Outcome at the `authorize_delivery` replay/quota fence. |
@@ -74,9 +75,38 @@ The gateway serves Prometheus metrics at `GET /metrics` on the **private health 
 | `push_gateway_reaper_failures_total` | counter | — | Retention reaper sweep failures. |
 | `push_gateway_readiness_failures_total` | counter | `cause` = `not_accepting` \| `authority` | Readiness probe failures by cause. |
 
-`push_gateway_delivery_errors_total` is intentionally **narrow**: it counts only selected exit classes of the `/v1/deliveries/apns` handler — `class` ∈ `invalid_grant` (grant rejected at the admission seam, before a permit is issued), `temporarily_unavailable` (authority unavailable at the admission seam), `profile_mismatch`, `token_custody` (endpoint-token open failure), `finish_failed` (detached disposition/join failure returned as 503). Request/auth/attestation/grant validation on the enrollment, delegation, rotation, and revocation handlers is **not** counted by this metric; it is a delivery-hot-path signal, not a total error rate across the API.
+`push_gateway_delivery_errors_total` is intentionally **narrow**: it counts only selected exit classes of the `/v1/deliveries/apns` handler. `class` ∈ `invalid_grant` (grant rejected at the admission seam, before a permit is issued), `rate_limited`, `temporarily_unavailable` (authority unavailable at the admission seam), `profile_mismatch`, `profile_disabled`, `token_custody` (endpoint-token open failure), `finish_failed` (detached disposition/join failure returned as 503). Request/auth/attestation/grant validation on the enrollment, delegation, rotation, and revocation handlers is **not** counted by this metric; it is a delivery-hot-path signal, not a total error rate across the API.
 
-Scraping is **opt-in** and off by default, so the default chart render is unchanged and `8081` keeps no pod ingress. To enable it, set `podMonitor.enabled=true` (renders a prometheus-operator `PodMonitor` scraping the `health` port `/metrics`) and `networkPolicy.monitoring.enabled=true` with `networkPolicy.monitoring.namespaceSelector` / `podSelector` naming your scraper — this adds a single `8081` ingress rule scoped to that source, never a blanket allowance. Node/kubelet-origin probe traffic remains exempt from NetworkPolicy regardless.
+Scraping is **opt-in** and off by default, so the default chart render is unchanged and `8081` keeps no pod ingress. For prometheus-operator, set `podMonitor.enabled=true` and `networkPolicy.monitoring.enabled=true` with `networkPolicy.monitoring.namespaceSelector` / `podSelector` naming your scraper. For Datadog Autodiscovery, leave `podMonitor.enabled=false`, supply the OpenMetrics check through `podAnnotations`, and enable the same narrowly selected NetworkPolicy ingress:
+
+```yaml
+podAnnotations:
+  ad.datadoghq.com/gateway.checks: |
+    {
+      "openmetrics": {
+        "init_config": {},
+        "instances": [{
+          "openmetrics_endpoint": "http://%%host%%:8081/metrics",
+          "service": "buzz-push-gateway",
+          "namespace": "block.buzz_push_gateway",
+          "metrics": ["push_gateway_.*"],
+          "histogram_buckets_as_distributions": true,
+          "send_distribution_buckets": true,
+          "send_monotonic_counter": true,
+          "collect_counters_with_distributions": true
+        }]
+      }
+    }
+networkPolicy:
+  monitoring:
+    enabled: true
+    namespaceSelector: # replace with the Datadog Agent namespace labels
+      kubernetes.io/metadata.name: datadog
+    podSelector: # replace with the Datadog Agent pod labels
+      app.kubernetes.io/name: datadog-agent
+```
+
+Both modes add one `8081` ingress rule scoped to the configured source, never a blanket allowance. Node/kubelet-origin probe traffic remains exempt from NetworkPolicy regardless. Do not enable `PodMonitor` in clusters without its CRD.
 
 Alerting rules ship as an opt-in prometheus-operator `PrometheusRule` (`prometheusRule.enabled=true`). Thresholds and operator actions:
 
@@ -192,7 +222,7 @@ gh attestation verify \
   --owner block
 ```
 
-Only after that command succeeds, set the exact digest as `image.digest`; the chart then renders `ghcr.io/block/buzz-push-gateway@sha256:...` and ignores the mutable tag. `values-production.yaml` is an intentionally invalid production-input contract: deployment CI must inject this verified `image.digest`, the provisioned dogfood Apple application identifier, an environment-owned Gateway parent reference, and the actual PostgreSQL network. Schema validation rejects the artifact when any remains empty; the render guard proves both rejection and a fully injected render.
+Only after that command succeeds, set the exact digest as `image.digest`; the chart then renders `ghcr.io/block/buzz-push-gateway@sha256:...` and ignores the mutable tag. `values-production.yaml` is an intentionally invalid production-input contract: deployment CI must inject this verified `image.digest`, the provisioned dogfood Apple application identifier, and the actual PostgreSQL network. In an environment with an existing ingress or service mesh route, keep `httpRoute.enabled=false`. If this chart owns a Gateway API route, enable it and inject an environment-owned `parentRef`; schema validation rejects an enabled route with no parent. The render guard proves both rejection of missing required inputs and fully injected renders.
 
 Network policy keeps APNs HTTPS and PostgreSQL egress in separate CIDR lists. APNs currently requires broad TCP/443 reachability; `networkPolicy.postgresEgressCidrs` must be narrowed to the production database network, and the DNS namespace/pod selectors must match the cluster DNS deployment. The sample private CIDR is not a claim about the production topology.
 

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1134,7 +1134,7 @@ CREATE TABLE push_gateway_installations (
     app_attest_key_id BYTEA NOT NULL UNIQUE CHECK (octet_length(app_attest_key_id) BETWEEN 1 AND 128),
     app_attest_public_key BYTEA NOT NULL CHECK (octet_length(app_attest_public_key) BETWEEN 33 AND 256),
     assertion_counter BIGINT NOT NULL CHECK (assertion_counter BETWEEN 0 AND 4294967295),
-    app_profile TEXT NOT NULL CHECK (app_profile IN ('buzz-ios-production','buzz-ios-sandbox')),
+    app_profile TEXT NOT NULL CHECK (app_profile = 'buzz-ios-dogfood'),
     token_ciphertext BYTEA NOT NULL CHECK (octet_length(token_ciphertext) BETWEEN 1 AND 2048),
     token_fingerprint BYTEA NOT NULL CHECK (length(token_fingerprint) = 32),
     endpoint_epoch BIGINT NOT NULL CHECK (endpoint_epoch > 0),


### PR DESCRIPTION
## Linear

- [BUZZ-17: Publish the MVP-compatible gateway chart](https://linear.app/squareup/issue/BUZZ-17/publish-the-mvp-compatible-gateway-chart)
- [BUZZ-26: Add Datadog-compatible push-gateway metrics and correct source drift](https://linear.app/squareup/issue/BUZZ-26/add-datadog-compatible-push-gateway-metrics-and-correct-source-drift)

## Summary

- cut `buzz-push-gateway` chart `0.2.0` from the landed certificate-backed dogfood configuration
- pin the reviewed amd64/arm64 gateway image and verify its SLSA provenance against the repository workflow and source commit
- support Datadog Autodiscovery on the private metrics listener without requiring Prometheus Operator CRDs
- align the desired schema, metrics documentation, and production ingress guidance with the current dogfood deployment contract

## Release evidence

The production values pin `ghcr.io/block/buzz-push-gateway@sha256:3936cad2d5cb0f6711c749024b96e56969d7e4506eb35d3519e3ef126fa6636d`. The OCI index contains linux/amd64 and linux/arm64 manifests, and its provenance resolves to source `4a9de1a3a121285ef475d630b2b5764044c02cde` through `block/buzz/.github/workflows/docker.yml`.

The branch name is `push-chart-release/0.2.0`, so merging this PR will create `push-chart-v0.2.0` and run the dedicated chart publisher. The `0.2.0` OCI chart is intentionally absent before merge; artifact verification remains a post-publish release check.

## Testing

- push gateway Helm render contract covering default, production ingress, explicit Gateway API, Prometheus, Datadog, reviewed image pinning, and invalid configurations
- push gateway chart release contract
- local Helm package inspection for chart and app version `0.2.0`
- repository pre-push differential gates
