### PR TITLE
feat(desktop): add Agentation design experiment

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -61,6 +61,7 @@
     "@tiptap/pm": "^3.22.3",
     "@tiptap/react": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",
+    "agentation": "3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",

--- a/desktop/public/AGENTATION_LICENSE.txt
+++ b/desktop/public/AGENTATION_LICENSE.txt
@@ -1,0 +1,27 @@
+PolyForm Shield License 1.0.0
+
+Copyright (c) 2026 Benji Taylor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to use,
+copy, modify, and distribute the Software, subject to the following conditions:
+
+1. You may not use the Software to provide a product or service that competes
+   with the Software or any product or service offered by the Licensor that
+   includes the Software.
+
+2. You may not remove or obscure any licensing, copyright, or other notices
+   included in the Software.
+
+3. If you distribute the Software or any derivative works, you must include a
+   copy of this license.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For more information, see https://polyformproject.org/licenses/shield/1.0.0

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -67,6 +67,7 @@ import { useArchiveAgentMetricsBridge } from "@/features/local-archive/useArchiv
 import { useObserverArchiveReconciliation } from "@/features/local-archive/useObserverArchiveSeed";
 import { useAgentMetricArchiveSeed } from "@/features/local-archive/useAgentMetricArchiveSeed";
 import { useProfileQuery } from "@/features/profile/hooks";
+import { AgentationExperimentRoot } from "@/features/agentation/AgentationExperimentRoot";
 import { SendFeedbackController } from "@/features/settings/ui/SendFeedbackController";
 import {
   DEFAULT_SETTINGS_SECTION,
@@ -982,6 +983,7 @@ export function AppShell() {
                     }}
                     relayUrl={communitiesHook.activeCommunity?.relayUrl}
                   />
+                  <AgentationExperimentRoot />
                   <SendFeedbackController
                     onOpenChange={setIsSendFeedbackOpen}
                     open={isSendFeedbackOpen}

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -67,7 +67,7 @@ import { useArchiveAgentMetricsBridge } from "@/features/local-archive/useArchiv
 import { useObserverArchiveReconciliation } from "@/features/local-archive/useObserverArchiveSeed";
 import { useAgentMetricArchiveSeed } from "@/features/local-archive/useAgentMetricArchiveSeed";
 import { useProfileQuery } from "@/features/profile/hooks";
-import { AgentationExperimentRoot } from "@/features/agentation/AgentationExperimentRoot";
+import { AgentationExperimentGate } from "@/features/agentation/AgentationExperimentGate";
 import { SendFeedbackController } from "@/features/settings/ui/SendFeedbackController";
 import {
   DEFAULT_SETTINGS_SECTION,
@@ -983,7 +983,7 @@ export function AppShell() {
                     }}
                     relayUrl={communitiesHook.activeCommunity?.relayUrl}
                   />
-                  <AgentationExperimentRoot />
+                  <AgentationExperimentGate />
                   <SendFeedbackController
                     onOpenChange={setIsSendFeedbackOpen}
                     open={isSendFeedbackOpen}

--- a/desktop/src/features/agentation/Agentation.production.test.mjs
+++ b/desktop/src/features/agentation/Agentation.production.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM(
+  "<!doctype html><html><head></head><body></body></html>",
+  {
+    url: "http://localhost/channel/test",
+  },
+);
+Object.assign(globalThis, {
+  cancelAnimationFrame: (id) => dom.window.clearTimeout(id),
+  document: dom.window.document,
+  Element: dom.window.Element,
+  HTMLElement: dom.window.HTMLElement,
+  localStorage: dom.window.localStorage,
+  Node: dom.window.Node,
+  requestAnimationFrame: (callback) =>
+    dom.window.setTimeout(() => callback(Date.now()), 0),
+  window: dom.window,
+});
+dom.window.matchMedia = () => ({
+  matches: false,
+  addEventListener() {},
+  removeEventListener() {},
+});
+dom.window.requestAnimationFrame = (callback) =>
+  dom.window.setTimeout(() => callback(Date.now()), 0);
+dom.window.cancelAnimationFrame = (id) => dom.window.clearTimeout(id);
+
+after(() => dom.window.close());
+
+test("patched production Agentation renders with a storage scope", async () => {
+  const { createElement } = await import("react");
+  const { render, waitFor } = await import("@testing-library/react");
+  const { Agentation } = await import("agentation");
+
+  const rendered = render(
+    createElement(Agentation, {
+      copyToClipboard: false,
+      storageScope: "relay.example:pubkey",
+    }),
+  );
+
+  await waitFor(
+    () => assert.ok(document.querySelector("[data-agentation-toolbar]")),
+    { timeout: 5_000 },
+  );
+  rendered.unmount();
+});

--- a/desktop/src/features/agentation/Agentation.production.test.mjs
+++ b/desktop/src/features/agentation/Agentation.production.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { after, test } from "node:test";
+import { after, beforeEach, test } from "node:test";
 import { JSDOM } from "jsdom";
 
 const dom = new JSDOM(
@@ -28,6 +28,11 @@ dom.window.requestAnimationFrame = (callback) =>
   dom.window.setTimeout(() => callback(Date.now()), 0);
 dom.window.cancelAnimationFrame = (id) => dom.window.clearTimeout(id);
 
+beforeEach(() => {
+  localStorage.clear();
+  document.body.innerHTML = "";
+});
+
 after(() => dom.window.close());
 
 test("patched production Agentation renders with a storage scope", async () => {
@@ -45,6 +50,129 @@ test("patched production Agentation renders with a storage scope", async () => {
   await waitFor(
     () => assert.ok(document.querySelector("[data-agentation-toolbar]")),
     { timeout: 5_000 },
+  );
+  rendered.unmount();
+});
+
+test("production Send and S shortcut follow explicit destination eligibility", async () => {
+  const { createElement } = await import("react");
+  const { fireEvent, render, waitFor } = await import("@testing-library/react");
+  const { Agentation } = await import("agentation");
+  const target = document.createElement("div");
+  target.id = "eligibility-target";
+  target.textContent = "Target";
+  document.body.append(target);
+  let submissions = 0;
+  const props = {
+    copyToClipboard: false,
+    demoAnnotations: [{ selector: "#eligibility-target", comment: "Fix it" }],
+    demoDelay: 250,
+    enableDemoMode: true,
+    onSubmit: async () => {
+      submissions += 1;
+      return { ok: false };
+    },
+    storageScope: "eligibility-scope",
+  };
+  const rendered = render(
+    createElement(Agentation, { ...props, submitEnabled: false }),
+  );
+  const send = await waitFor(() => {
+    const candidate = document.querySelector("[data-agentation-send]");
+    assert.ok(candidate);
+    assert.equal(candidate.disabled, true);
+    return candidate;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  fireEvent.click(send);
+  const invalidShortcut = new dom.window.KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "s",
+  });
+  document.dispatchEvent(invalidShortcut);
+  assert.equal(invalidShortcut.defaultPrevented, false);
+  assert.equal(submissions, 0);
+
+  rendered.rerender(
+    createElement(Agentation, { ...props, submitEnabled: true }),
+  );
+  await waitFor(() => assert.equal(send.disabled, false));
+  const validShortcut = new dom.window.KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "s",
+  });
+  document.dispatchEvent(validShortcut);
+  assert.equal(validShortcut.defaultPrevented, true);
+  await waitFor(() => assert.equal(submissions, 1));
+  rendered.unmount();
+});
+
+test("accepted submit clears its snapshot but preserves annotations added in flight", async () => {
+  const { createElement } = await import("react");
+  const { fireEvent, render, waitFor } = await import("@testing-library/react");
+  const { Agentation } = await import("agentation");
+  const target = document.createElement("div");
+  target.id = "deferred-target";
+  target.textContent = "Deferred";
+  document.body.append(target);
+  let resolveSubmit;
+  const cleared = [];
+  const rendered = render(
+    createElement(Agentation, {
+      copyToClipboard: false,
+      demoAnnotations: [
+        { selector: "#deferred-target", comment: "A" },
+        { selector: "#deferred-target", comment: "B" },
+      ],
+      demoDelay: 250,
+      enableDemoMode: true,
+      onAnnotationsClear: (batch) => cleared.push(batch),
+      onSubmit: () =>
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        }),
+      storageScope: "deferred-scope",
+      submitEnabled: true,
+    }),
+  );
+  const send = await waitFor(
+    () => {
+      const candidate = document.querySelector("[data-agentation-send]");
+      assert.ok(candidate);
+      assert.equal(candidate.disabled, false);
+      assert.equal(candidate.textContent?.includes("1"), true);
+      return candidate;
+    },
+    { timeout: 2_000 },
+  );
+  fireEvent.click(send);
+  await waitFor(
+    () => {
+      const scoped = JSON.parse(
+        localStorage.getItem(
+          "feedback-annotations-/buzz/deferred-scope/channel/test",
+        ) ?? "[]",
+      );
+      assert.equal(scoped.length, 2);
+    },
+    { timeout: 2_000 },
+  );
+  resolveSubmit({ ok: true });
+  await waitFor(() => assert.equal(cleared.length, 1), { timeout: 2_000 });
+  assert.deepEqual(
+    cleared[0].map((annotation) => annotation.comment),
+    ["A"],
+  );
+  const scoped = JSON.parse(
+    localStorage.getItem(
+      "feedback-annotations-/buzz/deferred-scope/channel/test",
+    ) ?? "[]",
+  );
+  assert.deepEqual(
+    scoped.map((annotation) => annotation.comment),
+    ["B"],
   );
   rendered.unmount();
 });

--- a/desktop/src/features/agentation/Agentation.production.test.mjs
+++ b/desktop/src/features/agentation/Agentation.production.test.mjs
@@ -109,6 +109,91 @@ test("production Send and S shortcut follow explicit destination eligibility", a
   rendered.unmount();
 });
 
+test("ambiguous retry clears only the accepted annotation version", async () => {
+  const { createElement } = await import("react");
+  const { fireEvent, render, waitFor } = await import("@testing-library/react");
+  const { Agentation } = await import("agentation");
+  const target = document.createElement("div");
+  target.id = "retry-edit-target";
+  target.textContent = "Retry edit";
+  document.body.append(target);
+  document.elementFromPoint = () => target;
+  let retainedBatch;
+  let attempts = 0;
+  const rendered = render(
+    createElement(Agentation, {
+      copyToClipboard: false,
+      demoAnnotations: [
+        { selector: "#retry-edit-target", comment: "Original A" },
+      ],
+      demoDelay: 250,
+      enableDemoMode: true,
+      onSubmit: async (_output, batch) => {
+        attempts += 1;
+        retainedBatch ??= batch;
+        return attempts === 1
+          ? { ok: false }
+          : { ok: true, acceptedAnnotations: retainedBatch };
+      },
+      storageScope: "retry-edit-scope",
+      submitEnabled: true,
+    }),
+  );
+  const send = await waitFor(() => {
+    const candidate = document.querySelector("[data-agentation-send]");
+    assert.ok(candidate);
+    assert.equal(candidate.disabled, false);
+    return candidate;
+  });
+  fireEvent.click(send);
+  await waitFor(() => assert.equal(attempts, 1));
+
+  const marker = await waitFor(() => {
+    const candidate = document.querySelector("[data-annotation-marker]");
+    assert.ok(candidate);
+    return candidate;
+  });
+  fireEvent.click(marker);
+  const editor = await waitFor(() => {
+    const candidate = document.querySelector(
+      'textarea[placeholder="Edit your feedback..."]',
+    );
+    assert.ok(candidate);
+    return candidate;
+  });
+  fireEvent.change(editor, { target: { value: "Edited A" } });
+  const save = await waitFor(() => {
+    const candidate = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Save",
+    );
+    assert.ok(candidate);
+    return candidate;
+  });
+  fireEvent.click(save);
+  await waitFor(() => {
+    const scoped = JSON.parse(
+      localStorage.getItem(
+        "feedback-annotations-/buzz/retry-edit-scope/channel/test",
+      ) ?? "[]",
+    );
+    assert.equal(scoped[0]?.comment, "Edited A");
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 2_600));
+  fireEvent.click(send);
+  await waitFor(() => assert.equal(attempts, 2));
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  const scoped = JSON.parse(
+    localStorage.getItem(
+      "feedback-annotations-/buzz/retry-edit-scope/channel/test",
+    ) ?? "[]",
+  );
+  assert.equal(scoped.length, 1);
+  assert.equal(scoped[0].id, retainedBatch[0].id);
+  assert.equal(scoped[0].comment, "Edited A");
+  rendered.unmount();
+});
+
 test("accepted submit clears its snapshot but preserves annotations added in flight", async () => {
   const { createElement } = await import("react");
   const { fireEvent, render, waitFor } = await import("@testing-library/react");

--- a/desktop/src/features/agentation/AgentationDestinationFields.tsx
+++ b/desktop/src/features/agentation/AgentationDestinationFields.tsx
@@ -1,0 +1,97 @@
+import type { Channel, RelayAgent } from "@/shared/api/types";
+import type { AgentationDestination } from "./agentationDestination";
+import {
+  eligibleAgentationAgents,
+  eligibleAgentationChannels,
+} from "./agentationDestination";
+
+type Props = {
+  agents: readonly RelayAgent[];
+  channels: readonly Channel[];
+  currentPubkey?: string;
+  destination: AgentationDestination | null;
+  onChange: (destination: AgentationDestination | null) => void;
+};
+
+export function AgentationDestinationFields({
+  agents,
+  channels,
+  currentPubkey,
+  destination,
+  onChange,
+}: Props) {
+  const eligibleChannels = eligibleAgentationChannels(channels);
+  const channel = eligibleChannels.find(
+    (candidate) => candidate.id === destination?.channelId,
+  );
+  const eligibleAgents = eligibleAgentationAgents(
+    channel,
+    agents,
+    currentPubkey,
+  );
+
+  return (
+    <div className="grid w-full gap-3 sm:grid-cols-2">
+      <label className="grid gap-1.5 text-xs font-medium">
+        Send to channel
+        <select
+          className="h-9 w-full rounded-lg border border-input/40 bg-background px-3 text-sm"
+          onChange={(event) =>
+            onChange(
+              event.target.value
+                ? { channelId: event.target.value, agentPubkey: "" }
+                : null,
+            )
+          }
+          value={channel?.id ?? ""}
+        >
+          <option value="">Choose a channel</option>
+          {eligibleChannels.map((candidate) => (
+            <option key={candidate.id} value={candidate.id}>
+              #{candidate.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="grid gap-1.5 text-xs font-medium">
+        Address agent
+        <select
+          className="h-9 w-full rounded-lg border border-input/40 bg-background px-3 text-sm disabled:opacity-50"
+          disabled={!channel}
+          onChange={(event) =>
+            onChange(
+              channel && event.target.value
+                ? { channelId: channel.id, agentPubkey: event.target.value }
+                : channel
+                  ? { channelId: channel.id, agentPubkey: "" }
+                  : null,
+            )
+          }
+          value={
+            eligibleAgents.some(
+              (candidate) => candidate.pubkey === destination?.agentPubkey,
+            )
+              ? destination?.agentPubkey
+              : ""
+          }
+        >
+          <option value="">
+            {channel && eligibleAgents.length === 0
+              ? "No addressable agents"
+              : "Choose an agent"}
+          </option>
+          {eligibleAgents.map((agent) => (
+            <option key={agent.pubkey} value={agent.pubkey}>
+              {agent.name}
+            </option>
+          ))}
+        </select>
+        {channel && eligibleAgents.length === 0 ? (
+          <span className="font-normal text-muted-foreground">
+            Add an agent to this channel before routing annotations.
+          </span>
+        ) : null}
+      </label>
+    </div>
+  );
+}

--- a/desktop/src/features/agentation/AgentationExperimentGate.tsx
+++ b/desktop/src/features/agentation/AgentationExperimentGate.tsx
@@ -1,0 +1,19 @@
+import { lazy, Suspense } from "react";
+import { useFeatureEnabled } from "@/shared/features";
+
+const LazyAgentationExperiment = lazy(() =>
+  import("./AgentationExperimentRoot").then((module) => ({
+    default: module.AgentationExperimentRoot,
+  })),
+);
+
+/** Keeps the third-party Agentation bundle entirely out of the disabled path. */
+export function AgentationExperimentGate() {
+  const enabled = useFeatureEnabled("agentationDesign");
+  if (!enabled) return null;
+  return (
+    <Suspense fallback={null}>
+      <LazyAgentationExperiment />
+    </Suspense>
+  );
+}

--- a/desktop/src/features/agentation/AgentationExperimentRoot.boundaries.test.mjs
+++ b/desktop/src/features/agentation/AgentationExperimentRoot.boundaries.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(
+  new URL("./AgentationExperimentRoot.tsx", import.meta.url),
+  "utf8",
+);
+
+test("scope changes remount the stateful submission owner, not only Agentation", () => {
+  assert.match(
+    source,
+    /<ScopedAgentationExperimentRoot\s+key=\{storageScope\}/,
+  );
+  const scopedOwner = source.indexOf("function ScopedAgentationExperimentRoot");
+  for (const stateName of [
+    "inFlight",
+    "batchSubmission",
+    "setStatus",
+    "setAnnotations",
+  ]) {
+    assert.ok(
+      source.indexOf(stateName) > scopedOwner,
+      `${stateName} must be scope-owned`,
+    );
+  }
+});
+
+test("retained ambiguous event owns retry destination and accepted annotation ids", () => {
+  assert.match(source, /const retainedSubmission = batchSubmission\.current/);
+  assert.match(source, /submitDestination = retainedSubmission/);
+  assert.match(source, /retained\?\.event\.content \?\?/);
+  assert.match(source, /acceptedAnnotationIds:/);
+  assert.match(source, /retained\?\.annotationIds \?\?/);
+});

--- a/desktop/src/features/agentation/AgentationExperimentRoot.boundaries.test.mjs
+++ b/desktop/src/features/agentation/AgentationExperimentRoot.boundaries.test.mjs
@@ -26,10 +26,14 @@ test("scope changes remount the stateful submission owner, not only Agentation",
   }
 });
 
-test("retained ambiguous event owns retry destination and accepted annotation ids", () => {
+test("retained ambiguous event owns retry destination and accepted annotation snapshots", () => {
   assert.match(source, /const retainedSubmission = batchSubmission\.current/);
   assert.match(source, /submitDestination = retainedSubmission/);
   assert.match(source, /retained\?\.event\.content \?\?/);
-  assert.match(source, /acceptedAnnotationIds:/);
-  assert.match(source, /retained\?\.annotationIds \?\?/);
+  assert.match(source, /acceptedAnnotations,/);
+  assert.match(source, /retained\?\.annotations \?\? batch/);
+  assert.match(
+    source,
+    /JSON\.stringify\(accepted\) === JSON\.stringify\(annotation\)/,
+  );
 });

--- a/desktop/src/features/agentation/AgentationExperimentRoot.tsx
+++ b/desktop/src/features/agentation/AgentationExperimentRoot.tsx
@@ -7,7 +7,8 @@ import { useChannelsQuery } from "@/features/channels/hooks";
 import { useCommunities } from "@/features/communities/useCommunities";
 import { useSendMessageMutation } from "@/features/messages/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
-import { useFeatureEnabled } from "@/shared/features";
+import { createRelayMessageEvent } from "@/shared/api/relayMessageEvent";
+import type { RelayEvent } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
 import { AgentationDestinationFields } from "./AgentationDestinationFields";
 import {
@@ -15,6 +16,16 @@ import {
   resolveAgentationDestination,
 } from "./agentationDestination";
 import { useAgentationDestination } from "./agentationStore";
+import {
+  clearRetainedAgentationSubmission,
+  readRetainedAgentationSubmission,
+  retainAgentationSubmission,
+} from "./agentationSubmissionStore";
+import {
+  agentationScope,
+  emitAgentationPendingChange,
+  readAgentationAnnotations,
+} from "./agentationPendingStore";
 
 type Status =
   | { type: "idle" }
@@ -27,12 +38,6 @@ type Status =
     };
 
 export function AgentationExperimentRoot() {
-  const enabled = useFeatureEnabled("agentationDesign");
-  if (!enabled) return null;
-  return <EnabledAgentationExperiment />;
-}
-
-function EnabledAgentationExperiment() {
   const identity = useIdentityQuery();
   const { activeCommunity } = useCommunities();
   const channelsQuery = useChannelsQuery();
@@ -41,7 +46,13 @@ function EnabledAgentationExperiment() {
     activeCommunity?.relayUrl,
     identity.data?.pubkey,
   );
-  const [annotations, setAnnotations] = React.useState<Annotation[]>([]);
+  const storageScope = agentationScope(
+    activeCommunity?.relayUrl,
+    identity.data?.pubkey,
+  );
+  const [annotations, setAnnotations] = React.useState<Annotation[]>(
+    () => readAgentationAnnotations(storageScope) as Annotation[],
+  );
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const [status, setStatus] = React.useState<Status>({ type: "idle" });
   const { goChannel } = useAppNavigation();
@@ -53,7 +64,18 @@ function EnabledAgentationExperiment() {
   const batchSubmission = React.useRef<{
     fingerprint: string;
     submissionId: string;
-  } | null>(null);
+    event: RelayEvent;
+  } | null>(readRetainedAgentationSubmission(storageScope));
+  React.useEffect(() => {
+    setAnnotations(readAgentationAnnotations(storageScope) as Annotation[]);
+    setStatus({ type: "idle" });
+    batchSubmission.current = readRetainedAgentationSubmission(storageScope);
+  }, [storageScope]);
+
+  React.useEffect(() => {
+    emitAgentationPendingChange(annotations.length);
+  }, [annotations]);
+
   const resolved = resolveAgentationDestination(
     destination,
     channelsQuery.data ?? [],
@@ -80,21 +102,37 @@ function EnabledAgentationExperiment() {
       }
       const channel = current.channel;
       const agent = current.agent;
-      const fingerprint = batch
-        .map((annotation) => annotation.id)
-        .sort()
-        .join(":");
-      const submissionId =
+      const fingerprint = [
+        channel.id,
+        agent.pubkey,
+        output,
+        ...batch.map((annotation) => annotation.id).sort(),
+      ].join(":");
+      const retained =
         batchSubmission.current?.fingerprint === fingerprint
-          ? batchSubmission.current.submissionId
-          : crypto.randomUUID();
-      batchSubmission.current = { fingerprint, submissionId };
-      const promise = send
-        .mutateAsync({
-          targetChannel: channel,
-          content: formatAgentationMessage(agent.name, output, submissionId),
-          mentionPubkeys: [agent.pubkey],
-        })
+          ? batchSubmission.current
+          : null;
+      const submissionId = retained?.submissionId ?? crypto.randomUUID();
+      const content = formatAgentationMessage(agent.name, output, submissionId);
+      const prepare = retained
+        ? Promise.resolve(retained.event)
+        : createRelayMessageEvent(channel.id, content, [agent.pubkey]).then(
+            (event) => {
+              const submission = { fingerprint, submissionId, event };
+              batchSubmission.current = submission;
+              retainAgentationSubmission(storageScope, submission);
+              return event;
+            },
+          );
+      const promise = prepare
+        .then((signedEvent) =>
+          send.mutateAsync({
+            targetChannel: channel,
+            content,
+            mentionPubkeys: [agent.pubkey],
+            signedEvent,
+          }),
+        )
         .then((event) => {
           setStatus({
             type: "sent",
@@ -103,6 +141,7 @@ function EnabledAgentationExperiment() {
             channelName: channel.name,
           });
           batchSubmission.current = null;
+          clearRetainedAgentationSubmission(storageScope);
           setAnnotations((existing) => {
             const accepted = new Set(batch.map((annotation) => annotation.id));
             return existing.filter(
@@ -127,14 +166,22 @@ function EnabledAgentationExperiment() {
       inFlight.current = promise;
       return promise;
     },
-    [agentsQuery.data, channelsQuery.data, destination, identity.data, send],
+    [
+      agentsQuery.data,
+      channelsQuery.data,
+      destination,
+      identity.data,
+      send,
+      storageScope,
+    ],
   );
 
   return (
     <>
       <Agentation
         copyToClipboard={false}
-        storageScope={`${activeCommunity?.relayUrl ?? "no-community"}:${identity.data?.pubkey ?? "no-identity"}`}
+        key={storageScope}
+        storageScope={storageScope}
         onAnnotationAdd={(annotation) =>
           setAnnotations((current) => [...current, annotation])
         }

--- a/desktop/src/features/agentation/AgentationExperimentRoot.tsx
+++ b/desktop/src/features/agentation/AgentationExperimentRoot.tsx
@@ -40,13 +40,28 @@ type Status =
 export function AgentationExperimentRoot() {
   const identity = useIdentityQuery();
   const { activeCommunity } = useCommunities();
-  const channelsQuery = useChannelsQuery();
-  const agentsQuery = useRelayAgentsQuery();
-  const [destination, setDestination] = useAgentationDestination(
+  const storageScope = agentationScope(
     activeCommunity?.relayUrl,
     identity.data?.pubkey,
   );
-  const storageScope = agentationScope(
+  return (
+    <ScopedAgentationExperimentRoot
+      key={storageScope}
+      storageScope={storageScope}
+    />
+  );
+}
+
+function ScopedAgentationExperimentRoot({
+  storageScope,
+}: {
+  storageScope: string;
+}) {
+  const identity = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
+  const channelsQuery = useChannelsQuery();
+  const agentsQuery = useRelayAgentsQuery();
+  const [destination, setDestination] = useAgentationDestination(
     activeCommunity?.relayUrl,
     identity.data?.pubkey,
   );
@@ -60,24 +75,28 @@ export function AgentationExperimentRoot() {
   const inFlight = React.useRef<Promise<{
     ok: boolean;
     eventId?: string;
+    acceptedAnnotationIds?: string[];
   }> | null>(null);
   const batchSubmission = React.useRef<{
     fingerprint: string;
     submissionId: string;
+    annotationIds: string[];
+    channelId: string;
+    agentPubkey: string;
     event: RelayEvent;
   } | null>(readRetainedAgentationSubmission(storageScope));
-  React.useEffect(() => {
-    setAnnotations(readAgentationAnnotations(storageScope) as Annotation[]);
-    setStatus({ type: "idle" });
-    batchSubmission.current = readRetainedAgentationSubmission(storageScope);
-  }, [storageScope]);
-
   React.useEffect(() => {
     emitAgentationPendingChange(annotations.length);
   }, [annotations]);
 
+  const retainedDestination = batchSubmission.current
+    ? {
+        channelId: batchSubmission.current.channelId,
+        agentPubkey: batchSubmission.current.agentPubkey,
+      }
+    : null;
   const resolved = resolveAgentationDestination(
-    destination,
+    retainedDestination ?? destination,
     channelsQuery.data ?? [],
     agentsQuery.data ?? [],
     identity.data?.pubkey,
@@ -86,8 +105,15 @@ export function AgentationExperimentRoot() {
   const submit = React.useCallback(
     (output: string, batch: Annotation[]) => {
       if (inFlight.current) return inFlight.current;
+      const retainedSubmission = batchSubmission.current;
+      const submitDestination = retainedSubmission
+        ? {
+            channelId: retainedSubmission.channelId,
+            agentPubkey: retainedSubmission.agentPubkey,
+          }
+        : destination;
       const current = resolveAgentationDestination(
-        destination,
+        submitDestination,
         channelsQuery.data ?? [],
         agentsQuery.data ?? [],
         identity.data?.pubkey,
@@ -108,17 +134,23 @@ export function AgentationExperimentRoot() {
         output,
         ...batch.map((annotation) => annotation.id).sort(),
       ].join(":");
-      const retained =
-        batchSubmission.current?.fingerprint === fingerprint
-          ? batchSubmission.current
-          : null;
+      const retained = retainedSubmission;
       const submissionId = retained?.submissionId ?? crypto.randomUUID();
-      const content = formatAgentationMessage(agent.name, output, submissionId);
+      const content =
+        retained?.event.content ??
+        formatAgentationMessage(agent.name, output, submissionId);
       const prepare = retained
         ? Promise.resolve(retained.event)
         : createRelayMessageEvent(channel.id, content, [agent.pubkey]).then(
             (event) => {
-              const submission = { fingerprint, submissionId, event };
+              const submission = {
+                fingerprint,
+                submissionId,
+                annotationIds: batch.map((annotation) => annotation.id),
+                channelId: channel.id,
+                agentPubkey: agent.pubkey,
+                event,
+              };
               batchSubmission.current = submission;
               retainAgentationSubmission(storageScope, submission);
               return event;
@@ -143,12 +175,21 @@ export function AgentationExperimentRoot() {
           batchSubmission.current = null;
           clearRetainedAgentationSubmission(storageScope);
           setAnnotations((existing) => {
-            const accepted = new Set(batch.map((annotation) => annotation.id));
+            const accepted = new Set(
+              retained?.annotationIds ??
+                batch.map((annotation) => annotation.id),
+            );
             return existing.filter(
               (annotation) => !accepted.has(annotation.id),
             );
           });
-          return { ok: true, eventId: event.id };
+          return {
+            ok: true,
+            eventId: event.id,
+            acceptedAnnotationIds:
+              retained?.annotationIds ??
+              batch.map((annotation) => annotation.id),
+          };
         })
         .catch((error: unknown) => {
           setStatus({
@@ -197,8 +238,16 @@ export function AgentationExperimentRoot() {
             ),
           )
         }
-        onAnnotationsClear={() => setAnnotations([])}
+        onAnnotationsClear={(cleared) => {
+          const clearedIds = new Set(
+            cleared.map((annotation) => annotation.id),
+          );
+          setAnnotations((current) =>
+            current.filter((annotation) => !clearedIds.has(annotation.id)),
+          );
+        }}
         onSubmit={submit}
+        submitEnabled={resolved.valid}
       />
       <aside
         className="fixed bottom-20 right-4 z-2147483646 w-[min(25rem,calc(100vw-2rem))] rounded-xl border border-border/70 bg-background/95 p-3 shadow-xl backdrop-blur"

--- a/desktop/src/features/agentation/AgentationExperimentRoot.tsx
+++ b/desktop/src/features/agentation/AgentationExperimentRoot.tsx
@@ -1,0 +1,222 @@
+import { Agentation, type Annotation } from "agentation";
+import { AlertCircle, Check, Settings2 } from "lucide-react";
+import * as React from "react";
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useRelayAgentsQuery } from "@/features/agents/hooks";
+import { useChannelsQuery } from "@/features/channels/hooks";
+import { useCommunities } from "@/features/communities/useCommunities";
+import { useSendMessageMutation } from "@/features/messages/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { useFeatureEnabled } from "@/shared/features";
+import { Button } from "@/shared/ui/button";
+import { AgentationDestinationFields } from "./AgentationDestinationFields";
+import {
+  formatAgentationMessage,
+  resolveAgentationDestination,
+} from "./agentationDestination";
+import { useAgentationDestination } from "./agentationStore";
+
+type Status =
+  | { type: "idle" }
+  | { type: "error"; message: string }
+  | {
+      type: "sent";
+      eventId: string;
+      channelId: string;
+      channelName: string;
+    };
+
+export function AgentationExperimentRoot() {
+  const enabled = useFeatureEnabled("agentationDesign");
+  if (!enabled) return null;
+  return <EnabledAgentationExperiment />;
+}
+
+function EnabledAgentationExperiment() {
+  const identity = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
+  const channelsQuery = useChannelsQuery();
+  const agentsQuery = useRelayAgentsQuery();
+  const [destination, setDestination] = useAgentationDestination(
+    activeCommunity?.relayUrl,
+    identity.data?.pubkey,
+  );
+  const [annotations, setAnnotations] = React.useState<Annotation[]>([]);
+  const [pickerOpen, setPickerOpen] = React.useState(false);
+  const [status, setStatus] = React.useState<Status>({ type: "idle" });
+  const { goChannel } = useAppNavigation();
+  const send = useSendMessageMutation(null, identity.data);
+  const inFlight = React.useRef<Promise<{
+    ok: boolean;
+    eventId?: string;
+  }> | null>(null);
+  const batchSubmission = React.useRef<{
+    fingerprint: string;
+    submissionId: string;
+  } | null>(null);
+  const resolved = resolveAgentationDestination(
+    destination,
+    channelsQuery.data ?? [],
+    agentsQuery.data ?? [],
+    identity.data?.pubkey,
+  );
+
+  const submit = React.useCallback(
+    (output: string, batch: Annotation[]) => {
+      if (inFlight.current) return inFlight.current;
+      const current = resolveAgentationDestination(
+        destination,
+        channelsQuery.data ?? [],
+        agentsQuery.data ?? [],
+        identity.data?.pubkey,
+      );
+      if (!current.valid || !current.channel || !current.agent) {
+        setPickerOpen(true);
+        setStatus({
+          type: "error",
+          message: "Choose a valid channel and agent before sending.",
+        });
+        return Promise.resolve({ ok: false });
+      }
+      const channel = current.channel;
+      const agent = current.agent;
+      const fingerprint = batch
+        .map((annotation) => annotation.id)
+        .sort()
+        .join(":");
+      const submissionId =
+        batchSubmission.current?.fingerprint === fingerprint
+          ? batchSubmission.current.submissionId
+          : crypto.randomUUID();
+      batchSubmission.current = { fingerprint, submissionId };
+      const promise = send
+        .mutateAsync({
+          targetChannel: channel,
+          content: formatAgentationMessage(agent.name, output, submissionId),
+          mentionPubkeys: [agent.pubkey],
+        })
+        .then((event) => {
+          setStatus({
+            type: "sent",
+            eventId: event.id,
+            channelId: channel.id,
+            channelName: channel.name,
+          });
+          batchSubmission.current = null;
+          setAnnotations((existing) => {
+            const accepted = new Set(batch.map((annotation) => annotation.id));
+            return existing.filter(
+              (annotation) => !accepted.has(annotation.id),
+            );
+          });
+          return { ok: true, eventId: event.id };
+        })
+        .catch((error: unknown) => {
+          setStatus({
+            type: "error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "The annotations could not be sent.",
+          });
+          return { ok: false };
+        })
+        .finally(() => {
+          inFlight.current = null;
+        });
+      inFlight.current = promise;
+      return promise;
+    },
+    [agentsQuery.data, channelsQuery.data, destination, identity.data, send],
+  );
+
+  return (
+    <>
+      <Agentation
+        copyToClipboard={false}
+        storageScope={`${activeCommunity?.relayUrl ?? "no-community"}:${identity.data?.pubkey ?? "no-identity"}`}
+        onAnnotationAdd={(annotation) =>
+          setAnnotations((current) => [...current, annotation])
+        }
+        onAnnotationDelete={(annotation) =>
+          setAnnotations((current) =>
+            current.filter((candidate) => candidate.id !== annotation.id),
+          )
+        }
+        onAnnotationUpdate={(annotation) =>
+          setAnnotations((current) =>
+            current.map((candidate) =>
+              candidate.id === annotation.id ? annotation : candidate,
+            ),
+          )
+        }
+        onAnnotationsClear={() => setAnnotations([])}
+        onSubmit={submit}
+      />
+      <aside
+        className="fixed bottom-20 right-4 z-2147483646 w-[min(25rem,calc(100vw-2rem))] rounded-xl border border-border/70 bg-background/95 p-3 shadow-xl backdrop-blur"
+        data-agentation-buzz-shell
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">
+              {resolved.valid
+                ? `#${resolved.channel?.name} → ${resolved.agent?.name}`
+                : "Choose a channel and agent to send"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {annotations.length} pending annotation
+              {annotations.length === 1 ? "" : "s"}
+            </p>
+          </div>
+          <Button
+            aria-expanded={pickerOpen}
+            aria-label="Choose Agentation destination"
+            onClick={() => setPickerOpen((open) => !open)}
+            size="icon"
+            variant="outline"
+          >
+            <Settings2 />
+          </Button>
+        </div>
+        {pickerOpen ? (
+          <div className="mt-3 border-t border-border/60 pt-3">
+            <AgentationDestinationFields
+              agents={agentsQuery.data ?? []}
+              channels={channelsQuery.data ?? []}
+              currentPubkey={identity.data?.pubkey}
+              destination={destination}
+              onChange={setDestination}
+            />
+          </div>
+        ) : null}
+        {status.type !== "idle" ? (
+          <p
+            aria-live="polite"
+            className={`mt-2 flex items-start gap-1.5 text-xs ${status.type === "error" ? "text-destructive" : "text-emerald-600"}`}
+          >
+            {status.type === "error" ? <AlertCircle /> : <Check />}
+            {status.type === "error" ? (
+              status.message
+            ) : (
+              <>
+                Sent to #{status.channelName}.{" "}
+                <button
+                  className="underline underline-offset-2"
+                  onClick={() =>
+                    void goChannel(status.channelId, {
+                      messageId: status.eventId,
+                    })
+                  }
+                  type="button"
+                >
+                  View message
+                </button>
+              </>
+            )}
+          </p>
+        ) : null}
+      </aside>
+    </>
+  );
+}

--- a/desktop/src/features/agentation/AgentationExperimentRoot.tsx
+++ b/desktop/src/features/agentation/AgentationExperimentRoot.tsx
@@ -75,12 +75,12 @@ function ScopedAgentationExperimentRoot({
   const inFlight = React.useRef<Promise<{
     ok: boolean;
     eventId?: string;
-    acceptedAnnotationIds?: string[];
+    acceptedAnnotations?: Annotation[];
   }> | null>(null);
   const batchSubmission = React.useRef<{
     fingerprint: string;
     submissionId: string;
-    annotationIds: string[];
+    annotations: Annotation[];
     channelId: string;
     agentPubkey: string;
     event: RelayEvent;
@@ -146,7 +146,7 @@ function ScopedAgentationExperimentRoot({
               const submission = {
                 fingerprint,
                 submissionId,
-                annotationIds: batch.map((annotation) => annotation.id),
+                annotations: batch,
                 channelId: channel.id,
                 agentPubkey: agent.pubkey,
                 event,
@@ -174,21 +174,21 @@ function ScopedAgentationExperimentRoot({
           });
           batchSubmission.current = null;
           clearRetainedAgentationSubmission(storageScope);
-          setAnnotations((existing) => {
-            const accepted = new Set(
-              retained?.annotationIds ??
-                batch.map((annotation) => annotation.id),
-            );
-            return existing.filter(
-              (annotation) => !accepted.has(annotation.id),
-            );
-          });
+          const acceptedAnnotations = retained?.annotations ?? batch;
+          setAnnotations((existing) =>
+            existing.filter(
+              (annotation) =>
+                !acceptedAnnotations.some(
+                  (accepted) =>
+                    accepted.id === annotation.id &&
+                    JSON.stringify(accepted) === JSON.stringify(annotation),
+                ),
+            ),
+          );
           return {
             ok: true,
             eventId: event.id,
-            acceptedAnnotationIds:
-              retained?.annotationIds ??
-              batch.map((annotation) => annotation.id),
+            acceptedAnnotations,
           };
         })
         .catch((error: unknown) => {
@@ -239,11 +239,15 @@ function ScopedAgentationExperimentRoot({
           )
         }
         onAnnotationsClear={(cleared) => {
-          const clearedIds = new Set(
-            cleared.map((annotation) => annotation.id),
-          );
           setAnnotations((current) =>
-            current.filter((annotation) => !clearedIds.has(annotation.id)),
+            current.filter(
+              (annotation) =>
+                !cleared.some(
+                  (accepted) =>
+                    accepted.id === annotation.id &&
+                    JSON.stringify(accepted) === JSON.stringify(annotation),
+                ),
+            ),
           );
         }}
         onSubmit={submit}

--- a/desktop/src/features/agentation/AgentationSettings.tsx
+++ b/desktop/src/features/agentation/AgentationSettings.tsx
@@ -1,0 +1,36 @@
+import { useRelayAgentsQuery } from "@/features/agents/hooks";
+import { useChannelsQuery } from "@/features/channels/hooks";
+import { useCommunities } from "@/features/communities/useCommunities";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { AgentationDestinationFields } from "./AgentationDestinationFields";
+import { useAgentationDestination } from "./agentationStore";
+
+export function AgentationSettings() {
+  const identity = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
+  const channels = useChannelsQuery();
+  const agents = useRelayAgentsQuery();
+  const [destination, setDestination] = useAgentationDestination(
+    activeCommunity?.relayUrl,
+    identity.data?.pubkey,
+  );
+  return (
+    <div className="w-full space-y-3 py-1">
+      <p className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span aria-hidden className="h-2 w-2 rounded-full bg-emerald-500" />
+        Ready on this computer
+      </p>
+      <AgentationDestinationFields
+        agents={agents.data ?? []}
+        channels={channels.data ?? []}
+        currentPubkey={identity.data?.pubkey}
+        destination={destination}
+        onChange={setDestination}
+      />
+      <p className="text-xs text-muted-foreground">
+        Annotations can include visible text from the screen. Nothing is sent
+        until you choose Send.
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/features/agentation/agentationDestination.test.mjs
+++ b/desktop/src/features/agentation/agentationDestination.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  eligibleAgentationAgents,
+  eligibleAgentationChannels,
+  formatAgentationMessage,
+  resolveAgentationDestination,
+} from "./agentationDestination.ts";
+
+const channel = (overrides = {}) => ({
+  id: "channel-1",
+  name: "design",
+  channelType: "stream",
+  visibility: "open",
+  description: "",
+  topic: null,
+  purpose: null,
+  memberCount: 2,
+  memberPubkeys: ["human", "agent"],
+  lastMessageAt: null,
+  archivedAt: null,
+  participants: [],
+  participantPubkeys: [],
+  isMember: true,
+  ttlSeconds: null,
+  ttlDeadline: null,
+  ...overrides,
+});
+const agent = (overrides = {}) => ({
+  pubkey: "agent",
+  ownerPubkey: "human",
+  name: "designbot",
+  agentType: "managed",
+  channels: ["design"],
+  channelIds: ["channel-1"],
+  capabilities: [],
+  status: "online",
+  respondTo: "owner-only",
+  respondToAllowlist: [],
+  ...overrides,
+});
+
+test("channel eligibility is stream-only, joined, and unarchived", () => {
+  const eligible = eligibleAgentationChannels([
+    channel(),
+    channel({ id: "forum", channelType: "forum" }),
+    channel({ id: "dm", channelType: "dm" }),
+    channel({ id: "left", isMember: false }),
+    channel({ id: "archived", archivedAt: "now" }),
+  ]);
+  assert.deepEqual(
+    eligible.map(({ id }) => id),
+    ["channel-1"],
+  );
+});
+
+test("agent eligibility requires membership, channel scope, and access", () => {
+  assert.deepEqual(
+    eligibleAgentationAgents(channel(), [agent()], "human").map(
+      ({ pubkey }) => pubkey,
+    ),
+    ["agent"],
+  );
+  assert.equal(
+    eligibleAgentationAgents(channel(), [agent()], "stranger").length,
+    0,
+  );
+  assert.equal(
+    eligibleAgentationAgents(
+      channel({ memberPubkeys: ["human"] }),
+      [agent()],
+      "human",
+    ).length,
+    0,
+  );
+});
+
+test("destination is revalidated against current channel and agent data", () => {
+  assert.equal(
+    resolveAgentationDestination(
+      { channelId: "channel-1", agentPubkey: "agent" },
+      [channel()],
+      [agent()],
+      "human",
+    ).valid,
+    true,
+  );
+  assert.equal(
+    resolveAgentationDestination(
+      { channelId: "channel-1", agentPubkey: "agent" },
+      [channel({ archivedAt: "now" })],
+      [agent()],
+      "human",
+    ).valid,
+    false,
+  );
+});
+
+test("message visibly addresses the agent and carries a stable submission id", () => {
+  assert.equal(
+    formatAgentationMessage(
+      "designbot",
+      "## Feedback\nDo this",
+      "submission-1",
+    ),
+    "@designbot Design feedback from Agentation:\n\n## Feedback\nDo this\n\n<!-- agentation-submission:submission-1 -->",
+  );
+});

--- a/desktop/src/features/agentation/agentationDestination.ts
+++ b/desktop/src/features/agentation/agentationDestination.ts
@@ -1,0 +1,70 @@
+import type { Channel, RelayAgent } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+export type AgentationDestination = {
+  channelId: string;
+  agentPubkey: string;
+};
+
+export function eligibleAgentationChannels(channels: readonly Channel[]) {
+  return channels.filter(
+    (channel) =>
+      channel.channelType === "stream" &&
+      channel.isMember &&
+      channel.archivedAt === null,
+  );
+}
+
+export function eligibleAgentationAgents(
+  channel: Channel | undefined,
+  agents: readonly RelayAgent[],
+  currentPubkey: string | undefined,
+) {
+  if (!channel) return [];
+  const members = new Set(channel.memberPubkeys.map(normalizePubkey));
+  const viewer = currentPubkey ? normalizePubkey(currentPubkey) : null;
+  return agents.filter((agent) => {
+    const agentPubkey = normalizePubkey(agent.pubkey);
+    if (!members.has(agentPubkey) || !agent.channelIds.includes(channel.id)) {
+      return false;
+    }
+    if (agent.respondTo === "anyone") return true;
+    if (agent.respondTo === "owner-only") {
+      return Boolean(
+        viewer &&
+          agent.ownerPubkey &&
+          normalizePubkey(agent.ownerPubkey) === viewer,
+      );
+    }
+    return Boolean(
+      viewer &&
+        agent.respondTo === "allowlist" &&
+        agent.respondToAllowlist.map(normalizePubkey).includes(viewer),
+    );
+  });
+}
+
+export function resolveAgentationDestination(
+  destination: AgentationDestination | null,
+  channels: readonly Channel[],
+  agents: readonly RelayAgent[],
+  currentPubkey: string | undefined,
+) {
+  const channel = eligibleAgentationChannels(channels).find(
+    (candidate) => candidate.id === destination?.channelId,
+  );
+  const agent = eligibleAgentationAgents(channel, agents, currentPubkey).find(
+    (candidate) =>
+      normalizePubkey(candidate.pubkey) ===
+      normalizePubkey(destination?.agentPubkey ?? ""),
+  );
+  return { channel, agent, valid: Boolean(channel && agent) };
+}
+
+export function formatAgentationMessage(
+  agentName: string,
+  output: string,
+  submissionId: string,
+) {
+  return `@${agentName} Design feedback from Agentation:\n\n${output.trim()}\n\n<!-- agentation-submission:${submissionId} -->`;
+}

--- a/desktop/src/features/agentation/agentationOffboarding.test.mjs
+++ b/desktop/src/features/agentation/agentationOffboarding.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import { JSDOM } from "jsdom";
+import { agentationPathname } from "./agentationPendingStore.ts";
+import {
+  discardAgentationPendingBundle,
+  readAgentationPendingBundle,
+} from "./agentationOffboarding.ts";
+import { retainAgentationSubmission } from "./agentationSubmissionStore.ts";
+
+const dom = new JSDOM("<!doctype html>", { url: "http://localhost/one" });
+Object.assign(globalThis, {
+  Event: dom.window.Event,
+  localStorage: dom.window.localStorage,
+  window: dom.window,
+});
+const event = {
+  id: "stable-event",
+  pubkey: "alice",
+  created_at: 1,
+  kind: 9,
+  tags: [["h", "channel"]],
+  content: "sensitive feedback",
+  sig: "signature",
+};
+
+beforeEach(() => localStorage.clear());
+
+test("export bundle includes retained signed payload and discard clears both stores", () => {
+  const scope = "scope";
+  localStorage.setItem(
+    `feedback-annotations-${agentationPathname(scope)}`,
+    JSON.stringify([{ id: "annotation-a" }]),
+  );
+  retainAgentationSubmission(scope, {
+    fingerprint: "batch",
+    submissionId: "submission",
+    annotationIds: ["annotation-a"],
+    channelId: "channel",
+    agentPubkey: "agent",
+    event,
+  });
+  const bundle = readAgentationPendingBundle(scope);
+  assert.deepEqual(bundle.annotations, [{ id: "annotation-a" }]);
+  assert.equal(bundle.retainedSubmission?.event.content, "sensitive feedback");
+  discardAgentationPendingBundle(scope);
+  assert.deepEqual(readAgentationPendingBundle(scope), {
+    annotations: [],
+    retainedSubmission: null,
+  });
+});

--- a/desktop/src/features/agentation/agentationOffboarding.test.mjs
+++ b/desktop/src/features/agentation/agentationOffboarding.test.mjs
@@ -35,7 +35,7 @@ test("export bundle includes retained signed payload and discard clears both sto
   retainAgentationSubmission(scope, {
     fingerprint: "batch",
     submissionId: "submission",
-    annotationIds: ["annotation-a"],
+    annotations: [{ id: "annotation-a", comment: "original" }],
     channelId: "channel",
     agentPubkey: "agent",
     event,

--- a/desktop/src/features/agentation/agentationOffboarding.ts
+++ b/desktop/src/features/agentation/agentationOffboarding.ts
@@ -1,0 +1,20 @@
+import {
+  clearAllAgentationAnnotations,
+  readAllAgentationAnnotations,
+} from "./agentationPendingStore";
+import {
+  clearRetainedAgentationSubmission,
+  readRetainedAgentationSubmission,
+} from "./agentationSubmissionStore";
+
+export function readAgentationPendingBundle(scope: string) {
+  return {
+    annotations: readAllAgentationAnnotations(scope),
+    retainedSubmission: readRetainedAgentationSubmission(scope),
+  };
+}
+
+export function discardAgentationPendingBundle(scope: string) {
+  clearAllAgentationAnnotations(scope);
+  clearRetainedAgentationSubmission(scope);
+}

--- a/desktop/src/features/agentation/agentationPendingStore.test.mjs
+++ b/desktop/src/features/agentation/agentationPendingStore.test.mjs
@@ -51,3 +51,18 @@ test("discard clears every route in only the selected scope", () => {
   assert.deepEqual(readAllAgentationAnnotations(scope), []);
   assert.equal(readAllAgentationAnnotations("other").length, 1);
 });
+
+test("scope prefix boundaries prevent read and clear collisions", () => {
+  const scope = "alice";
+  const collidingScope = "alice-extra";
+  localStorage.setItem(
+    `feedback-annotations-${agentationPathname(collidingScope, "/one")}`,
+    JSON.stringify([{ id: "other-scope" }]),
+  );
+
+  assert.deepEqual(readAllAgentationAnnotations(scope), []);
+  clearAllAgentationAnnotations(scope);
+  assert.deepEqual(readAllAgentationAnnotations(collidingScope), [
+    { id: "other-scope" },
+  ]);
+});

--- a/desktop/src/features/agentation/agentationPendingStore.test.mjs
+++ b/desktop/src/features/agentation/agentationPendingStore.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import { JSDOM } from "jsdom";
+import {
+  agentationPathname,
+  clearAllAgentationAnnotations,
+  readAgentationAnnotations,
+  readAllAgentationAnnotations,
+} from "./agentationPendingStore.ts";
+
+const dom = new JSDOM("<!doctype html>", { url: "http://localhost/one" });
+Object.assign(globalThis, {
+  Event: dom.window.Event,
+  localStorage: dom.window.localStorage,
+  window: dom.window,
+});
+
+beforeEach(() => localStorage.clear());
+
+test("pending reads stay inside one identity/community scope", () => {
+  const first = "wss://one:alice";
+  const second = "wss://two:bob";
+  localStorage.setItem(
+    `feedback-annotations-${agentationPathname(first, "/one")}`,
+    JSON.stringify([{ id: "first" }]),
+  );
+  localStorage.setItem(
+    `feedback-annotations-${agentationPathname(second, "/one")}`,
+    JSON.stringify([{ id: "second" }]),
+  );
+
+  assert.deepEqual(readAgentationAnnotations(first), [{ id: "first" }]);
+  assert.deepEqual(readAllAgentationAnnotations(first), [{ id: "first" }]);
+});
+
+test("discard clears every route in only the selected scope", () => {
+  const scope = "wss://one:alice";
+  for (const pathname of ["/one", "/two"]) {
+    localStorage.setItem(
+      `feedback-annotations-${agentationPathname(scope, pathname)}`,
+      JSON.stringify([{ id: pathname }]),
+    );
+  }
+  localStorage.setItem(
+    `feedback-annotations-${agentationPathname("other", "/one")}`,
+    JSON.stringify([{ id: "other" }]),
+  );
+
+  clearAllAgentationAnnotations(scope);
+
+  assert.deepEqual(readAllAgentationAnnotations(scope), []);
+  assert.equal(readAllAgentationAnnotations("other").length, 1);
+});

--- a/desktop/src/features/agentation/agentationPendingStore.ts
+++ b/desktop/src/features/agentation/agentationPendingStore.ts
@@ -13,7 +13,7 @@ export function agentationPathname(
 }
 
 function scopeStoragePrefix(scope: string) {
-  return `${STORAGE_PREFIX}/buzz/${encodeURIComponent(scope)}`;
+  return `${STORAGE_PREFIX}/buzz/${encodeURIComponent(scope)}/`;
 }
 
 export function readAgentationAnnotations(scope: string): unknown[] {

--- a/desktop/src/features/agentation/agentationPendingStore.ts
+++ b/desktop/src/features/agentation/agentationPendingStore.ts
@@ -1,0 +1,60 @@
+const STORAGE_PREFIX = "feedback-annotations-";
+export const AGENTATION_PENDING_CHANGE = "buzz-agentation-pending-change";
+
+export function agentationScope(relayUrl?: string, pubkey?: string) {
+  return `${relayUrl ?? "no-community"}:${pubkey ?? "no-identity"}`;
+}
+
+export function agentationPathname(
+  scope: string,
+  pathname = window.location.pathname,
+) {
+  return `/buzz/${encodeURIComponent(scope)}${pathname}`;
+}
+
+function scopeStoragePrefix(scope: string) {
+  return `${STORAGE_PREFIX}/buzz/${encodeURIComponent(scope)}`;
+}
+
+export function readAgentationAnnotations(scope: string): unknown[] {
+  try {
+    const raw = localStorage.getItem(
+      `${STORAGE_PREFIX}${agentationPathname(scope)}`,
+    );
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function readAllAgentationAnnotations(scope: string): unknown[] {
+  const found: unknown[] = [];
+  try {
+    const prefix = scopeStoragePrefix(scope);
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (!key?.startsWith(prefix)) continue;
+      const parsed: unknown = JSON.parse(localStorage.getItem(key) ?? "[]");
+      if (Array.isArray(parsed)) found.push(...parsed);
+    }
+  } catch {
+    return found;
+  }
+  return found;
+}
+
+export function clearAllAgentationAnnotations(scope: string) {
+  const keys: string[] = [];
+  const prefix = scopeStoragePrefix(scope);
+  for (let index = 0; index < localStorage.length; index += 1) {
+    const key = localStorage.key(index);
+    if (key?.startsWith(prefix)) keys.push(key);
+  }
+  for (const key of keys) localStorage.removeItem(key);
+  window.dispatchEvent(new Event(AGENTATION_PENDING_CHANGE));
+}
+
+export function emitAgentationPendingChange(_pendingCount?: number) {
+  window.dispatchEvent(new Event(AGENTATION_PENDING_CHANGE));
+}

--- a/desktop/src/features/agentation/agentationStore.ts
+++ b/desktop/src/features/agentation/agentationStore.ts
@@ -1,0 +1,75 @@
+import * as React from "react";
+import type { AgentationDestination } from "./agentationDestination";
+
+const EVENT = "buzz-agentation-destination-change";
+
+function key(relayUrl: string, pubkey: string) {
+  return `buzz:agentation:v1:${relayUrl}:${pubkey.toLowerCase()}`;
+}
+
+export function readAgentationDestination(
+  relayUrl: string,
+  pubkey: string,
+): AgentationDestination | null {
+  try {
+    const raw = localStorage.getItem(key(relayUrl, pubkey));
+    if (!raw) return null;
+    const value = JSON.parse(raw) as Partial<AgentationDestination>;
+    return typeof value.channelId === "string" &&
+      typeof value.agentPubkey === "string"
+      ? { channelId: value.channelId, agentPubkey: value.agentPubkey }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeAgentationDestination(
+  relayUrl: string,
+  pubkey: string,
+  destination: AgentationDestination | null,
+) {
+  const storageKey = key(relayUrl, pubkey);
+  if (destination)
+    localStorage.setItem(storageKey, JSON.stringify(destination));
+  else localStorage.removeItem(storageKey);
+  window.dispatchEvent(new CustomEvent(EVENT, { detail: storageKey }));
+}
+
+export function useAgentationDestination(relayUrl?: string, pubkey?: string) {
+  const scopeKey = relayUrl && pubkey ? key(relayUrl, pubkey) : null;
+  const [destination, setDestinationState] =
+    React.useState<AgentationDestination | null>(() =>
+      relayUrl && pubkey ? readAgentationDestination(relayUrl, pubkey) : null,
+    );
+
+  React.useEffect(() => {
+    setDestinationState(
+      relayUrl && pubkey ? readAgentationDestination(relayUrl, pubkey) : null,
+    );
+    if (!scopeKey || !relayUrl || !pubkey) return;
+    const scopedRelayUrl = relayUrl;
+    const scopedPubkey = pubkey;
+    const sync = (event: Event) => {
+      if (event instanceof CustomEvent && event.detail !== scopeKey) return;
+      setDestinationState(
+        readAgentationDestination(scopedRelayUrl, scopedPubkey),
+      );
+    };
+    window.addEventListener(EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, [pubkey, relayUrl, scopeKey]);
+
+  const setDestination = React.useCallback(
+    (next: AgentationDestination | null) => {
+      if (!relayUrl || !pubkey) return;
+      writeAgentationDestination(relayUrl, pubkey, next);
+    },
+    [pubkey, relayUrl],
+  );
+  return [destination, setDestination] as const;
+}

--- a/desktop/src/features/agentation/agentationSubmissionStore.test.mjs
+++ b/desktop/src/features/agentation/agentationSubmissionStore.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import { JSDOM } from "jsdom";
+import {
+  clearRetainedAgentationSubmission,
+  readRetainedAgentationSubmission,
+  retainAgentationSubmission,
+} from "./agentationSubmissionStore.ts";
+
+const dom = new JSDOM("<!doctype html>", { url: "http://localhost" });
+Object.assign(globalThis, { localStorage: dom.window.localStorage });
+const event = {
+  id: "stable-event",
+  pubkey: "alice",
+  created_at: 1,
+  kind: 9,
+  tags: [["h", "channel"]],
+  content: "feedback",
+  sig: "signature",
+};
+
+beforeEach(() => localStorage.clear());
+
+test("an ambiguous submission retains the exact signed event for retry", () => {
+  retainAgentationSubmission("scope", {
+    fingerprint: "batch",
+    submissionId: "submission",
+    event,
+  });
+
+  assert.equal(readRetainedAgentationSubmission("scope")?.event.id, event.id);
+  assert.equal(readRetainedAgentationSubmission("scope")?.event.sig, event.sig);
+  clearRetainedAgentationSubmission("scope");
+  assert.equal(readRetainedAgentationSubmission("scope"), null);
+});

--- a/desktop/src/features/agentation/agentationSubmissionStore.test.mjs
+++ b/desktop/src/features/agentation/agentationSubmissionStore.test.mjs
@@ -25,6 +25,9 @@ test("an ambiguous submission retains the exact signed event for retry", () => {
   retainAgentationSubmission("scope", {
     fingerprint: "batch",
     submissionId: "submission",
+    annotationIds: ["annotation-a"],
+    channelId: "channel",
+    agentPubkey: "agent",
     event,
   });
 

--- a/desktop/src/features/agentation/agentationSubmissionStore.test.mjs
+++ b/desktop/src/features/agentation/agentationSubmissionStore.test.mjs
@@ -25,12 +25,16 @@ test("an ambiguous submission retains the exact signed event for retry", () => {
   retainAgentationSubmission("scope", {
     fingerprint: "batch",
     submissionId: "submission",
-    annotationIds: ["annotation-a"],
+    annotations: [{ id: "annotation-a", comment: "original" }],
     channelId: "channel",
     agentPubkey: "agent",
     event,
   });
 
+  assert.equal(
+    readRetainedAgentationSubmission("scope")?.annotations[0]?.comment,
+    "original",
+  );
   assert.equal(readRetainedAgentationSubmission("scope")?.event.id, event.id);
   assert.equal(readRetainedAgentationSubmission("scope")?.event.sig, event.sig);
   clearRetainedAgentationSubmission("scope");

--- a/desktop/src/features/agentation/agentationSubmissionStore.ts
+++ b/desktop/src/features/agentation/agentationSubmissionStore.ts
@@ -1,0 +1,39 @@
+import type { RelayEvent } from "@/shared/api/types";
+
+export type RetainedAgentationSubmission = {
+  fingerprint: string;
+  submissionId: string;
+  event: RelayEvent;
+};
+
+function key(scope: string) {
+  return `buzz:agentation:submission:v1:${scope}`;
+}
+
+export function readRetainedAgentationSubmission(
+  scope: string,
+): RetainedAgentationSubmission | null {
+  try {
+    const raw = localStorage.getItem(key(scope));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<RetainedAgentationSubmission>;
+    return typeof parsed.fingerprint === "string" &&
+      typeof parsed.submissionId === "string" &&
+      typeof parsed.event?.id === "string"
+      ? (parsed as RetainedAgentationSubmission)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function retainAgentationSubmission(
+  scope: string,
+  submission: RetainedAgentationSubmission,
+) {
+  localStorage.setItem(key(scope), JSON.stringify(submission));
+}
+
+export function clearRetainedAgentationSubmission(scope: string) {
+  localStorage.removeItem(key(scope));
+}

--- a/desktop/src/features/agentation/agentationSubmissionStore.ts
+++ b/desktop/src/features/agentation/agentationSubmissionStore.ts
@@ -3,6 +3,9 @@ import type { RelayEvent } from "@/shared/api/types";
 export type RetainedAgentationSubmission = {
   fingerprint: string;
   submissionId: string;
+  annotationIds: string[];
+  channelId: string;
+  agentPubkey: string;
   event: RelayEvent;
 };
 
@@ -19,6 +22,10 @@ export function readRetainedAgentationSubmission(
     const parsed = JSON.parse(raw) as Partial<RetainedAgentationSubmission>;
     return typeof parsed.fingerprint === "string" &&
       typeof parsed.submissionId === "string" &&
+      Array.isArray(parsed.annotationIds) &&
+      parsed.annotationIds.every((id) => typeof id === "string") &&
+      typeof parsed.channelId === "string" &&
+      typeof parsed.agentPubkey === "string" &&
       typeof parsed.event?.id === "string"
       ? (parsed as RetainedAgentationSubmission)
       : null;

--- a/desktop/src/features/agentation/agentationSubmissionStore.ts
+++ b/desktop/src/features/agentation/agentationSubmissionStore.ts
@@ -1,9 +1,10 @@
+import type { Annotation } from "agentation";
 import type { RelayEvent } from "@/shared/api/types";
 
 export type RetainedAgentationSubmission = {
   fingerprint: string;
   submissionId: string;
-  annotationIds: string[];
+  annotations: Annotation[];
   channelId: string;
   agentPubkey: string;
   event: RelayEvent;
@@ -22,8 +23,13 @@ export function readRetainedAgentationSubmission(
     const parsed = JSON.parse(raw) as Partial<RetainedAgentationSubmission>;
     return typeof parsed.fingerprint === "string" &&
       typeof parsed.submissionId === "string" &&
-      Array.isArray(parsed.annotationIds) &&
-      parsed.annotationIds.every((id) => typeof id === "string") &&
+      Array.isArray(parsed.annotations) &&
+      parsed.annotations.every(
+        (annotation) =>
+          typeof annotation === "object" &&
+          annotation !== null &&
+          typeof annotation.id === "string",
+      ) &&
       typeof parsed.channelId === "string" &&
       typeof parsed.agentPubkey === "string" &&
       typeof parsed.event?.id === "string"

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -493,6 +493,8 @@ export function useSendMessageMutation(
       sentFromThreadRootId?: string | null;
       sentFromThreadRootExcerpt?: string | null;
       transport?: "auto" | "http";
+      /** A caller-retained signed event for idempotent replay after ambiguity. */
+      signedEvent?: RelayEvent;
     },
     MessageQueryContext | undefined
   >({
@@ -507,6 +509,7 @@ export function useSendMessageMutation(
       sentFromThreadRootId,
       sentFromThreadRootExcerpt,
       transport = "auto",
+      signedEvent,
     }) => {
       // Prefer a channel captured by the caller at compose time. Otherwise,
       // resolve a captured id from the shared channel cache so navigation
@@ -645,6 +648,23 @@ export function useSendMessageMutation(
           content: content.trim(),
           sig: "",
         };
+      }
+
+      if (signedEvent) {
+        if (
+          signedEvent.kind !== KIND_STREAM_MESSAGE ||
+          signedEvent.content !== content.trim() ||
+          !signedEvent.tags.some(
+            (tag) => tag[0] === "h" && tag[1] === effectiveChannel.id,
+          )
+        ) {
+          throw new Error("The retained message no longer matches this send.");
+        }
+        return relayClient.publishEvent(
+          signedEvent,
+          "Timed out while sending the message.",
+          "Failed to send the message.",
+        );
       }
 
       return relayClient.sendMessage(

--- a/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
+++ b/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
@@ -1,3 +1,4 @@
+import { AgentationSettings } from "@/features/agentation/AgentationSettings";
 import { setAgentManagedProfiles } from "@/shared/api/tauri";
 import { desktopFeatures, useFeatureToggle } from "@/shared/features";
 import type { FeatureDefinition } from "@/shared/features";
@@ -10,7 +11,7 @@ function FeatureRow({ feature }: { feature: FeatureDefinition }) {
   const switchId = `feature-toggle-${feature.id}`;
 
   return (
-    <SettingsOptionRow>
+    <SettingsOptionRow className="flex-wrap">
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium" id={`${switchId}-label`}>
           {feature.name}
@@ -35,6 +36,9 @@ function FeatureRow({ feature }: { feature: FeatureDefinition }) {
           }
         }}
       />
+      {feature.id === "agentationDesign" && enabled ? (
+        <AgentationSettings />
+      ) : null}
     </SettingsOptionRow>
   );
 }

--- a/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
+++ b/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
@@ -5,9 +5,13 @@ import { useIdentityQuery } from "@/shared/api/hooks";
 import {
   AGENTATION_PENDING_CHANGE,
   agentationScope,
-  clearAllAgentationAnnotations,
   readAllAgentationAnnotations,
 } from "@/features/agentation/agentationPendingStore";
+import {
+  discardAgentationPendingBundle,
+  readAgentationPendingBundle,
+} from "@/features/agentation/agentationOffboarding";
+import { readRetainedAgentationSubmission } from "@/features/agentation/agentationSubmissionStore";
 import { setAgentManagedProfiles } from "@/shared/api/tauri";
 import { desktopFeatures, useFeatureToggle } from "@/shared/features";
 import type { FeatureDefinition } from "@/shared/features";
@@ -92,8 +96,9 @@ function AgentationFeatureRow({ feature }: { feature: FeatureDefinition }) {
   };
 
   const exportPending = () => {
+    const bundle = readAgentationPendingBundle(scope);
     const url = URL.createObjectURL(
-      new Blob([JSON.stringify(pending, null, 2)], {
+      new Blob([JSON.stringify(bundle, null, 2)], {
         type: "application/json",
       }),
     );
@@ -120,7 +125,10 @@ function AgentationFeatureRow({ feature }: { feature: FeatureDefinition }) {
         checked={enabled}
         data-testid={switchId}
         onCheckedChange={(value) => {
-          if (!value && pending.length > 0) {
+          if (
+            !value &&
+            (pending.length > 0 || readRetainedAgentationSubmission(scope))
+          ) {
             setOffboardingOpen(true);
             return;
           }
@@ -148,7 +156,7 @@ function AgentationFeatureRow({ feature }: { feature: FeatureDefinition }) {
             </Button>
             <Button
               onClick={() => {
-                clearAllAgentationAnnotations(scope);
+                discardAgentationPendingBundle(scope);
                 disableAgentation();
               }}
               variant="destructive"

--- a/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
+++ b/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
@@ -1,14 +1,36 @@
+import * as React from "react";
 import { AgentationSettings } from "@/features/agentation/AgentationSettings";
+import { useCommunities } from "@/features/communities/useCommunities";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import {
+  AGENTATION_PENDING_CHANGE,
+  agentationScope,
+  clearAllAgentationAnnotations,
+  readAllAgentationAnnotations,
+} from "@/features/agentation/agentationPendingStore";
 import { setAgentManagedProfiles } from "@/shared/api/tauri";
 import { desktopFeatures, useFeatureToggle } from "@/shared/features";
 import type { FeatureDefinition } from "@/shared/features";
 import { Switch } from "@/shared/ui/switch";
+import { Button } from "@/shared/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
 import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 
 function FeatureRow({ feature }: { feature: FeatureDefinition }) {
   const [enabled, toggle] = useFeatureToggle(feature.id);
   const switchId = `feature-toggle-${feature.id}`;
+  if (feature.id === "agentationDesign") {
+    return <AgentationFeatureRow feature={feature} />;
+  }
 
   return (
     <SettingsOptionRow className="flex-wrap">
@@ -36,9 +58,106 @@ function FeatureRow({ feature }: { feature: FeatureDefinition }) {
           }
         }}
       />
-      {feature.id === "agentationDesign" && enabled ? (
-        <AgentationSettings />
-      ) : null}
+    </SettingsOptionRow>
+  );
+}
+
+function AgentationFeatureRow({ feature }: { feature: FeatureDefinition }) {
+  const [enabled, toggle] = useFeatureToggle(feature.id);
+  const switchId = `feature-toggle-${feature.id}`;
+  const identity = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
+  const scope = agentationScope(
+    activeCommunity?.relayUrl,
+    identity.data?.pubkey,
+  );
+  const [offboardingOpen, setOffboardingOpen] = React.useState(false);
+  const [pending, setPending] = React.useState(() =>
+    readAllAgentationAnnotations(scope),
+  );
+  React.useEffect(() => {
+    const refresh = () => setPending(readAllAgentationAnnotations(scope));
+    refresh();
+    window.addEventListener(AGENTATION_PENDING_CHANGE, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(AGENTATION_PENDING_CHANGE, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, [scope]);
+
+  const disableAgentation = () => {
+    toggle(false);
+    setOffboardingOpen(false);
+  };
+
+  const exportPending = () => {
+    const url = URL.createObjectURL(
+      new Blob([JSON.stringify(pending, null, 2)], {
+        type: "application/json",
+      }),
+    );
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "buzz-agentation-annotations.json";
+    link.click();
+    URL.revokeObjectURL(url);
+    disableAgentation();
+  };
+
+  return (
+    <SettingsOptionRow className="flex-wrap">
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium" id={`${switchId}-label`}>
+          {feature.name}
+        </p>
+        <p className="text-xs text-muted-foreground/70" data-settings-subcopy>
+          {feature.description}
+        </p>
+      </div>
+      <Switch
+        aria-labelledby={`${switchId}-label`}
+        checked={enabled}
+        data-testid={switchId}
+        onCheckedChange={(value) => {
+          if (!value && pending.length > 0) {
+            setOffboardingOpen(true);
+            return;
+          }
+          toggle(value);
+        }}
+      />
+      {enabled ? <AgentationSettings /> : null}
+      <AlertDialog onOpenChange={setOffboardingOpen} open={offboardingOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Turn off Agentation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have {pending.length} pending annotation
+              {pending.length === 1 ? "" : "s"}. Keep them locally for next
+              time, export a JSON copy, or discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button onClick={disableAgentation} variant="outline">
+              Keep locally
+            </Button>
+            <Button onClick={exportPending} variant="outline">
+              Export and turn off
+            </Button>
+            <Button
+              onClick={() => {
+                clearAllAgentationAnnotations(scope);
+                disableAgentation();
+              }}
+              variant="destructive"
+            >
+              Discard and turn off
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </SettingsOptionRow>
   );
 }

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -6,7 +6,6 @@ import {
 } from "@/shared/api/tauri";
 import type { PresenceStatus, RelayEvent } from "@/shared/api/types";
 import {
-  KIND_STREAM_MESSAGE,
   KIND_TYPING_INDICATOR,
   KIND_USER_STATUS,
   CHANNEL_EVENT_KINDS,
@@ -39,6 +38,7 @@ import {
 import { getChannelReconnectRepairEvents } from "@/shared/api/channelReconnectRepair";
 import { replayLiveSubscriptions } from "@/shared/api/relayReconnectReplay";
 import { publishSessionEvent } from "@/shared/api/relayEventPublisher";
+import { createRelayMessageEvent } from "@/shared/api/relayMessageEvent";
 import { activateRateLimitIfSignalled } from "@/shared/api/relayRateLimitGate";
 import {
   fetchChunkedHistory,
@@ -256,20 +256,12 @@ export class RelayClient {
     extraTags: string[][] = [],
   ) {
     await this.ensureConnected();
-
-    const tags: string[][] = [["h", channelId]];
-    for (const pubkey of mentionPubkeys) {
-      tags.push(["p", pubkey]);
-    }
-    for (const tag of extraTags) {
-      tags.push(tag);
-    }
-
-    const event = await signRelayEvent({
-      kind: KIND_STREAM_MESSAGE,
-      content: content.trim(),
-      tags,
-    });
+    const event = await createRelayMessageEvent(
+      channelId,
+      content,
+      mentionPubkeys,
+      extraTags,
+    );
 
     return this.publishEvent(
       event,

--- a/desktop/src/shared/api/relayMessageEvent.ts
+++ b/desktop/src/shared/api/relayMessageEvent.ts
@@ -1,0 +1,20 @@
+import { KIND_STREAM_MESSAGE } from "@/shared/constants/kinds";
+import { signRelayEvent } from "@/shared/api/tauri";
+
+/** Creates the ordinary signed kind-9 event used by message publication. */
+export function createRelayMessageEvent(
+  channelId: string,
+  content: string,
+  mentionPubkeys: string[] = [],
+  extraTags: string[][] = [],
+) {
+  return signRelayEvent({
+    kind: KIND_STREAM_MESSAGE,
+    content: content.trim(),
+    tags: [
+      ["h", channelId],
+      ...mentionPubkeys.map((pubkey) => ["p", pubkey]),
+      ...extraTags,
+    ],
+  });
+}

--- a/patches/agentation@3.0.2.patch
+++ b/patches/agentation@3.0.2.patch
@@ -1,64 +1,73 @@
 diff --git a/dist/index.d.mts b/dist/index.d.mts
-index 74302421cdde73d3b1d58952473adb0d744a2b8c..d2d7292f7c3b75a240d8c4d610fcdd00fa25e5c3 100644
+index 74302421cdde73d3b1d58952473adb0d744a2b8c..cfeddf7977489cd84257cf18980d8b0da0d61cee 100644
 --- a/dist/index.d.mts
 +++ b/dist/index.d.mts
-@@ -101,7 +101,9 @@ type PageFeedbackToolbarCSSProps = {
+@@ -101,7 +101,13 @@ type PageFeedbackToolbarCSSProps = {
      /** Callback fired when the copy button is clicked. Receives the markdown output. */
      onCopy?: (markdown: string) => void;
      /** Callback fired when "Send to Agent" is clicked. Receives the markdown output and annotations. */
 -    onSubmit?: (output: string, annotations: Annotation[]) => void;
-+    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string }>;
++    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string; acceptedAnnotationIds?: string[] }>;
++    /** Whether the current submit destination is valid. */
++    submitEnabled?: boolean;
++    /** Whether the current submit destination is valid. Defaults to callback/webhook availability. */
++    submitEnabled?: boolean;
 +    /** Scope local annotation storage to one signed-in identity/community. */
 +    storageScope?: string;
      /** Whether to copy to clipboard when the copy button is clicked. Defaults to true. */
      copyToClipboard?: boolean;
      /** Server URL for sync (e.g., "http://localhost:4747"). If not provided, uses localStorage only. */
-@@ -117,7 +119,7 @@ type PageFeedbackToolbarCSSProps = {
+@@ -117,7 +123,7 @@ type PageFeedbackToolbarCSSProps = {
  };
  /** Alias for PageFeedbackToolbarCSSProps */
  type AgentationProps = PageFeedbackToolbarCSSProps;
 -declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
-+declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, storageScope, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
++declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, submitEnabled, storageScope, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
 
  interface AnnotationPopupCSSProps {
      /** Element name to display in header */
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 74302421cdde73d3b1d58952473adb0d744a2b8c..d2d7292f7c3b75a240d8c4d610fcdd00fa25e5c3 100644
+index 74302421cdde73d3b1d58952473adb0d744a2b8c..cfeddf7977489cd84257cf18980d8b0da0d61cee 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
-@@ -101,7 +101,9 @@ type PageFeedbackToolbarCSSProps = {
+@@ -101,7 +101,13 @@ type PageFeedbackToolbarCSSProps = {
      /** Callback fired when the copy button is clicked. Receives the markdown output. */
      onCopy?: (markdown: string) => void;
      /** Callback fired when "Send to Agent" is clicked. Receives the markdown output and annotations. */
 -    onSubmit?: (output: string, annotations: Annotation[]) => void;
-+    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string }>;
++    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string; acceptedAnnotationIds?: string[] }>;
++    /** Whether the current submit destination is valid. */
++    submitEnabled?: boolean;
++    /** Whether the current submit destination is valid. Defaults to callback/webhook availability. */
++    submitEnabled?: boolean;
 +    /** Scope local annotation storage to one signed-in identity/community. */
 +    storageScope?: string;
      /** Whether to copy to clipboard when the copy button is clicked. Defaults to true. */
      copyToClipboard?: boolean;
      /** Server URL for sync (e.g., "http://localhost:4747"). If not provided, uses localStorage only. */
-@@ -117,7 +119,7 @@ type PageFeedbackToolbarCSSProps = {
+@@ -117,7 +123,7 @@ type PageFeedbackToolbarCSSProps = {
  };
  /** Alias for PageFeedbackToolbarCSSProps */
  type AgentationProps = PageFeedbackToolbarCSSProps;
 -declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
-+declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, storageScope, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
++declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, submitEnabled, storageScope, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
 
  interface AnnotationPopupCSSProps {
      /** Element name to display in header */
 diff --git a/dist/index.js b/dist/index.js
-index 07036659fc11b8a3c9d300536631056ec3f58297..3a11b0fb0b8cc1011a5e022a3c5dcd21fd8421bf 100644
+index 07036659fc11b8a3c9d300536631056ec3f58297..1dafc5d19d1970120ab2ee3546c7f552769e7b4d 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -8319,6 +8319,7 @@ function PageFeedbackToolbarCSS({
+@@ -8319,6 +8319,8 @@ function PageFeedbackToolbarCSS({
    onAnnotationsClear,
    onCopy,
    onSubmit,
++  submitEnabled,
 +  storageScope,
    copyToClipboard = true,
    endpoint,
    sessionId: initialSessionId,
-@@ -8510,7 +8511,7 @@ function PageFeedbackToolbarCSS({
+@@ -8510,7 +8512,7 @@ function PageFeedbackToolbarCSS({
    const popupRef = (0, import_react8.useRef)(null);
    const editPopupRef = (0, import_react8.useRef)(null);
    const scrollTimeoutRef = (0, import_react8.useRef)(null);
@@ -67,7 +76,20 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..3a11b0fb0b8cc1011a5e022a3c5dcd21
    (0, import_react8.useEffect)(() => {
      if (showSettings) {
        setShowSettingsVisible(true);
-@@ -10483,15 +10484,22 @@ function PageFeedbackToolbarCSS({
+@@ -10439,7 +10441,11 @@ function PageFeedbackToolbarCSS({
+     setCopied(true);
+     originalSetTimeout(() => setCopied(false), 2e3);
+     if (settings.autoClearAfterCopy) {
+-      originalSetTimeout(() => clearAll(), 500);
++      originalSetTimeout(() => {
++        const acceptedIds = new Set(annotations.map((annotation) => annotation.id));
++        setAnnotations((current) => current.filter((annotation) => !acceptedIds.has(annotation.id)));
++        onAnnotationsClear?.(annotations);
++      }, 500);
+     }
+   }, [
+     annotations,
+@@ -10483,16 +10489,32 @@ function PageFeedbackToolbarCSS({
          output += "\n" + rearrangeOutput;
        }
      }
@@ -78,10 +100,15 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..3a11b0fb0b8cc1011a5e022a3c5dcd21
 -    await new Promise((resolve) => originalSetTimeout(resolve, 150));
 -    const success = await fireWebhook("submit", { output, annotations }, true);
 +    let success = false;
++    let acceptedAnnotations = annotations;
 +    try {
 +      if (onSubmit) {
 +        const result = await onSubmit(output, annotations);
 +        success = result.ok;
++        if (result.acceptedAnnotationIds) {
++          const acceptedIds = new Set(result.acceptedAnnotationIds);
++          acceptedAnnotations = annotations.filter((annotation) => acceptedIds.has(annotation.id));
++        }
 +      } else {
 +        await new Promise((resolve) => originalSetTimeout(resolve, 150));
 +        success = await fireWebhook("submit", { output, annotations }, true);
@@ -92,63 +119,72 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..3a11b0fb0b8cc1011a5e022a3c5dcd21
      setSendState(success ? "sent" : "failed");
      originalSetTimeout(() => setSendState("idle"), 2500);
 -    if (success && settings.autoClearAfterCopy) {
+-      originalSetTimeout(() => clearAll(), 500);
 +    if (success) {
-       originalSetTimeout(() => clearAll(), 500);
++      originalSetTimeout(() => {
++        const acceptedIds = new Set(acceptedAnnotations.map((annotation) => annotation.id));
++        setAnnotations((current) => current.filter((annotation) => !acceptedIds.has(annotation.id)));
++        onAnnotationsClear?.(acceptedAnnotations);
++      }, 500);
      }
    }, [
-@@ -10673,8 +10681,8 @@ function PageFeedbackToolbarCSS({
+     onSubmit,
+@@ -10673,8 +10695,8 @@ function PageFeedbackToolbarCSS({
          }
        }
        if (e.key === "s" || e.key === "S") {
 -        const hasValidWebhook = isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
 -        if (annotations.length > 0 && hasValidWebhook && sendState === "idle") {
-+        const hasSubmitTarget = !!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
++        const hasSubmitTarget = submitEnabled ?? (!!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""));
 +        if (annotations.length > 0 && hasSubmitTarget && sendState === "idle") {
            e.preventDefault();
            hideTooltipsUntilMouseLeave();
            sendToWebhook();
-@@ -10694,6 +10702,7 @@ function PageFeedbackToolbarCSS({
+@@ -10694,6 +10716,8 @@ function PageFeedbackToolbarCSS({
      annotations.length,
      settings.webhookUrl,
      webhookUrl,
 +    onSubmit,
++    submitEnabled,
      sendState,
      sendToWebhook,
      toggleFreeze,
-@@ -10883,7 +10892,7 @@ function PageFeedbackToolbarCSS({
+@@ -10883,7 +10907,7 @@ function PageFeedbackToolbarCSS({
                        /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)(
                          "div",
                          {
 -                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles_module_default4.sendButtonVisible : ""}`,
-+                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && (onSubmit || !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) ? styles_module_default4.sendButtonVisible : ""}`,
++                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && ((submitEnabled ?? !!onSubmit) || !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) ? styles_module_default4.sendButtonVisible : ""}`,
                            children: [
                              /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)(
                                "button",
-@@ -10894,9 +10903,9 @@ function PageFeedbackToolbarCSS({
+@@ -10894,9 +10918,10 @@ function PageFeedbackToolbarCSS({
                                    hideTooltipsUntilMouseLeave();
                                    sendToWebhook();
                                  },
 -                                disabled: !hasAnnotations || !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
-+                                disabled: !hasAnnotations || !onSubmit && !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
++                                disabled: !hasAnnotations || !(submitEnabled ?? (!!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) || sendState === "sending",
++                                "data-agentation-send": true,
                                  "data-no-hover": sendState === "sent" || sendState === "failed",
 -                                tabIndex: isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
-+                                tabIndex: onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
++                                tabIndex: submitEnabled ?? (!!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? 0 : -1,
                                  children: [
                                    /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(IconSendArrow, { size: 24, state: sendState }),
                                    hasAnnotations && sendState === "idle" && /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(
 diff --git a/dist/index.mjs b/dist/index.mjs
-index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..b5b6a508b6624f2fe469bef461f69bed9a8d94c5 100644
+index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..44fd920d43b8f6a53f130d1ebf6fb92bb36bbe66 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -8235,6 +8235,7 @@ function PageFeedbackToolbarCSS({
+@@ -8235,6 +8235,8 @@ function PageFeedbackToolbarCSS({
    onAnnotationsClear,
    onCopy,
    onSubmit,
++  submitEnabled,
 +  storageScope,
    copyToClipboard = true,
    endpoint,
    sessionId: initialSessionId,
-@@ -8426,7 +8427,7 @@ function PageFeedbackToolbarCSS({
+@@ -8426,7 +8428,7 @@ function PageFeedbackToolbarCSS({
    const popupRef = useRef6(null);
    const editPopupRef = useRef6(null);
    const scrollTimeoutRef = useRef6(null);
@@ -157,7 +193,20 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..b5b6a508b6624f2fe469bef461f69bed
    useEffect6(() => {
      if (showSettings) {
        setShowSettingsVisible(true);
-@@ -10399,15 +10400,22 @@ function PageFeedbackToolbarCSS({
+@@ -10355,7 +10357,11 @@ function PageFeedbackToolbarCSS({
+     setCopied(true);
+     originalSetTimeout(() => setCopied(false), 2e3);
+     if (settings.autoClearAfterCopy) {
+-      originalSetTimeout(() => clearAll(), 500);
++      originalSetTimeout(() => {
++        const acceptedIds = new Set(annotations.map((annotation) => annotation.id));
++        setAnnotations((current) => current.filter((annotation) => !acceptedIds.has(annotation.id)));
++        onAnnotationsClear?.(annotations);
++      }, 500);
+     }
+   }, [
+     annotations,
+@@ -10399,16 +10405,32 @@ function PageFeedbackToolbarCSS({
          output += "\n" + rearrangeOutput;
        }
      }
@@ -168,10 +217,15 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..b5b6a508b6624f2fe469bef461f69bed
 -    await new Promise((resolve) => originalSetTimeout(resolve, 150));
 -    const success = await fireWebhook("submit", { output, annotations }, true);
 +    let success = false;
++    let acceptedAnnotations = annotations;
 +    try {
 +      if (onSubmit) {
 +        const result = await onSubmit(output, annotations);
 +        success = result.ok;
++        if (result.acceptedAnnotationIds) {
++          const acceptedIds = new Set(result.acceptedAnnotationIds);
++          acceptedAnnotations = annotations.filter((annotation) => acceptedIds.has(annotation.id));
++        }
 +      } else {
 +        await new Promise((resolve) => originalSetTimeout(resolve, 150));
 +        success = await fireWebhook("submit", { output, annotations }, true);
@@ -182,47 +236,55 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..b5b6a508b6624f2fe469bef461f69bed
      setSendState(success ? "sent" : "failed");
      originalSetTimeout(() => setSendState("idle"), 2500);
 -    if (success && settings.autoClearAfterCopy) {
+-      originalSetTimeout(() => clearAll(), 500);
 +    if (success) {
-       originalSetTimeout(() => clearAll(), 500);
++      originalSetTimeout(() => {
++        const acceptedIds = new Set(acceptedAnnotations.map((annotation) => annotation.id));
++        setAnnotations((current) => current.filter((annotation) => !acceptedIds.has(annotation.id)));
++        onAnnotationsClear?.(acceptedAnnotations);
++      }, 500);
      }
    }, [
-@@ -10589,8 +10597,8 @@ function PageFeedbackToolbarCSS({
+     onSubmit,
+@@ -10589,8 +10611,8 @@ function PageFeedbackToolbarCSS({
          }
        }
        if (e.key === "s" || e.key === "S") {
 -        const hasValidWebhook = isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
 -        if (annotations.length > 0 && hasValidWebhook && sendState === "idle") {
-+        const hasSubmitTarget = !!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
++        const hasSubmitTarget = submitEnabled ?? (!!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""));
 +        if (annotations.length > 0 && hasSubmitTarget && sendState === "idle") {
            e.preventDefault();
            hideTooltipsUntilMouseLeave();
            sendToWebhook();
-@@ -10610,6 +10618,7 @@ function PageFeedbackToolbarCSS({
+@@ -10610,6 +10632,8 @@ function PageFeedbackToolbarCSS({
      annotations.length,
      settings.webhookUrl,
      webhookUrl,
 +    onSubmit,
++    submitEnabled,
      sendState,
      sendToWebhook,
      toggleFreeze,
-@@ -10799,7 +10808,7 @@ function PageFeedbackToolbarCSS({
+@@ -10799,7 +10823,7 @@ function PageFeedbackToolbarCSS({
                        /* @__PURE__ */ jsxs13(
                          "div",
                          {
 -                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles_module_default4.sendButtonVisible : ""}`,
-+                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && (onSubmit || !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) ? styles_module_default4.sendButtonVisible : ""}`,
++                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && ((submitEnabled ?? !!onSubmit) || !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) ? styles_module_default4.sendButtonVisible : ""}`,
                            children: [
                              /* @__PURE__ */ jsxs13(
                                "button",
-@@ -10810,9 +10819,9 @@ function PageFeedbackToolbarCSS({
+@@ -10810,9 +10834,10 @@ function PageFeedbackToolbarCSS({
                                    hideTooltipsUntilMouseLeave();
                                    sendToWebhook();
                                  },
 -                                disabled: !hasAnnotations || !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
-+                                disabled: !hasAnnotations || !onSubmit && !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
++                                disabled: !hasAnnotations || !(submitEnabled ?? (!!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) || sendState === "sending",
++                                "data-agentation-send": true,
                                  "data-no-hover": sendState === "sent" || sendState === "failed",
 -                                tabIndex: isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
-+                                tabIndex: onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
++                                tabIndex: submitEnabled ?? (!!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? 0 : -1,
                                  children: [
                                    /* @__PURE__ */ jsx14(IconSendArrow, { size: 24, state: sendState }),
                                    hasAnnotations && sendState === "idle" && /* @__PURE__ */ jsx14(

--- a/patches/agentation@3.0.2.patch
+++ b/patches/agentation@3.0.2.patch
@@ -1,0 +1,194 @@
+diff --git a/dist/index.d.mts b/dist/index.d.mts
+index 74302421cdde73d3b1d58952473adb0d744a2b8c..60a80883f76e6db0827feb336eb79107428e23ab 100644
+--- a/dist/index.d.mts
++++ b/dist/index.d.mts
+@@ -101,7 +101,9 @@ type PageFeedbackToolbarCSSProps = {
+     /** Callback fired when the copy button is clicked. Receives the markdown output. */
+     onCopy?: (markdown: string) => void;
+     /** Callback fired when "Send to Agent" is clicked. Receives the markdown output and annotations. */
+-    onSubmit?: (output: string, annotations: Annotation[]) => void;
++    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string }>;
++    /** Scope local annotation storage to one signed-in identity/community. */
++    storageScope?: string;
+     /** Whether to copy to clipboard when the copy button is clicked. Defaults to true. */
+     copyToClipboard?: boolean;
+     /** Server URL for sync (e.g., "http://localhost:4747"). If not provided, uses localStorage only. */
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 74302421cdde73d3b1d58952473adb0d744a2b8c..60a80883f76e6db0827feb336eb79107428e23ab 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -101,7 +101,9 @@ type PageFeedbackToolbarCSSProps = {
+     /** Callback fired when the copy button is clicked. Receives the markdown output. */
+     onCopy?: (markdown: string) => void;
+     /** Callback fired when "Send to Agent" is clicked. Receives the markdown output and annotations. */
+-    onSubmit?: (output: string, annotations: Annotation[]) => void;
++    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string }>;
++    /** Scope local annotation storage to one signed-in identity/community. */
++    storageScope?: string;
+     /** Whether to copy to clipboard when the copy button is clicked. Defaults to true. */
+     copyToClipboard?: boolean;
+     /** Server URL for sync (e.g., "http://localhost:4747"). If not provided, uses localStorage only. */
+diff --git a/dist/index.js b/dist/index.js
+index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a84d2772e9 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -8510,7 +8510,7 @@ function PageFeedbackToolbarCSS({
+   const popupRef = (0, import_react8.useRef)(null);
+   const editPopupRef = (0, import_react8.useRef)(null);
+   const scrollTimeoutRef = (0, import_react8.useRef)(null);
+-  const pathname = typeof window !== "undefined" ? window.location.pathname : "/";
++  const pathname = typeof window !== "undefined" ? `${storageScope ? `/buzz/${encodeURIComponent(storageScope)}` : ""}${window.location.pathname}` : "/";
+   (0, import_react8.useEffect)(() => {
+     if (showSettings) {
+       setShowSettingsVisible(true);
+@@ -10483,15 +10483,22 @@ function PageFeedbackToolbarCSS({
+         output += "\n" + rearrangeOutput;
+       }
+     }
+-    if (onSubmit) {
+-      onSubmit(output, annotations);
+-    }
+     setSendState("sending");
+-    await new Promise((resolve) => originalSetTimeout(resolve, 150));
+-    const success = await fireWebhook("submit", { output, annotations }, true);
++    let success = false;
++    try {
++      if (onSubmit) {
++        const result = await onSubmit(output, annotations);
++        success = result.ok;
++      } else {
++        await new Promise((resolve) => originalSetTimeout(resolve, 150));
++        success = await fireWebhook("submit", { output, annotations }, true);
++      }
++    } catch {
++      success = false;
++    }
+     setSendState(success ? "sent" : "failed");
+     originalSetTimeout(() => setSendState("idle"), 2500);
+-    if (success && settings.autoClearAfterCopy) {
++    if (success) {
+       originalSetTimeout(() => clearAll(), 500);
+     }
+   }, [
+@@ -10673,8 +10680,8 @@ function PageFeedbackToolbarCSS({
+         }
+       }
+       if (e.key === "s" || e.key === "S") {
+-        const hasValidWebhook = isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
+-        if (annotations.length > 0 && hasValidWebhook && sendState === "idle") {
++        const hasSubmitTarget = !!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
++        if (annotations.length > 0 && hasSubmitTarget && sendState === "idle") {
+           e.preventDefault();
+           hideTooltipsUntilMouseLeave();
+           sendToWebhook();
+@@ -10694,6 +10701,7 @@ function PageFeedbackToolbarCSS({
+     annotations.length,
+     settings.webhookUrl,
+     webhookUrl,
++    onSubmit,
+     sendState,
+     sendToWebhook,
+     toggleFreeze,
+@@ -10883,7 +10891,7 @@ function PageFeedbackToolbarCSS({
+                       /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)(
+                         "div",
+                         {
+-                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles_module_default4.sendButtonVisible : ""}`,
++                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && (onSubmit || !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) ? styles_module_default4.sendButtonVisible : ""}`,
+                           children: [
+                             /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)(
+                               "button",
+@@ -10894,9 +10902,9 @@ function PageFeedbackToolbarCSS({
+                                   hideTooltipsUntilMouseLeave();
+                                   sendToWebhook();
+                                 },
+-                                disabled: !hasAnnotations || !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
++                                disabled: !hasAnnotations || !onSubmit && !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
+                                 "data-no-hover": sendState === "sent" || sendState === "failed",
+-                                tabIndex: isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
++                                tabIndex: onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
+                                 children: [
+                                   /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(IconSendArrow, { size: 24, state: sendState }),
+                                   hasAnnotations && sendState === "idle" && /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(
+diff --git a/dist/index.mjs b/dist/index.mjs
+index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..5ad82de385a03cedaa38fb3f0df4bb0e2241e9a9 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -8426,7 +8426,7 @@ function PageFeedbackToolbarCSS({
+   const popupRef = useRef6(null);
+   const editPopupRef = useRef6(null);
+   const scrollTimeoutRef = useRef6(null);
+-  const pathname = typeof window !== "undefined" ? window.location.pathname : "/";
++  const pathname = typeof window !== "undefined" ? `${storageScope ? `/buzz/${encodeURIComponent(storageScope)}` : ""}${window.location.pathname}` : "/";
+   useEffect6(() => {
+     if (showSettings) {
+       setShowSettingsVisible(true);
+@@ -10399,15 +10399,22 @@ function PageFeedbackToolbarCSS({
+         output += "\n" + rearrangeOutput;
+       }
+     }
+-    if (onSubmit) {
+-      onSubmit(output, annotations);
+-    }
+     setSendState("sending");
+-    await new Promise((resolve) => originalSetTimeout(resolve, 150));
+-    const success = await fireWebhook("submit", { output, annotations }, true);
++    let success = false;
++    try {
++      if (onSubmit) {
++        const result = await onSubmit(output, annotations);
++        success = result.ok;
++      } else {
++        await new Promise((resolve) => originalSetTimeout(resolve, 150));
++        success = await fireWebhook("submit", { output, annotations }, true);
++      }
++    } catch {
++      success = false;
++    }
+     setSendState(success ? "sent" : "failed");
+     originalSetTimeout(() => setSendState("idle"), 2500);
+-    if (success && settings.autoClearAfterCopy) {
++    if (success) {
+       originalSetTimeout(() => clearAll(), 500);
+     }
+   }, [
+@@ -10589,8 +10596,8 @@ function PageFeedbackToolbarCSS({
+         }
+       }
+       if (e.key === "s" || e.key === "S") {
+-        const hasValidWebhook = isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
+-        if (annotations.length > 0 && hasValidWebhook && sendState === "idle") {
++        const hasSubmitTarget = !!onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "");
++        if (annotations.length > 0 && hasSubmitTarget && sendState === "idle") {
+           e.preventDefault();
+           hideTooltipsUntilMouseLeave();
+           sendToWebhook();
+@@ -10610,6 +10617,7 @@ function PageFeedbackToolbarCSS({
+     annotations.length,
+     settings.webhookUrl,
+     webhookUrl,
++    onSubmit,
+     sendState,
+     sendToWebhook,
+     toggleFreeze,
+@@ -10799,7 +10807,7 @@ function PageFeedbackToolbarCSS({
+                       /* @__PURE__ */ jsxs13(
+                         "div",
+                         {
+-                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles_module_default4.sendButtonVisible : ""}`,
++                          className: `${styles_module_default4.buttonWrapper} ${styles_module_default4.sendButtonWrapper} ${isActive && (onSubmit || !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || ""))) ? styles_module_default4.sendButtonVisible : ""}`,
+                           children: [
+                             /* @__PURE__ */ jsxs13(
+                               "button",
+@@ -10810,9 +10818,9 @@ function PageFeedbackToolbarCSS({
+                                   hideTooltipsUntilMouseLeave();
+                                   sendToWebhook();
+                                 },
+-                                disabled: !hasAnnotations || !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
++                                disabled: !hasAnnotations || !onSubmit && !isValidUrl(settings.webhookUrl) && !isValidUrl(webhookUrl || "") || sendState === "sending",
+                                 "data-no-hover": sendState === "sent" || sendState === "failed",
+-                                tabIndex: isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
++                                tabIndex: onSubmit || isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "") ? 0 : -1,
+                                 children: [
+                                   /* @__PURE__ */ jsx14(IconSendArrow, { size: 24, state: sendState }),
+                                   hasAnnotations && sendState === "idle" && /* @__PURE__ */ jsx14(

--- a/patches/agentation@3.0.2.patch
+++ b/patches/agentation@3.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.d.mts b/dist/index.d.mts
-index 74302421cdde73d3b1d58952473adb0d744a2b8c..60a80883f76e6db0827feb336eb79107428e23ab 100644
+index 74302421cdde73d3b1d58952473adb0d744a2b8c..d2d7292f7c3b75a240d8c4d610fcdd00fa25e5c3 100644
 --- a/dist/index.d.mts
 +++ b/dist/index.d.mts
 @@ -101,7 +101,9 @@ type PageFeedbackToolbarCSSProps = {
@@ -13,8 +13,17 @@ index 74302421cdde73d3b1d58952473adb0d744a2b8c..60a80883f76e6db0827feb336eb79107
      /** Whether to copy to clipboard when the copy button is clicked. Defaults to true. */
      copyToClipboard?: boolean;
      /** Server URL for sync (e.g., "http://localhost:4747"). If not provided, uses localStorage only. */
+@@ -117,7 +119,7 @@ type PageFeedbackToolbarCSSProps = {
+ };
+ /** Alias for PageFeedbackToolbarCSSProps */
+ type AgentationProps = PageFeedbackToolbarCSSProps;
+-declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
++declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, storageScope, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
+
+ interface AnnotationPopupCSSProps {
+     /** Element name to display in header */
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 74302421cdde73d3b1d58952473adb0d744a2b8c..60a80883f76e6db0827feb336eb79107428e23ab 100644
+index 74302421cdde73d3b1d58952473adb0d744a2b8c..d2d7292f7c3b75a240d8c4d610fcdd00fa25e5c3 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -101,7 +101,9 @@ type PageFeedbackToolbarCSSProps = {
@@ -28,11 +37,28 @@ index 74302421cdde73d3b1d58952473adb0d744a2b8c..60a80883f76e6db0827feb336eb79107
      /** Whether to copy to clipboard when the copy button is clicked. Defaults to true. */
      copyToClipboard?: boolean;
      /** Server URL for sync (e.g., "http://localhost:4747"). If not provided, uses localStorage only. */
+@@ -117,7 +119,7 @@ type PageFeedbackToolbarCSSProps = {
+ };
+ /** Alias for PageFeedbackToolbarCSSProps */
+ type AgentationProps = PageFeedbackToolbarCSSProps;
+-declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
++declare function PageFeedbackToolbarCSS({ demoAnnotations, demoDelay, enableDemoMode, onAnnotationAdd, onAnnotationDelete, onAnnotationUpdate, onAnnotationsClear, onCopy, onSubmit, storageScope, copyToClipboard, endpoint, sessionId: initialSessionId, onSessionCreated, webhookUrl, className: userClassName, }?: PageFeedbackToolbarCSSProps): react.ReactPortal | null;
+
+ interface AnnotationPopupCSSProps {
+     /** Element name to display in header */
 diff --git a/dist/index.js b/dist/index.js
-index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a84d2772e9 100644
+index 07036659fc11b8a3c9d300536631056ec3f58297..3a11b0fb0b8cc1011a5e022a3c5dcd21fd8421bf 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -8510,7 +8510,7 @@ function PageFeedbackToolbarCSS({
+@@ -8319,6 +8319,7 @@ function PageFeedbackToolbarCSS({
+   onAnnotationsClear,
+   onCopy,
+   onSubmit,
++  storageScope,
+   copyToClipboard = true,
+   endpoint,
+   sessionId: initialSessionId,
+@@ -8510,7 +8511,7 @@ function PageFeedbackToolbarCSS({
    const popupRef = (0, import_react8.useRef)(null);
    const editPopupRef = (0, import_react8.useRef)(null);
    const scrollTimeoutRef = (0, import_react8.useRef)(null);
@@ -41,7 +67,7 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a8
    (0, import_react8.useEffect)(() => {
      if (showSettings) {
        setShowSettingsVisible(true);
-@@ -10483,15 +10483,22 @@ function PageFeedbackToolbarCSS({
+@@ -10483,15 +10484,22 @@ function PageFeedbackToolbarCSS({
          output += "\n" + rearrangeOutput;
        }
      }
@@ -70,7 +96,7 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a8
        originalSetTimeout(() => clearAll(), 500);
      }
    }, [
-@@ -10673,8 +10680,8 @@ function PageFeedbackToolbarCSS({
+@@ -10673,8 +10681,8 @@ function PageFeedbackToolbarCSS({
          }
        }
        if (e.key === "s" || e.key === "S") {
@@ -81,7 +107,7 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a8
            e.preventDefault();
            hideTooltipsUntilMouseLeave();
            sendToWebhook();
-@@ -10694,6 +10701,7 @@ function PageFeedbackToolbarCSS({
+@@ -10694,6 +10702,7 @@ function PageFeedbackToolbarCSS({
      annotations.length,
      settings.webhookUrl,
      webhookUrl,
@@ -89,7 +115,7 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a8
      sendState,
      sendToWebhook,
      toggleFreeze,
-@@ -10883,7 +10891,7 @@ function PageFeedbackToolbarCSS({
+@@ -10883,7 +10892,7 @@ function PageFeedbackToolbarCSS({
                        /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)(
                          "div",
                          {
@@ -98,7 +124,7 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a8
                            children: [
                              /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)(
                                "button",
-@@ -10894,9 +10902,9 @@ function PageFeedbackToolbarCSS({
+@@ -10894,9 +10903,9 @@ function PageFeedbackToolbarCSS({
                                    hideTooltipsUntilMouseLeave();
                                    sendToWebhook();
                                  },
@@ -111,10 +137,18 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..a1a86c2516be13c66c88934f48cfb3a8
                                    /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(IconSendArrow, { size: 24, state: sendState }),
                                    hasAnnotations && sendState === "idle" && /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(
 diff --git a/dist/index.mjs b/dist/index.mjs
-index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..5ad82de385a03cedaa38fb3f0df4bb0e2241e9a9 100644
+index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..b5b6a508b6624f2fe469bef461f69bed9a8d94c5 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -8426,7 +8426,7 @@ function PageFeedbackToolbarCSS({
+@@ -8235,6 +8235,7 @@ function PageFeedbackToolbarCSS({
+   onAnnotationsClear,
+   onCopy,
+   onSubmit,
++  storageScope,
+   copyToClipboard = true,
+   endpoint,
+   sessionId: initialSessionId,
+@@ -8426,7 +8427,7 @@ function PageFeedbackToolbarCSS({
    const popupRef = useRef6(null);
    const editPopupRef = useRef6(null);
    const scrollTimeoutRef = useRef6(null);
@@ -123,7 +157,7 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..5ad82de385a03cedaa38fb3f0df4bb0e
    useEffect6(() => {
      if (showSettings) {
        setShowSettingsVisible(true);
-@@ -10399,15 +10399,22 @@ function PageFeedbackToolbarCSS({
+@@ -10399,15 +10400,22 @@ function PageFeedbackToolbarCSS({
          output += "\n" + rearrangeOutput;
        }
      }
@@ -152,7 +186,7 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..5ad82de385a03cedaa38fb3f0df4bb0e
        originalSetTimeout(() => clearAll(), 500);
      }
    }, [
-@@ -10589,8 +10596,8 @@ function PageFeedbackToolbarCSS({
+@@ -10589,8 +10597,8 @@ function PageFeedbackToolbarCSS({
          }
        }
        if (e.key === "s" || e.key === "S") {
@@ -163,7 +197,7 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..5ad82de385a03cedaa38fb3f0df4bb0e
            e.preventDefault();
            hideTooltipsUntilMouseLeave();
            sendToWebhook();
-@@ -10610,6 +10617,7 @@ function PageFeedbackToolbarCSS({
+@@ -10610,6 +10618,7 @@ function PageFeedbackToolbarCSS({
      annotations.length,
      settings.webhookUrl,
      webhookUrl,
@@ -171,7 +205,7 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..5ad82de385a03cedaa38fb3f0df4bb0e
      sendState,
      sendToWebhook,
      toggleFreeze,
-@@ -10799,7 +10807,7 @@ function PageFeedbackToolbarCSS({
+@@ -10799,7 +10808,7 @@ function PageFeedbackToolbarCSS({
                        /* @__PURE__ */ jsxs13(
                          "div",
                          {
@@ -180,7 +214,7 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..5ad82de385a03cedaa38fb3f0df4bb0e
                            children: [
                              /* @__PURE__ */ jsxs13(
                                "button",
-@@ -10810,9 +10818,9 @@ function PageFeedbackToolbarCSS({
+@@ -10810,9 +10819,9 @@ function PageFeedbackToolbarCSS({
                                    hideTooltipsUntilMouseLeave();
                                    sendToWebhook();
                                  },

--- a/patches/agentation@3.0.2.patch
+++ b/patches/agentation@3.0.2.patch
@@ -2,14 +2,12 @@ diff --git a/dist/index.d.mts b/dist/index.d.mts
 index 74302421cdde73d3b1d58952473adb0d744a2b8c..cfeddf7977489cd84257cf18980d8b0da0d61cee 100644
 --- a/dist/index.d.mts
 +++ b/dist/index.d.mts
-@@ -101,7 +101,13 @@ type PageFeedbackToolbarCSSProps = {
+@@ -101,7 +101,11 @@ type PageFeedbackToolbarCSSProps = {
      /** Callback fired when the copy button is clicked. Receives the markdown output. */
      onCopy?: (markdown: string) => void;
      /** Callback fired when "Send to Agent" is clicked. Receives the markdown output and annotations. */
 -    onSubmit?: (output: string, annotations: Annotation[]) => void;
-+    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string; acceptedAnnotationIds?: string[] }>;
-+    /** Whether the current submit destination is valid. */
-+    submitEnabled?: boolean;
++    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string; acceptedAnnotations?: Annotation[] }>;
 +    /** Whether the current submit destination is valid. Defaults to callback/webhook availability. */
 +    submitEnabled?: boolean;
 +    /** Scope local annotation storage to one signed-in identity/community. */
@@ -30,14 +28,12 @@ diff --git a/dist/index.d.ts b/dist/index.d.ts
 index 74302421cdde73d3b1d58952473adb0d744a2b8c..cfeddf7977489cd84257cf18980d8b0da0d61cee 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
-@@ -101,7 +101,13 @@ type PageFeedbackToolbarCSSProps = {
+@@ -101,7 +101,11 @@ type PageFeedbackToolbarCSSProps = {
      /** Callback fired when the copy button is clicked. Receives the markdown output. */
      onCopy?: (markdown: string) => void;
      /** Callback fired when "Send to Agent" is clicked. Receives the markdown output and annotations. */
 -    onSubmit?: (output: string, annotations: Annotation[]) => void;
-+    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string; acceptedAnnotationIds?: string[] }>;
-+    /** Whether the current submit destination is valid. */
-+    submitEnabled?: boolean;
++    onSubmit?: (output: string, annotations: Annotation[]) => Promise<{ ok: boolean; eventId?: string; error?: string; acceptedAnnotations?: Annotation[] }>;
 +    /** Whether the current submit destination is valid. Defaults to callback/webhook availability. */
 +    submitEnabled?: boolean;
 +    /** Scope local annotation storage to one signed-in identity/community. */
@@ -89,7 +85,7 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..1dafc5d19d1970120ab2ee3546c7f552
      }
    }, [
      annotations,
-@@ -10483,16 +10489,32 @@ function PageFeedbackToolbarCSS({
+@@ -10483,16 +10489,30 @@ function PageFeedbackToolbarCSS({
          output += "\n" + rearrangeOutput;
        }
      }
@@ -105,9 +101,8 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..1dafc5d19d1970120ab2ee3546c7f552
 +      if (onSubmit) {
 +        const result = await onSubmit(output, annotations);
 +        success = result.ok;
-+        if (result.acceptedAnnotationIds) {
-+          const acceptedIds = new Set(result.acceptedAnnotationIds);
-+          acceptedAnnotations = annotations.filter((annotation) => acceptedIds.has(annotation.id));
++        if (result.acceptedAnnotations) {
++          acceptedAnnotations = result.acceptedAnnotations;
 +        }
 +      } else {
 +        await new Promise((resolve) => originalSetTimeout(resolve, 150));
@@ -122,8 +117,7 @@ index 07036659fc11b8a3c9d300536631056ec3f58297..1dafc5d19d1970120ab2ee3546c7f552
 -      originalSetTimeout(() => clearAll(), 500);
 +    if (success) {
 +      originalSetTimeout(() => {
-+        const acceptedIds = new Set(acceptedAnnotations.map((annotation) => annotation.id));
-+        setAnnotations((current) => current.filter((annotation) => !acceptedIds.has(annotation.id)));
++        setAnnotations((current) => current.filter((annotation) => !acceptedAnnotations.some((accepted) => accepted.id === annotation.id && JSON.stringify(accepted) === JSON.stringify(annotation))));
 +        onAnnotationsClear?.(acceptedAnnotations);
 +      }, 500);
      }
@@ -206,7 +200,7 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..44fd920d43b8f6a53f130d1ebf6fb92b
      }
    }, [
      annotations,
-@@ -10399,16 +10405,32 @@ function PageFeedbackToolbarCSS({
+@@ -10399,16 +10405,30 @@ function PageFeedbackToolbarCSS({
          output += "\n" + rearrangeOutput;
        }
      }
@@ -222,9 +216,8 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..44fd920d43b8f6a53f130d1ebf6fb92b
 +      if (onSubmit) {
 +        const result = await onSubmit(output, annotations);
 +        success = result.ok;
-+        if (result.acceptedAnnotationIds) {
-+          const acceptedIds = new Set(result.acceptedAnnotationIds);
-+          acceptedAnnotations = annotations.filter((annotation) => acceptedIds.has(annotation.id));
++        if (result.acceptedAnnotations) {
++          acceptedAnnotations = result.acceptedAnnotations;
 +        }
 +      } else {
 +        await new Promise((resolve) => originalSetTimeout(resolve, 150));
@@ -239,8 +232,7 @@ index b6662bd6b8bcc9555e22a4d1a0de99198e0c11b5..44fd920d43b8f6a53f130d1ebf6fb92b
 -      originalSetTimeout(() => clearAll(), 500);
 +    if (success) {
 +      originalSetTimeout(() => {
-+        const acceptedIds = new Set(acceptedAnnotations.map((annotation) => annotation.id));
-+        setAnnotations((current) => current.filter((annotation) => !acceptedIds.has(annotation.id)));
++        setAnnotations((current) => current.filter((annotation) => !acceptedAnnotations.some((accepted) => accepted.id === annotation.id && JSON.stringify(accepted) === JSON.stringify(annotation))));
 +        onAnnotationsClear?.(acceptedAnnotations);
 +      }, 500);
      }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   linkify-it: ^5.0.2
 
 patchedDependencies:
-  agentation@3.0.2: 8b807ef6e51bbf211e025a1578416fa802360af9ffc27be73736b6206315c695
+  agentation@3.0.2: 35e27ccabf8c35a63b89874b73fb8cf5bcc60c75a51052ac2dbeea971b287524
   isomorphic-git: e9b414a60d4cf1d8aa18f7a779483984e821989967c235662566e94ef0238d3f
   virtua@0.49.3: 30a7a92b94800ec37be8d36546ea98c04a05dcd0637f9fac27a06f016ba2eff4
 
@@ -177,7 +177,7 @@ importers:
         version: 3.22.5
       agentation:
         specifier: 3.0.2
-        version: 3.0.2(patch_hash=8b807ef6e51bbf211e025a1578416fa802360af9ffc27be73736b6206315c695)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 3.0.2(patch_hash=35e27ccabf8c35a63b89874b73fb8cf5bcc60c75a51052ac2dbeea971b287524)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5436,7 +5436,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agentation@3.0.2(patch_hash=8b807ef6e51bbf211e025a1578416fa802360af9ffc27be73736b6206315c695)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  agentation@3.0.2(patch_hash=35e27ccabf8c35a63b89874b73fb8cf5bcc60c75a51052ac2dbeea971b287524)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   linkify-it: ^5.0.2
 
 patchedDependencies:
+  agentation@3.0.2: 8b807ef6e51bbf211e025a1578416fa802360af9ffc27be73736b6206315c695
   isomorphic-git: e9b414a60d4cf1d8aa18f7a779483984e821989967c235662566e94ef0238d3f
   virtua@0.49.3: 30a7a92b94800ec37be8d36546ea98c04a05dcd0637f9fac27a06f016ba2eff4
 
@@ -174,6 +175,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.22.3
         version: 3.22.5
+      agentation:
+        specifier: 3.0.2
+        version: 3.0.2(patch_hash=8b807ef6e51bbf211e025a1578416fa802360af9ffc27be73736b6206315c695)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2167,6 +2171,17 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentation@3.0.2:
+    resolution: {integrity: sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -5420,6 +5435,11 @@ snapshots:
       event-target-shim: 5.0.1
 
   agent-base@7.1.4: {}
+
+  agentation@3.0.2(patch_hash=8b807ef6e51bbf211e025a1578416fa802360af9ffc27be73736b6206315c695)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   ansi-regex@5.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   linkify-it: ^5.0.2
 
 patchedDependencies:
-  agentation@3.0.2: 35e27ccabf8c35a63b89874b73fb8cf5bcc60c75a51052ac2dbeea971b287524
+  agentation@3.0.2: fde9dc45b9b08a7cdf76bf6e1dfc1ef667c581df703d1a38d3249f1a65757e08
   isomorphic-git: e9b414a60d4cf1d8aa18f7a779483984e821989967c235662566e94ef0238d3f
   virtua@0.49.3: 30a7a92b94800ec37be8d36546ea98c04a05dcd0637f9fac27a06f016ba2eff4
 
@@ -177,7 +177,7 @@ importers:
         version: 3.22.5
       agentation:
         specifier: 3.0.2
-        version: 3.0.2(patch_hash=35e27ccabf8c35a63b89874b73fb8cf5bcc60c75a51052ac2dbeea971b287524)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 3.0.2(patch_hash=fde9dc45b9b08a7cdf76bf6e1dfc1ef667c581df703d1a38d3249f1a65757e08)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5436,7 +5436,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agentation@3.0.2(patch_hash=35e27ccabf8c35a63b89874b73fb8cf5bcc60c75a51052ac2dbeea971b287524)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  agentation@3.0.2(patch_hash=fde9dc45b9b08a7cdf76bf6e1dfc1ef667c581df703d1a38d3249f1a65757e08)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   linkify-it: ^5.0.2
 
 patchedDependencies:
-  agentation@3.0.2: fde9dc45b9b08a7cdf76bf6e1dfc1ef667c581df703d1a38d3249f1a65757e08
+  agentation@3.0.2: 2672eab0929543b0570a1661d6bf116151e53d816e47ebc190dca8b55013f488
   isomorphic-git: e9b414a60d4cf1d8aa18f7a779483984e821989967c235662566e94ef0238d3f
   virtua@0.49.3: 30a7a92b94800ec37be8d36546ea98c04a05dcd0637f9fac27a06f016ba2eff4
 
@@ -177,7 +177,7 @@ importers:
         version: 3.22.5
       agentation:
         specifier: 3.0.2
-        version: 3.0.2(patch_hash=fde9dc45b9b08a7cdf76bf6e1dfc1ef667c581df703d1a38d3249f1a65757e08)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 3.0.2(patch_hash=2672eab0929543b0570a1661d6bf116151e53d816e47ebc190dca8b55013f488)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5436,7 +5436,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agentation@3.0.2(patch_hash=fde9dc45b9b08a7cdf76bf6e1dfc1ef667c581df703d1a38d3249f1a65757e08)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  agentation@3.0.2(patch_hash=2672eab0929543b0570a1661d6bf116151e53d816e47ebc190dca8b55013f488)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,5 +19,6 @@ overrides:
   # markdown-it resolves linkify-it >=5.0.2 on its own.
   linkify-it: "^5.0.2"
 patchedDependencies:
+  agentation@3.0.2: patches/agentation@3.0.2.patch
   isomorphic-git: patches/isomorphic-git.patch
   virtua@0.49.3: patches/virtua@0.49.3.patch

--- a/preview-features.json
+++ b/preview-features.json
@@ -26,6 +26,12 @@
       "platforms": ["desktop"]
     },
     {
+      "id": "agentationDesign",
+      "name": "Agentation for Design",
+      "description": "Annotate Buzz screens and send the feedback to an agent in a channel.",
+      "platforms": ["desktop"]
+    },
+    {
       "id": "agentManagedProfiles",
       "name": "Agent-managed profiles",
       "description": "Let agents manage their own relay name and avatar instead of restoring the desktop copy",


### PR DESCRIPTION
## Summary

- add the default-off **Agentation for Design** desktop experiment
- mount pinned Agentation UI only while enabled and keep annotations local
- add identity/community-scoped channel + addressable-agent destination selection
- send one ordinary signed Buzz message per accepted annotation batch
- patch Agentation's submit callback to await Buzz delivery and clear only after success

## Validation

- `pnpm --filter buzz typecheck`
- `pnpm --filter buzz test` — 5,841 passed
- `pnpm --filter buzz build`
- pre-push desktop check, typecheck, test, and file-size lanes passed at `6bfc7f63c85e9633b11a08b29fa49aacadb0fe96`

## Known boundary

Phase 1 is local-only and supports joined, unarchived stream channels. No managed localhost service/MCP, DMs, forums, screenshots, or broadcast routing. Runtime interaction validation still needs a signed desktop build/workflow; this PR does not merge or release anything.
