### PR TITLE
fix(cli): read set-profile --about from stdin when -

### DIFF
--- a/crates/buzz-cli/src/commands/users.rs
+++ b/crates/buzz-cli/src/commands/users.rs
@@ -547,6 +547,10 @@ pub async fn dispatch(
             about,
             nip05,
         } => {
+            // `--about -` matches messages/notes: substitute stdin for the
+            // sentinel. Without this, clap stores the literal "-" and the
+            // published kind:0 about field collapses to a single dash.
+            let about = resolve_about_arg(about, || crate::validate::read_or_stdin("-"))?;
             cmd_set_profile(
                 client,
                 name.as_deref(),
@@ -571,14 +575,54 @@ pub async fn dispatch(
     }
 }
 
+/// Resolve `--about`, treating `-` as "read stdin" the way messages/notes do.
+fn resolve_about_arg(
+    about: Option<String>,
+    read_stdin: impl FnOnce() -> Result<String, CliError>,
+) -> Result<Option<String>, CliError> {
+    match about.as_deref() {
+        Some("-") => Ok(Some(read_stdin()?)),
+        Some(value) => Ok(Some(value.to_string())),
+        None => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         owned_agent_pubkeys_from_events, owner_scoped_profiles, owner_verification,
-        presence_subject,
+        presence_subject, resolve_about_arg,
     };
+    use crate::error::CliError;
     use nostr::Keys;
     use serde_json::json;
+
+    #[test]
+    fn resolve_about_arg_passes_through_literal_bios() {
+        assert_eq!(
+            resolve_about_arg(Some("Scout Bee".into()), || unreachable!()).unwrap(),
+            Some("Scout Bee".into())
+        );
+        assert_eq!(resolve_about_arg(None, || unreachable!()).unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_about_arg_reads_stdin_for_dash_sentinel() {
+        let about = resolve_about_arg(Some("-".into()), || {
+            Ok("line one\nline two\n".into())
+        })
+        .unwrap();
+        assert_eq!(about.as_deref(), Some("line one\nline two\n"));
+    }
+
+    #[test]
+    fn resolve_about_arg_propagates_stdin_errors() {
+        let err = resolve_about_arg(Some("-".into()), || {
+            Err(CliError::Other("failed to read stdin".into()))
+        })
+        .unwrap_err();
+        assert!(matches!(err, CliError::Other(_)));
+    }
 
     #[test]
     fn owned_agent_lookup_matches_exact_name_case_insensitively() {

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -860,7 +860,7 @@ pub enum UsersCmd {
         /// Avatar URL
         #[arg(long)]
         avatar: Option<String>,
-        /// Bio / about text
+        /// Bio / about text. Use '-' to read from stdin
         #[arg(long)]
         about: Option<String>,
         /// NIP-05 identifier (e.g. user@example.com)


### PR DESCRIPTION
## Summary
- `buzz users set-profile --about -` stored the literal `-` in kind:0 instead of reading stdin (unlike messages/notes).
- Resolve the `-` sentinel through the existing stdin helper and document it on `--about`.

Fixes #7162

## Test plan
- [ ] `printf 'multi\nline\n' | buzz users set-profile --about -` publishes the full bio
- [ ] `buzz users set-profile --about 'literal'` still sets that string
- [ ] `cargo test -p buzz-cli resolve_about_arg`