### PR TITLE
feat(desktop): add save-for-later bookmarks via NIP-ER

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -101,6 +101,7 @@ export default defineConfig({
         "**/animated-avatar.spec.ts",
         "**/reminders.spec.ts",
         "**/reminder-click-repro.spec.ts",
+        "**/bookmarks.spec.ts",
         "**/virtualization.spec.ts",
         "**/scroll-history.spec.ts",
         "**/channel-dense-second-reach.spec.ts",

--- a/desktop/src/app/AppHuddleShell.tsx
+++ b/desktop/src/app/AppHuddleShell.tsx
@@ -3,6 +3,7 @@ import { AppHuddleBar } from "@/app/AppHuddleBar";
 import * as BuzzTheme from "@/app/BuzzThemeSurfaces";
 import { HuddleProvider, useHuddle } from "@/features/huddle";
 import { HUDDLE_SHORTCUT_EVENT } from "@/shared/lib/keyboard-shortcuts";
+import { BookmarkProvider } from "@/features/bookmarks/ui/BookmarkProvider";
 import { RemindMeLaterProvider } from "@/features/reminders/ui/RemindMeLaterProvider";
 import { cn } from "@/shared/lib/cn";
 
@@ -67,40 +68,42 @@ export function AppHuddleShell({
     >
       <HuddleShortcutHandler>
         <RemindMeLaterProvider pubkey={currentPubkey}>
-          <div
-            className="buzz-huddle-shell relative h-dvh overflow-hidden overscroll-none"
-            data-huddle-open={isDrawerOpen}
-            data-huddle-window={isRoom}
-          >
+          <BookmarkProvider pubkey={currentPubkey}>
             <div
-              aria-hidden="true"
-              className={cn(
-                "buzz-huddle-drawer-backdrop",
-                isDrawerOpen && "buzz-huddle-drawer-backdrop-open",
-              )}
-            />
-            <div
-              className={cn(
-                "buzz-huddle-app-surface z-10 flex min-h-0 flex-row overflow-hidden bg-background",
-                isDrawerOpen &&
-                  (isRoom
-                    ? "buzz-huddle-app-surface-room-open"
-                    : "buzz-huddle-app-surface-open"),
-              )}
+              className="buzz-huddle-shell relative h-dvh overflow-hidden overscroll-none"
+              data-huddle-open={isDrawerOpen}
+              data-huddle-window={isRoom}
             >
-              <BuzzTheme.GradientLayer />
-              {children}
-            </div>
-            {isRoom || !isCompanionOpen ? (
-              <div className="buzz-huddle-drawer-slot absolute inset-x-0 bottom-0 z-[2] h-(--buzz-huddle-drawer-height)">
-                <AppHuddleBar
-                  mode={isRoom ? "room" : "main"}
-                  onOpenHuddleWindow={isRoom ? undefined : onCompanionOpen}
-                  onVisibilityChange={onVisibilityChange}
-                />
+              <div
+                aria-hidden="true"
+                className={cn(
+                  "buzz-huddle-drawer-backdrop",
+                  isDrawerOpen && "buzz-huddle-drawer-backdrop-open",
+                )}
+              />
+              <div
+                className={cn(
+                  "buzz-huddle-app-surface z-10 flex min-h-0 flex-row overflow-hidden bg-background",
+                  isDrawerOpen &&
+                    (isRoom
+                      ? "buzz-huddle-app-surface-room-open"
+                      : "buzz-huddle-app-surface-open"),
+                )}
+              >
+                <BuzzTheme.GradientLayer />
+                {children}
               </div>
-            ) : null}
-          </div>
+              {isRoom || !isCompanionOpen ? (
+                <div className="buzz-huddle-drawer-slot absolute inset-x-0 bottom-0 z-[2] h-(--buzz-huddle-drawer-height)">
+                  <AppHuddleBar
+                    mode={isRoom ? "room" : "main"}
+                    onOpenHuddleWindow={isRoom ? undefined : onCompanionOpen}
+                    onVisibilityChange={onVisibilityChange}
+                  />
+                </div>
+              ) : null}
+            </div>
+          </BookmarkProvider>
         </RemindMeLaterProvider>
       </HuddleShortcutHandler>
     </HuddleProvider>

--- a/desktop/src/features/bookmarks/hooks.ts
+++ b/desktop/src/features/bookmarks/hooks.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import * as React from "react";
+
+import { collectBookmarks } from "@/features/bookmarks/lib/bookmarkFilters";
+import { createBookmark } from "@/features/bookmarks/lib/bookmarkService";
+import {
+  remindersQueryKey,
+  useRemindersQuery,
+} from "@/features/reminders/hooks";
+import { cancelReminder } from "@/features/reminders/lib/reminderService";
+import type {
+  Reminder,
+  ReminderTarget,
+} from "@/features/reminders/lib/reminderTypes";
+
+/**
+ * Bookmarks piggyback on the reminders query — both are the user's kind-30300
+ * events, so one cache and one invalidation spine keep the action-bar toggle,
+ * the Saved list, and every reminder surface consistent.
+ */
+export function useBookmarksQuery(pubkey: string | undefined) {
+  const query = useRemindersQuery(pubkey);
+  const data = query.data;
+  const derived = React.useMemo(() => {
+    const { bookmarks, byEventId } = collectBookmarks(data ?? []);
+    const savedEventIds: ReadonlySet<string> = new Set(byEventId.keys());
+    return { bookmarks, byEventId, savedEventIds };
+  }, [data]);
+  return { ...derived, isLoading: query.isLoading };
+}
+
+/**
+ * Save/remove both invalidate the shared reminders query, same as
+ * `useReminderMutations`. Remove cancels every duplicate d-tag for the
+ * message (multi-device saves), so one unsave clears the state everywhere.
+ */
+export function useBookmarkMutations(pubkey: string) {
+  const queryClient = useQueryClient();
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: remindersQueryKey(pubkey) });
+
+  const save = useMutation({
+    mutationFn: (target: ReminderTarget) => createBookmark(target),
+    onSuccess: invalidate,
+  });
+  const remove = useMutation({
+    mutationFn: (bookmarks: Reminder[]) =>
+      Promise.all(
+        bookmarks.map((bookmark) => cancelReminder(pubkey, bookmark)),
+      ),
+    onSuccess: invalidate,
+  });
+
+  return { save, remove };
+}

--- a/desktop/src/features/bookmarks/lib/bookmarkFilters.test.mjs
+++ b/desktop/src/features/bookmarks/lib/bookmarkFilters.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { collectBookmarks, isBookmark } from "./bookmarkFilters.ts";
+
+/**
+ * Build a Reminder fixture. Bookmark detection reads `status`, `notBefore`,
+ * and the target's field presence; `createdAt` orders the collected list.
+ */
+function reminder({
+  id = "r",
+  notBefore,
+  status = "pending",
+  target,
+  createdAt = 0,
+}) {
+  return {
+    id,
+    eventId: `${id}-evt`,
+    notBefore,
+    createdAt,
+    content: { status, target },
+  };
+}
+
+const TARGET = {
+  eventId: "msg-1",
+  channelId: "chan-1",
+  preview: "hello",
+  authorPubkey: "author-1",
+};
+
+test("isBookmark_pending_targeted_without_notBefore_is_bookmark", () => {
+  assert.equal(isBookmark(reminder({ target: TARGET })), true);
+});
+
+test("isBookmark_with_notBefore_is_a_reminder_not_a_bookmark", () => {
+  assert.equal(
+    isBookmark(reminder({ target: TARGET, notBefore: 1_000 })),
+    false,
+  );
+});
+
+test("isBookmark_cancelled_is_not_a_bookmark", () => {
+  assert.equal(
+    isBookmark(reminder({ target: TARGET, status: "cancelled" })),
+    false,
+  );
+});
+
+test("isBookmark_done_is_not_a_bookmark", () => {
+  assert.equal(isBookmark(reminder({ target: TARGET, status: "done" })), false);
+});
+
+test("isBookmark_without_target_is_not_a_bookmark", () => {
+  assert.equal(isBookmark(reminder({})), false);
+});
+
+test("isBookmark_empty_target_fields_are_not_navigable", () => {
+  assert.equal(
+    isBookmark(reminder({ target: { ...TARGET, channelId: "" } })),
+    false,
+  );
+});
+
+test("collectBookmarks_sorts_newest_first_and_groups_duplicates", () => {
+  const { bookmarks, byEventId } = collectBookmarks([
+    reminder({ id: "a", target: TARGET, createdAt: 10 }),
+    reminder({ id: "b", target: TARGET, createdAt: 30 }),
+    reminder({
+      id: "c",
+      target: { ...TARGET, eventId: "msg-2" },
+      createdAt: 20,
+    }),
+    reminder({ id: "d", target: TARGET, notBefore: 1_000, createdAt: 40 }),
+  ]);
+  assert.deepEqual(
+    bookmarks.map((r) => r.id),
+    ["b", "c", "a"],
+  );
+  assert.equal(byEventId.size, 2);
+  assert.deepEqual(
+    byEventId.get("msg-1")?.map((r) => r.id),
+    ["a", "b"],
+  );
+  assert.equal(byEventId.get("msg-2")?.length, 1);
+});
+
+test("collectBookmarks_excludes_non_bookmarks_entirely", () => {
+  const { bookmarks, byEventId } = collectBookmarks([
+    reminder({ id: "sched", target: TARGET, notBefore: 1_000 }),
+    reminder({ id: "note-only" }),
+    reminder({ id: "gone", target: TARGET, status: "cancelled" }),
+  ]);
+  assert.equal(bookmarks.length, 0);
+  assert.equal(byEventId.size, 0);
+});

--- a/desktop/src/features/bookmarks/lib/bookmarkFilters.ts
+++ b/desktop/src/features/bookmarks/lib/bookmarkFilters.ts
@@ -1,0 +1,43 @@
+import { isActiveReminder } from "@/features/reminders/lib/reminderFilters";
+import { hasNavigableTarget } from "@/features/reminders/lib/reminderNavigation";
+import type { Reminder } from "@/features/reminders/lib/reminderTypes";
+
+/**
+ * A bookmark is a NIP-ER kind-30300 event with no `not_before`: "a reminder
+ * without `not_before` is a bookmark (saved item with no due time)". Defined
+ * as pending-but-not-an-active-reminder so bookmarks and reminders partition
+ * the kind by construction; the navigable-target check keeps note-only
+ * reminders out. Every bookmark surface shares this one predicate.
+ */
+export function isBookmark(reminder: Reminder): boolean {
+  return (
+    reminder.content.status === "pending" &&
+    !isActiveReminder(reminder) &&
+    hasNavigableTarget(reminder.content.target)
+  );
+}
+
+/**
+ * One pass over the user's kind-30300 events: the bookmark list (newest
+ * first) plus a target-message-id index. Saving the same message from two
+ * devices yields two d-tags; keeping the array per key lets unsave cancel
+ * every copy while the action bar treats the message as saved once.
+ */
+export function collectBookmarks(reminders: readonly Reminder[]): {
+  bookmarks: Reminder[];
+  byEventId: Map<string, Reminder[]>;
+} {
+  const bookmarks: Reminder[] = [];
+  const byEventId = new Map<string, Reminder[]>();
+  for (const reminder of reminders) {
+    if (!isBookmark(reminder)) continue;
+    bookmarks.push(reminder);
+    const target = reminder.content.target;
+    if (!target) continue;
+    const group = byEventId.get(target.eventId) ?? [];
+    group.push(reminder);
+    byEventId.set(target.eventId, group);
+  }
+  bookmarks.sort((left, right) => right.createdAt - left.createdAt);
+  return { bookmarks, byEventId };
+}

--- a/desktop/src/features/bookmarks/lib/bookmarkService.ts
+++ b/desktop/src/features/bookmarks/lib/bookmarkService.ts
@@ -1,0 +1,32 @@
+import { randomDTag } from "@/features/reminders/lib/reminderService";
+import type {
+  ReminderContent,
+  ReminderTarget,
+} from "@/features/reminders/lib/reminderTypes";
+import { relayClient } from "@/shared/api/relayClient";
+import { nip44EncryptToSelf, signRelayEvent } from "@/shared/api/tauri";
+import type { RelayEvent } from "@/shared/api/types";
+import { KIND_EVENT_REMINDER } from "@/shared/constants/kinds";
+
+/**
+ * Publish a bookmark: a kind-30300 NIP-ER event whose tags carry only the
+ * random `d` identifier — omitting `not_before` is what makes it a saved
+ * item instead of a scheduled reminder. Unsave needs no counterpart here:
+ * `cancelReminder` already replaces a d-tag with a cancelled, expiring event.
+ */
+export async function createBookmark(
+  target: ReminderTarget,
+): Promise<RelayEvent> {
+  const content: ReminderContent = { target, status: "pending" };
+  const ciphertext = await nip44EncryptToSelf(JSON.stringify(content));
+  const event = await signRelayEvent({
+    kind: KIND_EVENT_REMINDER,
+    content: ciphertext,
+    tags: [["d", randomDTag()]],
+  });
+  return relayClient.publishEvent(
+    event,
+    "Timed out saving message.",
+    "Failed to save message.",
+  );
+}

--- a/desktop/src/features/bookmarks/ui/BookmarkProvider.tsx
+++ b/desktop/src/features/bookmarks/ui/BookmarkProvider.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+import {
+  useBookmarkMutations,
+  useBookmarksQuery,
+} from "@/features/bookmarks/hooks";
+import type {
+  Reminder,
+  ReminderTarget,
+} from "@/features/reminders/lib/reminderTypes";
+
+type BookmarkContextValue = {
+  /** Event IDs of messages the current user has saved, for toggle state. */
+  savedEventIds: ReadonlySet<string>;
+  /** The user's bookmarks, newest first — the Saved view's data. */
+  bookmarks: readonly Reminder[];
+  isLoading: boolean;
+  /**
+   * Save when unsaved, remove every duplicate copy when saved. Resolves when
+   * the mutation settles; callers keep their own per-row pending state so a
+   * toggle re-renders only the row it happened on.
+   */
+  toggleBookmark: (target: ReminderTarget) => Promise<void>;
+};
+
+const BookmarkContext = React.createContext<BookmarkContextValue>({
+  savedEventIds: new Set(),
+  bookmarks: [],
+  isLoading: false,
+  toggleBookmark: async () => {},
+});
+
+export function useBookmarks() {
+  return React.useContext(BookmarkContext);
+}
+
+/**
+ * Owns the save/unsave toggle every MessageActionBar reads. A context instead
+ * of the `onRemindLater` prop-drilling pattern: MessageRow sits at the
+ * file-size cap, and the action bar already consumes feature hooks directly.
+ */
+export function BookmarkProvider({
+  pubkey,
+  children,
+}: {
+  pubkey?: string;
+  children: React.ReactNode;
+}) {
+  const { bookmarks, byEventId, savedEventIds, isLoading } =
+    useBookmarksQuery(pubkey);
+  const { save, remove } = useBookmarkMutations(pubkey ?? "");
+
+  const saveAsync = save.mutateAsync;
+  const removeAsync = remove.mutateAsync;
+  const toggleBookmark = React.useCallback(
+    async (target: ReminderTarget) => {
+      if (!pubkey) return;
+      const existing = byEventId.get(target.eventId);
+      const isRemoval = Boolean(existing && existing.length > 0);
+      try {
+        if (existing && isRemoval) {
+          await removeAsync(existing);
+          toast.success("Removed from saved");
+        } else {
+          await saveAsync(target);
+          toast.success("Saved for later");
+        }
+      } catch {
+        toast.error(
+          isRemoval ? "Failed to remove from saved" : "Failed to save message",
+        );
+      }
+    },
+    [byEventId, pubkey, removeAsync, saveAsync],
+  );
+
+  const contextValue = React.useMemo(
+    () => ({ savedEventIds, bookmarks, isLoading, toggleBookmark }),
+    [savedEventIds, bookmarks, isLoading, toggleBookmark],
+  );
+
+  return (
+    <BookmarkContext.Provider value={contextValue}>
+      {children}
+    </BookmarkContext.Provider>
+  );
+}

--- a/desktop/src/features/bookmarks/ui/SavedPanel.tsx
+++ b/desktop/src/features/bookmarks/ui/SavedPanel.tsx
@@ -1,0 +1,126 @@
+import { Bookmark, BookmarkX } from "lucide-react";
+import * as React from "react";
+
+import { useBookmarks } from "@/features/bookmarks/ui/BookmarkProvider";
+import type { Reminder } from "@/features/reminders/lib/reminderTypes";
+import {
+  ReminderSourceLine,
+  useReminderNavigation,
+  useReminderSources,
+  type ReminderSource,
+} from "@/features/reminders/ui/RemindersPanel";
+import { formatItemTimestamp } from "@/shared/lib/datetime";
+import { Button } from "@/shared/ui/button";
+
+function SavedRow({
+  bookmark,
+  onNavigate,
+  onRemove,
+  source,
+}: {
+  bookmark: Reminder;
+  onNavigate: (bookmark: Reminder) => void;
+  onRemove: (bookmark: Reminder) => Promise<void>;
+  source: ReminderSource | null;
+}) {
+  // Local so removing this row disables only this row's button.
+  const [isRemoving, setIsRemoving] = React.useState(false);
+
+  return (
+    <div
+      className="flex items-start gap-3 border-b border-border/45 px-4 py-4 transition-colors focus-within:bg-muted/40 hover:bg-muted/40"
+      data-testid={`home-saved-item-${bookmark.id}`}
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Bookmark className="h-4 w-4" />
+      </span>
+      <button
+        className="flex min-w-0 flex-1 flex-col items-start gap-1 text-left enabled:hover:opacity-80"
+        onClick={() => onNavigate(bookmark)}
+        type="button"
+      >
+        {source ? <ReminderSourceLine source={source} /> : null}
+        <p className="max-w-full truncate text-sm font-medium">
+          {bookmark.content.target?.preview || "Saved message"}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Saved {formatItemTimestamp(bookmark.createdAt)}
+        </p>
+      </button>
+      <div className="flex shrink-0 items-center gap-1">
+        <Button
+          className="h-7 w-7 p-0"
+          data-testid={`home-saved-item-remove-${bookmark.id}`}
+          disabled={isRemoving}
+          onClick={() => {
+            setIsRemoving(true);
+            void onRemove(bookmark).finally(() => {
+              setIsRemoving(false);
+            });
+          }}
+          size="sm"
+          title="Remove from saved"
+          type="button"
+          variant="ghost"
+        >
+          <BookmarkX className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The Saved inbox view: every bookmark the user has, newest first, read from
+ * the shared BookmarkProvider. Rows navigate straight to the message — no
+ * detail pane — resolving the thread root the same way reminder rows do.
+ */
+export function SavedPanel() {
+  const { bookmarks, isLoading, toggleBookmark } = useBookmarks();
+  const sources = useReminderSources(bookmarks);
+  const handleNavigate = useReminderNavigation();
+
+  const handleRemove = React.useCallback(
+    (bookmark: Reminder) => {
+      const target = bookmark.content.target;
+      return target ? toggleBookmark(target) : Promise.resolve();
+    },
+    [toggleBookmark],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-muted-foreground">
+          Loading saved messages...
+        </p>
+      </div>
+    );
+  }
+
+  if (bookmarks.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-8">
+        <Bookmark className="h-8 w-8 text-muted-foreground/50" />
+        <p className="text-sm text-muted-foreground">No saved messages</p>
+        <p className="text-xs text-muted-foreground/70">
+          Use "Save for later" on any message to keep it here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {bookmarks.map((bookmark) => (
+        <SavedRow
+          bookmark={bookmark}
+          key={bookmark.id}
+          onNavigate={handleNavigate}
+          onRemove={handleRemove}
+          source={sources.get(bookmark.id) ?? null}
+        />
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/features/home/lib/inbox.ts
+++ b/desktop/src/features/home/lib/inbox.ts
@@ -32,7 +32,17 @@ export type InboxFilter =
   | "needs_action"
   | "agent_activity"
   | "reminders"
+  | "saved"
   | "drafts";
+
+/**
+ * Filters that render a personal list with their own panel (reminders, saved,
+ * drafts) instead of the feed item list — no feed selection model, no
+ * unread-only toggle.
+ */
+export function isPersonalFilter(filter: InboxFilter): boolean {
+  return filter === "reminders" || filter === "saved" || filter === "drafts";
+}
 
 export type InboxItem = {
   avatarUrl: string | null;

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -10,6 +10,7 @@ import {
   type InboxFilter,
   type InboxReply,
   buildInboxItems,
+  isPersonalFilter,
   findInboxItemByEventId,
   formatInboxFullTimestamp,
   getInboxItemConversationId,
@@ -119,7 +120,7 @@ export function HomeView({
     useHistorySearchState(INBOX_SEARCH_KEYS);
   const isReminders = filter === "reminders";
   const isDrafts = filter === "drafts";
-  const isMessagesMode = !isReminders && !isDrafts;
+  const isMessagesMode = !isPersonalFilter(filter);
   const allowMixedPersonalSelection = filter === "all";
   const {
     drafts: {
@@ -552,12 +553,9 @@ export function HomeView({
       setSelectedReminderId(null);
       setFilter(nextFilter);
 
-      if (
-        nextFilter === "reminders" ||
-        nextFilter === "drafts" ||
-        selection.preserveSelection
-      ) {
-        if (nextFilter === "reminders" || nextFilter === "drafts") {
+      const nextIsPersonal = isPersonalFilter(nextFilter);
+      if (nextIsPersonal || selection.preserveSelection) {
+        if (nextIsPersonal) {
           setAutoSelectedEventId(null);
           applyInboxSearchPatch({ item: null });
         }

--- a/desktop/src/features/home/ui/InboxFilterMenu.tsx
+++ b/desktop/src/features/home/ui/InboxFilterMenu.tsx
@@ -22,6 +22,7 @@ const INBOX_FILTER_OPTIONS: Array<{
   { value: "needs_action", label: "Needs action" },
   { value: "agent_activity", label: "Agents" },
   { value: "reminders", label: "Reminders" },
+  { value: "saved", label: "Saved" },
   { value: "drafts", label: "Drafts" },
 ];
 

--- a/desktop/src/features/home/ui/InboxListPane.tsx
+++ b/desktop/src/features/home/ui/InboxListPane.tsx
@@ -11,10 +11,12 @@ import * as React from "react";
 
 import {
   getInboxTypeLabel,
+  isPersonalFilter,
   type InboxFilter,
   type InboxItem,
   type InboxTypeLabel,
 } from "@/features/home/lib/inbox";
+import { SavedPanel } from "@/features/bookmarks/ui/SavedPanel";
 import { buildInboxListRows } from "@/features/home/lib/inboxListRows";
 import { hasRenderedVideoAttachment } from "@/features/messages/lib/videoReviewContext";
 import { getThreadReference } from "@/features/messages/lib/threading";
@@ -60,6 +62,7 @@ const INBOX_EMPTY_STATE_TITLES: Record<InboxFilter, string> = {
   needs_action: "Nothing needs action",
   agent_activity: "No agent updates found",
   reminders: "No reminders",
+  saved: "No saved messages",
   drafts: "No drafts",
 };
 
@@ -71,6 +74,7 @@ const INBOX_UNREAD_EMPTY_STATE_TITLES: Record<InboxFilter, string> = {
   needs_action: "No unread items needing action",
   agent_activity: "No unread agent updates",
   reminders: "No unread reminders",
+  saved: "No unread saved messages",
   drafts: "No unread drafts",
 };
 
@@ -271,6 +275,7 @@ export function InboxListPane({
 }: InboxListPaneProps) {
   const isReminders = filter === "reminders";
   const isDrafts = filter === "drafts";
+  const isSaved = filter === "saved";
   const isMixedInboxView = filter === "all";
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const inboxRows = React.useMemo(
@@ -622,7 +627,7 @@ export function InboxListPane({
                   <div
                     className={cn(
                       "flex min-h-9 items-center justify-between gap-3 rounded-lg px-2 py-1.5",
-                      (isReminders || isDrafts) && "opacity-50",
+                      isPersonalFilter(filter) && "opacity-50",
                     )}
                   >
                     <label
@@ -635,7 +640,7 @@ export function InboxListPane({
                       checked={unreadOnly}
                       className="shadow-none [&>span]:shadow-none"
                       data-testid="inbox-unread-only-toggle"
-                      disabled={isReminders || isDrafts}
+                      disabled={isPersonalFilter(filter)}
                       id="inbox-unread-only-switch"
                       onCheckedChange={onUnreadOnlyChange}
                     />
@@ -683,6 +688,13 @@ export function InboxListPane({
               selectedReminderId={selectedReminderId}
             />
           ) : null}
+        </div>
+      ) : isSaved ? (
+        <div
+          className="-mt-13 flex min-h-0 flex-1 flex-col overflow-hidden pt-13"
+          data-testid="home-inbox-saved"
+        >
+          <SavedPanel />
         </div>
       ) : isDrafts ? (
         <div

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -1,6 +1,8 @@
 import {
   BellOff,
   BellRing,
+  Bookmark,
+  BookmarkCheck,
   Clock,
   Copy,
   CornerUpLeft,
@@ -16,6 +18,7 @@ import {
 import * as React from "react";
 import { toast } from "sonner";
 
+import { useBookmarks } from "@/features/bookmarks/ui/BookmarkProvider";
 import { buildMessageLink } from "@/features/messages/lib/messageLink";
 import { EmojiPicker } from "@/features/custom-emoji/ui/EmojiPicker";
 import { useCustomEmoji } from "@/features/custom-emoji/hooks";
@@ -424,6 +427,10 @@ export const MessageActionBar = React.memo(function MessageActionBar({
 }) {
   const [isReactionPickerOpen, setIsReactionPickerOpen] = React.useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const { savedEventIds, toggleBookmark } = useBookmarks();
+  const isSaved = savedEventIds.has(message.id);
+  // Local so a toggle re-renders only this row, not every context subscriber.
+  const [isTogglingBookmark, setIsTogglingBookmark] = React.useState(false);
   const customEmoji = useCustomEmoji();
   const quickReactionEmojis = useQuickReactionEmojis(3, customEmoji);
   const quickReactionItems = React.useMemo(
@@ -609,6 +616,44 @@ export const MessageActionBar = React.memo(function MessageActionBar({
                 </Button>
               </TooltipTrigger>
               <TooltipContent>Copy link</TooltipContent>
+            </Tooltip>
+          ) : null}
+
+          {canCopyMessageLink(message, channelId) && message.pubkey ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  aria-label={isSaved ? "Remove from saved" : "Save for later"}
+                  className={ACTION_BUTTON_CLASS}
+                  data-testid={`bookmark-message-${message.id}`}
+                  disabled={isTogglingBookmark}
+                  onClick={() => {
+                    setIsTogglingBookmark(true);
+                    void toggleBookmark({
+                      eventId: message.id,
+                      channelId,
+                      preview: message.body.slice(0, 100),
+                      authorPubkey: message.pubkey ?? "",
+                    }).finally(() => {
+                      setIsTogglingBookmark(false);
+                    });
+                  }}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  {isSaved ? (
+                    <BookmarkCheck
+                      className={cn(ACTION_ICON_CLASS, "text-primary")}
+                    />
+                  ) : (
+                    <Bookmark className={ACTION_ICON_CLASS} />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isSaved ? "Remove from saved" : "Save for later"}
+              </TooltipContent>
             </Tooltip>
           ) : null}
 

--- a/desktop/src/features/reminders/lib/reminderFilters.ts
+++ b/desktop/src/features/reminders/lib/reminderFilters.ts
@@ -2,6 +2,18 @@ import type { Reminder } from "@/features/reminders/lib/reminderTypes";
 
 const nowSeconds = () => Math.floor(Date.now() / 1_000);
 
+/**
+ * A pending reminder that is actually scheduled — it carries a `not_before`.
+ * Its complement (pending without one) is a bookmark per NIP-ER, so sharing
+ * this predicate keeps the two features partitioning kind-30300 events by
+ * construction rather than by parallel hand-written conditions.
+ */
+export function isActiveReminder(reminder: Reminder): boolean {
+  return (
+    reminder.content.status === "pending" && reminder.notBefore !== undefined
+  );
+}
+
 /** A pending reminder whose `notBefore` has arrived (`<= now`). */
 export function isDue(reminder: Reminder, now: number): boolean {
   return (

--- a/desktop/src/features/reminders/lib/reminderService.ts
+++ b/desktop/src/features/reminders/lib/reminderService.ts
@@ -27,7 +27,7 @@ function extractDTag(event: RelayEvent): string | null {
  * Generate a reminder `d`-tag with 128 bits of entropy (NIP-ER line 58 MUST).
  * `crypto.randomUUID()` is UUIDv4 = only 122 random bits, so use 16 raw bytes.
  */
-function randomDTag(): string {
+export function randomDTag(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(16));
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
@@ -145,7 +145,9 @@ export async function fetchReminders(pubkey: string): Promise<Reminder[]> {
   const events = await relayClient.fetchEvents({
     kinds: [KIND_EVENT_REMINDER],
     authors: [pubkey],
-    limit: 200,
+    // Bookmarks share this kind-30300 window; a heavy saver must not crowd
+    // pending reminders out of the fetch.
+    limit: 500,
   });
 
   const results = await Promise.all(events.map(decryptReminder));

--- a/desktop/src/features/reminders/ui/RemindMeLaterProvider.tsx
+++ b/desktop/src/features/reminders/ui/RemindMeLaterProvider.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { useRemindersQuery } from "@/features/reminders/hooks";
+import { isActiveReminder } from "@/features/reminders/lib/reminderFilters";
 import type { ReminderTarget } from "@/features/reminders/lib/reminderTypes";
 import { RemindMeLaterDialog } from "./RemindMeLaterDialog";
 
@@ -39,10 +40,8 @@ export function RemindMeLaterProvider({
   const activeReminderEventIds = React.useMemo(() => {
     const ids = new Set<string>();
     for (const reminder of reminders ?? []) {
-      if (
-        reminder.content.status === "pending" &&
-        reminder.content.target?.eventId
-      ) {
+      // Bookmarks (pending without `not_before`) must not tint the message.
+      if (isActiveReminder(reminder) && reminder.content.target?.eventId) {
         ids.add(reminder.content.target.eventId);
       }
     }

--- a/desktop/src/features/reminders/ui/RemindersPanel.tsx
+++ b/desktop/src/features/reminders/ui/RemindersPanel.tsx
@@ -111,6 +111,49 @@ function formatReminderSourceLocation(source: ReminderSource): string {
     : `#${source.channelLabel}`;
 }
 
+/** Avatar + author + "in #channel" line shared by reminder and saved rows. */
+export function ReminderSourceLine({ source }: { source: ReminderSource }) {
+  return (
+    <div className="flex min-w-0 max-w-full items-center gap-1.5 text-xs text-muted-foreground">
+      <UserAvatar
+        avatarUrl={source.avatarUrl}
+        className="h-4 w-4 shrink-0"
+        displayName={source.authorLabel}
+        size="xs"
+      />
+      <span className="truncate font-medium text-foreground">
+        {source.authorLabel}
+      </span>
+      <span className="shrink-0">in</span>
+      <span className="truncate">{formatReminderSourceLocation(source)}</span>
+    </div>
+  );
+}
+
+/**
+ * Click-through for a reminder-target row: resolve the thread destination,
+ * then jump to the message in its channel. Shared by the reminder rows,
+ * the reminder detail pane, and the bookmarks Saved view.
+ */
+export function useReminderNavigation() {
+  const { goChannel } = useAppNavigation();
+  return React.useCallback(
+    async (reminder: Reminder) => {
+      const destination = await resolveReminderDestination(
+        reminder.content.target,
+      );
+      if (!destination) {
+        return;
+      }
+      void goChannel(destination.channelId, {
+        messageId: destination.messageId,
+        threadRootId: destination.threadRootId,
+      });
+    },
+    [goChannel],
+  );
+}
+
 function ReminderRow({
   isSelected = false,
   presentation = "card",
@@ -188,23 +231,7 @@ function ReminderRow({
         }}
         type="button"
       >
-        {source ? (
-          <div className="flex min-w-0 max-w-full items-center gap-1.5 text-xs text-muted-foreground">
-            <UserAvatar
-              avatarUrl={source.avatarUrl}
-              className="h-4 w-4 shrink-0"
-              displayName={source.authorLabel}
-              size="xs"
-            />
-            <span className="truncate font-medium text-foreground">
-              {source.authorLabel}
-            </span>
-            <span className="shrink-0">in</span>
-            <span className="truncate">
-              {formatReminderSourceLocation(source)}
-            </span>
-          </div>
-        ) : null}
+        {source ? <ReminderSourceLine source={source} /> : null}
         <p className="max-w-full truncate text-sm font-medium">
           {reminder.content.target?.preview ||
             reminder.content.note ||
@@ -274,24 +301,8 @@ export function RemindersPanel({
 }) {
   const remindersQuery = useRemindersQuery(pubkey);
   const reminders = remindersQuery.data;
-  const { goChannel } = useAppNavigation();
   const sources = useReminderSources(reminders ?? []);
-
-  const handleNavigate = React.useCallback(
-    async (reminder: Reminder) => {
-      const destination = await resolveReminderDestination(
-        reminder.content.target,
-      );
-      if (!destination) {
-        return;
-      }
-      void goChannel(destination.channelId, {
-        messageId: destination.messageId,
-        threadRootId: destination.threadRootId,
-      });
-    },
-    [goChannel],
-  );
+  const handleNavigate = useReminderNavigation();
 
   const groups = React.useMemo(
     () => groupReminders(reminders ?? [], includeDone),
@@ -372,7 +383,7 @@ export function ReminderDetailPane({
   pubkey: string;
   reminder: Reminder | null;
 }) {
-  const { goChannel } = useAppNavigation();
+  const navigateToReminder = useReminderNavigation();
   const reminderList = React.useMemo(
     () => (reminder ? [reminder] : []),
     [reminder],
@@ -402,15 +413,8 @@ export function ReminderDetailPane({
   const preview =
     reminder.content.target?.preview || reminder.content.note || "Reminder";
 
-  const handleNavigate = async () => {
-    const destination = await resolveReminderDestination(
-      reminder.content.target,
-    );
-    if (!destination) return;
-    void goChannel(destination.channelId, {
-      messageId: destination.messageId,
-      threadRootId: destination.threadRootId,
-    });
+  const handleNavigate = () => {
+    void navigateToReminder(reminder);
   };
 
   return (

--- a/desktop/tests/e2e/bookmarks.spec.ts
+++ b/desktop/tests/e2e/bookmarks.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+const MOCK_PUBKEY = "deadbeef".repeat(8);
+const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const ALICE_PUBKEY =
+  "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f";
+
+async function gotoInboxHome(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await expect(page.getByTestId("home-inbox")).toBeVisible();
+}
+
+// Saved is reached the same way as Reminders: the inbox filter dropdown.
+async function openSavedFilter(page: import("@playwright/test").Page) {
+  await page.getByTestId("inbox-filter-trigger").click();
+  await page.getByRole("menuitemradio", { name: "Saved" }).click();
+}
+
+// Bookmarks share the reminders kind-30300 seed hook and query cache; see
+// reminders.spec.ts for why the invalidate after seeding is required.
+async function seedReminders(
+  page: import("@playwright/test").Page,
+  events: unknown[],
+) {
+  await page.evaluate((seeded) => {
+    window.__BUZZ_E2E_SEED_MOCK_REMINDERS__?.(
+      seeded as Parameters<
+        NonNullable<typeof window.__BUZZ_E2E_SEED_MOCK_REMINDERS__>
+      >[0],
+    );
+    window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+      queryKey: ["reminders"],
+    });
+  }, events);
+}
+
+// A bookmark is a kind-30300 event with NO `not_before` tag (NIP-ER: a
+// reminder without one is a saved item).
+function mockBookmarkEvent(opts: {
+  id: string;
+  dTag: string;
+  content: string;
+  createdAt?: number;
+}) {
+  return {
+    id: opts.id,
+    pubkey: MOCK_PUBKEY,
+    created_at: opts.createdAt ?? Math.floor(Date.now() / 1000) - 300,
+    kind: 30300,
+    tags: [["d", opts.dTag]],
+    content: opts.content,
+    sig: "mocksig".repeat(20).slice(0, 128),
+  };
+}
+
+function aliceBookmarkContent() {
+  return JSON.stringify({
+    target: {
+      eventId: "mock-general-alice",
+      channelId: GENERAL_CHANNEL_ID,
+      preview: "Hey team — checking in.",
+      authorPubkey: ALICE_PUBKEY,
+    },
+    status: "pending",
+  });
+}
+
+function aliceReminderContent(note: string) {
+  return JSON.stringify({
+    target: {
+      eventId: "mock-general-alice",
+      channelId: GENERAL_CHANNEL_ID,
+      preview: "Hey team — checking in.",
+      authorPubkey: ALICE_PUBKEY,
+    },
+    note,
+    status: "pending",
+  });
+}
+
+test.describe("bookmarks", () => {
+  test.beforeEach(async ({ page }) => {
+    await installMockBridge(page);
+  });
+
+  test("01 — inbox filter dropdown shows Saved option", async ({ page }) => {
+    await gotoInboxHome(page);
+
+    await page.getByTestId("inbox-filter-trigger").click();
+    await expect(
+      page.getByRole("menuitemradio", { name: "Saved" }),
+    ).toBeVisible();
+    await waitForAnimations(page);
+  });
+
+  test("02 — hovering a message shows Save for later in the action bar", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+    const messageRow = page.getByTestId("message-row").first();
+    await messageRow.hover();
+
+    await expect(
+      messageRow.getByRole("button", { name: "Save for later" }),
+    ).toBeVisible();
+    await waitForAnimations(page);
+  });
+
+  test("03 — Saved panel empty state", async ({ page }) => {
+    await gotoInboxHome(page);
+
+    await openSavedFilter(page);
+    await expect(page.getByText("No saved messages")).toBeVisible();
+    await waitForAnimations(page);
+  });
+
+  test("04 — seeded bookmark appears in Saved with author and source", async ({
+    page,
+  }) => {
+    await gotoInboxHome(page);
+
+    await seedReminders(page, [
+      mockBookmarkEvent({
+        id: "bookmark-01",
+        dTag: "bm-01",
+        content: aliceBookmarkContent(),
+      }),
+    ]);
+
+    await openSavedFilter(page);
+    const savedPanel = page.getByTestId("home-inbox-saved");
+    await expect(savedPanel.getByTestId("home-saved-item-bm-01")).toBeVisible();
+    await expect(savedPanel.getByText("alice", { exact: true })).toBeVisible();
+    await expect(
+      savedPanel.getByText("#general", { exact: true }),
+    ).toBeVisible();
+    await expect(savedPanel.getByText("Hey team — checking in.")).toBeVisible();
+    await waitForAnimations(page);
+    await page.screenshot({
+      path: test.info().outputPath("saved-panel.png"),
+    });
+  });
+
+  test("05 — bookmarks and reminders stay out of each other's views", async ({
+    page,
+  }) => {
+    await gotoInboxHome(page);
+
+    await seedReminders(page, [
+      mockBookmarkEvent({
+        id: "bookmark-sep-01",
+        dTag: "bm-sep-01",
+        content: aliceBookmarkContent(),
+      }),
+      {
+        id: "reminder-sep-01",
+        pubkey: MOCK_PUBKEY,
+        created_at: Math.floor(Date.now() / 1000) - 300,
+        kind: 30300,
+        tags: [
+          ["d", "rem-sep-01"],
+          ["not_before", String(Math.floor(Date.now() / 1000) + 3600)],
+        ],
+        content: aliceReminderContent("Reply to Alice"),
+        sig: "mocksig".repeat(20).slice(0, 128),
+      },
+    ]);
+
+    await openSavedFilter(page);
+    const savedPanel = page.getByTestId("home-inbox-saved");
+    await expect(
+      savedPanel.getByTestId("home-saved-item-bm-sep-01"),
+    ).toBeVisible();
+    await expect(savedPanel.getByText("Reply to Alice")).not.toBeVisible();
+
+    // Let the Saved selection's dropdown fully close before reopening it —
+    // a click that lands mid-close animation is swallowed by Radix.
+    await waitForAnimations(page);
+    await page.getByTestId("inbox-filter-trigger").click();
+    await page.getByRole("menuitemradio", { name: "Reminders" }).click();
+    const remindersPanel = page.getByTestId("home-inbox-reminders");
+    await expect(
+      remindersPanel.getByTestId("home-reminder-item-rem-sep-01"),
+    ).toBeVisible();
+    await expect(
+      remindersPanel.getByTestId("home-saved-item-bm-sep-01"),
+    ).not.toBeVisible();
+    await waitForAnimations(page);
+  });
+
+  test("06 — action bar toggle saves, lists, and unsaves a message", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+    const messageRow = page
+      .getByTestId("message-row")
+      .filter({ hasText: "Hey team — checking in." })
+      .first();
+    await messageRow.hover();
+
+    const saveButton = messageRow.getByTestId(
+      "bookmark-message-mock-general-alice",
+    );
+    await expect(saveButton).toHaveAttribute("aria-label", "Save for later");
+    await saveButton.click();
+
+    // Publish round-trips through the mock relay's replaceable store, the
+    // shared query invalidates, and the same button flips to the saved state.
+    await expect(saveButton).toHaveAttribute("aria-label", "Remove from saved");
+    await page.screenshot({
+      path: test.info().outputPath("action-bar-saved.png"),
+    });
+
+    await page
+      .getByTestId("sidebar-primary-menu")
+      .getByRole("button", { name: "Inbox", exact: true })
+      .click();
+    await expect(page.getByTestId("home-inbox")).toBeVisible();
+    await openSavedFilter(page);
+    const savedPanel = page.getByTestId("home-inbox-saved");
+    await expect(savedPanel.getByText("Hey team — checking in.")).toBeVisible();
+
+    await savedPanel.getByRole("button", { name: "Remove from saved" }).click();
+    await expect(page.getByText("No saved messages")).toBeVisible();
+    await waitForAnimations(page);
+  });
+
+  test("07 — clicking a saved row navigates to the message in context", async ({
+    page,
+  }) => {
+    await gotoInboxHome(page);
+
+    await seedReminders(page, [
+      mockBookmarkEvent({
+        id: "bookmark-nav-01",
+        dTag: "bm-nav-01",
+        content: aliceBookmarkContent(),
+      }),
+    ]);
+
+    await openSavedFilter(page);
+    await page
+      .getByTestId("home-saved-item-bm-nav-01")
+      .getByRole("button")
+      .first()
+      .click();
+
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await expect(
+      page.getByTestId("message-timeline").getByText("Hey team — checking in."),
+    ).toBeVisible();
+    await waitForAnimations(page);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Slack-style **"Save for later"** feature to the desktop app:

- **Bookmark toggle** in the message hover action bar (between Copy link and the ⋯ menu): `Save for later` ⇄ `Remove from saved`, with a filled accent icon when saved. Renders anywhere `MessageActionBar` mounts (channel timeline and inbox detail).
- **Saved view** as a new inbox filter (`Inbox → filter → Saved`), following the precedent set when Reminders moved from a route into the inbox filter menu. Rows show author, `in #channel`, preview, and saved time; clicking a row jumps straight to the message (resolving the thread root like reminder rows do); a trailing button unsaves.

### Substrate: NIP-ER `kind:30300` with no `not_before` — the bookmark the protocol already defines

NIP-ER's own text: *"A reminder without `not_before` is a **bookmark (saved item with no due time)** or a terminal state"* (`docs/nips/NIP-ER.md:9`, tag rules at `:58`/`:69`), and the relay's `validate_event_reminder` already accepts exactly this shape (`crates/buzz-relay/src/handlers/ingest.rs`). So this PR is **UI-only — zero relay/db/Rust changes** — it lights up semantics the backend already ships:

- **Privacy is relay-enforced, not just encryption**: `kind:30300` is in `AUTHOR_ONLY_KINDS` (`crates/buzz-core/src/kind.rs`), so other members' REQs can never see that a bookmark exists. Content (target message id, preview) is NIP-44 self-encrypted as with reminders.
- **Per-item d-tags instead of one replaceable list**: no last-write-wins race dropping bookmarks when two devices toggle concurrently; multi-device duplicate saves collapse on read, and unsave cancels every matching d-tag.
- **Unsave is the existing `cancelReminder`** (replaceable cancel + jittered expiration) — no new write path.
- **One query/cache**: bookmarks piggyback on `useRemindersQuery` (same kind, same invalidation spine), so the action-bar toggle, Saved list, and every reminder surface stay consistent with no extra fetch machinery. `fetchReminders` limit is raised 200 → 500 since the kinds now share the window.
- Includes a small correctness fix in `RemindMeLaterProvider`: a pending 30300 **without** `not_before` no longer tints its message "Reminder set" (correct per NIP-ER; the state was unreachable before this feature).
- A few shared concepts are named once instead of copy-pasted: `isActiveReminder` (reminderFilters) so reminders/bookmarks partition the kind by construction, `isPersonalFilter` (inbox lib) for the reminders/saved/drafts filter family, and `ReminderSourceLine` + `useReminderNavigation` extracted from `RemindersPanel` — the latter also dedupes a pre-existing third copy of the navigate logic in `ReminderDetailPane`. Toggle in-flight state is per-row local, so a save/unsave re-renders only the row it happened on (every message row mounts a context-subscribed action bar).

Every reminder surface already filters on `notBefore !== undefined` (`reminderFilters.ts`), so bookmarks and reminders provably stay out of each other's views — covered by an e2e test below.

### Related issue

None found for issues. Closest existing work: **#3712** implements the same feature on a different substrate (a single NIP-78 `kind:30078` `d="bookmarks"` encrypted list) and left the storage choice flagged as a "decision to sanity-check". This PR is offered as the NIP-ER answer to that open question — relay-enforced author-only reads, no whole-list replace race, and no new sync engine — rather than as competition; happy to consolidate on whichever substrate maintainers prefer and close one of the two.

### Testing

All run from `desktop/` on `aarch64-apple-darwin`:

- `pnpm typecheck` — clean
- `pnpm check` (biome + px-text + pubkey-truncation guards) — clean
- `pnpm test` — 5,807 passing, including 8 new node tests for the bookmark predicate/collection (`bookmarkFilters.test.mjs`)
- `pnpm build` — clean
- `node scripts/check-file-sizes.mjs` — passes; `HomeView.tsx` lands at 991/1000 (2 lines below main), `MessageRow.tsx` and `AppShell.tsx` untouched (the context-provider design exists to respect the ratchet)
- Playwright: new `tests/e2e/bookmarks.spec.ts` (registered in the smoke project), **7/7 passing**: filter option · action-bar button on hover · empty state · seeded bookmark row with author/source · bookmarks and reminders isolated from each other's views · full click round-trip (save → icon flips → listed in Saved → unsave → gone) · saved-row click navigates to the message in context. Existing `smoke.spec.ts` + `navigation.spec.ts` (52 tests) still pass.
- Not run: `just ci` Rust/mobile lanes (no Rust or mobile files are touched).

**Screenshots** (captured by the e2e spec):

Action bar with the toggle in its saved state:

![action bar with bookmark toggle saved](https://raw.githubusercontent.com/Junhan2/buzz/assets-bookmarks/action-bar-saved.png)

Saved inbox filter listing a bookmarked message:

![saved inbox filter view](https://raw.githubusercontent.com/Junhan2/buzz/assets-bookmarks/saved-panel.png)

The e2e harness's mock relay replicates the replaceable-per-d-tag store, so the click round-trip above exercises the real publish/replace flow; NIP-44 encryption and signing go through the same code path reminders already use in production. The author-only read gate is relay code (`handlers/req.rs`) exercised by existing relay tests, not by this PR.

### Deferred follow-ups

- Named bookmark collections (`kind:30003`-style sets) and notes on saved items
- A saved-count badge on the filter option
- Web/mobile parity
- While the Saved filter is open, the right pane intentionally keeps the messages-mode "Select a message" placeholder (saved rows navigate away rather than opening a detail pane); a dedicated Saved detail pane would need the `HomePersonalInboxDetail` machinery extended and is deferred
- Bookmarks and reminders share one `{kinds:[30300]}` fetch window (raised to 500 here); truly decoupling the two budgets needs relay-side filtering on `not_before` presence, deferred as a relay change
