### PR TITLE
feat: add databricks fable 5.1 model capabilities

### DIFF
--- a/crates/buzz-agent/src/model_capabilities.rs
+++ b/crates/buzz-agent/src/model_capabilities.rs
@@ -634,6 +634,7 @@ mod tests {
     Q::Vector { id: "resolver-exact-raw-id-probe", provider: "databricks_v2", raw_model_id: "databricks-gpt-5-4-mini", note: Some("Probes a raw id that has an exact record.") },
     Q::Vector { id: "dbv2-claude-fable-5-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-claude-fable-5", note: Some("Probes the canonical Databricks Fable 5 endpoint record.") },
     Q::Vector { id: "dbv2-goose-claude-fable-5-alias-probe", provider: "databricks_v2", raw_model_id: "goose-claude-fable-5", note: Some("Probes a prefixed alias of the Databricks Fable 5 endpoint.") },
+    Q::Vector { id: "dbv2-claude-fable-5-1-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-claude-fable-5-1", note: Some("Probes the canonical Databricks Fable 5.1 endpoint record.") },
     Q::Vector { id: "dbv2-claude-opus-4-8-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-claude-opus-4-8", note: Some("Probes the canonical Databricks Opus 4.8 endpoint record.") },
     Q::Vector { id: "dbv2-goose-claude-opus-4-8-alias-probe", provider: "databricks_v2", raw_model_id: "goose-claude-opus-4-8", note: Some("Probes a prefixed alias of the Databricks Opus 4.8 endpoint.") },
     Q::Vector { id: "dbv2-claude-opus-5-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-claude-opus-5", note: Some("Probes the canonical Databricks Opus 5 endpoint record.") },
@@ -743,7 +744,7 @@ mod tests {
     Q::Vector { id: "dbv2-inkling-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-inkling", note: Some("Probes the Inkling endpoint record and label.") },
     Q::Vector { id: "dbv2-uc-fqn-gemini-3-5-flash-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.gemini-3-5-flash", note: Some("Probes strip parity on a system.ai. UC FQN carrying the gemini- token (resolve carries no label; the alias label path is unit-tested).") },
     Q::Vector { id: "dbv2-uc-fqn-meta-llama-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.meta-llama-3-3-70b-instruct", note: Some("Probes strip parity on a UC FQN where the llama- token strips through meta-.") },
-    Q::Vector { id: "dbv2-uc-goose-deepseek-strip-probe", provider: "databricks_v2", raw_model_id: "data_workflow_tools.goose.goose-deepseek-v4-pro-0813", note: Some("Probes strip parity on a goose- prefixed UC FQN carrying the deepseek- token.") },
+    Q::Vector { id: "dbv2-uc-fqn-deepseek-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.deepseek-v4-pro-0813", note: Some("Probes strip parity on a UC FQN carrying the deepseek- token.") },
     Q::Vector { id: "dbv2-uc-fqn-inkling-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.inkling", note: Some("Probes strip parity on a UC FQN carrying the bare inkling token.") },
     Q::Section { group: "Label/capability token isolation probes (#6955 review pass 1)", note: Some("Pins that label_family_tokens (the UC-humanization superset) never leaks into capability resolve(): capability stripping still uses only claude-/gpt-/kimi-, so a label token appearing before a gpt- marker must NOT displace the gpt-5-pro exact profile.") },
     Q::Vector { id: "isolation-openai-gemini-gpt-5-pro-probe", provider: "openai", raw_model_id: "tenant-gemini-gpt-5-pro", note: Some("The gemini- label token must not strip here; capability resolve keeps the gpt-5-pro high-only profile.") },
@@ -843,7 +844,7 @@ mod tests {
     }
 
     #[test]
-    fn corpus_has_exactly_139_executable_vectors() {
+    fn corpus_has_exactly_140_executable_vectors() {
         // Locks the vector count so a silent INPUTS edit can't quietly drop
         // coverage; must equal the gate in the TS harness
         // (modelCapabilitiesCorpus.test.mjs).
@@ -852,7 +853,7 @@ mod tests {
             .filter(|q| matches!(q, Q::Vector { .. }))
             .count();
         assert_eq!(
-            vectors, 139,
+            vectors, 140,
             "corpus executable-vector count changed; update this gate deliberately"
         );
     }
@@ -873,7 +874,7 @@ mod tests {
 
     #[test]
     fn databricks_v2_fqn_uses_neutral_concrete_unknown_capabilities() {
-        let fqn = resolve("databricks_v2", "data_workflow_tools.goose.goose-kimi-k3");
+        let fqn = resolve("databricks_v2", "system.ai.kimi-k3");
         let fallback = resolve("databricks_v2", "some-unknown-xyz");
         assert_eq!(fqn.thinking_mode, fallback.thinking_mode);
         assert_eq!(fqn.supported_efforts, fallback.supported_efforts);
@@ -1056,16 +1057,10 @@ mod tests {
             ("system.ai.qwen35-122b-a10b", "Qwen3.5 122B A10B"),
             ("system.ai.gemma-3-12b", "Gemma 3 12B"),
             ("system.ai.inkling", "Inkling"),
-            (
-                "data_workflow_tools.goose.goose-deepseek-v4-flash-0731",
-                "DeepSeek V4 Flash",
-            ),
-            ("data_workflow_tools.goose.goose-glm-5-3", "GLM-5.3"),
-            (
-                "data_workflow_tools.goose.goose-glm-5-3-flash",
-                "GLM-5.3 Flash",
-            ),
-            ("data_workflow_tools.goose.goose-grok-4-6", "Grok 4.6"),
+            ("system.ai.deepseek-v4-flash-0731", "DeepSeek V4 Flash"),
+            ("system.ai.glm-5-3", "GLM-5.3"),
+            ("system.ai.glm-5-3-flash", "GLM-5.3 Flash"),
+            ("system.ai.grok-4-6", "Grok 4.6"),
         ] {
             assert_eq!(databricks_registry_label(fqn), Some(label), "fqn={fqn}");
         }

--- a/desktop/src/features/agents/ui/modelCapabilitiesCorpus.test.mjs
+++ b/desktop/src/features/agents/ui/modelCapabilitiesCorpus.test.mjs
@@ -25,10 +25,10 @@ const corpus = JSON.parse(readFileSync(fileURLToPath(corpusUrl), "utf8"));
 // (`_group`) are skipped. Mirrors the Rust corpus filter.
 const executable = corpus.filter((entry) => entry.expect != null);
 
-test("corpus has exactly 139 executable vectors", () => {
+test("corpus has exactly 140 executable vectors", () => {
   // Locks the vector count so a silent corpus edit can't quietly drop coverage;
   // must equal the gate in the Rust suite (model_capabilities.rs).
-  assert.equal(executable.length, 139);
+  assert.equal(executable.length, 140);
 });
 
 test("registry label aliases refuse an unprefixed query", () => {
@@ -45,7 +45,7 @@ test("registry label aliases refuse an unprefixed query", () => {
   );
 });
 
-test("UC model-family FQNs and goose- aliases humanize onto their base records", () => {
+test("UC model-family FQNs humanize onto their base records", () => {
   // #6918 follow-up: the shared UC-FQN (`system.ai.…`) and goose- alias forms
   // must resolve onto the same base databricks_v2 records via the new family
   // tokens. Mirrors the Rust `test_databricks_registry_label_lookup` coverage.
@@ -64,13 +64,10 @@ test("UC model-family FQNs and goose- aliases humanize onto their base records",
     ["system.ai.qwen35-122b-a10b", "Qwen3.5 122B A10B"],
     ["system.ai.gemma-3-12b", "Gemma 3 12B"],
     ["system.ai.inkling", "Inkling"],
-    [
-      "data_workflow_tools.goose.goose-deepseek-v4-flash-0731",
-      "DeepSeek V4 Flash",
-    ],
-    ["data_workflow_tools.goose.goose-glm-5-3", "GLM-5.3"],
-    ["data_workflow_tools.goose.goose-glm-5-3-flash", "GLM-5.3 Flash"],
-    ["data_workflow_tools.goose.goose-grok-4-6", "Grok 4.6"],
+    ["system.ai.deepseek-v4-flash-0731", "DeepSeek V4 Flash"],
+    ["system.ai.glm-5-3", "GLM-5.3"],
+    ["system.ai.glm-5-3-flash", "GLM-5.3 Flash"],
+    ["system.ai.grok-4-6", "Grok 4.6"],
   ];
   for (const [fqn, label] of cases) {
     assert.equal(databricksRegistryLabel(fqn), label, `fqn=${fqn}`);
@@ -97,10 +94,7 @@ test("registry label aliases refuse ambiguous stripped record keys", () => {
 });
 
 test("Unity Catalog FQNs use neutral concrete-unknown capabilities", () => {
-  const fqn = resolveModelCapabilities(
-    "databricks_v2",
-    "data_workflow_tools.goose.goose-kimi-k3",
-  );
+  const fqn = resolveModelCapabilities("databricks_v2", "system.ai.kimi-k3");
   const fallback = resolveModelCapabilities(
     "databricks_v2",
     "some-unknown-xyz",

--- a/desktop/tests/e2e/global-agent-config-screenshots.spec.ts
+++ b/desktop/tests/e2e/global-agent-config-screenshots.spec.ts
@@ -251,7 +251,7 @@ test.describe("global agent config screenshots", () => {
   test("defaults render Databricks model labels without changing persisted ids", async ({
     page,
   }) => {
-    const modelId = "data_workflow_tools.goose.goose-glm-5-3";
+    const modelId = "system.ai.glm-5-3";
     await installMockBridge(page, {
       globalAgentConfig: {
         preferred_runtime: "goose",
@@ -277,6 +277,50 @@ test.describe("global agent config screenshots", () => {
 
     const model = page.getByTestId("global-agent-model");
     await expect(model).toHaveText("GLM-5.3");
+
+    const persisted = await page.evaluate(async () =>
+      (
+        window as typeof window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+            command: string,
+            payload: unknown,
+          ) => Promise<unknown>;
+        }
+      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_global_agent_config", null),
+    );
+    expect(persisted).toMatchObject({ model: modelId });
+  });
+
+  test("defaults render the Fable 5.1 label without changing the persisted id", async ({
+    page,
+  }) => {
+    const modelId = "databricks-claude-fable-5-1";
+    await installMockBridge(page, {
+      globalAgentConfig: {
+        preferred_runtime: "goose",
+        provider: "databricks_v2",
+        model: modelId,
+        env_vars: {},
+      },
+      discoverAgentModels: {
+        models: [{ id: modelId, name: modelId }],
+        supportsSwitching: true,
+        selectedModel: modelId,
+      },
+      runtimeFileConfigs: {
+        goose: {
+          provider: "databricks_v2",
+          model: modelId,
+          satisfiedEnvKeys: ["DATABRICKS_HOST"],
+        },
+      },
+    });
+
+    await openAiDefaultsSettings(page);
+
+    const model = page.getByTestId("global-agent-model");
+    await expect(model).toHaveText("Claude Fable 5.1");
+    await expect(model).toHaveAttribute("data-value", modelId);
 
     const persisted = await page.evaluate(async () =>
       (

--- a/scripts/model-capabilities.json
+++ b/scripts/model-capabilities.json
@@ -489,6 +489,24 @@
     },
     {
       "provider": "databricks_v2",
+      "raw_model_id": "databricks-claude-fable-5-1",
+      "registry_label": "Claude Fable 5.1",
+      "thinking_mode": "adaptive",
+      "supported_efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_effort": "high",
+      "databricks_v2_wire_route": "anthropic-messages",
+      "normalization_policy": "none",
+      "_provenance": "all axes materialized from family:anthropic-adaptive-xhigh-fable-5",
+      "_source": "models.dev anthropic catalog label; Databricks workspace endpoint is absent from its provider catalog"
+    },
+    {
+      "provider": "databricks_v2",
       "raw_model_id": "databricks-claude-opus-4-8",
       "registry_label": "Claude Opus 4.8",
       "thinking_mode": "adaptive",

--- a/scripts/normative-corpus.json
+++ b/scripts/normative-corpus.json
@@ -760,6 +760,26 @@
     }
   },
   {
+    "id": "dbv2-claude-fable-5-1-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-claude-fable-5-1",
+    "_note": "Probes the canonical Databricks Fable 5.1 endpoint record.",
+    "expect": {
+      "thinking_mode": "adaptive",
+      "supported_efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_effort": "high",
+      "databricks_v2_wire_route": "anthropic-messages",
+      "normalization_policy": "none",
+      "registry_label": "Claude Fable 5.1"
+    }
+  },
+  {
     "id": "dbv2-claude-opus-4-8-exact-record-probe",
     "provider": "databricks_v2",
     "raw_model_id": "databricks-claude-opus-4-8",
@@ -2708,10 +2728,10 @@
     }
   },
   {
-    "id": "dbv2-uc-goose-deepseek-strip-probe",
+    "id": "dbv2-uc-fqn-deepseek-strip-probe",
     "provider": "databricks_v2",
-    "raw_model_id": "data_workflow_tools.goose.goose-deepseek-v4-pro-0813",
-    "_note": "Probes strip parity on a goose- prefixed UC FQN carrying the deepseek- token.",
+    "raw_model_id": "system.ai.deepseek-v4-pro-0813",
+    "_note": "Probes strip parity on a UC FQN carrying the deepseek- token.",
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [


### PR DESCRIPTION
## Summary
- add the canonical public Databricks `Claude Fable 5.1` model record
- match the existing Fable family contract: adaptive thinking, `low|medium|high|xhigh|max`, default `high`, Anthropic Messages, and no normalization
- add generated Rust/TypeScript corpus coverage and canonical Global Defaults label/persistence coverage
- remove deployment-specific catalog references from the repository

## Scope
This is metadata and regression coverage only. It does not change model-capability resolution or production frontend logic.

## Validation
- `cargo fmt --check`
- `node --test desktop/src/features/agents/ui/modelCapabilitiesCorpus.test.mjs`
- `cargo test -p buzz-agent`
- `pnpm build:e2e`
- `pnpm exec playwright test --project=smoke --grep 'defaults render the Fable 5.1 label without changing the persisted id'` — 1 passed
- repository search for the removed catalog prefix — no matches
