### PR TITLE
feat(desktop): support packager-supplied Node runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Install [Git for Windows](https://git-scm.com/download/win) — it ships Git Bas
 
 If you'd rather point buzz at a different bash-compatible shell, set `BUZZ_SHELL` to its path (e.g. `BUZZ_SHELL=C:\path\to\bash.exe`). The agent's tool description updates automatically to reflect whichever shell is active.
 
+To use a trusted Node.js 24 runtime you already have, set `BUZZ_NODE_BIN_DIR` to the absolute directory that contains `node` and `npm`.
+
 ---
 
 ## Architecture

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
@@ -382,10 +382,20 @@ fn managed_node_install_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn node_runtime_supported(
+    managed_artifact_available: bool,
+    override_is_set: bool,
+    managed_bin_dir_available: bool,
+) -> bool {
+    override_is_set || (managed_artifact_available && managed_bin_dir_available)
+}
+
 pub(super) fn managed_node_runtime_supported() -> bool {
-    MANAGED_NODE_ARTIFACT.is_some()
-        && (crate::managed_agents::buzz_node_bin_dir_override_is_set()
-            || crate::managed_agents::buzz_managed_node_bin_dir().is_some())
+    node_runtime_supported(
+        MANAGED_NODE_ARTIFACT.is_some(),
+        crate::managed_agents::buzz_node_bin_dir_override_is_set(),
+        crate::managed_agents::buzz_managed_node_bin_dir().is_some(),
+    )
 }
 
 pub(super) fn ensure_managed_node_runtime_blocking() -> Result<(), Box<InstallStepResult>> {

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
@@ -6,6 +6,7 @@ use std::{io::Read, io::Write};
 use crate::managed_agents::{is_npm_global_install, InstallStepResult};
 
 const MANAGED_NODE_VERSION: &str = "v24.18.0";
+const MANAGED_NODE_MAJOR: u64 = 24;
 const MANAGED_NODE_MAX_BYTES: u64 = 90 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy)]
@@ -102,14 +103,109 @@ fn managed_node_failed_step(stderr: String) -> InstallStepResult {
     }
 }
 
-pub(super) fn managed_node_runtime_ready() -> bool {
-    let Some(node) = crate::managed_agents::buzz_managed_node_bin_path() else {
-        return false;
+fn configured_node_failed_step(stderr: String) -> InstallStepResult {
+    InstallStepResult {
+        step: "node".to_string(),
+        command: "configured Node.js runtime".to_string(),
+        success: false,
+        stdout: String::new(),
+        stderr,
+        exit_code: None,
+        hint: Some(format!(
+            "Set {} to an absolute Node.js 24 bin directory containing executable node and npm, restart Buzz, then click Install again.",
+            crate::managed_agents::BUZZ_NODE_BIN_DIR_ENV
+        )),
+    }
+}
+
+fn managed_node_readiness_failed_step(stderr: String) -> InstallStepResult {
+    InstallStepResult {
+        step: "node".to_string(),
+        command: "managed Node.js runtime".to_string(),
+        success: false,
+        stdout: String::new(),
+        stderr,
+        exit_code: None,
+        hint: Some(format!(
+            "This system could not run Buzz's private Node.js binary. Set {} to a trusted Node.js 24 bin directory, restart Buzz, then click Install again.",
+            crate::managed_agents::BUZZ_NODE_BIN_DIR_ENV
+        )),
+    }
+}
+
+fn node_executable(bin_dir: &std::path::Path) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        bin_dir.join("node.exe")
+    }
+    #[cfg(not(windows))]
+    {
+        bin_dir.join("node")
+    }
+}
+
+fn parse_node_version(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.strip_prefix('v')?.split('.');
+    let parse = |part: &str| {
+        (!part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+            .then(|| part.parse::<u64>().ok())
+            .flatten()
+    };
+    let parsed = (
+        parse(parts.next()?)?,
+        parse(parts.next()?)?,
+        parse(parts.next()?)?,
+    );
+    parts.next().is_none().then_some(parsed)
+}
+
+fn override_node_version_supported(version: &str) -> bool {
+    parse_node_version(version).is_some_and(|(major, _, _)| major == MANAGED_NODE_MAJOR)
+}
+
+fn managed_node_version_supported(version: &str) -> bool {
+    version == MANAGED_NODE_VERSION
+}
+
+fn active_node_runtime_result() -> Result<(), String> {
+    let override_dir = crate::managed_agents::buzz_node_bin_dir_override()?;
+    let (node, is_override) = match override_dir {
+        Some(dir) => (node_executable(&dir), true),
+        None => (
+            crate::managed_agents::buzz_managed_node_bin_path()
+                .ok_or_else(|| "failed to resolve managed Node.js executable".to_string())?,
+            false,
+        ),
     };
     if !node.is_file() {
-        return false;
+        return Err(format!(
+            "Node.js executable does not exist: {}",
+            node.display()
+        ));
     }
-    probe_node(&node, MANAGED_NODE_VERSION, Duration::from_secs(3))
+
+    let actual = probe_node_result(&node, Duration::from_secs(3))?;
+    let supported = if is_override {
+        override_node_version_supported(&actual)
+    } else {
+        managed_node_version_supported(&actual)
+    };
+    if supported {
+        Ok(())
+    } else if is_override {
+        Err(format!(
+            "{} must provide Node.js 24, but node --version returned {actual:?}",
+            crate::managed_agents::BUZZ_NODE_BIN_DIR_ENV
+        ))
+    } else {
+        Err(format!(
+            "managed node --version returned {actual:?}, expected {MANAGED_NODE_VERSION:?}"
+        ))
+    }
+}
+
+pub(super) fn managed_node_runtime_ready() -> bool {
+    active_node_runtime_result().is_ok()
 }
 
 /// Run `executable --version` with a bounded deadline and return `true` only
@@ -123,34 +219,44 @@ pub(super) fn managed_node_runtime_ready() -> bool {
 /// so an unconditional group SIGKILL on every exit path terminates all
 /// descendants.  On Windows, `terminate_process` issues `taskkill /T /F` for
 /// tree-wide cleanup.  SIGKILL to an already-dead group returns ESRCH (no-op).
+#[cfg(test)]
 pub(super) fn probe_node(
     executable: &std::path::Path,
     expected_version: &str,
     timeout: Duration,
 ) -> bool {
-    let tmp = match tempfile::NamedTempFile::new() {
-        Ok(f) => f,
-        Err(_) => return false,
-    };
-    let out_file = match tmp.reopen() {
-        Ok(f) => f,
-        Err(_) => return false,
-    };
+    probe_node_result(executable, timeout).is_ok_and(|version| version == expected_version)
+}
+
+pub(super) fn probe_node_result(
+    executable: &std::path::Path,
+    timeout: Duration,
+) -> Result<String, String> {
+    let mut stdout = tempfile::NamedTempFile::new()
+        .map_err(|error| format!("create node probe stdout file: {error}"))?;
+    let out_file = stdout
+        .reopen()
+        .map_err(|error| format!("open node probe stdout file: {error}"))?;
+    let mut stderr = tempfile::NamedTempFile::new()
+        .map_err(|error| format!("create node probe stderr file: {error}"))?;
+    let err_file = stderr
+        .reopen()
+        .map_err(|error| format!("open node probe stderr file: {error}"))?;
 
     let mut cmd = std::process::Command::new(executable);
     cmd.arg("--version")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::from(out_file))
-        .stderr(std::process::Stdio::null());
+        .stderr(std::process::Stdio::from(err_file));
     crate::util::configure_no_window(&mut cmd);
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
         cmd.process_group(0);
     }
-    let Ok(mut child) = cmd.spawn() else {
-        return false;
-    };
+    let mut child = cmd
+        .spawn()
+        .map_err(|error| format!("run '{} --version': {error}", executable.display()))?;
 
     let deadline = std::time::Instant::now() + timeout;
     let exit_status = loop {
@@ -160,14 +266,20 @@ pub(super) fn probe_node(
                 if std::time::Instant::now() >= deadline {
                     kill_probe_group(child.id());
                     let _ = child.wait();
-                    return false;
+                    return Err(format!(
+                        "'{} --version' timed out after {timeout:?}",
+                        executable.display()
+                    ));
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
-            Err(_) => {
+            Err(error) => {
                 kill_probe_group(child.id());
                 let _ = child.wait();
-                return false;
+                return Err(format!(
+                    "wait for '{} --version': {error}",
+                    executable.display()
+                ));
             }
         }
     };
@@ -175,15 +287,25 @@ pub(super) fn probe_node(
     // Group-kill unconditionally: SIGKILL to a dead group is ESRCH (no-op).
     kill_probe_group(child.id());
 
+    let mut error_output = String::new();
+    if let Err(error) = stderr.as_file_mut().read_to_string(&mut error_output) {
+        return Err(format!("read node probe stderr: {error}"));
+    }
     if !exit_status.success() {
-        return false;
+        let detail = error_output.trim();
+        return Err(if detail.is_empty() {
+            format!("node --version exited with {exit_status}")
+        } else {
+            format!("node --version exited with {exit_status}: {detail}")
+        });
     }
 
     let mut output = String::new();
-    if std::io::Read::read_to_string(&mut tmp.as_file(), &mut output).is_err() {
-        return false;
-    }
-    output.trim() == expected_version
+    stdout
+        .as_file_mut()
+        .read_to_string(&mut output)
+        .map_err(|error| format!("read node probe stdout: {error}"))?;
+    Ok(output.trim().to_string())
 }
 
 /// Kill the probe's process group/tree unconditionally (no TERM grace — this
@@ -212,7 +334,9 @@ fn kill_probe_group(pid: u32) {
 /// missing forces `ensure_managed_node_runtime_blocking` to re-download Node and
 /// npm to reinstall the shims.
 pub(super) fn managed_node_orphaned() -> bool {
-    managed_node_runtime_supported() && !managed_node_runtime_ready()
+    crate::managed_agents::buzz_node_bin_dir_override().is_ok()
+        && managed_node_runtime_supported()
+        && !managed_node_runtime_ready()
 }
 
 /// Returns `true` when an adapter at `resolved` should be invalidated.
@@ -259,10 +383,21 @@ fn managed_node_install_lock() -> &'static Mutex<()> {
 }
 
 pub(super) fn managed_node_runtime_supported() -> bool {
-    MANAGED_NODE_ARTIFACT.is_some() && crate::managed_agents::buzz_managed_node_bin_dir().is_some()
+    MANAGED_NODE_ARTIFACT.is_some()
+        && (crate::managed_agents::buzz_node_bin_dir_override_is_set()
+            || crate::managed_agents::buzz_managed_node_bin_dir().is_some())
 }
 
 pub(super) fn ensure_managed_node_runtime_blocking() -> Result<(), Box<InstallStepResult>> {
+    match crate::managed_agents::buzz_node_bin_dir_override() {
+        Err(error) => return Err(Box::new(configured_node_failed_step(error))),
+        Ok(Some(_)) => {
+            return active_node_runtime_result()
+                .map_err(|error| Box::new(configured_node_failed_step(error)));
+        }
+        Ok(None) => {}
+    }
+
     if managed_node_runtime_ready() {
         return Ok(());
     }
@@ -288,13 +423,11 @@ pub(super) fn ensure_managed_node_runtime_blocking() -> Result<(), Box<InstallSt
 
     install_managed_node_runtime(&root, artifact)
         .map_err(|err| Box::new(managed_node_failed_step(err)))?;
-    if managed_node_runtime_ready() {
-        Ok(())
-    } else {
-        Err(Box::new(managed_node_failed_step(
-            "managed Node.js runtime did not pass readiness after install".to_string(),
+    active_node_runtime_result().map_err(|error| {
+        Box::new(managed_node_readiness_failed_step(format!(
+            "managed Node.js runtime did not pass readiness after install: {error}"
         )))
-    }
+    })
 }
 
 fn install_managed_node_runtime(

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
@@ -52,6 +52,80 @@ fn test_shell_quote_escapes_single_quotes() {
     );
 }
 
+fn write_executable(path: &std::path::Path) {
+    std::fs::write(path, b"").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn valid_node_bin_dir() -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().unwrap();
+    #[cfg(windows)]
+    for command in ["node.exe", "npm.cmd", "npm"] {
+        write_executable(&dir.path().join(command));
+    }
+    #[cfg(not(windows))]
+    for command in ["node", "npm"] {
+        write_executable(&dir.path().join(command));
+    }
+    dir
+}
+
+#[test]
+fn test_validate_node_bin_dir_requires_absolute_executable_node_and_npm() {
+    let valid = valid_node_bin_dir();
+    assert_eq!(
+        crate::managed_agents::validate_node_bin_dir(valid.path()).unwrap(),
+        valid.path()
+    );
+
+    let relative =
+        crate::managed_agents::validate_node_bin_dir(std::path::Path::new("node/bin")).unwrap_err();
+    assert!(relative.contains("absolute path"), "error: {relative}");
+
+    let missing = tempfile::TempDir::new().unwrap();
+    #[cfg(windows)]
+    write_executable(&missing.path().join("node.exe"));
+    #[cfg(not(windows))]
+    write_executable(&missing.path().join("node"));
+    let missing_npm = crate::managed_agents::validate_node_bin_dir(missing.path()).unwrap_err();
+    assert!(missing_npm.contains("npm"), "error: {missing_npm}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_validate_node_bin_dir_rejects_non_executable_node() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = valid_node_bin_dir();
+    let node = dir.path().join("node");
+    std::fs::set_permissions(&node, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let error = crate::managed_agents::validate_node_bin_dir(dir.path()).unwrap_err();
+    assert!(error.contains("executable node"), "error: {error}");
+}
+
+#[test]
+fn test_node_version_policies_keep_download_exact_and_allow_node_24_override() {
+    assert!(managed_node_version_supported("v24.18.0"));
+    assert!(!managed_node_version_supported("v24.19.0"));
+
+    for version in ["v24.5.0", "v24.18.0", "v24.19.0"] {
+        assert!(
+            override_node_version_supported(version),
+            "override must accept {version}"
+        );
+    }
+    for version in ["v23.19.0", "v25.0.0", "24.19.0", "v24.19", "v24.19.0-rc1"] {
+        assert!(
+            !override_node_version_supported(version),
+            "override must reject {version}"
+        );
+    }
+}
+
 // ── zip validation tests ──────────────────────────────────────────────────────
 
 /// Build an in-memory zip archive with the supplied entry names and return
@@ -290,7 +364,7 @@ fn test_probe_node_descendant_holds_stdout_returns_promptly_and_kills_group() {
     // Line 2: background the sleep and record its PID.
     // Line 3: emit the expected version and exit so the direct child exits promptly.
     let script_content = format!(
-        "#!/bin/sh\necho $$ > {pgid_file_path}\n/bin/sleep 60 &\necho $! > {desc_pid_file_path}\necho v24.18.0\nexit 0\n"
+        "#!/bin/sh\necho $$ > {pgid_file_path}\nsleep 60 &\necho $! > {desc_pid_file_path}\necho v24.18.0\nexit 0\n"
     );
     std::fs::write(&script, script_content.as_bytes()).unwrap();
     std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -363,7 +437,7 @@ fn test_probe_node_times_out_on_hung_binary() {
     use std::os::unix::fs::PermissionsExt;
     let tmp_dir = tempfile::TempDir::new().unwrap();
     let script = tmp_dir.path().join("hung.sh");
-    std::fs::write(&script, b"#!/bin/sh\n/bin/sleep 30\n").unwrap();
+    std::fs::write(&script, b"#!/bin/sh\nsleep 30\n").unwrap();
     std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     let probe_timeout = std::time::Duration::from_secs(3);
@@ -403,6 +477,25 @@ fn test_probe_node_returns_false_on_nonzero_exit() {
         !result,
         "probe_node must return false when the process exits non-zero"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_probe_node_result_reports_exit_status_and_stderr() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("stub-ld.sh");
+    std::fs::write(
+        &script,
+        b"#!/bin/sh\necho 'NixOS cannot run dynamically linked executables' >&2\nexit 127\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let error = probe_node_result(&script, std::time::Duration::from_secs(3)).unwrap_err();
+    assert!(error.contains("127"), "error: {error}");
+    assert!(error.contains("NixOS cannot run"), "error: {error}");
 }
 
 /// Scenario 4 — wrong version output: probe_node must return false when stdout

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
@@ -126,6 +126,13 @@ fn test_node_version_policies_keep_download_exact_and_allow_node_24_override() {
     }
 }
 
+#[test]
+fn test_packager_override_does_not_require_managed_artifact() {
+    assert!(node_runtime_supported(false, true, false));
+    assert!(node_runtime_supported(true, false, true));
+    assert!(!node_runtime_supported(false, false, false));
+}
+
 // ── zip validation tests ──────────────────────────────────────────────────────
 
 /// Build an in-memory zip archive with the supplied entry names and return

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use crate::managed_agents::{
     buzz_managed_command_path, buzz_managed_node_bin_dir, buzz_managed_npm_bin_dir,
-    AcpAvailabilityStatus, AcpRuntimeCatalogEntry, AuthStatus, CommandAvailabilityInfo,
-    HarnessSource,
+    buzz_node_bin_dir_override_is_set, AcpAvailabilityStatus, AcpRuntimeCatalogEntry, AuthStatus,
+    CommandAvailabilityInfo, HarnessSource,
 };
 mod auth_status_cache;
 mod bounded_command;
@@ -1143,13 +1143,14 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime, force: bool) -
         | AcpAvailabilityStatus::NotInstalled => runtime.cli_install_instructions_url,
     };
 
-    // node_required now means Buzz cannot provide npm for this platform.
-    // On supported desktop platforms, Buzz downloads a private Node/npm
-    // runtime into app data before running npm-backed adapter installs.
+    // node_required means Buzz cannot provide npm for this platform. A
+    // configured override is handled by the install flow so invalid values can
+    // surface their specific error instead of an unrelated nodejs.org link.
     let node_required = matches!(
         availability,
         AcpAvailabilityStatus::AdapterMissing | AcpAvailabilityStatus::NotInstalled
     ) && runtime_needs_npm(runtime)
+        && !buzz_node_bin_dir_override_is_set()
         && buzz_managed_node_bin_dir().is_none()
         && resolve("npm").is_none()
         && resolve("node").is_none();

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1143,9 +1143,8 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime, force: bool) -
         | AcpAvailabilityStatus::NotInstalled => runtime.cli_install_instructions_url,
     };
 
-    // node_required means Buzz cannot provide npm for this platform. A
-    // configured override is handled by the install flow so invalid values can
-    // surface their specific error instead of an unrelated nodejs.org link.
+    // A configured override stays in the install flow so invalid values surface
+    // their specific error instead of an unrelated nodejs.org link.
     let node_required = matches!(
         availability,
         AcpAvailabilityStatus::AdapterMissing | AcpAvailabilityStatus::NotInstalled

--- a/desktop/src-tauri/src/managed_agents/managed_node_paths.rs
+++ b/desktop/src-tauri/src/managed_agents/managed_node_paths.rs
@@ -1,4 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Absolute directory containing a packager-supplied Node.js runtime.
+///
+/// Setting this bypasses Buzz's SHA-pinned Node.js download, so it must only
+/// point to a trusted directory containing both `node` and `npm`.
+pub(crate) const BUZZ_NODE_BIN_DIR_ENV: &str = "BUZZ_NODE_BIN_DIR";
 
 pub(crate) fn buzz_managed_npm_prefix() -> Option<PathBuf> {
     dirs::data_dir().map(|dir| dir.join("Buzz").join("node-tools"))
@@ -10,7 +16,7 @@ pub(crate) fn buzz_managed_node_root() -> Option<PathBuf> {
     dirs::data_dir().map(|dir| dir.join("Buzz").join("runtimes").join("node"))
 }
 
-pub(crate) fn buzz_managed_node_bin_dir() -> Option<PathBuf> {
+fn default_managed_node_bin_dir() -> Option<PathBuf> {
     let (platform, bin_subdir): (&str, Option<&str>) =
         match (std::env::consts::OS, std::env::consts::ARCH) {
             ("macos", "aarch64") => ("darwin-arm64", Some("bin")),
@@ -29,6 +35,53 @@ pub(crate) fn buzz_managed_node_bin_dir() -> Option<PathBuf> {
             None => dir,
         }
     })
+}
+
+pub(crate) fn validate_node_bin_dir(dir: &Path) -> Result<PathBuf, String> {
+    if !dir.is_absolute() {
+        return Err(format!("{BUZZ_NODE_BIN_DIR_ENV} must be an absolute path"));
+    }
+    if !dir.is_dir() {
+        return Err(format!(
+            "{BUZZ_NODE_BIN_DIR_ENV} is not a directory: {}",
+            dir.display()
+        ));
+    }
+
+    #[cfg(windows)]
+    let required = ["node.exe", "npm.cmd", "npm"];
+    #[cfg(not(windows))]
+    let required = ["node", "npm"];
+
+    for command in required {
+        let path = dir.join(command);
+        if !is_executable_file(&path) {
+            return Err(format!(
+                "{BUZZ_NODE_BIN_DIR_ENV} must contain an executable {command}: {}",
+                path.display()
+            ));
+        }
+    }
+
+    Ok(dir.to_path_buf())
+}
+
+pub(crate) fn buzz_node_bin_dir_override() -> Result<Option<PathBuf>, String> {
+    std::env::var_os(BUZZ_NODE_BIN_DIR_ENV)
+        .map(|value| validate_node_bin_dir(Path::new(&value)))
+        .transpose()
+}
+
+pub(crate) fn buzz_node_bin_dir_override_is_set() -> bool {
+    std::env::var_os(BUZZ_NODE_BIN_DIR_ENV).is_some()
+}
+
+pub(crate) fn buzz_managed_node_bin_dir() -> Option<PathBuf> {
+    match buzz_node_bin_dir_override() {
+        Ok(Some(dir)) => Some(dir),
+        Ok(None) => default_managed_node_bin_dir(),
+        Err(_) => None,
+    }
 }
 
 pub(crate) fn buzz_managed_node_bin_path() -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

- Add an opt-in `BUZZ_NODE_BIN_DIR` for packager-supplied Node.js 24 runtimes.
- Keep the SHA-pinned managed runtime and its exact version check unchanged when the variable is unset.
- Fail closed on invalid overrides and include process stderr in readiness errors, including NixOS stub-ld exit 127.
- Keep npm installs in Buzz's writable private prefix and reuse the existing `PATH` composition.

This gives NixOS packages a narrow integration point without requiring the host-wide `programs.nix-ld` compatibility loader. Behavior remains unchanged when the variable is unset.

### Related issue

Fixes #7152. Related to #2604. Packaging work in #3734 and #6924 can use the new setting.

### Testing

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_node -- --nocapture` (29 passed)
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --workspace` (3,033 library tests passed, 18 ignored as documented; CSP, terminal, integration, and doc tests passed)
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- Built a complete NixOS 26.11 x86_64 system candidate with `programs.nix-ld.enable = false`. The package wrapper contains `BUZZ_NODE_BIN_DIR=/nix/store/...-nodejs-24.19.0/bin`, and the Buzz package installation checks passed. The candidate was not activated.

AI assistance: GPT-5.6-sol assisted with implementation and review. Sebastian Friedrich reviewed the complete diff and test results and takes responsibility for the change.
