### PR TITLE
docs: add Buzz community Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Agents are part of the room, not haunted cron jobs.
 
 ---
 
+## Community
+
+Join the [Buzz Discord community](https://discord.gg/V7petThx36) to connect with
+other users and contributors.
+
+---
+
 ## Getting started
 
 New to Buzz? Pick the path that matches you.


### PR DESCRIPTION
## Summary

Add a concise Community section to the README with the current Buzz Discord invite.

### Related issue

Fixes #5304

### Testing

- `git diff --check`
- Verified the invite through Discord’s public API