### PR TITLE
fix(desktop): explain an unavailable harness instead of blaming model discovery

### DIFF
--- a/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
+++ b/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
@@ -222,12 +222,13 @@ test("getPersonaModelOptions for buzz-agent with no provider returns default mod
   assert.equal(options[0]?.id, "");
 });
 
-// ── formatModelDiscoveryErrorStatus — runtime unavailable ────────────────────
+// ── formatModelDiscoveryErrorStatus — unrecognised error text ────────────────
 //
-// When selectedRuntime.availability !== "available", AgentDefinitionDialog and
-// usePersonaModelDiscovery now call formatModelDiscoveryErrorStatus with a
-// synthetic "Runtime not available: <availability>" error. Verify the status
-// is non-null (so the UI surfaces the reason) for each unavailability reason.
+// Availability reasons no longer reach this formatter — they are mapped by
+// `formatRuntimeAvailabilityStatus` (see #7088 and its tests in
+// personaModelDiscoveryStatus.test.mjs). This case is kept because it pins the
+// formatter's behaviour for error text it has no specific handler for: it must
+// still return a usable status rather than null.
 
 test("formatModelDiscoveryErrorStatus returns a non-null status for runtime unavailable errors", () => {
   for (const availability of [

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatModelDiscoveryErrorStatus } from "./personaModelDiscoveryStatus.ts";
+import {
+  formatModelDiscoveryErrorStatus,
+  formatRuntimeAvailabilityStatus,
+} from "./personaModelDiscoveryStatus.ts";
 
 test("model discovery status names missing Anthropic credentials", () => {
   const status = formatModelDiscoveryErrorStatus(
@@ -157,4 +160,52 @@ test("non-auth -32000 errors do NOT get the sign-in copy", () => {
   assert.equal(status?.tone, "warning");
   assert.doesNotMatch(status?.message ?? "", /sign-in/i);
   assert.match(status?.message ?? "", /Using built-in model options/);
+});
+
+// ── formatRuntimeAvailabilityStatus — the harness itself is unavailable ───────
+//
+// Regression for #7088: an availability reason used to be wrapped in a
+// synthetic `Runtime not available: <reason>` error and handed to
+// formatModelDiscoveryErrorStatus, which has no handler for it and fell
+// through to the generic "could not load live models for <provider>" copy.
+// That blamed the provider for a missing local adapter or CLI, and contradicted
+// the harness dropdown, which already names the reason.
+
+test("runtime availability status names a missing CLI and the next step", () => {
+  const status = formatRuntimeAvailabilityStatus("cli_missing", "Claude Code");
+
+  assert.equal(status.tone, "warning");
+  assert.match(status.message, /Claude Code/);
+  assert.match(status.message, /CLI/);
+  assert.doesNotMatch(status.message, /load live models/);
+});
+
+test("runtime availability status covers every unavailable reason", () => {
+  const expectations = [
+    ["cli_missing", /CLI/],
+    ["not_installed", /not installed/],
+    ["adapter_missing", /adapter/],
+    ["adapter_outdated", /out of date/],
+  ];
+
+  for (const [availability, pattern] of expectations) {
+    const status = formatRuntimeAvailabilityStatus(availability, "Codex");
+
+    assert.equal(status.tone, "warning", `${availability} warns`);
+    assert.match(status.message, pattern, `${availability} names its reason`);
+    assert.match(status.message, /Codex/, `${availability} names the harness`);
+    // The provider is not at fault, so the provider-oriented fallback copy
+    // must never appear for an availability reason.
+    assert.doesNotMatch(
+      status.message,
+      /load live models/,
+      `${availability} does not blame model discovery`,
+    );
+  }
+});
+
+test("runtime availability status falls back to a generic harness noun", () => {
+  const status = formatRuntimeAvailabilityStatus("not_installed", "   ");
+
+  assert.match(status.message, /This harness is not installed/);
 });

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -3,6 +3,46 @@ export type PersonaModelDiscoveryStatus = {
   tone: "muted" | "warning";
 };
 
+/**
+ * Availability reasons the ACP runtime catalog reports for a harness that
+ * cannot run. `available` is excluded: it has no status to explain.
+ */
+export type UnavailableRuntimeAvailability =
+  | "adapter_missing"
+  | "adapter_outdated"
+  | "cli_missing"
+  | "not_installed";
+
+/**
+ * Explains a harness that the catalog already knows is unavailable.
+ *
+ * This is deliberately not routed through `formatModelDiscoveryErrorStatus`:
+ * that formatter interprets *live catalog fetch* failures, so an availability
+ * reason falls through to its generic "could not load live models for
+ * <provider>" fallback and blames the provider for a missing local adapter or
+ * CLI. The harness dropdown already names the reason via
+ * `formatRuntimeOptionLabel`; this keeps the model status line consistent with
+ * it.
+ */
+export function formatRuntimeAvailabilityStatus(
+  availability: UnavailableRuntimeAvailability,
+  agentLabel?: string,
+): PersonaModelDiscoveryStatus {
+  const harness = agentLabel?.trim() ? agentLabel.trim() : "This harness";
+  const reason =
+    availability === "cli_missing"
+      ? `${harness} is installed but its CLI was not found. Install the CLI and sign in, then reopen this dialog.`
+      : availability === "not_installed"
+        ? `${harness} is not installed. Install it, then reopen this dialog.`
+        : availability === "adapter_missing"
+          ? `${harness} is missing its ACP adapter. Install the adapter, then reopen this dialog.`
+          : `${harness}'s ACP adapter is out of date. Update the adapter, then reopen this dialog.`;
+  return {
+    message: `Using built-in model options. ${reason}`,
+    tone: "warning",
+  };
+}
+
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -9,6 +9,7 @@ import type { EnvVarsValue } from "./EnvVarsEditor";
 import {
   formatModelDiscoveryErrorStatus,
   type PersonaModelDiscoveryStatus,
+  formatRuntimeAvailabilityStatus,
 } from "./personaModelDiscoveryStatus";
 import type { PersonaModelOption } from "./agentConfigOptions";
 import { providerRequiresExplicitModel } from "./agentConfigOptions";
@@ -251,9 +252,8 @@ export function usePersonaModelDiscovery({
         selectedRuntimeAvailability !== "available"
       ) {
         setModelDiscoveryStatus(
-          formatModelDiscoveryErrorStatus(
-            new Error(`Runtime not available: ${selectedRuntimeAvailability}`),
-            trimmedProvider,
+          formatRuntimeAvailabilityStatus(
+            selectedRuntimeAvailability,
             selectedRuntimeLabel,
           ),
         );


### PR DESCRIPTION
## Why

Fixes #7088. When the ACP runtime catalog already knows a harness cannot run
(`cli_missing`, `adapter_missing`, `adapter_outdated`, `not_installed`), the model
field still showed the generic *live catalog fetch* failure, so the dialog
contradicted itself: the harness dropdown named the real reason while the status
line pointed at the provider.

## Root cause

`usePersonaModelDiscovery` wrapped the availability enum in a synthetic error and
sent it through the model-discovery error formatter:

```ts
formatModelDiscoveryErrorStatus(
  new Error(`Runtime not available: ${selectedRuntimeAvailability}`),
  trimmedProvider,
  selectedRuntimeLabel,
)
```

`formatModelDiscoveryErrorStatus` interprets *catalog fetch* failures — shared
compute, authentication, missing API keys, Databricks OAuth. `"Runtime not
available: adapter_missing"` matches none of them, so it fell through to the
provider-oriented fallback (`personaModelDiscoveryStatus.ts`):

```
Using built-in model options. Could not load live models for <provider>.
```

## What

- Add `formatRuntimeAvailabilityStatus(availability, agentLabel)` and map the enum
  directly, as the issue asks. The provider is not consulted, because it is not
  at fault.
- Wording follows `formatRuntimeOptionLabel` (`agentConfigOptions.tsx`), which
  already names these reasons on the dropdown row, so both lines now agree; each
  message adds the next action.

## Before / after

Agent defaults → Default harness → *Claude Code (adapter missing)*.

**Before** — the status line blames the provider and contradicts the dropdown one row above it:

![before](https://raw.githubusercontent.com/PresentJay/buzz/7ac682ab59cf816365d2812789c47845a2f74704/pr-7088--01-before.png)

**After** — it names the adapter and what to do next:

![after](https://raw.githubusercontent.com/PresentJay/buzz/7ac682ab59cf816365d2812789c47845a2f74704/pr-7088--02-after.png)

## Tests

New cases in `personaModelDiscoveryStatus.test.mjs` cover all four availability
reasons, assert the harness label appears, and assert the provider fallback copy
(`/load live models/`) never does. They fail on `main` (the export does not exist)
and pass here.

The existing case in `agentConfigOptions.test.mjs` only asserted the synthetic
error produced a non-null status — the issue calls this out. Availability reasons
no longer reach that formatter, so its comment now says what the case still pins:
unrecognised error text must not return `null`.

Fork PRs need maintainer approval before CI runs, so local results for `f3ea5ad83`
(branched from `origin/main`), via the repo's Hermit toolchain:

```
pnpm typecheck  ✔  tsc --noEmit
pnpm check      ✔  biome + check:px-text + check:pubkey-truncation
pnpm test       ✔  5884 pass / 0 fail
```