### PR TITLE
feat(desktop): add agents without starting

### DIFF
--- a/desktop/src/features/agents/channelAgents.test.mjs
+++ b/desktop/src/features/agents/channelAgents.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+import { attachManagedAgentToChannel } from "./channelAgents.ts";
+
+const AGENT_PUBKEY = "a".repeat(64);
+
+function rawAgent(status = "stopped", backend = { type: "local" }) {
+  return {
+    pubkey: AGENT_PUBKEY,
+    name: "reviewer",
+    persona_id: null,
+    runtime: null,
+    team_id: null,
+    relay_url: "ws://localhost:3000",
+    acp_command: "buzz-acp",
+    agent_command: "codex",
+    agent_command_override: null,
+    agent_args: [],
+    mcp_command: "",
+    turn_timeout_seconds: 30,
+    idle_timeout_seconds: null,
+    max_turn_duration_seconds: null,
+    parallelism: 1,
+    system_prompt: null,
+    avatar_url: null,
+    model: null,
+    provider: null,
+    persona_out_of_date: false,
+    persona_orphaned: false,
+    needs_restart: false,
+    restart_diff: [],
+    env_vars: {},
+    status,
+    pid: status === "running" ? 123 : null,
+    created_at: "2026-09-01T00:00:00Z",
+    updated_at: "2026-09-01T00:00:00Z",
+    last_started_at: null,
+    last_stopped_at: null,
+    last_exit_code: null,
+    last_error: null,
+    last_error_code: null,
+    log_path: null,
+    start_on_app_launch: false,
+    auto_restart_on_config_change: true,
+    backend,
+    backend_agent_id: null,
+    respond_to: "owner-only",
+    respond_to_allowlist: [],
+  };
+}
+
+function managedAgent(status = "stopped", backend = { type: "local" }) {
+  const raw = rawAgent(status, backend);
+  return {
+    ...raw,
+    personaId: raw.persona_id,
+    teamId: raw.team_id,
+    relayUrl: raw.relay_url,
+    acpCommand: raw.acp_command,
+    agentCommand: raw.agent_command,
+    agentCommandOverride: raw.agent_command_override,
+    agentArgs: raw.agent_args,
+    mcpCommand: raw.mcp_command,
+    turnTimeoutSeconds: raw.turn_timeout_seconds,
+    idleTimeoutSeconds: raw.idle_timeout_seconds,
+    maxTurnDurationSeconds: raw.max_turn_duration_seconds,
+    systemPrompt: raw.system_prompt,
+    avatarUrl: raw.avatar_url,
+    personaOutOfDate: raw.persona_out_of_date,
+    personaOrphaned: raw.persona_orphaned,
+    needsRestart: raw.needs_restart,
+    restartDiff: raw.restart_diff,
+    envVars: raw.env_vars,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+    lastStartedAt: raw.last_started_at,
+    lastStoppedAt: raw.last_stopped_at,
+    lastExitCode: raw.last_exit_code,
+    lastError: raw.last_error,
+    lastErrorCode: raw.last_error_code,
+    logPath: raw.log_path,
+    startOnAppLaunch: raw.start_on_app_launch,
+    autoRestartOnConfigChange: raw.auto_restart_on_config_change,
+    backendAgentId: raw.backend_agent_id,
+    respondTo: raw.respond_to,
+    respondToAllowlist: raw.respond_to_allowlist,
+  };
+}
+
+function installTauriInvoke(t, handler) {
+  const prior = globalThis.window;
+  globalThis.window = { __TAURI_INTERNALS__: { invoke: handler } };
+  t.after(() => {
+    mock.restoreAll();
+    globalThis.window = prior;
+  });
+}
+
+test("add without starting verifies stopped state through the production seam", async (t) => {
+  const calls = [];
+  installTauriInvoke(t, async (command, args) => {
+    calls.push([command, args]);
+    if (command === "add_channel_members") {
+      return { added: [AGENT_PUBKEY], errors: [] };
+    }
+    if (command === "list_managed_agents") {
+      return [rawAgent("stopped")];
+    }
+    throw new Error(`unexpected command: ${command}`);
+  });
+
+  const result = await attachManagedAgentToChannel("channel-1", {
+    agent: managedAgent("stopped"),
+    ensureRunning: false,
+  });
+
+  assert.equal(result.membershipAdded, true);
+  assert.equal(result.started, false);
+  assert.equal(result.agent.status, "stopped");
+  assert.deepEqual(
+    calls.map(([command]) => command),
+    ["add_channel_members", "list_managed_agents"],
+  );
+});
+
+test("add without starting rejects stale running input before membership", async (t) => {
+  const calls = [];
+  installTauriInvoke(t, async (command, args) => {
+    calls.push([command, args]);
+    throw new Error(`unexpected command: ${command}`);
+  });
+
+  await assert.rejects(
+    attachManagedAgentToChannel("channel-1", {
+      agent: managedAgent("running"),
+      ensureRunning: false,
+    }),
+    /no longer stopped/,
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("add without starting fails closed when membership is not confirmed", async (t) => {
+  const calls = [];
+  installTauriInvoke(t, async (command, args) => {
+    calls.push([command, args]);
+    if (command === "add_channel_members") {
+      return { added: [], errors: [] };
+    }
+    throw new Error(`unexpected command: ${command}`);
+  });
+
+  await assert.rejects(
+    attachManagedAgentToChannel("channel-1", {
+      agent: managedAgent("stopped"),
+      ensureRunning: false,
+    }),
+    /membership was not confirmed/,
+  );
+  assert.deepEqual(
+    calls.map(([command]) => command),
+    ["add_channel_members"],
+  );
+});
+
+test("post-membership stopped-state drift is a visible partial failure", async (t) => {
+  const calls = [];
+  installTauriInvoke(t, async (command, args) => {
+    calls.push([command, args]);
+    if (command === "add_channel_members") {
+      return { added: [AGENT_PUBKEY], errors: [] };
+    }
+    if (command === "list_managed_agents") {
+      return [rawAgent("running")];
+    }
+    throw new Error(`unexpected command: ${command}`);
+  });
+
+  await assert.rejects(
+    attachManagedAgentToChannel("channel-1", {
+      agent: managedAgent("stopped"),
+      ensureRunning: false,
+    }),
+    /was added, but its stopped state could not be verified/,
+  );
+  assert.deepEqual(
+    calls.map(([command]) => command),
+    ["add_channel_members", "list_managed_agents"],
+  );
+});
+
+test("the existing default still adds and starts a stopped local agent", async (t) => {
+  const calls = [];
+  installTauriInvoke(t, async (command, args) => {
+    calls.push([command, args]);
+    if (command === "add_channel_members") {
+      return { added: [AGENT_PUBKEY], errors: [] };
+    }
+    if (command === "start_managed_agent") {
+      return rawAgent("running");
+    }
+    throw new Error(`unexpected command: ${command}`);
+  });
+
+  const result = await attachManagedAgentToChannel("channel-1", {
+    agent: managedAgent("stopped"),
+  });
+
+  assert.equal(result.membershipAdded, true);
+  assert.equal(result.started, true);
+  assert.equal(result.agent.status, "running");
+  assert.deepEqual(
+    calls.map(([command]) => command),
+    ["add_channel_members", "start_managed_agent"],
+  );
+});

--- a/desktop/src/features/agents/channelAgents.ts
+++ b/desktop/src/features/agents/channelAgents.ts
@@ -149,6 +149,20 @@ export async function attachManagedAgentToChannel(
   const role = input.role ?? "bot";
   const ensureRunning = input.ensureRunning ?? true;
   const agentPubkey = normalizePubkey(input.agent.pubkey);
+
+  if (!ensureRunning) {
+    if (input.agent.backend.type !== "local") {
+      throw new Error(
+        "Adding without starting is only available for local agents.",
+      );
+    }
+    if (input.agent.status !== "stopped") {
+      throw new Error(
+        "This agent is no longer stopped. Refresh and choose Add and start instead.",
+      );
+    }
+  }
+
   const membershipResult = await addChannelMembers({
     channelId,
     pubkeys: [input.agent.pubkey],
@@ -163,11 +177,28 @@ export async function attachManagedAgentToChannel(
   const membershipAdded = membershipResult.added.some(
     (pubkey) => normalizePubkey(pubkey) === agentPubkey,
   );
+  if (!ensureRunning && !membershipAdded) {
+    throw new Error("Agent membership was not confirmed.");
+  }
 
   let agent = input.agent;
   let started = false;
 
-  if (ensureRunning) {
+  if (!ensureRunning) {
+    try {
+      const verifiedAgent = (await listManagedAgents()).find(
+        (candidate) => normalizePubkey(candidate.pubkey) === agentPubkey,
+      );
+      if (verifiedAgent?.status !== "stopped") {
+        throw new Error("stopped state changed");
+      }
+      agent = verifiedAgent;
+    } catch {
+      throw new Error(
+        "Agent was added, but its stopped state could not be verified.",
+      );
+    }
+  } else {
     // Running agents (local or provider) auto-discover new channel membership
     // via the harness's membership notifications — no restart needed. Only
     // not-yet-running agents need a start/deploy call before the first mention

--- a/desktop/src/features/channels/ui/AddMemberSearchResultRow.tsx
+++ b/desktop/src/features/channels/ui/AddMemberSearchResultRow.tsx
@@ -19,14 +19,18 @@ export function formatAddCandidateName(user: UserSearchResult) {
 export function AddMemberSearchResultRow({
   disabled,
   onSelect,
+  onSelectWithoutStarting,
   ownerLabel,
   user,
 }: {
   disabled: boolean;
   onSelect: (user: UserSearchResult) => void;
+  onSelectWithoutStarting?: (user: UserSearchResult) => void;
   ownerLabel?: string | null;
   user: UserSearchResult;
 }) {
+  const candidateName = formatAddCandidateName(user);
+
   return (
     <div
       className={cn(
@@ -35,17 +39,20 @@ export function AddMemberSearchResultRow({
       )}
       data-testid={`channel-user-search-result-${user.pubkey}`}
     >
-      <button
-        aria-label={`Select ${formatAddCandidateName(user)}`}
-        className="absolute inset-0 z-0 cursor-pointer focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-        disabled={disabled}
-        onClick={() => onSelect(user)}
-        type="button"
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 z-0 cursor-pointer",
+          disabled && "pointer-events-none cursor-default",
+        )}
+        onClick={() => {
+          if (!disabled) onSelect(user);
+        }}
       />
       <UserAvatar
         avatarUrl={user.avatarUrl}
         className="pointer-events-none relative z-10 h-8 w-8 text-xs shadow-none"
-        displayName={formatAddCandidateName(user)}
+        displayName={candidateName}
         shape={user.isAgent ? "squircle" : "circle"}
         size="sm"
       />
@@ -54,7 +61,7 @@ export function AddMemberSearchResultRow({
           <div className="min-w-0">
             <div className="flex min-w-0 items-center gap-2">
               <span className="truncate text-sm font-medium tracking-tight">
-                {formatAddCandidateName(user)}
+                {candidateName}
               </span>
               <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
                 <Bot aria-hidden="true" className="h-4 w-4" />
@@ -72,22 +79,43 @@ export function AddMemberSearchResultRow({
           </div>
         ) : (
           <span className="block truncate text-sm font-medium tracking-tight">
-            {formatAddCandidateName(user)}
+            {candidateName}
           </span>
         )}
       </div>
-      <Button
-        className="relative z-20 shrink-0"
-        disabled={disabled}
-        onClick={(event) => {
-          event.stopPropagation();
-          onSelect(user);
-        }}
-        size="sm"
-        type="button"
-      >
-        Add
-      </Button>
+      <div className="relative z-20 flex shrink-0 items-center gap-2">
+        {onSelectWithoutStarting ? (
+          <Button
+            aria-label={`Add ${candidateName} without starting`}
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              onSelectWithoutStarting(user);
+            }}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Add without starting
+          </Button>
+        ) : null}
+        <Button
+          aria-label={
+            onSelectWithoutStarting
+              ? `Add ${candidateName} and start`
+              : `Add ${candidateName}`
+          }
+          disabled={disabled}
+          onClick={(event) => {
+            event.stopPropagation();
+            onSelect(user);
+          }}
+          size="sm"
+          type="button"
+        >
+          {onSelectWithoutStarting ? "Add and start" : "Add"}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -555,20 +555,27 @@ export function MembersSidebar({
     return null;
   }
 
-  async function handleAddSearchResult(user: UserSearchResult) {
+  async function handleAddSearchResult(
+    user: UserSearchResult,
+    options: { ensureRunning?: boolean } = {},
+  ) {
     if (addingMemberPubkeys.has(user.pubkey)) {
       return;
     }
 
+    setInviteSubmissionErrors((prev) =>
+      prev.filter(
+        (error) =>
+          normalizePubkey(error.pubkey) !== normalizePubkey(user.pubkey),
+      ),
+    );
     setAddingMemberPubkeys((prev) => new Set(prev).add(user.pubkey));
 
     try {
-      // A local managed agent needs a running harness pair in this community,
-      // not just channel membership — a bare membership add leaves it deaf
-      // until someone @mentions it or manually starts the pair. Route it
-      // through the attach helper, which adds membership AND ensures the active
-      // community's pair is running (idempotent: a live pair is left alone).
-      // Humans and provider agents keep the plain membership add.
+      // Local managed agents offer two explicit owner actions: attach and
+      // start (the existing default), or attach while preserving a verified
+      // stopped state. Humans and provider agents keep the plain membership
+      // add.
       const managedAgent = managedAgentByPubkey.get(
         normalizePubkey(user.pubkey),
       );
@@ -576,9 +583,8 @@ export function MembersSidebar({
         try {
           await attachManagedAgentToChannel(channelId, {
             agent: managedAgent,
-            ensureRunning: true,
+            ensureRunning: options.ensureRunning ?? true,
           });
-          await invalidateChannelState(queryClient, channelId);
         } catch (error) {
           setInviteSubmissionErrors((prev) => [
             ...prev,
@@ -588,6 +594,11 @@ export function MembersSidebar({
                 error instanceof Error ? error.message : "Failed to add agent.",
             },
           ]);
+        } finally {
+          // Verification can fail after membership was accepted. Refresh even
+          // on error so partial success is visible instead of looking like a
+          // failed no-op.
+          await invalidateChannelState(queryClient, channelId);
         }
         return;
       }
@@ -792,23 +803,42 @@ export function MembersSidebar({
                             Not in this channel
                           </SearchResultSectionTitle>
                         ) : null}
-                        {addSearchResults.map((user) => (
-                          <AddMemberSearchResultRow
-                            disabled={
-                              addingMemberPubkeys.has(user.pubkey) || isArchived
-                            }
-                            key={user.pubkey}
-                            onSelect={(selectedUser) => {
-                              void handleAddSearchResult(selectedUser);
-                            }}
-                            ownerLabel={formatOwnerLabel(
-                              user.ownerPubkey,
-                              identityQuery.data?.pubkey,
-                              addSearchOwnerProfilesQuery.data?.profiles,
-                            )}
-                            user={user}
-                          />
-                        ))}
+                        {addSearchResults.map((user) => {
+                          const managedAgent = managedAgentByPubkey.get(
+                            normalizePubkey(user.pubkey),
+                          );
+                          const canAddWithoutStarting =
+                            managedAgent?.backend.type === "local" &&
+                            managedAgent.status === "stopped";
+
+                          return (
+                            <AddMemberSearchResultRow
+                              disabled={
+                                addingMemberPubkeys.has(user.pubkey) ||
+                                isArchived
+                              }
+                              key={user.pubkey}
+                              onSelect={(selectedUser) => {
+                                void handleAddSearchResult(selectedUser);
+                              }}
+                              onSelectWithoutStarting={
+                                canAddWithoutStarting
+                                  ? (selectedUser) => {
+                                      void handleAddSearchResult(selectedUser, {
+                                        ensureRunning: false,
+                                      });
+                                    }
+                                  : undefined
+                              }
+                              ownerLabel={formatOwnerLabel(
+                                user.ownerPubkey,
+                                identityQuery.data?.pubkey,
+                                addSearchOwnerProfilesQuery.data?.profiles,
+                              )}
+                              user={user}
+                            />
+                          );
+                        })}
                         {isAddSearchLoading ? (
                           <p className="px-4 py-3 text-sm text-muted-foreground">
                             Searching...

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -4342,6 +4342,82 @@ test("members sidebar can invite and remove managed agents", async ({
   await expectMembersTriggerCount(page, initialMemberCount);
 });
 
+test("members sidebar can add a stopped local agent without starting it", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
+  });
+  await page.goto("/");
+  await openMembersSidebar(page, "general");
+  await page.getByTestId("channel-management-search-users").fill("char");
+
+  const result = page.getByTestId(
+    `channel-user-search-result-${TEST_IDENTITIES.charlie.pubkey}`,
+  );
+  await expect(
+    result.getByRole("button", {
+      name: "Add charlie without starting",
+    }),
+  ).toBeVisible();
+  await expect(
+    result.getByRole("button", { name: "Add charlie and start" }),
+  ).toBeVisible();
+
+  const baselineCommands = await readCommandLog(page);
+  await result
+    .getByRole("button", { name: "Add charlie without starting" })
+    .click();
+
+  await expect(
+    page.getByTestId(`sidebar-member-${TEST_IDENTITIES.charlie.pubkey}`),
+  ).toContainText("charlie");
+
+  const commandsAfterAction = (await readCommandLog(page)).slice(
+    baselineCommands.length,
+  );
+  expect(commandsAfterAction).toContain("add_channel_members");
+  expect(commandsAfterAction).toContain("list_managed_agents");
+  expect(commandsAfterAction).not.toContain("start_managed_agent");
+  expect(commandsAfterAction).not.toContain("start_managed_agent_runtime");
+
+  const agents = await invokeMockCommand<
+    Array<{ pubkey: string; status: string }>
+  >(page, "list_managed_agents");
+  expect(
+    agents.find((agent) => agent.pubkey === TEST_IDENTITIES.charlie.pubkey)
+      ?.status,
+  ).toBe("stopped");
+
+  // Reload the isolated mock state and prove the same explicit action is
+  // keyboard-operable, not only pointer-operable.
+  await page.reload();
+  await openMembersSidebar(page, "general");
+  await page.getByTestId("channel-management-search-users").fill("char");
+  const keyboardResult = page.getByTestId(
+    `channel-user-search-result-${TEST_IDENTITIES.charlie.pubkey}`,
+  );
+  const addWithoutStartingButton = keyboardResult.getByRole("button", {
+    name: "Add charlie without starting",
+  });
+  await addWithoutStartingButton.focus();
+  await expect(addWithoutStartingButton).toBeFocused();
+  await addWithoutStartingButton.press("Enter");
+  await expect(
+    page.getByTestId(`sidebar-member-${TEST_IDENTITIES.charlie.pubkey}`),
+  ).toContainText("charlie");
+  expect(await readCommandLog(page)).not.toContain("start_managed_agent");
+  expect(await readCommandLog(page)).not.toContain(
+    "start_managed_agent_runtime",
+  );
+});
+
 test("members sidebar pages add-member search beyond the first 50 people", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Adds an explicit **Add without starting** action for stopped local managed agents in the channel members sidebar.

The new path:

- publishes channel membership without calling either managed-agent start command;
- verifies through the production agent-list seam that the agent remains stopped;
- reports unconfirmed membership and post-membership status drift as visible failures; and
- leaves the existing row-click and **Add and start** behavior unchanged.

The two actions have distinct accessible labels. The regression coverage exercises pointer and keyboard activation and asserts that no start command is emitted.

### Related issue

Fixes #7202.

Related but distinct: #4835 concerns finding and re-adding removed personal agents, while #6468 concerns externally managed runtimes.

### Testing

- `pnpm check` (existing unrelated warnings only)
- desktop unit suite: 5,886 passed
- focused Playwright: existing managed-agent invite/remove plus new stopped-agent no-start flow, 2 passed
- production desktop build
- workspace Rust formatting, clippy, and all ten infra-free Rust unit groups (including 899 `buzz-acp` tests)
- web production build
- Flutter analyze and mobile suite: 2,019 passed
- `git diff --check`

The aggregate local `just ci` command could not finish `desktop-tauri-test` because the Mac ran out of disk while linking the unchanged Rust desktop library. No Rust or Tauri source is modified by this PR; the repository-hosted CI remains the authoritative full-platform gate.

#### Before

![Before: a stopped local agent exposes one Add action](https://raw.githubusercontent.com/block/buzz/f12aada9ba73521f8b0287cbe3ffca0abd8f552c/pr-7205--before-single-add.png)

#### After

![After: a stopped local agent exposes Add without starting and Add and start](https://raw.githubusercontent.com/block/buzz/f12aada9ba73521f8b0287cbe3ffca0abd8f552c/pr-7205--after-add-without-starting.png)
