### PR TITLE
fix(mobile): show forum channels on home

### DIFF
--- a/mobile/lib/features/channels/channels_page/body.dart
+++ b/mobile/lib/features/channels/channels_page/body.dart
@@ -119,6 +119,9 @@ class _SliverChannelsList extends HookConsumerWidget {
     final streamChannels = visibleChannels
         .where((channel) => channel.isStream)
         .toList();
+    final forumChannels = visibleChannels
+        .where((channel) => channel.isForum)
+        .toList();
     final dmChannels = sortDmChannelsByDisplayLabel(
       visibleChannels.where((channel) => channel.isDm),
       currentPubkey: currentPubkey,
@@ -126,6 +129,7 @@ class _SliverChannelsList extends HookConsumerWidget {
 
     final starredExpanded = useState(true);
     final channelsExpanded = useState(true);
+    final forumsExpanded = useState(true);
     final dmsExpanded = useState(true);
     final sortState = ref.watch(channelSortProvider);
     final initialSeedComplete = useState(false);
@@ -200,6 +204,10 @@ class _SliverChannelsList extends HookConsumerWidget {
           )
           .toList(),
       sortState.sortModeFor('channels'),
+    );
+    final sortedForumChannels = sortChannelsForList(
+      forumChannels,
+      sortState.sortModeFor('forums'),
     );
     // DMs default to the display-label alphabetical order (labels can differ
     // from channel names); Recent mode reorders by last message time.
@@ -364,6 +372,21 @@ class _SliverChannelsList extends HookConsumerWidget {
               emptyLabel: 'No stream channels yet',
               sortMode: sortState.sortModeFor('channels'),
               onSortModeChange: (mode) => setSortMode('channels', mode),
+              onSelectChannel: onSelectChannel,
+            ),
+            _ChannelSection(
+              title: 'Forums',
+              icon: LucideIcons.messageSquareText,
+              showTopDivider: true,
+              expanded: forumsExpanded.value,
+              onToggle: () => forumsExpanded.value = !forumsExpanded.value,
+              channels: sortedForumChannels,
+              unreadChannelIds: unreadChannelIds,
+              mutedChannelIds: mutedChannelIds,
+              currentPubkey: currentPubkey,
+              emptyLabel: 'No forums yet',
+              sortMode: sortState.sortModeFor('forums'),
+              onSortModeChange: (mode) => setSortMode('forums', mode),
               onSelectChannel: onSelectChannel,
             ),
             _ChannelSection(

--- a/mobile/test/features/channels/channels_page_test.dart
+++ b/mobile/test/features/channels/channels_page_test.dart
@@ -141,17 +141,26 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('general'), findsOneWidget);
-    expect(find.text('design-forum'), findsNothing);
+    expect(find.text('design-forum'), findsOneWidget);
     expect(find.text('Alice'), findsOneWidget);
     expect(find.text('Channels'), findsOneWidget);
-    expect(find.text('FORUMS'), findsNothing);
+    expect(find.text('Forums'), findsOneWidget);
     expect(find.text('DMs'), findsOneWidget);
     expect(find.text('Community'), findsOneWidget);
     expect(find.byTooltip('Create or start conversation'), findsOneWidget);
     expect(find.byTooltip('Channels options'), findsOneWidget);
+    expect(find.byTooltip('Forums options'), findsOneWidget);
     expect(find.byIcon(LucideIcons.ellipsisVertical), findsWidgets);
     expect(find.byIcon(LucideIcons.arrowUpDown), findsNothing);
     expect(find.byTooltip('DMs options'), findsOneWidget);
+
+    await tester.tap(find.text('Forums'));
+    await tester.pumpAndSettle();
+    expect(find.text('design-forum'), findsNothing);
+
+    await tester.tap(find.text('Forums'));
+    await tester.pumpAndSettle();
+    expect(find.text('design-forum'), findsOneWidget);
 
     await tester.tap(find.byTooltip('Channels options'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- show joined, active forum channels in a dedicated **Forums** section on mobile Home
- preserve the existing sorting, unread, mute, and channel-opening behavior
- cover forum visibility and collapse/expand behavior with a widget regression test

## Problem
`ChannelsNotifier` already returns forum channels, but `_SliverChannelsList` only partitions visible channels into streams and DMs. Forum channels are therefore silently omitted from the mobile Home list, even though the existing channel detail route can render them.

Addresses the forum-channel visibility portion of #6766.

## Testing
- [x] `git diff --check`
- [x] focused source-contract verification for forum partition, section, sorting, routing, and widget assertions
- [ ] `dart format --output=none --set-exit-if-changed .` — local pinned Flutter/Dart bootstrap is unavailable on this Windows host; relying on PR CI
- [ ] `flutter test test/features/channels/channels_page_test.dart` — local pinned Flutter/Dart bootstrap is unavailable on this Windows host; relying on PR CI

## UI evidence
No emulator screenshot is attached because this host cannot launch the repository's pinned Flutter toolchain. The visual change is limited to a new collapsible **Forums** section between **Channels** and **DMs**, using the existing `_ChannelSection` component and `messageSquareText` icon.

## Duplicate search
No open PR implementing mobile forum-list visibility was found. The closest existing report is #6766.