### PR TITLE
feat(relay): make the NIP-10 thread depth limit configurable

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -342,6 +342,7 @@ out of the box with `just setup` or `just relay`. Common overrides:
 | `BUZZ_ALLOW_NIP_OA_AUTH`        | `false`                     | Enable NIP-OA owner attestation for membership |
 | `BUZZ_WEB_DIR`                  | unset (source), `/srv/buzz/web` (container) | Directory containing the invite landing bundle; the production container enables it so `/invite/{code}` always works |
 | `BUZZ_SERVE_GIT_WEB_GUI`        | `false`                     | Set to `true` or `1` to expose the bundled Git repository browser at `/` and `/repos/...`; invite routes do not depend on this flag |
+| `BUZZ_MAX_THREAD_DEPTH`         | `100`                       | Maximum NIP-10 reply nesting accepted on ingest; deeper replies are rejected with `thread depth limit exceeded`. Must be a positive integer |
 
 CLI-side, only two matter for testing:
 

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -12,6 +12,8 @@ use tracing::warn;
 /// Must comfortably exceed accepted event content sizes after Nostr JSON and
 /// NIP-44 encryption overhead.
 pub const DEFAULT_MAX_FRAME_BYTES: usize = 512 * 1024;
+/// Maximum NIP-10 reply nesting depth accepted on ingest.
+pub const DEFAULT_MAX_THREAD_DEPTH: u64 = 100;
 
 /// Errors that can occur while loading relay configuration.
 #[derive(Debug, Error)]
@@ -174,6 +176,8 @@ pub struct Config {
     pub send_buffer_size: usize,
     /// Maximum inbound WebSocket frame size in bytes.
     pub max_frame_bytes: usize,
+    /// Maximum NIP-10 reply nesting depth accepted on ingest.
+    pub max_thread_depth: u64,
     /// Number of consecutive buffer-full events tolerated before cancelling a slow client.
     pub slow_client_grace_limit: u8,
     /// Authentication provider configuration.
@@ -648,6 +652,8 @@ impl Config {
             .and_then(|v| v.parse().ok())
             .unwrap_or(1_000);
 
+        let max_thread_depth =
+            positive_u64_from_env("BUZZ_MAX_THREAD_DEPTH", DEFAULT_MAX_THREAD_DEPTH)?;
         let max_frame_bytes = std::env::var("BUZZ_MAX_FRAME_BYTES")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
@@ -1216,6 +1222,7 @@ impl Config {
             max_concurrent_handlers,
             send_buffer_size,
             max_frame_bytes,
+            max_thread_depth,
             slow_client_grace_limit,
             auth,
             require_auth_token,
@@ -2331,6 +2338,33 @@ mod tests {
         let config = Config::from_env().expect("config");
         std::env::remove_var("BUZZ_MAX_FRAME_BYTES");
         assert_eq!(config.max_frame_bytes, 262_144);
+    }
+
+    #[test]
+    fn max_thread_depth_defaults_and_can_be_configured() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        std::env::remove_var("BUZZ_MAX_THREAD_DEPTH");
+        let config = Config::from_env().expect("config");
+        assert_eq!(config.max_thread_depth, DEFAULT_MAX_THREAD_DEPTH);
+
+        std::env::set_var("BUZZ_MAX_THREAD_DEPTH", "12");
+        let config = Config::from_env().expect("config");
+        std::env::remove_var("BUZZ_MAX_THREAD_DEPTH");
+        assert_eq!(config.max_thread_depth, 12);
+    }
+
+    #[test]
+    fn max_thread_depth_rejects_zero_and_garbage() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        for bad in ["0", "-1", "not-a-number"] {
+            std::env::set_var("BUZZ_MAX_THREAD_DEPTH", bad);
+            let result = Config::from_env();
+            std::env::remove_var("BUZZ_MAX_THREAD_DEPTH");
+            assert!(
+                result.is_err(),
+                "BUZZ_MAX_THREAD_DEPTH={bad} should be rejected, not silently defaulted"
+            );
+        }
     }
 
     #[test]

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -872,7 +872,7 @@ pub(crate) async fn resolve_nip10_thread_meta(
                 parent_created
             };
             let depth = meta.depth + 1;
-            if depth > 100 {
+            if i64::from(depth) > state.config.max_thread_depth as i64 {
                 return Err("thread depth limit exceeded".to_string());
             }
             (effective_root, root_ts, depth)
@@ -1078,7 +1078,7 @@ pub(crate) async fn resolve_relay_reply_thread_meta(
         }
     };
 
-    if depth > 100 {
+    if i64::from(depth) > state.config.max_thread_depth as i64 {
         return Err("thread depth limit exceeded".to_string());
     }
 


### PR DESCRIPTION
## Summary

The relay rejects replies nested deeper than a hardcoded `100`. That works as a runaway
guard, but it sits well past the point where a thread is still readable, and an operator
has no way to enforce a shallower convention on their own relay.

This adds `BUZZ_MAX_THREAD_DEPTH`, parsed with the existing `positive_u64_from_env` helper
so it validates like the rate limits do: zero and non-numeric values are rejected at
startup rather than silently falling back to the default. Behaviour is unchanged when the
variable is unset.

Both ingest depth checks are covered, the one in the metadata path and the one in
`resolve_relay_reply_thread_meta`. Leaving either hardcoded would let a configured limit
apply on one ingest path but not the other. Both already had `AppState` in scope, so no
plumbing was needed.

### Related issue

None found. Searched issues and PRs for "thread depth", "MAX_THREAD_DEPTH" and "depth
limit exceeded"; the closest is #930, which covers agent thread-depth conventions rather
than the relay ingest guard.

### Testing

Two unit tests in `crates/buzz-relay/src/config.rs`:

- `max_thread_depth_defaults_and_can_be_configured`: the default applies when the variable
  is unset, and the configured value is used when set.
- `max_thread_depth_rejects_zero_and_garbage`: startup rejects `0` and non-numeric values.

`cargo test -p buzz-relay thread` passes (12 tests) on top of `1c8321cd0`. No UI change.
