### PR TITLE
Hide download action on voice notes

### DIFF
--- a/desktop/src/features/messages/ui/AudioMessageAttachment.tsx
+++ b/desktop/src/features/messages/ui/AudioMessageAttachment.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 
 import {
   formatVoiceNoteDuration,
+  isVoiceNoteAttachment,
   nextVoiceNotePlaybackRate,
   resolveAudioAttachment,
   summarizeWaveform,
@@ -51,7 +52,10 @@ export function renderAudioMessageAttachment(
 ) {
   const attachment = resolveAudioAttachment(entry, href, label);
   return attachment ? (
-    <AudioMessageAttachment {...attachment} downloadUrl={downloadUrl} />
+    <AudioMessageAttachment
+      {...attachment}
+      downloadUrl={isVoiceNoteAttachment(entry) ? undefined : downloadUrl}
+    />
   ) : null;
 }
 

--- a/desktop/tests/e2e/voice-note.spec.ts
+++ b/desktop/tests/e2e/voice-note.spec.ts
@@ -431,6 +431,39 @@ test("generic audio retains the relay-native download action", async ({
     });
 });
 
+test("voice notes omit the relay-native download action", async ({ page }) => {
+  const audioUrl = `http://localhost:3000/media/${"e".repeat(64)}.mp4`;
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await waitForMockLiveSubscription(page, "general");
+  await page.evaluate(
+    ({ href }) => {
+      const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+      if (!emit) throw new Error("Mock message emitter is unavailable.");
+      emit({
+        channelName: "general",
+        content: `[voice-note-123.mp4](${href})`,
+        extraTags: [
+          [
+            "imeta",
+            `url ${href}`,
+            "m video/mp4",
+            "duration 9.4",
+            "filename voice-note-123.mp4",
+          ],
+        ],
+      });
+    },
+    { href: audioUrl },
+  );
+
+  const card = page.getByTestId("audio-message-attachment").last();
+  await expect(card).toBeVisible();
+  await expect(
+    card.getByRole("button", { name: "Download voice-note-123.mp4" }),
+  ).toHaveCount(0);
+});
+
 test("hard-caps audio work and cancels active and queued loads on unmount", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- hide the native Download action on voice-note cards
- preserve Download for ordinary relay-hosted audio attachments
- add focused E2E coverage for both behaviors

Follow-up to #6978.

## Testing

- `pnpm -C desktop exec biome check src/features/messages/ui/AudioMessageAttachment.tsx tests/e2e/voice-note.spec.ts`
- `pnpm -C desktop typecheck`
- `pnpm -C desktop build:e2e`
- `pnpm -C desktop exec playwright test tests/e2e/voice-note.spec.ts --project=smoke` (13/13)
- pre-push desktop suite (5,881/5,881)