### PR TITLE
fix(acp): avoid duplicate Hermes 0.21 replies

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -227,6 +227,10 @@ pub struct AcpClient {
     /// ACP final text. Disabled adapters keep using their own Buzz CLI reply
     /// path and must not retain progress chunks as fallback content.
     final_text_capture_enabled: bool,
+    /// Whether this initialized ACP process needs the harness to submit its
+    /// final text. This is negotiated from the adapter handshake, rather than
+    /// inferred from the configured command alone.
+    final_text_fallback_enabled: bool,
     /// A prompt emitted more final text than Buzz can publish in one message.
     /// Never truncate a response silently; the pool skips the fallback instead.
     final_text_overflowed: bool,
@@ -581,6 +585,7 @@ impl AcpClient {
             standard_adapter,
             final_text: String::new(),
             final_text_capture_enabled: false,
+            final_text_fallback_enabled: false,
             final_text_overflowed: false,
         })
     }
@@ -628,6 +633,19 @@ impl AcpClient {
         self.final_text_capture_enabled = enabled;
         self.final_text.clear();
         self.final_text_overflowed = false;
+    }
+
+    /// Record whether this initialized process requires harness final-text
+    /// delivery. The caller derives this from the ACP handshake after every
+    /// spawn, including respawns.
+    pub(crate) fn set_final_text_fallback_enabled(&mut self, enabled: bool) {
+        self.final_text_fallback_enabled = enabled;
+    }
+
+    /// Whether the current initialized process requires harness final-text
+    /// delivery.
+    pub(crate) fn final_text_fallback_enabled(&self) -> bool {
+        self.final_text_fallback_enabled
     }
 
     /// Emit a semantic event to the local observer feed, if enabled.

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -22,6 +22,11 @@ use crate::usage::{
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
 
+/// Maximum final text retained from ACP `agent_message_chunk` updates for one
+/// prompt. This matches Buzz's stream-message content limit, so a retained
+/// response can be published without truncation.
+const MAX_FINAL_TEXT_BYTES: usize = 64 * 1024;
+
 /// An MCP server configuration passed to `session/new`.
 ///
 /// Corresponds to the `McpServerStdio` variant in the ACP schema.
@@ -214,6 +219,17 @@ pub struct AcpClient {
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
     standard_adapter: Option<StandardAdapterKind>,
+    /// Text emitted through ACP `agent_message_chunk` notifications for the
+    /// current prompt. The harness can publish this when an adapter cannot use
+    /// the Buzz CLI from its tool environment.
+    final_text: String,
+    /// Whether the configured adapter relies on the harness to publish its
+    /// ACP final text. Disabled adapters keep using their own Buzz CLI reply
+    /// path and must not retain progress chunks as fallback content.
+    final_text_capture_enabled: bool,
+    /// A prompt emitted more final text than Buzz can publish in one message.
+    /// Never truncate a response silently; the pool skips the fallback instead.
+    final_text_overflowed: bool,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -563,6 +579,9 @@ impl AcpClient {
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
+            final_text: String::new(),
+            final_text_capture_enabled: false,
+            final_text_overflowed: false,
         })
     }
 
@@ -585,6 +604,30 @@ impl AcpClient {
     /// Return the pool slot index for this agent process.
     pub(crate) fn observer_agent_index(&self) -> Option<usize> {
         self.observer_agent_index
+    }
+
+    /// Take the current prompt's complete user-facing ACP text.
+    ///
+    /// Returns `None` when the agent emitted no displayable text or exceeded
+    /// Buzz's message limit. Starting every `session/prompt` clears the prior
+    /// value, so setup/initial-message output cannot leak into a later reply.
+    pub(crate) fn take_final_text(&mut self) -> Option<String> {
+        let overflowed = std::mem::replace(&mut self.final_text_overflowed, false);
+        let text = std::mem::take(&mut self.final_text);
+        if overflowed || text.trim().is_empty() {
+            None
+        } else {
+            Some(text)
+        }
+    }
+
+    /// Configure capture for the next ACP prompt. Only adapters in Buzz's
+    /// final-text fallback allowlist enable this; other adapters publish their
+    /// own channel reply and can emit non-final progress chunks.
+    pub(crate) fn set_final_text_capture(&mut self, enabled: bool) {
+        self.final_text_capture_enabled = enabled;
+        self.final_text.clear();
+        self.final_text_overflowed = false;
     }
 
     /// Emit a semantic event to the local observer feed, if enabled.
@@ -781,6 +824,10 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        // ACP text belongs to exactly one prompt. Clearing here keeps an
+        // initial-message or failed-turn response from becoming a later reply.
+        self.final_text.clear();
+        self.final_text_overflowed = false;
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -1756,6 +1803,18 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    if self.final_text_capture_enabled
+                        && self.final_text.len().saturating_add(text.len()) <= MAX_FINAL_TEXT_BYTES
+                    {
+                        self.final_text.push_str(text);
+                    } else if self.final_text_capture_enabled && !self.final_text_overflowed {
+                        self.final_text_overflowed = true;
+                        tracing::warn!(
+                            target: "acp::stream",
+                            max_bytes = MAX_FINAL_TEXT_BYTES,
+                            "agent final text exceeds the Buzz message limit; fallback reply suppressed"
+                        );
+                    }
                 }
                 false
             }
@@ -3747,6 +3806,53 @@ mod tests {
                 },
             }
         })
+    }
+
+    fn agent_message_chunk_msg(text: &str) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "test-session",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"text": text},
+                },
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn final_text_accumulates_agent_message_chunks_and_drains_once() {
+        let mut client = spawn_inert_client().await;
+        client.set_final_text_capture(true);
+        let _ = client.handle_session_update(&agent_message_chunk_msg("first "));
+        let _ = client.handle_session_update(&agent_message_chunk_msg("reply"));
+
+        assert_eq!(client.take_final_text().as_deref(), Some("first reply"));
+        assert_eq!(
+            client.take_final_text(),
+            None,
+            "take must drain the prior turn"
+        );
+    }
+
+    #[tokio::test]
+    async fn final_text_over_message_limit_is_not_published() {
+        let mut client = spawn_inert_client().await;
+        client.set_final_text_capture(true);
+        let oversized = "x".repeat(MAX_FINAL_TEXT_BYTES + 1);
+        let _ = client.handle_session_update(&agent_message_chunk_msg(&oversized));
+
+        assert_eq!(client.take_final_text(), None);
+    }
+
+    #[tokio::test]
+    async fn final_text_capture_is_disabled_until_the_adapter_is_allowlisted() {
+        let mut client = spawn_inert_client().await;
+        let _ = client.handle_session_update(&agent_message_chunk_msg("progress output"));
+
+        assert_eq!(client.take_final_text(), None);
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -533,8 +533,8 @@ pub struct Config {
     pub relay_url: String,
     pub agent_command: String,
     pub agent_args: Vec<String>,
-    /// Whether this adapter cannot publish through the Buzz CLI and therefore
-    /// relies on the harness to publish its ACP final text.
+    /// Whether the configured command may use harness final-text delivery.
+    /// The initialized adapter version narrows this per process.
     pub final_text_fallback_enabled: bool,
     pub mcp_command: String,
     pub idle_timeout_secs: u64,
@@ -803,19 +803,71 @@ pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'sta
     }
 }
 
-/// Whether Buzz must publish the agent's final ACP text itself.
+/// Whether the configured command is a Hermes adapter that may need final-text
+/// fallback delivery.
 ///
-/// This is deliberately an explicit adapter allowlist, not a best-effort
-/// duplicate check. Adapters that can run `buzz` publish their own replies and
-/// may emit progress chunks before their final answer; enabling the fallback
-/// for them can double-post or publish that progress as a reply. Hermes blocks
-/// Buzz credentials from its tool-shell environment, so its ACP text is the
-/// supported delivery path until the adapter changes that security model.
+/// The command identity is only a candidate gate. Hermes 0.21+ reports its
+/// version during ACP initialization and can use the Buzz-managed terminal to
+/// publish directly; that per-process capability is evaluated by
+/// [`needs_final_text_fallback`]. Keeping the candidate narrow prevents other
+/// adapters' progress chunks from becoming duplicate replies.
 pub(crate) fn supports_final_text_fallback(command: &str) -> bool {
     matches!(
         normalize_agent_command_identity(command).as_str(),
         "hermes" | "hermes-agent" | "hermes-acp"
     )
+}
+
+/// Whether this initialized adapter still needs harness final-text delivery.
+///
+/// Hermes 0.21.0 introduced direct `buzz messages send` delivery from its
+/// Buzz-managed terminal. Only a Buzz-managed process whose ACP handshake
+/// identifies itself as Hermes 0.21 or newer opts out of the fallback. A
+/// missing Buzz-managed marker, missing or malformed handshake, or older
+/// adapter remains on the fallback path so legacy and credential-isolated
+/// Hermes installations retain delivery.
+pub(crate) fn needs_final_text_fallback(
+    command: &str,
+    init_result: &serde_json::Value,
+    buzz_managed: bool,
+) -> bool {
+    if !supports_final_text_fallback(command) {
+        return false;
+    }
+    if !buzz_managed {
+        return true;
+    }
+
+    let Some(info) = init_result.get("agentInfo") else {
+        return true;
+    };
+    if info.get("name").and_then(|value| value.as_str()) != Some("hermes-agent") {
+        return true;
+    }
+    let Some(version) = info.get("version").and_then(|value| value.as_str()) else {
+        return true;
+    };
+
+    let mut components = version.split('.');
+    let parse_component =
+        |component: Option<&str>| component.and_then(|value| value.parse::<u64>().ok());
+    let (Some(major), Some(minor), Some(patch)) = (
+        parse_component(components.next()),
+        parse_component(components.next()),
+        parse_component(components.next()),
+    ) else {
+        return true;
+    };
+    // Do not trust versions with trailing data (for example, a pre-release)
+    // to have the stable 0.21 delivery behavior. The conservative fallback
+    // preserves a reply when the capability cannot be established.
+    if components.next().is_some()
+        || patch.to_string() != version.rsplit('.').next().unwrap_or_default()
+    {
+        return true;
+    }
+
+    (major, minor, patch) < (0, 21, 0)
 }
 
 /// Build the `CODEX_CONFIG` environment variable that enables full outbound
@@ -1785,6 +1837,37 @@ mod tests {
             assert!(
                 !supports_final_text_fallback(command),
                 "{command} must retain agent-authored reply delivery"
+            );
+        }
+    }
+
+    #[test]
+    fn direct_capable_hermes_uses_its_own_buzz_delivery() {
+        let init = serde_json::json!({
+            "agentInfo": {"name": "hermes-agent", "version": "0.21.0"}
+        });
+
+        assert!(
+            !needs_final_text_fallback("hermes-acp", &init, true),
+            "Hermes 0.21 must not create a duplicate harness reply"
+        );
+        assert!(
+            needs_final_text_fallback("hermes-acp", &init, false),
+            "a credential-isolated Hermes 0.21 must retain harness delivery"
+        );
+    }
+
+    #[test]
+    fn legacy_or_unrecognized_hermes_retains_final_text_fallback() {
+        for init in [
+            serde_json::json!({"agentInfo": {"name": "hermes-agent", "version": "0.20.9"}}),
+            serde_json::json!({"agentInfo": {"name": "hermes-agent", "version": "dev"}}),
+            serde_json::json!({"agentInfo": {"name": "other-agent", "version": "0.21.0"}}),
+            serde_json::json!({}),
+        ] {
+            assert!(
+                needs_final_text_fallback("hermes-acp", &init, true),
+                "unrecognized or legacy Hermes must retain fail-safe delivery: {init}"
             );
         }
     }

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -533,6 +533,9 @@ pub struct Config {
     pub relay_url: String,
     pub agent_command: String,
     pub agent_args: Vec<String>,
+    /// Whether this adapter cannot publish through the Buzz CLI and therefore
+    /// relies on the harness to publish its ACP final text.
+    pub final_text_fallback_enabled: bool,
     pub mcp_command: String,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
@@ -800,6 +803,21 @@ pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'sta
     }
 }
 
+/// Whether Buzz must publish the agent's final ACP text itself.
+///
+/// This is deliberately an explicit adapter allowlist, not a best-effort
+/// duplicate check. Adapters that can run `buzz` publish their own replies and
+/// may emit progress chunks before their final answer; enabling the fallback
+/// for them can double-post or publish that progress as a reply. Hermes blocks
+/// Buzz credentials from its tool-shell environment, so its ACP text is the
+/// supported delivery path until the adapter changes that security model.
+pub(crate) fn supports_final_text_fallback(command: &str) -> bool {
+    matches!(
+        normalize_agent_command_identity(command).as_str(),
+        "hermes" | "hermes-agent" | "hermes-acp"
+    )
+}
+
 /// Build the `CODEX_CONFIG` environment variable that enables full outbound
 /// network access in Codex's macOS Seatbelt sandbox.
 ///
@@ -988,6 +1006,7 @@ impl Config {
         }
 
         let agent_args = normalize_agent_args(&agent_command, args.agent_args);
+        let final_text_fallback_enabled = supports_final_text_fallback(&agent_command);
 
         if let Some(ref channels) = args.channels {
             for ch in channels {
@@ -1140,6 +1159,7 @@ impl Config {
             relay_url: args.relay_url,
             agent_command,
             agent_args,
+            final_text_fallback_enabled,
             mcp_command: args.mcp_command,
             idle_timeout_secs,
             max_turn_duration_secs,
@@ -1523,6 +1543,7 @@ mod tests {
             relay_url: "ws://localhost:3000".into(),
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
+            final_text_fallback_enabled: false,
             mcp_command: "".into(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
@@ -1742,6 +1763,28 @@ mod tests {
             assert!(
                 default_agent_env(command).is_empty(),
                 "non-Hermes command must have no env defaults: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn final_text_fallback_is_allowlisted_to_hermes() {
+        for command in [
+            "hermes",
+            "hermes-agent",
+            "/usr/local/bin/hermes-acp",
+            r"C:\\Users\\test\\AppData\\Roaming\\npm\\hermes-acp.cmd",
+        ] {
+            assert!(
+                supports_final_text_fallback(command),
+                "{command} must enable the Hermes final-text fallback"
+            );
+        }
+
+        for command in ["codex-acp", "claude-agent-acp", "goose", "custom-acp"] {
+            assert!(
+                !supports_final_text_fallback(command),
+                "{command} must retain agent-authored reply delivery"
             );
         }
     }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2727,7 +2727,6 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
-        final_text_fallback_enabled: config.final_text_fallback_enabled,
     });
 
     if !config.memory_enabled {
@@ -2965,10 +2964,20 @@ async fn tokio_main() -> Result<()> {
                 let args = config.agent_args.clone();
                 let env = config.persona_env_vars.clone();
                 let has_codex = config.has_generated_codex_config;
+                let final_text_fallback_candidate = config.final_text_fallback_enabled;
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result = spawn_and_init(
+                        &cmd,
+                        &args,
+                        &env,
+                        has_codex,
+                        final_text_fallback_candidate,
+                        idx,
+                        observer,
+                    )
+                    .await;
                     guard.send(result);
                 });
             }
@@ -4953,12 +4962,22 @@ fn recover_panicked_agent(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let final_text_fallback_candidate = config.final_text_fallback_enabled;
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            has_codex,
+            final_text_fallback_candidate,
+            i,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 }
@@ -5181,6 +5200,7 @@ fn spawn_respawn_task(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let final_text_fallback_candidate = config.final_text_fallback_enabled;
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
@@ -5192,7 +5212,16 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            has_codex,
+            final_text_fallback_candidate,
+            index,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 
@@ -5236,6 +5265,7 @@ struct PoolStartup {
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
     has_generated_codex_config: bool,
+    final_text_fallback_candidate: bool,
     model: Option<String>,
     effort_level: Option<String>,
     observer: Option<observer::ObserverHandle>,
@@ -5249,6 +5279,7 @@ impl PoolStartup {
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
             has_generated_codex_config: config.has_generated_codex_config,
+            final_text_fallback_candidate: config.final_text_fallback_enabled,
             model: config.model.clone(),
             effort_level: config.effort_level.clone(),
             observer,
@@ -5289,6 +5320,15 @@ async fn initialize_agent_pool(
                 };
                 match initialize_result {
                     Ok(Ok(init_result)) => {
+                        acp.set_final_text_fallback_enabled(
+                            startup.final_text_fallback_candidate
+                                && config::needs_final_text_fallback(
+                                    &startup.command,
+                                    &init_result,
+                                    std::env::var_os("BUZZ_MANAGED_AGENT")
+                                        .is_some_and(|value| !value.is_empty()),
+                                ),
+                        );
                         tracing::info!(agent = i, "agent initialized: {init_result}");
                         let protocol_version =
                             init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
@@ -5301,6 +5341,7 @@ async fn initialize_agent_pool(
                                 .and_then(|v| v.as_str())
                                 .unwrap_or("unknown"),
                             steering_supported = acp.steering_supported(),
+                            final_text_fallback_enabled = acp.final_text_fallback_enabled(),
                             "agent initialized"
                         );
                         acp.observe(
@@ -5372,6 +5413,7 @@ async fn spawn_and_init(
     args: &[String],
     extra_env: &[(String, String)],
     has_generated_codex_config: bool,
+    final_text_fallback_candidate: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
@@ -5382,6 +5424,15 @@ async fn spawn_and_init(
 
     match acp.initialize().await {
         Ok(init_result) => {
+            acp.set_final_text_fallback_enabled(
+                final_text_fallback_candidate
+                    && config::needs_final_text_fallback(
+                        command,
+                        &init_result,
+                        std::env::var_os("BUZZ_MANAGED_AGENT")
+                            .is_some_and(|value| !value.is_empty()),
+                    ),
+            );
             tracing::info!("agent initialized: {init_result}");
             let protocol_version = init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
             acp.observe(

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2727,6 +2727,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        final_text_fallback_enabled: config.final_text_fallback_enabled,
     });
 
     if !config.memory_enabled {
@@ -8825,6 +8826,7 @@ mod build_mcp_servers_tests {
             relay_url: "ws://localhost:3000".into(),
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
+            final_text_fallback_enabled: false,
             mcp_command: "test-mcp-server".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
@@ -9050,6 +9052,7 @@ mod error_outcome_emission_tests {
             // feed emission under test.
             agent_command: "true".into(),
             agent_args: vec![],
+            final_text_fallback_enabled: false,
             mcp_command: "test-mcp-server".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -48,6 +48,8 @@ use crate::scope::SessionScope;
 /// the turn as "recently active" (eligible for requeue instead of dead-letter).
 const RECENT_ACTIVITY_WINDOW: Duration = Duration::from_secs(60);
 
+const FINAL_TEXT_REPLY_SUBMIT_TIMEOUT: Duration = Duration::from_secs(5);
+
 // FlushBatch and BatchEvent derive Clone (added in queue.rs) so we can store
 // a recoverable copy in TaskMeta for panic recovery in Queue mode.
 
@@ -806,6 +808,9 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Whether the configured ACP adapter is allowlisted to rely on harness
+    /// publication of its final text instead of posting through `buzz` itself.
+    pub final_text_fallback_enabled: bool,
 }
 
 impl AgentPool {
@@ -2740,6 +2745,9 @@ pub async fn run_prompt_task(
             .collect(),
         None => prompt_sections.iter().map(String::as_str).collect(),
     };
+    agent
+        .acp
+        .set_final_text_capture(ctx.final_text_fallback_enabled && batch.is_some());
     let prompt_bytes: usize = prompt_blocks.iter().map(|block| block.len()).sum();
     let has_standing_context = match &source {
         PromptSource::Channel(_) => !standing.sections().is_empty(),
@@ -2943,6 +2951,14 @@ pub async fn run_prompt_task(
                             Some(buzz_core::agent_turn_metric::StopReason::EndTurn),
                         )
                         .await;
+                        if ctx.final_text_fallback_enabled {
+                            publish_final_text_reply(
+                                &ctx.rest_client,
+                                batch.as_ref(),
+                                agent.acp.take_final_text(),
+                            )
+                            .await;
+                        }
                         send_prompt_result(
                             &result_tx,
                             &turn_id,
@@ -3017,6 +3033,17 @@ pub async fn run_prompt_task(
                 Some(core_stop),
             )
             .await;
+
+            if ctx.final_text_fallback_enabled
+                && matches!(&stop_reason, StopReason::EndTurn | StopReason::Refusal)
+            {
+                publish_final_text_reply(
+                    &ctx.rest_client,
+                    batch.as_ref(),
+                    agent.acp.take_final_text(),
+                )
+                .await;
+            }
 
             send_prompt_result(
                 &result_tx,
@@ -4517,6 +4544,84 @@ fn record_scope_delivery_success(
     );
 }
 
+/// Publish ACP final text for adapters that cannot post through `buzz`.
+///
+/// The harness owns the relay signer, while some ACP adapters deliberately
+/// isolate their tool subprocess environment from Buzz credentials. We retain
+/// the agent's `agent_message_chunk` text in [`AcpClient`] and publish it here
+/// only after a normal terminal turn. The adapter allowlist is the deduplication
+/// boundary: adapters that can post through the CLI do not capture or submit
+/// final text, so no reply-tag convention can cause a duplicate.
+async fn publish_final_text_reply(
+    rest: &RestClient,
+    batch: Option<&FlushBatch>,
+    final_text: Option<String>,
+) {
+    let (Some(batch), Some(final_text)) = (batch, final_text) else {
+        return;
+    };
+    let Some(triggering_event) = batch.events.last().map(|event| &event.event) else {
+        return;
+    };
+
+    let trigger_id = triggering_event.id.to_hex();
+    let thread_tags = crate::queue::parse_thread_tags(triggering_event);
+    let root_event_id = thread_tags
+        .root_event_id
+        .as_deref()
+        .and_then(|id| nostr::EventId::from_hex(id).ok())
+        .unwrap_or(triggering_event.id);
+    let thread_ref = buzz_sdk::ThreadRef {
+        root_event_id,
+        parent_event_id: triggering_event.id,
+    };
+    let builder = match buzz_sdk::build_message(
+        batch.channel_id,
+        &final_text,
+        Some(&thread_ref),
+        &[],
+        false,
+        &[],
+    ) {
+        Ok(builder) => builder,
+        Err(error) => {
+            tracing::warn!(
+                channel = %batch.channel_id,
+                "could not build ACP final-text fallback reply: {error}"
+            );
+            return;
+        }
+    };
+    let event = match builder.sign_with_keys(&rest.keys) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::warn!(
+                channel = %batch.channel_id,
+                "could not sign ACP final-text fallback reply: {error}"
+            );
+            return;
+        }
+    };
+    match timeout(FINAL_TEXT_REPLY_SUBMIT_TIMEOUT, rest.submit_event(&event)).await {
+        Ok(Ok(_)) => tracing::info!(
+            channel = %batch.channel_id,
+            trigger = %trigger_id,
+            "published ACP final-text fallback reply"
+        ),
+        Ok(Err(error)) => tracing::warn!(
+            channel = %batch.channel_id,
+            trigger = %trigger_id,
+            "ACP final-text fallback reply failed: {error}"
+        ),
+        Err(_) => tracing::warn!(
+            channel = %batch.channel_id,
+            trigger = %trigger_id,
+            timeout_ms = FINAL_TEXT_REPLY_SUBMIT_TIMEOUT.as_millis() as u64,
+            "ACP final-text fallback reply timed out"
+        ),
+    }
+}
+
 //
 // Two-phase lifecycle visible to users:
 //   👀  "seen"    — event was queued and an agent will handle it
@@ -5145,6 +5250,124 @@ mod tests {
             args: vec![],
             env: vec![],
         }
+    }
+
+    fn final_text_batch(channel_id: Uuid, event: nostr::Event) -> FlushBatch {
+        FlushBatch {
+            channel_id,
+            events: vec![crate::queue::BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn final_text_fallback_posts_a_threaded_reply() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fallback server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (posted_tx, posted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept event submission");
+            let mut request = vec![0; 32 * 1024];
+            let read = socket.read(&mut request).await.expect("read request");
+            let request = String::from_utf8(request[..read].to_vec()).expect("utf8 request");
+            assert!(request.starts_with("POST /events "));
+            let body = request
+                .split("\r\n\r\n")
+                .nth(1)
+                .expect("event request body")
+                .to_owned();
+            posted_tx.send(body).expect("deliver submitted event");
+            let response_body = r#"{"accepted":true}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        let agent_keys = Keys::generate();
+        let rest = RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: agent_keys.clone(),
+            auth_tag_json: None,
+        };
+        let channel_id = Uuid::new_v4();
+        let triggering_event = EventBuilder::new(Kind::Custom(9), "please reply")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign trigger");
+        let trigger_id = triggering_event.id.to_hex();
+        let batch = final_text_batch(channel_id, triggering_event);
+
+        publish_final_text_reply(&rest, Some(&batch), Some("Hermes reply".into())).await;
+
+        let body = posted_rx.await.expect("fallback event was submitted");
+        let event: nostr::Event = serde_json::from_str(&body).expect("submitted event");
+        server.await.expect("server completes");
+
+        assert_eq!(event.content, "Hermes reply");
+        assert_eq!(event.pubkey, agent_keys.public_key());
+        let tags: Vec<Vec<String>> = event
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+        assert!(tags.iter().any(|tag| {
+            tag.first().is_some_and(|value| value == "h")
+                && tag
+                    .get(1)
+                    .is_some_and(|value| value == &channel_id.to_string())
+        }));
+        assert!(tags.iter().any(|tag| {
+            tag.first().is_some_and(|value| value == "e")
+                && tag.get(1).is_some_and(|value| value == &trigger_id)
+                && tag.get(3).is_some_and(|value| value == "reply")
+        }));
+    }
+
+    #[tokio::test]
+    async fn final_text_fallback_does_not_submit_without_final_text() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind missing-text server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_ok()
+        });
+
+        let rest = RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        };
+        let batch = final_text_batch(
+            Uuid::new_v4(),
+            EventBuilder::new(Kind::Custom(9), "already answered")
+                .sign_with_keys(&Keys::generate())
+                .expect("sign trigger"),
+        );
+
+        publish_final_text_reply(&rest, Some(&batch), None).await;
+
+        assert!(
+            !server.await.expect("server completes"),
+            "missing ACP final text must not send a fallback request"
+        );
     }
 
     #[test]
@@ -8687,6 +8910,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            final_text_fallback_enabled: false,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -808,9 +808,6 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
-    /// Whether the configured ACP adapter is allowlisted to rely on harness
-    /// publication of its final text instead of posting through `buzz` itself.
-    pub final_text_fallback_enabled: bool,
 }
 
 impl AgentPool {
@@ -2745,9 +2742,10 @@ pub async fn run_prompt_task(
             .collect(),
         None => prompt_sections.iter().map(String::as_str).collect(),
     };
+    let final_text_fallback_enabled = agent.acp.final_text_fallback_enabled();
     agent
         .acp
-        .set_final_text_capture(ctx.final_text_fallback_enabled && batch.is_some());
+        .set_final_text_capture(final_text_fallback_enabled && batch.is_some());
     let prompt_bytes: usize = prompt_blocks.iter().map(|block| block.len()).sum();
     let has_standing_context = match &source {
         PromptSource::Channel(_) => !standing.sections().is_empty(),
@@ -2951,7 +2949,7 @@ pub async fn run_prompt_task(
                             Some(buzz_core::agent_turn_metric::StopReason::EndTurn),
                         )
                         .await;
-                        if ctx.final_text_fallback_enabled {
+                        if final_text_fallback_enabled {
                             publish_final_text_reply(
                                 &ctx.rest_client,
                                 batch.as_ref(),
@@ -3034,7 +3032,7 @@ pub async fn run_prompt_task(
             )
             .await;
 
-            if ctx.final_text_fallback_enabled
+            if final_text_fallback_enabled
                 && matches!(&stop_reason, StopReason::EndTurn | StopReason::Refusal)
             {
                 publish_final_text_reply(
@@ -5255,6 +5253,7 @@ mod tests {
     fn final_text_batch(channel_id: Uuid, event: nostr::Event) -> FlushBatch {
         FlushBatch {
             channel_id,
+            scope: conv(channel_id),
             events: vec![crate::queue::BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -5305,7 +5304,20 @@ mod tests {
             auth_tag_json: None,
         };
         let channel_id = Uuid::new_v4();
+        let root_event = EventBuilder::new(Kind::Custom(9), "thread root")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign root");
+        let root_id = root_event.id.to_hex();
+        let parent_event = EventBuilder::new(Kind::Custom(9), "thread parent")
+            .tags([Tag::parse(["e", &root_id, "", "root"]).expect("root tag")])
+            .sign_with_keys(&Keys::generate())
+            .expect("sign parent");
+        let parent_id = parent_event.id.to_hex();
         let triggering_event = EventBuilder::new(Kind::Custom(9), "please reply")
+            .tags([
+                Tag::parse(["e", &root_id, "", "root"]).expect("root tag"),
+                Tag::parse(["e", &parent_id, "", "reply"]).expect("reply tag"),
+            ])
             .sign_with_keys(&Keys::generate())
             .expect("sign trigger");
         let trigger_id = triggering_event.id.to_hex();
@@ -5329,6 +5341,11 @@ mod tests {
                 && tag
                     .get(1)
                     .is_some_and(|value| value == &channel_id.to_string())
+        }));
+        assert!(tags.iter().any(|tag| {
+            tag.first().is_some_and(|value| value == "e")
+                && tag.get(1).is_some_and(|value| value == &root_id)
+                && tag.get(3).is_some_and(|value| value == "root")
         }));
         assert!(tags.iter().any(|tag| {
             tag.first().is_some_and(|value| value == "e")
@@ -8910,7 +8927,6 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
-            final_text_fallback_enabled: false,
         }
     }
 


### PR DESCRIPTION
## Summary

- Negotiate Hermes final-text fallback from the ACP `agentInfo` handshake rather than normalized command identity alone.
- Hermes 0.21+ publishes through the existing Buzz-managed terminal; `buzz-acp` neither captures nor submits a fallback reply.
- Missing, malformed, unrecognized, and pre-0.21 Hermes handshakes retain the existing signed fallback delivery.
- Preserve the fallback path’s NIP-10 root and parent tags; add no credential environment forwarding.

## Validation

- `cargo test -p buzz-acp` (744 unit + 9 lifecycle tests)
- `cargo fmt --check -p buzz-acp`
- `cargo clippy -p buzz-acp --tests -- -D warnings`
- GitHub Actions on head: DCO, Semgrep OSS, zizmor, and Codex Security Review succeeded. The general CI workflow did not dispatch for this draft.

Draft opened early while work was in progress.