### PR TITLE
fix(desktop): retain automatic mentions only in threads

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -754,7 +754,6 @@ export const ChannelPane = React.memo(function ChannelPane({
                   ) : null}
                   <ComposerDockBackdrop gutterClassName="inset-x-5" />
                   <MessageComposer
-                    audienceContext={{ type: "channel" }}
                     channelId={activeChannel?.id ?? null}
                     channelName={activeChannel?.name ?? "channel"}
                     channelType={activeChannel?.channelType ?? null}

--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -495,6 +495,10 @@ function InboxMessageDetailPane({
       : null;
   const isThreadContext =
     !isDirectMessage && hasInboxThreadContext(item, messages);
+  const threadRootTags = isThreadContext
+    ? (displayMessages.find((message) => message.id === item.conversationId)
+        ?.tags ?? [])
+    : [];
   const contextLabel = isThreadContext
     ? isDirectMessage
       ? `Thread with ${item.senderLabel}`
@@ -804,7 +808,14 @@ function InboxMessageDetailPane({
           />
           <div className="pointer-events-auto">
             <MessageComposer
-              audienceContext={isDirectMessage ? null : { type: "thread" }}
+              audienceContext={
+                isDirectMessage
+                  ? null
+                  : {
+                      type: "thread",
+                      rootTags: threadRootTags,
+                    }
+              }
               channelId={item.item.channelId}
               channelName={item.channelLabel ?? "channel"}
               channelType={composerChannelType}

--- a/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
@@ -219,6 +219,21 @@ test("explicitly excluded agents are not auto-promoted again", async () => {
   assert.deepEqual(currentAudiences(store), { [scope]: [agentA] });
 });
 
+test("initialization preserves exclusions across thread remounts", async () => {
+  const store = await loadStore(14);
+  const scope = `${ownerA}:channel-a:thread-a`;
+
+  store.initializePersistentAgentAudience(scope, [agentA]);
+  assert.deepEqual(currentAudiences(store), { [scope]: [agentA] });
+
+  store.excludePersistentAgentAudienceMember(scope, agentA);
+  store.initializePersistentAgentAudience(scope, [agentA]);
+  assert.deepEqual(currentAudiences(store), { [scope]: [] });
+
+  store.addPersistentAgentAudienceMember(scope, agentA);
+  assert.deepEqual(currentAudiences(store), { [scope]: [agentA] });
+});
+
 test("explicit re-selection reinstates an excluded agent", async () => {
   const store = await loadStore(13);
   const scope = `${ownerA}:channel-a:channel`;

--- a/desktop/src/features/messages/lib/persistentAgentAudience.ts
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.ts
@@ -160,6 +160,23 @@ export function removePersistentAgentAudienceMembersIfUnchanged({
   return true;
 }
 
+export function initializePersistentAgentAudience(
+  scope: string,
+  pubkeys: Iterable<string>,
+): void {
+  if (!scope) return;
+  const excluded = excludedPubkeysByScope.get(scope);
+  const initialPubkeys = normalizePubkeys(pubkeys).filter(
+    (pubkey) =>
+      !(audiences[scope] ?? []).includes(pubkey) && !excluded?.has(pubkey),
+  );
+  if (initialPubkeys.length === 0) return;
+  setPersistentAgentAudience(scope, [
+    ...(audiences[scope] ?? []),
+    ...initialPubkeys,
+  ]);
+}
+
 export function addPersistentAgentAudienceMember(
   scope: string,
   pubkey: string,

--- a/desktop/src/features/messages/ui/ComposerAddressControls.test.mjs
+++ b/desktop/src/features/messages/ui/ComposerAddressControls.test.mjs
@@ -72,7 +72,7 @@ test("mention control expands with automatically mentioned agents", async () => 
   const avatar = view.getByTestId("composer-address-lock-agent-pubkey");
   assert.ok(avatar);
   const manage = view.getByRole("button", {
-    name: "Manage automatic agent mentions",
+    name: "Manage mentions",
   });
   assert.match(manage.className, /(?:^|\s)-ml-2(?:\s|$)/);
   assert.match(manage.className, /(?:^|\s)pl-2(?:\s|$)/);
@@ -82,18 +82,18 @@ test("mention control expands with automatically mentioned agents", async () => 
     /(?:^|\s)pr-1\.5(?:\s|$)/,
   );
   assert.match(
-    view.getByRole("button", { name: "Manage automatic agent mentions" })
-      .parentElement?.className ?? "",
+    view.getByRole("button", { name: "Manage mentions" }).parentElement
+      ?.className ?? "",
     /(?:^|\s)bg-primary\/15(?:\s|$)/,
   );
   assert.match(
-    view.getByRole("button", { name: "Manage automatic agent mentions" })
-      .parentElement?.className ?? "",
+    view.getByRole("button", { name: "Manage mentions" }).parentElement
+      ?.className ?? "",
     /(?:^|\s)text-primary(?:\s|$)/,
   );
   assert.doesNotMatch(
-    view.getByRole("button", { name: "Manage automatic agent mentions" })
-      .parentElement?.className ?? "",
+    view.getByRole("button", { name: "Manage mentions" }).parentElement
+      ?.className ?? "",
     /(?:^|\s)bg-accent\/70(?:\s|$)/,
   );
   assert.doesNotMatch(

--- a/desktop/src/features/messages/ui/ComposerAddressControls.test.mjs
+++ b/desktop/src/features/messages/ui/ComposerAddressControls.test.mjs
@@ -110,7 +110,13 @@ test("mention control expands with automatically mentioned agents", async () => 
       /scale\(0.8\)/,
     );
   }
-  const remove = view.getByTestId("composer-address-lock-remove-agent-pubkey");
+  const remove = view.getByRole("button", {
+    name: "Don't automatically mention Agent Ada in this thread",
+  });
+  assert.equal(
+    remove.getAttribute("aria-label")?.includes("conversation"),
+    false,
+  );
   const removeChrome = remove.querySelector("span.absolute");
   assert.match(
     removeChrome?.className ?? "",

--- a/desktop/src/features/messages/ui/ComposerAddressControls.tsx
+++ b/desktop/src/features/messages/ui/ComposerAddressControls.tsx
@@ -228,7 +228,7 @@ export function ComposerMentionButton({
                     <Tooltip disableHoverableContent key={agent.pubkey}>
                       <TooltipTrigger asChild>
                         <motion.button
-                          aria-label={`Don't automatically mention ${agent.displayName} in this conversation`}
+                          aria-label={`Don't automatically mention ${agent.displayName} in this thread`}
                           animate={{ opacity: 1, scale: 1 }}
                           className="group/address relative rounded-full focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
                           data-testid={`composer-address-lock-remove-${agent.pubkey}`}
@@ -270,7 +270,7 @@ export function ComposerMentionButton({
                       </TooltipTrigger>
                       <TooltipContent>
                         Don't automatically mention {agent.displayName} in this
-                        conversation
+                        thread
                       </TooltipContent>
                     </Tooltip>
                   ))}

--- a/desktop/src/features/messages/ui/ComposerAddressControls.tsx
+++ b/desktop/src/features/messages/ui/ComposerAddressControls.tsx
@@ -180,11 +180,7 @@ export function ComposerMentionButton({
           <Tooltip disableHoverableContent>
             <TooltipTrigger asChild>
               <button
-                aria-label={
-                  hasAgents
-                    ? "Manage automatic agent mentions"
-                    : "Mention someone"
-                }
+                aria-label={hasAgents ? "Manage mentions" : "Mention someone"}
                 className={cn(
                   "flex h-8 items-center justify-center rounded-lg focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
                   showActiveChrome
@@ -205,9 +201,7 @@ export function ComposerMentionButton({
               </button>
             </TooltipTrigger>
             <TooltipContent>
-              {hasAgents
-                ? "Manage automatic agent mentions"
-                : "Mention someone"}
+              {hasAgents ? "Manage mentions" : "Mention someone"}
             </TooltipContent>
           </Tooltip>
           <AnimatePresence

--- a/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
@@ -50,7 +50,6 @@ test("agent rows offer automatic mention controls", async () => {
   const props = {
     suggestions: [suggestion],
     selectedIndex: 0,
-    composerOwnsFocus: true,
     onSelect: (value) => selected.push(value),
     onToggleAlwaysAddressAgent: (value) => toggled.push(value),
     lockedAgentPubkeys: new Set(),
@@ -94,7 +93,7 @@ test("agent rows offer automatic mention controls", async () => {
     }),
   );
   const selectedAction = view.getByRole("button", {
-    name: "Don't automatically mention Agent Ada in this conversation",
+    name: "Don't automatically mention Agent Ada in this thread",
   });
   assert.equal(selectedAction.getAttribute("aria-pressed"), "true");
   assert.equal(selectedAction.getAttribute("data-state"), "on");
@@ -106,7 +105,7 @@ test("agent rows offer automatic mention controls", async () => {
   assert.deepEqual(toggled, [suggestion, suggestion]);
 });
 
-test("options expand in place without replacing the people list", async () => {
+test("automatic mention setting is visible by default without an options ingress", async () => {
   const React = await import("react");
   const { fireEvent, render } = await import("@testing-library/react");
   const { MentionAutocomplete } = await import("./MentionAutocomplete.tsx");
@@ -120,68 +119,30 @@ test("options expand in place without replacing the people list", async () => {
     React.createElement(MentionAutocomplete, {
       suggestions: [suggestion],
       selectedIndex: 0,
-      composerOwnsFocus: true,
       onSelect: () => {},
       keepMentionedAgentsPinned: true,
       onKeepMentionedAgentsPinnedChange: (value) => changes.push(value),
     }),
   );
 
-  const options = view.getByRole("button", { name: "Options" });
-  assert.equal(options.getAttribute("aria-expanded"), "false");
-  assert.match(options.parentElement?.className ?? "", /(?:^|\s)w-24(?:\s|$)/);
-  assert.ok(view.getByRole("button", { name: "Mention Agent Ada" }));
-  assert.equal(
-    view.queryByRole("switch", { name: "Automatically mention agents" }),
-    null,
-  );
-
-  fireEvent.click(options);
-  assert.equal(options.getAttribute("aria-expanded"), "true");
+  assert.equal(view.queryByRole("button", { name: "Options" }), null);
+  assert.ok(view.getByTestId("mention-options-settings"));
+  const settings = view.getByTestId("mention-options-settings");
+  assert.ok(settings.classList.contains("w-80"));
+  assert.ok(settings.classList.contains("max-w-full"));
+  assert.ok(settings.parentElement?.classList.contains("justify-end"));
   const toggle = view.getByRole("switch", {
     name: "Automatically mention agents",
   });
   assert.equal(toggle.getAttribute("data-state"), "checked");
-  assert.ok(view.getByText("After you mention them once"));
+  assert.ok(view.getByText("Address selected agents in thread replies"));
   assert.ok(view.getByRole("button", { name: "Mention Agent Ada" }));
 
   fireEvent.click(toggle);
   assert.deepEqual(changes, [false]);
-
-  view.rerender(
-    React.createElement(MentionAutocomplete, {
-      suggestions: [],
-      selectedIndex: 0,
-      composerOwnsFocus: true,
-      onSelect: () => {},
-      keepMentionedAgentsPinned: false,
-      onKeepMentionedAgentsPinnedChange: (value) => changes.push(value),
-    }),
-  );
-  assert.equal(view.queryByRole("button", { name: "Options" }), null);
-
-  view.rerender(
-    React.createElement(MentionAutocomplete, {
-      suggestions: [suggestion],
-      selectedIndex: 0,
-      composerOwnsFocus: true,
-      onSelect: () => {},
-      keepMentionedAgentsPinned: false,
-      onKeepMentionedAgentsPinnedChange: (value) => changes.push(value),
-    }),
-  );
-  assert.equal(
-    view.getByRole("button", { name: "Options" }).getAttribute("aria-expanded"),
-    "false",
-  );
-  assert.equal(
-    view.queryByRole("switch", { name: "Automatically mention agents" }),
-    null,
-  );
-  assert.ok(view.getByRole("button", { name: "Mention Agent Ada" }));
 });
 
-test("automatic selection loads the setting once, then updates it in place", async () => {
+test("automatic selection updates the visible setting in place", async () => {
   const React = await import("react");
   const { render } = await import("@testing-library/react");
   const { MentionAutocomplete } = await import("./MentionAutocomplete.tsx");
@@ -193,39 +154,22 @@ test("automatic selection loads the setting once, then updates it in place", asy
   const props = {
     suggestions: [suggestion],
     selectedIndex: 0,
-    composerOwnsFocus: true,
     onSelect: () => {},
     keepMentionedAgentsPinned: false,
     onKeepMentionedAgentsPinnedChange: () => {},
   };
-  const view = render(
-    React.createElement(MentionAutocomplete, {
-      ...props,
-      openOptionsRequest: 0,
-    }),
-  );
-
-  view.rerender(
-    React.createElement(MentionAutocomplete, {
-      ...props,
-      openOptionsRequest: 1,
-    }),
-  );
-  assert.equal(
-    view.getByRole("button", { name: "Options" }).getAttribute("aria-expanded"),
-    "true",
-  );
+  const view = render(React.createElement(MentionAutocomplete, props));
+  const settings = view.getByTestId("mention-options-settings");
   const toggle = view.getByRole("switch", {
     name: "Automatically mention agents",
   });
-  const settings = view.getByTestId("mention-options-settings");
   assert.equal(toggle.getAttribute("data-state"), "unchecked");
 
   view.rerender(
     React.createElement(MentionAutocomplete, {
       ...props,
       keepMentionedAgentsPinned: true,
-      openOptionsRequest: 2,
+      openOptionsRequest: 1,
     }),
   );
   assert.equal(view.getByTestId("mention-options-settings"), settings);
@@ -257,7 +201,6 @@ test("clicking outside dismisses the tray without intercepting its trigger", asy
         React.createElement(MentionAutocomplete, {
           suggestions: [suggestion],
           selectedIndex: 0,
-          composerOwnsFocus: true,
           onDismiss: () => {
             dismissCount += 1;
           },
@@ -317,7 +260,6 @@ test("collision npubs sit inline with agent metadata", async () => {
     React.createElement(MentionAutocomplete, {
       suggestions,
       selectedIndex: 0,
-      composerOwnsFocus: true,
       onSelect: () => {},
     }),
   );
@@ -335,201 +277,52 @@ test("collision npubs sit inline with agent metadata", async () => {
   }
 });
 
-test("focusMentionOptionsTrigger hands focus to the Options trigger", async () => {
+test("does not intercept Tab from the editor", async () => {
   const React = await import("react");
-  const { render } = await import("@testing-library/react");
-  const { MentionAutocomplete, focusMentionOptionsTrigger } = await import(
-    "./MentionAutocomplete.tsx"
-  );
-  const suggestion = {
-    pubkey: "agent-pubkey",
-    displayName: "Agent Ada",
-    isAgent: true,
-  };
+  const { fireEvent, render } = await import("@testing-library/react");
+  const { MentionAutocomplete } = await import("./MentionAutocomplete.tsx");
+  const { TooltipProvider } = await import("@/shared/ui/tooltip");
+  const suggestions = [
+    {
+      pubkey: "agent-a",
+      displayName: "Agent Ada",
+      isAgent: true,
+    },
+    {
+      pubkey: "agent-b",
+      displayName: "Agent Bea",
+      isAgent: true,
+    },
+  ];
   const view = render(
     React.createElement(
-      "form",
-      { "data-testid": "composer-form" },
-      React.createElement("input", { "aria-label": "Message" }),
-      React.createElement(MentionAutocomplete, {
-        suggestions: [suggestion],
-        selectedIndex: 0,
-        composerOwnsFocus: true,
-        onSelect: () => {},
-        keepMentionedAgentsPinned: true,
-        onKeepMentionedAgentsPinnedChange: () => {},
-      }),
+      TooltipProvider,
+      null,
+      React.createElement(
+        "form",
+        null,
+        React.createElement(
+          "div",
+          { "data-testid": "message-input-scroll" },
+          React.createElement("input", { "aria-label": "Message" }),
+        ),
+        React.createElement(MentionAutocomplete, {
+          suggestions,
+          selectedIndex: 1,
+          onSelect: () => {},
+          onToggleAlwaysAddressAgent: () => {},
+        }),
+      ),
     ),
   );
 
-  const form = view.getByTestId("composer-form");
   const input = view.getByRole("textbox", { name: "Message" });
   input.focus();
+  const wasNotCancelled = fireEvent.keyDown(input, { key: "Tab" });
 
-  assert.equal(focusMentionOptionsTrigger(form), true);
-  assert.equal(
-    document.activeElement,
-    view.getByTestId("mention-options-trigger"),
-  );
-});
-
-test("focusMentionOptionsTrigger declines when no Options surface renders", async () => {
-  const React = await import("react");
-  const { render } = await import("@testing-library/react");
-  const { MentionAutocomplete, focusMentionOptionsTrigger } = await import(
-    "./MentionAutocomplete.tsx"
-  );
-  const suggestion = {
-    pubkey: "agent-pubkey",
-    displayName: "Agent Ada",
-    isAgent: true,
-  };
-  const view = render(
-    React.createElement(
-      "form",
-      { "data-testid": "composer-form" },
-      React.createElement("input", { "aria-label": "Message" }),
-      // No onKeepMentionedAgentsPinnedChange: composers without audience
-      // controls render no Options surface, so the key event must fall
-      // through to its default backward focus move instead of stranding
-      // focus.
-      React.createElement(MentionAutocomplete, {
-        suggestions: [suggestion],
-        selectedIndex: 0,
-        composerOwnsFocus: true,
-        onSelect: () => {},
-      }),
-    ),
-  );
-
-  const form = view.getByTestId("composer-form");
-  const input = view.getByRole("textbox", { name: "Message" });
-  input.focus();
-
-  assert.equal(focusMentionOptionsTrigger(form), false);
+  assert.equal(wasNotCancelled, true);
   assert.equal(document.activeElement, input);
-  assert.equal(focusMentionOptionsTrigger(null), false);
 });
-
-test("Escape inside the overlay returns focus to the editor and dismisses", async () => {
-  const React = await import("react");
-  const { fireEvent, render } = await import("@testing-library/react");
-  const { MentionAutocomplete, focusMentionOptionsTrigger } = await import(
-    "./MentionAutocomplete.tsx"
-  );
-  const dismissals = [];
-  const view = render(
-    React.createElement(
-      "form",
-      { "data-testid": "composer-form" },
-      React.createElement("input", {
-        "aria-label": "Message",
-        "data-testid": "message-input",
-      }),
-      React.createElement(MentionAutocomplete, {
-        suggestions: [
-          {
-            pubkey: "agent-pubkey",
-            displayName: "Agent Ada",
-            isAgent: true,
-          },
-        ],
-        selectedIndex: 0,
-        composerOwnsFocus: true,
-        onDismiss: () => dismissals.push(true),
-        onSelect: () => {},
-        keepMentionedAgentsPinned: true,
-        onKeepMentionedAgentsPinnedChange: () => {},
-      }),
-    ),
-  );
-
-  const form = view.getByTestId("composer-form");
-  assert.equal(focusMentionOptionsTrigger(form), true);
-  const trigger = view.getByTestId("mention-options-trigger");
-  const wasNotCancelled = fireEvent.keyDown(trigger, { key: "Escape" });
-
-  assert.equal(wasNotCancelled, false);
-  assert.equal(document.activeElement, view.getByTestId("message-input"));
-  assert.deepEqual(dismissals, [true]);
-});
-
-test("renders nothing while the composer does not own focus", async () => {
-  const React = await import("react");
-  const { render } = await import("@testing-library/react");
-  const { MentionAutocomplete } = await import("./MentionAutocomplete.tsx");
-  const props = {
-    suggestions: [
-      {
-        pubkey: "agent-pubkey",
-        displayName: "Agent Ada",
-        isAgent: true,
-      },
-    ],
-    selectedIndex: 0,
-    composerOwnsFocus: false,
-    onSelect: () => {},
-  };
-  const view = render(React.createElement(MentionAutocomplete, props));
-
-  assert.equal(view.queryByTestId("mention-autocomplete-layer"), null);
-
-  view.rerender(
-    React.createElement(MentionAutocomplete, {
-      ...props,
-      composerOwnsFocus: true,
-    }),
-  );
-  assert.ok(view.getByTestId("mention-autocomplete-layer"));
-});
-
-test("container presses do not blur the editor out from under the overlay", async () => {
-  const React = await import("react");
-  const { fireEvent, render } = await import("@testing-library/react");
-  const { MentionAutocomplete } = await import("./MentionAutocomplete.tsx");
-  const mention = {
-    pubkey: "agent-pubkey",
-    displayName: "Agent Ada",
-    isAgent: true,
-  };
-  const selected = [];
-  const pinnedChanges = [];
-  const view = render(
-    React.createElement(MentionAutocomplete, {
-      suggestions: [mention],
-      selectedIndex: 0,
-      composerOwnsFocus: true,
-      onSelect: (value) => selected.push(value),
-      keepMentionedAgentsPinned: true,
-      onKeepMentionedAgentsPinnedChange: (value) => pinnedChanges.push(value),
-    }),
-  );
-
-  // fireEvent returns false when the dispatched event was canceled, which is
-  // what keeps a contenteditable from losing focus on mousedown.
-  assert.equal(
-    fireEvent.mouseDown(view.getByTestId("mention-autocomplete")),
-    false,
-  );
-
-  const options = view.getByRole("button", { name: "Options" });
-  assert.equal(fireEvent.mouseDown(options.parentElement), false);
-
-  // A label hands focus to its control from the click default action, which
-  // no mousedown guard can cancel, so the label drives the switch itself.
-  fireEvent.click(options);
-  assert.equal(
-    fireEvent.click(view.getByText("Automatically mention agents")),
-    false,
-  );
-  assert.deepEqual(pinnedChanges, [false]);
-
-  // The row buttons must keep selecting: preventing mousedown on the
-  // containers, not pointerdown, leaves their compatibility events intact.
-  fireEvent.mouseDown(view.getByRole("button", { name: "Mention Agent Ada" }));
-  assert.deepEqual(selected, [mention]);
-});
-
 function suggestion(agentProvenance) {
   return {
     pubkey: "1".repeat(64),

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-import { Bot, ChevronRight, Pin, Users } from "lucide-react";
+import { Bot, Pin, Users } from "lucide-react";
 import { OtherSetupAgentMarker } from "@/features/agents/ui/OtherSetupAgentMarker";
-import { motion } from "motion/react";
 import type { TeamMentionMember } from "@/features/messages/lib/mentionCandidates";
 
 import { Badge } from "@/shared/ui/badge";
@@ -37,14 +36,7 @@ export type MentionSuggestion = {
 type MentionAutocompleteProps = {
   suggestions: MentionSuggestion[];
   selectedIndex: number;
-  /**
-   * Whether the owning composer owns document focus — its editor or this
-   * overlay's own controls (see useComposerFocusOwnership). The focus gate
-   * lives here rather than in each composer so a background composer
-   * replaying a stale update (e.g. a shared mid-send disabled toggle) can't
-   * resurrect its suggestion overlay, while keyboard focus moving into the
-   * Options controls keeps the overlay mounted.
-   */
+  /** Whether the owning composer currently owns document focus. */
   composerOwnsFocus: boolean;
   onFetchMore?: () => void;
   onSelect: (suggestion: MentionSuggestion) => void;
@@ -65,17 +57,12 @@ export function showMentionAgentProvenanceMarker(
   return hasNameCollision && suggestion.agentProvenance === "managed-elsewhere";
 }
 
-/**
- * Move keyboard focus to the mention overlay's Options trigger inside
- * `container` (the composer form). Returns false when the trigger isn't
- * rendered — overlay closed, or a composer without audience controls — so
- * the caller can leave the key event to its default behavior.
- */
+/** Focus the now-always-visible automatic-mentions switch. */
 export function focusMentionOptionsTrigger(
   container: HTMLElement | null,
 ): boolean {
   const trigger = container?.querySelector<HTMLElement>(
-    "[data-mention-options-trigger]",
+    '[data-testid="mention-keep-agents-pinned-toggle"]',
   );
   if (!trigger) return false;
   trigger.focus();
@@ -85,7 +72,7 @@ export function focusMentionOptionsTrigger(
 export const MentionAutocomplete = React.memo(function MentionAutocomplete({
   suggestions,
   selectedIndex,
-  composerOwnsFocus,
+  composerOwnsFocus = true,
   onFetchMore,
   onSelect,
   lockedAgentPubkeys,
@@ -100,9 +87,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
   const rootRef = React.useRef<HTMLDivElement>(null);
   const optionsSurfaceRef = React.useRef<HTMLDivElement>(null);
   const listRef = React.useRef<HTMLDivElement>(null);
-  const optionsId = React.useId();
   const keepPinnedSwitchId = React.useId();
-  const [optionsOpen, setOptionsOpen] = React.useState(false);
   const handledOptionsRequestRef = React.useRef(0);
   const alwaysAddressShortcut = getPlatformKeysById("always-address-agent");
 
@@ -114,23 +99,10 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
   }, [selectedIndex]);
 
   React.useEffect(() => {
-    if (suggestions.length === 0) {
-      setOptionsOpen(false);
-    }
-  }, [suggestions.length]);
-
-  React.useEffect(() => {
     if (openOptionsRequest <= handledOptionsRequestRef.current) return;
     handledOptionsRequestRef.current = openOptionsRequest;
-
-    // The first request waits for the entrance to finish. Once visible, apply
-    // later requests in place so toggling a pin cannot replay that entrance.
-    if (optionsOpen) {
-      onOptionsRevealComplete?.(openOptionsRequest);
-      return;
-    }
-    setOptionsOpen(true);
-  }, [onOptionsRevealComplete, openOptionsRequest, optionsOpen]);
+    onOptionsRevealComplete?.(openOptionsRequest);
+  }, [onOptionsRevealComplete, openOptionsRequest]);
 
   React.useEffect(() => {
     if (!onDismiss) return;
@@ -172,12 +144,6 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
     }
   }, [onFetchMore]);
 
-  // Escape from inside the overlay is the keyboard counterpart of pressing
-  // outside it: hand focus back to the editor the overlay belongs to, then
-  // dismiss. Focusing first keeps the composer's focus ownership unbroken, so
-  // the overlay never unmounts with focus stranded on the document. Escape in
-  // the editor itself never reaches here — that path is the composer's own
-  // key handler.
   const handleOverlayKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.key !== "Escape") return;
@@ -206,7 +172,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
   }
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: the overlay's own controls are the interactive elements; this listener only gives them the standard Escape-to-dismiss exit.
+    // biome-ignore lint/a11y/noStaticElementInteractions: the overlay's controls own keyboard interaction; Escape returns focus to the editor.
     <div
       className={cn(
         "absolute left-0 right-0 z-50 px-3 sm:px-4",
@@ -222,90 +188,47 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
             {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer-only guard, no behavior of its own — an unprevented mousedown on this surface (its padding, the switch's label) blurs the editor, and the focus gate above would unmount the overlay before the click lands. */}
             <div
               className={cn(
-                "max-w-full overflow-hidden rounded-xl text-popover-foreground ring-1 ring-border/50 transition-[width] duration-200 ease-out",
+                "w-80 max-w-full overflow-hidden rounded-xl text-popover-foreground ring-1 ring-border/50",
                 POPOVER_SURFACE_CLASS,
-                optionsOpen ? "w-72" : "w-24",
               )}
+              data-testid="mention-options-settings"
               onMouseDown={(event) => event.preventDefault()}
               ref={optionsSurfaceRef}
               style={POPOVER_SHADOW_STYLE}
             >
-              {optionsOpen ? (
-                <motion.div
-                  animate={{ opacity: 1, y: 0 }}
-                  className="w-72"
-                  data-testid="mention-options-settings"
-                  id={optionsId}
-                  initial={{ opacity: 0, y: 4 }}
-                  onAnimationComplete={() => {
-                    if (openOptionsRequest > 0) {
-                      onOptionsRevealComplete?.(openOptionsRequest);
-                    }
+              <div className="flex min-h-14 items-center justify-between gap-4 px-3.5 py-2.5">
+                {/* biome-ignore lint/a11y/useKeyWithClickEvents: pointer-only label affordance; the associated switch remains the keyboard path. */}
+                <label
+                  className="flex min-w-0 flex-col"
+                  htmlFor={keepPinnedSwitchId}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onKeepMentionedAgentsPinnedChange(
+                      !keepMentionedAgentsPinned,
+                    );
                   }}
-                  transition={{ duration: 0.16, ease: "easeOut" }}
                 >
-                  <div className="flex min-h-12 items-center justify-between gap-3 px-3 py-2">
-                    {/* A label moves focus to its control from the click
-                        default action, not from mousedown, so the surface's
-                        mousedown guard alone can't keep the editor focused
-                        here. Cancel the forwarding and drive the switch
-                        directly; the association still names the control for
-                        assistive tech, which reaches the switch by keyboard
-                        without going through this label. */}
-                    {/* biome-ignore lint/a11y/useKeyWithClickEvents: pointer-only affordance; the switch it labels is the keyboard-accessible path. */}
-                    <label
-                      className="flex min-w-0 flex-col"
-                      htmlFor={keepPinnedSwitchId}
-                      onClick={(event) => {
-                        event.preventDefault();
-                        onKeepMentionedAgentsPinnedChange?.(
-                          !keepMentionedAgentsPinned,
-                        );
-                      }}
-                    >
-                      <span className="text-sm font-medium">
-                        Automatically mention agents
-                      </span>
-                      <span className="text-2xs text-muted-foreground">
-                        After you mention them once
-                      </span>
-                    </label>
-                    <Switch
-                      aria-label="Automatically mention agents"
-                      checked={keepMentionedAgentsPinned}
-                      className="shadow-none [&>span]:shadow-none"
-                      data-testid="mention-keep-agents-pinned-toggle"
-                      id={keepPinnedSwitchId}
-                      onCheckedChange={onKeepMentionedAgentsPinnedChange}
-                      onMouseDown={(event) => event.preventDefault()}
-                    />
-                  </div>
-                  <div className="mx-3 border-t border-border/50" />
-                </motion.div>
-              ) : null}
-              <button
-                aria-controls={optionsId}
-                aria-expanded={optionsOpen}
-                className="flex h-8 w-full items-center justify-between gap-1 px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-popover-foreground"
-                data-mention-options-trigger
-                data-testid="mention-options-trigger"
-                onClick={() => setOptionsOpen((open) => !open)}
-                onMouseDown={(event) => event.preventDefault()}
-                type="button"
-              >
-                <span>Options</span>
-                <motion.span
-                  animate={{ rotate: optionsOpen ? -90 : 0 }}
-                  className="inline-flex"
-                  transition={{ duration: 0.16, ease: "easeOut" }}
-                >
-                  <ChevronRight aria-hidden="true" className="h-3.5 w-3.5" />
-                </motion.span>
-              </button>
+                  <span className="whitespace-nowrap text-sm font-medium">
+                    Automatically mention agents
+                  </span>
+                  <span className="text-2xs text-muted-foreground">
+                    Address selected agents in thread replies
+                  </span>
+                </label>
+                <Switch
+                  aria-label="Automatically mention agents"
+                  checked={keepMentionedAgentsPinned}
+                  className="shrink-0 shadow-none [&>span]:shadow-none"
+                  data-testid="mention-keep-agents-pinned-toggle"
+                  id={keepPinnedSwitchId}
+                  onCheckedChange={onKeepMentionedAgentsPinnedChange}
+                  onMouseDown={(event) => event.preventDefault()}
+                />
+              </div>
             </div>
           </div>
         ) : null}
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer-only guard, same as the options surface — here it covers presses on the scrollbar and the list's padding ring. */}
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer-only guard keeps padding and scrollbar presses from blurring the owning editor. */}
         <div
           className={cn(
             "max-h-48 w-full overflow-y-auto rounded-xl p-1",
@@ -479,7 +402,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
                     <TooltipTrigger asChild>
                       <span className="absolute right-3 top-1/2 inline-flex -translate-y-1/2">
                         <Toggle
-                          aria-label={`${isAlwaysAddressed ? "Don't automatically mention" : "Automatically mention"} ${suggestion.displayName}${isAlwaysAddressed ? " in this conversation" : ""}`}
+                          aria-label={`${isAlwaysAddressed ? "Don't automatically mention" : "Automatically mention"} ${suggestion.displayName}${isAlwaysAddressed ? " in this thread" : ""}`}
                           className="h-6 w-6 p-0 data-[state=on]:bg-primary/15 data-[state=on]:text-primary"
                           data-always-address-pubkey={suggestion.pubkey?.toLowerCase()}
                           data-testid={`mention-always-address-${suggestion.pubkey}`}
@@ -510,7 +433,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
                     >
                       <span>
                         {isAlwaysAddressed
-                          ? "Don't automatically mention in this conversation"
+                          ? "Don't automatically mention in this thread"
                           : "Automatically mention"}
                       </span>
                       {alwaysAddressShortcut ? (

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -28,14 +28,8 @@ import {
 import { useComposerFocusOwnership } from "@/features/messages/lib/useComposerFocusOwnership";
 import { isMentionCodeContext } from "@/features/messages/lib/mentionCodeContext";
 import { useMentions } from "@/features/messages/lib/useMentions";
-import {
-  getPersistentAgentAudienceScope,
-  usePersistentAgentAudience,
-} from "@/features/messages/lib/persistentAgentAudience";
-import {
-  setKeepMentionedAgentsPinned,
-  useKeepMentionedAgentsPinned,
-} from "@/features/messages/lib/autoPinMentionedAgentsPreference";
+import { getPersistentAgentAudienceScope } from "@/features/messages/lib/persistentAgentAudience";
+import { setKeepMentionedAgentsPinned } from "@/features/messages/lib/autoPinMentionedAgentsPreference";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { CUSTOM_EMOJI_NODE_NAME } from "@/features/messages/lib/customEmojiNode";
 import {
@@ -66,6 +60,7 @@ import { useComposerContentState } from "./useComposerContentState";
 import { useComposerPasteHandler } from "./useComposerPasteHandler";
 import { useDraftPersistLifecycle } from "./useDraftPersistSnapshot";
 import { useImplicitAgentMentionProvenance } from "./useImplicitAgentMentionProvenance";
+import { useThreadAgentAudience } from "./useThreadAgentAudience";
 import { submitMessageEdit } from "./submitMessageEdit";
 import { prepareBackgroundLinkPreviews } from "@/features/messages/lib/linkPreviewPreparationStore";
 import { useComposerLinkPreviews } from "./useComposerLinkPreviews";
@@ -326,8 +321,12 @@ function MessageComposerImpl({
   onLinkSelectionChangeRef.current = linkEditor.showFromCursor;
   onLinkShortcutRef.current = linkEditor.openFromShortcut;
   useComposerSpoilerParticles(richText.editor, composerScrollRef);
-  const persistentAudience = usePersistentAgentAudience(audienceScope);
-  const keepMentionedAgentsPinned = useKeepMentionedAgentsPinned();
+  const { audience: persistentAudience, keepMentionedAgentsPinned } =
+    useThreadAgentAudience({
+      isAgentPubkey: mentions.isAgentPubkey,
+      rootTags: audienceContext?.rootTags ?? [],
+      scope: audienceScope,
+    });
   const addressPulse = useAddressMentionPulse();
   const {
     completeOptionsReveal: completeMentionOptionsReveal,
@@ -425,16 +424,11 @@ function MessageComposerImpl({
       setSpoileredAttachmentUrls(restoredSpoileredAttachmentUrls);
     }
   }, [editTarget?.id]);
-  // ── Focus on reply ──────────────────────────────────────────────────
-  // Use focusPreserve so that re-renders (e.g. new messages arriving in
-  // a thread) don't yank the cursor to the end while the user is editing.
   React.useEffect(() => {
     if (!replyTarget || composerDisabled) return;
     richText.focusPreserve();
   }, [composerDisabled, replyTarget, richText.focusPreserve]);
   useComposerAutofocus(richText.focus, effectiveDraftKey, composerDisabled);
-  // Hooks return a plain-text edit descriptor; `replacePlainTextRange`
-  // applies it as a single ProseMirror transaction (no markdown round-trip).
   const applyAutocompleteEdit = React.useCallback(
     (edit: AutocompleteEdit) => {
       richText.replacePlainTextRange(
@@ -511,10 +505,6 @@ function MessageComposerImpl({
   const insertEmoji = React.useCallback(
     (emoji: string) => {
       if (!richText.editor) return;
-      // A `:shortcode:` for a known custom emoji becomes a selectable atom
-      // node (same as the input rule / autocomplete), so it can be selected,
-      // copied, and deleted as one unit. Everything else (native unicode)
-      // inserts as plain content.
       const match = /^:([^:\s]+):$/.exec(emoji);
       const shortcode = match?.[1]?.toLowerCase();
       const known =
@@ -891,7 +881,11 @@ function MessageComposerImpl({
               onEmojiSelect={applyEmojiInsert}
               onMentionSelect={selectMentionSuggestion}
               onOptionsRevealComplete={completeMentionOptionsReveal}
-              onToggleAlwaysAddressAgent={toggleAlwaysAddressAgent}
+              onToggleAlwaysAddressAgent={(suggestion) =>
+                toggleAlwaysAddressAgent(suggestion, {
+                  preserveMention: true,
+                })
+              }
             />
             {media.uploadState.status === "error" ? (
               <div className="mb-2 rounded-lg bg-destructive/10 px-3 py-2 text-xs text-destructive">

--- a/desktop/src/features/messages/ui/MessageComposer.types.ts
+++ b/desktop/src/features/messages/ui/MessageComposer.types.ts
@@ -25,7 +25,8 @@ export type MessageComposerEditTarget = {
 
 export type MessageComposerProps = {
   audienceContext?: {
-    type: "channel" | "thread";
+    rootTags?: readonly string[][];
+    type: "thread";
   } | null;
   channelId?: string | null;
   channelName: string;

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -830,7 +830,10 @@ export function MessageThreadPanel({
           >
             <ComposerDockBackdrop gutterClassName="inset-x-5" />
             <MessageComposer
-              audienceContext={{ type: "thread" }}
+              audienceContext={{
+                type: "thread",
+                rootTags: threadHead.tags,
+              }}
               channelId={channelId}
               channelName={channelName}
               channelType={channel?.channelType ?? null}

--- a/desktop/src/features/messages/ui/persistentAgentAudienceHosts.test.mjs
+++ b/desktop/src/features/messages/ui/persistentAgentAudienceHosts.test.mjs
@@ -6,7 +6,7 @@ async function source(relativePath) {
   return readFile(new URL(relativePath, import.meta.url), "utf8");
 }
 
-test("supported conversation hosts opt into explicit audience contexts", async () => {
+test("only thread conversation hosts opt into persistent audiences", async () => {
   const [channelPane, threadPanel, newMessage, inboxDetail] = await Promise.all(
     [
       source("../../channels/ui/ChannelPane.tsx"),
@@ -16,9 +16,12 @@ test("supported conversation hosts opt into explicit audience contexts", async (
     ],
   );
 
-  assert.match(channelPane, /audienceContext=\{\{ type: "channel" \}\}/);
+  assert.doesNotMatch(channelPane, /audienceContext=/);
   assert.doesNotMatch(newMessage, /audienceContext=/);
-  assert.match(threadPanel, /audienceContext=\{\{ type: "thread" \}\}/);
+  assert.match(
+    threadPanel,
+    /audienceContext=\{\{[\s\S]*type: "thread",[\s\S]*rootTags: threadHead\.tags,[\s\S]*\}\}/,
+  );
   assert.match(inboxDetail, /type: "thread"/);
   assert.doesNotMatch(threadPanel, /audienceContext=\{[\s\S]*threadRootId/);
   assert.doesNotMatch(inboxDetail, /audienceContext=\{[\s\S]*threadRootId/);

--- a/desktop/src/features/messages/ui/useAgentAddressLockPicker.test.mjs
+++ b/desktop/src/features/messages/ui/useAgentAddressLockPicker.test.mjs
@@ -140,7 +140,7 @@ test("always addressing a new agent delegates the first add for immediate confir
   assert.deepEqual(pulsedPubkeys, []);
 });
 
-test("toggling an addressed agent keeps autocomplete open and removes the lock", async () => {
+test("unpinning an addressed agent keeps its current mention and autocomplete open", async () => {
   const { act, renderHook } = await import("@testing-library/react");
   const { useAgentAddressLockPicker } = await import(
     "./useAgentAddressLockPicker.ts"
@@ -187,20 +187,17 @@ test("toggling an addressed agent keeps autocomplete open and removes the lock",
   );
 
   act(() => {
-    result.current.toggleAlwaysAddressAgent({
-      pubkey: "agent-pubkey",
-      displayName: "Agent Ada",
-      isAgent: true,
-    });
+    result.current.toggleAlwaysAddressAgent(
+      {
+        pubkey: "agent-pubkey",
+        displayName: "Agent Ada",
+        isAgent: true,
+      },
+      { preserveMention: true },
+    );
   });
 
-  assert.deepEqual(appliedEdits, [
-    {
-      replaceFromOffset: 4,
-      replaceToOffset: 15,
-      insertText: "",
-    },
-  ]);
+  assert.deepEqual(appliedEdits, []);
   assert.equal(cancelCount, 0);
   assert.deepEqual(removedPubkeys, ["agent-pubkey"]);
   assert.deepEqual(pulsedPubkeys, []);

--- a/desktop/src/features/messages/ui/useAgentAddressLockPicker.ts
+++ b/desktop/src/features/messages/ui/useAgentAddressLockPicker.ts
@@ -14,45 +14,6 @@ import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
 import type { ComposerAddressAgent } from "./ComposerAddressControls";
 import type { MentionSuggestion } from "./MentionAutocomplete";
 
-function buildMentionRemovalEdits(
-  text: string,
-  displayNames: readonly string[],
-  queryRange?: { start: number; end: number },
-): AutocompleteEdit[] {
-  const ranges = displayNames.flatMap((displayName) =>
-    getMentionOffsets(text, displayName).map((start) => {
-      let end = start + `@${displayName}`.length;
-      if (text[end] === " ") end += 1;
-      return { start, end };
-    }),
-  );
-  if (queryRange) {
-    ranges.push({
-      start: Math.max(0, Math.min(queryRange.start, text.length)),
-      end: Math.max(0, Math.min(queryRange.end, text.length)),
-    });
-  }
-
-  const merged = ranges
-    .filter(({ start, end }) => start < end)
-    .sort((left, right) => left.start - right.start)
-    .reduce<Array<{ start: number; end: number }>>((result, range) => {
-      const previous = result.at(-1);
-      if (previous && range.start <= previous.end) {
-        previous.end = Math.max(previous.end, range.end);
-      } else {
-        result.push({ ...range });
-      }
-      return result;
-    }, []);
-
-  return merged.reverse().map(({ start, end }) => ({
-    replaceFromOffset: start,
-    replaceToOffset: end,
-    insertText: "",
-  }));
-}
-
 export function useAgentAddressLockPicker({
   applyAutocompleteEdit,
   audience,
@@ -177,13 +138,21 @@ export function useAgentAddressLockPicker({
     ],
   );
 
-  const removeAddressedAgent = React.useCallback(
+  const unpinAddressedAgent = React.useCallback(
     (pubkey: string) => {
       const normalized = normalizePubkey(pubkey);
       if (!audienceScope || !normalized) return;
       unpinnedAgentPubkeysRef.current.add(normalized);
       const excludePubkey = audience.excludePubkey ?? audience.removePubkey;
       excludePubkey(normalized);
+    },
+    [audience.excludePubkey, audience.removePubkey, audienceScope],
+  );
+  const removeAddressedAgent = React.useCallback(
+    (pubkey: string) => {
+      const normalized = normalizePubkey(pubkey);
+      if (!audienceScope || !normalized) return;
+      unpinAddressedAgent(normalized);
       const displayName = lockedAgents.find(
         (agent) => agent.pubkey === normalized,
       )?.displayName;
@@ -206,43 +175,27 @@ export function useAgentAddressLockPicker({
     },
     [
       applyAutocompleteEdit,
-      audience.excludePubkey,
-      audience.removePubkey,
       audienceScope,
       lockedAgents,
       onImplicitPrefixRemoved,
       richText.getPlainTextAndCursor,
-    ],
-  );
-  const removeAddressedAgentMentions = React.useCallback(
-    (pubkey: string) => {
-      const normalized = normalizePubkey(pubkey);
-      if (!audienceScope || !normalized) return;
-      const { text } = richText.getPlainTextAndCursor();
-      const matchingDisplayNames = mentions
-        .getDraftMentionRefs(text)
-        .filter((ref) => normalizePubkey(ref.pubkey) === normalized)
-        .map((ref) => ref.displayName);
-      for (const edit of buildMentionRemovalEdits(text, matchingDisplayNames)) {
-        applyAutocompleteEdit(edit);
-      }
-      removeAddressedAgent(normalized);
-    },
-    [
-      applyAutocompleteEdit,
-      audienceScope,
-      mentions.getDraftMentionRefs,
-      removeAddressedAgent,
-      richText.getPlainTextAndCursor,
+      unpinAddressedAgent,
     ],
   );
   const toggleAlwaysAddressAgent = React.useCallback(
-    (suggestion: MentionSuggestion) => {
+    (
+      suggestion: MentionSuggestion,
+      options: { preserveMention?: boolean } = {},
+    ) => {
       const pubkey = normalizePubkey(suggestion.pubkey ?? "");
       if (!audienceScope || !pubkey || !suggestion.isAgent) return;
 
       if (lockedAgentPubkeys.has(pubkey)) {
-        removeAddressedAgentMentions(pubkey);
+        if (options.preserveMention) {
+          unpinAddressedAgent(pubkey);
+        } else {
+          removeAddressedAgent(pubkey);
+        }
         setAnnouncement(
           `Stopped automatically mentioning ${suggestion.displayName}`,
         );
@@ -313,9 +266,10 @@ export function useAgentAddressLockPicker({
       onAddressAgentMention,
       onImplicitPrefixInserted,
       onPulseAddressLock,
-      removeAddressedAgentMentions,
+      removeAddressedAgent,
       richText.getPlainTextAndCursor,
       trackMentionAddressedAgent,
+      unpinAddressedAgent,
     ],
   );
 

--- a/desktop/src/features/messages/ui/useThreadAgentAudience.ts
+++ b/desktop/src/features/messages/ui/useThreadAgentAudience.ts
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import { useKeepMentionedAgentsPinned } from "@/features/messages/lib/autoPinMentionedAgentsPreference";
+import { usePersistentAgentAudience } from "@/features/messages/lib/persistentAgentAudience";
+
+export function useThreadAgentAudience({
+  isAgentPubkey,
+  rootTags,
+  scope,
+}: {
+  isAgentPubkey: (pubkey: string) => boolean;
+  rootTags: readonly string[][];
+  scope: string | null;
+}) {
+  const audience = usePersistentAgentAudience(scope);
+  const keepMentionedAgentsPinned = useKeepMentionedAgentsPinned();
+
+  React.useEffect(() => {
+    if (!scope || !keepMentionedAgentsPinned) return;
+    for (const tag of rootTags) {
+      const pubkey = tag[0] === "p" ? tag[1] : null;
+      if (pubkey && isAgentPubkey(pubkey)) audience.addPubkey(pubkey);
+    }
+  }, [
+    audience.addPubkey,
+    isAgentPubkey,
+    keepMentionedAgentsPinned,
+    rootTags,
+    scope,
+  ]);
+
+  return { audience, keepMentionedAgentsPinned };
+}

--- a/desktop/src/features/messages/ui/useThreadAgentAudience.ts
+++ b/desktop/src/features/messages/ui/useThreadAgentAudience.ts
@@ -1,7 +1,10 @@
 import * as React from "react";
 
 import { useKeepMentionedAgentsPinned } from "@/features/messages/lib/autoPinMentionedAgentsPreference";
-import { usePersistentAgentAudience } from "@/features/messages/lib/persistentAgentAudience";
+import {
+  initializePersistentAgentAudience,
+  usePersistentAgentAudience,
+} from "@/features/messages/lib/persistentAgentAudience";
 
 export function useThreadAgentAudience({
   isAgentPubkey,
@@ -15,19 +18,19 @@ export function useThreadAgentAudience({
   const audience = usePersistentAgentAudience(scope);
   const keepMentionedAgentsPinned = useKeepMentionedAgentsPinned();
 
+  const rootAgentPubkeys = React.useMemo(
+    () =>
+      rootTags.flatMap((tag) => {
+        const pubkey = tag[0] === "p" ? tag[1] : null;
+        return pubkey && isAgentPubkey(pubkey) ? [pubkey] : [];
+      }),
+    [isAgentPubkey, rootTags],
+  );
+
   React.useEffect(() => {
     if (!scope || !keepMentionedAgentsPinned) return;
-    for (const tag of rootTags) {
-      const pubkey = tag[0] === "p" ? tag[1] : null;
-      if (pubkey && isAgentPubkey(pubkey)) audience.addPubkey(pubkey);
-    }
-  }, [
-    audience.addPubkey,
-    isAgentPubkey,
-    keepMentionedAgentsPinned,
-    rootTags,
-    scope,
-  ]);
+    initializePersistentAgentAudience(scope, rootAgentPubkeys);
+  }, [keepMentionedAgentsPinned, rootAgentPubkeys, scope]);
 
   return { audience, keepMentionedAgentsPinned };
 }

--- a/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
+++ b/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
@@ -37,7 +37,7 @@ export function AgentsSettingsPanel() {
                 className="mt-0.5 text-sm text-muted-foreground/70"
                 data-settings-subcopy
               >
-                After you mention them once
+                Address selected agents in thread replies
               </p>
             </div>
             <Switch

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -416,12 +416,10 @@ test("duplicate owned agents preserve provenance and exact pubkey selection", as
   expect(fullNpubs).toHaveLength(2);
   expect(new Set(fullNpubs).size).toBe(2);
 
-  await managedRow
-    .getByRole("button", { name: "Automatically mention carl", exact: true })
-    .click();
+  await managedRow.getByRole("button", { name: "Mention carl" }).click();
   await expect(
     page.getByTestId(`composer-address-lock-${managedPubkey}`),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     page.getByTestId(`composer-address-lock-${relayPubkey}`),
   ).toHaveCount(0);
@@ -430,21 +428,18 @@ test("duplicate owned agents preserve provenance and exact pubkey selection", as
   await expect
     .poll(() => readOutgoingMentionPubkeys(page, "@carl local"))
     .toEqual([managedPubkey]);
-  await expect(input).toHaveText("@carl ");
+  await expect(input).toHaveText("");
 
-  await page.getByTestId(`composer-address-lock-${managedPubkey}`).click();
   await input.fill("@carl");
   const reopenedDropdown = autocomplete(page);
   await expect(reopenedDropdown).toBeVisible();
   const reopenedRelayRow = reopenedDropdown.getByTestId(
     `mention-suggestion-${relayPubkey}`,
   );
-  await reopenedRelayRow
-    .getByRole("button", { name: "Automatically mention carl", exact: true })
-    .click();
+  await reopenedRelayRow.getByRole("button", { name: "Mention carl" }).click();
   await expect(
     page.getByTestId(`composer-address-lock-${relayPubkey}`),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     page.getByTestId(`composer-address-lock-${managedPubkey}`),
   ).toHaveCount(0);
@@ -1441,7 +1436,7 @@ test("managed relay-profile agents with member roles can be addressed explicitly
   await expect(charlieRow.getByText("agent")).toBeVisible();
   await charlieRow
     .getByRole("button", {
-      name: "Automatically mention charlie",
+      name: "Mention charlie",
       exact: true,
     })
     .click();
@@ -1450,12 +1445,7 @@ test("managed relay-profile agents with member roles can be addressed explicitly
   await expect(input.locator(".agent-mention-highlight")).toHaveText("charlie");
   await expect(
     page.getByTestId(`composer-address-lock-${TEST_IDENTITIES.charlie.pubkey}`),
-  ).toBeVisible();
-  await expect(
-    page.getByRole("status").filter({
-      hasText: "Automatically mentioning charlie",
-    }),
-  ).toBeVisible();
+  ).toHaveCount(0);
 });
 
 test("other-owned agents without a shared channel are hidden from mentions", async ({
@@ -2957,7 +2947,7 @@ test("a managed non-member agent from a DM can be addressed explicitly", async (
   await expect(input.locator(".mention-chip")).toHaveCount(0);
   await charlieRow
     .getByRole("button", {
-      name: "Automatically mention charlie",
+      name: "Mention charlie",
       exact: true,
     })
     .click();
@@ -2966,7 +2956,7 @@ test("a managed non-member agent from a DM can be addressed explicitly", async (
   await expect(input.locator(".agent-mention-highlight")).toHaveText("charlie");
   await expect(
     page.getByTestId(`composer-address-lock-${TEST_IDENTITIES.charlie.pubkey}`),
-  ).toBeVisible();
+  ).toHaveCount(0);
 });
 
 test("global non-member people can be selected from channel mentions", async ({

--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -92,6 +92,20 @@ async function pressPrimaryShiftM(page: Page) {
   await page.keyboard.press(`${isMac ? "Meta" : "Control"}+Shift+M`);
 }
 
+async function readPersistedDraftContent(page: Page, draftKey: string) {
+  return page.evaluate((key) => {
+    for (const storageKey of Object.keys(window.localStorage)) {
+      if (!storageKey.startsWith("buzz-drafts.v2:")) continue;
+      const drafts = JSON.parse(
+        window.localStorage.getItem(storageKey) ?? "{}",
+      ) as Record<string, { content?: string }>;
+      const draft = drafts[key];
+      if (draft) return draft.content ?? "";
+    }
+    return "";
+  }, draftKey);
+}
+
 async function readOutgoingMentionPubkeys(page: Page, content: string) {
   return page.evaluate((expectedContent) => {
     const signedEvent = window.__BUZZ_E2E_SIGNED_EVENTS__?.find(
@@ -271,9 +285,9 @@ test("automatically mentions multiple agents from the mention picker", async ({
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   await automaticallyMention(composer, "Morgarita");
   await automaticallyMention(composer, "Vogue");
 
@@ -284,7 +298,7 @@ test("automatically mentions multiple agents from the mention picker", async ({
     composer.getByTestId(`composer-address-lock-${AGENT_B}`),
   ).toBeVisible();
   await expect(
-    composer.getByRole("button", { name: "Manage automatic agent mentions" }),
+    composer.getByRole("button", { name: "Manage mentions" }),
   ).toBeVisible();
 });
 
@@ -292,21 +306,25 @@ test("keeps the composer and global automatic mention settings synchronized", as
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   await composer.getByTestId("message-insert-mention").click();
-  const optionsTrigger = composer.getByTestId("mention-options-trigger");
-  await expect(optionsTrigger).toHaveAttribute("aria-expanded", "false");
-  await composer
-    .getByTestId("mention-autocomplete")
-    .getByRole("button", { name: "Automatically mention Morgarita" })
-    .click();
-  await expect(optionsTrigger).toHaveAttribute("aria-expanded", "true");
   const composerToggle = composer.getByTestId(
     "mention-keep-agents-pinned-toggle",
   );
   await expect(composerToggle).toHaveAttribute("data-state", "unchecked");
+  const settings = composer.getByTestId("mention-options-settings");
+  await expect(settings).toBeVisible();
+  const settingsBox = await settings.boundingBox();
+  const heading = settings.getByText("Automatically mention agents");
+  const headingBox = await heading.boundingBox();
+  expect(settingsBox?.width).toBeGreaterThanOrEqual(300);
+  expect(headingBox?.height).toBeLessThanOrEqual(20);
+  await composer
+    .getByTestId("mention-autocomplete")
+    .getByRole("button", { name: "Automatically mention Morgarita" })
+    .click();
   await expect(composerToggle).toHaveAttribute("data-state", "checked", {
     timeout: 1_500,
   });
@@ -316,8 +334,7 @@ test("keeps the composer and global automatic mention settings synchronized", as
     .getByRole("button", { name: "Turn off" })
     .click();
   await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
-  await expect(optionsTrigger).toHaveAttribute("aria-expanded", "true");
-  await expect(composerToggle).toHaveAttribute("data-state", "checked");
+  await expect(composer.getByTestId("mention-options-settings")).toBeVisible();
   await expect(composerToggle).toHaveAttribute("data-state", "unchecked", {
     timeout: 1_500,
   });
@@ -336,7 +353,6 @@ test("keeps the composer and global automatic mention settings synchronized", as
     composer.getByTestId(`composer-address-lock-${AGENT_A}`),
   ).toHaveCount(0);
   await composer.getByTestId("message-insert-mention").click();
-  await composer.getByTestId("mention-options-trigger").click();
   await expect(
     composer.getByTestId("mention-keep-agents-pinned-toggle"),
   ).toHaveAttribute("data-state", "unchecked");
@@ -347,7 +363,7 @@ test("keeps the composer and global automatic mention settings synchronized", as
   ).toHaveAttribute("aria-pressed", "false");
 });
 
-test("hides automatic mention state while disabled without clearing the draft", async ({
+test("the disabled root composer preserves its explicit draft without audience controls", async ({
   page,
 }) => {
   await installAudienceFixtures(page);
@@ -355,11 +371,8 @@ test("hides automatic mention state while disabled without clearing the draft", 
 
   const composer = channelComposer(page);
   const input = composer.getByTestId("message-input");
-  await automaticallyMention(composer, "Morgarita");
-  await input.type("draft text");
-  await expect(
-    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toBeVisible();
+  await input.fill("explicit draft text");
+  await expect(composer.getByTestId("composer-address-locks")).toHaveCount(0);
 
   await page.getByTestId("channel-management-trigger").click();
   await expect(page.getByTestId("channel-management-sheet")).toBeVisible();
@@ -368,22 +381,8 @@ test("hides automatic mention state while disabled without clearing the draft", 
   await page.getByTestId("auxiliary-panel-close").click();
 
   await expect(input).toHaveAttribute("contenteditable", "false");
-  await expect(input).toHaveText("@Morgarita draft text");
-  await expect(
-    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toHaveCount(0);
-
-  await page.getByTestId("channel-management-trigger").click();
-  await expect(page.getByTestId("channel-management-sheet")).toBeVisible();
-  await page.getByTestId("channel-management-unarchive").click();
-  await expect(page.getByTestId("channel-management-archive")).toBeVisible();
-  await page.getByTestId("auxiliary-panel-close").click();
-
-  await expect(input).toHaveAttribute("contenteditable", "true");
-  await expect(input).toHaveText("@Morgarita draft text");
-  await expect(
-    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toBeVisible();
+  await expect(input).toHaveText("explicit draft text");
+  await expect(composer.getByTestId("composer-address-locks")).toHaveCount(0);
 });
 
 test("Tab inserts a one-time agent mention by default", async ({ page }) => {
@@ -418,12 +417,11 @@ test("disabling automatic mentions leaves the composer empty after send", async 
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await composer.getByTestId("message-insert-mention").click();
-  await composer.getByTestId("mention-options-trigger").click();
   const preference = composer.getByTestId("mention-keep-agents-pinned-toggle");
   await expect(preference).toHaveAttribute("data-state", "checked");
   await preference.click();
@@ -452,9 +450,9 @@ test("primary+Shift+M addresses the default agent, then toggles the highlighted 
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await input.fill("draft text");
   await pressPrimaryShiftM(page);
@@ -500,10 +498,10 @@ test("primary+Shift+M favors the most recently mentioned eligible agent", async 
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
   await emitMockMessage(page, "Please ask Vogue", [AGENT_B]);
 
-  const input = channelComposer(page).getByTestId("message-input");
+  const input = threadComposer(page).getByTestId("message-input");
   await input.fill("draft text");
   await input.press("ArrowLeft");
   await input.press("ArrowLeft");
@@ -522,13 +520,13 @@ test("the mention button opens settings and can undo an address", async ({
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   await automaticallyMention(composer, "Morgarita");
   const input = composer.getByTestId("message-input");
   const ingress = composer.getByRole("button", {
-    name: "Manage automatic agent mentions",
+    name: "Manage mentions",
   });
 
   await input.type("draft text");
@@ -536,31 +534,34 @@ test("the mention button opens settings and can undo an address", async ({
   const menu = composer.getByTestId("mention-autocomplete");
   await expect(menu).toBeVisible();
   await expect(input).toHaveText("@Morgarita draft text");
-  await page.getByTestId("mention-options-trigger").click();
   await expect(
     page.getByTestId("mention-keep-agents-pinned-toggle"),
   ).toBeVisible();
   const layerBox = await composer
     .getByTestId("mention-autocomplete-layer")
     .boundingBox();
-  const optionsBox = await page
-    .getByTestId("mention-options-trigger")
+  const settingsBox = await page
+    .getByTestId("mention-options-settings")
     .boundingBox();
+  const menuBox = await menu.boundingBox();
   expect(layerBox).not.toBeNull();
-  expect(optionsBox).not.toBeNull();
-  if (!layerBox || !optionsBox) throw new Error("Mention tray is not laid out");
-  await page.mouse.click(layerBox.x + 4, optionsBox.y + optionsBox.height / 2);
+  expect(settingsBox).not.toBeNull();
+  expect(menuBox).not.toBeNull();
+  if (!layerBox || !settingsBox || !menuBox) {
+    throw new Error("Mention tray is not laid out");
+  }
+  await page.mouse.click(
+    layerBox.x + layerBox.width / 2,
+    (settingsBox.y + settingsBox.height + menuBox.y) / 2,
+  );
   await expect(menu).toHaveCount(0);
   await expect(input).toHaveText("@Morgarita draft text");
   await ingress.click();
   await expect(menu).toBeVisible();
-  await expect(page.getByTestId("mention-options-trigger")).toHaveAttribute(
-    "aria-expanded",
-    "false",
-  );
+  await expect(page.getByTestId("mention-options-settings")).toBeVisible();
   await expect(
     page.getByTestId("mention-keep-agents-pinned-toggle"),
-  ).toHaveCount(0);
+  ).toBeVisible();
   await ingress.click();
   await expect(menu).toHaveCount(0);
   await expect(input).toHaveText("@Morgarita draft text");
@@ -569,16 +570,16 @@ test("the mention button opens settings and can undo an address", async ({
   await expect(page.getByTestId("user-profile-panel")).toHaveCount(0);
   await expect(
     menu.getByRole("button", {
-      name: "Don't automatically mention Morgarita in this conversation",
+      name: "Don't automatically mention Morgarita in this thread",
     }),
   ).toHaveAttribute("aria-pressed", "true");
 
   await menu
     .getByRole("button", {
-      name: "Don't automatically mention Morgarita in this conversation",
+      name: "Don't automatically mention Morgarita in this thread",
     })
     .click();
-  await expect(input).toHaveText("draft text");
+  await expect(input).toHaveText("@Morgarita draft text");
   await expect(
     composer.getByRole("button", { name: "Mention someone" }),
   ).toBeVisible();
@@ -656,7 +657,7 @@ test("always-mentioned agents remain selected without replaying their animation 
     { timeout: 500 },
   );
   await expect(
-    composer.getByRole("button", { name: "Manage automatic agent mentions" }),
+    composer.getByRole("button", { name: "Manage mentions" }),
   ).toBeVisible();
   await expect(input).toBeFocused();
   await expect(composer.getByTestId("mention-autocomplete")).toHaveCount(0);
@@ -690,7 +691,7 @@ test("always-mentioned agents remain selected without replaying their animation 
   ).toHaveCount(1);
 });
 
-test("the unfocused main composer keeps its dismissed mention menu closed through a thread send", async ({
+test("the unfocused root composer keeps its dismissed mention menu closed through a thread send", async ({
   page,
 }) => {
   await installAudienceFixtures(page, { sendMessageDelayMs: 1_500 });
@@ -698,12 +699,7 @@ test("the unfocused main composer keeps its dismissed mention menu closed throug
 
   const mainComposer = channelComposer(page);
   const mainInput = mainComposer.getByTestId("message-input");
-  await automaticallyMention(mainComposer, "Morgarita");
-  await mainInput.fill("@Morgarita earlier message");
-  await mainInput.press("Enter");
-  await expect(mainInput).toHaveText("@Morgarita ");
-  await mainInput.fill("@Morgarita");
-  await expect(mainInput).toHaveText("@Morgarita");
+  await mainInput.fill("@Mor");
   await expect(mainComposer.getByTestId("mention-autocomplete")).toBeVisible();
   await mainInput.press("Escape");
   await expect(mainComposer.getByTestId("mention-autocomplete")).toHaveCount(0);
@@ -760,9 +756,9 @@ test("pressing a mention overlay's own container keeps it open", async ({
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await composer.getByTestId("message-insert-mention").click();
   const list = composer.getByTestId("mention-autocomplete");
@@ -782,7 +778,6 @@ test("pressing a mention overlay's own container keeps it open", async ({
   // Same hazard on the options surface, where it needs no exotic scrollbar
   // setting to reproduce: the switch's label text is a container press, so the
   // overlay used to vanish before the forwarded click reached the switch.
-  await composer.getByTestId("mention-options-trigger").click();
   const preference = composer.getByTestId("mention-keep-agents-pinned-toggle");
   await expect(preference).toHaveAttribute("data-state", "checked");
   await composer
@@ -793,14 +788,14 @@ test("pressing a mention overlay's own container keeps it open", async ({
   await expect(list).toBeVisible();
 });
 
-test("the mention Options controls are reachable and operable by keyboard", async ({
+test("the mention setting is reachable and operable by keyboard", async ({
   page,
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
   await openThread(page);
 
-  const mainComposer = channelComposer(page);
+  const mainComposer = threadComposer(page);
   const mainInput = mainComposer.getByTestId("message-input");
   await mainInput.click();
   await mainInput.fill("@Mor");
@@ -821,23 +816,15 @@ test("the mention Options controls are reachable and operable by keyboard", asyn
   });
 
   // Forward Tab still selects the highlighted suggestion, so Shift+Tab is the
-  // route into the overlay. It only reaches the Options controls if the focus
-  // gate treats them as composer-owned focus rather than unmounting on the
-  // editor's blur.
+  // route into the always-visible setting. The focus gate must treat it as
+  // composer-owned focus rather than unmounting on the editor's blur.
   await mainInput.press("Shift+Tab");
-  const optionsTrigger = mainComposer.getByTestId("mention-options-trigger");
-  await expect(optionsTrigger).toBeFocused();
-
-  await page.keyboard.press("Enter");
   const preference = mainComposer.getByTestId(
     "mention-keep-agents-pinned-toggle",
   );
-  await expect(preference).toBeVisible();
+  await expect(preference).toBeFocused();
   await expect(preference).toHaveAttribute("data-state", "checked");
 
-  // The switch sits before its trigger in the expanded surface's tab order.
-  await page.keyboard.press("Shift+Tab");
-  await expect(preference).toBeFocused();
   await page.keyboard.press("Space");
   await expect(preference).toHaveAttribute("data-state", "unchecked");
 
@@ -866,9 +853,9 @@ test("the mention Options controls are reachable and operable by keyboard", asyn
   // under test.
   await mainInput.fill("@Mor");
   await expect(list).toBeVisible();
-  const threadInput = threadComposer(page).getByTestId("message-input");
-  await threadInput.focus();
-  await expect(threadInput).toBeFocused();
+  const rootInput = channelComposer(page).getByTestId("message-input");
+  await rootInput.focus();
+  await expect(rootInput).toBeFocused();
   await expect(list).toHaveCount(0);
 });
 
@@ -907,9 +894,9 @@ test("a manual mention persists when automatic mentions are enabled", async ({
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page, { sendMessageDelayMs: 1_500 });
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await input.fill("@Mor");
   await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
@@ -928,7 +915,7 @@ test("a manual mention persists when automatic mentions are enabled", async ({
   await expect(autoPinConfirmation).not.toContainText(
     "Future messages in this channel will include this agent.",
   );
-  await expect(autoPinConfirmation).toHaveAttribute("data-side", "right");
+  await expect(autoPinConfirmation).toHaveAttribute("data-side", "left");
   await expect(autoPinConfirmation.locator("span")).toHaveCSS(
     "white-space",
     "nowrap",
@@ -948,8 +935,8 @@ test("a manual mention persists when automatic mentions are enabled", async ({
   if (!addressControlBox || !confirmationBox) {
     throw new Error("Automatic mention confirmation is not laid out");
   }
-  expect(confirmationBox.x).toBeGreaterThan(
-    addressControlBox.x + addressControlBox.width,
+  expect(confirmationBox.x + confirmationBox.width).toBeLessThanOrEqual(
+    addressControlBox.x,
   );
   const turnOffAction = autoPinConfirmation.getByRole("button", {
     name: "Turn off",
@@ -974,6 +961,9 @@ test("a manual mention persists when automatic mentions are enabled", async ({
     .poll(() => readOutgoingMentionPubkeys(page, "@Morgarita hello"))
     .toContain(AGENT_A);
 
+  await expect(input).toHaveAttribute("contenteditable", "true", {
+    timeout: 2_500,
+  });
   await input.fill("follow up");
   await expect(
     composer.getByTestId(`composer-address-lock-${AGENT_A}`),
@@ -989,9 +979,9 @@ test("the auto-pin popover can turn off automatic agent mentions", async ({
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await input.fill("@Mor");
   await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
@@ -1010,10 +1000,7 @@ test("the auto-pin popover can turn off automatic agent mentions", async ({
   await autoPinConfirmation.getByRole("button", { name: "Turn off" }).click();
 
   await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
-  await expect(composer.getByTestId("mention-options-trigger")).toHaveAttribute(
-    "aria-expanded",
-    "true",
-  );
+  await expect(composer.getByTestId("mention-options-settings")).toBeVisible();
   await expect(
     composer.getByTestId("mention-keep-agents-pinned-toggle"),
   ).toHaveAttribute("data-state", "unchecked");
@@ -1029,9 +1016,9 @@ test("the auto-pin popover can turn off automatic agent mentions", async ({
 test("the auto-pin popover remains open while hovered", async ({ page }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await input.fill("@Mor");
   await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
@@ -1053,9 +1040,9 @@ test("removing the mention chip dismisses the auto-pin popover", async ({
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await input.fill("@Mor");
   await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
@@ -1076,31 +1063,23 @@ test("removing the mention chip dismisses the auto-pin popover", async ({
   await expect(autoPinConfirmation).toHaveCount(0);
 });
 
-test("automatic mentions are scoped to their channel or thread composer", async ({
+test("automatic mentions exist only in thread composers and stay thread-scoped", async ({
   page,
 }) => {
   await installAudienceFixtures(page);
   await openGeneral(page);
-  await automaticallyMention(channelComposer(page), "Morgarita");
-  await expect(
-    channelComposer(page).getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toBeVisible();
 
-  await openThread(page);
+  const rootComposer = channelComposer(page);
+  await rootComposer.getByTestId("message-insert-mention").click();
   await expect(
-    threadComposer(page).getByTestId(`composer-address-lock-${AGENT_A}`),
+    rootComposer.getByTestId("mention-options-settings"),
+  ).toHaveCount(0);
+  await expect(
+    rootComposer.getByRole("button", { name: /^Automatically mention / }),
   ).toHaveCount(0);
 
+  await openThread(page);
   await automaticallyMention(threadComposer(page), "Vogue");
-  await openGeneral(page);
-  await expect(
-    channelComposer(page).getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toBeVisible();
-  await expect(
-    channelComposer(page).getByTestId(`composer-address-lock-${AGENT_B}`),
-  ).toHaveCount(0);
-
-  await openThread(page);
   await expect(
     threadComposer(page).getByTestId(`composer-address-lock-${AGENT_B}`),
   ).toBeVisible();
@@ -1111,72 +1090,47 @@ test("automatic mentions are scoped to their channel or thread composer", async 
   ).toHaveCount(0);
 });
 
-test("a thread automatic mention preserves an explicitly unpinned root agent", async ({
+test("a root agent mention is explicit for one message and never becomes retained", async ({
   page,
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page, { agentAName: "claude code" });
   await openGeneral(page);
 
-  const rootComposer = channelComposer(page);
-  const rootInput = rootComposer.getByTestId("message-input");
-  await automaticallyMention(rootComposer, "claude code");
+  const composer = channelComposer(page);
+  const input = composer.getByTestId("message-input");
+  const firstRootMessage = "@claude code one time";
+  await input.fill("@cla");
+  await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
+  await input.press("Tab");
+  await input.pressSequentially(" one time");
+  await expect(input).toHaveText(firstRootMessage);
   await expect(
-    rootComposer.getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toBeVisible();
-  await rootComposer
-    .getByTestId(`composer-address-lock-remove-${AGENT_A}`)
-    .click();
-  await expect(rootInput).toHaveText("");
-  await expect(
-    rootComposer.getByTestId(`composer-address-lock-${AGENT_A}`),
+    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
   ).toHaveCount(0);
+  await input.press("Enter");
 
-  await rootInput.fill("@cla");
-  await expect(rootComposer.getByTestId("mention-autocomplete")).toBeVisible();
-  await rootInput.press("Tab");
-  await rootInput.type("one time");
-  await rootInput.press("Enter");
-  await expect(rootInput).toHaveText("");
-  await expect(
-    rootComposer.getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toHaveCount(0);
-
-  await openThread(page);
-  const activeThreadComposer = threadComposer(page);
-  const threadInput = activeThreadComposer.getByTestId("message-input");
-  await threadInput.fill("@cla");
-  await expect(
-    activeThreadComposer.getByTestId("mention-autocomplete"),
-  ).toBeVisible();
-  await threadInput.press("Tab");
-  await expect(
-    activeThreadComposer.getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toBeVisible();
-  await threadInput.type("thread message");
-  await threadInput.press("Enter");
-
-  await openGeneral(page);
-  await expect(
-    channelComposer(page).getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toHaveCount(0);
-
-  const restoredRootInput = channelComposer(page).getByTestId("message-input");
-  await restoredRootInput.fill("@cla");
-  await expect(
-    channelComposer(page).getByTestId("mention-autocomplete"),
-  ).toBeVisible();
-  await restoredRootInput.press("Tab");
-  await expect(
-    channelComposer(page).getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toHaveCount(0);
-  await restoredRootInput.type("one time");
-  await restoredRootInput.press("Enter");
-
-  await expect(restoredRootInput).toHaveText("");
-  await expect(
-    channelComposer(page).getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toHaveCount(0);
+  await expect(input).toHaveText("");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (pubkey) =>
+          Boolean(
+            window.__BUZZ_E2E_SIGNED_EVENTS__?.some((event) =>
+              (event.tags ?? []).some(
+                (tag) => tag[0] === "p" && tag[1] === pubkey,
+              ),
+            ),
+          ),
+        AGENT_A,
+      ),
+    )
+    .toBe(true);
+  await input.fill("next root message");
+  await input.press("Enter");
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, "next root message"))
+    .toEqual([]);
 });
 
 test("an unchecked agent remains excluded while automatic mentions stay enabled", async ({
@@ -1184,10 +1138,10 @@ test("an unchecked agent remains excluded while automatic mentions stay enabled"
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
-  await automaticallyMention(channelComposer(page), "Morgarita");
+  await openThread(page);
+  await automaticallyMention(threadComposer(page), "Morgarita");
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await composer.getByTestId(`composer-address-lock-remove-${AGENT_A}`).click();
   await expect(input).toHaveText("");
@@ -1208,9 +1162,9 @@ test("re-adding a deleted automatic mention restores its automatic mention state
 }) => {
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await automaticallyMention(composer, "Morgarita");
 
@@ -1246,13 +1200,13 @@ test("implicit automatic mentions stay out of persisted drafts", async ({
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
-  await automaticallyMention(channelComposer(page), "Morgarita");
-  const input = channelComposer(page).getByTestId("message-input");
+  await openThread(page);
+  await automaticallyMention(threadComposer(page), "Morgarita");
+  const input = threadComposer(page).getByTestId("message-input");
   await input.type("draft text");
 
-  await openThread(page);
   await openGeneral(page);
+  await openThread(page);
 
   await expect(input).toHaveText("@Morgarita draft text");
   await expect(input.locator(".agent-mention-highlight")).toHaveCount(1);
@@ -1266,19 +1220,7 @@ test("implicit automatic mentions stay out of persisted drafts", async ({
   await expect(page.getByTestId("chat-title")).toHaveText("random");
 
   await expect
-    .poll(() =>
-      page.evaluate((channelId) => {
-        for (const storageKey of Object.keys(window.localStorage)) {
-          if (!storageKey.startsWith("buzz-drafts.v2:")) continue;
-          const drafts = JSON.parse(
-            window.localStorage.getItem(storageKey) ?? "{}",
-          ) as Record<string, { channelId?: string; content?: string }>;
-          const draft = drafts[channelId];
-          if (draft?.channelId === channelId) return draft.content ?? "";
-        }
-        return "";
-      }, CHANNEL_ID),
-    )
+    .poll(() => readPersistedDraftContent(page, `thread:${THREAD_ROOT_ID}`))
     .toBe("draft text continues");
 });
 
@@ -1286,37 +1228,23 @@ test("an authored duplicate leading mention survives draft restoration", async (
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
-  await automaticallyMention(channelComposer(page), "Morgarita");
-  const input = channelComposer(page).getByTestId("message-input");
+  await openThread(page);
+  await automaticallyMention(threadComposer(page), "Morgarita");
+  const input = threadComposer(page).getByTestId("message-input");
   await input.pressSequentially("@Morgarita authored duplicate");
 
-  await openThread(page);
   await openGeneral(page);
+  await openThread(page);
 
-  await expect(input).toHaveText("@Morgarita @Morgarita authored duplicate");
-  // Exact typed mentions now resolve on Space, so both the automatic prefix and
-  // the authored duplicate retain mention identity after restoration.
-  await expect(input.locator(".agent-mention-highlight")).toHaveCount(2);
+  await expect(input).toHaveText("@Morgarita authored duplicate");
+  await expect(input.locator(".agent-mention-highlight")).toHaveCount(1);
 
   await page.goto(`/#/channels/${RANDOM_CHANNEL_ID}`, {
     waitUntil: "domcontentloaded",
   });
   await expect(page.getByTestId("chat-title")).toHaveText("random");
   await expect
-    .poll(() =>
-      page.evaluate((channelId) => {
-        for (const storageKey of Object.keys(window.localStorage)) {
-          if (!storageKey.startsWith("buzz-drafts.v2:")) continue;
-          const drafts = JSON.parse(
-            window.localStorage.getItem(storageKey) ?? "{}",
-          ) as Record<string, { channelId?: string; content?: string }>;
-          const draft = drafts[channelId];
-          if (draft?.channelId === channelId) return draft.content ?? "";
-        }
-        return "";
-      }, CHANNEL_ID),
-    )
+    .poll(() => readPersistedDraftContent(page, `thread:${THREAD_ROOT_ID}`))
     .toBe("@Morgarita authored duplicate");
 });
 
@@ -1324,8 +1252,8 @@ test("typed deletion preserves an identical authored mention in drafts", async (
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
-  const composer = channelComposer(page);
+  await openThread(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await automaticallyMention(composer, "Morgarita");
 
@@ -1344,20 +1272,7 @@ test("typed deletion preserves an identical authored mention in drafts", async (
     waitUntil: "domcontentloaded",
   });
   await expect
-    .poll(() =>
-      page.evaluate((channelId) => {
-        for (const storageKey of Object.keys(window.localStorage)) {
-          if (!storageKey.startsWith("buzz-drafts.v2:")) continue;
-          const draft = (
-            JSON.parse(
-              window.localStorage.getItem(storageKey) ?? "{}",
-            ) as Record<string, { content?: string }>
-          )[channelId];
-          if (draft) return draft.content ?? "";
-        }
-        return "";
-      }, CHANNEL_ID),
-    )
+    .poll(() => readPersistedDraftContent(page, `thread:${THREAD_ROOT_ID}`))
     .toBe("@Morgarita manual after typed deletion");
 });
 
@@ -1365,8 +1280,8 @@ test("removing an automatic mention preserves an identical authored mention in d
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
-  const composer = channelComposer(page);
+  await openThread(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
 
   await automaticallyMention(composer, "Morgarita");
@@ -1377,20 +1292,7 @@ test("removing an automatic mention preserves an identical authored mention in d
   });
 
   await expect
-    .poll(() =>
-      page.evaluate((channelId) => {
-        for (const storageKey of Object.keys(window.localStorage)) {
-          if (!storageKey.startsWith("buzz-drafts.v2:")) continue;
-          const draft = (
-            JSON.parse(
-              window.localStorage.getItem(storageKey) ?? "{}",
-            ) as Record<string, { content?: string }>
-          )[channelId];
-          if (draft) return draft.content ?? "";
-        }
-        return "";
-      }, CHANNEL_ID),
-    )
+    .poll(() => readPersistedDraftContent(page, `thread:${THREAD_ROOT_ID}`))
     .toBe("@Morgarita manual after removal");
 });
 
@@ -1398,35 +1300,22 @@ test("multiple automatic mentions stay out of persisted drafts", async ({
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
-  const composer = channelComposer(page);
+  await openThread(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await automaticallyMention(composer, "Morgarita");
   await automaticallyMention(composer, "Vogue");
   await input.pressSequentially("draft text");
 
-  await openThread(page);
   await openGeneral(page);
-  await expect(input).toHaveText("@Vogue @Morgarita draft text");
+  await openThread(page);
+  await expect(input).toHaveText("@Morgarita @Vogue draft text");
   await expect(input.locator(".agent-mention-highlight")).toHaveCount(2);
   await page.goto(`/#/channels/${RANDOM_CHANNEL_ID}`, {
     waitUntil: "domcontentloaded",
   });
   await expect
-    .poll(() =>
-      page.evaluate((channelId) => {
-        for (const storageKey of Object.keys(window.localStorage)) {
-          if (!storageKey.startsWith("buzz-drafts.v2:")) continue;
-          const draft = (
-            JSON.parse(
-              window.localStorage.getItem(storageKey) ?? "{}",
-            ) as Record<string, { content?: string }>
-          )[channelId];
-          if (draft) return draft.content ?? "";
-        }
-        return "";
-      }, CHANNEL_ID),
-    )
+    .poll(() => readPersistedDraftContent(page, `thread:${THREAD_ROOT_ID}`))
     .toBe("draft text");
 });
 
@@ -1434,8 +1323,8 @@ test("re-enabling an automatic mention preserves an authored duplicate after dra
   page,
 }) => {
   await installAudienceFixtures(page);
-  await openGeneral(page);
-  const composer = channelComposer(page);
+  await openThread(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
 
   await automaticallyMention(composer, "Morgarita");
@@ -1444,30 +1333,18 @@ test("re-enabling an automatic mention preserves an authored duplicate after dra
 
   await automaticallyMention(composer, "Morgarita");
   await input.pressSequentially("@Morgarita authored duplicate");
-  await openThread(page);
   await openGeneral(page);
+  await openThread(page);
 
-  await expect(input).toHaveText("@Morgarita @Morgarita authored duplicate");
-  await expect(input.locator(".agent-mention-highlight")).toHaveCount(2);
+  await expect(input).toHaveText("@Morgarita authored duplicate");
+  await expect(input.locator(".agent-mention-highlight")).toHaveCount(1);
 
   await page.goto(`/#/channels/${RANDOM_CHANNEL_ID}`, {
     waitUntil: "domcontentloaded",
   });
   await expect(page.getByTestId("chat-title")).toHaveText("random");
   await expect
-    .poll(() =>
-      page.evaluate((channelId) => {
-        for (const storageKey of Object.keys(window.localStorage)) {
-          if (!storageKey.startsWith("buzz-drafts.v2:")) continue;
-          const drafts = JSON.parse(
-            window.localStorage.getItem(storageKey) ?? "{}",
-          ) as Record<string, { channelId?: string; content?: string }>;
-          const draft = drafts[channelId];
-          if (draft?.channelId === channelId) return draft.content ?? "";
-        }
-        return "";
-      }, CHANNEL_ID),
-    )
+    .poll(() => readPersistedDraftContent(page, `thread:${THREAD_ROOT_ID}`))
     .toBe("@Morgarita authored duplicate");
 });
 
@@ -1475,8 +1352,8 @@ test("a restored multi-word automatic mention remains a chip with the caret afte
   page,
 }) => {
   await installAudienceFixtures(page, { agentAName: "claude code" });
-  await openGeneral(page);
-  const originalComposer = channelComposer(page);
+  await openThread(page);
+  const originalComposer = threadComposer(page);
   await automaticallyMention(originalComposer, "claude code");
   const originalInput = originalComposer.getByTestId("message-input");
   await originalInput.pressSequentially("hello");
@@ -1490,9 +1367,9 @@ test("a restored multi-word automatic mention remains a chip with the caret afte
     waitUntil: "domcontentloaded",
   });
   await expect(page.getByTestId("chat-title")).toHaveText("random");
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   const expectedContent = "@claude code ";
   await expect(input).toHaveText(expectedContent);
@@ -1501,7 +1378,7 @@ test("a restored multi-word automatic mention remains a chip with the caret afte
     composer.getByTestId(`composer-address-lock-${AGENT_A}`),
   ).toBeVisible();
   await expect(
-    composer.getByRole("button", { name: "Manage automatic agent mentions" }),
+    composer.getByRole("button", { name: "Manage mentions" }),
   ).toBeVisible();
   await page.waitForTimeout(500);
   await expect(input.locator(".agent-mention-highlight")).toHaveCount(1);
@@ -1524,9 +1401,9 @@ test("reduced motion removes addressed agents without spatial animation", async 
   await page.emulateMedia({ reducedMotion: "reduce" });
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await input.fill("@Mor");
   await expect(composer.getByTestId("mention-autocomplete")).toBeVisible();
@@ -1572,7 +1449,7 @@ test("the mention-button placement fits the narrow composer", async ({
   await automaticallyMention(overlay, "Vogue");
   await expect(overlay.getByTestId("composer-address-locks")).toBeVisible();
   await expect(
-    overlay.getByRole("button", { name: "Manage automatic agent mentions" }),
+    overlay.getByRole("button", { name: "Manage mentions" }),
   ).toBeVisible();
   await waitForAnimations(page);
   await composer.screenshot({ path: `${SHOTS}/narrow-mention-button.png` });
@@ -1581,9 +1458,9 @@ test("the mention-button placement fits the narrow composer", async ({
 test("captures the lightweight auto-pin popover", async ({ page }) => {
   await seedTheme(page, "buzz-dark");
   await installAudienceFixtures(page);
-  await openGeneral(page);
+  await openThread(page);
 
-  const composer = channelComposer(page);
+  const composer = threadComposer(page);
   const input = composer.getByTestId("message-input");
   await input.fill("draft text");
   await pressPrimaryShiftM(page);

--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -1133,6 +1133,56 @@ test("a root agent mention is explicit for one message and never becomes retaine
     .toEqual([]);
 });
 
+test("a removed root-inherited agent stays excluded after the thread reopens", async ({
+  page,
+}) => {
+  await keepMentionedAgentsPinned(page);
+  await installAudienceFixtures(page);
+  await openGeneral(page);
+
+  const rootId = "c".repeat(64);
+  await page.evaluate(
+    ({ agentPubkey, eventId }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: "@Morgarita root request",
+        id: eventId,
+        mentionPubkeys: [agentPubkey],
+      });
+    },
+    { agentPubkey: AGENT_A, eventId: rootId },
+  );
+  await openThread(page, rootId);
+
+  let composer = threadComposer(page);
+  await expect(
+    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
+  ).toBeVisible();
+  await expect(composer.getByTestId("message-input")).toHaveText("@Morgarita ");
+  await composer.getByTestId(`composer-address-lock-remove-${AGENT_A}`).click();
+  await expect(composer.getByTestId("message-input")).toHaveText("");
+
+  await page.goto(`/#/channels/${RANDOM_CHANNEL_ID}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+  await openThread(page, rootId);
+
+  composer = threadComposer(page);
+  const input = composer.getByTestId("message-input");
+  await expect(
+    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
+  ).toHaveCount(0);
+  await expect(input).toHaveText("");
+
+  const reply = "plain reply after reopening";
+  await input.fill(reply);
+  await input.press("Enter");
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, reply))
+    .not.toContain(AGENT_A);
+});
+
 test("an unchecked agent remains excluded while automatic mentions stay enabled", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -5,6 +5,7 @@ import { installMockBridge } from "../helpers/bridge";
 
 const SHOTS = "test-results/persistent-agent-audience";
 const CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const RANDOM_CHANNEL_ID = "9dae0116-799b-5071-a0a8-fdd30a91a35d";
 const AGENT_A = "a".repeat(64);
 const AGENT_B = "b".repeat(64);
 const THREAD_ROOT_ID = "mock-general-welcome";

--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -5,7 +5,6 @@ import { installMockBridge } from "../helpers/bridge";
 
 const SHOTS = "test-results/persistent-agent-audience";
 const CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
-const RANDOM_CHANNEL_ID = "9dae0116-799b-5071-a0a8-fdd30a91a35d";
 const AGENT_A = "a".repeat(64);
 const AGENT_B = "b".repeat(64);
 const THREAD_ROOT_ID = "mock-general-welcome";
@@ -47,6 +46,24 @@ async function automaticallyMention(
     `@${displayName}`,
   );
   await composer.locator("[data-mention-picker-trigger]").click();
+}
+
+async function waitForMockLiveSubscription(page: Page, channelName: string) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (currentChannelName) =>
+          window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: currentChannelName,
+          }) ?? false,
+        channelName,
+      ),
+    )
+    .toBe(true);
+}
+
+async function waitForTimelineSettled(page: Page) {
+  await expect(page.locator("[data-render-pending]")).toHaveCount(0);
 }
 
 async function openGeneral(page: Page) {
@@ -1139,20 +1156,30 @@ test("a removed root-inherited agent stays excluded after the thread reopens", a
   await keepMentionedAgentsPinned(page);
   await installAudienceFixtures(page);
   await openGeneral(page);
+  await waitForMockLiveSubscription(page, "general");
 
   const rootId = "c".repeat(64);
+  const rootContent = "@Morgarita root request";
   await page.evaluate(
-    ({ agentPubkey, eventId }) => {
+    ({ agentPubkey, content, eventId }) => {
       window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
         channelName: "general",
-        content: "@Morgarita root request",
+        content,
         id: eventId,
         mentionPubkeys: [agentPubkey],
       });
     },
-    { agentPubkey: AGENT_A, eventId: rootId },
+    { agentPubkey: AGENT_A, content: rootContent, eventId: rootId },
   );
-  await openThread(page, rootId);
+  await waitForTimelineSettled(page);
+
+  const rootRow = page
+    .getByTestId("message-timeline")
+    .locator(`[data-testid="message-row"][data-message-id="${rootId}"]`);
+  await expect(rootRow).toBeVisible();
+  await rootRow.hover();
+  await rootRow.getByRole("button", { name: "Reply" }).click();
+  await expect(page.getByTestId("message-thread-panel")).toBeVisible();
 
   let composer = threadComposer(page);
   await expect(
@@ -1162,11 +1189,23 @@ test("a removed root-inherited agent stays excluded after the thread reopens", a
   await composer.getByTestId(`composer-address-lock-remove-${AGENT_A}`).click();
   await expect(composer.getByTestId("message-input")).toHaveText("");
 
-  await page.goto(`/#/channels/${RANDOM_CHANNEL_ID}`, {
-    waitUntil: "domcontentloaded",
-  });
-  await expect(page.getByTestId("chat-title")).toHaveText("random");
-  await openThread(page, rootId);
+  const threadPanel = page.getByTestId("message-thread-panel");
+  await threadPanel.getByTestId("auxiliary-panel-close").click();
+  await expect(threadPanel).toBeHidden();
+
+  const loadedRootTags = await page.evaluate(async (eventId) => {
+    const raw = await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_event", {
+      eventId,
+    });
+    return typeof raw === "string"
+      ? (JSON.parse(raw) as { tags?: string[][] }).tags
+      : null;
+  }, rootId);
+  expect(loadedRootTags).toContainEqual(["p", AGENT_A]);
+
+  await rootRow.hover();
+  await rootRow.getByRole("button", { name: "Reply" }).click();
+  await expect(threadPanel).toBeVisible();
 
   composer = threadComposer(page);
   const input = composer.getByTestId("message-input");

--- a/desktop/tests/e2e/send-channel-binding.spec.ts
+++ b/desktop/tests/e2e/send-channel-binding.spec.ts
@@ -84,12 +84,12 @@ test("message with agent mention lands in compose-time channel despite mid-send 
   await input.press("Enter");
   await page.keyboard.type(` ${MESSAGE_TEXT}`);
 
-  // Verify the inline mention and persistent address are present before submitting.
+  // Verify the inline mention is present without creating thread-retained state.
   await expect(input).toHaveText(`@BotA  ${MESSAGE_TEXT}`);
   await expect(input.locator(".agent-mention-highlight")).toHaveText("BotA");
   await expect(
     page.getByTestId(`composer-address-lock-${OUT_OF_CHANNEL_BOT_PUBKEY}`),
-  ).toBeVisible();
+  ).toHaveCount(0);
 
   // Snapshot the baseline command count before sending
   const baselineCommands = await readCommandLog(page);


### PR DESCRIPTION
**Category:** fix
**User Impact:** Top-level channel messages now notify only agents explicitly selected for that message, while thread replies visibly retain their addressed agents.

**Problem:** Channel-root and thread composers presented the same automatic-mention model even though retained recipients are only predictable within an ongoing thread. That could make a new top-level message notify an agent the sender did not deliberately choose for that message.

**Solution:** Make retained audiences a thread-only capability. Root messages remain explicit and one-shot; threads retain visible, removable agent recipients, with the automatic-mention setting exposed directly in the mention picker.

<details>
<summary>File changes</summary>

**desktop/src/features/channels/ui/ChannelPane.tsx**
Removes persistent audience state from the channel-root composer.

**desktop/src/features/messages/ui/ComposerAddressControls.tsx**
Uses the broader **Manage mentions** label because the picker includes people as well as automatic agent controls.

**desktop/src/features/messages/ui/ComposerAddressControls.test.mjs**
Locks the updated accessible label and active treatment.

**desktop/src/features/messages/ui/MentionAutocomplete.tsx**
Shows the right-aligned automatic-mention setting directly, uses thread-specific copy, preserves keyboard/focus behavior, and keeps the current mention when retention is unchecked.

**desktop/src/features/messages/ui/MentionAutocomplete.test.mjs**
Covers the always-visible setting, compact layout, copy, and thread-scoped agent actions.

**desktop/src/features/messages/ui/MessageComposer.tsx**
Separates unpinning an agent for future replies from removing its current draft mention.

**desktop/src/features/messages/ui/MessageComposer.types.ts**
Narrows retained audience contexts to threads.

**desktop/src/features/messages/ui/persistentAgentAudienceHosts.test.mjs**
Prevents channel-root and new-message hosts from opting back into retained audiences.

**desktop/src/features/messages/ui/useAgentAddressLockPicker.ts**
Splits unpin and current-mention removal semantics.

**desktop/src/features/messages/ui/useAgentAddressLockPicker.test.mjs**
Verifies unpinning retains the current draft mention.

**desktop/src/features/settings/ui/AgentsSettingsPanel.tsx**
Describes the preference as addressing selected agents in thread replies.

**desktop/tests/e2e/persistent-agent-audience.spec.ts**
Moves retained-audience lifecycle coverage to thread composers and adds root, settings, layout, focus, keyboard, unpin, and draft regressions.

**desktop/src/features/messages/ui/MessageComposerAutocompletes.tsx**
Preserves composer focus ownership while routing the thread-only controls.

**desktop/src/features/messages/ui/useComposerFocusOwnership.ts**
Keeps focus within the composer while interacting with its mention overlay controls.

</details>

### Reproduction steps

1. Enable **Automatically mention agents** under agent settings.
2. In a channel root, select an agent and send a message. Confirm the agent is addressed once, no retained-recipient control appears, and the next root message has no agent recipient.
3. Open a thread and select an agent. Confirm the visible recipient persists into later replies.
4. Open **Manage mentions** in the thread composer. Confirm the automatic-mention setting is immediately visible, right-aligned, and labeled **Address selected agents in thread replies**.
5. Uncheck a selected agent. Confirm its current draft mention remains, while later replies no longer retain it automatically.
