### PR TITLE
fix(desktop): classify SCP-style SSH clone URLs as external

### DIFF
--- a/desktop/src/features/projects/lib/projectCloneUrl.test.mjs
+++ b/desktop/src/features/projects/lib/projectCloneUrl.test.mjs
@@ -79,6 +79,24 @@ test("projectRepoHost identifies an external repository by host", () => {
   );
 });
 
+test("projectRepoHost classifies SCP-style SSH remotes as external", () => {
+  assert.deepEqual(
+    projectRepoHost("git@github.com:block/buzz.git", ORIGIN),
+    { kind: "external", host: "github.com" },
+  );
+  assert.deepEqual(
+    projectRepoHost("git@gitlab.example.org:group/repo", ORIGIN),
+    { kind: "external", host: "gitlab.example.org" },
+  );
+});
+
+test("projectRepoHost still parses ssh:// URLs via WHATWG", () => {
+  assert.deepEqual(
+    projectRepoHost("ssh://git@github.com/block/buzz.git", ORIGIN),
+    { kind: "external", host: "github.com" },
+  );
+});
+
 test("projectRepoHost treats a non-repository relay path as external", () => {
   assert.deepEqual(projectRepoHost(`${ORIGIN}/other/path`, ORIGIN), {
     kind: "external",
@@ -111,6 +129,20 @@ test("repositoryDisplayPath renders an external repo as host/path without .git",
     repositoryDisplayPath(
       {
         cloneUrls: ["https://github.com/block/buzz.git"],
+        dtag: "buzz",
+        owner: OWNER,
+      },
+      ORIGIN,
+    ),
+    "github.com/block/buzz",
+  );
+});
+
+test("repositoryDisplayPath renders an SCP-style SSH remote without .git", () => {
+  assert.equal(
+    repositoryDisplayPath(
+      {
+        cloneUrls: ["git@github.com:block/buzz.git"],
         dtag: "buzz",
         owner: OWNER,
       },

--- a/desktop/src/features/projects/lib/projectRepoHost.ts
+++ b/desktop/src/features/projects/lib/projectRepoHost.ts
@@ -6,6 +6,25 @@ export type ProjectRepoHost =
   | { kind: "unresolved" };
 
 /**
+ * Parse git's SCP-like SSH remote (`git@host:owner/repo.git`). WHATWG `URL`
+ * rejects that form (`git@host` is not a scheme), which previously forced
+ * `projectRepoHost` to `{ kind: "unresolved" }` and broke Projects Fetch.
+ */
+export function parseScpStyleSshUrl(
+  cloneUrl: string,
+): { host: string; pathname: string } | null {
+  // Already a real URL (https://, ssh://, …) — leave to `new URL`.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(cloneUrl)) return null;
+  const match = /^([^@/\s]+)@([^:/\s]+):(.+)$/.exec(cloneUrl.trim());
+  if (!match) return null;
+  const host = match[2];
+  const rawPath = match[3];
+  if (!host || !rawPath || rawPath.includes("://")) return null;
+  const pathname = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  return { host, pathname };
+}
+
+/**
  * Classifies the canonical git remote using the same origin and path boundary
  * enforced by the Tauri git commands. This is presentation/query gating only;
  * Rust remains the security boundary for clone operations.
@@ -15,6 +34,11 @@ export function projectRepoHost(
   relayOrigin: string | null | undefined,
 ): ProjectRepoHost {
   if (!cloneUrl || !relayOrigin) return { kind: "unresolved" };
+
+  const scp = parseScpStyleSshUrl(cloneUrl);
+  if (scp) {
+    return { kind: "external", host: scp.host };
+  }
 
   try {
     const clone = new URL(cloneUrl);
@@ -83,7 +107,10 @@ export function repositoryDisplayPath(
     const path = url.pathname.replace(/\.git$/, "").replace(/\/+$/, "");
     return `${url.host}${path}`;
   } catch {
-    return null;
+    const scp = parseScpStyleSshUrl(cloneUrl);
+    if (!scp) return null;
+    const path = scp.pathname.replace(/\.git$/, "").replace(/\/+$/, "");
+    return `${scp.host}${path}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- `git@host:owner/repo.git` remotes failed WHATWG `URL` parsing, so Projects treated them as `unresolved` and Fetch errored with "Repository unavailable".
- Parse the SCP-like form as `external`, and render the same host/path in the repository header.

Fixes #7181

## Test plan
- [ ] `node --import ./test-loader.mjs --experimental-strip-types --test src/features/projects/lib/projectCloneUrl.test.mjs` (in `desktop/`)
- [ ] Announce a repo whose clone tag is `git@github.com:owner/repo.git` — Projects shows Open (not Fetch) and a `github.com/owner/repo` path
- [ ] HTTPS and `ssh://` remotes still classify the same as before