### PR TITLE
chore(hooks): scope rust-tests pre-push lane to touched crates

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,6 +29,19 @@
 # - `commit-msg` has no glob: it rewrites the commit message, not files. Note
 #   Git only runs it for `git commit` and `git merge` — other flows need their own
 #   flag: `git rebase --signoff`, `git cherry-pick -s`.
+# - `rust-tests` uses scripts/rust-tests-selective.sh instead of `just test-unit`
+#   directly. The script maps changed paths to crates (directory-prefix only, no
+#   dependency graph) and runs only affected packages' shaped suites. Full-battery
+#   triggers (Cargo.lock, root Cargo.toml, Justfile, migrations/, schema/, etc.)
+#   and any unmapped path fall back to `just test-unit` unchanged. Per-package
+#   invocation shapes (buzz-auth doctests, buzz-conformance all-targets, etc.)
+#   live in the script's PACKAGE_TABLE with a drift guard. The local lane is a
+#   fast pre-filter; CI's full `cargo clippy --workspace --all-targets` and
+#   dorny/paths-filter matrix remain the authoritative gate.
+# - `desktop-tauri-checks` is intentionally coarse-grained: scoping it per-crate
+#   requires the tauri workspace's transitive path-dep closure (dependency-graph
+#   machinery deferred). It fires on all crate changes. CI remains authoritative
+#   for this lane.
 #
 # `rc` points `lefthook install` at `bin/.lefthookrc`, which the generated
 # `.git/hooks/*` dispatchers source before their `$LEFTHOOK_BIN`-first lookup. It
@@ -94,7 +107,7 @@ pre-push:
     rust-tests:
       files: git diff --name-only origin/main...HEAD
       glob: ["crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "Justfile"]
-      run: just test-unit
+      run: ./scripts/rust-tests-selective.sh
     desktop-check:
       files: git diff --name-only origin/main...HEAD
       glob: ["desktop/**", "pnpm-lock.yaml"]

--- a/scripts/rust-tests-selective.sh
+++ b/scripts/rust-tests-selective.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# rust-tests-selective.sh — change-aware pre-push Rust test lane (Variant A).
+#
+# Scopes `just test-unit` to the subset of packages that this branch
+# actually touched, falling back to the full battery whenever the scope
+# cannot be determined safely.
+#
+# Selection logic (path→crate only, no dependency graph):
+#   1. Full-battery triggers: Cargo.lock, root Cargo.toml, rust-toolchain.toml,
+#      deny.toml, Justfile, scripts/run-tests.sh, migrations/**, schema/**,
+#      any changed path that doesn't map to a crate, or any script error.
+#   2. Crate mapping: crates/<name>/** → <name>; examples/<name>/** → <name>.
+#   3. Per-package invocation shapes (the PACKAGE_TABLE below) are the single
+#      source of truth for how each package's suite is run. A drift guard diffs
+#      this table's package list against the enumeration in `just test-unit` at
+#      every run; a mismatch falls back to the full battery.
+#
+# Note: desktop-tauri-checks is unchanged in this round — gating it per-crate
+# requires the tauri workspace's transitive path-dep closure (dependency-graph
+# machinery deferred per Will's direction). That lane still fires on all crate
+# changes via its lefthook glob.
+#
+# CI (dorny/paths-filter + full `cargo clippy --workspace --all-targets`)
+# remains the authoritative gate; this script is a fast pre-filter only.
+
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Per-package invocation table.
+# Each entry: "<pkg>:<mode>" where mode is one of:
+#   lib          → cargo nextest run -p <pkg> --lib
+#   all          → cargo nextest run -p <pkg>          (all targets)
+#   lib+doc      → cargo nextest run -p <pkg> --lib  +  cargo test -p <pkg> --doc
+#   relay        → the scoped buzz-relay invocation (special-cased below)
+# ---------------------------------------------------------------------------
+declare -A PACKAGE_TABLE=(
+    [buzz-core]="lib"
+    [buzz-auth]="lib+doc"
+    [buzz-voice]="lib"
+    [buzz-cli]="all"
+    [buzz-db]="lib"
+    [buzz-conformance]="all"
+    [buzz-push-gateway]="all"
+    [buzz-backend-kubernetes]="all"
+    [buzz-agent]="lib"
+    [buzz-relay]="relay"
+    [buzz-acp]="lib"
+)
+
+# Canonical ordered list from just test-unit — drift guard compares this.
+# Update both lists together if test-unit adds or removes a package.
+CANONICAL_PACKAGES=(
+    buzz-core
+    buzz-auth
+    buzz-voice
+    buzz-cli
+    buzz-db
+    buzz-conformance
+    buzz-push-gateway
+    buzz-backend-kubernetes
+    buzz-agent
+    buzz-relay
+    buzz-acp
+)
+
+# ---------------------------------------------------------------------------
+# Drift guard: verify PACKAGE_TABLE keys match CANONICAL_PACKAGES exactly.
+# ---------------------------------------------------------------------------
+drift_guard() {
+    local table_keys
+    table_keys=$(printf '%s\n' "${!PACKAGE_TABLE[@]}" | sort)
+    local canonical_sorted
+    canonical_sorted=$(printf '%s\n' "${CANONICAL_PACKAGES[@]}" | sort)
+    if [[ "$table_keys" != "$canonical_sorted" ]]; then
+        echo "rust-tests-selective: DRIFT DETECTED — PACKAGE_TABLE keys do not" >&2
+        echo "  match CANONICAL_PACKAGES. Update both lists together." >&2
+        echo "  Table keys:  $(printf '%s\n' "${!PACKAGE_TABLE[@]}" | sort | tr '\n' ' ')" >&2
+        echo "  Canonical:   $(printf '%s\n' "${CANONICAL_PACKAGES[@]}" | sort | tr '\n' ' ')" >&2
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Full-battery fallback.
+# ---------------------------------------------------------------------------
+run_full_battery() {
+    echo "rust-tests-selective: running full battery (just test-unit)" >&2
+    exec just test-unit
+}
+
+# ---------------------------------------------------------------------------
+# Run one package's shaped suite. Returns non-zero on failure.
+# ---------------------------------------------------------------------------
+run_package() {
+    local pkg="$1"
+    local mode="${PACKAGE_TABLE[$pkg]}"
+    case "$mode" in
+        lib)
+            cargo nextest run -p "$pkg" --lib
+            ;;
+        all)
+            cargo nextest run -p "$pkg"
+            ;;
+        lib+doc)
+            cargo nextest run -p "$pkg" --lib
+            cargo test -p "$pkg" --doc
+            ;;
+        relay)
+            cargo nextest run -p buzz-relay --lib \
+                -E 'test(/^api::admin::/) - test(=api::admin::tests::disabled_mode_allows_unauthenticated_requests_on_the_admin_host) - test(=api::admin::tests::nip98_mode_unrostered_signer_does_not_consume_a_replay_slot)'
+            ;;
+        *)
+            echo "rust-tests-selective: unknown mode '$mode' for package '$pkg'" >&2
+            return 1
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+# Step 0a: require cargo-nextest — selective invocations always use it.
+# If it's absent (e.g. minimal CI environment), fall back to full battery,
+# which handles the nextest-absent case via ./scripts/run-tests.sh unit.
+if ! command -v cargo-nextest &>/dev/null; then
+    echo "rust-tests-selective: cargo-nextest not found; falling back to full battery" >&2
+    run_full_battery
+fi
+
+# Step 0b: drift guard — fail closed if table is stale.
+if ! drift_guard; then
+    run_full_battery
+fi
+
+# Step 1: compute changed paths via three-dot diff against origin/main.
+# (lefthook already sets $LEFTHOOK_OUTPUT_LOG / provides files via env, but
+# we recompute here so the script is usable standalone and in the harness.)
+if ! changed_paths=$(git diff --name-only origin/main...HEAD 2>/dev/null); then
+    echo "rust-tests-selective: git diff failed; falling back to full battery" >&2
+    run_full_battery
+fi
+
+# Step 2: full-battery trigger patterns.
+FULL_TRIGGERS=(
+    "^Cargo\.lock$"
+    "^Cargo\.toml$"
+    "^rust-toolchain\.toml$"
+    "^deny\.toml$"
+    "^Justfile$"
+    "^scripts/run-tests\.sh$"
+    "^migrations/"
+    "^schema/"
+)
+
+for pattern in "${FULL_TRIGGERS[@]}"; do
+    if echo "$changed_paths" | grep -qE "$pattern"; then
+        echo "rust-tests-selective: full-battery trigger matched ('$pattern')" >&2
+        run_full_battery
+    fi
+done
+
+# Step 3: map changed paths to crate names.
+declare -A touched_crates
+
+while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+
+    if [[ "$path" =~ ^crates/([^/]+)/ ]]; then
+        touched_crates["${BASH_REMATCH[1]}"]=1
+    elif [[ "$path" =~ ^examples/([^/]+)/ ]]; then
+        touched_crates["${BASH_REMATCH[1]}"]=1
+    else
+        # Path outside crates/examples/ and not caught by full-battery triggers.
+        # Fail closed.
+        echo "rust-tests-selective: unmapped path '$path'; falling back to full battery" >&2
+        run_full_battery
+    fi
+done <<< "$changed_paths"
+
+# Step 4: if nothing changed (e.g. deletion-only push already skipped by
+# lefthook), nothing to do.
+if [[ ${#touched_crates[@]} -eq 0 ]]; then
+    echo "rust-tests-selective: no Rust crate changes detected; skipping Rust tests" >&2
+    exit 0
+fi
+
+# Step 5: intersect touched crates with PACKAGE_TABLE.
+# Crates touched that are NOT in the table (e.g. buzz-ws-client, buzz-sdk)
+# are not exercised by test-unit, so they don't need a suite run.
+# Any crate outside the table that is also NOT in the workspace is the unmapped
+# case we already handled above; we reach here only for valid workspace members.
+pkgs_to_run=()
+for crate in "${!touched_crates[@]}"; do
+    if [[ -v "PACKAGE_TABLE[$crate]" ]]; then
+        pkgs_to_run+=("$crate")
+    fi
+    # Crates with no suite entry in test-unit are silently skipped —
+    # CI's full clippy + check lane covers them.
+done
+
+if [[ ${#pkgs_to_run[@]} -eq 0 ]]; then
+    echo "rust-tests-selective: touched crates have no test-unit suites; skipping" >&2
+    exit 0
+fi
+
+# Step 6: run the local relay key setup (mirrors test-unit's preamble).
+./scripts/test-ensure-local-relay-key.sh
+
+# Step 7: run shaped suites for each selected package.
+echo "rust-tests-selective: running suites for: ${pkgs_to_run[*]}" >&2
+for pkg in "${pkgs_to_run[@]}"; do
+    run_package "$pkg"
+done
+
+echo "rust-tests-selective: selective run complete" >&2


### PR DESCRIPTION
## Problem

The `rust-tests` pre-push lane ran `just test-unit` (11 nextest invocations, ~460s) unconditionally on every push that touched any crate. Single-crate branches paid the same bill as workspace-wide changes. Combined with the 10-minute MCP shell cap, agents working on isolated crates couldn't push at all — the hook ran longer than the tool allowed.

## Solution

Replace the bare `run: just test-unit` in `lefthook.yml` with a new `scripts/rust-tests-selective.sh` that maps changed paths to crates (directory prefix only, no dependency graph — Variant A) and runs only the touched packages' suites.

### Selection logic

- **Path → crate**: `crates/<name>/**` → `<name>`; `examples/<name>/**` → `<name>`
- **Full-battery triggers** (always falls back to `just test-unit`): `Cargo.lock`, root `Cargo.toml`, `rust-toolchain.toml`, `deny.toml`, `Justfile`, `scripts/run-tests.sh`, `migrations/**`, `schema/**`, any path outside `crates/`/`examples/`, or any script error
- **cargo-nextest absent**: falls back to full battery (which handles the `else` path via `scripts/run-tests.sh unit`)

### Per-package invocation shape parity

Each package's invocation shape is preserved exactly in a `PACKAGE_TABLE` inside the script — the single source of truth:

| Package | Mode |
|---------|------|
| `buzz-auth` | nextest `--lib` + `cargo test --doc` (sealed-authority compile_fail doctests) |
| `buzz-conformance` | nextest all targets (no `--lib`) |
| `buzz-cli` | nextest all targets (no `--lib`) |
| `buzz-relay` | nextest `--lib` scoped to `api::admin::` filter |
| all others | nextest `--lib` |

A **drift guard** compares `PACKAGE_TABLE` keys against a `CANONICAL_PACKAGES` list at every run; a mismatch falls back to the full battery. Both lists must be updated together when `just test-unit` adds or removes a package.

### desktop-tauri-checks

Left intentionally coarse-grained this round — scoping it per-crate requires the tauri workspace's transitive path-dep closure (dependency-graph machinery deferred). Noted in the `lefthook.yml` header.

### Typical impact

| Branch type | Before | After |
|-------------|--------|-------|
| Single-crate (e.g. `buzz-dev-mcp`) | ~460s full battery | ~0s (no suite entry) |
| `buzz-acp` only | ~460s | ~30s |
| `buzz-auth` only | ~460s | ~45s (lib + doc) |
| `Cargo.lock` change | ~460s | ~460s (full battery) |

CI (`dorny/paths-filter` + `cargo clippy --workspace --all-targets`) remains the authoritative gate.
