### PR TITLE
Fix Desktop picker for channel bot members

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -221,6 +221,38 @@ test("getMentionableAgentPubkeys: scopes channel composers and fails closed with
   );
 });
 
+test("getMentionableAgentPubkeys: admits signed bot members only in their channel composer", () => {
+  const base = {
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [PUB_A],
+    channelMemberAgentPubkeys: [PUB_C.toUpperCase()],
+    relayAgents: [],
+    sharedChannelIds: new Set(["general"]),
+  };
+
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      ...base,
+      eligibilityScope: { type: "channel", channelId: "general" },
+    }),
+    new Set([PUB_A, PUB_C]),
+  );
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      ...base,
+      eligibilityScope: { type: "community" },
+    }),
+    new Set([PUB_A]),
+  );
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      ...base,
+      eligibilityScope: { type: "managed-only" },
+    }),
+    new Set([PUB_A]),
+  );
+});
+
 test("autocomplete helper extraction preserves safe filtering and labels", () => {
   assert.equal(isAgentMentionChannelType("stream"), true);
   assert.equal(isAgentMentionChannelType("forum"), true);

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -64,18 +64,26 @@ export function getMentionableAgentPubkeys({
   currentPubkey,
   eligibilityScope,
   managedAgentPubkeys,
+  channelMemberAgentPubkeys = [],
   relayAgents,
   sharedChannelIds,
 }: {
   currentPubkey?: string | null;
   eligibilityScope: AgentEligibilityScope;
   managedAgentPubkeys: Iterable<string>;
+  channelMemberAgentPubkeys?: Iterable<string>;
   relayAgents: readonly RelayAgent[] | undefined;
   sharedChannelIds: ReadonlySet<string>;
 }) {
   const pubkeys = new Set(
     [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
   );
+
+  if (eligibilityScope.type === "channel") {
+    for (const pubkey of channelMemberAgentPubkeys) {
+      pubkeys.add(normalizePubkey(pubkey));
+    }
+  }
 
   for (const agent of relayAgents ?? []) {
     const isAllowed =

--- a/desktop/src/features/messages/lib/agentMentionRevalidation.test.mjs
+++ b/desktop/src/features/messages/lib/agentMentionRevalidation.test.mjs
@@ -34,6 +34,24 @@ test("relay policy revalidation admits an authorized external agent", async () =
   ]);
 });
 
+test("channel revalidation preserves a signed bot member without a directory record", async () => {
+  const pubkey = "d".repeat(64);
+  const result = await revalidateAgentMentionPubkeys({
+    pubkeys: [pubkey],
+    agentPubkeys: new Set([pubkey]),
+    currentPubkey: "a".repeat(64),
+    eligibilityScope: { type: "channel", channelId: "general" },
+    channelMemberAgentPubkeys: new Set([pubkey]),
+    sharedChannelIds: new Set(["general"]),
+    refetchManagedAgents: async () => ({ data: [], error: null }),
+    fetchRelayAgents: async () => {
+      throw new Error("directory unavailable");
+    },
+  });
+
+  assert.deepEqual(result, [pubkey]);
+});
+
 test("fresh managed evidence survives unrelated relay authorization errors", async () => {
   const result = await revalidateAgentMentionPubkeys({
     ...options(),

--- a/desktop/src/features/messages/lib/agentMentionRevalidation.ts
+++ b/desktop/src/features/messages/lib/agentMentionRevalidation.ts
@@ -19,6 +19,7 @@ export async function revalidateAgentMentionPubkeys({
   agentPubkeys,
   currentPubkey,
   eligibilityScope,
+  channelMemberAgentPubkeys = new Set(),
   sharedChannelIds,
   refetchManagedAgents,
   fetchRelayAgents,
@@ -27,6 +28,7 @@ export async function revalidateAgentMentionPubkeys({
   agentPubkeys: ReadonlySet<string>;
   currentPubkey: string | null;
   eligibilityScope: AgentEligibilityScope;
+  channelMemberAgentPubkeys?: ReadonlySet<string>;
   sharedChannelIds: ReadonlySet<string>;
   refetchManagedAgents: () => Promise<DirectoryResult<ManagedAgent[]>>;
   fetchRelayAgents: (pubkeys: string[]) => Promise<RelayAgent[]>;
@@ -54,13 +56,18 @@ export async function revalidateAgentMentionPubkeys({
     currentPubkey,
     eligibilityScope,
     managedAgentPubkeys: managedPubkeys,
+    channelMemberAgentPubkeys,
     relayAgents: relayDirectoryReady ? relayAgents : [],
     sharedChannelIds,
   });
   const admittedPubkeys = new Set(
     [...agentPubkeys].filter((pubkey) => {
       const isManagedAgent = managedPubkeys.has(normalizePubkey(pubkey));
-      const directoryReady = isManagedAgent || relayDirectoryReady;
+      const isChannelMemberAgent = channelMemberAgentPubkeys.has(
+        normalizePubkey(pubkey),
+      );
+      const directoryReady =
+        isManagedAgent || isChannelMemberAgent || relayDirectoryReady;
       return (
         getAgentMentionAdmission({
           isAgent: true,
@@ -79,6 +86,7 @@ export function useAgentMentionRevalidation({
   getSelectedAgentPubkeys,
   currentPubkey,
   eligibilityScope,
+  channelMemberAgentPubkeys = new Set(),
   sharedChannelIds,
   refetchManagedAgents,
 }: {
@@ -86,6 +94,7 @@ export function useAgentMentionRevalidation({
   getSelectedAgentPubkeys: () => ReadonlySet<string>;
   currentPubkey: string | null;
   eligibilityScope: AgentEligibilityScope;
+  channelMemberAgentPubkeys?: ReadonlySet<string>;
   sharedChannelIds: ReadonlySet<string>;
   refetchManagedAgents: () => Promise<DirectoryResult<ManagedAgent[]>>;
 }) {
@@ -96,6 +105,7 @@ export function useAgentMentionRevalidation({
         agentPubkeys: new Set([...agentPubkeys, ...getSelectedAgentPubkeys()]),
         currentPubkey,
         eligibilityScope,
+        channelMemberAgentPubkeys,
         sharedChannelIds,
         refetchManagedAgents,
         fetchRelayAgents: (requestedPubkeys) =>
@@ -110,6 +120,7 @@ export function useAgentMentionRevalidation({
       agentPubkeys,
       currentPubkey,
       eligibilityScope,
+      channelMemberAgentPubkeys,
       getSelectedAgentPubkeys,
       refetchManagedAgents,
       sharedChannelIds,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -177,6 +177,22 @@ export function useMentions(
   const mentionChannelId = isAgentMentionChannelType(options?.channelType)
     ? channelId
     : null;
+  const channelMemberAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (members ?? [])
+          .filter((member) => {
+            const pubkey = normalizePubkey(member.pubkey);
+            return (
+              member.isAgent === true ||
+              member.role === "bot" ||
+              profiles?.[pubkey]?.isAgent === true
+            );
+          })
+          .map((member) => normalizePubkey(member.pubkey)),
+      ),
+    [members, profiles],
+  );
   const mentionableAgentPubkeys = React.useMemo(
     () =>
       getMentionableAgentPubkeys({
@@ -185,12 +201,14 @@ export function useMentions(
           ? { type: "channel", channelId: mentionChannelId }
           : { type: "managed-only" },
         managedAgentPubkeys,
+        channelMemberAgentPubkeys,
         relayAgents: relayAgentsQuery.data,
         sharedChannelIds,
       }),
     [
       currentPubkey,
       managedAgentPubkeys,
+      channelMemberAgentPubkeys,
       mentionChannelId,
       relayAgentsQuery.data,
       sharedChannelIds,
@@ -814,6 +832,7 @@ export function useMentions(
     eligibilityScope: mentionChannelId
       ? { type: "channel", channelId: mentionChannelId }
       : { type: "managed-only" },
+    channelMemberAgentPubkeys,
     sharedChannelIds,
     refetchManagedAgents: managedAgentsQuery.refetch,
   });


### PR DESCRIPTION
## Summary

- admit signed channel `role=bot` members to Desktop mention autocomplete in that exact stream/forum channel
- preserve those roster-authorized mentions during send-time revalidation when the optional relay-agent directory is unavailable
- keep new-DM recipients and community-wide add-member discovery unchanged

## Problem

Desktop classified signed bot members as agents, then filtered them out unless the same machine also had a matching managed-agent or relay-agent directory entry. This made remote/Hermes agents disappear from the picker, while mobile continued to show channel members.

## Tests

- `corepack pnpm test` — 5,478 passed, 0 failed
- `corepack pnpm typecheck` — passed
- Biome, text-size, pubkey-truncation, and `git diff --check` — passed; only pre-existing Biome findings outside this diff

## Safety boundary

Roster-derived admission is channel-scoped. DMs and community-wide discovery remain unchanged, so agents from unrelated channels are not exposed.
