### PR TITLE
chore(ci): lower Codex security review effort

### DIFF
--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -222,7 +222,7 @@ jobs:
       contents: read
     env:
       CODEX_MODEL: gpt-5.6-sol
-      CODEX_REASONING_EFFORT: max
+      CODEX_REASONING_EFFORT: high
       CODEX_REVIEW_API_KEY_PRESENT: ${{ secrets.CODEX_REVIEW_API_KEY != '' }}
       REVIEW_CONTEXT: review-context
       REVIEW_REPOSITORY: review-target


### PR DESCRIPTION
Changes `CODEX_REASONING_EFFORT` from `max` to `high` in the `security-review` job.

`max` increases both normal review latency and exposure to the upstream PTY-shutdown hang ([openai/codex-action#169](https://github.com/openai/codex-action/issues/169)) where Codex finishes writing its output file but holds stdio open. The composite `uses:` action ignores the 30-minute step timeout and continues running until the 40-minute job timeout fires; at that point GitHub cancels the entire job and the `always()` salvage step never gets to run. `high` retains a high reasoning setting while trading some depth for speed, reducing typical completion time and shrinking the window during which a hung process blocks the salvage path.

No other behavior changes. Action pin, CLI version, model, output schema, prompt, and timeout values are unchanged.