### PR TITLE
fix(desktop): spawn agents with the workspace relay URL, not the canonical identity

### DIFF
--- a/crates/buzz-core/src/relay.rs
+++ b/crates/buzz-core/src/relay.rs
@@ -77,6 +77,59 @@ pub fn normalize_relay_url(raw: &str) -> Result<String, NormalizeRelayUrlError> 
     Ok(url.to_string().trim_end_matches('/').to_string())
 }
 
+/// Errors from [`resolve_agent_dial_relay_url`].
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ResolveAgentDialRelayUrlError {
+    /// Either URL failed identity normalization.
+    #[error(transparent)]
+    Normalize(#[from] NormalizeRelayUrlError),
+    /// Workspace and pair identity normalize to different communities.
+    #[error(
+        "refusing to dial workspace relay `{workspace_url}` for pair identity `{identity_url}`: \
+         they normalize to different communities (`{workspace_identity}` vs `{pair_identity}`)"
+    )]
+    CommunityMismatch {
+        /// Configured workspace relay spelling.
+        workspace_url: String,
+        /// Canonical pair identity URL.
+        identity_url: String,
+        /// Normalized form of `workspace_url`.
+        workspace_identity: String,
+        /// Normalized form of `identity_url`.
+        pair_identity: String,
+    },
+}
+
+/// Resolve the WebSocket URL a managed-agent child must dial.
+///
+/// `identity_url` is the canonical pair key from [`normalize_relay_url`]
+/// (loopback spellings fold to `127.0.0.1` for dedup). That form is correct
+/// for identity/receipts, but relays select communities from the literal HTTP
+/// `Host` / authority — so dialing the canonical spelling while the desktop
+/// joined as `localhost` lands the agent in a different (often empty) tenant
+/// (#4888).
+///
+/// When the workspace URL normalizes to the same identity, return the
+/// workspace spelling verbatim so Host-bound tenancy matches the UI. If the
+/// two normalize differently, fail closed rather than silently attaching the
+/// child to another community.
+pub fn resolve_agent_dial_relay_url(
+    workspace_url: &str,
+    identity_url: &str,
+) -> Result<String, ResolveAgentDialRelayUrlError> {
+    let workspace_identity = normalize_relay_url(workspace_url)?;
+    let pair_identity = normalize_relay_url(identity_url)?;
+    if workspace_identity != pair_identity {
+        return Err(ResolveAgentDialRelayUrlError::CommunityMismatch {
+            workspace_url: workspace_url.to_string(),
+            identity_url: identity_url.to_string(),
+            workspace_identity,
+            pair_identity,
+        });
+    }
+    Ok(workspace_url.trim().trim_end_matches('/').to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -89,6 +142,59 @@ mod tests {
         assert_eq!(ipv6, ipv4);
         assert_eq!(ipv4, localhost);
         assert_eq!(localhost, "wss://127.0.0.1");
+    }
+
+    #[test]
+    fn dial_preserves_localhost_when_identity_folded_to_loopback_ip() {
+        // Regression for #4888: runtime identity stores 127.0.0.1, but the
+        // child must dial the workspace's localhost authority.
+        let identity = normalize_relay_url("ws://localhost:3000").unwrap();
+        assert_eq!(identity, "ws://127.0.0.1:3000");
+        assert_eq!(
+            resolve_agent_dial_relay_url("ws://localhost:3000", &identity).unwrap(),
+            "ws://localhost:3000"
+        );
+    }
+
+    #[test]
+    fn dial_preserves_ipv4_loopback_when_workspace_uses_it() {
+        let identity = normalize_relay_url("ws://127.0.0.1:3000").unwrap();
+        assert_eq!(
+            resolve_agent_dial_relay_url("ws://127.0.0.1:3000", &identity).unwrap(),
+            "ws://127.0.0.1:3000"
+        );
+    }
+
+    #[test]
+    fn dial_strips_trailing_slash_but_keeps_authority() {
+        let identity = normalize_relay_url("ws://localhost:3000/").unwrap();
+        assert_eq!(
+            resolve_agent_dial_relay_url("ws://localhost:3000/", &identity).unwrap(),
+            "ws://localhost:3000"
+        );
+    }
+
+    #[test]
+    fn dial_rejects_workspace_that_normalizes_to_a_different_community() {
+        let identity = normalize_relay_url("wss://one.example").unwrap();
+        let err = resolve_agent_dial_relay_url("wss://two.example", &identity).unwrap_err();
+        assert!(
+            matches!(err, ResolveAgentDialRelayUrlError::CommunityMismatch { .. }),
+            "expected fail-closed mismatch, got: {err}"
+        );
+    }
+
+    #[test]
+    fn removing_authority_preservation_would_break_localhost_dial() {
+        // Falsifiable guard: dialing the identity URL is exactly the #4888 bug.
+        let workspace = "ws://localhost:3000";
+        let identity = normalize_relay_url(workspace).unwrap();
+        let dial = resolve_agent_dial_relay_url(workspace, &identity).unwrap();
+        assert_ne!(
+            dial, identity,
+            "dial must not collapse to the canonical identity spelling for localhost"
+        );
+        assert_eq!(dial, workspace);
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -460,14 +460,31 @@ pub fn spawn_agent_child(
     let effective_command = &descriptor.command;
     let agent_args = &descriptor.args;
 
+    // Identity (`runtime_key.relay_url`) is the canonical pair key — loopback
+    // hosts fold to 127.0.0.1 for dedup. The child must dial the workspace's
+    // configured authority instead: relay tenancy keys off the literal Host,
+    // so spawning with the canonical spelling while the desktop joined as
+    // `localhost` puts the agent in a different community (#4888). Resolve
+    // before log markers / process spawn so a mismatch leaves no side effects.
+    let workspace_relay_url = {
+        let state = app.state::<crate::app_state::AppState>();
+        crate::relay::relay_ws_url_with_override(&state)
+    };
+    let effective_relay_url = crate::relay::resolve_agent_dial_relay_url(
+        &workspace_relay_url,
+        &runtime_key.relay_url,
+    )?;
+
     let log_path = super::managed_agent_runtime_log_path(app, &runtime_key)?;
     append_log_marker(
         &log_path,
         &format!(
-            "\n=== starting {} ({}) at {} ===",
+            "\n=== starting {} ({}) at {} ===\n=== relay identity={} dial={} ===",
             record.name,
             record.pubkey,
-            now_iso()
+            now_iso(),
+            runtime_key.relay_url,
+            effective_relay_url,
         ),
     )?;
 
@@ -498,9 +515,6 @@ pub fn spawn_agent_child(
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| effective_command.clone());
 
-    // The caller supplies the explicit canonical pair relay. This is the only
-    // relay this child may connect to, regardless of the record/workspace default.
-    let effective_relay_url = runtime_key.relay_url.clone();
     // Augment PATH for DMG launches so child processes can find:
     //   - bundled CLI via ~/.local/bin symlink
     //   - nvm-managed node/npm (nvm initializes only in interactive shells)

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -985,6 +985,19 @@ pub fn meaningful_agent_error_from_log(path: &Path) -> Option<AgentLogError> {
                 code: Some(-32002),
             });
         }
+        // #4888 silent-idle variant: harness connected to an empty tenant
+        // (often loopback Host mismatch) and will never answer mentions.
+        if line.contains("no channel subscriptions resolved")
+            && line.contains("agent will sit idle")
+        {
+            return Some(AgentLogError {
+                message: "Agent connected but discovered no channels — the relay \
+Host may not match this community (e.g. localhost vs 127.0.0.1). \
+Check the harness dial URL in the agent log."
+                    .to_string(),
+                code: None,
+            });
+        }
         None
     })
 }

--- a/desktop/src-tauri/src/managed_agents/storage_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/storage_tests.rs
@@ -388,6 +388,23 @@ fn meaningful_agent_error_from_log_does_not_promote_midline_auth_text() {
 }
 
 #[test]
+fn meaningful_agent_error_from_log_promotes_empty_tenant_idle() {
+    // Dual-seeded loopback communities make the wrong dial succeed but leave
+    // the agent subscribed to nothing (#4888 silent-idle variant).
+    let file = write_log(
+        "INFO buzz_acp: discovered 0 channel(s)\n\
+         WARN buzz_acp: no channel subscriptions resolved — agent will sit idle\n",
+    );
+    let result = super::meaningful_agent_error_from_log(file.path()).unwrap();
+    assert!(
+        result.message.contains("discovered no channels"),
+        "got: {}",
+        result.message
+    );
+    assert!(result.message.contains("localhost vs 127.0.0.1"));
+}
+
+#[test]
 fn strips_ansi_from_typical_tracing_line() {
     let input = "\x1b[2m2026-05-27T15:16:32\x1b[0m \x1b[32m INFO\x1b[0m \x1b[2mbuzz_acp\x1b[0m\x1b[2m:\x1b[0m starting";
     assert_eq!(

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -83,6 +83,18 @@ pub fn effective_agent_relay_url(_record_relay: &str, workspace_relay: &str) -> 
     workspace_relay.to_string()
 }
 
+/// Desktop wrapper around [`buzz_core_pkg::relay::resolve_agent_dial_relay_url`].
+///
+/// Keeps spawn call sites on `Result<String, String>` while the typed error and
+/// regression tests live in `buzz-core` next to `normalize_relay_url` (#4888).
+pub fn resolve_agent_dial_relay_url(
+    workspace_url: &str,
+    identity_url: &str,
+) -> Result<String, String> {
+    buzz_core_pkg::relay::resolve_agent_dial_relay_url(workspace_url, identity_url)
+        .map_err(|error| error.to_string())
+}
+
 pub fn relay_http_base_url(relay_url: &str) -> String {
     let trimmed = relay_url.trim().trim_end_matches('/');
 

--- a/desktop/src-tauri/src/relay/tests.rs
+++ b/desktop/src-tauri/src/relay/tests.rs
@@ -3,7 +3,8 @@
 
 use super::{
     build_profile_event, classify_intercepted_response, effective_agent_relay_url,
-    extract_retry_in_hint, parse_command_response, relay_http_base_url, MALFORMED_RESPONSE_MESSAGE,
+    extract_retry_in_hint, parse_command_response, relay_http_base_url,
+    resolve_agent_dial_relay_url, MALFORMED_RESPONSE_MESSAGE,
 };
 use serde::Deserialize;
 
@@ -134,6 +135,17 @@ fn whitespace_only_relay_resolves_to_workspace() {
     assert_eq!(
         effective_agent_relay_url("   ", "wss://staging.example.com"),
         "wss://staging.example.com"
+    );
+}
+
+#[test]
+fn dial_wrapper_preserves_localhost_for_spawn_path() {
+    // Thin desktop wrapper must keep the buzz-core #4888 contract so
+    // `spawn_agent_child` cannot regress independently of core tests.
+    let identity = buzz_core_pkg::relay::normalize_relay_url("ws://localhost:3000").unwrap();
+    assert_eq!(
+        resolve_agent_dial_relay_url("ws://localhost:3000", &identity).unwrap(),
+        "ws://localhost:3000"
     );
 }
 


### PR DESCRIPTION
## Problem

No managed agent can reply reliably in local dev when Desktop joins
`ws://localhost:3000`. Agents start, connect, then either sit idle:

```
INFO  buzz_acp: discovered 0 channel(s)
WARN  buzz_acp: no channel subscriptions resolved — agent will sit idle
```

or fail to connect with a Host-bound 404. The desktop itself is fine; only
the spawned harness is wrong. The failure is easy to miss unless you open
the per-agent log.

## Cause

`buzz_core::relay::normalize_relay_url` folds loopback hosts to `127.0.0.1`
for identity. That is correct for runtime keys, receipts, and dedup — its
own docs say connection code may retain the configured URL.

`ManagedAgentRuntimeKey::new` stores that canonical form, and
`spawn_agent_child` used `runtime_key.relay_url` as `BUZZ_RELAY_URL`.
Relay tenancy keys off the literal Host, and local seed/compose often
keeps `localhost:3000` and `127.0.0.1:3000` as separate communities. So
the agent authenticates into a different (often empty or unmapped) tenant.

The HTTP path already pins this via
`loopback_ws_localhost_preserves_authority`. Spawn did not.

## Fix

- Add `resolve_agent_dial_relay_url` in `buzz-core`: keep identity
  canonical; when workspace and pair normalize to the same community,
  dial the workspace spelling; otherwise fail closed.
- Wire `spawn_agent_child` through that helper for `BUZZ_RELAY_URL` /
  related HTTP / snapshot. Log `identity=` and `dial=` at start.
- Promote empty-tenant idle lines to a readable `AgentLogError`.

Identity migration and receipt/restart dial persistence are out of scope.

## Related

- Fixes #4888.
- Supersedes #6393 (same root cause; this adds a shared helper, fail-closed
  mismatch, falsifiable tests, and idle visibility).
- Does not replace #4859 (receipt / restart persistence of the dial
  spelling).
- Does not compete with #2881 / #4345 (identity fold direction) or
  #4784 / #2619 (tenant `normalize_host` fold).

## Testing

- `cargo test -p buzz-core --lib relay::tests`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib dial_`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib meaningful_agent_error_from_log_promotes_empty_tenant_idle`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib relay::tests`
- Local Desktop on `ws://localhost:3000`, started Fizz:

```
identity=ws://127.0.0.1:3000 dial=ws://localhost:3000
discovered 1 channel(s)
```

No `sit idle`. `@Fizz` received a setup-mode reply on the correct tenant.
Same machine: `localhost:3000` had channels/membership;
`127.0.0.1:3000` was empty — the old identity dial would land there.
