### PR TITLE
fix(desktop): prevent stale backup password encryption

### DIFF
--- a/desktop/src/features/onboarding/lib/encryptedBackup.test.mjs
+++ b/desktop/src/features/onboarding/lib/encryptedBackup.test.mjs
@@ -44,17 +44,33 @@ test("background encryption remains silent until download is clicked", () => {
   assert.equal(state.savedPassword, false);
   assert.equal(state.requestId, null);
 });
-test("stale async completions cannot replace current request", () => {
-  const state = reduce([
+test("editing during encryption invalidates the in-flight request", () => {
+  const edited = reduce([
     { type: "set-passphrase", value: "one-two-three-four" },
     { type: "encrypt-started", requestId: 1 },
     { type: "set-passphrase", value: "five-six-seven-eight" },
-    { type: "encrypt-started", requestId: 2 },
-    { type: "encrypt-succeeded", requestId: 1, ncryptsec: "ncryptsec1stale" },
   ]);
-  assert.equal(state.requestId, 2);
-  assert.equal(state.encrypted, null);
-  assert.equal(state.passphrase, "five-six-seven-eight");
+  assert.equal(edited.requestId, null);
+  assert.equal(pendingEncryptPassphrase(edited), "five-six-seven-eight");
+
+  const queued = reduce([{ type: "download-clicked" }], edited);
+  const afterStaleCompletion = reduce(
+    [
+      {
+        type: "encrypt-succeeded",
+        requestId: 1,
+        ncryptsec: "ncryptsec1stale",
+      },
+    ],
+    queued,
+  );
+  assert.equal(afterStaleCompletion.requestId, null);
+  assert.equal(afterStaleCompletion.downloadPending, true);
+  assert.equal(afterStaleCompletion.ncryptsec, null);
+  assert.equal(
+    pendingEncryptPassphrase(afterStaleCompletion),
+    "five-six-seven-eight",
+  );
 });
 test("failure clears submitted password", () => {
   const state = reduce([

--- a/desktop/src/features/onboarding/lib/encryptedBackup.ts
+++ b/desktop/src/features/onboarding/lib/encryptedBackup.ts
@@ -41,6 +41,7 @@ export function encryptedBackupReducer(
       return {
         ...state,
         passphrase: event.value,
+        requestId: null,
         encrypted: null,
         createError: null,
       };

--- a/desktop/tests/e2e/onboarding-backup.spec.ts
+++ b/desktop/tests/e2e/onboarding-backup.spec.ts
@@ -7,8 +7,11 @@ import {
   startWindowFileDrag,
 } from "../helpers/fileDrag";
 
-async function enterMachineBackup(page: import("@playwright/test").Page) {
-  await installMockBridge(page, undefined, {
+async function enterMachineBackup(
+  page: import("@playwright/test").Page,
+  mock?: Parameters<typeof installMockBridge>[1],
+) {
+  await installMockBridge(page, mock, {
     skipCommunitySeed: true,
     skipOnboardingSeed: true,
   });
@@ -35,6 +38,14 @@ async function invokedCommands(page: import("@playwright/test").Page) {
     () =>
       (window as Window & { __BUZZ_E2E_COMMANDS__?: string[] })
         .__BUZZ_E2E_COMMANDS__ ?? [],
+  );
+}
+
+async function encryptionPasswords(page: import("@playwright/test").Page) {
+  return page.evaluate(() =>
+    (window.__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [])
+      .filter(({ command }) => command === "create_ncryptsec_backup")
+      .map(({ payload }) => (payload as { password?: string }).password),
   );
 }
 
@@ -266,6 +277,30 @@ test("download happy path: generated password, encrypt, native save, Next", asyn
   await expect(page.getByTestId("onboarding-next")).toBeEnabled();
   await page.getByTestId("onboarding-next").click();
   await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
+});
+
+test("editing a password during encryption saves only the latest value", async ({
+  page,
+}) => {
+  await enterMachineBackup(page, {
+    backupEncryptionDelayMs: 750,
+  });
+  await openPasswordBackup(page);
+
+  const input = page.getByTestId("backup-passphrase-input");
+  const firstPassword = "first-password";
+  const latestPassword = "first-password-finished";
+  await input.fill(firstPassword);
+  await expect.poll(() => encryptionPasswords(page)).toEqual([firstPassword]);
+
+  await input.fill(latestPassword);
+  await page.getByTestId("encrypted-backup-create").click();
+  await expect
+    .poll(() => encryptionPasswords(page))
+    .toEqual([firstPassword, latestPassword]);
+  await expect(
+    page.getByRole("heading", { name: "Optionally, test your backup" }),
+  ).toBeVisible();
 });
 
 test("security view returns to the yellow onboarding view", async ({


### PR DESCRIPTION
**Category:** fix
**User Impact:** Editing a backup password while encryption is running now reliably saves the backup with the final password shown in Buzz.

**Problem:** On slower machines, onboarding could finish encrypting with an earlier password value after the user continued editing, leaving a valid backup that rejected the password they recorded.

**Solution:** Password edits now invalidate the active encryption generation, so stale completions are ignored and the final value is encrypted before the backup workflow advances.

<details>
<summary>File changes</summary>

**desktop/src/features/onboarding/lib/encryptedBackup.ts**
Invalidate the active encryption request whenever the password changes, reusing the existing request-ID fence to reject stale results.

**desktop/src/features/onboarding/lib/encryptedBackup.test.mjs**
Replace the synthetic two-request scenario with the production transition: edit during request one, queue the download, reject request one's completion, and keep the final password eligible for encryption.

**desktop/tests/e2e/onboarding-backup.spec.ts**
Add delayed bridge coverage that widens the slow-machine race window, inspects the passwords sent across the Tauri IPC seam, and verifies onboarding advances only after encrypting the final value.

</details>

## Reproduction Steps

1. Start the desktop onboarding flow with a newly generated machine identity and choose the password-protected backup option.
2. Enter a valid password and pause long enough for background encryption to start.
3. Continue editing the password, then click **Backup** while the original request is still running.
4. Verify the original completion is ignored, encryption runs with the final password, and onboarding advances only after that latest request succeeds.

## Validation

- `pnpm check`
- `pnpm test` — 5,880 tests passed
- `pnpm build:e2e`
- `pnpm exec playwright test tests/e2e/onboarding-backup.spec.ts tests/e2e/profile-backup-settings.spec.ts --project=smoke` — 17 tests passed
- Falsifiability mutation: removing the request invalidation makes both the reducer regression and freshly rebuilt Playwright race test fail.

The Playwright regression uses a 750 ms encryption delay to simulate the wider timing window seen on slower Windows machines. It is not native Windows execution; the repository's Windows build CI supplies platform-specific build coverage.
