### PR TITLE
fix(acp): anchor DM top-level messages so agents actually publish replies

### DIFF
--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1646,8 +1646,12 @@ fn format_context_hints(
                     s.push_str(&format!("\nParent: {parent}"));
                 }
             }
-            if let Some(event_id) = reply_anchor {
+        }
+        if let Some(event_id) = reply_anchor {
+            if is_reply {
                 append_reply_instruction(&mut s, event_id);
+            } else {
+                append_new_thread_reply_instruction(&mut s, event_id);
             }
         }
         crate::prompt_framing::semantic_section("context", &s)
@@ -2017,10 +2021,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     // there. DMs are always 1:1 with a human, so they always anchor.
     let sender_pubkey = last_event.event.pubkey.to_hex();
     let reply_anchor = if is_dm {
-        thread_tags
-            .root_event_id
-            .is_some()
-            .then(|| last_event.event.id.to_hex())
+        Some(last_event.event.id.to_hex())
     } else {
         resolve_reply_anchor(
             &sender_pubkey,
@@ -4026,23 +4027,28 @@ mod tests {
                                 "Scope: channel"
                             }));
                         }
+                        // DMs anchor every human-facing turn, same as
+                        // non-DM scopes, but always to the triggering
+                        // event itself (DM replies nest by message, not
+                        // by thread root — see the `reply_anchor` comment
+                        // above). Non-DM anchors to the thread root when
+                        // already a reply, else to the triggering event.
                         assert_eq!(
                             prompt.contains("This is a new top-level message"),
-                            !is_dm && !is_reply
+                            !is_reply
                         );
-                        if !is_dm || is_reply {
-                            let anchor = if is_dm {
+                        let anchor = if is_dm {
+                            if is_reply {
                                 reply.id.to_hex()
-                            } else if is_reply {
-                                root.to_uppercase()
                             } else {
                                 root.clone()
-                            };
-                            assert!(prompt.contains(&format!("--reply-to {anchor}")));
+                            }
+                        } else if is_reply {
+                            root.to_uppercase()
                         } else {
-                            assert!(!prompt.contains("--reply-to"));
-                            assert!(prompt.contains("buzz messages get"));
-                        }
+                            root.clone()
+                        };
+                        assert!(prompt.contains(&format!("--reply-to {anchor}")));
                     }
                 }
             }
@@ -5324,9 +5330,13 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_instruction_absent_for_dm_non_reply() {
+    fn test_reply_instruction_present_for_dm_non_reply() {
+        // Regression test: a DM's first (top-level) message used to get no
+        // reply-anchor at all, so the agent was never told to post via
+        // `buzz messages send` and its answer was silently never published.
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
+        let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
             scope: conv(ch),
@@ -5354,8 +5364,9 @@ mod tests {
         )
         .join("\n\n");
         assert!(
-            !prompt.contains("--reply-to"),
-            "DM non-reply should NOT include reply instruction"
+            prompt.contains(&format!("--reply-to {event_id}")),
+            "DM non-reply should still include a reply instruction, anchored \
+             to the triggering event"
         );
     }
 


### PR DESCRIPTION
## Summary
- `format_context_hints()` only told the agent how to publish a reply (`buzz messages send ... --reply-to <id>`) for a DM turn when `thread_tags.root_event_id` was `Some` — i.e. only when the triggering message was already a threaded reply. A DM's *first* message has no thread yet, so `reply_anchor` was computed as `None` and the agent received zero guidance to call `buzz messages send`.
- Symptom: the agent completes the turn and composes a full answer, but nothing ever reaches the relay — a silent, hard-to-notice failure since everything upstream (mention delivery, model call, turn-metric publish) succeeds normally.
- Fixed `reply_anchor` for DMs to always anchor to the triggering event (matching the existing top-level non-DM behavior), and moved the instruction append in `format_context_hints` outside the "already a reply" gate so a fresh top-level DM message gets `append_new_thread_reply_instruction`, the same way a top-level channel mention already does.
- Updated `test_reply_instruction_present_for_dm_thread_reply`'s sibling test (renamed from `test_reply_instruction_absent_for_dm_non_reply`, which asserted the old buggy behavior by name) and the `prompt_session_scope_matrix_preserves_turn_routing` matrix test to match.

Found while running a headless (non-Desktop) `buzz-acp` + `claude-agent-acp` deployment: reproduced on 3 consecutive turns in a fresh DM, 0/3 replies delivered, confirmed via the relay's Postgres store that no kind:9 event was ever published despite `pool::prompt: turn complete ... end_turn` logging successfully each time.

## Test plan
- [x] `cargo test -p buzz-acp --lib queue::` — 145 passed, 0 failed
- [x] `cargo test -p buzz-acp --lib` — 900 passed, 0 failed
- [x] `cargo fmt -p buzz-acp -- --check`
- [x] `cargo clippy -p buzz-acp --lib -- -D warnings`
- [x] Verified live against a real relay: before the fix, a fresh DM mention produced 0/3 replies (turn completed, nothing published); after the fix, the agent calls `buzz messages send` and the reply lands in the channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtWphutJHK9rVF6iMccohi