### PR TITLE
feat(agents): agent media sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -882,6 +882,13 @@ jobs:
           cargo test -p buzz-test-client --test e2e_persona --test e2e_team_catalog --test e2e_nostr_interop --test e2e_project -- --ignored --nocapture
           cargo test -p buzz-test-client --test e2e_relay invite -- --ignored --nocapture
           cargo test -p buzz-test-client --test e2e_relay nip43_membership_snapshots_are_rejected -- --ignored --nocapture
+          # Agent media sessions: the stored-state half of 48200/48201
+          # authorization -- who may announce, and which start an end may
+          # close. Those predicates need a real community, channel and NIP-OA
+          # registration, so the in-crate shape tests cannot reach them; this
+          # binary is the only thing that fails if the gate is removed. Every
+          # test in it is #[ignore]d, so it runs nowhere unless selected here.
+          cargo test -p buzz-test-client --test e2e_agent_media_session -- --ignored --nocapture
         env:
           RELAY_URL: ws://localhost:3000
           GIT_CREDENTIAL_NOSTR_BIN: ${{ github.workspace }}/target/ci/git-credential-nostr

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -604,14 +604,36 @@ pub const KIND_HUDDLE_GUIDELINES: u32 = 48106;
 /// does not itself carry. The relay stores and fans out the announcement; the
 /// media itself never transits the relay.
 ///
-/// Channel-scoped via `h`. Only a registered agent may announce one, and
-/// ownership is the signature rather than a tag — an agent does not `p`-tag
-/// itself. An `e` tag references the message that triggered the session, so
-/// clients can anchor the session to it.
+/// Channel-scoped via `h`. Ownership is the signature rather than a tag — an
+/// agent does not `p`-tag itself. An `e` tag references the message that
+/// triggered the session, so clients can anchor the session to it.
+///
+/// **Only a registered agent may announce one**, and that is a stricter test
+/// than channel membership: the relay resolves an owner for the signing pubkey
+/// and refuses the announcement when there is none. A plain member cannot
+/// announce a session, and neither can an agent whose channel role merely says
+/// `bot` — the role and the registration are different facts. An external agent
+/// becomes registered by presenting a NIP-OA `auth` tag — an owner-signed
+/// attestation over the agent's own pubkey — inside its NIP-42 `AUTH` event,
+/// which the relay verifies and records. See
+/// `buzz_sdk::nip_oa::compute_auth_tag` for the construction; note that
+/// nothing in this repository mints such a tag outside of tests, so a gateway
+/// author has to build one.
 ///
 /// Content is a versioned JSON body naming the provider, its connection
 /// parameters, a token endpoint, the participant list, the track kinds a viewer
 /// may subscribe to or publish, and `expires_at`.
+///
+/// `token_endpoint` is fetched by clients rather than by the relay, so it
+/// carries one obligation the relay cannot check: it **must answer CORS
+/// preflight requests**. A viewer authenticates its token request with a NIP-98
+/// `Authorization` header, which is never a "simple" header, so the browser
+/// sends `OPTIONS` first and blocks the real request when that goes
+/// unanswered. The failure is worth stating because it misleads: the request
+/// never reaches the endpoint's handler, so the client reports an opaque
+/// network error and the gateway's own logs show only a rejected `OPTIONS` —
+/// which reads as unreachable rather than as misconfigured. The relay validates
+/// only that the scheme is http(s).
 ///
 /// `expires_at` is a unix timestamp after which clients stop rendering the
 /// session. It is a **presentation expiry, not a lease**: it reaps nothing on

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -632,13 +632,21 @@ pub const KIND_HUDDLE_GUIDELINES: u32 = 48106;
 /// | Field | Type | Relay | Client |
 /// |---|---|---|---|
 /// | `provider` | string | required; must be a known provider | required; unknown ⇒ event ignored |
-/// | `connect.url` | string | required, non-empty, `ws(s)`/`http(s)` | required, non-empty |
-/// | `connect.room` | string | required, non-empty | required, non-empty |
+/// | `connect.url` | string | required; a `ws(s)`/`http(s)` URL with a host | required; same rule |
+/// | `connect.room` | string | required, non-blank | required, non-blank |
 /// | `expires_at` | integer | required; `> created_at`, at most one hour after it | required; `> created_at` |
-/// | `token_endpoint` | string | optional; `http(s)` when present | optional; dropped unless `http(s)` |
+/// | `token_endpoint` | string | optional; an `http(s)` URL with a host | optional; dropped unless it is one |
 /// | `participants` | array | not validated | see below — decides what renders |
 /// | `viewer.subscribe`, `viewer.publish` | arrays | not validated | unknown names dropped |
 /// | `v` | integer | not validated | not read |
+///
+/// Both URLs are parsed, not prefix-matched, on both sides. `"wss://"` and
+/// `"https://["` name an allowed scheme and no host, and an announcement
+/// carrying one is refused rather than stored: it would fan out to the whole
+/// channel for every client to fail on separately, which is the outcome
+/// validating the field exists to prevent. `connect.room` is checked after
+/// trimming, because a room of spaces fails at the provider exactly as an
+/// empty one does.
 ///
 /// Track kinds are `avatar_video`, `camera`, `screen` and `audio`; anything
 /// else is discarded. `avatar_video` is an agent's rendered face.
@@ -663,9 +671,9 @@ pub const KIND_HUDDLE_GUIDELINES: u32 = 48106;
 /// An announcer serving `token_endpoint` owes three things the relay cannot
 /// check: verify the caller's NIP-98 signature over the exact request URL,
 /// confirm the caller is a member of the channel in the `h` tag before minting
-/// anything, and answer CORS preflight (below). The relay validates only the
-/// scheme, so an endpoint that skips the first two is an open credential mint
-/// reachable from a world-readable event.
+/// anything, and answer CORS preflight (below). The relay validates only that
+/// the endpoint is a fetchable URL, so an endpoint that skips the first two is
+/// an open credential mint reachable from a world-readable event.
 ///
 /// The CORS obligation is worth expanding, because it is the one whose failure
 /// misleads. A viewer authenticates its token request with a NIP-98

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -615,25 +615,66 @@ pub const KIND_HUDDLE_GUIDELINES: u32 = 48106;
 /// `bot` — the role and the registration are different facts. An external agent
 /// becomes registered by presenting a NIP-OA `auth` tag — an owner-signed
 /// attestation over the agent's own pubkey — inside its NIP-42 `AUTH` event,
-/// which the relay verifies and records. See
-/// `buzz_sdk::nip_oa::compute_auth_tag` for the construction; note that
-/// nothing in this repository mints such a tag outside of tests, so a gateway
-/// author has to build one.
+/// which the relay verifies and records. Mint one with
+/// `cargo run -p buzz-sdk --example compute_auth_tag -- <owner_secret>
+/// <agent_pubkey> [conditions]`, which prints the tag JSON; see
+/// `buzz_sdk::nip_oa::compute_auth_tag` for the construction. The owner key
+/// must differ from the agent key — self-attestation is refused. Leave
+/// `conditions` empty unless you mean them: ingest does not consult them on
+/// this path, so a narrow one only risks breaking the agent's other events.
 ///
-/// Content is a versioned JSON body naming the provider, its connection
-/// parameters, a token endpoint, the participant list, the track kinds a viewer
-/// may subscribe to or publish, and `expires_at`.
+/// # Content
 ///
-/// `token_endpoint` is fetched by clients rather than by the relay, so it
-/// carries one obligation the relay cannot check: it **must answer CORS
-/// preflight requests**. A viewer authenticates its token request with a NIP-98
+/// A JSON object. **This kind is announced by software outside this
+/// repository**, so the field-level contract is stated here rather than left
+/// to the two implementations that enforce it.
+///
+/// | Field | Type | Relay | Client |
+/// |---|---|---|---|
+/// | `provider` | string | required; must be a known provider | required; unknown ⇒ event ignored |
+/// | `connect.url` | string | required, non-empty, `ws(s)`/`http(s)` | required, non-empty |
+/// | `connect.room` | string | required, non-empty | required, non-empty |
+/// | `expires_at` | integer | required; `> created_at`, at most one hour after it | required; `> created_at` |
+/// | `token_endpoint` | string | optional; `http(s)` when present | optional; dropped unless `http(s)` |
+/// | `participants` | array | not validated | see below — decides what renders |
+/// | `viewer.subscribe`, `viewer.publish` | arrays | not validated | unknown names dropped |
+/// | `v` | integer | not validated | not read |
+///
+/// Track kinds are `avatar_video`, `camera`, `screen` and `audio`; anything
+/// else is discarded. `avatar_video` is an agent's rendered face.
+///
+/// `participants` is a list of `{"pubkey": <hex>, "tracks": [<kind>, …]}`. The
+/// relay does not check it, and a client cannot ignore it: **an announcement
+/// that omits it usually renders nothing.** A client accepts a remote track as
+/// the agent's when the publisher's provider identity contains the agent's
+/// pubkey, and otherwise falls back to this declaration — exactly one declared
+/// publisher of that track kind, and that publisher being the agent. No
+/// provider is obliged to put a pubkey in its participant identity, and the
+/// avatar vendors this was built against do not, so the declaration is what
+/// makes the agent's video and voice attributable. Declaring somebody else as the sole publisher
+/// of a track kind is read as a statement that the track is not the agent's,
+/// not as an ambiguity to resolve in the agent's favour.
+///
+/// Omitting `token_endpoint` is legitimate — a provider may deliver its
+/// credential another way — but with no endpoint a viewer is simply told it
+/// cannot join. It is optional because that failure is visible; the `connect`
+/// fields are required because theirs is silent.
+///
+/// An announcer serving `token_endpoint` owes three things the relay cannot
+/// check: verify the caller's NIP-98 signature over the exact request URL,
+/// confirm the caller is a member of the channel in the `h` tag before minting
+/// anything, and answer CORS preflight (below). The relay validates only the
+/// scheme, so an endpoint that skips the first two is an open credential mint
+/// reachable from a world-readable event.
+///
+/// The CORS obligation is worth expanding, because it is the one whose failure
+/// misleads. A viewer authenticates its token request with a NIP-98
 /// `Authorization` header, which is never a "simple" header, so the browser
 /// sends `OPTIONS` first and blocks the real request when that goes
-/// unanswered. The failure is worth stating because it misleads: the request
-/// never reaches the endpoint's handler, so the client reports an opaque
-/// network error and the gateway's own logs show only a rejected `OPTIONS` —
-/// which reads as unreachable rather than as misconfigured. The relay validates
-/// only that the scheme is http(s).
+/// unanswered. The request never reaches the endpoint's handler, so the client
+/// reports an opaque network error and the announcer's own logs show only a
+/// rejected `OPTIONS` — which reads as unreachable rather than as
+/// misconfigured.
 ///
 /// `expires_at` is a unix timestamp after which clients stop rendering the
 /// session. It is a **presentation expiry, not a lease**: it reaps nothing on

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -597,6 +597,46 @@ pub const KIND_HUDDLE_ENDED: u32 = 48103;
 /// Huddle channel guidelines/rules document.
 pub const KIND_HUDDLE_GUIDELINES: u32 = 48106;
 
+/// An agent media session hosted by an external provider was started.
+///
+/// Announces that an agent has opened a realtime audio/video session for a
+/// channel — the counterpart to [`KIND_HUDDLE_STARTED`] for sessions the relay
+/// does not itself carry. The relay stores and fans out the announcement; the
+/// media itself never transits the relay.
+///
+/// Channel-scoped via `h`. Only a registered agent may announce one, and
+/// ownership is the signature rather than a tag — an agent does not `p`-tag
+/// itself. An `e` tag references the message that triggered the session, so
+/// clients can anchor the session to it.
+///
+/// Content is a versioned JSON body naming the provider, its connection
+/// parameters, a token endpoint, the participant list, the track kinds a viewer
+/// may subscribe to or publish, and `expires_at`.
+///
+/// `expires_at` is a unix timestamp after which clients stop rendering the
+/// session. It is a **presentation expiry, not a lease**: it reaps nothing on
+/// the provider. It is required because the closing
+/// [`KIND_AGENT_MEDIA_SESSION_ENDED`] may never arrive — an agent that crashes
+/// publishes no end event — and a card with no stated end would advertise a
+/// dead room indefinitely. The relay bounds it by a maximum session duration,
+/// and additionally by the channel's own deadline when the channel is
+/// ephemeral.
+///
+/// Deliberately not ephemeral: a member who opens the channel after the
+/// announcement must still be able to discover and join a live session.
+pub const KIND_AGENT_MEDIA_SESSION_STARTED: u32 = 48200;
+/// An agent media session ended.
+///
+/// Mirrors [`KIND_HUDDLE_ENDED`]. Channel-scoped via `h`, and carries exactly
+/// one `e` tag referencing the [`KIND_AGENT_MEDIA_SESSION_STARTED`] it closes —
+/// exactly one, because the relay checks the ender's standing against that
+/// start's signer, a question two starts have no single answer to.
+///
+/// Two signers may end a session: the agent that owns it, or the relay closing
+/// one on the owner's behalf. A relay-signed end carries exactly one `p` tag
+/// naming that owner, since signer and subject differ there.
+pub const KIND_AGENT_MEDIA_SESSION_ENDED: u32 = 48201;
+
 // Media (49000–49999)
 /// Internal kind for media upload audit entries. Not a relay event kind.
 pub const KIND_MEDIA_UPLOAD: u32 = 49001;
@@ -751,6 +791,8 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_HUDDLE_PARTICIPANT_LEFT,
     KIND_HUDDLE_ENDED,
     KIND_HUDDLE_GUIDELINES,
+    KIND_AGENT_MEDIA_SESSION_STARTED,
+    KIND_AGENT_MEDIA_SESSION_ENDED,
     KIND_MEDIA_UPLOAD,
     KIND_GIT_REPO_ANNOUNCEMENT,
     KIND_GIT_REPO_STATE,
@@ -879,6 +921,16 @@ const _: () = assert!(
 const _: () = assert!(KIND_AUTH <= u16::MAX as u32);
 const _: () = assert!(KIND_CANVAS <= u16::MAX as u32);
 const _: () = assert!(KIND_HUDDLE_GUIDELINES <= u16::MAX as u32);
+const _: () = assert!(KIND_AGENT_MEDIA_SESSION_ENDED <= u16::MAX as u32);
+// Compile-time: agent media session events are regular stored kinds — a late
+// joiner must be able to query a live session, so they must not be ephemeral,
+// and there is one event per session start/end, so they must not be replaceable.
+const _: () = assert!(!is_ephemeral(KIND_AGENT_MEDIA_SESSION_STARTED));
+const _: () = assert!(!is_replaceable(KIND_AGENT_MEDIA_SESSION_STARTED));
+const _: () = assert!(!is_parameterized_replaceable(
+    KIND_AGENT_MEDIA_SESSION_STARTED
+));
+const _: () = assert!(!is_ephemeral(KIND_AGENT_MEDIA_SESSION_ENDED));
 const _: () = assert!(EPHEMERAL_KIND_MIN < EPHEMERAL_KIND_MAX);
 // Compile-time: KIND_AGENT_TURN_METRIC is a regular stored kind (not ephemeral, not replaceable).
 const _: () = assert!(!is_ephemeral(KIND_AGENT_TURN_METRIC));

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -12,7 +12,8 @@ use uuid::Uuid;
 use buzz_auth::Scope;
 use buzz_core::kind::{
     event_kind_u32, is_identity_archive_request_kind, is_parameterized_replaceable,
-    is_relay_admin_kind, KIND_AGENT_ENGRAM, KIND_AGENT_PROFILE, KIND_AGENT_TURN_METRIC,
+    is_relay_admin_kind, KIND_AGENT_ENGRAM, KIND_AGENT_MEDIA_SESSION_ENDED,
+    KIND_AGENT_MEDIA_SESSION_STARTED, KIND_AGENT_PROFILE, KIND_AGENT_TURN_METRIC,
     KIND_APPROVAL_DENY, KIND_APPROVAL_GRANT, KIND_AUTH, KIND_BOOKMARK_LIST, KIND_BOOKMARK_SET,
     KIND_CANVAS, KIND_CONTACT_LIST, KIND_DELETION, KIND_DM_ADD_MEMBER, KIND_DM_HIDE, KIND_DM_OPEN,
     KIND_EMOJI_LIST, KIND_EMOJI_SET, KIND_EVENT_REMINDER, KIND_FOLLOW_SET, KIND_FORUM_COMMENT,
@@ -76,6 +77,407 @@ fn map_huddle_backing_channel_error(error: buzz_db::DbError) -> IngestError {
 
 fn expected_huddle_backing_ttl(ephemeral_ttl_override: Option<i32>) -> i32 {
     ephemeral_ttl_override.unwrap_or(3600)
+}
+
+/// Maximum `content` length for an agent media session announcement.
+///
+/// The body names a provider, its connection parameters, a token endpoint and a
+/// participant list — kilobytes, not megabytes. A tight bound keeps a
+/// world-readable channel event from becoming a blob store.
+const MAX_MEDIA_SESSION_CONTENT_BYTES: usize = 8 * 1024;
+
+/// Providers this relay will admit in a media session announcement.
+///
+/// An allowlist rather than a free-form string: clients act on `provider` to
+/// choose a transport, so an unknown value is a client-side dispatch failure at
+/// best. New providers are added here deliberately.
+const KNOWN_MEDIA_PROVIDERS: &[&str] = &["livekit"];
+
+/// Collect the pubkeys named by `p` tags.
+fn p_tag_pubkeys(event: &Event) -> Vec<String> {
+    event
+        .tags
+        .iter()
+        .filter(|tag| tag.kind().to_string() == "p")
+        .filter_map(|tag| tag.content().map(str::to_ascii_lowercase))
+        .collect()
+}
+
+/// Whether any `e` tag is present and every one is a 64-char hex event id.
+fn e_tags_well_formed(event: &Event) -> bool {
+    event
+        .tags
+        .iter()
+        .filter(|tag| tag.kind().to_string() == "e")
+        .all(|tag| {
+            tag.content()
+                .is_some_and(|v| v.len() == 64 && v.chars().all(|c| c.is_ascii_hexdigit()))
+        })
+}
+
+/// Maximum lifetime an agent media session announcement may claim.
+///
+/// `expires_at` is a presentation expiry, not a lease: it stops clients
+/// rendering a card for a room nobody is in, and reaps nothing. A generous
+/// bound therefore buys only a longer window in which a dead session still
+/// looks live. One hour matches [`expected_huddle_backing_ttl`], the longest a
+/// Huddle survives without traffic.
+const MAX_MEDIA_SESSION_DURATION_SECS: i64 = 3600;
+
+/// What the shape pass recovered, handed to the pass that needs the database.
+///
+/// The split keeps every rule decidable from the event alone inside
+/// [`validate_agent_media_session_shape`], which is pure and unit tested as
+/// such, and confines Postgres to [`validate_agent_media_session_links`].
+enum MediaSessionShape {
+    /// Not a 48200 / 48201 event — nothing to check.
+    Other,
+    /// A well-formed start, claiming to stop being worth rendering at this
+    /// unix timestamp.
+    Start { expires_at: i64 },
+    /// A well-formed end, naming the one start it closes.
+    End { start_event_id: Vec<u8> },
+}
+
+/// Validate everything about an agent media session event (48200 / 48201) that
+/// is decidable from the event itself.
+///
+/// The relay does not carry this media — it only vouches for the announcement.
+/// So the guarantees it can offer are exactly: the session belongs to the agent
+/// that signed for it, the body is well-formed, the provider is one clients
+/// know how to dispatch on, and the announcement says when it stops being worth
+/// rendering. Channel scope and membership are enforced upstream by
+/// [`requires_h_channel_scope`] and the membership check.
+///
+/// Ownership comes from the signature, not from a `p` tag: an agent announcing
+/// its own session does not tag itself (nostr strips a self-referential `p` tag
+/// on signing, so it could not even if it wanted to). A `p` tag is meaningful
+/// only when signer and subject differ — the relay closing a session it did not
+/// open.
+fn validate_agent_media_session_shape(
+    relay_pubkey: &[u8; 32],
+    event: &Event,
+    kind: u32,
+) -> Result<MediaSessionShape, IngestError> {
+    if kind != KIND_AGENT_MEDIA_SESSION_STARTED && kind != KIND_AGENT_MEDIA_SESSION_ENDED {
+        return Ok(MediaSessionShape::Other);
+    }
+
+    let signer = hex::encode(event.pubkey.to_bytes());
+    let relay_is_signer = signer == hex::encode(relay_pubkey);
+    let p_tags = p_tag_pubkeys(event);
+
+    for tagged in &p_tags {
+        if tagged.len() != 64 || !tagged.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(IngestError::Rejected(
+                "invalid: agent media session p tag must be a 64-char hex pubkey".into(),
+            ));
+        }
+    }
+
+    if relay_is_signer {
+        // Janitorial parity with huddles: the relay may close a session it did
+        // not open, but must never announce one — and it has to say whose it was.
+        if kind != KIND_AGENT_MEDIA_SESSION_STARTED {
+            if p_tags.len() != 1 {
+                return Err(IngestError::Rejected(
+                    "invalid: relay-signed media session end must name the agent \
+                     via exactly one p tag"
+                        .into(),
+                ));
+            }
+        } else {
+            return Err(IngestError::Rejected(
+                "invalid: only an agent may announce its own media session".into(),
+            ));
+        }
+    } else if p_tags.iter().any(|tagged| tagged != &signer) {
+        // A session card is clickable and names a token endpoint of the signer's
+        // choosing. Attributing one to an identity you do not hold is the
+        // impersonation this guard exists to stop.
+        return Err(IngestError::Rejected(
+            "invalid: agent media session may not be attributed to another identity".into(),
+        ));
+    }
+
+    if !e_tags_well_formed(event) {
+        return Err(IngestError::Rejected(
+            "invalid: agent media session e tags must be 64-char hex event ids".into(),
+        ));
+    }
+
+    if event.content.len() > MAX_MEDIA_SESSION_CONTENT_BYTES {
+        return Err(IngestError::Rejected(
+            "invalid: agent media session content exceeds the size limit".into(),
+        ));
+    }
+
+    if kind == KIND_AGENT_MEDIA_SESSION_ENDED {
+        // An end event is meaningless without the start it closes, and
+        // ambiguous with more than one: the relay resolves that reference to
+        // check ownership against the start's signer, a question two starts
+        // have no single answer to.
+        let mut e_tags = event
+            .tags
+            .iter()
+            .filter(|tag| tag.kind().to_string() == "e")
+            .filter_map(|tag| tag.content());
+        let referenced = e_tags.next().ok_or_else(|| {
+            IngestError::Rejected(
+                "invalid: agent media session end must reference its start via an e tag".into(),
+            )
+        })?;
+        if e_tags.next().is_some() {
+            return Err(IngestError::Rejected(
+                "invalid: agent media session end must reference exactly one start".into(),
+            ));
+        }
+        let start_event_id = hex::decode(referenced).map_err(|_| {
+            IngestError::Rejected(
+                "invalid: agent media session e tags must be 64-char hex event ids".into(),
+            )
+        })?;
+        return Ok(MediaSessionShape::End { start_event_id });
+    }
+
+    let body: serde_json::Value = serde_json::from_str(&event.content).map_err(|_| {
+        IngestError::Rejected("invalid: agent media session content must be JSON".into())
+    })?;
+    let provider = body
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            IngestError::Rejected("invalid: agent media session must name a provider".into())
+        })?;
+    if !KNOWN_MEDIA_PROVIDERS.contains(&provider) {
+        return Err(IngestError::Rejected(
+            "invalid: unknown agent media session provider".into(),
+        ));
+    }
+    if !body.get("connect").is_some_and(|v| v.is_object()) {
+        return Err(IngestError::Rejected(
+            "invalid: agent media session must carry a connect object".into(),
+        ));
+    }
+    // Viewers fetch a short-lived credential from `token_endpoint`, so a scheme
+    // other than http(s) is never legitimate -- it would make a world-readable
+    // channel event a vector for whatever the client's URL handler does with
+    // `file:`, `data:` or `javascript:`. https is expected in production; plain
+    // http stays admissible so a self-hosted gateway can be reached on a LAN.
+    if let Some(endpoint) = body.get("token_endpoint") {
+        let endpoint = endpoint.as_str().ok_or_else(|| {
+            IngestError::Rejected(
+                "invalid: agent media session token_endpoint must be a string".into(),
+            )
+        })?;
+        if !endpoint.starts_with("https://") && !endpoint.starts_with("http://") {
+            return Err(IngestError::Rejected(
+                "invalid: agent media session token_endpoint must be http(s)".into(),
+            ));
+        }
+    }
+
+    // A card with no stated end renders until something contradicts it, and the
+    // only thing that can is a 48201 that may never arrive — a crashed agent
+    // publishes nothing. Requiring the expiry up front means a session that
+    // dies badly still stops rendering.
+    let expires_at = body
+        .get("expires_at")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| {
+            IngestError::Rejected(
+                "invalid: agent media session must carry an integer expires_at".into(),
+            )
+        })?;
+    // Measured against `created_at` rather than the relay's clock: the same
+    // event must decide the same way on every relay and in every replay, and
+    // `created_at` is already bounded for skew upstream.
+    let created_at = event.created_at.as_secs() as i64;
+    if expires_at <= created_at {
+        return Err(IngestError::Rejected(
+            "invalid: agent media session expires_at must be after its created_at".into(),
+        ));
+    }
+    if expires_at - created_at > MAX_MEDIA_SESSION_DURATION_SECS {
+        return Err(IngestError::Rejected(
+            "invalid: agent media session expires_at exceeds the maximum session duration".into(),
+        ));
+    }
+
+    Ok(MediaSessionShape::Start { expires_at })
+}
+
+/// Whether an end event may close the start it references.
+///
+/// Two shapes and no others: the owner closes its own session, or the relay
+/// closes one on the owner's behalf and names the owner it closed it for.
+/// Anyone else ending someone's session is a denial of service against a live
+/// call, so this defaults closed.
+///
+/// Split from the database fetch because the rule is decidable from identities
+/// alone, and a rule that needs Postgres to test is a rule that goes untested.
+fn media_session_end_is_authorized(
+    end_signer: &str,
+    end_p_tags: &[String],
+    start_signer: &str,
+    relay_pubkey_hex: &str,
+) -> bool {
+    if end_signer == start_signer {
+        return true;
+    }
+    end_signer == relay_pubkey_hex && end_p_tags.len() == 1 && end_p_tags[0] == start_signer
+}
+
+/// Whether a claimed expiry fits inside the channel it is announced into.
+///
+/// An ephemeral channel — a Huddle's backing stream — carries its own deadline.
+/// A session card that outlives the channel holding it can only mislead, so the
+/// announcement may not claim past that deadline. A permanent channel imposes
+/// no cap: 48200 is a generic agent media session kind, not a Huddle-only one,
+/// so the Huddle rule is conditional rather than general.
+///
+/// `ttl_deadline` is the whole test because the store sets it exactly when
+/// `ttl_seconds` is set — at creation and on every update — so its presence is
+/// what "ephemeral" means here.
+fn media_session_expiry_fits_channel(
+    expires_at: i64,
+    channel_ttl_deadline: Option<chrono::DateTime<Utc>>,
+) -> bool {
+    channel_ttl_deadline.is_none_or(|deadline| expires_at <= deadline.timestamp())
+}
+
+/// Validate the parts of an agent media session event that reference stored
+/// state: who may announce one, and which start an end actually closes.
+async fn validate_agent_media_session_links(
+    tenant: &TenantContext,
+    state: &AppState,
+    event: &Event,
+    shape: MediaSessionShape,
+) -> Result<(), IngestError> {
+    match shape {
+        MediaSessionShape::Other => Ok(()),
+        MediaSessionShape::Start { expires_at } => {
+            let channel_id = media_session_channel_id(event)?;
+            // The kind is named for agent media sessions and clients render the
+            // card under an agent's identity, so the announcer has to be one.
+            // Without this the contract is "any member may announce a session",
+            // which is a different feature wearing this one's name.
+            let announcer = event.pubkey.to_bytes();
+            let policy = state
+                .db
+                .get_agent_channel_policy(tenant.community(), &announcer)
+                .await
+                .map_err(|error| {
+                    IngestError::Internal(format!(
+                        "error: resolving agent media session announcer: {error}"
+                    ))
+                })?;
+            if !matches!(policy, Some((_, Some(_)))) {
+                return Err(IngestError::Rejected(
+                    "invalid: only a registered agent may announce a media session".into(),
+                ));
+            }
+
+            let channel = state
+                .db
+                .get_channel(tenant.community(), channel_id)
+                .await
+                .map_err(map_media_session_channel_error)?;
+            if !media_session_expiry_fits_channel(expires_at, channel.ttl_deadline) {
+                return Err(IngestError::Rejected(
+                    "invalid: agent media session expires_at outlives its ephemeral channel".into(),
+                ));
+            }
+            Ok(())
+        }
+        MediaSessionShape::End { start_event_id } => {
+            let channel_id = media_session_channel_id(event)?;
+            let start = state
+                .db
+                .get_event_by_id(tenant.community(), &start_event_id)
+                .await
+                .map_err(|error| {
+                    IngestError::Internal(format!(
+                        "error: loading agent media session start: {error}"
+                    ))
+                })?
+                .ok_or_else(|| {
+                    IngestError::Rejected(
+                        "invalid: agent media session end references an unknown start".into(),
+                    )
+                })?;
+
+            if event_kind_u32(&start.event) != KIND_AGENT_MEDIA_SESSION_STARTED {
+                return Err(IngestError::Rejected(
+                    "invalid: agent media session end must reference a session start".into(),
+                ));
+            }
+            // The lookup is community-scoped, so this is the remaining half of
+            // "same community and channel". An end published elsewhere would
+            // retire a card its own readers never saw.
+            if start.channel_id != Some(channel_id) {
+                return Err(IngestError::Rejected(
+                    "invalid: agent media session end must be published in the start's channel"
+                        .into(),
+                ));
+            }
+
+            let relay_hex = hex::encode(state.relay_keypair.public_key().to_bytes());
+            let start_signer = hex::encode(start.event.pubkey.to_bytes());
+            if !media_session_end_is_authorized(
+                &hex::encode(event.pubkey.to_bytes()),
+                &p_tag_pubkeys(event),
+                &start_signer,
+                &relay_hex,
+            ) {
+                return Err(IngestError::Rejected(
+                    "invalid: only the session owner or the relay may end an agent media session"
+                        .into(),
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+/// The channel an agent media session event is scoped to.
+///
+/// Cannot fail while [`requires_h_channel_scope`] covers both kinds. Checked
+/// anyway so a future removal fails closed, rather than silently comparing
+/// `None` against `None` when matching an end to its start.
+fn media_session_channel_id(event: &Event) -> Result<Uuid, IngestError> {
+    extract_channel_id(event).ok_or_else(|| {
+        IngestError::Rejected("invalid: agent media session must name a channel".into())
+    })
+}
+
+fn map_media_session_channel_error(error: buzz_db::DbError) -> IngestError {
+    match error {
+        buzz_db::DbError::ChannelNotFound(_) => {
+            IngestError::Rejected("invalid: agent media session channel not found".into())
+        }
+        error => IngestError::Internal(format!(
+            "error: loading agent media session channel: {error}"
+        )),
+    }
+}
+
+/// Validate an agent media session lifecycle event (48200 / 48201).
+///
+/// Two passes: everything the event decides about itself, then the references
+/// that need stored state.
+async fn validate_agent_media_session_event(
+    tenant: &TenantContext,
+    state: &AppState,
+    event: &Event,
+    kind: u32,
+) -> Result<(), IngestError> {
+    let shape = validate_agent_media_session_shape(
+        &state.relay_keypair.public_key().to_bytes(),
+        event,
+        kind,
+    )?;
+    validate_agent_media_session_links(tenant, state, event, shape).await
 }
 
 async fn validate_huddle_lifecycle_event(
@@ -525,6 +927,11 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         | KIND_HUDDLE_PARTICIPANT_LEFT
         | KIND_HUDDLE_ENDED
         | KIND_HUDDLE_GUIDELINES => Ok(Scope::ChannelsWrite),
+        // Agent media session lifecycle: same shape as the huddle lifecycle
+        // events above, for sessions carried by an external provider.
+        KIND_AGENT_MEDIA_SESSION_STARTED | KIND_AGENT_MEDIA_SESSION_ENDED => {
+            Ok(Scope::ChannelsWrite)
+        }
         // NIP-34: Git repository events
         KIND_GIT_REPO_ANNOUNCEMENT | KIND_GIT_REPO_STATE => Ok(Scope::ReposWrite),
         // NIP-MP: a project is repository metadata — grouping repositories needs
@@ -729,6 +1136,9 @@ pub(crate) fn requires_h_channel_scope(kind: u32) -> bool {
             | KIND_HUDDLE_PARTICIPANT_LEFT
             | KIND_HUDDLE_ENDED
             | KIND_HUDDLE_GUIDELINES
+            // Agent media sessions are announced into the channel they serve
+            | KIND_AGENT_MEDIA_SESSION_STARTED
+            | KIND_AGENT_MEDIA_SESSION_ENDED
     )
 }
 
@@ -2653,6 +3063,7 @@ async fn ingest_event_inner(
     }
 
     validate_huddle_lifecycle_event(tenant, state, &event, kind_u32).await?;
+    validate_agent_media_session_event(tenant, state, &event, kind_u32).await?;
 
     if crate::handlers::side_effects::is_admin_kind(kind_u32) {
         crate::handlers::side_effects::validate_admin_event(tenant, kind_u32, &event, state)
@@ -5521,6 +5932,593 @@ mod postgres_tests {
         assert_eq!(
             counts.get(&("ws".to_owned(), "invalid".to_owned())),
             Some(&1)
+        );
+    }
+
+    // --- Agent media sessions (48200 / 48201) -------------------------------
+
+    /// Build a media session event signed by `keys`.
+    ///
+    /// Note: nostr strips a `p` tag equal to the signer's own pubkey, so a
+    /// self-attributed session simply has no `p` tag — which is exactly the
+    /// shape the validator expects.
+    fn media_session_event(
+        keys: &nostr::Keys,
+        kind: u32,
+        content: &str,
+        extra_tags: Vec<nostr::Tag>,
+    ) -> Event {
+        let mut tags = vec![nostr::Tag::parse(["h", &Uuid::new_v4().to_string()]).expect("h tag")];
+        tags.extend(extra_tags);
+        EventBuilder::new(Kind::Custom(kind as u16), content)
+            .tags(tags)
+            .sign_with_keys(keys)
+            .expect("sign media session event")
+    }
+
+    fn e_tag(seed: char) -> nostr::Tag {
+        nostr::Tag::parse(["e", &seed.to_string().repeat(64)]).expect("e tag")
+    }
+
+    /// A valid start body expiring ten minutes out.
+    ///
+    /// Built rather than a constant because the validator measures `expires_at`
+    /// against the event's own `created_at`, which `sign_with_keys` stamps at
+    /// signing time — a fixed timestamp would age into a failure.
+    fn livekit_body() -> String {
+        livekit_body_expiring_in(600)
+    }
+
+    fn livekit_body_expiring_in(offset_secs: i64) -> String {
+        let expires_at = nostr::Timestamp::now().as_secs() as i64 + offset_secs;
+        format!(
+            r#"{{"v":1,"provider":"livekit","connect":{{"url":"wss://x","room":"r"}},"expires_at":{expires_at}}}"#
+        )
+    }
+
+    const RELAY_KEY: [u8; 32] = [7u8; 32];
+
+    #[test]
+    fn media_session_start_accepts_the_agents_own_announcement() {
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body(),
+            vec![],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn media_session_start_rejects_attribution_to_another_identity() {
+        // The card is clickable and names a token endpoint of the signer's
+        // choosing, so a session attributed to an identity you do not hold is
+        // the impersonation the guard exists to stop.
+        let keys = nostr::Keys::generate();
+        let someone_else = hex::encode(nostr::Keys::generate().public_key().to_bytes());
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body(),
+            vec![nostr::Tag::parse(["p", someone_else.as_str()]).expect("p tag")],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_start_rejects_a_relay_signed_announcement() {
+        let relay_keys = nostr::Keys::generate();
+        let relay_pubkey = relay_keys.public_key().to_bytes();
+        let event = media_session_event(
+            &relay_keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body(),
+            vec![],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &relay_pubkey,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_start_rejects_unknown_provider() {
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            r#"{"provider":"not-a-provider","connect":{}}"#,
+            vec![],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_start_requires_a_connect_object() {
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            r#"{"provider":"livekit"}"#,
+            vec![],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_start_rejects_non_json_content() {
+        let keys = nostr::Keys::generate();
+        let event =
+            media_session_event(&keys, KIND_AGENT_MEDIA_SESSION_STARTED, "not json", vec![]);
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_start_rejects_non_http_token_endpoint() {
+        let keys = nostr::Keys::generate();
+        for endpoint in [
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "data:text/html,x",
+        ] {
+            let event = media_session_event(
+                &keys,
+                KIND_AGENT_MEDIA_SESSION_STARTED,
+                &format!(
+                    r#"{{"provider":"livekit","connect":{{}},"token_endpoint":"{endpoint}"}}"#
+                ),
+                vec![],
+            );
+            assert!(
+                validate_agent_media_session_shape(
+                    &RELAY_KEY,
+                    &event,
+                    KIND_AGENT_MEDIA_SESSION_STARTED
+                )
+                .is_err(),
+                "expected {endpoint} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn media_session_content_is_size_capped_for_both_kinds() {
+        let keys = nostr::Keys::generate();
+        // One past the cap: the check is `>`, so exactly-at-limit is admissible.
+        let padding = "x".repeat(MAX_MEDIA_SESSION_CONTENT_BYTES + 1);
+
+        let start = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &format!(r#"{{"provider":"livekit","connect":{{}},"pad":"{padding}"}}"#),
+            vec![],
+        );
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &start,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+
+        // The end event once took an early return before the size check.
+        let end = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_ENDED,
+            &padding,
+            vec![e_tag('c')],
+        );
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &end,
+            KIND_AGENT_MEDIA_SESSION_ENDED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_content_exactly_at_the_cap_is_admissible() {
+        let keys = nostr::Keys::generate();
+        let expires_at = nostr::Timestamp::now().as_secs() as i64 + 600;
+        let prefix =
+            format!(r#"{{"provider":"livekit","connect":{{}},"expires_at":{expires_at},"pad":""#);
+        let suffix = r#""}"#;
+        let pad = "x".repeat(MAX_MEDIA_SESSION_CONTENT_BYTES - prefix.len() - suffix.len());
+        let body = format!("{prefix}{pad}{suffix}");
+        assert_eq!(body.len(), MAX_MEDIA_SESSION_CONTENT_BYTES);
+
+        let event = media_session_event(&keys, KIND_AGENT_MEDIA_SESSION_STARTED, &body, vec![]);
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn media_session_end_requires_an_e_tag_to_its_start() {
+        let keys = nostr::Keys::generate();
+
+        let dangling = media_session_event(&keys, KIND_AGENT_MEDIA_SESSION_ENDED, "", vec![]);
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &dangling,
+            KIND_AGENT_MEDIA_SESSION_ENDED
+        )
+        .is_err());
+
+        let linked =
+            media_session_event(&keys, KIND_AGENT_MEDIA_SESSION_ENDED, "", vec![e_tag('a')]);
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &linked,
+            KIND_AGENT_MEDIA_SESSION_ENDED
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn media_session_end_rejects_a_malformed_e_tag() {
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_ENDED,
+            "",
+            vec![nostr::Tag::parse(["e", "not-hex"]).expect("e tag")],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_ENDED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_end_lets_the_relay_close_a_session_it_names() {
+        let relay_keys = nostr::Keys::generate();
+        let relay_pubkey = relay_keys.public_key().to_bytes();
+        let agent = hex::encode(nostr::Keys::generate().public_key().to_bytes());
+
+        let named = media_session_event(
+            &relay_keys,
+            KIND_AGENT_MEDIA_SESSION_ENDED,
+            "",
+            vec![
+                nostr::Tag::parse(["p", agent.as_str()]).expect("p tag"),
+                e_tag('b'),
+            ],
+        );
+        assert!(validate_agent_media_session_shape(
+            &relay_pubkey,
+            &named,
+            KIND_AGENT_MEDIA_SESSION_ENDED
+        )
+        .is_ok());
+
+        // Without a p tag the relay has not said whose session it closed.
+        let anonymous = media_session_event(
+            &relay_keys,
+            KIND_AGENT_MEDIA_SESSION_ENDED,
+            "",
+            vec![e_tag('b')],
+        );
+        assert!(validate_agent_media_session_shape(
+            &relay_pubkey,
+            &anonymous,
+            KIND_AGENT_MEDIA_SESSION_ENDED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_rejects_a_malformed_p_tag() {
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body(),
+            vec![nostr::Tag::parse(["p", "beef"]).expect("p tag")],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_kinds_are_channel_scoped() {
+        // Without an `h` tag a session announcement would be a workspace-global
+        // event naming a channel it cannot be authorized against.
+        assert!(requires_h_channel_scope(KIND_AGENT_MEDIA_SESSION_STARTED));
+        assert!(requires_h_channel_scope(KIND_AGENT_MEDIA_SESSION_ENDED));
+    }
+
+    #[test]
+    fn media_session_start_requires_an_expires_at() {
+        // A card with no stated end renders until a 48201 contradicts it, and a
+        // crashed agent publishes nothing.
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            r#"{"provider":"livekit","connect":{"url":"wss://x","room":"r"}}"#,
+            vec![],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_start_rejects_a_non_integer_expires_at() {
+        // A float, a formatted string or a null is a client that did something
+        // other than read its clock; none of them has a defined comparison here.
+        let keys = nostr::Keys::generate();
+        for value in ["1.5", r#""later""#, "null", "true"] {
+            let event = media_session_event(
+                &keys,
+                KIND_AGENT_MEDIA_SESSION_STARTED,
+                &format!(r#"{{"provider":"livekit","connect":{{}},"expires_at":{value}}}"#),
+                vec![],
+            );
+            assert!(
+                validate_agent_media_session_shape(
+                    &RELAY_KEY,
+                    &event,
+                    KIND_AGENT_MEDIA_SESSION_STARTED
+                )
+                .is_err(),
+                "expected expires_at {value} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn media_session_start_rejects_an_expiry_that_is_not_in_the_future() {
+        let keys = nostr::Keys::generate();
+        for offset in [0, -1, -3600] {
+            let event = media_session_event(
+                &keys,
+                KIND_AGENT_MEDIA_SESSION_STARTED,
+                &livekit_body_expiring_in(offset),
+                vec![],
+            );
+            assert!(
+                validate_agent_media_session_shape(
+                    &RELAY_KEY,
+                    &event,
+                    KIND_AGENT_MEDIA_SESSION_STARTED
+                )
+                .is_err(),
+                "expected an expiry {offset}s from created_at to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn media_session_start_caps_the_claimed_duration() {
+        let keys = nostr::Keys::generate();
+
+        // The check is `>`, so exactly-at-the-cap is admissible.
+        let at_cap = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body_expiring_in(MAX_MEDIA_SESSION_DURATION_SECS),
+            vec![],
+        );
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &at_cap,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_ok());
+
+        let past_cap = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body_expiring_in(MAX_MEDIA_SESSION_DURATION_SECS + 60),
+            vec![],
+        );
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &past_cap,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_start_shape_carries_the_expiry_forward() {
+        // The links pass caps this against an ephemeral channel's deadline, so
+        // the shape pass has to hand it over rather than merely approve it.
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body(),
+            vec![],
+        );
+
+        let shape = validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+        )
+        .expect("valid start");
+        let MediaSessionShape::Start { expires_at } = shape else {
+            panic!("expected a start shape");
+        };
+        assert!(expires_at > event.created_at.as_secs() as i64);
+    }
+
+    #[test]
+    fn media_session_end_rejects_more_than_one_start_reference() {
+        // Ownership is checked against the referenced start's signer. Two
+        // starts are two answers, so the relay refuses to pick one.
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_ENDED,
+            "",
+            vec![e_tag('a'), e_tag('b')],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_ENDED
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_session_end_shape_carries_the_referenced_start_forward() {
+        let keys = nostr::Keys::generate();
+        let event =
+            media_session_event(&keys, KIND_AGENT_MEDIA_SESSION_ENDED, "", vec![e_tag('a')]);
+
+        let shape =
+            validate_agent_media_session_shape(&RELAY_KEY, &event, KIND_AGENT_MEDIA_SESSION_ENDED)
+                .expect("valid end");
+        let MediaSessionShape::End { start_event_id } = shape else {
+            panic!("expected an end shape");
+        };
+        assert_eq!(start_event_id, hex::decode("a".repeat(64)).expect("hex"));
+    }
+
+    #[test]
+    fn media_session_end_authorizes_the_session_owner() {
+        let agent = "aa".repeat(32);
+        let relay = "bb".repeat(32);
+
+        assert!(media_session_end_is_authorized(&agent, &[], &agent, &relay));
+    }
+
+    #[test]
+    fn media_session_end_authorizes_the_relay_when_it_names_the_owner() {
+        let agent = "aa".repeat(32);
+        let relay = "bb".repeat(32);
+        let other = "cc".repeat(32);
+
+        assert!(media_session_end_is_authorized(
+            &relay,
+            std::slice::from_ref(&agent),
+            &agent,
+            &relay
+        ));
+
+        // Naming somebody else, nobody, or several people is not naming the owner.
+        assert!(!media_session_end_is_authorized(
+            &relay,
+            std::slice::from_ref(&other),
+            &agent,
+            &relay
+        ));
+        assert!(!media_session_end_is_authorized(
+            &relay,
+            &[],
+            &agent,
+            &relay
+        ));
+        assert!(!media_session_end_is_authorized(
+            &relay,
+            &[agent.clone(), other],
+            &agent,
+            &relay
+        ));
+    }
+
+    #[test]
+    fn media_session_end_refuses_a_third_party() {
+        // Ending a stranger's live call is a denial of service, and the p-tag
+        // form belongs to the relay alone.
+        let agent = "aa".repeat(32);
+        let relay = "bb".repeat(32);
+        let stranger = "cc".repeat(32);
+
+        assert!(!media_session_end_is_authorized(
+            &stranger,
+            &[],
+            &agent,
+            &relay
+        ));
+        assert!(!media_session_end_is_authorized(
+            &stranger,
+            std::slice::from_ref(&agent),
+            &agent,
+            &relay
+        ));
+    }
+
+    #[test]
+    fn media_session_expiry_is_capped_by_an_ephemeral_channels_deadline() {
+        let deadline = chrono::DateTime::from_timestamp(2_000, 0).expect("timestamp");
+
+        assert!(media_session_expiry_fits_channel(1_999, Some(deadline)));
+        assert!(media_session_expiry_fits_channel(2_000, Some(deadline)));
+        assert!(!media_session_expiry_fits_channel(2_001, Some(deadline)));
+    }
+
+    #[test]
+    fn media_session_expiry_is_uncapped_in_a_permanent_channel() {
+        // 48200 is a generic agent media session kind, not a Huddle-only one, so
+        // a channel with no deadline imposes none. The duration cap in the shape
+        // pass is what bounds the claim there.
+        assert!(media_session_expiry_fits_channel(i64::MAX, None));
+    }
+
+    #[test]
+    fn media_session_validator_ignores_unrelated_kinds() {
+        let keys = nostr::Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "hi")
+            .sign_with_keys(&keys)
+            .expect("sign message");
+
+        assert!(
+            validate_agent_media_session_shape(&RELAY_KEY, &event, KIND_STREAM_MESSAGE).is_ok()
         );
     }
 }

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -93,6 +93,16 @@ const MAX_MEDIA_SESSION_CONTENT_BYTES: usize = 8 * 1024;
 /// best. New providers are added here deliberately.
 const KNOWN_MEDIA_PROVIDERS: &[&str] = &["livekit"];
 
+/// Schemes a media transport URL may use.
+///
+/// A client hands `connect.url` straight to its provider SDK, so the same
+/// reasoning as `token_endpoint` applies: a world-readable channel event must
+/// not be able to name `javascript:`, `data:` or `file:`. LiveKit's own client
+/// accepts the websocket and the http form and converts between them, so both
+/// are admissible, and the unencrypted variants stay in so a self-hosted
+/// gateway can be reached on a LAN.
+const MEDIA_TRANSPORT_SCHEMES: &[&str] = &["wss://", "ws://", "https://", "http://"];
+
 /// Collect the pubkeys named by `p` tags.
 fn p_tag_pubkeys(event: &Event) -> Vec<String> {
     event
@@ -254,9 +264,44 @@ fn validate_agent_media_session_shape(
             "invalid: unknown agent media session provider".into(),
         ));
     }
-    if !body.get("connect").is_some_and(|v| v.is_object()) {
+    // `connect` carries the transport, so an announcement whose transport is
+    // unusable is not an announcement at all: every client can do nothing but
+    // drop it, silently, after the relay has already fanned it out to the whole
+    // channel. Both fields are required non-empty for that reason, matching
+    // what the desktop's `parseAgentMediaSession` refuses to render. Checking
+    // only that `connect` was an object let `{}` through, and a stored, valid,
+    // unjoinable session reports nothing anywhere.
+    let connect = body
+        .get("connect")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            IngestError::Rejected("invalid: agent media session must carry a connect object".into())
+        })?;
+    let url = connect
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    if url.is_empty() {
         return Err(IngestError::Rejected(
-            "invalid: agent media session must carry a connect object".into(),
+            "invalid: agent media session connect.url must be a non-empty string".into(),
+        ));
+    }
+    if !MEDIA_TRANSPORT_SCHEMES
+        .iter()
+        .any(|scheme| url.starts_with(scheme))
+    {
+        return Err(IngestError::Rejected(
+            "invalid: agent media session connect.url must be ws(s) or http(s)".into(),
+        ));
+    }
+    if connect
+        .get("room")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .is_empty()
+    {
+        return Err(IngestError::Rejected(
+            "invalid: agent media session connect.room must be a non-empty string".into(),
         ));
     }
     // Viewers fetch a short-lived credential from `token_endpoint`, so a scheme
@@ -264,6 +309,12 @@ fn validate_agent_media_session_shape(
     // channel event a vector for whatever the client's URL handler does with
     // `file:`, `data:` or `javascript:`. https is expected in production; plain
     // http stays admissible so a self-hosted gateway can be reached on a LAN.
+    //
+    // Presence stays optional, unlike the `connect` fields above, and the line
+    // between them is whether the failure is silent: a viewer that finds no
+    // endpoint is told so in the panel, and a later provider may carry its
+    // credential some other way, so this is a client-side dead end rather than
+    // an event the relay should refuse to store.
     if let Some(endpoint) = body.get("token_endpoint") {
         let endpoint = endpoint.as_str().ok_or_else(|| {
             IngestError::Rejected(
@@ -5976,6 +6027,12 @@ mod postgres_tests {
         )
     }
 
+    /// A start body carrying `connect` verbatim, valid in every other respect.
+    fn livekit_body_with_connect(connect: &str) -> String {
+        let expires_at = nostr::Timestamp::now().as_secs() as i64 + 600;
+        format!(r#"{{"v":1,"provider":"livekit","connect":{connect},"expires_at":{expires_at}}}"#)
+    }
+
     const RELAY_KEY: [u8; 32] = [7u8; 32];
 
     #[test]
@@ -5985,6 +6042,100 @@ mod postgres_tests {
             &keys,
             KIND_AGENT_MEDIA_SESSION_STARTED,
             &livekit_body(),
+            vec![],
+        );
+
+        assert!(validate_agent_media_session_shape(
+            &RELAY_KEY,
+            &event,
+            KIND_AGENT_MEDIA_SESSION_STARTED
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn media_session_start_rejects_an_unusable_connect_object() {
+        // Every one of these used to be accepted: `connect` was checked for
+        // being an object and nothing further. The relay then stored and fanned
+        // out a session no client could join, and nothing reported it — the
+        // desktop's own parse drops such an announcement silently, by design.
+        let keys = nostr::Keys::generate();
+        for connect in [
+            r#"{}"#,
+            r#"{"room":"r"}"#,
+            r#"{"url":"wss://x"}"#,
+            r#"{"url":"","room":"r"}"#,
+            r#"{"url":"wss://x","room":""}"#,
+            r#"{"url":42,"room":"r"}"#,
+            r#"{"url":"wss://x","room":7}"#,
+            // The scheme guard `token_endpoint` already had, which `connect.url`
+            // did not — and it is `connect.url` that a client dials.
+            r#"{"url":"javascript:alert(1)","room":"r"}"#,
+            r#"{"url":"file:///etc/passwd","room":"r"}"#,
+            r#"{"url":"data:text/html,x","room":"r"}"#,
+        ] {
+            let event = media_session_event(
+                &keys,
+                KIND_AGENT_MEDIA_SESSION_STARTED,
+                &livekit_body_with_connect(connect),
+                vec![],
+            );
+
+            assert!(
+                validate_agent_media_session_shape(
+                    &RELAY_KEY,
+                    &event,
+                    KIND_AGENT_MEDIA_SESSION_STARTED
+                )
+                .is_err(),
+                "connect {connect} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn media_session_start_accepts_every_transport_a_client_can_dial() {
+        // The allowlist must not be narrower than the SDK: LiveKit's client
+        // takes the websocket and the http form and converts between them, and
+        // a self-hosted gateway on a LAN has no certificate.
+        let keys = nostr::Keys::generate();
+        for connect in [
+            r#"{"url":"wss://x.livekit.cloud","room":"r"}"#,
+            r#"{"url":"ws://127.0.0.1:7880","room":"r"}"#,
+            r#"{"url":"https://x.livekit.cloud","room":"r"}"#,
+            r#"{"url":"http://127.0.0.1:7880","room":"r"}"#,
+        ] {
+            let event = media_session_event(
+                &keys,
+                KIND_AGENT_MEDIA_SESSION_STARTED,
+                &livekit_body_with_connect(connect),
+                vec![],
+            );
+
+            assert!(
+                validate_agent_media_session_shape(
+                    &RELAY_KEY,
+                    &event,
+                    KIND_AGENT_MEDIA_SESSION_STARTED
+                )
+                .is_ok(),
+                "connect {connect} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn media_session_start_accepts_an_announcement_with_no_token_endpoint() {
+        // Deliberate, and the counterpart to the `connect` rules above. A
+        // viewer that finds no endpoint is told so in the panel, so this fails
+        // loudly at the client; an unusable `connect` fails silently, which is
+        // what the relay refuses to store. A later provider may also carry its
+        // credential some other way.
+        let keys = nostr::Keys::generate();
+        let event = media_session_event(
+            &keys,
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            &livekit_body_with_connect(r#"{"url":"wss://x","room":"r"}"#),
             vec![],
         );
 
@@ -6153,8 +6304,12 @@ mod postgres_tests {
     fn media_session_content_exactly_at_the_cap_is_admissible() {
         let keys = nostr::Keys::generate();
         let expires_at = nostr::Timestamp::now().as_secs() as i64 + 600;
-        let prefix =
-            format!(r#"{{"provider":"livekit","connect":{{}},"expires_at":{expires_at},"pad":""#);
+        // A usable `connect`, not `{}`: the boundary this pins is the content
+        // size, and a body the validator rejects for another reason would pass
+        // this test whatever the cap did.
+        let prefix = format!(
+            r#"{{"provider":"livekit","connect":{{"url":"wss://x","room":"r"}},"expires_at":{expires_at},"pad":""#
+        );
         let suffix = r#""}"#;
         let pad = "x".repeat(MAX_MEDIA_SESSION_CONTENT_BYTES - prefix.len() - suffix.len());
         let body = format!("{prefix}{pad}{suffix}");

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -41,6 +41,7 @@ use buzz_core::tenant::TenantContext;
 use buzz_core::verification::verify_event;
 use buzz_core::CommunityId;
 use nostr::Event;
+use url::Url;
 
 use crate::state::AppState;
 
@@ -101,7 +102,31 @@ const KNOWN_MEDIA_PROVIDERS: &[&str] = &["livekit"];
 /// accepts the websocket and the http form and converts between them, so both
 /// are admissible, and the unencrypted variants stay in so a self-hosted
 /// gateway can be reached on a LAN.
-const MEDIA_TRANSPORT_SCHEMES: &[&str] = &["wss://", "ws://", "https://", "http://"];
+const MEDIA_TRANSPORT_SCHEMES: &[&str] = &["wss", "ws", "https", "http"];
+
+/// Schemes a viewer may fetch a room credential from.
+const TOKEN_ENDPOINT_SCHEMES: &[&str] = &["https", "http"];
+
+/// Whether `candidate` is a URL with one of `schemes` that a client can dial.
+///
+/// Parsed rather than prefix-matched. A prefix test answers a different
+/// question than the one being asked: `"wss://"` and `"https://["` both begin
+/// with an allowed scheme and neither addresses anything, so both would be
+/// stored and fanned out for every client in the channel to fail on
+/// separately. That is the failure this validation exists to prevent, so
+/// admitting it by inspection is worse than not checking at all.
+///
+/// The four admissible schemes are all WHATWG special schemes, so the parser
+/// requires an authority for each and an empty or malformed host is a parse
+/// error rather than something to test for afterwards. The host is checked
+/// anyway: the rule being enforced is "a client can dial this", and reading it
+/// off the guard should not require knowing which schemes are special.
+fn is_dialable_url(candidate: &str, schemes: &[&str]) -> bool {
+    let Ok(parsed) = Url::parse(candidate) else {
+        return false;
+    };
+    schemes.contains(&parsed.scheme()) && parsed.host_str().is_some_and(|host| !host.is_empty())
+}
 
 /// Collect the pubkeys named by `p` tags.
 fn p_tag_pubkeys(event: &Event) -> Vec<String> {
@@ -286,18 +311,20 @@ fn validate_agent_media_session_shape(
             "invalid: agent media session connect.url must be a non-empty string".into(),
         ));
     }
-    if !MEDIA_TRANSPORT_SCHEMES
-        .iter()
-        .any(|scheme| url.starts_with(scheme))
-    {
+    if !is_dialable_url(url, MEDIA_TRANSPORT_SCHEMES) {
         return Err(IngestError::Rejected(
-            "invalid: agent media session connect.url must be ws(s) or http(s)".into(),
+            "invalid: agent media session connect.url must be a ws(s) or http(s) URL with a host"
+                .into(),
         ));
     }
+    // Trimmed before the emptiness test: a room of spaces is not a room, and
+    // it fails at the provider rather than here, which is the same silent
+    // unjoinable session an empty one would be.
     if connect
         .get("room")
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default()
+        .trim()
         .is_empty()
     {
         return Err(IngestError::Rejected(
@@ -321,9 +348,10 @@ fn validate_agent_media_session_shape(
                 "invalid: agent media session token_endpoint must be a string".into(),
             )
         })?;
-        if !endpoint.starts_with("https://") && !endpoint.starts_with("http://") {
+        if !is_dialable_url(endpoint, TOKEN_ENDPOINT_SCHEMES) {
             return Err(IngestError::Rejected(
-                "invalid: agent media session token_endpoint must be http(s)".into(),
+                "invalid: agent media session token_endpoint must be an http(s) URL with a host"
+                    .into(),
             ));
         }
     }
@@ -6033,6 +6061,18 @@ mod postgres_tests {
         format!(r#"{{"v":1,"provider":"livekit","connect":{connect},"expires_at":{expires_at}}}"#)
     }
 
+    /// A start body carrying `token_endpoint`, valid in every other respect.
+    ///
+    /// The `connect` object has to be a usable one, or the endpoint is never
+    /// reached: shape validation returns on the first failure, so a body that
+    /// is also missing a transport passes its test whatever the endpoint says.
+    fn livekit_body_with_token_endpoint(endpoint: &str) -> String {
+        let expires_at = nostr::Timestamp::now().as_secs() as i64 + 600;
+        format!(
+            r#"{{"v":1,"provider":"livekit","connect":{{"url":"wss://x","room":"r"}},"token_endpoint":"{endpoint}","expires_at":{expires_at}}}"#
+        )
+    }
+
     const RELAY_KEY: [u8; 32] = [7u8; 32];
 
     #[test]
@@ -6073,6 +6113,15 @@ mod postgres_tests {
             r#"{"url":"javascript:alert(1)","room":"r"}"#,
             r#"{"url":"file:///etc/passwd","room":"r"}"#,
             r#"{"url":"data:text/html,x","room":"r"}"#,
+            // An allowed scheme in front of nothing dialable. A prefix test
+            // accepts every one of these, which is why the guard parses.
+            r#"{"url":"wss://","room":"r"}"#,
+            r#"{"url":"https://","room":"r"}"#,
+            r#"{"url":"wss://[","room":"r"}"#,
+            r#"{"url":"wss:// /r","room":"r"}"#,
+            // A room of spaces fails at the provider exactly as an empty one
+            // does, so it is the same unjoinable session.
+            r#"{"url":"wss://x","room":"   "}"#,
         ] {
             let event = media_session_event(
                 &keys,
@@ -6239,19 +6288,52 @@ mod postgres_tests {
     }
 
     #[test]
+    fn media_session_start_accepts_a_usable_token_endpoint() {
+        // The refusals above are only meaningful next to this: a guard that
+        // tightened until it rejected every endpoint would pass all of them.
+        let keys = nostr::Keys::generate();
+        for endpoint in [
+            "https://gateway.example/token",
+            "http://127.0.0.1:8080/token",
+            "https://gateway.example:8443/v1/token?x=1",
+        ] {
+            let event = media_session_event(
+                &keys,
+                KIND_AGENT_MEDIA_SESSION_STARTED,
+                &livekit_body_with_token_endpoint(endpoint),
+                vec![],
+            );
+            assert!(
+                validate_agent_media_session_shape(
+                    &RELAY_KEY,
+                    &event,
+                    KIND_AGENT_MEDIA_SESSION_STARTED
+                )
+                .is_ok(),
+                "expected {endpoint} to be accepted"
+            );
+        }
+    }
+
+    #[test]
     fn media_session_start_rejects_non_http_token_endpoint() {
         let keys = nostr::Keys::generate();
         for endpoint in [
             "javascript:alert(1)",
             "file:///etc/passwd",
             "data:text/html,x",
+            // Hostless and malformed, which a prefix test admits.
+            "https://",
+            "http://",
+            "https://[",
+            // A websocket transport is dialable, but a viewer fetches its
+            // credential over HTTP and hands this to `fetch`.
+            "wss://x",
         ] {
             let event = media_session_event(
                 &keys,
                 KIND_AGENT_MEDIA_SESSION_STARTED,
-                &format!(
-                    r#"{{"provider":"livekit","connect":{{}},"token_endpoint":"{endpoint}"}}"#
-                ),
+                &livekit_body_with_token_endpoint(endpoint),
                 vec![],
             );
             assert!(

--- a/crates/buzz-test-client/tests/e2e_agent_media_session.rs
+++ b/crates/buzz-test-client/tests/e2e_agent_media_session.rs
@@ -1,0 +1,344 @@
+//! End-to-end tests for agent media sessions (kind:48200 / kind:48201).
+//!
+//! These bind the relay's *stored-state* authorization for the two kinds —
+//! the half that `validate_agent_media_session_links` decides and that the
+//! in-crate shape tests cannot reach, because every predicate here needs a
+//! real community, a real channel, and a real owner→agent registration:
+//!
+//! - only a registered agent may announce a session;
+//! - an end must name a start that exists and is a start;
+//! - an end must be published in the channel its start was announced in;
+//! - only the session's owner (or the relay) may end it.
+//!
+//! Each refusal is paired with the acceptance it is the refusal *of*. A guard
+//! that tightened until it rejected everything would satisfy the refusals
+//! alone, so on their own they prove nothing about the boundary they claim to
+//! describe.
+//!
+//! Ownership is established the way production establishes it: the agent
+//! authenticates over NIP-42 carrying a NIP-OA `auth` tag signed by its owner,
+//! and the relay materializes the relationship. Seeding `agent_owner_pubkey`
+//! directly would test a row the feature does not read.
+//!
+//! # Running
+//!
+//! Start the relay, then run:
+//!
+//! ```text
+//! cargo test --test e2e_agent_media_session -- --ignored
+//! ```
+
+use buzz_core::kind::{KIND_AGENT_MEDIA_SESSION_ENDED, KIND_AGENT_MEDIA_SESSION_STARTED};
+use buzz_sdk::nip_oa;
+use buzz_test_client::{BuzzTestClient, OkResponse};
+use nostr::{EventBuilder, Keys, Kind, Tag};
+
+fn relay_url() -> String {
+    std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+}
+
+/// Create a fresh open channel, signed by `creator` over its own authenticated
+/// connection, and return its UUID string.
+///
+/// Published over the WebSocket rather than `POST /events` on purpose. The HTTP
+/// bridge is a second authorization surface — a relay running with
+/// `BUZZ_REQUIRE_AUTH_TOKEN` refuses a bare `X-Pubkey` submission — and setup
+/// failing for a reason unrelated to media sessions makes every test in this
+/// file unrunnable against a relay that is otherwise perfectly able to answer
+/// the question being asked. NIP-42 is the path these tests already depend on.
+async fn create_channel(client: &mut BuzzTestClient, creator: &Keys) -> String {
+    let channel_uuid = uuid::Uuid::new_v4();
+
+    let event = EventBuilder::new(Kind::Custom(9007), "")
+        .tags(vec![
+            Tag::parse(["h", &channel_uuid.to_string()]).unwrap(),
+            Tag::parse(["name", &format!("ams-e2e-{}", channel_uuid.simple())]).unwrap(),
+            Tag::parse(["channel_type", "stream"]).unwrap(),
+            Tag::parse(["visibility", "open"]).unwrap(),
+        ])
+        .sign_with_keys(creator)
+        .unwrap();
+
+    let ok = client
+        .send_event(event)
+        .await
+        .expect("send create-channel event");
+    assert!(ok.accepted, "channel creation not accepted: {}", ok.message);
+    channel_uuid.to_string()
+}
+
+/// Connect `agent` with a NIP-OA `auth` tag signed by `owner`.
+///
+/// This is what makes the pubkey a *registered agent* as far as the media
+/// session gate is concerned: the relay records the owner during auth, and
+/// the gate resolves it back out.
+async fn connect_registered_agent(agent: &Keys, owner: &Keys) -> BuzzTestClient {
+    let tag_json = nip_oa::compute_auth_tag(owner, &agent.public_key(), "kind=9")
+        .expect("compute NIP-OA auth tag");
+    let auth_tag = nip_oa::parse_auth_tag(&tag_json).expect("parse NIP-OA auth tag");
+    let mut client = BuzzTestClient::connect_unauthenticated(&relay_url())
+        .await
+        .expect("connect agent unauthenticated");
+    client
+        .authenticate_with_nip_oa(agent, &auth_tag)
+        .await
+        .expect("NIP-OA auth");
+    client
+}
+
+/// Add `member` to `channel_id` via kind:9000 (PUT_USER), signed by `actor`.
+async fn add_channel_member(
+    client: &mut BuzzTestClient,
+    actor: &Keys,
+    channel_id: &str,
+    member: &Keys,
+) {
+    let event = EventBuilder::new(Kind::Custom(9000), "")
+        .tags(vec![
+            Tag::parse(["h", channel_id]).unwrap(),
+            Tag::parse(["p", &member.public_key().to_hex()]).unwrap(),
+        ])
+        .sign_with_keys(actor)
+        .unwrap();
+    let ok = client.send_event(event).await.expect("send PUT_USER");
+    assert!(
+        ok.accepted,
+        "adding a channel member failed: {}",
+        ok.message
+    );
+}
+
+/// A valid 48200 body expiring `offset_secs` from now.
+fn session_body(offset_secs: i64) -> String {
+    let expires_at = nostr::Timestamp::now().as_secs() as i64 + offset_secs;
+    format!(
+        r#"{{"v":1,"provider":"livekit","connect":{{"url":"wss://media.example","room":"r-{}"}},"expires_at":{expires_at}}}"#,
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+async fn announce_session(
+    client: &mut BuzzTestClient,
+    signer: &Keys,
+    channel_id: &str,
+) -> OkResponse {
+    let event = EventBuilder::new(
+        Kind::Custom(KIND_AGENT_MEDIA_SESSION_STARTED as u16),
+        session_body(600),
+    )
+    .tags(vec![Tag::parse(["h", channel_id]).unwrap()])
+    .sign_with_keys(signer)
+    .unwrap();
+    client.send_event(event).await.expect("send 48200")
+}
+
+async fn end_session(
+    client: &mut BuzzTestClient,
+    signer: &Keys,
+    channel_id: &str,
+    start_event_id: &str,
+) -> OkResponse {
+    let event = EventBuilder::new(Kind::Custom(KIND_AGENT_MEDIA_SESSION_ENDED as u16), "")
+        .tags(vec![
+            Tag::parse(["h", channel_id]).unwrap(),
+            Tag::parse(["e", start_event_id]).unwrap(),
+        ])
+        .sign_with_keys(signer)
+        .unwrap();
+    client.send_event(event).await.expect("send 48201")
+}
+
+// ─── who may announce ──────────────────────────────────────────────────────
+
+/// The acceptance the refusal below is the refusal *of*.
+#[tokio::test]
+#[ignore]
+async fn registered_agent_can_announce_a_session() {
+    let owner = Keys::generate();
+    let agent = Keys::generate();
+    let mut client = connect_registered_agent(&agent, &owner).await;
+    let channel_id = create_channel(&mut client, &agent).await;
+
+    let ok = announce_session(&mut client, &agent, &channel_id).await;
+    assert!(
+        ok.accepted,
+        "a registered agent's own announcement was rejected: {}",
+        ok.message
+    );
+
+    client.disconnect().await.ok();
+}
+
+/// The gate itself: a member of the channel who is not a registered agent
+/// cannot announce a session there.
+///
+/// This is the whole security boundary of the feature. Without it the contract
+/// is "any member may announce a media session under an agent's identity",
+/// which is a different feature wearing this one's name — and the card renders
+/// as an agent either way.
+#[tokio::test]
+#[ignore]
+async fn an_unregistered_member_cannot_announce_a_session() {
+    let human = Keys::generate();
+    let mut client = BuzzTestClient::connect(&relay_url(), &human)
+        .await
+        .expect("connect human");
+    let channel_id = create_channel(&mut client, &human).await;
+
+    // The channel's own creator, so a refusal here cannot be membership.
+    let ok = announce_session(&mut client, &human, &channel_id).await;
+    assert!(
+        !ok.accepted,
+        "an unregistered member announced a media session"
+    );
+    assert!(
+        ok.message.contains("registered agent"),
+        "expected the registered-agent refusal, got: {}",
+        ok.message
+    );
+
+    client.disconnect().await.ok();
+}
+
+// ─── who may end, and what an end may name ─────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn a_session_owner_can_end_its_own_session() {
+    let owner = Keys::generate();
+    let agent = Keys::generate();
+    let mut client = connect_registered_agent(&agent, &owner).await;
+    let channel_id = create_channel(&mut client, &agent).await;
+
+    let start = announce_session(&mut client, &agent, &channel_id).await;
+    assert!(start.accepted, "announcement rejected: {}", start.message);
+
+    let ok = end_session(&mut client, &agent, &channel_id, &start.event_id).await;
+    assert!(
+        ok.accepted,
+        "an agent could not end its own session: {}",
+        ok.message
+    );
+
+    client.disconnect().await.ok();
+}
+
+/// A third party cannot retire somebody else's live session.
+///
+/// The third party is itself a registered agent and a member of the channel,
+/// and its own announcement is accepted first. Without that, a refusal here
+/// would be ambiguous: it could just as well be the membership gate or the
+/// registered-agent gate, and the end-authorization rule would be untested
+/// while appearing covered.
+#[tokio::test]
+#[ignore]
+async fn a_third_party_cannot_end_another_agents_session() {
+    let owner = Keys::generate();
+    let agent = Keys::generate();
+    let intruder_owner = Keys::generate();
+    let intruder = Keys::generate();
+
+    let mut agent_client = connect_registered_agent(&agent, &owner).await;
+    let channel_id = create_channel(&mut agent_client, &agent).await;
+    add_channel_member(&mut agent_client, &agent, &channel_id, &intruder).await;
+
+    let start = announce_session(&mut agent_client, &agent, &channel_id).await;
+    assert!(start.accepted, "announcement rejected: {}", start.message);
+
+    let mut intruder_client = connect_registered_agent(&intruder, &intruder_owner).await;
+    let own = announce_session(&mut intruder_client, &intruder, &channel_id).await;
+    assert!(
+        own.accepted,
+        "the intruder must be able to publish here, or the refusal below proves nothing: {}",
+        own.message
+    );
+
+    let ok = end_session(
+        &mut intruder_client,
+        &intruder,
+        &channel_id,
+        &start.event_id,
+    )
+    .await;
+    assert!(!ok.accepted, "a third party ended another agent's session");
+    assert!(
+        ok.message.contains("session owner"),
+        "expected the end-authorization refusal, got: {}",
+        ok.message
+    );
+
+    agent_client.disconnect().await.ok();
+    intruder_client.disconnect().await.ok();
+}
+
+#[tokio::test]
+#[ignore]
+async fn an_end_must_name_a_start_that_exists() {
+    let owner = Keys::generate();
+    let agent = Keys::generate();
+    let mut client = connect_registered_agent(&agent, &owner).await;
+    let channel_id = create_channel(&mut client, &agent).await;
+
+    let unknown = "b".repeat(64);
+    let ok = end_session(&mut client, &agent, &channel_id, &unknown).await;
+    assert!(!ok.accepted, "an end named a start that does not exist");
+    assert!(
+        ok.message.contains("unknown start"),
+        "expected the unknown-start refusal, got: {}",
+        ok.message
+    );
+
+    client.disconnect().await.ok();
+}
+
+/// An `e` tag to some *other* stored event is not a session start.
+#[tokio::test]
+#[ignore]
+async fn an_end_must_reference_a_session_start() {
+    let owner = Keys::generate();
+    let agent = Keys::generate();
+    let mut client = connect_registered_agent(&agent, &owner).await;
+    let channel_id = create_channel(&mut client, &agent).await;
+
+    let content = format!("not-a-session-{}", uuid::Uuid::new_v4());
+    let message = client
+        .send_text_message(&agent, &channel_id, &content, 9)
+        .await
+        .expect("send message");
+    assert!(message.accepted, "message rejected: {}", message.message);
+
+    let ok = end_session(&mut client, &agent, &channel_id, &message.event_id).await;
+    assert!(!ok.accepted, "an end referenced an ordinary message");
+    assert!(
+        ok.message.contains("session start"),
+        "expected the wrong-kind refusal, got: {}",
+        ok.message
+    );
+
+    client.disconnect().await.ok();
+}
+
+/// An end published in a different channel would retire a card its own readers
+/// never saw.
+#[tokio::test]
+#[ignore]
+async fn an_end_must_be_published_in_the_starts_channel() {
+    let owner = Keys::generate();
+    let agent = Keys::generate();
+    let mut client = connect_registered_agent(&agent, &owner).await;
+    let channel_id = create_channel(&mut client, &agent).await;
+    let elsewhere = create_channel(&mut client, &agent).await;
+
+    let start = announce_session(&mut client, &agent, &channel_id).await;
+    assert!(start.accepted, "announcement rejected: {}", start.message);
+
+    let ok = end_session(&mut client, &agent, &elsewhere, &start.event_id).await;
+    assert!(!ok.accepted, "an end retired a start from another channel");
+    assert!(
+        ok.message.contains("start's channel"),
+        "expected the channel-scoping refusal, got: {}",
+        ok.message
+    );
+
+    client.disconnect().await.ok();
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -67,6 +67,7 @@
     "emoji-mart": "^5.6.0",
     "jdenticon": "^3.3.0",
     "linkifyjs": "^4.3.2",
+    "livekit-client": "^2.22.0",
     "lucide-react": "^1.0.0",
     "mdast-util-from-markdown": "^2.0.3",
     "motion": "^12.38.0",

--- a/desktop/src-tauri/src/commands/channel_reconnect_repair.rs
+++ b/desktop/src-tauri/src/commands/channel_reconnect_repair.rs
@@ -3,8 +3,9 @@ use tauri::State;
 use crate::{app_state::AppState, relay::query_relay};
 
 const MAX_REPAIR_PAGE_LIMIT: u32 = 500;
-const CHANNEL_REPAIR_KINDS: [u32; 15] = [
+const CHANNEL_REPAIR_KINDS: [u32; 17] = [
     5, 7, 9, 9005, 40001, 40002, 40003, 40008, 40099, 45001, 45003, 48100, 48101, 48102, 48103,
+    48200, 48201,
 ];
 
 fn build_channel_reconnect_repair_filter(

--- a/desktop/src/features/agents/lib/agentMediaAttach.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaAttach.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * The lip-sync invariant.
+ *
+ * Provenance: the first audio fix gave the voice its own hidden `<audio>`
+ * element, and the avatar's lips drifted against the speech — two elements
+ * play from two independent clocks. LiveKit's `attach` merges tracks into the
+ * element's existing `MediaStream`, so one element is one clock. These pin
+ * "both tracks, one element" so the drift cannot come back quietly.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { attachSessionTracks } from "./agentMediaAttach.ts";
+
+/** A stand-in element; the rule never touches the DOM. */
+const ELEMENT = { tagName: "VIDEO" };
+
+/** An attacher that records the element it was given and its detach calls. */
+function spy() {
+  const calls = [];
+  const detached = [];
+  const attach = (element) => {
+    calls.push(element);
+    return () => detached.push(element);
+  };
+  return { attach, calls, detached };
+}
+
+test("attachSessionTracks puts audio and video on the same element", () => {
+  const video = spy();
+  const audio = spy();
+
+  attachSessionTracks(ELEMENT, {
+    attachAudio: audio.attach,
+    attachVideo: video.attach,
+  });
+
+  assert.deepEqual(video.calls, [ELEMENT]);
+  assert.deepEqual(audio.calls, [ELEMENT]);
+  assert.equal(
+    audio.calls[0],
+    video.calls[0],
+    "one element means one playback clock — this is the lip-sync guarantee",
+  );
+});
+
+test("attachSessionTracks attaches video before audio", () => {
+  // The SDK decides `element.muted` from the stream's audio tracks as each one
+  // attaches, so the video track must be there first for both to be seen.
+  const order = [];
+  attachSessionTracks(ELEMENT, {
+    attachAudio: () => {
+      order.push("audio");
+      return () => {};
+    },
+    attachVideo: () => {
+      order.push("video");
+      return () => {};
+    },
+  });
+  assert.deepEqual(order, ["video", "audio"]);
+});
+
+test("attachSessionTracks detaches everything it attached", () => {
+  const video = spy();
+  const audio = spy();
+
+  const detach = attachSessionTracks(ELEMENT, {
+    attachAudio: audio.attach,
+    attachVideo: video.attach,
+  });
+  detach();
+
+  assert.deepEqual(video.detached, [ELEMENT], "video detached");
+  assert.deepEqual(audio.detached, [ELEMENT], "audio detached");
+});
+
+test("attachSessionTracks handles a session with no audio yet", () => {
+  // Tracks arrive independently: the face may render a beat before the voice
+  // is subscribed, and that must not throw or leave a detach missing.
+  const video = spy();
+
+  const detach = attachSessionTracks(ELEMENT, {
+    attachAudio: null,
+    attachVideo: video.attach,
+  });
+  detach();
+
+  assert.deepEqual(video.calls, [ELEMENT]);
+  assert.deepEqual(video.detached, [ELEMENT]);
+});
+
+test("attachSessionTracks is a no-op when no track is available", () => {
+  const detach = attachSessionTracks(ELEMENT, {
+    attachAudio: null,
+    attachVideo: null,
+  });
+  assert.doesNotThrow(detach);
+});

--- a/desktop/src/features/agents/lib/agentMediaAttach.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaAttach.test.mjs
@@ -6,6 +6,17 @@
  * play from two independent clocks. LiveKit's `attach` merges tracks into the
  * element's existing `MediaStream`, so one element is one clock. These pin
  * "both tracks, one element" so the drift cannot come back quietly.
+ *
+ * What they do not pin, stated plainly because the gap is easy to miss: the
+ * element below is a stand-in and both attachers are spies, so LiveKit never
+ * runs. The SDK behaviour that caused the original silence — `attachToElement`
+ * setting `element.muted` from the stream's own audio-track count — is
+ * unverified here, as is everything in `useAgentMediaRoom` and
+ * `AgentMediaSurface`: autoplay recovery, teardown, microphone state,
+ * reconnection. Pinning any of it needs a real media element and the real SDK,
+ * which the desktop unit lane (node, no DOM) cannot give and the mock-bridge
+ * Playwright lane has no room to join. So the rule is pinned; the SDK's own
+ * muting is covered only by the live run that exposed it.
  */
 
 import assert from "node:assert/strict";

--- a/desktop/src/features/agents/lib/agentMediaAttach.ts
+++ b/desktop/src/features/agents/lib/agentMediaAttach.ts
@@ -1,0 +1,41 @@
+/**
+ * Attaching a session's remote tracks to a media element.
+ *
+ * Its own module so the rule can be tested without loading `livekit-client` or
+ * a DOM: the attach functions are supplied by the caller, and this decides only
+ * *where* they land.
+ */
+
+/** The attach callbacks `useAgentMediaRoom` exposes for a live session. */
+export type SessionTrackAttachers = {
+  attachAudio: ((element: HTMLMediaElement) => () => void) | null;
+  attachVideo: ((element: HTMLVideoElement) => () => void) | null;
+};
+
+/**
+ * Attach every available track to `element`, returning one detach for all.
+ *
+ * **One element for both tracks, deliberately.** LiveKit's `attach` merges a
+ * track into whatever `MediaStream` the element already carries, so a single
+ * element means one stream, one jitter buffer and one playback clock — which is
+ * what holds the voice on the lips. Two elements play from two independent
+ * clocks and drift audibly; that shipped once and was reported as bad lip-sync.
+ *
+ * It is also how the element becomes audible at all. LiveKit's
+ * `attachToElement` sets `element.muted = mediaStream.getAudioTracks().length
+ * === 0`, so a video-only stream is muted by the SDK no matter what the markup
+ * says — which is why attaching video alone produced a silent avatar.
+ */
+export function attachSessionTracks(
+  element: HTMLVideoElement,
+  { attachAudio, attachVideo }: SessionTrackAttachers,
+): () => void {
+  const detach: Array<() => void> = [];
+  // Video first, so the element's stream exists before the audio track joins
+  // it and the SDK's mute heuristic sees both.
+  if (attachVideo) detach.push(attachVideo(element));
+  if (attachAudio) detach.push(attachAudio(element));
+  return () => {
+    for (const dispose of detach) dispose();
+  };
+}

--- a/desktop/src/features/agents/lib/agentMediaAutoOpen.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaAutoOpen.test.mjs
@@ -1,9 +1,11 @@
 /**
  * Who a session opens itself for.
  *
- * The rule is narrow by design: the member who asked. Anything wider lets an
- * agent's announcement seize the screen of whoever happens to be reading the
- * channel, which is why these tests spend most of their effort on refusals.
+ * The rule is narrow by design: the member who asked, of this agent, here, just
+ * now. Anything wider lets an agent's announcement seize the screen of whoever
+ * happens to be reading the channel — and because the announcement cites its
+ * own justification, a citation the agent chose must not be taken at face
+ * value. That is why these tests spend most of their effort on refusals.
  */
 
 import assert from "node:assert/strict";
@@ -13,13 +15,15 @@ import { AUTO_OPEN_MAX_AGE_SECS, planAutoOpen } from "./agentMediaAutoOpen.ts";
 
 const ME = "a".repeat(64);
 const SOMEONE = "b".repeat(64);
+const AGENT = "c".repeat(64);
+const OTHER_AGENT = "d".repeat(64);
 const NOW = 1_700_000_000;
 
 /** A session as the fold would hand it over. */
 function session(overrides = {}) {
   return {
     eventId: "e".repeat(64),
-    agentPubkey: "c".repeat(64),
+    agentPubkey: AGENT,
     channelId: "chan-1",
     sourceEventId: "s".repeat(64),
     startedAt: NOW - 5,
@@ -27,8 +31,18 @@ function session(overrides = {}) {
   };
 }
 
+/** A source message that satisfies every condition unless overridden. */
+function source(overrides = {}) {
+  return {
+    author: ME,
+    channelId: "chan-1",
+    addressed: new Set([AGENT]),
+    ...overrides,
+  };
+}
+
 const NONE = new Set();
-const requesterIs = (pubkey) => () => pubkey;
+const sourceIs = (value) => () => value;
 const unresolved = () => undefined;
 
 test("planAutoOpen opens the session this member asked for", () => {
@@ -37,11 +51,26 @@ test("planAutoOpen opens the session this member asked for", () => {
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: requesterIs(ME),
+    sourceOf: sourceIs(source()),
     sessions: [mine],
   });
   assert.equal(plan.open, mine);
   assert.deepEqual(plan.resolve, []);
+});
+
+test("planAutoOpen opens for a reply that addresses the agent", () => {
+  // The reply path p-tags an author as well as any typed mention, so a reply
+  // to the agent addresses it without the member typing its name. That is
+  // still this member engaging with this agent, and it must not be refused.
+  const mine = session();
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    sourceOf: sourceIs(source({ addressed: new Set([SOMEONE, AGENT]) })),
+    sessions: [mine],
+  });
+  assert.equal(plan.open, mine);
 });
 
 test("planAutoOpen refuses a session somebody else asked for", () => {
@@ -49,40 +78,89 @@ test("planAutoOpen refuses a session somebody else asked for", () => {
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: requesterIs(SOMEONE),
+    sourceOf: sourceIs(source({ author: SOMEONE })),
     sessions: [session()],
   });
   assert.equal(plan.open, null);
   assert.deepEqual(plan.resolve, []);
 });
 
-test("planAutoOpen asks for an unknown author instead of assuming", () => {
+test("planAutoOpen refuses a source message from another channel", () => {
+  // Otherwise a message this member wrote somewhere else — including a channel
+  // they are not watching — justifies taking over the view here.
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    sourceOf: sourceIs(source({ channelId: "chan-2" })),
+    sessions: [session({ channelId: "chan-1" })],
+  });
+  assert.equal(plan.open, null);
+});
+
+test("planAutoOpen refuses a source message with no channel", () => {
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    sourceOf: sourceIs(source({ channelId: null })),
+    sessions: [session()],
+  });
+  assert.equal(plan.open, null);
+});
+
+test("planAutoOpen refuses a source message that does not address the agent", () => {
+  // The load-bearing refusal. Without it every message this member wrote in
+  // the channel is a citation the agent can help itself to, and an agent can
+  // open its own panel on somebody who never asked it for anything.
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    sourceOf: sourceIs(source({ addressed: new Set() })),
+    sessions: [session()],
+  });
+  assert.equal(plan.open, null);
+});
+
+test("planAutoOpen refuses a source message addressed to a different agent", () => {
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    sourceOf: sourceIs(source({ addressed: new Set([OTHER_AGENT]) })),
+    sessions: [session({ agentPubkey: AGENT })],
+  });
+  assert.equal(plan.open, null);
+});
+
+test("planAutoOpen asks for an unknown source instead of assuming", () => {
   // An unresolved lookup read as "not mine" would mean the panel never opens
   // and nothing ever says why.
   const plan = planAutoOpen({
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: unresolved,
+    sourceOf: unresolved,
     sessions: [session()],
   });
   assert.equal(plan.open, null);
   assert.deepEqual(plan.resolve, ["s".repeat(64)]);
 });
 
-test("planAutoOpen does not retry a lookup that found no author", () => {
+test("planAutoOpen does not retry a lookup that found nothing", () => {
   const plan = planAutoOpen({
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: requesterIs(""),
+    sourceOf: sourceIs({ author: "", channelId: null, addressed: new Set() }),
     sessions: [session()],
   });
   assert.equal(plan.open, null);
   assert.deepEqual(
     plan.resolve,
     [],
-    "an empty author is resolved, not pending",
+    "an unreadable source is resolved, not pending",
   );
 });
 
@@ -93,7 +171,7 @@ test("planAutoOpen refuses a session it has already handled", () => {
     currentPubkey: ME,
     handled: new Set([mine.eventId]),
     nowSeconds: NOW,
-    requesterOf: requesterIs(ME),
+    sourceOf: sourceIs(source()),
     sessions: [mine],
   });
   assert.equal(plan.open, null);
@@ -105,7 +183,7 @@ test("planAutoOpen refuses a session older than the window", () => {
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: requesterIs(ME),
+    sourceOf: sourceIs(source()),
     sessions: [session({ startedAt: NOW - AUTO_OPEN_MAX_AGE_SECS - 1 })],
   });
   assert.equal(plan.open, null);
@@ -118,7 +196,7 @@ test("planAutoOpen accepts a session right at the age limit", () => {
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: requesterIs(ME),
+    sourceOf: sourceIs(source()),
     sessions: [mine],
   });
   assert.equal(plan.open, mine);
@@ -129,7 +207,7 @@ test("planAutoOpen refuses a session that names no source message", () => {
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: requesterIs(ME),
+    sourceOf: sourceIs(source()),
     sessions: [session({ sourceEventId: null })],
   });
   assert.equal(plan.open, null);
@@ -140,7 +218,7 @@ test("planAutoOpen does nothing before this member's identity is known", () => {
     currentPubkey: null,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: requesterIs(ME),
+    sourceOf: sourceIs(source()),
     sessions: [session()],
   });
   assert.equal(plan.open, null);
@@ -160,8 +238,28 @@ test("planAutoOpen takes the newest decidable session", () => {
     currentPubkey: ME,
     handled: NONE,
     nowSeconds: NOW,
-    requesterOf: (id) => (id === mine.sourceEventId ? ME : undefined),
+    sourceOf: (id) => (id === mine.sourceEventId ? source() : undefined),
     sessions: [pending, mine],
+  });
+  assert.equal(plan.open, mine);
+});
+
+test("planAutoOpen keeps looking after refusing a decidable session", () => {
+  // A refusal is not a stop. An agent that cites an unusable message must not
+  // shadow a session further down the list that this member really did ask for.
+  const theirs = session({
+    eventId: "1".repeat(64),
+    sourceEventId: "8".repeat(64),
+    startedAt: NOW - 1,
+  });
+  const mine = session({ eventId: "2".repeat(64), startedAt: NOW - 10 });
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    sourceOf: (id) =>
+      id === mine.sourceEventId ? source() : source({ author: SOMEONE }),
+    sessions: [theirs, mine],
   });
   assert.equal(plan.open, mine);
 });

--- a/desktop/src/features/agents/lib/agentMediaAutoOpen.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaAutoOpen.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * Who a session opens itself for.
+ *
+ * The rule is narrow by design: the member who asked. Anything wider lets an
+ * agent's announcement seize the screen of whoever happens to be reading the
+ * channel, which is why these tests spend most of their effort on refusals.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AUTO_OPEN_MAX_AGE_SECS, planAutoOpen } from "./agentMediaAutoOpen.ts";
+
+const ME = "a".repeat(64);
+const SOMEONE = "b".repeat(64);
+const NOW = 1_700_000_000;
+
+/** A session as the fold would hand it over. */
+function session(overrides = {}) {
+  return {
+    eventId: "e".repeat(64),
+    agentPubkey: "c".repeat(64),
+    channelId: "chan-1",
+    sourceEventId: "s".repeat(64),
+    startedAt: NOW - 5,
+    ...overrides,
+  };
+}
+
+const NONE = new Set();
+const requesterIs = (pubkey) => () => pubkey;
+const unresolved = () => undefined;
+
+test("planAutoOpen opens the session this member asked for", () => {
+  const mine = session();
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: requesterIs(ME),
+    sessions: [mine],
+  });
+  assert.equal(plan.open, mine);
+  assert.deepEqual(plan.resolve, []);
+});
+
+test("planAutoOpen refuses a session somebody else asked for", () => {
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: requesterIs(SOMEONE),
+    sessions: [session()],
+  });
+  assert.equal(plan.open, null);
+  assert.deepEqual(plan.resolve, []);
+});
+
+test("planAutoOpen asks for an unknown author instead of assuming", () => {
+  // An unresolved lookup read as "not mine" would mean the panel never opens
+  // and nothing ever says why.
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: unresolved,
+    sessions: [session()],
+  });
+  assert.equal(plan.open, null);
+  assert.deepEqual(plan.resolve, ["s".repeat(64)]);
+});
+
+test("planAutoOpen does not retry a lookup that found no author", () => {
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: requesterIs(""),
+    sessions: [session()],
+  });
+  assert.equal(plan.open, null);
+  assert.deepEqual(
+    plan.resolve,
+    [],
+    "an empty author is resolved, not pending",
+  );
+});
+
+test("planAutoOpen refuses a session it has already handled", () => {
+  // Closing the panel has to be final, or auto-open becomes an argument.
+  const mine = session();
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: new Set([mine.eventId]),
+    nowSeconds: NOW,
+    requesterOf: requesterIs(ME),
+    sessions: [mine],
+  });
+  assert.equal(plan.open, null);
+});
+
+test("planAutoOpen refuses a session older than the window", () => {
+  // Re-entering a channel is not a fresh request.
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: requesterIs(ME),
+    sessions: [session({ startedAt: NOW - AUTO_OPEN_MAX_AGE_SECS - 1 })],
+  });
+  assert.equal(plan.open, null);
+  assert.deepEqual(plan.resolve, [], "a stale session is not worth resolving");
+});
+
+test("planAutoOpen accepts a session right at the age limit", () => {
+  const mine = session({ startedAt: NOW - AUTO_OPEN_MAX_AGE_SECS });
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: requesterIs(ME),
+    sessions: [mine],
+  });
+  assert.equal(plan.open, mine);
+});
+
+test("planAutoOpen refuses a session that names no source message", () => {
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: requesterIs(ME),
+    sessions: [session({ sourceEventId: null })],
+  });
+  assert.equal(plan.open, null);
+});
+
+test("planAutoOpen does nothing before this member's identity is known", () => {
+  const plan = planAutoOpen({
+    currentPubkey: null,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: requesterIs(ME),
+    sessions: [session()],
+  });
+  assert.equal(plan.open, null);
+  assert.deepEqual(plan.resolve, []);
+});
+
+test("planAutoOpen takes the newest decidable session", () => {
+  // A newer session still waiting on a lookup must not hold back an older one
+  // that already qualifies.
+  const pending = session({
+    eventId: "1".repeat(64),
+    sourceEventId: "9".repeat(64),
+    startedAt: NOW - 1,
+  });
+  const mine = session({ eventId: "2".repeat(64), startedAt: NOW - 10 });
+  const plan = planAutoOpen({
+    currentPubkey: ME,
+    handled: NONE,
+    nowSeconds: NOW,
+    requesterOf: (id) => (id === mine.sourceEventId ? ME : undefined),
+    sessions: [pending, mine],
+  });
+  assert.equal(plan.open, mine);
+});

--- a/desktop/src/features/agents/lib/agentMediaAutoOpen.ts
+++ b/desktop/src/features/agents/lib/agentMediaAutoOpen.ts
@@ -9,13 +9,34 @@ import type { AgentMediaSession } from "./agentMediaSession";
  */
 export const AUTO_OPEN_MAX_AGE_SECS = 60;
 
+/**
+ * What a session's source message has to say for itself.
+ *
+ * Read from the message rather than taken on the announcement's word: the
+ * announcement is written by the agent, and the whole question is whether its
+ * claim about who asked is true.
+ */
+export type AutoOpenSource = {
+  /**
+   * The message's author, or `""` when it was looked up and could not be read.
+   *
+   * `""` never equals a pubkey, so an unreadable message refuses rather than
+   * pending — see the note on {@link AutoOpenPlan.resolve}.
+   */
+  author: string;
+  /** The channel the message was sent in, or `null` when it names none. */
+  channelId: string | null;
+  /** Pubkeys the message addresses — its `p` tags, normalized. */
+  addressed: ReadonlySet<string>;
+};
+
 export type AutoOpenPlan = {
   /** The session whose panel should open now, if one qualifies. */
   open: AgentMediaSession | null;
   /**
-   * Source event ids whose author is still unknown.
+   * Source event ids that have not been looked up yet.
    *
-   * Returned rather than guessed: an unresolved author must not be read as
+   * Returned rather than guessed: an unresolved source must not be read as
    * "not mine", or a slow lookup would silently mean no panel ever opens.
    */
   resolve: string[];
@@ -24,11 +45,33 @@ export type AutoOpenPlan = {
 /**
  * Decide whether a live session should open its own panel unprompted.
  *
- * One thing justifies taking over the view: this member asked for the session.
- * That is decidable from the announcement alone — a 48200 names the message
- * that caused it in its `e` tag, so the session is this member's when this
- * member signed that message. No wire addition, and it works for any gateway
- * that sets the tag.
+ * One thing justifies taking over the view: this member asked this agent for
+ * this session, just now. A 48200 names the message that caused it in its `e`
+ * tag, so the claim is checkable — but the announcement is the agent's own
+ * account of events, and an agent that may announce sessions may cite whatever
+ * message it likes. The tag says where to look; it settles nothing by itself.
+ *
+ * So all four of these must hold of the cited message, and each closes a
+ * distinct way the citation could be false:
+ *
+ * 1. **This member wrote it.** Otherwise the session is somebody else's.
+ * 2. **It was sent in the channel the session was announced in.** Otherwise a
+ *    message from an unrelated channel — including one the agent is in and
+ *    this member is not watching — would qualify.
+ * 3. **It addresses this session's agent.** Without this, *any* message this
+ *    member wrote in the channel is a valid citation, which in a channel they
+ *    talk in is a message the agent can simply pick. This is the condition
+ *    that makes the other three worth checking.
+ * 4. **The session is younger than {@link AUTO_OPEN_MAX_AGE_SECS}.** A request
+ *    from an hour ago is not a request now, and re-entering a channel is not a
+ *    fresh one.
+ *
+ * There is deliberately no check that the message predates the session. It
+ * would read as the obvious fifth condition and it protects nothing: the `e`
+ * tag has to name an event that already existed when the announcement was
+ * signed. What it would add is a false negative, because the two timestamps
+ * come from different clocks — the member's client and the gateway — and a few
+ * seconds of skew in the wrong direction would silently stop the panel opening.
  *
  * Everything else is refused on purpose:
  *
@@ -38,8 +81,6 @@ export type AutoOpenPlan = {
  *   offers, and this is the one case where acting for the member is warranted.
  * - A session already in `handled` is skipped, so closing the panel is final
  *   rather than the start of an argument.
- * - A session older than {@link AUTO_OPEN_MAX_AGE_SECS} is skipped, so
- *   re-entering a channel is not mistaken for a fresh request.
  *
  * Sessions are newest first, and the first *decidable* match wins. A newer
  * session waiting on a lookup does not hold back an older one that already
@@ -50,14 +91,14 @@ export function planAutoOpen(opts: {
   handled: ReadonlySet<string>;
   nowSeconds: number;
   /**
-   * The author of a source event, or `undefined` while it is unknown. Use a
-   * non-pubkey value (e.g. `""`) for "looked up, no author found", so a failed
-   * lookup is not retried forever.
+   * What is known about a source message, or `undefined` while it has not been
+   * looked up. A looked-up-but-unreadable message is an {@link AutoOpenSource}
+   * with an empty `author`, so a failed lookup is not retried forever.
    */
-  requesterOf: (sourceEventId: string) => string | undefined;
+  sourceOf: (sourceEventId: string) => AutoOpenSource | undefined;
   sessions: readonly AgentMediaSession[];
 }): AutoOpenPlan {
-  const { currentPubkey, handled, nowSeconds, requesterOf, sessions } = opts;
+  const { currentPubkey, handled, nowSeconds, sourceOf, sessions } = opts;
   if (!currentPubkey) return { open: null, resolve: [] };
 
   const resolve: string[] = [];
@@ -66,12 +107,15 @@ export function planAutoOpen(opts: {
     if (!session.sourceEventId) continue;
     if (nowSeconds - session.startedAt > AUTO_OPEN_MAX_AGE_SECS) continue;
 
-    const requester = requesterOf(session.sourceEventId);
-    if (requester === undefined) {
+    const source = sourceOf(session.sourceEventId);
+    if (source === undefined) {
       resolve.push(session.sourceEventId);
       continue;
     }
-    if (requester === currentPubkey) return { open: session, resolve: [] };
+    if (source.author !== currentPubkey) continue;
+    if (source.channelId !== session.channelId) continue;
+    if (!source.addressed.has(session.agentPubkey)) continue;
+    return { open: session, resolve: [] };
   }
   return { open: null, resolve };
 }

--- a/desktop/src/features/agents/lib/agentMediaAutoOpen.ts
+++ b/desktop/src/features/agents/lib/agentMediaAutoOpen.ts
@@ -1,0 +1,77 @@
+import type { AgentMediaSession } from "./agentMediaSession";
+
+/**
+ * How recently a session must have started for its panel to open by itself.
+ *
+ * Auto-opening says "you just asked for this", so it has to expire. Without a
+ * bound, walking back into a channel where a session was started half an hour
+ * ago would take the view over again, long after the request that justified it.
+ */
+export const AUTO_OPEN_MAX_AGE_SECS = 60;
+
+export type AutoOpenPlan = {
+  /** The session whose panel should open now, if one qualifies. */
+  open: AgentMediaSession | null;
+  /**
+   * Source event ids whose author is still unknown.
+   *
+   * Returned rather than guessed: an unresolved author must not be read as
+   * "not mine", or a slow lookup would silently mean no panel ever opens.
+   */
+  resolve: string[];
+};
+
+/**
+ * Decide whether a live session should open its own panel unprompted.
+ *
+ * One thing justifies taking over the view: this member asked for the session.
+ * That is decidable from the announcement alone — a 48200 names the message
+ * that caused it in its `e` tag, so the session is this member's when this
+ * member signed that message. No wire addition, and it works for any gateway
+ * that sets the tag.
+ *
+ * Everything else is refused on purpose:
+ *
+ * - Opening for every viewer would let an agent seize the screen of anyone who
+ *   happened to be reading the channel. The announcement is already visible in
+ *   the members bar and in the agent's own "I'm live" message; those are
+ *   offers, and this is the one case where acting for the member is warranted.
+ * - A session already in `handled` is skipped, so closing the panel is final
+ *   rather than the start of an argument.
+ * - A session older than {@link AUTO_OPEN_MAX_AGE_SECS} is skipped, so
+ *   re-entering a channel is not mistaken for a fresh request.
+ *
+ * Sessions are newest first, and the first *decidable* match wins. A newer
+ * session waiting on a lookup does not hold back an older one that already
+ * qualifies; the newer one gets its turn on the next pass if it also qualifies.
+ */
+export function planAutoOpen(opts: {
+  currentPubkey: string | null;
+  handled: ReadonlySet<string>;
+  nowSeconds: number;
+  /**
+   * The author of a source event, or `undefined` while it is unknown. Use a
+   * non-pubkey value (e.g. `""`) for "looked up, no author found", so a failed
+   * lookup is not retried forever.
+   */
+  requesterOf: (sourceEventId: string) => string | undefined;
+  sessions: readonly AgentMediaSession[];
+}): AutoOpenPlan {
+  const { currentPubkey, handled, nowSeconds, requesterOf, sessions } = opts;
+  if (!currentPubkey) return { open: null, resolve: [] };
+
+  const resolve: string[] = [];
+  for (const session of sessions) {
+    if (handled.has(session.eventId)) continue;
+    if (!session.sourceEventId) continue;
+    if (nowSeconds - session.startedAt > AUTO_OPEN_MAX_AGE_SECS) continue;
+
+    const requester = requesterOf(session.sourceEventId);
+    if (requester === undefined) {
+      resolve.push(session.sourceEventId);
+      continue;
+    }
+    if (requester === currentPubkey) return { open: session, resolve: [] };
+  }
+  return { open: null, resolve };
+}

--- a/desktop/src/features/agents/lib/agentMediaEntries.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaEntries.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * What the channel indicator lists, and what it claims.
+ *
+ * Provenance: the indicator showed a count and then opened whichever session
+ * was newest, so a second live agent was named by the badge and reachable
+ * nowhere in that control. The count itself was a session count wearing an
+ * agent count's wording.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  agentMediaEntries,
+  describeAgentMediaEntries,
+} from "./agentMediaEntries.ts";
+
+const CARA = "a".repeat(64);
+const RAY = "b".repeat(64);
+
+const NAMES = { [CARA]: "Cara", [RAY]: "Ray" };
+const labelFor = (pubkey) => NAMES[pubkey] ?? "unknown";
+
+test("agentMediaEntries lists one entry per session, newest first", () => {
+  const entries = agentMediaEntries(
+    [{ agentPubkey: RAY }, { agentPubkey: CARA }],
+    labelFor,
+  );
+  assert.deepEqual(entries, [
+    { agentPubkey: RAY, label: "Ray" },
+    { agentPubkey: CARA, label: "Cara" },
+  ]);
+});
+
+test("agentMediaEntries collapses two sessions from one agent", () => {
+  // The relay enforces no one-session-at-a-time rule, so an agent that
+  // announces again before its first expires has two live starts. Both rows
+  // would open the same panel.
+  const entries = agentMediaEntries(
+    [{ agentPubkey: CARA }, { agentPubkey: CARA }],
+    labelFor,
+  );
+  assert.deepEqual(entries, [{ agentPubkey: CARA, label: "Cara" }]);
+});
+
+test("agentMediaEntries resolves a label once per agent", () => {
+  const asked = [];
+  agentMediaEntries(
+    [{ agentPubkey: CARA }, { agentPubkey: CARA }, { agentPubkey: RAY }],
+    (pubkey) => {
+      asked.push(pubkey);
+      return labelFor(pubkey);
+    },
+  );
+  assert.deepEqual(asked, [CARA, RAY]);
+});
+
+test("describeAgentMediaEntries names a single agent and counts the rest", () => {
+  assert.equal(describeAgentMediaEntries([]), "");
+  assert.equal(
+    describeAgentMediaEntries([{ agentPubkey: CARA, label: "Cara" }]),
+    "Cara is live",
+  );
+  assert.equal(
+    describeAgentMediaEntries([
+      { agentPubkey: CARA, label: "Cara" },
+      { agentPubkey: RAY, label: "Ray" },
+    ]),
+    "2 agents are live",
+  );
+});
+
+test("describeAgentMediaEntries counts agents rather than sessions", () => {
+  // Two sessions, one agent: "2 agents are live" would have been false.
+  const entries = agentMediaEntries(
+    [{ agentPubkey: CARA }, { agentPubkey: CARA }],
+    labelFor,
+  );
+  assert.equal(describeAgentMediaEntries(entries), "Cara is live");
+});

--- a/desktop/src/features/agents/lib/agentMediaEntries.ts
+++ b/desktop/src/features/agents/lib/agentMediaEntries.ts
@@ -1,0 +1,51 @@
+import type { AgentMediaSession } from "./agentMediaSession";
+
+/** One live agent, as a channel indicator lists it. */
+export type AgentMediaEntry = {
+  agentPubkey: string;
+  label: string;
+};
+
+/**
+ * One entry per live agent, newest session first.
+ *
+ * Deduped by pubkey, which the session list is not: nothing stops an agent
+ * announcing a second session before its first expires, since the relay
+ * enforces no one-at-a-time rule. Two rows for one agent would both open the
+ * same panel while the badge beside them claimed two agents were live. The
+ * first wins, and sessions arrive newest first, so that is the current one.
+ *
+ * `labelFor` is called once per agent rather than once per session, and the
+ * caller keeps profile resolution — this module stays testable without a query
+ * client.
+ */
+export function agentMediaEntries(
+  sessions: readonly Pick<AgentMediaSession, "agentPubkey">[],
+  labelFor: (agentPubkey: string) => string,
+): AgentMediaEntry[] {
+  const entries: AgentMediaEntry[] = [];
+  const seen = new Set<string>();
+  for (const session of sessions) {
+    if (seen.has(session.agentPubkey)) continue;
+    seen.add(session.agentPubkey);
+    entries.push({
+      agentPubkey: session.agentPubkey,
+      label: labelFor(session.agentPubkey),
+    });
+  }
+  return entries;
+}
+
+/**
+ * What the indicator says it is showing.
+ *
+ * Counts agents, not sessions, because that is what the wording claims. An
+ * agent with a stale session still live alongside its current one is one agent.
+ */
+export function describeAgentMediaEntries(
+  entries: readonly AgentMediaEntry[],
+): string {
+  if (entries.length === 0) return "";
+  if (entries.length === 1) return `${entries[0].label} is live`;
+  return `${entries.length} agents are live`;
+}

--- a/desktop/src/features/agents/lib/agentMediaSession.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaSession.test.mjs
@@ -6,6 +6,7 @@ import {
   isSessionExpired,
   parseAgentMediaSession,
   parseAgentMediaSessionEnd,
+  trackBelongsToSessionAgent,
 } from "./agentMediaSession.ts";
 
 const AGENT = "a".repeat(64);
@@ -272,4 +273,110 @@ test("endRetiresSession refuses an end naming a different start", () => {
   });
   assert.ok(end);
   assert.equal(endRetiresSession(end, session), false);
+});
+
+// -- trackBelongsToSessionAgent -------------------------------------------
+//
+// The panel plays only the announcing agent's tracks. Audio reached these
+// tests the hard way: the room hook dropped every non-video track, so the
+// avatar rendered silently and the surface's own comment ("hearing it is the
+// point") described behaviour the code did not have.
+
+const OTHER = "b".repeat(64);
+
+/** A session whose announcement declares `participants`. */
+function sessionWith(participants) {
+  const session = parseAgentMediaSession(
+    announcement({
+      content: JSON.stringify({
+        v: 1,
+        provider: "livekit",
+        connect: { url: "wss://example.livekit.cloud", room: "room-1" },
+        participants,
+        expires_at: EXPIRES_AT,
+      }),
+    }),
+  );
+  assert.ok(session);
+  return session;
+}
+
+const SOLE_AVATAR = [{ pubkey: AGENT, tracks: ["avatar_video", "audio"] }];
+
+test("trackBelongsToSessionAgent accepts a track whose identity names the agent", () => {
+  const session = sessionWith(SOLE_AVATAR);
+  for (const kind of ["video", "audio"]) {
+    assert.equal(
+      trackBelongsToSessionAgent(session, `anam-avatar-${AGENT}`, kind),
+      true,
+    );
+  }
+});
+
+test("trackBelongsToSessionAgent matches an identity regardless of case", () => {
+  const session = sessionWith(SOLE_AVATAR);
+  assert.equal(
+    trackBelongsToSessionAgent(session, AGENT.toUpperCase(), "audio"),
+    true,
+  );
+});
+
+test("trackBelongsToSessionAgent accepts a foreign identity when the announcement declares one publisher of that kind", () => {
+  // The gateway is not obliged to put the pubkey in its provider identity, and
+  // LiveKit's avatar worker joins as `anam-avatar-agent`. One declared
+  // publisher makes a single track of that kind unambiguous anyway.
+  const session = sessionWith(SOLE_AVATAR);
+  for (const kind of ["video", "audio"]) {
+    assert.equal(
+      trackBelongsToSessionAgent(session, "anam-avatar-agent", kind),
+      true,
+    );
+  }
+});
+
+test("trackBelongsToSessionAgent refuses a foreign identity once two publishers declare that kind", () => {
+  const session = sessionWith([
+    { pubkey: AGENT, tracks: ["avatar_video", "audio"] },
+    { pubkey: OTHER, tracks: ["audio"] },
+  ]);
+  // Two declared audio publishers: this voice could be either, so it must not
+  // play under the agent's face.
+  assert.equal(
+    trackBelongsToSessionAgent(session, "some-other-participant", "audio"),
+    false,
+  );
+  // The video declaration is untouched by the second audio publisher — the
+  // kinds are counted separately, so a multi-voice room still shows the face.
+  assert.equal(
+    trackBelongsToSessionAgent(session, "some-other-participant", "video"),
+    true,
+  );
+});
+
+test("trackBelongsToSessionAgent refuses a foreign identity when the announcement declares nothing", () => {
+  const session = sessionWith([]);
+  for (const kind of ["video", "audio"]) {
+    assert.equal(
+      trackBelongsToSessionAgent(session, "anam-avatar-agent", kind),
+      false,
+    );
+  }
+});
+
+test("trackBelongsToSessionAgent counts each kind against its own declaration", () => {
+  // An announcement may grant audio to a participant that publishes no face.
+  const session = sessionWith([
+    { pubkey: AGENT, tracks: ["avatar_video"] },
+    { pubkey: OTHER, tracks: ["audio"] },
+  ]);
+  assert.equal(
+    trackBelongsToSessionAgent(session, "unnamed", "video"),
+    true,
+    "one declared avatar publisher",
+  );
+  assert.equal(
+    trackBelongsToSessionAgent(session, "unnamed", "audio"),
+    true,
+    "one declared audio publisher, even though it is not the agent's own entry",
+  );
 });

--- a/desktop/src/features/agents/lib/agentMediaSession.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaSession.test.mjs
@@ -105,6 +105,17 @@ test("parseAgentMediaSession returns null without usable connect params", () => 
     { url: "wss://x" },
     { room: "r" },
     { url: "", room: "r" },
+    // Schemes this client would never dial.
+    { url: "javascript:alert(1)", room: "r" },
+    { url: "file:///etc/passwd", room: "r" },
+    // An allowed scheme in front of nothing dialable. A prefix test admits
+    // every one of these, which is why the check parses.
+    { url: "wss://", room: "r" },
+    { url: "https://", room: "r" },
+    { url: "wss://[", room: "r" },
+    // A room of spaces is as unjoinable as an empty one, and fails later —
+    // at the provider, after a token has already been minted for it.
+    { url: "wss://x", room: "   " },
   ]) {
     const content = JSON.stringify({
       provider: "livekit",
@@ -119,13 +130,42 @@ test("parseAgentMediaSession returns null without usable connect params", () => 
   }
 });
 
-test("parseAgentMediaSession drops a non-http token endpoint but keeps the session", () => {
+test("parseAgentMediaSession drops an unfetchable token endpoint but keeps the session", () => {
   // A session with no endpoint is one this viewer cannot get a token for —
-  // still worth surfacing, unlike a javascript:/file: URL we would ever fetch.
-  const content = body({ token_endpoint: "javascript:alert(1)" });
-  const session = parseAgentMediaSession(announcement({ content }));
-  assert.ok(session);
-  assert.equal(session.tokenEndpoint, null);
+  // still worth surfacing, unlike a URL we would never fetch or could not.
+  for (const endpoint of [
+    "javascript:alert(1)",
+    "file:///etc/passwd",
+    // Hostless and malformed, which a prefix test admits.
+    "https://",
+    "https://[",
+    // Dialable as a transport, but a token is fetched over HTTP.
+    "wss://x",
+  ]) {
+    const content = body({ token_endpoint: endpoint });
+    const session = parseAgentMediaSession(announcement({ content }));
+    assert.ok(session, `expected ${endpoint} to leave the session standing`);
+    assert.equal(
+      session.tokenEndpoint,
+      null,
+      `expected ${endpoint} to be dropped`,
+    );
+  }
+});
+
+test("parseAgentMediaSession keeps a token endpoint it can fetch", () => {
+  // The refusals above only mean something next to this: a check that
+  // tightened until it dropped every endpoint would satisfy all of them.
+  for (const endpoint of [
+    "https://gateway.example/token",
+    "http://127.0.0.1:8080/token",
+    "https://gateway.example:8443/v1/token?x=1",
+  ]) {
+    const content = body({ token_endpoint: endpoint });
+    const session = parseAgentMediaSession(announcement({ content }));
+    assert.ok(session);
+    assert.equal(session.tokenEndpoint, endpoint);
+  }
 });
 
 test("parseAgentMediaSession ignores track kinds it does not know", () => {

--- a/desktop/src/features/agents/lib/agentMediaSession.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaSession.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   endRetiresSession,
+  foldLiveSessions,
   isSessionExpired,
   parseAgentMediaSession,
   parseAgentMediaSessionEnd,
@@ -364,7 +365,8 @@ test("trackBelongsToSessionAgent refuses a foreign identity when the announcemen
 });
 
 test("trackBelongsToSessionAgent counts each kind against its own declaration", () => {
-  // An announcement may grant audio to a participant that publishes no face.
+  // An announcement may name a face publisher and give the voice to somebody
+  // else entirely.
   const session = sessionWith([
     { pubkey: AGENT, tracks: ["avatar_video"] },
     { pubkey: OTHER, tracks: ["audio"] },
@@ -372,11 +374,191 @@ test("trackBelongsToSessionAgent counts each kind against its own declaration", 
   assert.equal(
     trackBelongsToSessionAgent(session, "unnamed", "video"),
     true,
-    "one declared avatar publisher",
+    "one declared avatar publisher, and it is the agent",
   );
+  // The one declared voice is somebody else's. That is not an ambiguity to
+  // resolve in the agent's favour: the announcement says outright that this
+  // session's audio is not the agent's.
   assert.equal(
     trackBelongsToSessionAgent(session, "unnamed", "audio"),
-    true,
-    "one declared audio publisher, even though it is not the agent's own entry",
+    false,
+    "the sole declared audio publisher is not the agent",
   );
+});
+
+test("trackBelongsToSessionAgent refuses a viewer that joined under its own pubkey", () => {
+  // The case that actually occurs, and the reason a declaration alone cannot
+  // decide this. The gateway joins a viewer as `identity = <viewer pubkey>`,
+  // and a v1 announcement grants viewers a microphone. Two members open one
+  // session, the second unmutes, and without this check its voice replaces the
+  // agent's for the first — under the agent's face.
+  const session = sessionWith(SOLE_AVATAR);
+  for (const kind of ["video", "audio"]) {
+    assert.equal(trackBelongsToSessionAgent(session, OTHER, kind), false);
+    assert.equal(
+      trackBelongsToSessionAgent(session, OTHER.toUpperCase(), kind),
+      false,
+      "identity case must not defeat the check",
+    );
+    assert.equal(
+      trackBelongsToSessionAgent(session, `viewer-${OTHER}`, kind),
+      false,
+      "a pubkey anywhere in the identity names that participant",
+    );
+  }
+});
+
+test("trackBelongsToSessionAgent trusts the agent's own identity over an ambiguous declaration", () => {
+  // Rule order: an identity naming the agent settles it, so a room with
+  // several declared voices still plays the one that proved whose it is.
+  const session = sessionWith([
+    { pubkey: AGENT, tracks: ["avatar_video", "audio"] },
+    { pubkey: OTHER, tracks: ["audio"] },
+  ]);
+  assert.equal(
+    trackBelongsToSessionAgent(session, `anam-avatar-${AGENT}`, "audio"),
+    true,
+  );
+});
+
+// -- foldLiveSessions -----------------------------------------------------
+//
+// Provenance: this fold used to live inside the hook and reparsed every event
+// on every arrival, so each live session got a fresh object each time.
+// `useAgentMediaRoom` keys a whole WebRTC connection on that object — so
+// another agent going live dropped an open call, and every replayed history
+// event cost its own viewer token request. These pin the identity contract that
+// fixed it, which no type can express.
+
+const START_A = "1".repeat(64);
+const START_B = "2".repeat(64);
+const NONE = [];
+
+/** A 48200 that is distinct from the others by construction. */
+function start({ id, pubkey = AGENT, createdAt = CREATED_AT }) {
+  return announcement({
+    id,
+    pubkey,
+    created_at: createdAt,
+    content: JSON.stringify({
+      v: 1,
+      provider: "livekit",
+      connect: { url: "wss://example.livekit.cloud", room: id },
+      participants: [{ pubkey, tracks: ["avatar_video", "audio"] }],
+      expires_at: createdAt + 600,
+    }),
+  });
+}
+
+/** A 48201 closing `startId`, signed by `signer`. */
+function end({ startId, signer = AGENT }) {
+  return {
+    id: `d${startId.slice(1)}`,
+    pubkey: signer,
+    kind: 48201,
+    created_at: CREATED_AT + 10,
+    tags: [
+      ["h", CHANNEL],
+      ["e", startId],
+    ],
+    content: "",
+  };
+}
+
+test("foldLiveSessions returns the previous array when nothing changed", () => {
+  const events = [start({ id: START_A })];
+  const first = foldLiveSessions(events, NONE, CREATED_AT);
+  assert.equal(first.length, 1);
+  assert.ok(
+    Object.is(foldLiveSessions(events, first, CREATED_AT), first),
+    "an unchanged fold must not re-render every consumer",
+  );
+});
+
+test("foldLiveSessions keeps a live session's object when another arrives", () => {
+  // The regression this exists for. An unrelated agent going live must not
+  // rebuild the session being watched, or the open call is torn down and
+  // rejoined for someone else's announcement.
+  const a = start({ id: START_A });
+  const first = foldLiveSessions([a], NONE, CREATED_AT);
+  const second = foldLiveSessions(
+    [a, start({ id: START_B, pubkey: OTHER, createdAt: CREATED_AT + 5 })],
+    first,
+    CREATED_AT,
+  );
+  assert.equal(second.length, 2);
+  assert.ok(
+    !Object.is(second, first),
+    "the set changed, so the array must too",
+  );
+  assert.ok(
+    Object.is(
+      second.find((session) => session.eventId === START_A),
+      first[0],
+    ),
+    "the watched session must still be the same object",
+  );
+});
+
+test("foldLiveSessions orders newest first", () => {
+  const live = foldLiveSessions(
+    [
+      start({ id: START_A }),
+      start({ id: START_B, pubkey: OTHER, createdAt: CREATED_AT + 5 }),
+    ],
+    NONE,
+    CREATED_AT,
+  );
+  assert.deepEqual(
+    live.map((session) => session.eventId),
+    [START_B, START_A],
+  );
+});
+
+test("foldLiveSessions drops a session its owner ended", () => {
+  const a = start({ id: START_A });
+  const first = foldLiveSessions([a], NONE, CREATED_AT);
+  const second = foldLiveSessions(
+    [a, end({ startId: START_A })],
+    first,
+    CREATED_AT,
+  );
+  assert.deepEqual(second, []);
+  assert.ok(!Object.is(second, first));
+});
+
+test("foldLiveSessions honours an end that arrived before its start", () => {
+  // Replay order is not causal order, which is the whole reason this refolds
+  // rather than updating incrementally.
+  const live = foldLiveSessions(
+    [end({ startId: START_A }), start({ id: START_A })],
+    NONE,
+    CREATED_AT,
+  );
+  assert.deepEqual(live, []);
+});
+
+test("foldLiveSessions keeps a session a third party tried to end", () => {
+  const live = foldLiveSessions(
+    [start({ id: START_A }), end({ startId: START_A, signer: OTHER })],
+    NONE,
+    CREATED_AT,
+  );
+  assert.equal(live.length, 1);
+});
+
+test("foldLiveSessions drops a session past its expiry", () => {
+  const live = foldLiveSessions(
+    [start({ id: START_A })],
+    NONE,
+    CREATED_AT + 600,
+  );
+  assert.deepEqual(live, []);
+});
+
+test("foldLiveSessions does not resurrect a session the events no longer carry", () => {
+  // `previous` is a source of objects, never of membership.
+  const first = foldLiveSessions([start({ id: START_A })], NONE, CREATED_AT);
+  assert.equal(first.length, 1);
+  assert.deepEqual(foldLiveSessions([], first, CREATED_AT), []);
 });

--- a/desktop/src/features/agents/lib/agentMediaSession.test.mjs
+++ b/desktop/src/features/agents/lib/agentMediaSession.test.mjs
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  endRetiresSession,
+  isSessionExpired,
+  parseAgentMediaSession,
+  parseAgentMediaSessionEnd,
+} from "./agentMediaSession.ts";
+
+const AGENT = "a".repeat(64);
+const CHANNEL = "3f1c9f5a-1111-4222-8333-444455556666";
+const CREATED_AT = 1_700_000_000;
+const EXPIRES_AT = CREATED_AT + 600;
+
+/** A well-formed body, so each test states only what it is about. */
+function body(overrides = {}) {
+  return JSON.stringify({
+    provider: "livekit",
+    connect: { url: "wss://x", room: "r" },
+    expires_at: EXPIRES_AT,
+    ...overrides,
+  });
+}
+
+function announcement(overrides = {}) {
+  const { content, tags, ...rest } = overrides;
+  return {
+    id: "e".repeat(64),
+    pubkey: AGENT,
+    kind: 48200,
+    created_at: CREATED_AT,
+    tags: tags ?? [["h", CHANNEL]],
+    content:
+      content ??
+      JSON.stringify({
+        v: 1,
+        provider: "livekit",
+        connect: { url: "wss://example.livekit.cloud", room: "room-1" },
+        token_endpoint: "https://gateway.example/media/token",
+        participants: [{ pubkey: AGENT, tracks: ["avatar_video", "audio"] }],
+        viewer: { subscribe: ["avatar_video", "audio"], publish: ["audio"] },
+        expires_at: EXPIRES_AT,
+      }),
+    ...rest,
+  };
+}
+
+test("parseAgentMediaSession reads a v1 announcement", () => {
+  const session = parseAgentMediaSession(announcement());
+  assert.ok(session);
+  assert.equal(session.agentPubkey, AGENT);
+  assert.equal(session.channelId, CHANNEL);
+  assert.equal(session.serverUrl, "wss://example.livekit.cloud");
+  assert.equal(session.room, "room-1");
+  assert.equal(session.tokenEndpoint, "https://gateway.example/media/token");
+  assert.equal(session.startedAt, CREATED_AT);
+  assert.equal(session.expiresAt, EXPIRES_AT);
+});
+
+test("parseAgentMediaSession takes ownership from the signature, not a p tag", () => {
+  const impostor = "b".repeat(64);
+  const session = parseAgentMediaSession(
+    announcement({
+      tags: [
+        ["h", CHANNEL],
+        ["p", impostor],
+      ],
+    }),
+  );
+  assert.equal(session?.agentPubkey, AGENT);
+});
+
+test("parseAgentMediaSession keeps the triggering message id", () => {
+  const source = "c".repeat(64);
+  const session = parseAgentMediaSession(
+    announcement({
+      tags: [
+        ["h", CHANNEL],
+        ["e", source],
+      ],
+    }),
+  );
+  assert.equal(session?.sourceEventId, source);
+});
+
+test("parseAgentMediaSession returns null without an h tag", () => {
+  assert.equal(parseAgentMediaSession(announcement({ tags: [] })), null);
+});
+
+test("parseAgentMediaSession returns null on non-JSON content", () => {
+  assert.equal(parseAgentMediaSession(announcement({ content: "nope" })), null);
+});
+
+test("parseAgentMediaSession returns null for a provider it cannot connect to", () => {
+  const content = body({ provider: "hologram-net" });
+  assert.equal(parseAgentMediaSession(announcement({ content })), null);
+});
+
+test("parseAgentMediaSession returns null without usable connect params", () => {
+  for (const connect of [
+    {},
+    { url: "wss://x" },
+    { room: "r" },
+    { url: "", room: "r" },
+  ]) {
+    const content = JSON.stringify({
+      provider: "livekit",
+      connect,
+      expires_at: EXPIRES_AT,
+    });
+    assert.equal(
+      parseAgentMediaSession(announcement({ content })),
+      null,
+      `expected ${JSON.stringify(connect)} to be rejected`,
+    );
+  }
+});
+
+test("parseAgentMediaSession drops a non-http token endpoint but keeps the session", () => {
+  // A session with no endpoint is one this viewer cannot get a token for —
+  // still worth surfacing, unlike a javascript:/file: URL we would ever fetch.
+  const content = body({ token_endpoint: "javascript:alert(1)" });
+  const session = parseAgentMediaSession(announcement({ content }));
+  assert.ok(session);
+  assert.equal(session.tokenEndpoint, null);
+});
+
+test("parseAgentMediaSession ignores track kinds it does not know", () => {
+  const content = body({
+    viewer: { subscribe: ["avatar_video", "hologram"], publish: ["audio", 7] },
+  });
+  const session = parseAgentMediaSession(announcement({ content }));
+  assert.deepEqual(session?.viewer.subscribe, ["avatar_video"]);
+  assert.deepEqual(session?.viewer.publish, ["audio"]);
+});
+
+test("parseAgentMediaSession skips malformed participant entries", () => {
+  const content = body({
+    participants: [{ tracks: ["audio"] }, null, { pubkey: AGENT, tracks: [] }],
+  });
+  const session = parseAgentMediaSession(announcement({ content }));
+  assert.equal(session?.participants.length, 1);
+  assert.equal(session?.participants[0].pubkey, AGENT);
+});
+
+test("parseAgentMediaSession fails closed without a usable expires_at", () => {
+  // No default: any default is a guess about how long a room this client cannot
+  // see stays alive, and the generous guess keeps a dead card on screen.
+  for (const expires of [undefined, null, "later", 1.5, Number.NaN]) {
+    const record = {
+      provider: "livekit",
+      connect: { url: "wss://x", room: "r" },
+    };
+    if (expires !== undefined) record.expires_at = expires;
+    assert.equal(
+      parseAgentMediaSession(announcement({ content: JSON.stringify(record) })),
+      null,
+      `expected expires_at ${String(expires)} to be rejected`,
+    );
+  }
+});
+
+test("parseAgentMediaSession rejects an expiry at or before the announcement", () => {
+  for (const expires of [CREATED_AT, CREATED_AT - 1]) {
+    const content = body({ expires_at: expires });
+    assert.equal(
+      parseAgentMediaSession(announcement({ content })),
+      null,
+      `expected expires_at ${expires} to be rejected`,
+    );
+  }
+});
+
+test("isSessionExpired turns over at the announced second", () => {
+  const session = parseAgentMediaSession(announcement());
+  assert.ok(session);
+  assert.equal(isSessionExpired(session, EXPIRES_AT - 1), false);
+  assert.equal(isSessionExpired(session, EXPIRES_AT), true);
+  assert.equal(isSessionExpired(session, EXPIRES_AT + 1), true);
+});
+
+test("parseAgentMediaSessionEnd names the start it closes", () => {
+  const start = "d".repeat(64);
+  const end = parseAgentMediaSessionEnd({
+    pubkey: AGENT,
+    tags: [
+      ["h", CHANNEL],
+      ["e", start],
+    ],
+  });
+  assert.equal(end?.startEventId, start);
+  assert.equal(end?.signer, AGENT);
+  assert.equal(end?.subject, null);
+});
+
+test("parseAgentMediaSessionEnd returns null when it names no start", () => {
+  assert.equal(
+    parseAgentMediaSessionEnd({ pubkey: AGENT, tags: [["h", CHANNEL]] }),
+    null,
+  );
+});
+
+test("parseAgentMediaSessionEnd reads a lone p tag as the subject", () => {
+  const relay = "f".repeat(64);
+  const start = "d".repeat(64);
+  const end = parseAgentMediaSessionEnd({
+    pubkey: relay,
+    tags: [
+      ["e", start],
+      ["p", AGENT],
+    ],
+  });
+  assert.equal(end?.subject, AGENT);
+
+  // Several p tags name nobody in particular, so there is no subject.
+  const ambiguous = parseAgentMediaSessionEnd({
+    pubkey: relay,
+    tags: [
+      ["e", start],
+      ["p", AGENT],
+      ["p", "b".repeat(64)],
+    ],
+  });
+  assert.equal(ambiguous?.subject, null);
+});
+
+test("endRetiresSession honours the session owner", () => {
+  const session = parseAgentMediaSession(announcement());
+  assert.ok(session);
+  const end = parseAgentMediaSessionEnd({
+    pubkey: AGENT,
+    tags: [["e", session.eventId]],
+  });
+  assert.ok(end);
+  assert.equal(endRetiresSession(end, session), true);
+});
+
+test("endRetiresSession honours a relay-signed end naming the owner", () => {
+  const session = parseAgentMediaSession(announcement());
+  assert.ok(session);
+  const end = parseAgentMediaSessionEnd({
+    pubkey: "f".repeat(64),
+    tags: [
+      ["e", session.eventId],
+      ["p", AGENT],
+    ],
+  });
+  assert.ok(end);
+  assert.equal(endRetiresSession(end, session), true);
+});
+
+test("endRetiresSession refuses a third party", () => {
+  // Otherwise any member could retire another agent's live card by publishing
+  // a 48201 that names its start.
+  const session = parseAgentMediaSession(announcement());
+  assert.ok(session);
+  const end = parseAgentMediaSessionEnd({
+    pubkey: "b".repeat(64),
+    tags: [["e", session.eventId]],
+  });
+  assert.ok(end);
+  assert.equal(endRetiresSession(end, session), false);
+});
+
+test("endRetiresSession refuses an end naming a different start", () => {
+  const session = parseAgentMediaSession(announcement());
+  assert.ok(session);
+  const end = parseAgentMediaSessionEnd({
+    pubkey: AGENT,
+    tags: [["e", "9".repeat(64)]],
+  });
+  assert.ok(end);
+  assert.equal(endRetiresSession(end, session), false);
+});

--- a/desktop/src/features/agents/lib/agentMediaSession.ts
+++ b/desktop/src/features/agents/lib/agentMediaSession.ts
@@ -239,3 +239,40 @@ export function isSessionExpired(
 ): boolean {
   return session.expiresAt <= nowSeconds;
 }
+
+/**
+ * Whether a track published by `participantIdentity` is this session's agent's.
+ *
+ * Called for every subscribed track, because only the announcing agent's face
+ * and voice belong in its panel. A room may carry other publishers once
+ * sessions go multi-party, and rendering the wrong face — or playing the wrong
+ * voice under the right one — is worse than rendering nothing.
+ *
+ * Two ways to qualify, in order:
+ *
+ * 1. The provider identity contains the agent's hex pubkey. This is what a
+ *    gateway is expected to do, and it is unambiguous.
+ * 2. Failing that, the announcement declares exactly one publisher of this
+ *    track kind. Then a single track of that kind cannot be anyone else's, and
+ *    refusing it would strand v1 on an identity convention the wire format
+ *    never actually promised.
+ *
+ * Audio is checked the same way as video and against its own declaration: an
+ * announcement may name one avatar publisher and several audio ones, and the
+ * agent's face arriving unambiguously says nothing about whose voice this is.
+ */
+export function trackBelongsToSessionAgent(
+  session: AgentMediaSession,
+  participantIdentity: string,
+  kind: "audio" | "video",
+): boolean {
+  // `session.agentPubkey` is normalized at parse time; the identity is not.
+  if (participantIdentity.toLowerCase().includes(session.agentPubkey)) {
+    return true;
+  }
+  const declared: MediaTrackKind = kind === "video" ? "avatar_video" : "audio";
+  return (
+    session.participants.filter((entry) => entry.tracks.includes(declared))
+      .length === 1
+  );
+}

--- a/desktop/src/features/agents/lib/agentMediaSession.ts
+++ b/desktop/src/features/agents/lib/agentMediaSession.ts
@@ -1,0 +1,241 @@
+import type { RelayEvent } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+/**
+ * The `provider` values this client knows how to connect to.
+ *
+ * Mirrors `KNOWN_MEDIA_PROVIDERS` in the relay's ingest validation. The relay
+ * refuses to store an announcement naming anything else, so an unknown value
+ * here means the relay is newer than the client — render nothing rather than
+ * guessing at a transport.
+ */
+export const SUPPORTED_MEDIA_PROVIDERS = ["livekit"] as const;
+
+export type MediaProvider = (typeof SUPPORTED_MEDIA_PROVIDERS)[number];
+
+/** Track kinds a session may carry. `avatar_video` is an agent's rendered face. */
+export type MediaTrackKind = "avatar_video" | "camera" | "screen" | "audio";
+
+export type MediaSessionParticipant = {
+  pubkey: string;
+  tracks: MediaTrackKind[];
+};
+
+/**
+ * A live agent media session, parsed from a kind:48200 announcement.
+ *
+ * `viewer` is what *this* client may do in the room. v1 announcements grant
+ * subscribe-only video plus outbound audio; screen share and camera arrive in
+ * later versions without a wire change.
+ */
+export type AgentMediaSession = {
+  /** The 48200 event id — the anchor an eventual 48201 references. */
+  eventId: string;
+  /** Whose session this is. The announcement's signer. */
+  agentPubkey: string;
+  channelId: string;
+  /** The message that prompted the session, when there was one. */
+  sourceEventId: string | null;
+  provider: MediaProvider;
+  serverUrl: string;
+  room: string;
+  /** Where to exchange this viewer's identity for a short-lived room token. */
+  tokenEndpoint: string | null;
+  participants: MediaSessionParticipant[];
+  viewer: {
+    subscribe: MediaTrackKind[];
+    publish: MediaTrackKind[];
+  };
+  startedAt: number;
+  /**
+   * Unix seconds after which this session stops being worth rendering.
+   *
+   * A presentation expiry, not a lease — it reaps nothing on the provider. It
+   * exists because the 48201 that would retire this card may never arrive: an
+   * agent that crashes publishes no end event, and the card would otherwise
+   * advertise a dead room until the channel is reloaded.
+   */
+  expiresAt: number;
+};
+
+const TRACK_KINDS: readonly MediaTrackKind[] = [
+  "avatar_video",
+  "camera",
+  "screen",
+  "audio",
+];
+
+function asTrackKinds(value: unknown): MediaTrackKind[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is MediaTrackKind =>
+    TRACK_KINDS.includes(entry as MediaTrackKind),
+  );
+}
+
+function firstTagValue(event: RelayEvent, name: string): string | null {
+  for (const tag of event.tags ?? []) {
+    if (tag[0] === name && typeof tag[1] === "string" && tag[1].length > 0) {
+      return tag[1];
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse a kind:48200 announcement into a session, or null if unusable.
+ *
+ * Returns null rather than throwing: an announcement is untrusted input from
+ * another member, and one malformed event must not take the panel down. The
+ * relay validates the same fields at ingest, so a null here means either a
+ * relay that skipped validation or a provider this client is too old to know.
+ */
+export function parseAgentMediaSession(
+  event: RelayEvent,
+): AgentMediaSession | null {
+  const channelId = firstTagValue(event, "h");
+  if (!channelId) return null;
+
+  let body: unknown;
+  try {
+    body = JSON.parse(event.content);
+  } catch {
+    return null;
+  }
+  if (typeof body !== "object" || body === null) return null;
+  const record = body as Record<string, unknown>;
+
+  const provider = record.provider;
+  if (
+    typeof provider !== "string" ||
+    !SUPPORTED_MEDIA_PROVIDERS.includes(provider as MediaProvider)
+  ) {
+    return null;
+  }
+
+  const connect = record.connect;
+  if (typeof connect !== "object" || connect === null) return null;
+  const { url, room } = connect as Record<string, unknown>;
+  if (typeof url !== "string" || typeof room !== "string") return null;
+  if (url.length === 0 || room.length === 0) return null;
+
+  // The relay already rejects a non-http(s) token endpoint, but this client
+  // must not depend on that: an announcement can also arrive from a relay
+  // running an older ingest. Drop the endpoint rather than the session — a
+  // session with no endpoint is simply one this viewer cannot get a token for.
+  const rawEndpoint = record.token_endpoint;
+  const tokenEndpoint =
+    typeof rawEndpoint === "string" &&
+    (rawEndpoint.startsWith("https://") || rawEndpoint.startsWith("http://"))
+      ? rawEndpoint
+      : null;
+
+  const participants: MediaSessionParticipant[] = Array.isArray(
+    record.participants,
+  )
+    ? record.participants.flatMap((entry) => {
+        if (typeof entry !== "object" || entry === null) return [];
+        const { pubkey, tracks } = entry as Record<string, unknown>;
+        if (typeof pubkey !== "string") return [];
+        return [
+          { pubkey: normalizePubkey(pubkey), tracks: asTrackKinds(tracks) },
+        ];
+      })
+    : [];
+
+  const viewer =
+    typeof record.viewer === "object" && record.viewer !== null
+      ? (record.viewer as Record<string, unknown>)
+      : {};
+
+  // Fail closed on a missing or unusable expiry rather than defaulting to one.
+  // Any default is a guess about how long a room this client cannot see stays
+  // alive, and the generous guess is the one that keeps a dead card on screen.
+  // The relay requires the field, so a body without it is an older relay.
+  const expiresAt = record.expires_at;
+  if (typeof expiresAt !== "number" || !Number.isSafeInteger(expiresAt)) {
+    return null;
+  }
+  if (expiresAt <= event.created_at) return null;
+
+  return {
+    eventId: event.id,
+    // Ownership is the signature, not a tag — the relay enforces that an agent
+    // announces only its own session (or the relay ends one, naming the agent).
+    agentPubkey: normalizePubkey(event.pubkey),
+    channelId,
+    sourceEventId: firstTagValue(event, "e"),
+    provider: provider as MediaProvider,
+    serverUrl: url,
+    room,
+    tokenEndpoint,
+    participants,
+    viewer: {
+      subscribe: asTrackKinds(viewer.subscribe),
+      publish: asTrackKinds(viewer.publish),
+    },
+    startedAt: event.created_at,
+    expiresAt,
+  };
+}
+
+/** A kind:48201 event, reduced to what deciding whether to honour it needs. */
+export type AgentMediaSessionEnd = {
+  /** The 48200 event id this end closes. */
+  startEventId: string;
+  /** Who signed the end. */
+  signer: string;
+  /** The single `p` tag, when there is exactly one — the relay-signed shape. */
+  subject: string | null;
+};
+
+/** Parse a kind:48201 event, or null if it names no start. */
+export function parseAgentMediaSessionEnd(
+  event: RelayEvent,
+): AgentMediaSessionEnd | null {
+  const startEventId = firstTagValue(event, "e");
+  if (!startEventId) return null;
+
+  const pTags = (event.tags ?? [])
+    .filter((tag) => tag[0] === "p" && typeof tag[1] === "string")
+    .map((tag) => normalizePubkey(tag[1] as string));
+
+  return {
+    startEventId,
+    signer: normalizePubkey(event.pubkey),
+    subject: pTags.length === 1 ? pTags[0] : null,
+  };
+}
+
+/**
+ * Whether `end` may retire `session`.
+ *
+ * Two shapes and no others, matching the relay's rule: the owner ends its own
+ * session, or the relay ends one and names the owner in a single `p` tag.
+ *
+ * This client cannot verify that the second shape really came from the relay —
+ * it does not know the relay's pubkey. It does not have to: the relay rejects a
+ * `p` tag naming anyone but the signer unless the signer is the relay itself,
+ * so no third party can produce this shape. Honouring it here admits nothing a
+ * relay running this ingest would have stored anyway, and the first shape —
+ * signer equals owner — is checked outright.
+ *
+ * Without either check, any member could retire another agent's live card by
+ * publishing a 48201 naming its start.
+ */
+export function endRetiresSession(
+  end: AgentMediaSessionEnd,
+  session: AgentMediaSession,
+): boolean {
+  if (end.startEventId !== session.eventId) return false;
+  return (
+    end.signer === session.agentPubkey || end.subject === session.agentPubkey
+  );
+}
+
+/** Whether `session` has passed its announced expiry at `nowSeconds`. */
+export function isSessionExpired(
+  session: AgentMediaSession,
+  nowSeconds: number,
+): boolean {
+  return session.expiresAt <= nowSeconds;
+}

--- a/desktop/src/features/agents/lib/agentMediaSession.ts
+++ b/desktop/src/features/agents/lib/agentMediaSession.ts
@@ -76,6 +76,36 @@ function asTrackKinds(value: unknown): MediaTrackKind[] {
   );
 }
 
+/** Protocols a media transport URL may use. Mirrors the relay's allowlist. */
+const MEDIA_TRANSPORT_PROTOCOLS = ["wss:", "ws:", "https:", "http:"] as const;
+
+/** Protocols a viewer may fetch a room credential from. */
+const TOKEN_ENDPOINT_PROTOCOLS = ["https:", "http:"] as const;
+
+/**
+ * Whether `candidate` is a URL with one of `protocols` that this client can
+ * dial.
+ *
+ * Parsed rather than prefix-matched, for the reason the relay parses: `"wss://"`
+ * and `"https://["` both start with an allowed scheme and address nothing. The
+ * relay refuses both, and this check exists precisely for announcements that
+ * did not come through a relay running that ingest — so matching on a prefix
+ * would leave it agreeing with the relay only on the cases the relay already
+ * caught.
+ */
+function isDialableUrl(
+  candidate: string,
+  protocols: readonly string[],
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return false;
+  }
+  return protocols.includes(parsed.protocol) && parsed.hostname.length > 0;
+}
+
 function firstTagValue(event: RelayEvent, name: string): string | null {
   for (const tag of event.tags ?? []) {
     if (tag[0] === name && typeof tag[1] === "string" && tag[1].length > 0) {
@@ -120,7 +150,10 @@ export function parseAgentMediaSession(
   if (typeof connect !== "object" || connect === null) return null;
   const { url, room } = connect as Record<string, unknown>;
   if (typeof url !== "string" || typeof room !== "string") return null;
-  if (url.length === 0 || room.length === 0) return null;
+  if (!isDialableUrl(url, MEDIA_TRANSPORT_PROTOCOLS)) return null;
+  // A room of whitespace is as unjoinable as an empty one, and fails later and
+  // less legibly — at the provider, after a token has already been minted.
+  if (room.trim().length === 0) return null;
 
   // The relay already rejects a non-http(s) token endpoint, but this client
   // must not depend on that: an announcement can also arrive from a relay
@@ -129,7 +162,7 @@ export function parseAgentMediaSession(
   const rawEndpoint = record.token_endpoint;
   const tokenEndpoint =
     typeof rawEndpoint === "string" &&
-    (rawEndpoint.startsWith("https://") || rawEndpoint.startsWith("http://"))
+    isDialableUrl(rawEndpoint, TOKEN_ENDPOINT_PROTOCOLS)
       ? rawEndpoint
       : null;
 

--- a/desktop/src/features/agents/lib/agentMediaSession.ts
+++ b/desktop/src/features/agents/lib/agentMediaSession.ts
@@ -1,4 +1,8 @@
 import type { RelayEvent } from "@/shared/api/types";
+import {
+  KIND_AGENT_MEDIA_SESSION_ENDED,
+  KIND_AGENT_MEDIA_SESSION_STARTED,
+} from "@/shared/constants/kinds";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 /**
@@ -241,23 +245,42 @@ export function isSessionExpired(
 }
 
 /**
+ * A 64-char lowercase-hex run inside a provider identity.
+ *
+ * Every identity this room mints for a *person* is exactly one of these: the
+ * gateway joins a viewer under its own Buzz pubkey. An identity carrying a
+ * pubkey is therefore naming a specific participant, and the test below is
+ * reached only once that pubkey is known not to be the agent's.
+ */
+const PUBKEY_IN_IDENTITY = /[0-9a-f]{64}/;
+
+/**
  * Whether a track published by `participantIdentity` is this session's agent's.
  *
  * Called for every subscribed track, because only the announcing agent's face
- * and voice belong in its panel. A room may carry other publishers once
- * sessions go multi-party, and rendering the wrong face — or playing the wrong
- * voice under the right one — is worse than rendering nothing.
+ * and voice belong in its panel. Getting this wrong is not a cosmetic slip: the
+ * room hook holds one audio track, so admitting somebody else's voice *detaches
+ * the agent's*. One member unmuting would silence the agent for another and
+ * speak under its face.
  *
- * Two ways to qualify, in order:
+ * Three rules, in order:
  *
- * 1. The provider identity contains the agent's hex pubkey. This is what a
- *    gateway is expected to do, and it is unambiguous.
- * 2. Failing that, the announcement declares exactly one publisher of this
- *    track kind. Then a single track of that kind cannot be anyone else's, and
- *    refusing it would strand v1 on an identity convention the wire format
- *    never actually promised.
+ * 1. The provider identity contains the agent's hex pubkey. Unambiguous, and
+ *    the only rule that proves anything about who actually published.
+ * 2. Otherwise, an identity carrying some *other* pubkey is refused outright.
+ *    Viewers join as their own pubkey and a v1 announcement grants them a
+ *    microphone, so this is the case that genuinely occurs.
+ * 3. Only then may the announcement's declaration settle it: exactly one
+ *    declared publisher of this track kind, and that publisher is the agent.
  *
- * Audio is checked the same way as video and against its own declaration: an
+ * Rule 3 cannot be dropped in favour of rule 1, tempting as that is. No gateway
+ * is obliged to put a pubkey in its provider identity, and the one this was
+ * built against does not — the Anam avatar worker joins under an identity of
+ * Anam's choosing, and the gateway's `agent_token` helper, whose docstring
+ * calls the identity contract load-bearing, has no callers. Requiring rule 1
+ * would leave every session today faceless.
+ *
+ * Audio is checked against its own declaration rather than video's: an
  * announcement may name one avatar publisher and several audio ones, and the
  * agent's face arriving unambiguously says nothing about whose voice this is.
  */
@@ -267,12 +290,102 @@ export function trackBelongsToSessionAgent(
   kind: "audio" | "video",
 ): boolean {
   // `session.agentPubkey` is normalized at parse time; the identity is not.
-  if (participantIdentity.toLowerCase().includes(session.agentPubkey)) {
-    return true;
-  }
+  const identity = participantIdentity.toLowerCase();
+  if (identity.includes(session.agentPubkey)) return true;
+  if (PUBKEY_IN_IDENTITY.test(identity)) return false;
+
   const declared: MediaTrackKind = kind === "video" ? "avatar_video" : "audio";
-  return (
-    session.participants.filter((entry) => entry.tracks.includes(declared))
-      .length === 1
+  const publishers = session.participants.filter((entry) =>
+    entry.tracks.includes(declared),
   );
+  // The sole declared publisher has to be the agent. Counting alone admits an
+  // announcement naming somebody else as the only voice — which is not an
+  // ambiguity to resolve in the agent's favour, but a statement that the voice
+  // is not the agent's.
+  return (
+    publishers.length === 1 && publishers[0].pubkey === session.agentPubkey
+  );
+}
+
+/**
+ * Whether two folds produced the same live set, element identity included.
+ *
+ * Elements are compared by reference, which is exactly the question: the fold
+ * reuses a previously parsed session for an unchanged event, so a differing
+ * reference means the content differed too.
+ */
+function sessionsUnchanged(
+  a: readonly AgentMediaSession[],
+  b: readonly AgentMediaSession[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (!Object.is(a[index], b[index])) return false;
+  }
+  return true;
+}
+
+/**
+ * Fold lifecycle events into a channel's live sessions, newest first.
+ *
+ * A fold over everything seen rather than an incremental update: lifecycle
+ * events are rare, replay on reconnect is common, and refolding is correct
+ * regardless of arrival order — an end that arrives before its start still
+ * retires that start. A session leaves the set two ways, an end event its owner
+ * was entitled to publish, or its own announced expiry passing. The second
+ * exists because the first may never happen: an agent that crashes publishes no
+ * 48201.
+ *
+ * **Identity-preserving, and that is a correctness requirement rather than an
+ * optimisation.** `useAgentMediaRoom` keys a whole WebRTC connection on the
+ * session object, so handing it a fresh object for an unchanged session tears
+ * the call down, fetches another viewer token and rejoins. Refolding on every
+ * arrival used to do exactly that: an unrelated agent starting or ending a
+ * session — or any expiry firing — interrupted an open call, and each replayed
+ * history event cost its own token request.
+ *
+ * Two guarantees carry that. A 48200 is immutable, so a session already parsed
+ * under an event id can only parse to the same value and the object from
+ * `previous` is reused. And when the outcome matches `previous` entirely,
+ * `previous` itself is returned, so `setState` bails out instead of
+ * re-rendering every consumer.
+ */
+export function foldLiveSessions(
+  events: Iterable<RelayEvent>,
+  previous: readonly AgentMediaSession[],
+  nowSeconds: number,
+): readonly AgentMediaSession[] {
+  const started: AgentMediaSession[] = [];
+  const ends: AgentMediaSessionEnd[] = [];
+  const parsed = new Map(previous.map((session) => [session.eventId, session]));
+
+  for (const event of events) {
+    if (event.kind === KIND_AGENT_MEDIA_SESSION_STARTED) {
+      const already = parsed.get(event.id);
+      if (already) {
+        started.push(already);
+        continue;
+      }
+      const session = parseAgentMediaSession(event);
+      if (session) started.push(session);
+      continue;
+    }
+    if (event.kind === KIND_AGENT_MEDIA_SESSION_ENDED) {
+      const end = parseAgentMediaSessionEnd(event);
+      if (end) ends.push(end);
+    }
+  }
+
+  const live = started
+    .filter(
+      (session) =>
+        // Check the ender's standing rather than matching on the event id
+        // alone: without it any member could retire another agent's live card
+        // by publishing a 48201 that names its start.
+        !ends.some((end) => endRetiresSession(end, session)) &&
+        !isSessionExpired(session, nowSeconds),
+    )
+    .sort((a, b) => b.startedAt - a.startedAt);
+
+  return sessionsUnchanged(previous, live) ? previous : live;
 }

--- a/desktop/src/features/agents/lib/micRequestQueue.test.mjs
+++ b/desktop/src/features/agents/lib/micRequestQueue.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * What a burst of microphone taps leaves behind.
+ *
+ * Two properties, and both are about a microphone rather than about tidy
+ * state: the device ends where the member last asked it to, and nothing ever
+ * reports "muted" on behalf of a request the member has already superseded.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMicRequestQueue } from "./micRequestQueue.ts";
+
+/**
+ * Let queued work reach `apply`.
+ *
+ * Requests are chained onto a promise, so the provider call is made in a later
+ * microtask and never synchronously with the tap that asked for it.
+ */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/** A controllable `apply`: records calls, settles when told. */
+function deferredApply() {
+  const calls = [];
+  const pending = [];
+  const apply = (enabled) =>
+    new Promise((resolve, reject) => {
+      calls.push(enabled);
+      pending.push({ resolve, reject });
+    });
+  return { apply, calls, pending };
+}
+
+test("taps landing together cost one call, carrying the settled value", {
+  timeout: 5_000,
+}, async () => {
+  const { apply, calls, pending } = deferredApply();
+  const queue = createMicRequestQueue(apply);
+
+  // Three taps in one tick. Each supersedes the last before any of them has
+  // had a turn, so the first two are dropped without ever being applied.
+  queue.request(true, () => {});
+  queue.request(false, () => {});
+  queue.request(true, () => {});
+  await tick();
+
+  assert.deepEqual(calls, [true], "one provider call, not three");
+
+  // Settling it and letting the chain drain, rather than awaiting the chain
+  // itself: a queue that applied every superseded request would leave calls
+  // nothing ever settles, and awaiting it would hang here instead of failing.
+  pending[0].resolve();
+  await tick();
+
+  assert.deepEqual(
+    calls,
+    [true],
+    "the values passed through never reach the device",
+  );
+});
+
+test("the device ends where the member last asked, not where the slowest call did", {
+  timeout: 5_000,
+}, async () => {
+  const { apply, calls, pending } = deferredApply();
+  const queue = createMicRequestQueue(apply);
+
+  queue.request(true, () => {});
+  const off = queue.request(false, () => {});
+  await tick();
+  pending[0].resolve();
+  await off;
+
+  assert.equal(
+    calls.at(-1),
+    false,
+    "the last applied value is the last one requested",
+  );
+});
+
+test("a superseded request's failure does not report muted", {
+  timeout: 5_000,
+}, async () => {
+  const { apply, pending } = deferredApply();
+  const queue = createMicRequestQueue(apply);
+
+  let reportedMuted = false;
+  const mark = () => {
+    reportedMuted = true;
+  };
+  // The member unmutes; that call reaches the device and is still running when
+  // they tap again. The first attempt then fails, after it stopped speaking
+  // for them.
+  queue.request(true, mark);
+  await tick();
+  const newer = queue.request(true, mark);
+  pending[0].reject(new Error("device busy"));
+  await tick();
+  pending[1].resolve();
+  await newer;
+
+  assert.equal(
+    reportedMuted,
+    false,
+    "a stale rejection must not label a newer request's microphone as muted",
+  );
+});
+
+test("the newest request's failure does report muted", {
+  timeout: 5_000,
+}, async () => {
+  // The refusal above means nothing without this: a fence that suppressed
+  // every failure would satisfy it while leaving the indicator lying the
+  // other way, claiming an open microphone that never opened.
+  const { apply, pending } = deferredApply();
+  const queue = createMicRequestQueue(apply);
+
+  let reportedMuted = false;
+  const only = queue.request(true, () => {
+    reportedMuted = true;
+  });
+  await tick();
+  pending[0].reject(new Error("permission denied"));
+  await only;
+
+  assert.equal(reportedMuted, true);
+});
+
+test("superseding drops a queued request before it reaches the device", {
+  timeout: 5_000,
+}, async () => {
+  const { apply, calls, pending } = deferredApply();
+  const queue = createMicRequestQueue(apply);
+
+  queue.request(true, () => {});
+  await tick();
+  // Queued behind the in-flight call, then the room changes underneath it.
+  const queued = queue.request(false, () => {});
+  queue.supersede();
+  pending[0].resolve();
+  await queued;
+
+  assert.deepEqual(
+    calls,
+    [true],
+    "a request superseded by a room change never reaches the device",
+  );
+});
+
+test("a failure does not wedge the queue", { timeout: 5_000 }, async () => {
+  // The queue is one promise chain, so a rejection escaping it would silently
+  // stop every later request — the microphone button would go dead after the
+  // first denied permission prompt.
+  const { apply, calls, pending } = deferredApply();
+  const queue = createMicRequestQueue(apply);
+
+  const failing = queue.request(true, () => {});
+  await tick();
+  pending[0].reject(new Error("denied"));
+  await failing;
+
+  const next = queue.request(true, () => {});
+  await tick();
+  pending[1].resolve();
+  await next;
+
+  assert.deepEqual(calls, [true, true], "a later request still reaches apply");
+});

--- a/desktop/src/features/agents/lib/micRequestQueue.ts
+++ b/desktop/src/features/agents/lib/micRequestQueue.ts
@@ -1,0 +1,83 @@
+/**
+ * Serialize microphone on/off requests so the last one asked for is the one
+ * that lands.
+ *
+ * Toggling is a single tap, so two requests overlap easily — and the first
+ * unmute is the slowest case of all, because it may wait on a permission
+ * prompt and `getUserMedia`. That is exactly when somebody taps again.
+ *
+ * The provider SDK reconciles most of this already: LiveKit's disable path
+ * looks for a publication still in flight and mutes it once it appears. Two
+ * gaps are left, and the second is the one that matters here.
+ *
+ * That wait has a timeout. When it expires the SDK logs and gives up, while
+ * the enable it could not find goes on to publish — a microphone left open by
+ * a request the member superseded.
+ *
+ * And the *reported* state is nobody's job but ours. Without a fence, a
+ * superseded request's rejection reverts the indicator to muted while a newer
+ * request has the microphone genuinely open. A microphone somebody believes is
+ * off is not a state-tidiness concern, so this errs toward never claiming
+ * "muted" on behalf of a request that no longer speaks for the member.
+ */
+export type MicRequestQueue = {
+  /**
+   * Ask for the microphone to be `enabled`.
+   *
+   * `onFailure` runs only if this request is still the newest when it fails,
+   * so a stale rejection cannot describe a newer request's device.
+   *
+   * Returns the queue's tail, which callers may await in tests. Production
+   * does not: the outcome reaches the UI through `onFailure`.
+   */
+  request: (enabled: boolean, onFailure: () => void) => Promise<void>;
+  /**
+   * Supersede every in-flight request without issuing a new one.
+   *
+   * Called when the room changes: a request settling afterwards describes a
+   * connection that no longer exists, and must neither reach the SDK nor write
+   * state about it.
+   */
+  supersede: () => void;
+};
+
+/**
+ * Build a queue that applies microphone requests one at a time.
+ *
+ * `apply` is the provider call. At most one runs at a time, and a request that
+ * is no longer the newest when its turn comes is dropped rather than applied.
+ * So the values a member passes through on the way to the one they settle on
+ * never reach the device — they are discarded, not queued up to be replayed at
+ * it one after another.
+ *
+ * How many calls a burst costs depends on its timing, and neither number is a
+ * promise worth making: taps landing in one tick supersede each other before
+ * any call starts and cost a single call, while a tap arriving after a call is
+ * already in flight cannot recall it and costs a second.
+ */
+export function createMicRequestQueue(
+  apply: (enabled: boolean) => Promise<void>,
+): MicRequestQueue {
+  let latest = 0;
+  let tail: Promise<void> = Promise.resolve();
+
+  return {
+    request(enabled, onFailure) {
+      latest += 1;
+      const generation = latest;
+      tail = tail
+        .then(async () => {
+          if (latest !== generation) return;
+          await apply(enabled);
+        })
+        .catch(() => {
+          if (latest !== generation) return;
+          onFailure();
+        });
+      return tail;
+    },
+    supersede() {
+      latest += 1;
+    },
+  };
+}

--- a/desktop/src/features/agents/lib/useAgentMediaRoom.ts
+++ b/desktop/src/features/agents/lib/useAgentMediaRoom.ts
@@ -1,0 +1,223 @@
+import * as React from "react";
+import {
+  ConnectionState,
+  type RemoteParticipant,
+  type RemoteTrack,
+  type RemoteTrackPublication,
+  Room,
+  RoomEvent,
+  Track,
+} from "livekit-client";
+
+import { nip98PostHeader } from "@/shared/api/nip98";
+import type { AgentMediaSession } from "./agentMediaSession";
+
+/** Bound the token request so an unreachable gateway surfaces in seconds. */
+const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+
+export type AgentMediaRoomStatus =
+  | "idle"
+  | "authorizing"
+  | "connecting"
+  | "connected"
+  | "error";
+
+export type AgentMediaRoomState = {
+  status: AgentMediaRoomStatus;
+  /** Human-readable failure, set only when `status` is `"error"`. */
+  error: string | null;
+  /**
+   * Attach the agent's video to an element. Returns a detach function.
+   *
+   * Exposed as a callback rather than a raw track so the caller never has to
+   * remember to detach — LiveKit reuses the underlying element otherwise, and a
+   * stale attachment keeps a decoded video surface alive after the panel closes.
+   */
+  attachVideo: ((element: HTMLVideoElement) => () => void) | null;
+  /** Whether the local microphone is publishing. */
+  micEnabled: boolean;
+  setMicEnabled: (enabled: boolean) => void;
+  /** True when the session grants this viewer outbound audio. */
+  canPublishAudio: boolean;
+};
+
+async function fetchViewerToken(session: AgentMediaSession): Promise<string> {
+  if (!session.tokenEndpoint) {
+    throw new Error("This session did not publish a token endpoint.");
+  }
+  const body = JSON.stringify({
+    channel_id: session.channelId,
+    session_event_id: session.eventId,
+    room: session.room,
+  });
+  // The gateway learns *who* is asking from the NIP-98 event's signature, then
+  // checks that pubkey's membership of the announcing channel before minting.
+  // The client never holds a provider API secret.
+  const authorization = await nip98PostHeader(session.tokenEndpoint, body);
+  const response = await fetch(session.tokenEndpoint, {
+    method: "POST",
+    headers: {
+      Authorization: authorization,
+      "Content-Type": "application/json",
+    },
+    body,
+    signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+  });
+  const json = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  if (!response.ok) {
+    const message =
+      typeof json.error === "string" ? json.error : `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  if (typeof json.token !== "string" || json.token.length === 0) {
+    throw new Error("Gateway returned no token.");
+  }
+  return json.token;
+}
+
+/**
+ * Join the provider room for `session` and expose the agent's video.
+ *
+ * Subscribe-only by default: the microphone starts off and is never enabled
+ * without an explicit call, because this hook mounts as soon as the panel opens
+ * and silently hot-miking someone is not acceptable. Disconnects on unmount and
+ * on session change — leaving the room open would keep a WebRTC connection (and
+ * the provider's meter) running behind a closed panel.
+ */
+export function useAgentMediaRoom(
+  session: AgentMediaSession | null,
+): AgentMediaRoomState {
+  const [status, setStatus] = React.useState<AgentMediaRoomStatus>("idle");
+  const [error, setError] = React.useState<string | null>(null);
+  const [videoTrack, setVideoTrack] = React.useState<RemoteTrack | null>(null);
+  const [micEnabled, setMicEnabledState] = React.useState(false);
+  const roomRef = React.useRef<Room | null>(null);
+
+  const canPublishAudio = session?.viewer.publish.includes("audio") ?? false;
+
+  React.useEffect(() => {
+    if (!session) {
+      setStatus("idle");
+      setError(null);
+      setVideoTrack(null);
+      return;
+    }
+
+    let disposed = false;
+    const room = new Room();
+    roomRef.current = room;
+    setMicEnabledState(false);
+
+    const onSubscribed = (
+      track: RemoteTrack,
+      _publication: RemoteTrackPublication,
+      participant: RemoteParticipant,
+    ) => {
+      if (disposed || track.kind !== Track.Kind.Video) return;
+      // Only the announcing agent's video belongs in this panel — a room may
+      // carry other publishers once sessions go multi-party, and rendering the
+      // wrong face is worse than rendering none.
+      //
+      // The gateway is expected to put the agent's hex pubkey in its LiveKit
+      // identity. When it does, match on that. When it does not, fall back to
+      // the announcement: if it declares exactly one avatar publisher then a
+      // single video track is unambiguous, and refusing it would strand v1 on
+      // an identity convention the wire format never actually promised.
+      const identity = participant.identity.toLowerCase();
+      const identifiesAgent = identity.includes(session.agentPubkey);
+      const soleAvatarPublisher =
+        session.participants.filter((entry) =>
+          entry.tracks.includes("avatar_video"),
+        ).length === 1;
+      if (!identifiesAgent && !soleAvatarPublisher) return;
+      setVideoTrack(track);
+    };
+
+    const onUnsubscribed = (track: RemoteTrack) => {
+      if (disposed) return;
+      setVideoTrack((current) => (current === track ? null : current));
+    };
+
+    const onStateChanged = (state: ConnectionState) => {
+      if (disposed) return;
+      if (state === ConnectionState.Connected) setStatus("connected");
+      else if (state === ConnectionState.Reconnecting) setStatus("connecting");
+    };
+
+    const onDisconnected = () => {
+      if (disposed) return;
+      setVideoTrack(null);
+      setStatus("idle");
+    };
+
+    room
+      .on(RoomEvent.TrackSubscribed, onSubscribed)
+      .on(RoomEvent.TrackUnsubscribed, onUnsubscribed)
+      .on(RoomEvent.ConnectionStateChanged, onStateChanged)
+      .on(RoomEvent.Disconnected, onDisconnected);
+
+    setStatus("authorizing");
+    setError(null);
+
+    void (async () => {
+      try {
+        const token = await fetchViewerToken(session);
+        if (disposed) return;
+        setStatus("connecting");
+        await room.connect(session.serverUrl, token);
+        if (disposed) {
+          await room.disconnect();
+          return;
+        }
+        setStatus("connected");
+      } catch (cause) {
+        if (disposed) return;
+        setStatus("error");
+        setError(cause instanceof Error ? cause.message : "Failed to connect.");
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      room
+        .off(RoomEvent.TrackSubscribed, onSubscribed)
+        .off(RoomEvent.TrackUnsubscribed, onUnsubscribed)
+        .off(RoomEvent.ConnectionStateChanged, onStateChanged)
+        .off(RoomEvent.Disconnected, onDisconnected);
+      void room.disconnect();
+      if (roomRef.current === room) roomRef.current = null;
+      setVideoTrack(null);
+    };
+  }, [session]);
+
+  const attachVideo = React.useMemo(() => {
+    if (!videoTrack) return null;
+    return (element: HTMLVideoElement) => {
+      videoTrack.attach(element);
+      return () => {
+        videoTrack.detach(element);
+      };
+    };
+  }, [videoTrack]);
+
+  const setMicEnabled = React.useCallback((enabled: boolean) => {
+    const room = roomRef.current;
+    if (!room) return;
+    setMicEnabledState(enabled);
+    void room.localParticipant.setMicrophoneEnabled(enabled).catch(() => {
+      setMicEnabledState(false);
+    });
+  }, []);
+
+  return {
+    status,
+    error,
+    attachVideo,
+    micEnabled,
+    setMicEnabled,
+    canPublishAudio,
+  };
+}

--- a/desktop/src/features/agents/lib/useAgentMediaRoom.ts
+++ b/desktop/src/features/agents/lib/useAgentMediaRoom.ts
@@ -19,6 +19,64 @@ import { createMicRequestQueue, type MicRequestQueue } from "./micRequestQueue";
 /** Bound the token request so an unreachable gateway surfaces in seconds. */
 const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
 
+/**
+ * Bound the token response.
+ *
+ * The endpoint is named by the announcement, so the address this client signs
+ * a NIP-98 request to and reads a reply from is chosen by the announcing
+ * agent. The request timeout already caps how long a reply may take, but a
+ * fast link delivers a great deal in fifteen seconds, and the reply is a small
+ * JSON object — kilobytes, not megabytes. Reading it in bounded chunks costs
+ * nothing and removes the question.
+ */
+const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
+
+/**
+ * Read a response body as JSON, refusing one that runs past the cap.
+ *
+ * Streams rather than checking `Content-Length`, because a body sent with
+ * chunked encoding declares no length and the header is the sender's claim in
+ * any case. Returns `{}` for a body that is absent or not JSON: the caller
+ * distinguishes an HTTP failure from a malformed success on its own, and both
+ * of those want the status, not a parse error.
+ */
+async function readCappedJson(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  if (!response.body) return {};
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_TOKEN_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new Error("The gateway's response was too large.");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(body));
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
 export type AgentMediaRoomStatus =
   | "idle"
   | "authorizing"
@@ -86,10 +144,7 @@ async function fetchViewerToken(session: AgentMediaSession): Promise<string> {
     body,
     signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
   });
-  const json = (await response.json().catch(() => ({}))) as Record<
-    string,
-    unknown
-  >;
+  const json = await readCappedJson(response);
   if (!response.ok) {
     const message =
       typeof json.error === "string" ? json.error : `HTTP ${response.status}`;

--- a/desktop/src/features/agents/lib/useAgentMediaRoom.ts
+++ b/desktop/src/features/agents/lib/useAgentMediaRoom.ts
@@ -14,6 +14,7 @@ import {
   type AgentMediaSession,
   trackBelongsToSessionAgent,
 } from "./agentMediaSession";
+import { createMicRequestQueue, type MicRequestQueue } from "./micRequestQueue";
 
 /** Bound the token request so an unreachable gateway surfaces in seconds. */
 const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
@@ -125,6 +126,16 @@ export function useAgentMediaRoom(
   const [audioBlocked, setAudioBlocked] = React.useState(false);
   const [micEnabled, setMicEnabledState] = React.useState(false);
   const roomRef = React.useRef<Room | null>(null);
+  // One queue for the hook's lifetime, reading the room at apply time rather
+  // than capturing it, so a room swap does not need a second queue.
+  const micQueueRef = React.useRef<MicRequestQueue | null>(null);
+  if (!micQueueRef.current) {
+    micQueueRef.current = createMicRequestQueue(async (enabled) => {
+      const room = roomRef.current;
+      if (!room) return;
+      await room.localParticipant.setMicrophoneEnabled(enabled);
+    });
+  }
 
   const canPublishAudio = session?.viewer.publish.includes("audio") ?? false;
 
@@ -141,6 +152,9 @@ export function useAgentMediaRoom(
     let disposed = false;
     const room = new Room();
     roomRef.current = room;
+    // Supersede any request still in flight for the previous room, so its
+    // outcome cannot write state that describes a connection now gone.
+    micQueueRef.current?.supersede();
     setMicEnabledState(false);
 
     const onSubscribed = (
@@ -272,13 +286,19 @@ export function useAgentMediaRoom(
     void room.startAudio().catch(() => {});
   }, []);
 
+  /**
+   * Turn this viewer's microphone on or off.
+   *
+   * The indicator moves at once, because the member asked and waiting on the
+   * device to agree makes the button feel broken. Reverting it is left to the
+   * queue, which reverts only on behalf of the request still speaking for the
+   * member — see {@link createMicRequestQueue} for why a stale revert here
+   * would be a microphone somebody believes is off.
+   */
   const setMicEnabled = React.useCallback((enabled: boolean) => {
-    const room = roomRef.current;
-    if (!room) return;
+    if (!roomRef.current) return;
     setMicEnabledState(enabled);
-    void room.localParticipant.setMicrophoneEnabled(enabled).catch(() => {
-      setMicEnabledState(false);
-    });
+    void micQueueRef.current?.request(enabled, () => setMicEnabledState(false));
   }, []);
 
   return {

--- a/desktop/src/features/agents/lib/useAgentMediaRoom.ts
+++ b/desktop/src/features/agents/lib/useAgentMediaRoom.ts
@@ -108,6 +108,12 @@ async function fetchViewerToken(session: AgentMediaSession): Promise<string> {
  * and silently hot-miking someone is not acceptable. Disconnects on unmount and
  * on session change — leaving the room open would keep a WebRTC connection (and
  * the provider's meter) running behind a closed panel.
+ *
+ * The identity of `session` is part of the contract, not only its contents: the
+ * effect below re-runs whenever the object changes, and re-running means
+ * disconnect, another viewer token and a fresh join. Pass the object
+ * `foldLiveSessions` produced — which is what `useAgentMediaSession` returns —
+ * never one re-derived per render.
  */
 export function useAgentMediaRoom(
   session: AgentMediaSession | null,

--- a/desktop/src/features/agents/lib/useAgentMediaRoom.ts
+++ b/desktop/src/features/agents/lib/useAgentMediaRoom.ts
@@ -10,7 +10,10 @@ import {
 } from "livekit-client";
 
 import { nip98PostHeader } from "@/shared/api/nip98";
-import type { AgentMediaSession } from "./agentMediaSession";
+import {
+  type AgentMediaSession,
+  trackBelongsToSessionAgent,
+} from "./agentMediaSession";
 
 /** Bound the token request so an unreachable gateway surfaces in seconds. */
 const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
@@ -34,6 +37,25 @@ export type AgentMediaRoomState = {
    * stale attachment keeps a decoded video surface alive after the panel closes.
    */
   attachVideo: ((element: HTMLVideoElement) => () => void) | null;
+  /**
+   * Attach the agent's audio to an element. Returns a detach function.
+   *
+   * Separate from `attachVideo` because a media element plays only the tracks
+   * in the stream it was given: attaching the video track alone renders a
+   * silent face, which is what shipped before this existed.
+   */
+  attachAudio: ((element: HTMLMediaElement) => () => void) | null;
+  /**
+   * True when the browser is refusing to start audio without a gesture.
+   *
+   * Autoplay policy is per-document and sticky, so opening the panel by
+   * clicking usually satisfies it — but the token fetch and the room connect
+   * happen after that click, and a viewer who arrived some other way has no
+   * gesture at all. When this is set, call `enableAudio` from a real click.
+   */
+  audioBlocked: boolean;
+  /** Start audio playback after a user gesture. Safe to call at any time. */
+  enableAudio: () => void;
   /** Whether the local microphone is publishing. */
   micEnabled: boolean;
   setMicEnabled: (enabled: boolean) => void;
@@ -93,6 +115,8 @@ export function useAgentMediaRoom(
   const [status, setStatus] = React.useState<AgentMediaRoomStatus>("idle");
   const [error, setError] = React.useState<string | null>(null);
   const [videoTrack, setVideoTrack] = React.useState<RemoteTrack | null>(null);
+  const [audioTrack, setAudioTrack] = React.useState<RemoteTrack | null>(null);
+  const [audioBlocked, setAudioBlocked] = React.useState(false);
   const [micEnabled, setMicEnabledState] = React.useState(false);
   const roomRef = React.useRef<Room | null>(null);
 
@@ -103,6 +127,8 @@ export function useAgentMediaRoom(
       setStatus("idle");
       setError(null);
       setVideoTrack(null);
+      setAudioTrack(null);
+      setAudioBlocked(false);
       return;
     }
 
@@ -116,29 +142,35 @@ export function useAgentMediaRoom(
       _publication: RemoteTrackPublication,
       participant: RemoteParticipant,
     ) => {
-      if (disposed || track.kind !== Track.Kind.Video) return;
-      // Only the announcing agent's video belongs in this panel — a room may
-      // carry other publishers once sessions go multi-party, and rendering the
-      // wrong face is worse than rendering none.
-      //
-      // The gateway is expected to put the agent's hex pubkey in its LiveKit
-      // identity. When it does, match on that. When it does not, fall back to
-      // the announcement: if it declares exactly one avatar publisher then a
-      // single video track is unambiguous, and refusing it would strand v1 on
-      // an identity convention the wire format never actually promised.
-      const identity = participant.identity.toLowerCase();
-      const identifiesAgent = identity.includes(session.agentPubkey);
-      const soleAvatarPublisher =
-        session.participants.filter((entry) =>
-          entry.tracks.includes("avatar_video"),
-        ).length === 1;
-      if (!identifiesAgent && !soleAvatarPublisher) return;
-      setVideoTrack(track);
+      if (disposed) return;
+      const isVideo = track.kind === Track.Kind.Video;
+      const isAudio = track.kind === Track.Kind.Audio;
+      if (!isVideo && !isAudio) return;
+
+      // Only the announcing agent's tracks belong in this panel; the rule
+      // itself lives with the other announcement logic so it can be tested
+      // without a room.
+      if (
+        !trackBelongsToSessionAgent(
+          session,
+          participant.identity,
+          isVideo ? "video" : "audio",
+        )
+      ) {
+        return;
+      }
+
+      if (isVideo) {
+        setVideoTrack(track);
+        return;
+      }
+      setAudioTrack(track);
     };
 
     const onUnsubscribed = (track: RemoteTrack) => {
       if (disposed) return;
       setVideoTrack((current) => (current === track ? null : current));
+      setAudioTrack((current) => (current === track ? null : current));
     };
 
     const onStateChanged = (state: ConnectionState) => {
@@ -150,13 +182,23 @@ export function useAgentMediaRoom(
     const onDisconnected = () => {
       if (disposed) return;
       setVideoTrack(null);
+      setAudioTrack(null);
       setStatus("idle");
+    };
+
+    // The browser, not LiveKit, decides whether audio may start. Track its
+    // answer rather than assuming success, so a blocked room can offer a
+    // gesture instead of playing silently and looking broken.
+    const onAudioPlaybackChanged = () => {
+      if (disposed) return;
+      setAudioBlocked(!room.canPlaybackAudio);
     };
 
     room
       .on(RoomEvent.TrackSubscribed, onSubscribed)
       .on(RoomEvent.TrackUnsubscribed, onUnsubscribed)
       .on(RoomEvent.ConnectionStateChanged, onStateChanged)
+      .on(RoomEvent.AudioPlaybackStatusChanged, onAudioPlaybackChanged)
       .on(RoomEvent.Disconnected, onDisconnected);
 
     setStatus("authorizing");
@@ -186,10 +228,13 @@ export function useAgentMediaRoom(
         .off(RoomEvent.TrackSubscribed, onSubscribed)
         .off(RoomEvent.TrackUnsubscribed, onUnsubscribed)
         .off(RoomEvent.ConnectionStateChanged, onStateChanged)
+        .off(RoomEvent.AudioPlaybackStatusChanged, onAudioPlaybackChanged)
         .off(RoomEvent.Disconnected, onDisconnected);
       void room.disconnect();
       if (roomRef.current === room) roomRef.current = null;
       setVideoTrack(null);
+      setAudioTrack(null);
+      setAudioBlocked(false);
     };
   }, [session]);
 
@@ -202,6 +247,24 @@ export function useAgentMediaRoom(
       };
     };
   }, [videoTrack]);
+
+  const attachAudio = React.useMemo(() => {
+    if (!audioTrack) return null;
+    return (element: HTMLMediaElement) => {
+      audioTrack.attach(element);
+      return () => {
+        audioTrack.detach(element);
+      };
+    };
+  }, [audioTrack]);
+
+  const enableAudio = React.useCallback(() => {
+    const room = roomRef.current;
+    if (!room) return;
+    // Success fires AudioPlaybackStatusChanged, which clears the flag; a
+    // rejection leaves it set so the affordance stays available.
+    void room.startAudio().catch(() => {});
+  }, []);
 
   const setMicEnabled = React.useCallback((enabled: boolean) => {
     const room = roomRef.current;
@@ -216,6 +279,9 @@ export function useAgentMediaRoom(
     status,
     error,
     attachVideo,
+    attachAudio,
+    audioBlocked,
+    enableAudio,
     micEnabled,
     setMicEnabled,
     canPublishAudio,

--- a/desktop/src/features/agents/lib/useAgentMediaSessions.ts
+++ b/desktop/src/features/agents/lib/useAgentMediaSessions.ts
@@ -7,14 +7,7 @@ import {
   KIND_AGENT_MEDIA_SESSION_STARTED,
 } from "@/shared/constants/kinds";
 import { normalizePubkey } from "@/shared/lib/pubkey";
-import {
-  type AgentMediaSession,
-  type AgentMediaSessionEnd,
-  endRetiresSession,
-  isSessionExpired,
-  parseAgentMediaSession,
-  parseAgentMediaSessionEnd,
-} from "./agentMediaSession";
+import { type AgentMediaSession, foldLiveSessions } from "./agentMediaSession";
 
 /**
  * Ceiling on an expiry wake-up.
@@ -27,26 +20,61 @@ import {
 const MAX_EXPIRY_TIMER_MS = 2 ** 31 - 1;
 
 /**
+ * One shared empty result, so "nothing live" is always the same reference.
+ *
+ * A fresh `[]` per mount or per reset would undo the identity preservation
+ * `foldLiveSessions` exists for: every consumer memo keyed on the list would
+ * recompute, and a channel with no session would churn as loudly as one with.
+ */
+const NO_SESSIONS: readonly AgentMediaSession[] = [];
+
+/**
+ * How far back the backfill looks for a session that could still be live.
+ *
+ * A start cannot outlive the relay's cap on `expires_at`, which is one hour
+ * past its `created_at`, so anything older than that is provably dead and
+ * asking for it only spends the page on corpses. Doubled deliberately: a client
+ * whose window is shorter than the relay's cap stops discovering live sessions
+ * on join, and it fails silently, so the slack absorbs that cap growing before
+ * this constant catches up with it.
+ */
+const HISTORY_WINDOW_SECS = 2 * 60 * 60;
+
+/**
+ * Page size for that backfill.
+ *
+ * The window above should be what bounds discovery, not the page. A relay
+ * returns the *newest* matching events, so too small a page silently drops the
+ * oldest still-live start as soon as a channel produces enough lifecycle
+ * events — at the previous 100 that took only fifty sessions in an hour.
+ *
+ * This is still a cap, so saturation is reported rather than passed over in
+ * silence. The durable fix is one replaceable event per agent instead of a
+ * growing log, which is a wire change rather than a bigger number here.
+ */
+const HISTORY_LIMIT = 500;
+
+/**
  * Live agent media sessions for a channel, newest first.
  *
- * Reconstructs from the full event history on every arrival rather than
- * mutating incrementally — the same choice `HuddleIndicator` makes, and for the
- * same reason: lifecycle events are rare, replay on reconnect is common, and a
- * fold over everything seen is correct regardless of arrival order. An end
- * event that arrives before its start still retires that start.
+ * The fold itself is `foldLiveSessions` — pure, and identity-preserving for a
+ * session that has not changed. That property is load-bearing: read its doc
+ * before altering how this hook publishes its result, because an open call is
+ * torn down and rejoined whenever the selected session's object changes.
  *
- * A session leaves the list two ways: an end event its owner is entitled to
- * publish, or its own announced expiry passing. The second exists because the
- * first may never happen — an agent that crashes publishes no 48201.
+ * This hook owns the parts a pure fold cannot: the subscription, the
+ * accumulated event set, and a wake-up for the one way a session can leave the
+ * list without any event arriving — its announced expiry passing.
  */
 export function useAgentMediaSessions(
   channelId: string | null,
-): AgentMediaSession[] {
-  const [sessions, setSessions] = React.useState<AgentMediaSession[]>([]);
+): readonly AgentMediaSession[] {
+  const [sessions, setSessions] =
+    React.useState<readonly AgentMediaSession[]>(NO_SESSIONS);
 
   React.useEffect(() => {
     if (!channelId) {
-      setSessions([]);
+      setSessions(NO_SESSIONS);
       return;
     }
 
@@ -54,38 +82,23 @@ export function useAgentMediaSessions(
     let cleanup: (() => void) | null = null;
     let expiryTimer: ReturnType<typeof setTimeout> | null = null;
     const seen = new Map<string, RelayEvent>();
+    // The previous fold, held here rather than read back from state: each
+    // arrival is its own React commit, and a fold must build on the objects the
+    // last one produced for their identity to survive.
+    let live: readonly AgentMediaSession[] = NO_SESSIONS;
 
     function reconstruct() {
-      const started: AgentMediaSession[] = [];
-      const ends: AgentMediaSessionEnd[] = [];
-
-      for (const event of seen.values()) {
-        if (event.kind === KIND_AGENT_MEDIA_SESSION_STARTED) {
-          const session = parseAgentMediaSession(event);
-          if (session) started.push(session);
-          continue;
-        }
-        if (event.kind === KIND_AGENT_MEDIA_SESSION_ENDED) {
-          const end = parseAgentMediaSessionEnd(event);
-          if (end) ends.push(end);
-        }
-      }
-
-      const nowSeconds = Math.floor(Date.now() / 1000);
-      const live = started
-        .filter(
-          (session) =>
-            // Check the ender's standing rather than matching on the event id
-            // alone: without it any member could retire another agent's live
-            // card by publishing a 48201 that names its start.
-            !ends.some((end) => endRetiresSession(end, session)) &&
-            !isSessionExpired(session, nowSeconds),
-        )
-        .sort((a, b) => b.startedAt - a.startedAt);
-
+      const next = foldLiveSessions(
+        seen.values(),
+        live,
+        Math.floor(Date.now() / 1000),
+      );
       if (disposed) return;
-      setSessions(live);
-      scheduleNextExpiry(live);
+      live = next;
+      // An unchanged fold returns the same array, so React bails out here
+      // rather than re-rendering every consumer.
+      setSessions(next);
+      scheduleNextExpiry(next);
     }
 
     /**
@@ -95,12 +108,12 @@ export function useAgentMediaSessions(
      * to react to, so on a quiet channel the card would stay on screen until
      * something unrelated arrived.
      */
-    function scheduleNextExpiry(live: AgentMediaSession[]) {
+    function scheduleNextExpiry(current: readonly AgentMediaSession[]) {
       if (expiryTimer !== null) clearTimeout(expiryTimer);
       expiryTimer = null;
-      if (live.length === 0) return;
+      if (current.length === 0) return;
 
-      const soonest = Math.min(...live.map((session) => session.expiresAt));
+      const soonest = Math.min(...current.map((session) => session.expiresAt));
       // A second past the boundary rather than on it, so the re-run sees the
       // expiry as passed under either rounding of the clock.
       const delayMs = Math.min(
@@ -109,6 +122,11 @@ export function useAgentMediaSessions(
       );
       expiryTimer = setTimeout(reconstruct, delayMs);
     }
+
+    // Counted until readiness only, so it measures the stored backfill rather
+    // than the live tail that follows it.
+    let backfilled = 0;
+    let backfillComplete = false;
 
     relayClient
       .subscribeLive(
@@ -123,14 +141,31 @@ export function useAgentMediaSessions(
             KIND_AGENT_MEDIA_SESSION_ENDED,
           ],
           "#h": [channelId],
-          limit: 100,
+          // Ask for the events that can still describe a live session, rather
+          // than for a fixed number of the most recent ones. An end always
+          // follows the start it closes, so bounding the window by a start's
+          // maximum lifetime keeps both halves of every pair that matters.
+          since: Math.floor(Date.now() / 1000) - HISTORY_WINDOW_SECS,
+          limit: HISTORY_LIMIT,
         },
         (event: RelayEvent) => {
           if (disposed) return;
+          if (!backfillComplete) backfilled += 1;
           // Dedup by event id — reconnect replays history.
           if (seen.has(event.id)) return;
           seen.set(event.id, event);
           reconstruct();
+        },
+        (readiness) => {
+          backfillComplete = true;
+          if (disposed || backfilled < HISTORY_LIMIT) return;
+          // Saturated: the relay had at least a full page inside the window, so
+          // the oldest live session in this channel may simply not have been
+          // sent. Silence here would read as "nothing else is live".
+          console.warn(
+            "[useAgentMediaSessions] lifecycle backfill filled its page; an older live session may be missing",
+            { channelId, limit: HISTORY_LIMIT, readiness },
+          );
         },
       )
       .then((dispose) => {
@@ -152,7 +187,7 @@ export function useAgentMediaSessions(
       disposed = true;
       if (expiryTimer !== null) clearTimeout(expiryTimer);
       cleanup?.();
-      setSessions([]);
+      setSessions(NO_SESSIONS);
     };
   }, [channelId]);
 
@@ -171,6 +206,8 @@ export function useAgentMediaSession(
     // normalized) but callers pass an agent record's pubkey, which may carry
     // mixed case. An unnormalized compare silently never matches.
     const wanted = normalizePubkey(agentPubkey);
+    // `find` returns the fold's own object, so the identity `useAgentMediaRoom`
+    // depends on is passed through rather than rebuilt here.
     return sessions.find((session) => session.agentPubkey === wanted) ?? null;
   }, [sessions, agentPubkey]);
 }

--- a/desktop/src/features/agents/lib/useAgentMediaSessions.ts
+++ b/desktop/src/features/agents/lib/useAgentMediaSessions.ts
@@ -1,0 +1,176 @@
+import * as React from "react";
+
+import { relayClient } from "@/shared/api/relayClient";
+import type { RelayEvent } from "@/shared/api/types";
+import {
+  KIND_AGENT_MEDIA_SESSION_ENDED,
+  KIND_AGENT_MEDIA_SESSION_STARTED,
+} from "@/shared/constants/kinds";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import {
+  type AgentMediaSession,
+  type AgentMediaSessionEnd,
+  endRetiresSession,
+  isSessionExpired,
+  parseAgentMediaSession,
+  parseAgentMediaSessionEnd,
+} from "./agentMediaSession";
+
+/**
+ * Ceiling on an expiry wake-up.
+ *
+ * `setTimeout` truncates a delay past 2^31 ms to a 32-bit value, which fires
+ * almost immediately and spins. The relay caps a session's claimed duration
+ * well below this, but an announcement can also arrive from a relay that does
+ * not — clamp rather than trust the wire.
+ */
+const MAX_EXPIRY_TIMER_MS = 2 ** 31 - 1;
+
+/**
+ * Live agent media sessions for a channel, newest first.
+ *
+ * Reconstructs from the full event history on every arrival rather than
+ * mutating incrementally — the same choice `HuddleIndicator` makes, and for the
+ * same reason: lifecycle events are rare, replay on reconnect is common, and a
+ * fold over everything seen is correct regardless of arrival order. An end
+ * event that arrives before its start still retires that start.
+ *
+ * A session leaves the list two ways: an end event its owner is entitled to
+ * publish, or its own announced expiry passing. The second exists because the
+ * first may never happen — an agent that crashes publishes no 48201.
+ */
+export function useAgentMediaSessions(
+  channelId: string | null,
+): AgentMediaSession[] {
+  const [sessions, setSessions] = React.useState<AgentMediaSession[]>([]);
+
+  React.useEffect(() => {
+    if (!channelId) {
+      setSessions([]);
+      return;
+    }
+
+    let disposed = false;
+    let cleanup: (() => void) | null = null;
+    let expiryTimer: ReturnType<typeof setTimeout> | null = null;
+    const seen = new Map<string, RelayEvent>();
+
+    function reconstruct() {
+      const started: AgentMediaSession[] = [];
+      const ends: AgentMediaSessionEnd[] = [];
+
+      for (const event of seen.values()) {
+        if (event.kind === KIND_AGENT_MEDIA_SESSION_STARTED) {
+          const session = parseAgentMediaSession(event);
+          if (session) started.push(session);
+          continue;
+        }
+        if (event.kind === KIND_AGENT_MEDIA_SESSION_ENDED) {
+          const end = parseAgentMediaSessionEnd(event);
+          if (end) ends.push(end);
+        }
+      }
+
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const live = started
+        .filter(
+          (session) =>
+            // Check the ender's standing rather than matching on the event id
+            // alone: without it any member could retire another agent's live
+            // card by publishing a 48201 that names its start.
+            !ends.some((end) => endRetiresSession(end, session)) &&
+            !isSessionExpired(session, nowSeconds),
+        )
+        .sort((a, b) => b.startedAt - a.startedAt);
+
+      if (disposed) return;
+      setSessions(live);
+      scheduleNextExpiry(live);
+    }
+
+    /**
+     * Re-run the fold when the soonest expiry passes.
+     *
+     * Nothing else would: a session that dies without a 48201 leaves no event
+     * to react to, so on a quiet channel the card would stay on screen until
+     * something unrelated arrived.
+     */
+    function scheduleNextExpiry(live: AgentMediaSession[]) {
+      if (expiryTimer !== null) clearTimeout(expiryTimer);
+      expiryTimer = null;
+      if (live.length === 0) return;
+
+      const soonest = Math.min(...live.map((session) => session.expiresAt));
+      // A second past the boundary rather than on it, so the re-run sees the
+      // expiry as passed under either rounding of the clock.
+      const delayMs = Math.min(
+        Math.max(soonest * 1000 - Date.now(), 0) + 1_000,
+        MAX_EXPIRY_TIMER_MS,
+      );
+      expiryTimer = setTimeout(reconstruct, delayMs);
+    }
+
+    relayClient
+      .subscribeLive(
+        {
+          // Narrow rather than riding the channel window: the panel needs to
+          // know a session is live the moment it opens, and must not have that
+          // answer delayed behind a page of regular messages. History is
+          // included so a member who opens the channel mid-session still
+          // discovers it.
+          kinds: [
+            KIND_AGENT_MEDIA_SESSION_STARTED,
+            KIND_AGENT_MEDIA_SESSION_ENDED,
+          ],
+          "#h": [channelId],
+          limit: 100,
+        },
+        (event: RelayEvent) => {
+          if (disposed) return;
+          // Dedup by event id — reconnect replays history.
+          if (seen.has(event.id)) return;
+          seen.set(event.id, event);
+          reconstruct();
+        },
+      )
+      .then((dispose) => {
+        if (disposed) {
+          void dispose();
+          return;
+        }
+        cleanup = () => void dispose();
+      })
+      .catch((error) => {
+        console.error(
+          "[useAgentMediaSessions] subscription failed",
+          channelId,
+          error,
+        );
+      });
+
+    return () => {
+      disposed = true;
+      if (expiryTimer !== null) clearTimeout(expiryTimer);
+      cleanup?.();
+      setSessions([]);
+    };
+  }, [channelId]);
+
+  return sessions;
+}
+
+/** The live session belonging to `agentPubkey`, if there is one. */
+export function useAgentMediaSession(
+  channelId: string | null,
+  agentPubkey: string | null,
+): AgentMediaSession | null {
+  const sessions = useAgentMediaSessions(channelId);
+  return React.useMemo(() => {
+    if (!agentPubkey) return null;
+    // Normalize both sides: session pubkeys come from parsed events (already
+    // normalized) but callers pass an agent record's pubkey, which may carry
+    // mixed case. An unnormalized compare silently never matches.
+    const wanted = normalizePubkey(agentPubkey);
+    return sessions.find((session) => session.agentPubkey === wanted) ?? null;
+  }, [sessions, agentPubkey]);
+}

--- a/desktop/src/features/agents/lib/useAutoOpenRequestedMedia.ts
+++ b/desktop/src/features/agents/lib/useAutoOpenRequestedMedia.ts
@@ -1,0 +1,128 @@
+import * as React from "react";
+
+import { relayClient } from "@/shared/api/relayClient";
+import {
+  KIND_STREAM_MESSAGE,
+  KIND_STREAM_MESSAGE_V2,
+} from "@/shared/constants/kinds";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { planAutoOpen } from "./agentMediaAutoOpen";
+import type { AgentMediaSession } from "./agentMediaSession";
+
+/**
+ * Sessions whose panel has already been opened for this member.
+ *
+ * Module-level rather than a ref, so closing the panel and navigating away does
+ * not re-arm the auto-open. Community-scoped, therefore reset in
+ * `resetCommunityState()` — see `useCommunityInit.ts`.
+ */
+const autoOpened = new Set<string>();
+
+/** Forget which sessions have auto-opened. Called on a community switch. */
+export function resetAutoOpenedAgentMedia() {
+  autoOpened.clear();
+}
+
+/** Value stored for a source event that was looked up but has no author. */
+const NO_AUTHOR = "";
+
+const EMPTY_REQUESTERS: ReadonlyMap<string, string> = new Map();
+
+/**
+ * Open an agent's session panel when this member's own mention started it.
+ *
+ * The agent's "I'm live in this channel" message and the members-bar indicator
+ * stay as they are — they are the offer, for anyone in the channel and for
+ * anyone arriving later. This adds the one case where acting for the member is
+ * warranted rather than presumptuous: they asked a moment ago, so the panel
+ * they were going to click opens itself.
+ *
+ * The requester is read from the announcement's `e` tag, which names the
+ * message that caused the session. That message's author is fetched by id when
+ * it is not already known, because the member may have sent it from another
+ * device — the local composer's memory would not cover that.
+ *
+ * `panelOpen` suppresses the takeover when a panel is already on screen, and
+ * the session is marked handled anyway. Pulling somebody out of an agent panel
+ * they are reading is worse than not opening; deferring it until they close
+ * that panel would be worse still, because the ambush would arrive with no
+ * connection to anything they just did.
+ */
+export function useAutoOpenRequestedAgentMedia({
+  currentPubkey,
+  openAgentSession,
+  panelOpen,
+  sessions,
+}: {
+  currentPubkey: string | null | undefined;
+  openAgentSession: (agentPubkey: string, channelId?: string | null) => void;
+  panelOpen: boolean;
+  sessions: readonly AgentMediaSession[];
+}) {
+  // Normalized here rather than trusted from the caller: a mixed-case pubkey
+  // would compare unequal to the event author and quietly open nothing.
+  const me = currentPubkey ? normalizePubkey(currentPubkey) : null;
+  const [requesters, setRequesters] =
+    React.useState<ReadonlyMap<string, string>>(EMPTY_REQUESTERS);
+  // Kept in refs so a new callback identity or a panel opening does not re-run
+  // the decision; only the sessions and what is known about them should.
+  const openRef = React.useRef(openAgentSession);
+  openRef.current = openAgentSession;
+  const panelOpenRef = React.useRef(panelOpen);
+  panelOpenRef.current = panelOpen;
+
+  React.useEffect(() => {
+    const plan = planAutoOpen({
+      currentPubkey: me,
+      handled: autoOpened,
+      nowSeconds: Math.floor(Date.now() / 1000),
+      requesterOf: (sourceEventId) => requesters.get(sourceEventId),
+      sessions,
+    });
+
+    if (plan.open) {
+      const session = plan.open;
+      autoOpened.add(session.eventId);
+      if (!panelOpenRef.current) {
+        openRef.current(session.agentPubkey, session.channelId);
+      }
+      return;
+    }
+
+    if (plan.resolve.length === 0) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const events = await relayClient.fetchEvents({
+          ids: plan.resolve,
+          // A filter without kinds trips the relay's p-gate; both message kinds
+          // can carry a mention.
+          kinds: [KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_V2],
+          limit: plan.resolve.length,
+        });
+        if (cancelled) return;
+        setRequesters((previous) => {
+          const next = new Map(previous);
+          // Record every id that was asked about, found or not, so a message
+          // this member cannot read is not looked up again on every arrival.
+          for (const id of plan.resolve) next.set(id, NO_AUTHOR);
+          for (const event of events) {
+            next.set(event.id, normalizePubkey(event.pubkey));
+          }
+          return next;
+        });
+      } catch (error) {
+        if (cancelled) return;
+        console.error(
+          "[useAutoOpenRequestedAgentMedia] could not resolve a session's source message",
+          error,
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [me, requesters, sessions]);
+}

--- a/desktop/src/features/agents/lib/useAutoOpenRequestedMedia.ts
+++ b/desktop/src/features/agents/lib/useAutoOpenRequestedMedia.ts
@@ -1,12 +1,13 @@
 import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
+import type { RelayEvent } from "@/shared/api/types";
 import {
   KIND_STREAM_MESSAGE,
   KIND_STREAM_MESSAGE_V2,
 } from "@/shared/constants/kinds";
 import { normalizePubkey } from "@/shared/lib/pubkey";
-import { planAutoOpen } from "./agentMediaAutoOpen";
+import { type AutoOpenSource, planAutoOpen } from "./agentMediaAutoOpen";
 import type { AgentMediaSession } from "./agentMediaSession";
 
 /**
@@ -23,10 +24,38 @@ export function resetAutoOpenedAgentMedia() {
   autoOpened.clear();
 }
 
-/** Value stored for a source event that was looked up but has no author. */
-const NO_AUTHOR = "";
+/**
+ * Stored for a source event that was asked about but did not come back.
+ *
+ * An empty author matches no pubkey, so this refuses the session outright
+ * rather than leaving it pending and looked up again on every arrival.
+ */
+const UNREADABLE_SOURCE: AutoOpenSource = {
+  author: "",
+  channelId: null,
+  addressed: new Set(),
+};
 
-const EMPTY_REQUESTERS: ReadonlyMap<string, string> = new Map();
+const EMPTY_SOURCES: ReadonlyMap<string, AutoOpenSource> = new Map();
+
+/**
+ * Reduce a source message to the facts the auto-open decision checks.
+ *
+ * Both message kinds carry the channel in `h` and address people with `p`,
+ * so one reader covers them. `p` is read as a set because a message addresses
+ * everyone it names — its author included, on the reply path — and the
+ * decision only ever asks whether a particular agent is among them.
+ */
+function readSource(event: RelayEvent): AutoOpenSource {
+  let channelId: string | null = null;
+  const addressed = new Set<string>();
+  for (const tag of event.tags ?? []) {
+    if (typeof tag[1] !== "string" || tag[1].length === 0) continue;
+    if (tag[0] === "h" && channelId === null) channelId = tag[1];
+    else if (tag[0] === "p") addressed.add(normalizePubkey(tag[1]));
+  }
+  return { author: normalizePubkey(event.pubkey), channelId, addressed };
+}
 
 /**
  * Open an agent's session panel when this member's own mention started it.
@@ -37,10 +66,11 @@ const EMPTY_REQUESTERS: ReadonlyMap<string, string> = new Map();
  * warranted rather than presumptuous: they asked a moment ago, so the panel
  * they were going to click opens itself.
  *
- * The requester is read from the announcement's `e` tag, which names the
- * message that caused the session. That message's author is fetched by id when
- * it is not already known, because the member may have sent it from another
- * device — the local composer's memory would not cover that.
+ * The announcement's `e` tag names the message that caused the session, and
+ * that message is fetched by id — not read from the local composer, which
+ * would miss a mention this member sent from another device. What the fetched
+ * message has to prove is in {@link planAutoOpen}; fetching it is the only
+ * reason this hook exists, because the announcement alone cannot establish it.
  *
  * `panelOpen` suppresses the takeover when a panel is already on screen, and
  * the session is marked handled anyway. Pulling somebody out of an agent panel
@@ -62,8 +92,8 @@ export function useAutoOpenRequestedAgentMedia({
   // Normalized here rather than trusted from the caller: a mixed-case pubkey
   // would compare unequal to the event author and quietly open nothing.
   const me = currentPubkey ? normalizePubkey(currentPubkey) : null;
-  const [requesters, setRequesters] =
-    React.useState<ReadonlyMap<string, string>>(EMPTY_REQUESTERS);
+  const [sources, setSources] =
+    React.useState<ReadonlyMap<string, AutoOpenSource>>(EMPTY_SOURCES);
   // Kept in refs so a new callback identity or a panel opening does not re-run
   // the decision; only the sessions and what is known about them should.
   const openRef = React.useRef(openAgentSession);
@@ -76,7 +106,7 @@ export function useAutoOpenRequestedAgentMedia({
       currentPubkey: me,
       handled: autoOpened,
       nowSeconds: Math.floor(Date.now() / 1000),
-      requesterOf: (sourceEventId) => requesters.get(sourceEventId),
+      sourceOf: (sourceEventId) => sources.get(sourceEventId),
       sessions,
     });
 
@@ -102,14 +132,12 @@ export function useAutoOpenRequestedAgentMedia({
           limit: plan.resolve.length,
         });
         if (cancelled) return;
-        setRequesters((previous) => {
+        setSources((previous) => {
           const next = new Map(previous);
           // Record every id that was asked about, found or not, so a message
           // this member cannot read is not looked up again on every arrival.
-          for (const id of plan.resolve) next.set(id, NO_AUTHOR);
-          for (const event of events) {
-            next.set(event.id, normalizePubkey(event.pubkey));
-          }
+          for (const id of plan.resolve) next.set(id, UNREADABLE_SOURCE);
+          for (const event of events) next.set(event.id, readSource(event));
           return next;
         });
       } catch (error) {
@@ -124,5 +152,5 @@ export function useAutoOpenRequestedAgentMedia({
     return () => {
       cancelled = true;
     };
-  }, [me, requesters, sessions]);
+  }, [me, sources, sessions]);
 }

--- a/desktop/src/features/agents/ui/AgentMediaIndicator.tsx
+++ b/desktop/src/features/agents/ui/AgentMediaIndicator.tsx
@@ -1,0 +1,124 @@
+import { Video } from "lucide-react";
+import * as React from "react";
+
+import { useAgentMediaSessions } from "@/features/agents/lib/useAgentMediaSessions";
+import { useOpenAgentActivity } from "@/features/agents/useOpenAgentActivity";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { DropdownMenuItem } from "@/shared/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+
+type AgentMediaIndicatorProps = {
+  channelId: string;
+  className?: string;
+  renderMode?: "button" | "menu-item";
+};
+
+/**
+ * Channel-level presence for a live agent media session (kind:48200).
+ *
+ * Media is channel presence, like a huddle — not an entry in one agent's work
+ * log. It sits beside `HuddleIndicator` for that reason, and deliberately not
+ * in the composer activity bar: that bar reports agents *working* (kind:24200
+ * observer frames, kind:20002 typing), and an agent on camera is a different
+ * claim that should not be filed under the same affordance. The bar is also
+ * hidden whenever attention is away from the composer, which is exactly when a
+ * live session most needs to be findable.
+ *
+ * There is no start action, which is the other difference from a huddle: a
+ * session is announced by the agent that hosts it, so a member can only join
+ * one that already exists. With nothing live this renders nothing.
+ *
+ * Clicking opens the agent's session panel, where `AgentMediaSurface` mounts
+ * and requests the viewer token. `useOpenAgentActivity` covers both routes:
+ * in a channel view an `AgentSessionProvider` opens the panel in place;
+ * elsewhere (e.g. the inbox) it navigates to the channel first.
+ */
+export function AgentMediaIndicator({
+  channelId,
+  className,
+  renderMode = "button",
+}: AgentMediaIndicatorProps) {
+  const sessions = useAgentMediaSessions(channelId);
+  const { openAgentActivity } = useOpenAgentActivity();
+  const agentPubkeys = React.useMemo(
+    () => sessions.map((session) => session.agentPubkey),
+    [sessions],
+  );
+  // Named agents read far better than truncated keys, and the batch query is
+  // disabled on an empty list — so a channel with no session costs no request.
+  const profilesQuery = useUsersBatchQuery(agentPubkeys);
+  const profiles = profilesQuery.data?.profiles;
+
+  const labels = React.useMemo(
+    () =>
+      sessions.map((session) =>
+        resolveUserLabel({ pubkey: session.agentPubkey, profiles }),
+      ),
+    [profiles, sessions],
+  );
+
+  if (sessions.length === 0) {
+    return null;
+  }
+
+  // Newest first (the hook's order): the session a member most likely means.
+  const primary = sessions[0];
+  const sessionCount = sessions.length;
+  const description =
+    sessionCount === 1
+      ? `${labels[0]} is live`
+      : `${sessionCount} agents are live`;
+
+  function handleOpen() {
+    openAgentActivity(primary.agentPubkey, { channelId });
+  }
+
+  if (renderMode === "menu-item") {
+    return (
+      <DropdownMenuItem
+        className={className}
+        data-testid="channel-agent-media-trigger"
+        onSelect={handleOpen}
+      >
+        <Video />
+        <span>{description}</span>
+        {sessionCount > 1 ? (
+          <span className="ml-auto text-xs text-muted-foreground">
+            {sessionCount}
+          </span>
+        ) : null}
+      </DropdownMenuItem>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          aria-label={`Open live video — ${description}`}
+          className={cn("relative", className)}
+          data-testid="channel-agent-media-trigger"
+          onClick={handleOpen}
+          size="icon"
+          type="button"
+          variant="outline"
+        >
+          <Video />
+          {/* Distinct from the huddle ring: audio and video are different
+              rooms, and two identical pulses beside each other read as one
+              feature with a duplicated button. */}
+          <span className="absolute inset-0 animate-pulse rounded-lg ring-2 ring-primary/60" />
+          {sessionCount > 1 ? (
+            <span className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full border border-border bg-background px-0.5 text-2xs font-bold text-muted-foreground">
+              {sessionCount}
+            </span>
+          ) : null}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{description}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/desktop/src/features/agents/ui/AgentMediaIndicator.tsx
+++ b/desktop/src/features/agents/ui/AgentMediaIndicator.tsx
@@ -1,13 +1,22 @@
 import { Video } from "lucide-react";
 import * as React from "react";
 
+import {
+  agentMediaEntries,
+  describeAgentMediaEntries,
+} from "@/features/agents/lib/agentMediaEntries";
 import { useAgentMediaSessions } from "@/features/agents/lib/useAgentMediaSessions";
 import { useOpenAgentActivity } from "@/features/agents/useOpenAgentActivity";
-import { resolveUserLabel } from "@/features/profile/lib/identity";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { DropdownMenuItem } from "@/shared/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 type AgentMediaIndicatorProps = {
@@ -31,10 +40,14 @@ type AgentMediaIndicatorProps = {
  * session is announced by the agent that hosts it, so a member can only join
  * one that already exists. With nothing live this renders nothing.
  *
- * Clicking opens the agent's session panel, where `AgentMediaSurface` mounts
- * and requests the viewer token. `useOpenAgentActivity` covers both routes:
- * in a channel view an `AgentSessionProvider` opens the panel in place;
- * elsewhere (e.g. the inbox) it navigates to the channel first.
+ * With one agent live, clicking opens its session panel. With several, the
+ * control opens a list and every agent gets its own row — a count on its own
+ * named a number the member could not act on, since the button opened whichever
+ * session was newest and the others had no affordance here at all. Either way
+ * the panel is where `AgentMediaSurface` mounts and requests the viewer token.
+ * `useOpenAgentActivity` covers both routes: in a channel view an
+ * `AgentSessionProvider` opens the panel in place; elsewhere (e.g. the inbox) it
+ * navigates to the channel first.
  */
 export function AgentMediaIndicator({
   channelId,
@@ -44,7 +57,7 @@ export function AgentMediaIndicator({
   const sessions = useAgentMediaSessions(channelId);
   const { openAgentActivity } = useOpenAgentActivity();
   const agentPubkeys = React.useMemo(
-    () => sessions.map((session) => session.agentPubkey),
+    () => Array.from(new Set(sessions.map((session) => session.agentPubkey))),
     [sessions],
   );
   // Named agents read far better than truncated keys, and the batch query is
@@ -52,73 +65,96 @@ export function AgentMediaIndicator({
   const profilesQuery = useUsersBatchQuery(agentPubkeys);
   const profiles = profilesQuery.data?.profiles;
 
-  const labels = React.useMemo(
+  const entries = React.useMemo(
     () =>
-      sessions.map((session) =>
-        resolveUserLabel({ pubkey: session.agentPubkey, profiles }),
+      agentMediaEntries(sessions, (agentPubkey) =>
+        resolveUserLabel({ pubkey: agentPubkey, profiles }),
       ),
     [profiles, sessions],
   );
 
-  if (sessions.length === 0) {
+  const open = React.useCallback(
+    (agentPubkey: string) => {
+      openAgentActivity(agentPubkey, { channelId });
+    },
+    [channelId, openAgentActivity],
+  );
+
+  if (entries.length === 0) {
     return null;
   }
 
-  // Newest first (the hook's order): the session a member most likely means.
-  const primary = sessions[0];
-  const sessionCount = sessions.length;
-  const description =
-    sessionCount === 1
-      ? `${labels[0]} is live`
-      : `${sessionCount} agents are live`;
+  const description = describeAgentMediaEntries(entries);
+  const sole = entries.length === 1 ? entries[0] : null;
 
-  function handleOpen() {
-    openAgentActivity(primary.agentPubkey, { channelId });
-  }
-
-  if (renderMode === "menu-item") {
-    return (
+  const renderRows = (itemClassName?: string) =>
+    entries.map((entry) => (
       <DropdownMenuItem
-        className={className}
-        data-testid="channel-agent-media-trigger"
-        onSelect={handleOpen}
+        className={itemClassName}
+        data-testid="channel-agent-media-item"
+        key={entry.agentPubkey}
+        onSelect={() => open(entry.agentPubkey)}
       >
         <Video />
-        <span>{description}</span>
-        {sessionCount > 1 ? (
-          <span className="ml-auto text-xs text-muted-foreground">
-            {sessionCount}
-          </span>
-        ) : null}
+        <span>{`${entry.label} is live`}</span>
       </DropdownMenuItem>
+    ));
+
+  // Already inside the channel actions menu: contribute rows straight to it
+  // rather than nesting a second menu, so one live agent costs one click here
+  // too. A fragment rather than a wrapper, so the items stay direct children of
+  // the menu content that styles and navigates them.
+  if (renderMode === "menu-item") {
+    return <>{renderRows(className)}</>;
+  }
+
+  const trigger = (
+    <Button
+      aria-label={
+        sole
+          ? `Open live video — ${description}`
+          : `Choose a live agent — ${description}`
+      }
+      className={cn("relative", className)}
+      data-testid="channel-agent-media-trigger"
+      // Left off in the several-agents case so the menu trigger can supply its
+      // own: Radix merges an `asChild` child's handler with the one it injects,
+      // and both would fire.
+      onClick={sole ? () => open(sole.agentPubkey) : undefined}
+      size="icon"
+      type="button"
+      variant="outline"
+    >
+      <Video />
+      {/* Distinct from the huddle ring: audio and video are different
+          rooms, and two identical pulses beside each other read as one
+          feature with a duplicated button. */}
+      <span className="absolute inset-0 animate-pulse rounded-lg ring-2 ring-primary/60" />
+      {entries.length > 1 ? (
+        <span className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full border border-border bg-background px-0.5 text-2xs font-bold text-muted-foreground">
+          {entries.length}
+        </span>
+      ) : null}
+    </Button>
+  );
+
+  if (sole) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+        <TooltipContent>{description}</TooltipContent>
+      </Tooltip>
     );
   }
 
+  // No tooltip on this branch: the menu names every agent, and a tooltip
+  // wrapping a menu trigger fights the popover for the same pointer.
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          aria-label={`Open live video — ${description}`}
-          className={cn("relative", className)}
-          data-testid="channel-agent-media-trigger"
-          onClick={handleOpen}
-          size="icon"
-          type="button"
-          variant="outline"
-        >
-          <Video />
-          {/* Distinct from the huddle ring: audio and video are different
-              rooms, and two identical pulses beside each other read as one
-              feature with a duplicated button. */}
-          <span className="absolute inset-0 animate-pulse rounded-lg ring-2 ring-primary/60" />
-          {sessionCount > 1 ? (
-            <span className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full border border-border bg-background px-0.5 text-2xs font-bold text-muted-foreground">
-              {sessionCount}
-            </span>
-          ) : null}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>{description}</TooltipContent>
-    </Tooltip>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        {renderRows()}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/desktop/src/features/agents/ui/AgentMediaSurface.tsx
+++ b/desktop/src/features/agents/ui/AgentMediaSurface.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+import { CircleAlert, Mic, MicOff, VideoOff } from "lucide-react";
+
+import type { AgentMediaSession } from "@/features/agents/lib/agentMediaSession";
+import { useAgentMediaRoom } from "@/features/agents/lib/useAgentMediaRoom";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { Spinner } from "@/shared/ui/spinner";
+
+type AgentMediaSurfaceProps = {
+  agentLabel: string;
+  className?: string;
+  session: AgentMediaSession;
+};
+
+/** Attach the remote video track to a `<video>` for as long as both exist. */
+function AgentVideoElement({
+  attachVideo,
+  label,
+}: {
+  attachVideo: (element: HTMLVideoElement) => () => void;
+  label: string;
+}) {
+  const ref = React.useRef<HTMLVideoElement | null>(null);
+
+  React.useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    return attachVideo(element);
+  }, [attachVideo]);
+
+  return (
+    // Live WebRTC stream: a static track file cannot caption it. The agent's
+    // speech is transcribed into the channel as signed events instead, which is
+    // the durable accessible record.
+    // biome-ignore lint/a11y/useMediaCaption: live stream, see above
+    <video
+      aria-label={`${label} video`}
+      autoPlay
+      className="h-full w-full object-cover"
+      data-testid="agent-media-video"
+      // Not muted: the agent's audio rides its own track in the same room, and
+      // hearing it is the point. Lip-sync holds because both come from one
+      // transport with one clock.
+      playsInline
+      ref={ref}
+    />
+  );
+}
+
+/**
+ * The live video surface for an agent media session.
+ *
+ * Renders inside the agent's session panel, above its activity — the face and
+ * its work in one place, which is where the conversation already is. The tile
+ * carries the face only: tool results, transcripts and artifacts stay in the
+ * channel as signed events, so the avatar speaks while Buzz keeps the evidence.
+ */
+export function AgentMediaSurface({
+  agentLabel,
+  className,
+  session,
+}: AgentMediaSurfaceProps) {
+  const {
+    status,
+    error,
+    attachVideo,
+    micEnabled,
+    setMicEnabled,
+    canPublishAudio,
+  } = useAgentMediaRoom(session);
+
+  return (
+    <section
+      aria-label={`${agentLabel} live video`}
+      className={cn("flex flex-col gap-2", className)}
+      data-testid="agent-media-surface"
+    >
+      <div className="relative flex aspect-video w-full items-center justify-center overflow-hidden rounded-lg bg-muted">
+        {status === "error" ? (
+          <div
+            className="flex flex-col items-center gap-2 px-6 text-center"
+            data-testid="agent-media-error"
+          >
+            <CircleAlert className="size-6 text-destructive" />
+            <span className="text-sm text-muted-foreground">
+              {error ?? "Could not join the session."}
+            </span>
+          </div>
+        ) : attachVideo ? (
+          <AgentVideoElement attachVideo={attachVideo} label={agentLabel} />
+        ) : status === "connected" ? (
+          <div
+            className="flex flex-col items-center gap-2 text-muted-foreground"
+            data-testid="agent-media-no-video"
+          >
+            <VideoOff className="size-6" />
+            <span className="text-sm">No video on this session yet.</span>
+          </div>
+        ) : (
+          <div
+            className="flex flex-col items-center gap-2 text-muted-foreground"
+            data-testid="agent-media-connecting"
+          >
+            <Spinner />
+            <span className="text-sm">
+              {status === "authorizing" ? "Authorizing…" : "Connecting…"}
+            </span>
+          </div>
+        )}
+
+        {canPublishAudio ? (
+          <Button
+            aria-label={micEnabled ? "Mute microphone" : "Unmute microphone"}
+            className="absolute bottom-2 right-2"
+            data-testid="agent-media-mic-toggle"
+            disabled={status !== "connected"}
+            onClick={() => setMicEnabled(!micEnabled)}
+            size="icon"
+            title={micEnabled ? "Mute microphone" : "Unmute microphone"}
+            type="button"
+            variant="secondary"
+          >
+            {micEnabled ? <Mic /> : <MicOff />}
+          </Button>
+        ) : null}
+      </div>
+      <p className="text-2xs text-muted-foreground">
+        AI-generated avatar and voice.
+      </p>
+    </section>
+  );
+}

--- a/desktop/src/features/agents/ui/AgentMediaSurface.tsx
+++ b/desktop/src/features/agents/ui/AgentMediaSurface.tsx
@@ -122,7 +122,12 @@ export function AgentMediaSurface({
 
   return (
     <section
-      aria-label={`${agentLabel} live video`}
+      // Names the region, not the video inside it. A named `section` is a
+      // landmark, so a label restating the `<video>`'s own gives a screen
+      // reader two stops a word apart for one thing. This region also holds
+      // the disclosure line and the microphone control, so naming the session
+      // is both more accurate and audibly distinct.
+      aria-label={`${agentLabel} media session`}
       className={cn("flex flex-col gap-2", className)}
       data-testid="agent-media-surface"
     >

--- a/desktop/src/features/agents/ui/AgentMediaSurface.tsx
+++ b/desktop/src/features/agents/ui/AgentMediaSurface.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { CircleAlert, Mic, MicOff, VideoOff } from "lucide-react";
+import { CircleAlert, Mic, MicOff, VideoOff, Volume2 } from "lucide-react";
 
+import { attachSessionTracks } from "@/features/agents/lib/agentMediaAttach";
 import type { AgentMediaSession } from "@/features/agents/lib/agentMediaSession";
 import { useAgentMediaRoom } from "@/features/agents/lib/useAgentMediaRoom";
 import { cn } from "@/shared/lib/cn";
@@ -13,11 +14,25 @@ type AgentMediaSurfaceProps = {
   session: AgentMediaSession;
 };
 
-/** Attach the remote video track to a `<video>` for as long as both exist. */
-function AgentVideoElement({
+/**
+ * Attach the agent's tracks to one `<video>` for as long as they exist.
+ *
+ * **Both tracks go on the same element, deliberately.** LiveKit's `attach`
+ * merges a track into whatever `MediaStream` the element already carries, so one
+ * element means one stream, one jitter buffer and one playback clock — which is
+ * what keeps the voice on the lips. Two elements play from two independent
+ * clocks and drift audibly.
+ *
+ * It is also how the element ends up audible at all: `attachToElement` sets
+ * `element.muted = mediaStream.getAudioTracks().length === 0`, so a video-only
+ * stream is muted by the SDK no matter what the markup says.
+ */
+function AgentMediaElement({
+  attachAudio,
   attachVideo,
   label,
 }: {
+  attachAudio: ((element: HTMLMediaElement) => () => void) | null;
   attachVideo: (element: HTMLVideoElement) => () => void;
   label: string;
 }) {
@@ -26,8 +41,8 @@ function AgentVideoElement({
   React.useEffect(() => {
     const element = ref.current;
     if (!element) return;
-    return attachVideo(element);
-  }, [attachVideo]);
+    return attachSessionTracks(element, { attachAudio, attachVideo });
+  }, [attachAudio, attachVideo]);
 
   return (
     // Live WebRTC stream: a static track file cannot caption it. The agent's
@@ -39,10 +54,42 @@ function AgentVideoElement({
       autoPlay
       className="h-full w-full object-cover"
       data-testid="agent-media-video"
-      // Not muted: the agent's audio rides its own track in the same room, and
-      // hearing it is the point. Lip-sync holds because both come from one
-      // transport with one clock.
       playsInline
+      ref={ref}
+    />
+  );
+}
+
+/**
+ * Play the agent's audio when there is no video to carry it.
+ *
+ * A session may announce audio only, or its video may drop while the call
+ * continues. Hidden, because there is nothing to look at and a second set of
+ * media controls would invite muting the agent by way of a control that looks
+ * like it belongs to the tile.
+ */
+function AgentAudioOnlyElement({
+  attachAudio,
+  label,
+}: {
+  attachAudio: (element: HTMLMediaElement) => () => void;
+  label: string;
+}) {
+  const ref = React.useRef<HTMLAudioElement | null>(null);
+
+  React.useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    return attachAudio(element);
+  }, [attachAudio]);
+
+  return (
+    // Same live-stream exemption as the video element above.
+    // biome-ignore lint/a11y/useMediaCaption: live stream, see above
+    <audio
+      aria-label={`${label} audio`}
+      autoPlay
+      className="hidden"
       ref={ref}
     />
   );
@@ -65,6 +112,9 @@ export function AgentMediaSurface({
     status,
     error,
     attachVideo,
+    attachAudio,
+    audioBlocked,
+    enableAudio,
     micEnabled,
     setMicEnabled,
     canPublishAudio,
@@ -88,7 +138,11 @@ export function AgentMediaSurface({
             </span>
           </div>
         ) : attachVideo ? (
-          <AgentVideoElement attachVideo={attachVideo} label={agentLabel} />
+          <AgentMediaElement
+            attachAudio={attachAudio}
+            attachVideo={attachVideo}
+            label={agentLabel}
+          />
         ) : status === "connected" ? (
           <div
             className="flex flex-col items-center gap-2 text-muted-foreground"
@@ -108,6 +162,24 @@ export function AgentMediaSurface({
             </span>
           </div>
         )}
+
+        {attachAudio && !attachVideo ? (
+          <AgentAudioOnlyElement attachAudio={attachAudio} label={agentLabel} />
+        ) : null}
+
+        {audioBlocked ? (
+          <Button
+            className="absolute bottom-2 left-2"
+            data-testid="agent-media-enable-audio"
+            onClick={enableAudio}
+            size="sm"
+            type="button"
+            variant="secondary"
+          >
+            <Volume2 />
+            Enable sound
+          </Button>
+        ) : null}
 
         {canPublishAudio ? (
           <Button

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/features/agents/ui/agentSessionPanelLayout";
 import { deriveTranscriptBlockIds } from "@/features/agents/ui/agentSessionTranscriptGrouping";
 import type { ObserverEvent } from "@/features/agents/ui/agentSessionTypes";
+import { AgentMediaSurface } from "@/features/agents/ui/AgentMediaSurface";
+import { useAgentMediaSession } from "@/features/agents/lib/useAgentMediaSessions";
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
 import {
   useArchivedChannelEvents,
@@ -101,6 +103,13 @@ export function AgentSessionThreadPanel({
   const isLive = isManagedAgentActive(agent);
   const isOverlay = useIsThreadPanelOverlay();
   const sessionChannelId = channelId ?? channel?.id ?? null;
+
+  // A live media session for *this* agent in *this* channel, if one is running.
+  // Null the rest of the time, which is the common case. The hook still holds a
+  // narrow 48200/48201 subscription while the panel is open — that is how a
+  // session that starts later shows up — but it joins no room until there is
+  // one, so nothing is negotiated and nothing is metered.
+  const mediaSession = useAgentMediaSession(sessionChannelId, agent.pubkey);
   // Unified working signal, scoped to this panel's channel (or all channels
   // when the panel is unscoped) — observer turns primary, typing fallback.
   const { working: isWorking } = useAgentWorking(
@@ -514,6 +523,13 @@ export function AgentSessionThreadPanel({
         className="overflow-y-auto px-3 pb-4"
         panelPadding
       >
+        {mediaSession ? (
+          <AgentMediaSurface
+            agentLabel={agentLabel}
+            className="pb-3 pt-2"
+            session={mediaSession}
+          />
+        ) : null}
         <div ref={topSentinelRef} aria-hidden className="h-px" />
         <div ref={contentRef}>
           <ManagedAgentSessionPanel

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -537,9 +537,16 @@ export function AgentSessionThreadPanel({
             channelId={sessionChannelId}
             className="border-0 bg-transparent px-0 py-2 shadow-none"
             emptyDescription={
-              sessionChannelId
-                ? `Mention ${agent.name} in the channel to see its work here.`
-                : `Mention ${agent.name} in any channel to see its work here.`
+              // A live media session already answers "mention it to see
+              // something" — the member is watching the agent right now, and
+              // repeating the instruction reads as though nothing happened.
+              // The block still renders, because a media agent may also do ACP
+              // work, and that work belongs here rather than in the video.
+              mediaSession
+                ? `${agent.name} is live above. Tool calls and edits appear here.`
+                : sessionChannelId
+                  ? `Mention ${agent.name} in the channel to see its work here.`
+                  : `Mention ${agent.name} in any channel to see its work here.`
             }
             profiles={profiles}
             rawLayout="exclusive"

--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -12,6 +12,7 @@ import {
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
 import { mergeChannelKnownAgentPubkeys } from "@/features/agents/knownAgentPubkeys";
+import { AgentMediaIndicator } from "@/features/agents/ui/AgentMediaIndicator";
 import { requestOpenCreateAgent } from "@/features/agents/openCreateAgentEvent";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
 import {
@@ -189,6 +190,13 @@ export function ChannelMembersBar({
     />
   );
 
+  const agentMediaIndicator = (
+    <AgentMediaIndicator
+      channelId={channel.id}
+      renderMode={variant === "compact" ? "menu-item" : "button"}
+    />
+  );
+
   const controls =
     variant === "compact" ? (
       <div className="flex items-center gap-[6px]">
@@ -215,6 +223,7 @@ export function ChannelMembersBar({
                 {memberCount}
               </span>
             </DropdownMenuItem>
+            {agentMediaIndicator}
             {huddleIndicator}
             <DropdownMenuItem
               data-testid="channel-management-trigger"
@@ -247,6 +256,8 @@ export function ChannelMembersBar({
           </TooltipTrigger>
           <TooltipContent>Channel members</TooltipContent>
         </Tooltip>
+
+        {agentMediaIndicator}
 
         {huddleIndicator}
 

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -355,6 +355,7 @@ export function ChannelScreen({
     agentSessionCandidates,
     botTypingEntries,
     humanTypingPubkeys,
+    mediaSessions,
     threadTypingPubkeys,
   } = useChannelActivityTyping({
     activeChannel,
@@ -580,6 +581,8 @@ export function ChannelScreen({
   } = useChannelAgentSessions({
     activeChannel,
     activeChannelId,
+    currentPubkey,
+    mediaSessions,
     agentsLoaded:
       !channelMembersQuery.isLoading &&
       !managedAgentsQuery.isLoading &&

--- a/desktop/src/features/channels/ui/useChannelActivityTyping.ts
+++ b/desktop/src/features/channels/ui/useChannelActivityTyping.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { reportChannelBotTyping } from "@/features/agents/agentWorkingSignal";
+import { useAgentMediaSessions } from "@/features/agents/lib/useAgentMediaSessions";
 import type { TypingIndicatorEntry } from "@/features/messages/useChannelTyping";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type {
@@ -49,14 +50,27 @@ export function useChannelActivityTyping({
   relayAgents: RelayAgent[];
   typingEntries: TypingIndicatorEntry[];
 }) {
+  // A live media session is channel presence, so it qualifies its agent for a
+  // session panel the same way a roster bot role does. Without this an agent
+  // that only publishes video has no panel, and the surface that renders it
+  // cannot mount — see buildChannelAgentSessionCandidates.
+  const mediaSessions = useAgentMediaSessions(activeChannelId);
   const agentCandidates = React.useMemo(
     () =>
       buildChannelAgentSessionCandidates({
         channelMembers,
         managedAgents,
+        mediaSessions,
         relayAgents,
       }),
-    [channelMembers, managedAgents, relayAgents],
+    [channelMembers, managedAgents, mediaSessions, relayAgents],
+  );
+  const mediaSessionPubkeys = React.useMemo(
+    () =>
+      new Set(
+        mediaSessions.map((session) => normalizePubkey(session.agentPubkey)),
+      ),
+    [mediaSessions],
   );
   const channelAgentSessionAgents = React.useMemo(
     () =>
@@ -65,8 +79,15 @@ export function useChannelActivityTyping({
         activeChannelId,
         agents: agentCandidates,
         channelMembers,
+        mediaSessionPubkeys,
       }),
-    [activeChannel, activeChannelId, agentCandidates, channelMembers],
+    [
+      activeChannel,
+      activeChannelId,
+      agentCandidates,
+      channelMembers,
+      mediaSessionPubkeys,
+    ],
   );
   const channelAgentPubkeys = React.useMemo(
     () =>

--- a/desktop/src/features/channels/ui/useChannelActivityTyping.ts
+++ b/desktop/src/features/channels/ui/useChannelActivityTyping.ts
@@ -147,6 +147,10 @@ export function useChannelActivityTyping({
     botTypingEntries,
     channelAgentSessionAgents,
     humanTypingPubkeys,
+    // Handed back rather than subscribed to again by the caller: this hook
+    // already holds the channel's sessions, and every extra
+    // `useAgentMediaSessions` call is another relay REQ for the same filter.
+    mediaSessions,
     threadTypingPubkeys,
   };
 }

--- a/desktop/src/features/channels/ui/useChannelAgentSessions.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelAgentSessions.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildChannelAgentSessionCandidates,
+  getChannelAgentSessionAgents,
+} from "./useChannelAgentSessions.ts";
+
+const CHANNEL_ID = "7fdd5a94-7523-5b86-b574-9124de6cdc0d";
+const OTHER_CHANNEL_ID = "adafd400-706c-5c13-bf02-bc2ebb45b1c7";
+const MEDIA_AGENT =
+  "e38c4fec9cddd9833d05a9dd7279606dcf321b95c3739c265423e211e8f1b789";
+const MANAGED_AGENT =
+  "db2f4298db2f4298db2f4298db2f4298db2f4298db2f4298db2f4298db2f4298";
+
+const CHANNEL = { id: CHANNEL_ID, name: "general" };
+
+function mediaSession(overrides = {}) {
+  return { agentPubkey: MEDIA_AGENT, channelId: CHANNEL_ID, ...overrides };
+}
+
+function pubkeySet(...pubkeys) {
+  return new Set(pubkeys.map((pubkey) => pubkey.toLowerCase()));
+}
+
+describe("media-only agents qualify for a session panel", () => {
+  // The regression this whole path exists for: an external agent that
+  // publishes video emits no kind:24200 observer frame and no kind:20002
+  // typing indicator, so every activity-derived signal is silent. It is also
+  // not desktop-managed and has no kind:10100 registration, and nothing marks
+  // an external agent as a bot at add-time — so its roster role is `member`.
+  // Before the media source it matched none of the three candidate rules, the
+  // panel could not be opened, AgentMediaSurface never mounted, and no viewer
+  // token was ever requested.
+  const memberRoster = [
+    { pubkey: MEDIA_AGENT, role: "member", displayName: "Cara" },
+  ];
+
+  it("does not qualify a plain member without a session", () => {
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: memberRoster,
+      managedAgents: [],
+      relayAgents: [],
+    });
+
+    assert.equal(candidates.length, 0);
+  });
+
+  it("qualifies the agent on the announcement alone", () => {
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: memberRoster,
+      managedAgents: [],
+      mediaSessions: [mediaSession()],
+      relayAgents: [],
+    });
+
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].pubkey, MEDIA_AGENT);
+    assert.equal(candidates[0].agentSource, "media");
+    // Nothing can interrupt a turn that no ACP harness is running.
+    assert.equal(candidates[0].canInterruptTurn, false);
+    // The session is the scope, so the channel is declared on the candidate.
+    assert.deepEqual(candidates[0].channelIds, [CHANNEL_ID]);
+  });
+
+  it("keeps the agent through the channel filter", () => {
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: memberRoster,
+      managedAgents: [],
+      mediaSessions: [mediaSession()],
+      relayAgents: [],
+    });
+
+    const agents = getChannelAgentSessionAgents({
+      activeChannel: CHANNEL,
+      activeChannelId: CHANNEL_ID,
+      agents: candidates,
+      channelMembers: memberRoster,
+      mediaSessionPubkeys: pubkeySet(MEDIA_AGENT),
+    });
+
+    assert.deepEqual(
+      agents.map((agent) => agent.pubkey),
+      [MEDIA_AGENT],
+    );
+  });
+
+  it("keeps the agent even when it is not on the roster at all", () => {
+    // Membership and a live session are separate claims. An agent that
+    // announces a session in a channel is visible in it for as long as the
+    // session lives, whatever the roster snapshot says.
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: [],
+      managedAgents: [],
+      mediaSessions: [mediaSession()],
+      relayAgents: [],
+    });
+
+    const agents = getChannelAgentSessionAgents({
+      activeChannel: CHANNEL,
+      activeChannelId: CHANNEL_ID,
+      agents: candidates,
+      channelMembers: [],
+      mediaSessionPubkeys: pubkeySet(MEDIA_AGENT),
+    });
+
+    assert.deepEqual(
+      agents.map((agent) => agent.pubkey),
+      [MEDIA_AGENT],
+    );
+  });
+
+  it("names the agent from its pubkey when no agent record exists", () => {
+    const [candidate] = buildChannelAgentSessionCandidates({
+      channelMembers: [],
+      managedAgents: [],
+      mediaSessions: [mediaSession()],
+      relayAgents: [],
+    });
+
+    // resolveUserLabel prefers the kind:0 profile at render; this fallback
+    // shows only for an agent that has published no profile.
+    assert.equal(candidate.name, "e38c4fec…b789");
+  });
+
+  it("matches the announcing pubkey case-insensitively", () => {
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: [{ pubkey: MEDIA_AGENT, role: "bot" }],
+      managedAgents: [],
+      mediaSessions: [mediaSession({ agentPubkey: MEDIA_AGENT.toUpperCase() })],
+      relayAgents: [],
+    });
+
+    // One agent, not two: the roster bot already claimed the key.
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].agentSource, "member-bot");
+  });
+});
+
+describe("a media session does not overwrite a richer agent record", () => {
+  it("keeps the managed record and adds the session's channel", () => {
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: [],
+      managedAgents: [
+        { pubkey: MANAGED_AGENT, name: "OpenCode", status: "deployed" },
+      ],
+      mediaSessions: [mediaSession({ agentPubkey: MANAGED_AGENT })],
+      relayAgents: [
+        {
+          pubkey: MANAGED_AGENT,
+          name: "OpenCode",
+          status: "online",
+          channelIds: [OTHER_CHANNEL_ID],
+          channels: [],
+        },
+      ],
+    });
+
+    assert.equal(candidates.length, 1);
+    const [agent] = candidates;
+    assert.equal(agent.name, "OpenCode");
+    assert.equal(agent.agentSource, "managed");
+    // Still interruptible — the media session says nothing about its harness.
+    assert.equal(agent.canInterruptTurn, true);
+    assert.deepEqual(agent.channelIds, [OTHER_CHANNEL_ID, CHANNEL_ID]);
+  });
+
+  it("does not duplicate a channel the record already declares", () => {
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: [],
+      managedAgents: [],
+      mediaSessions: [mediaSession({ agentPubkey: MANAGED_AGENT })],
+      relayAgents: [
+        {
+          pubkey: MANAGED_AGENT,
+          name: "OpenCode",
+          status: "online",
+          channelIds: [CHANNEL_ID],
+          channels: [],
+        },
+      ],
+    });
+
+    assert.deepEqual(candidates[0].channelIds, [CHANNEL_ID]);
+  });
+});
+
+describe("a session scopes only its own channel", () => {
+  it("does not qualify the agent in a channel it is not live in", () => {
+    const candidates = buildChannelAgentSessionCandidates({
+      channelMembers: [],
+      managedAgents: [],
+      mediaSessions: [mediaSession({ channelId: OTHER_CHANNEL_ID })],
+      relayAgents: [],
+    });
+
+    const agents = getChannelAgentSessionAgents({
+      activeChannel: CHANNEL,
+      activeChannelId: CHANNEL_ID,
+      agents: candidates,
+      channelMembers: [],
+      // The hook derives this set from the active channel's subscription, so
+      // a session in another channel contributes nothing here.
+      mediaSessionPubkeys: new Set(),
+    });
+
+    assert.deepEqual(agents, []);
+  });
+});

--- a/desktop/src/features/channels/ui/useChannelAgentSessions.ts
+++ b/desktop/src/features/channels/ui/useChannelAgentSessions.ts
@@ -8,6 +8,8 @@ import type {
   RelayAgent,
 } from "@/shared/api/types";
 import { usePanelReturnTarget } from "@/shared/hooks/usePanelReturnTarget";
+import type { AgentMediaSession } from "@/features/agents/lib/agentMediaSession";
+import { useAutoOpenRequestedAgentMedia } from "@/features/agents/lib/useAutoOpenRequestedMedia";
 import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
 import {
   channelBotMemberPubkeySet,
@@ -34,8 +36,11 @@ type UseChannelAgentSessionsOptions = {
   activeChannelId: string | null;
   agentsLoaded: boolean;
   channelMembers?: ChannelMember[];
+  currentPubkey?: string | null;
   handleOpenThread: (message: TimelineMessage) => void;
   managedAgents: ChannelAgentSessionAgent[];
+  /** Live media sessions for this channel, for the requester auto-open below. */
+  mediaSessions: readonly AgentMediaSession[];
   openAgentSessionPubkey: string | null;
   openThreadHeadId: string | null;
   profilePanelPubkey?: string | null;
@@ -220,8 +225,10 @@ export function useChannelAgentSessions({
   activeChannelId,
   agentsLoaded,
   channelMembers,
+  currentPubkey,
   handleOpenThread,
   managedAgents,
+  mediaSessions,
   openAgentSessionPubkey,
   openThreadHeadId,
   profilePanelPubkey = null,
@@ -299,6 +306,16 @@ export function useChannelAgentSessions({
       setThreadScrollTargetId,
     ],
   );
+
+  // A session this member's own mention started opens its panel here rather
+  // than leaving them hunting for the indicator. This hook already owns every
+  // other way a panel opens, so the automatic one belongs with them.
+  useAutoOpenRequestedAgentMedia({
+    currentPubkey,
+    openAgentSession,
+    panelOpen: openAgentSessionPubkey !== null,
+    sessions: mediaSessions,
+  });
 
   // Back restores the pane the Activity panel replaced; with no recorded
   // target (opened from the composer with no pane, or a direct/restored

--- a/desktop/src/features/channels/ui/useChannelAgentSessions.ts
+++ b/desktop/src/features/channels/ui/useChannelAgentSessions.ts
@@ -23,7 +23,7 @@ export type ChannelAgentSessionAgent = Pick<
   ManagedAgent,
   "pubkey" | "name" | "status"
 > & {
-  agentSource: "managed" | "member-bot" | "relay";
+  agentSource: "managed" | "media" | "member-bot" | "relay";
   canInterruptTurn: boolean;
   channelIds?: string[];
   channels?: string[];
@@ -59,10 +59,18 @@ function relayStatusToManagedStatus(
 export function buildChannelAgentSessionCandidates({
   channelMembers,
   managedAgents,
+  mediaSessions,
   relayAgents,
 }: {
   channelMembers?: ChannelMember[];
   managedAgents: ManagedAgent[];
+  /**
+   * Live media sessions announced in this channel (kind:48200).
+   *
+   * Structural rather than the parsed `AgentMediaSession` type so this stays a
+   * pure function over plain data, testable without the subscription hook.
+   */
+  mediaSessions?: readonly { agentPubkey: string; channelId: string }[];
   relayAgents: RelayAgent[];
 }): ChannelAgentSessionAgent[] {
   const byPubkey = new Map<string, ChannelAgentSessionAgent>();
@@ -108,6 +116,40 @@ export function buildChannelAgentSessionCandidates({
     });
   }
 
+  // A live media session qualifies its agent by itself. An agent that only
+  // publishes video is none of the three sources above: not desktop-managed,
+  // no kind:10100 registration, and its `channel_members.role` may well say
+  // `member` — nothing marks an external agent as a bot at add-time. Without
+  // this it has no session panel, so `AgentMediaSurface` can never mount, no
+  // viewer token is ever requested, and the room it announced sits empty.
+  //
+  // Last, so an agent that already has a record keeps that record's name and
+  // interrupt affordance; the session only vouches for the channel.
+  for (const session of mediaSessions ?? []) {
+    const key = normalizePubkey(session.agentPubkey);
+    const existing = byPubkey.get(key);
+    if (existing) {
+      if (!(existing.channelIds ?? []).includes(session.channelId)) {
+        byPubkey.set(key, {
+          ...existing,
+          channelIds: [...(existing.channelIds ?? []), session.channelId],
+        });
+      }
+      continue;
+    }
+
+    byPubkey.set(key, {
+      pubkey: session.agentPubkey,
+      // No agent record to name it. `resolveUserLabel` prefers the kind:0
+      // profile at render, so this shows only for an agent with no profile.
+      name: truncatePubkey(session.agentPubkey),
+      status: "deployed",
+      agentSource: "media",
+      canInterruptTurn: false,
+      channelIds: [session.channelId],
+    });
+  }
+
   return [...byPubkey.values()];
 }
 
@@ -116,11 +158,14 @@ export function getChannelAgentSessionAgents({
   activeChannelId,
   agents,
   channelMembers,
+  mediaSessionPubkeys,
 }: {
   activeChannel: Channel | null;
   activeChannelId: string | null;
   agents: ChannelAgentSessionAgent[];
   channelMembers?: ChannelMember[];
+  /** Normalized pubkeys with a live media session in this channel. */
+  mediaSessionPubkeys?: ReadonlySet<string>;
 }): ChannelAgentSessionAgent[] {
   if (!activeChannelId || !activeChannel) {
     return [];
@@ -138,6 +183,12 @@ export function getChannelAgentSessionAgents({
 
   return agents.filter((agent) => {
     const normalizedPubkey = normalizePubkey(agent.pubkey);
+    // A session announced in this channel is its own scope, whatever the
+    // roster says. Checked before the source rules so a managed or registered
+    // agent that is on camera here without being a member still qualifies.
+    if (mediaSessionPubkeys?.has(normalizedPubkey)) {
+      return true;
+    }
     const channelIds = agent.channelIds ?? [];
     const channels = agent.channels ?? [];
     const hasDeclaredChannelScope =

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -30,6 +30,7 @@ import {
   saveActiveAgentTurnsForCommunity,
   restoreActiveAgentTurnsForCommunity,
 } from "@/features/agents/activeAgentTurnsStore";
+import { resetAutoOpenedAgentMedia } from "@/features/agents/lib/useAutoOpenRequestedMedia";
 import { resetAgentWorkingSignal } from "@/features/agents/agentWorkingSignal";
 import { resetAgentObserverStore } from "@/features/agents/observerRelayStore";
 import { resetAvatarPresentations } from "@/features/profile/avatarPresentationStore";
@@ -64,6 +65,7 @@ async function resetCommunityState({
   resetAgentObserverStore();
   resetActiveAgentTurnsStore();
   resetAgentWorkingSignal();
+  resetAutoOpenedAgentMedia();
   if (isTauri() && isMacPlatform()) {
     void clearTrayAgentActivity();
   }

--- a/desktop/src/features/gifs/relay.ts
+++ b/desktop/src/features/gifs/relay.ts
@@ -7,10 +7,9 @@ import {
   type RelayGifSearchInfo,
 } from "@/features/gifs/api";
 import { relayHttpFromWs } from "@/shared/api/inviteHelpers";
-import { signRelayEvent } from "@/shared/api/tauri";
+import { nip98PostHeader } from "@/shared/api/nip98";
 
 const KLIPY_CUSTOMER_ID_STORAGE_KEY_PREFIX = "buzz:klipy-customer-id:v1:";
-const NIP98_KIND = 27235;
 
 function customerId(relayUrl: string): string {
   if (typeof window === "undefined") return globalThis.crypto.randomUUID();
@@ -28,30 +27,6 @@ function customerId(relayUrl: string): string {
     // over a process-wide fallback that would correlate unrelated relays.
     return globalThis.crypto.randomUUID();
   }
-}
-
-async function sha256Hex(text: string): Promise<string> {
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(text),
-  );
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-async function nip98PostHeader(url: string, body: string): Promise<string> {
-  const authEvent = await signRelayEvent({
-    kind: NIP98_KIND,
-    content: "",
-    tags: [
-      ["u", url],
-      ["method", "POST"],
-      ["payload", await sha256Hex(body)],
-      ["nonce", crypto.randomUUID()],
-    ],
-  });
-  return `Nostr ${btoa(JSON.stringify(authEvent))}`;
 }
 
 const FRIENDLY_GIF_ERRORS: Record<string, string> = {

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -27,7 +27,6 @@ import {
   KIND_JOB_REQUEST,
   KIND_JOB_RESULT,
   KIND_HUDDLE_STARTED,
-  KIND_AGENT_MEDIA_SESSION_STARTED,
   KIND_DELETION,
   KIND_NIP29_DELETE_EVENT,
   KIND_REACTION,
@@ -62,8 +61,7 @@ export function isTimelineContentEvent(event: RelayEvent) {
     event.kind === KIND_JOB_RESULT ||
     event.kind === KIND_JOB_CANCEL ||
     event.kind === KIND_JOB_ERROR ||
-    event.kind === KIND_HUDDLE_STARTED ||
-    event.kind === KIND_AGENT_MEDIA_SESSION_STARTED
+    event.kind === KIND_HUDDLE_STARTED
   );
 }
 

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -27,6 +27,7 @@ import {
   KIND_JOB_REQUEST,
   KIND_JOB_RESULT,
   KIND_HUDDLE_STARTED,
+  KIND_AGENT_MEDIA_SESSION_STARTED,
   KIND_DELETION,
   KIND_NIP29_DELETE_EVENT,
   KIND_REACTION,
@@ -61,7 +62,8 @@ export function isTimelineContentEvent(event: RelayEvent) {
     event.kind === KIND_JOB_RESULT ||
     event.kind === KIND_JOB_CANCEL ||
     event.kind === KIND_JOB_ERROR ||
-    event.kind === KIND_HUDDLE_STARTED
+    event.kind === KIND_HUDDLE_STARTED ||
+    event.kind === KIND_AGENT_MEDIA_SESSION_STARTED
   );
 }
 

--- a/desktop/src/shared/api/invites.ts
+++ b/desktop/src/shared/api/invites.ts
@@ -1,9 +1,6 @@
 import { relayHttpFromWs } from "@/shared/api/inviteHelpers";
-import {
-  getRelayHttpUrl,
-  invokeTauri,
-  signRelayEvent,
-} from "@/shared/api/tauri";
+import { nip98PostHeader } from "@/shared/api/nip98";
+import { getRelayHttpUrl, invokeTauri } from "@/shared/api/tauri";
 
 // Relay invite data layer. Both endpoints are NIP-98-authed HTTP POSTs
 // (mirrors the read path in moderation.ts, plus the payload tag the relay
@@ -13,8 +10,6 @@ import {
 // - POST /api/invites/claim  — claim a code, signed by the *joining* key.
 //   This one targets an arbitrary relay (the invite's relay, not necessarily
 //   the active community), so the claim helper takes an explicit ws URL.
-
-const NIP98_KIND = 27235;
 
 // Bound invite requests so an unreachable relay surfaces as an error in the
 // invite-loading UI within seconds instead of hanging for the OS-level
@@ -42,38 +37,6 @@ export type ClaimResult = {
   host: string;
   role: string;
 };
-
-async function sha256Hex(text: string): Promise<string> {
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(text),
-  );
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-/**
- * Build the NIP-98 `Authorization` header for a POST with a body.
- *
- * The relay requires a `payload` tag carrying sha256(body) for signed POSTs
- * (api/invites.rs passes `require_payload: true`), and verifies the `u` tag
- * against the exact request URL — so the caller finalizes both before signing.
- */
-async function nip98PostHeader(url: string, body: string): Promise<string> {
-  const authEvent = await signRelayEvent({
-    kind: NIP98_KIND,
-    content: "",
-    tags: [
-      ["u", url],
-      ["method", "POST"],
-      ["payload", await sha256Hex(body)],
-      ["nonce", crypto.randomUUID()],
-    ],
-  });
-  // NIP-98 events carry empty content and ASCII-only tags, so btoa is safe here.
-  return `Nostr ${btoa(JSON.stringify(authEvent))}`;
-}
 
 async function invitePost<T>(
   httpBase: string,

--- a/desktop/src/shared/api/nip98.ts
+++ b/desktop/src/shared/api/nip98.ts
@@ -1,0 +1,40 @@
+import { signRelayEvent } from "@/shared/api/tauri";
+
+/** NIP-98 HTTP auth event kind. */
+export const NIP98_KIND = 27235;
+
+/** Lowercase hex sha256 of `text`, for the NIP-98 `payload` tag. */
+export async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Build the NIP-98 `Authorization` header for a POST with a body.
+ *
+ * The verifier requires a `payload` tag carrying sha256(body) for signed POSTs
+ * and checks the `u` tag against the exact request URL — so the caller must
+ * finalize both the URL and the body before signing.
+ */
+export async function nip98PostHeader(
+  url: string,
+  body: string,
+): Promise<string> {
+  const authEvent = await signRelayEvent({
+    kind: NIP98_KIND,
+    content: "",
+    tags: [
+      ["u", url],
+      ["method", "POST"],
+      ["payload", await sha256Hex(body)],
+      ["nonce", crypto.randomUUID()],
+    ],
+  });
+  // NIP-98 events carry empty content and ASCII-only tags, so btoa is safe.
+  return `Nostr ${btoa(JSON.stringify(authEvent))}`;
+}

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -41,6 +41,10 @@ export const KIND_HUDDLE_STARTED = 48100;
 export const KIND_HUDDLE_PARTICIPANT_JOINED = 48101;
 export const KIND_HUDDLE_PARTICIPANT_LEFT = 48102;
 export const KIND_HUDDLE_ENDED = 48103;
+// Agent media sessions: realtime audio/video carried by an external
+// provider and announced into the channel. The relay never carries the media.
+export const KIND_AGENT_MEDIA_SESSION_STARTED = 48200;
+export const KIND_AGENT_MEDIA_SESSION_ENDED = 48201;
 // NIP-78 application-specific data. All use kind 30078; the relay
 // differentiates them by d-tag ("read-state:<slotId>", "channel-sections",
 // "channel-mutes", "channel-stars", "channel-sort", "project-sidebar-membership").
@@ -110,6 +114,8 @@ export const CHANNEL_EVENT_KINDS = [
   KIND_HUDDLE_PARTICIPANT_JOINED, // 48101 — huddle lifecycle overlay
   KIND_HUDDLE_PARTICIPANT_LEFT, // 48102 — huddle lifecycle overlay
   KIND_HUDDLE_ENDED, // 48103 — huddle lifecycle overlay
+  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200 — visible agent media session card
+  KIND_AGENT_MEDIA_SESSION_ENDED, // 48201 — media session lifecycle overlay
 ] as const;
 
 // Auxiliary (non-row) timeline kinds: events that overlay onto or hide an
@@ -146,6 +152,7 @@ export const CHANNEL_TIMELINE_CONTENT_KINDS = [
   KIND_JOB_CANCEL, // 43005
   KIND_JOB_ERROR, // 43006
   KIND_HUDDLE_STARTED, // 48100 — huddle session card
+  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200 — agent media session card
 ] as const;
 
 // Timeline kinds that are NOT conversational: relay-signed system rows
@@ -165,6 +172,8 @@ const NON_CONVERSATIONAL_UNREAD_KINDS: ReadonlySet<number> = new Set([
   KIND_HUDDLE_PARTICIPANT_JOINED, // 48101
   KIND_HUDDLE_PARTICIPANT_LEFT, // 48102
   KIND_HUDDLE_ENDED, // 48103
+  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200 — visible but non-conversational
+  KIND_AGENT_MEDIA_SESSION_ENDED, // 48201
 ]);
 
 // Whether a timeline message kind should count toward unread tallies. An

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -114,8 +114,10 @@ export const CHANNEL_EVENT_KINDS = [
   KIND_HUDDLE_PARTICIPANT_JOINED, // 48101 — huddle lifecycle overlay
   KIND_HUDDLE_PARTICIPANT_LEFT, // 48102 — huddle lifecycle overlay
   KIND_HUDDLE_ENDED, // 48103 — huddle lifecycle overlay
-  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200 — visible agent media session card
-  KIND_AGENT_MEDIA_SESSION_ENDED, // 48201 — media session lifecycle overlay
+  // Control events: subscribed so a panel learns of a live session on
+  // reconnect, but they render no timeline row of their own.
+  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200
+  KIND_AGENT_MEDIA_SESSION_ENDED, // 48201
 ] as const;
 
 // Auxiliary (non-row) timeline kinds: events that overlay onto or hide an
@@ -152,7 +154,6 @@ export const CHANNEL_TIMELINE_CONTENT_KINDS = [
   KIND_JOB_CANCEL, // 43005
   KIND_JOB_ERROR, // 43006
   KIND_HUDDLE_STARTED, // 48100 — huddle session card
-  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200 — agent media session card
 ] as const;
 
 // Timeline kinds that are NOT conversational: relay-signed system rows
@@ -172,7 +173,9 @@ const NON_CONVERSATIONAL_UNREAD_KINDS: ReadonlySet<number> = new Set([
   KIND_HUDDLE_PARTICIPANT_JOINED, // 48101
   KIND_HUDDLE_PARTICIPANT_LEFT, // 48102
   KIND_HUDDLE_ENDED, // 48103
-  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200 — visible but non-conversational
+  // Not rows today; listed so that if a surface ever renders them they stay
+  // out of the unread pill.
+  KIND_AGENT_MEDIA_SESSION_STARTED, // 48200
   KIND_AGENT_MEDIA_SESSION_ENDED, // 48201
 ]);
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5704,7 +5704,7 @@ async function handleGetChannelReconnectRepair(
 ): Promise<RelayEvent[]> {
   const kinds = new Set([
     5, 7, 9, 9005, 40001, 40002, 40003, 40008, 40099, 45001, 45003, 48100,
-    48101, 48102, 48103,
+    48101, 48102, 48103, 48200, 48201,
   ]);
   const filter: Record<string, unknown> = {
     "#h": [args.channelId],

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -48,6 +48,12 @@ abstract final class EventKind {
   static const huddleParticipantLeft = 48102;
   static const huddleEnded = 48103;
 
+  /// Agent media sessions: realtime audio/video carried by an external
+  /// provider and announced into the channel. The relay never carries the
+  /// media itself.
+  static const agentMediaSessionStarted = 48200;
+  static const agentMediaSessionEnded = 48201;
+
   /// Event kinds that represent user-visible channel messages.
   static const channelMessageEventKinds = [
     streamMessage, // 9
@@ -71,6 +77,8 @@ abstract final class EventKind {
     huddleParticipantJoined, // 48101 — huddle lifecycle metadata
     huddleParticipantLeft, // 48102 — huddle lifecycle metadata
     huddleEnded, // 48103 — visible huddle ended row
+    agentMediaSessionStarted, // 48200 — visible agent media session card
+    agentMediaSessionEnded, // 48201 — visible media session ended row
   ];
 
   /// Auxiliary timeline kinds that overlay or hide existing rows.
@@ -95,6 +103,8 @@ abstract final class EventKind {
     jobError,
     huddleStarted,
     huddleEnded,
+    agentMediaSessionStarted,
+    agentMediaSessionEnded,
   ];
 }
 

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -77,8 +77,6 @@ abstract final class EventKind {
     huddleParticipantJoined, // 48101 — huddle lifecycle metadata
     huddleParticipantLeft, // 48102 — huddle lifecycle metadata
     huddleEnded, // 48103 — visible huddle ended row
-    agentMediaSessionStarted, // 48200 — visible agent media session card
-    agentMediaSessionEnded, // 48201 — visible media session ended row
   ];
 
   /// Auxiliary timeline kinds that overlay or hide existing rows.
@@ -103,8 +101,6 @@ abstract final class EventKind {
     jobError,
     huddleStarted,
     huddleEnded,
-    agentMediaSessionStarted,
-    agentMediaSessionEnded,
   ];
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       linkifyjs:
         specifier: ^4.3.2
         version: 4.3.2
+      livekit-client:
+        specifier: ^2.22.0
+        version: 2.22.0(@types/dom-mediacapture-record@1.0.22)
       lucide-react:
         specifier: ^1.0.0
         version: 1.16.0(react@19.2.8)
@@ -572,6 +575,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bufbuild/protobuf@1.10.1':
+    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
+
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
@@ -700,6 +706,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@livekit/mutex@1.1.1':
+    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+
+  '@livekit/protocol@1.50.4':
+    resolution: {integrity: sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==}
 
   '@mediapipe/tasks-vision@0.10.35':
     resolution: {integrity: sha512-HOvadwVRE6JC+45nyYhmnywnr5h/J8KZvOeUNVOG9q/0875pZgItznFB9bRTvLc264YSJqiZ1NsIpCStJw/egg==}
@@ -2058,6 +2070,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dom-mediacapture-record@1.0.22':
+    resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2676,6 +2691,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2784,12 +2802,21 @@ packages:
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
+  livekit-client@2.22.0:
+    resolution: {integrity: sha512-GLtYQfRh/RsvXaOX1x609bFZ17yyKmKWDqu9JmkMKn9vIFLi2GsapRv9gT8OJO/1R2dsitrkbGmloyUfxWQsaA==}
+    peerDependencies:
+      '@types/dom-mediacapture-record': ^1
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3301,6 +3328,9 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3310,6 +3340,13 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
+
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3467,6 +3504,9 @@ packages:
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
+
+  typed-emitter@2.1.0:
+    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -3664,6 +3704,10 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  webrtc-adapter@9.0.6:
+    resolution: {integrity: sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -3923,6 +3967,8 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.16':
     optional: true
 
+  '@bufbuild/protobuf@1.10.1': {}
+
   '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -4047,6 +4093,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@livekit/mutex@1.1.1': {}
+
+  '@livekit/protocol@1.50.4':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
 
   '@mediapipe/tasks-vision@0.10.35': {}
 
@@ -5313,6 +5365,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/dom-mediacapture-record@1.0.22': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -5883,6 +5937,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.10: {}
+
   js-tokens@4.0.0: {}
 
   jsdom@27.4.0(@noble/hashes@2.2.0):
@@ -5976,11 +6032,26 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
+  livekit-client@2.22.0(@types/dom-mediacapture-record@1.0.22):
+    dependencies:
+      '@livekit/mutex': 1.1.1
+      '@livekit/protocol': 1.50.4
+      '@types/dom-mediacapture-record': 1.0.22
+      events: 3.3.0
+      jose: 6.2.10
+      loglevel: 1.9.2
+      sdp-transform: 2.15.0
+      tslib: 2.8.1
+      typed-emitter: 2.1.0
+      webrtc-adapter: 9.0.6
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
 
   lodash@4.18.1: {}
+
+  loglevel@1.9.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -6760,6 +6831,11 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   safe-buffer@5.2.1: {}
 
   saxes@6.0.0:
@@ -6767,6 +6843,10 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  sdp-transform@2.15.0: {}
+
+  sdp@3.2.2: {}
 
   semver@6.3.1: {}
 
@@ -6923,6 +7003,10 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
+  typed-emitter@2.1.0:
+    optionalDependencies:
+      rxjs: 7.8.2
+
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
@@ -7068,6 +7152,10 @@ snapshots:
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  webrtc-adapter@9.0.6:
+    dependencies:
+      sdp: 3.2.2
 
   whatwg-mimetype@4.0.0: {}
 


### PR DESCRIPTION
Agents can have live audio and video conversations in a channel.

An agent opens a real-time audio/video session with an external provider. The
agent then announces the session as a channel event. Channel members can join
the session from the members bar.

Buzz's built-in agent voice uses an on-device pipeline:

**STT → LLM → TTS**

This pipeline is turn-based by design. It does not support full-duplex audio.
It also cannot call tools while it speaks.

This feature uses a different design. The external provider manages the media
because it already supports this function. Buzz provides functions that the
provider does not provide: membership, identity, fan-out, and a durable session
record.

The relay does not carry media. A session is a provider room that a Buzz event
announces. Therefore, this feature does not make the relay an SFU. It also does
not add video to the relay roadmap.

## What this does not add

This change does not add the service that creates and publishes session events.

The relay validates, authorizes, stores, and fans out the events. The client
displays the session and lets members join it. No component in this change
announces a session. The desktop client cannot announce a session by
architecture. It uses these kinds only in a subscription filter and a parser.

**Adopters must build a gateway, or use another external service, to create
rooms and publish the start and end events.**

This is the first Buzz kind whose producer is external code. For this reason,
the wire contract is documented field by field on
`KIND_AGENT_MEDIA_SESSION_STARTED`. It is not left for readers to infer from
the two implementations that enforce it.

Reviewers should examine these two areas carefully. Both can fail silently.

- **The relay does not validate `participants`.** This field decides what the
  client displays. The client assigns a track to the agent when the provider
  identity contains the agent's pubkey. An identity carrying a different pubkey
  is refused. Only when the identity carries no pubkey at all does the client
  fall back to the `participants` declaration. Providers do not have to include
  a pubkey in an identity. Avatar vendors do not include one.
- **An endpoint that serves `token_endpoint`** must verify NIP-98, check
  channel membership, and answer CORS preflight requests. The relay validates
  only the endpoint scheme.

## What this adds

### Relay

The relay adds two event kinds in `buzz-core/src/kind.rs` and validates them
during ingest.

**`48200` — agent media session started**

- The event is scoped to a channel by `h`.
- It can include an `e` tag that points to the message that caused the session.
- The event signature establishes ownership. No ownership tag is used.

**`48201` — agent media session ended**

- The event contains exactly one `e` tag.
- The tag must point to the start event that the end event closes.

The relay checks are the main purpose of the relay work.

- **Only a registered agent can announce a session.** The relay resolves an
  owner for the signing pubkey. It rejects the event if it cannot resolve an
  owner. This check is stricter than channel membership. It is also independent
  of a `bot` channel role.
- **A session can be ended by the agent that owns it, or by the relay acting on
  that agent's behalf.** A relay-signed end names the owning agent in a `p`
  tag, because there the signer and the subject differ.
- **`expires_at` is required and has a limited range.** If an agent crashes,
  the client stops showing its session card. The card does not advertise a dead
  room forever.

### Desktop

The desktop client makes a session visible and joinable.

- A session indicator appears in the channel members bar, next to the huddle
  indicator.
- The agent session panel contains a media surface. It shows the agent video
  and voice, a microphone control, and the disclosure: "AI-generated avatar and
  voice."
- A viewer exchanges its Buzz identity for a short-lived provider token through
  NIP-98. The announcer checks that the viewer is a channel member.
- If a member's own mention started the session, the client opens the panel for
  that member. Other members use the session indicator to open it.

The announcement names the message that caused it, but that citation is the
agent's own account, so the client checks it rather than trusting it. The panel
opens by itself only when the cited message was written by this member, in this
channel, addressing this agent, for a session less than a minute old.

### Mobile

Mobile adds only the two kind constants. It does not add a mobile session
surface.

## Design decisions

### Provider name

`provider` identifies the transport. It does not identify the avatar vendor.

The provider is in an allowlist in both `ingest.rs` and the client. The client
uses this value to select an SDK.

You can change an avatar vendor without changing this contract. A new transport
requires updates to both allowlists and a second room hook.

### Location of the session indicator

The session indicator is in the members bar, not the composer activity bar.

A live session is channel presence, like a huddle. It is not part of an agent
work history. The composer activity bar is hidden when the user is not looking
at the composer. It also combines media, typing, and ACP activity.

### Session persistence

Session events are not ephemeral.

A member who opens a channel after an announcement must still be able to find
and join a live session.

## Testing

Unit tests cover the session parser, track attribution, the automatic
panel-open rule, the microphone request queue, channel agent-session assembly,
and the relay's shape validation.

`crates/buzz-test-client/tests/e2e_agent_media_session.rs` covers the
authorization the shape tests cannot reach, because each predicate needs a real
community, channel, and owner→agent registration:

- only a registered agent may announce a session;
- an end must name a start that exists and is a start;
- an end must be published in its start's channel; and
- only the session's owner, or the relay, may end it.

Every refusal is paired with the acceptance it is the refusal of, so a guard
that tightened until it rejected everything would not pass. Ownership is
established over NIP-OA rather than by seeding the column, so the test exercises
the path production uses. The binary is selected explicitly in the Relay E2E
job — its tests are `#[ignore]`d, so it would otherwise run nowhere.

The feature was also tested end to end against a real deployment. The test used
a LiveKit room, an Anam avatar, and an external gateway.

The tested flow was:

1. A user mentions an agent from the composer.
2. The gateway creates a room.
3. The relay accepts a `48200` event.
4. The session indicator appears in the members bar.
5. The client opens the panel for the requesting user.
6. The viewer receives a token.
7. The client renders video.
8. The user and agent have a two-way voice conversation.

The announcing agent was registered through NIP-OA, not through a seeded
database row. During the test:

1. The agent owner column was cleared.
2. The agent authenticated again with an owner-signed `auth` tag.
3. The relay materialized the owner.
4. The relay accepted the session announcement only after that step.

The session ended cleanly with a `48201` event when the room became empty.

Screenshots from this test run are in a comment below.
