### PR TITLE
fix(desktop): keep catch-up reachable for buffered messages

### DIFF
--- a/desktop/src/features/messages/ui/MessageTimeline.test.mjs
+++ b/desktop/src/features/messages/ui/MessageTimeline.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import { after, afterEach, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+import * as React from "react";
+
+// Drive the virtualizer's public bottom-state callback deterministically; jsdom
+// has no layout. Keep MessageTimeline, its buffer/scroll hooks and UnreadPill
+// real, so this covers the control's consumption of semantic AND physical state.
+const hooks = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (
+      specifier === "./TimelineMessageList" &&
+      context.parentURL?.endsWith("/MessageTimeline.tsx")
+    ) {
+      return { shortCircuit: true, url: "buzz-timeline-test:list" };
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (url === "buzz-timeline-test:list") {
+      return {
+        format: "module",
+        shortCircuit: true,
+        source:
+          "export function TimelineMessageList(props) { return globalThis.__TIMELINE_TEST_LIST__(props); }",
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+  pretendToBeVisual: true,
+});
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  localStorage: dom.window.localStorage,
+  IS_REACT_ACT_ENVIRONMENT: true,
+  requestAnimationFrame: dom.window.requestAnimationFrame.bind(dom.window),
+  cancelAnimationFrame: dom.window.cancelAnimationFrame.bind(dom.window),
+});
+
+const { act, cleanup, fireEvent, render } = await import(
+  "@testing-library/react"
+);
+const { MessageTimeline } = await import("./MessageTimeline.tsx");
+let listProps;
+let bottomJumps = [];
+const virtualizerApi = {
+  scrollToBottom: (behavior) => bottomJumps.push(behavior),
+  settleAtBottom: () => {},
+  cancelBottomIntent: () => {},
+  scrollToMessage: () => false,
+};
+globalThis.__TIMELINE_TEST_LIST__ = function TimelineList(props) {
+  listProps = props;
+  React.useEffect(() => {
+    props.onVirtualizerApiChange(virtualizerApi);
+  }, [props.onVirtualizerApiChange]);
+  return React.createElement(
+    "div",
+    { "data-testid": "test-message-list" },
+    props.messages.map((message) =>
+      React.createElement("p", { key: message.id }, message.body),
+    ),
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  bottomJumps = [];
+});
+after(() => {
+  hooks.deregister();
+  delete globalThis.__TIMELINE_TEST_LIST__;
+  dom.window.close();
+});
+
+const row = (id, body) => ({
+  id,
+  body,
+  author: "Alice",
+  createdAt: 1,
+  time: "12:00",
+  depth: 0,
+});
+const initial = row("initial", "Already reading");
+const incoming = row("incoming", "Accepted shared message");
+const older = row("older", "Earlier history");
+
+async function frame() {
+  await act(async () => {
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+  });
+}
+
+async function reportBottom(atBottom) {
+  act(() => listProps.onAtBottomStateChange(atBottom));
+  await frame();
+}
+
+function mount(messages = [initial]) {
+  return render(
+    React.createElement(MessageTimeline, { channelId: "channel-a", messages }),
+  );
+}
+
+function update(view, messages) {
+  view.rerender(
+    React.createElement(MessageTimeline, { channelId: "channel-a", messages }),
+  );
+}
+
+test("buffered arrivals keep a clickable catch-up at physical bottom without releasing the semantic tail", async () => {
+  const view = mount();
+  await reportBottom(true);
+  await reportBottom(false);
+  // A frozen-model reflow reports physical bottom; MessageTimeline suppresses
+  // this synthetic transition, preserving the reader's semantic freeze.
+  await reportBottom(true);
+  bottomJumps = [];
+  assert.equal(view.queryByTestId("message-scroll-to-latest"), null);
+
+  update(view, [initial, incoming]);
+  assert.equal(view.queryByText(incoming.body), null);
+  const catchUp = view.getByRole("button", { name: "1 new message" });
+  assert.equal(catchUp.dataset.testid, "message-scroll-to-latest");
+  assert.equal(catchUp.disabled, false);
+  assert.deepEqual(bottomJumps, [], "arrival must not force a scroll");
+
+  fireEvent.click(catchUp);
+  await frame();
+  assert.ok(view.getByText(incoming.body));
+  assert.equal(view.queryByTestId("message-scroll-to-latest"), null);
+  assert.deepEqual(
+    bottomJumps,
+    ["auto"],
+    "explicit catch-up keeps its existing scroll action",
+  );
+});
+
+test("history browsing keeps Jump to latest and admits prepends without releasing new arrivals", async () => {
+  const view = mount();
+  await reportBottom(true);
+  await reportBottom(false);
+  assert.ok(view.getByRole("button", { name: "Jump to latest" }));
+  bottomJumps = [];
+
+  update(view, [older, initial, incoming]);
+  // Wait for the real prepend settle gate (quiet window plus stable frames).
+  assert.ok(await view.findByText(older.body));
+  assert.ok(view.getByText(initial.body));
+  assert.equal(view.queryByText(incoming.body), null);
+  assert.ok(view.getByRole("button", { name: "1 new message" }));
+  assert.deepEqual(bottomJumps, []);
+});
+
+test("a real return to the semantic tail still releases buffered arrivals", async () => {
+  const view = mount();
+  await reportBottom(true);
+  await reportBottom(false);
+  await reportBottom(true); // suppressed synthetic return
+  update(view, [initial, incoming]);
+  assert.equal(view.queryByText(incoming.body), null);
+
+  await reportBottom(false);
+  await reportBottom(true); // genuine reader return
+  assert.ok(view.getByText(incoming.body));
+  assert.equal(view.queryByTestId("message-scroll-to-latest"), null);
+});
+
+test("the live tail with no pending rows does not invent a catch-up pill", async () => {
+  const view = mount();
+  await reportBottom(true);
+  assert.equal(view.queryByTestId("message-scroll-to-latest"), null);
+  update(view, [initial, incoming]);
+  assert.ok(view.getByText(incoming.body));
+  assert.equal(view.queryByTestId("message-scroll-to-latest"), null);
+});

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -875,7 +875,9 @@ const MessageTimelineBase = React.forwardRef<
           )}
         </div>
 
-        {!isAtBottom ? (
+        {/* The frozen tail can physically reach bottom while newer rows are
+            still buffered. Keep the catch-up action reachable in that state. */}
+        {!isAtBottom || bufferedTimeline.pendingCount > 0 ? (
           <div
             className={cn(
               "pointer-events-none absolute inset-x-0 bottom-4 z-50 flex justify-center px-4",


### PR DESCRIPTION
## Summary
Keep the existing **new messages / Jump to latest** button reachable whenever the timeline has buffered messages, even if its frozen rows physically reach the bottom of the viewport.

A reader can leave the semantic live tail, then reflow to the physical bottom of the shorter frozen model. New accepted messages remain buffered intentionally to preserve reading position, but the old `!isAtBottom` render gate hides the only catch-up action. This change adds `bufferedTimeline.pendingCount > 0` to that gate. The existing explicit click still releases the buffer and scrolls to latest; arrival, history, virtualizer and cache semantics are unchanged.

The regression renders the actual `MessageTimeline`, buffer/scroll/settle hooks and `UnreadPill`, stubbing only the layout-owning message list to drive its public bottom-state callback deterministically. Four cases cover the stranded queue and clickable recovery, zero pending, history prepends without forced scrolling, and genuine semantic return. Removing the production guard causes the recovery case to fail (3 pass / 1 fail); restoring it passes all four.

### Related issue
Discovered while investigating [#7145](https://github.com/block/buzz/pull/7145), [CI run 33444394321](https://github.com/block/buzz/actions/runs/33444394321). Smoke3 fails at `messaging.spec.ts:2629`, **shared-message visibility/catch-up before the author/avatar assertions**, not an avatar-image check. This is a separate baseline repair, not a Start/Move change. Related timeline work: #7006. Searched open PRs for timeline/catch-up duplicates; no duplicate repair found.

### Baseline results
[Baseline and fixed result evidence with source-labelled screenshots](https://github.com/block/buzz/pull/7151#issuecomment-5486776592).

Preserved diagnosis experiment (not a claim of green main): unchanged CI-merge source and fresh main `2f3dd850db3afe27e56f18cbcd3548eabdd9b9c2` each fail **5/6** geometry cases at the same shared-row visibility predicate. Both caches contain the accepted message. Main plus this one-condition repair passes **6/6**.

Fresh fetch for this PR: `0affe527` (seven newer commits). The original messaging spec and `MessageTimeline`, `useBufferedTimelineMessages`, `useAnchoredScroll` have **no delta** from the diagnosis baseline. The saved patch was verified against SHA-256 `14e126c1ddb762b0a989f3a8b84a13c92b1502739ec4d7622122529ab65abcee` before applying.

### Fixed results
Final source `b13c975cdf4fe2aabf93030b5c8f8e8566fc7d5b`:
- Focused component/buffer/snapshot/scroll-policy/settle tests: **74/74 pass**.
- Full desktop JS suite: **5,827/5,827 pass**.
- TypeScript `--noEmit`, package Biome 2.4.16 + text/pubkey guards, differential file-size gate: **pass** (existing package lint warnings remain).
- Fresh Vite E2E build + original send-thread-to-channel workflow: **6/6 pass**, retries **0**, width 1280, heights 600/650/700/720/750/800, Chromium CDP CPU throttle 4. All original shared-row, author/avatar fallback, thread-root link/click, attachment/link-preview, mention/emoji, and signed-send-payload assertions remain intact. The temporary diagnostic geometry/telemetry harness is **not** part of the PR.
- Mutation check: removing only the production repair yields **3 pass / 1 fail** in the new component suite, specifically missing the accessible `1 new message` button.

Local tooling note: pnpm's auto-install rejected the reused dependency symlinks before running tests; equivalent package commands ran directly without installing/mutating shared dependencies. Hermit's older Biome 2.4.7 reports unrelated baseline errors; the lockfile-installed package Biome 2.4.16 passes. No unrelated source was changed. Full Rust/mobile/service builds were intentionally not run for this two-file renderer/test repair; current PR CI supplies the remote gate.

### Remote CI result
[Exact-head CI and gate report](https://github.com/block/buzz/pull/7151#issuecomment-5486931895): CI33455413702 completed successfully. All executed technical checks pass, including Desktop Core/builds/four smoke shards and both integration shards. The original failing messaging workflow passes first attempt (4.4s). Five other smoke cases required CI-configured retries; this is not a claim of universally first-attempt-clean smoke or green unpatched main.

### Review / integration gate
Draft for human review; do not merge or ready-mark automatically. #7145 remains at `8671f76f` untouched. After this baseline repair lands through repository/human authority, #7145 must **rebase** on updated main, rerun affected validation, and get a genuinely new source-bound package for the changed renderer. No merge-from-main, stacked base or cherry-pick into #7145 is being proposed without explicit disposition.

No native app launch, OS keychain/config/credential read, service/DB reset, paid security review, package rebuild/relabel, or changes to #7140. Mock browser evidence is not native release certification.
