### PR TITLE
feat(huddles): support local OpenAI-compatible STT

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -108,6 +108,11 @@ Real-time voice runs over a WebSocket Opus relay built into `buzz-relay`. Buzz a
 - Agents join the same audio relay as humans — they bring their own STT/TTS
 - Huddle lifecycle flows as Nostr events: started, joined, left, ended
 
+Desktop transcription can use a local OpenAI-compatible endpoint. Set
+`BUZZ_STT_OPENAI_URL` and `BUZZ_STT_OPENAI_API_KEY`; the endpoint must use
+loopback HTTP. `BUZZ_STT_OPENAI_MODEL`, `BUZZ_STT_OPENAI_LANGUAGE`, and
+`BUZZ_STT_OPENAI_PROMPT` optionally select the model, language, and prompt.
+
 Voice, room lifecycle, and lifecycle events are wired. Recording and per-track publishing are planned.
 
 ---

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -99,7 +99,7 @@ nostr = { version = "0.44", features = ["nip44", "nip49"] }
 getrandom = "0.2"
 zeroize = "1"
 percent-encoding = "2"
-reqwest = { version = "0.13", features = ["json", "query", "stream", "blocking"] }
+reqwest = { version = "0.13", features = ["json", "query", "stream", "blocking", "multipart"] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"] }
 url = "2"
 buzz_core_pkg = { package = "buzz-core", path = "../../crates/buzz-core" }

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -35,6 +35,7 @@ pub mod jitter;
 mod latency_bench;
 mod local_barge_in;
 pub mod models;
+mod openai_stt;
 pub mod pipeline;
 pub mod playout;
 pub mod pocket;

--- a/desktop/src-tauri/src/huddle/openai_stt.rs
+++ b/desktop/src-tauri/src/huddle/openai_stt.rs
@@ -1,0 +1,282 @@
+use reqwest::blocking::{multipart, Client};
+use serde::Deserialize;
+use std::{net::IpAddr, time::Duration};
+use url::Url;
+
+const DECODE_TIMEOUT: Duration = Duration::from_secs(90);
+
+pub(super) struct OpenAiSttConfig {
+    endpoint: Url,
+    api_key: String,
+    model: String,
+    language: String,
+    prompt: String,
+}
+
+impl OpenAiSttConfig {
+    pub(super) fn from_env() -> Result<Option<Self>, String> {
+        let endpoint = match std::env::var("BUZZ_STT_OPENAI_URL") {
+            Ok(endpoint) if !endpoint.trim().is_empty() => endpoint,
+            _ => return Ok(None),
+        };
+        let api_key = std::env::var("BUZZ_STT_OPENAI_API_KEY")
+            .map_err(|_| "BUZZ_STT_OPENAI_API_KEY is required when local STT is configured")?;
+        let model = std::env::var("BUZZ_STT_OPENAI_MODEL")
+            .unwrap_or_else(|_| "whisper-large-v3-turbo-asr-fp16".into());
+        let language = std::env::var("BUZZ_STT_OPENAI_LANGUAGE").unwrap_or_else(|_| "tr".into());
+        let prompt = std::env::var("BUZZ_STT_OPENAI_PROMPT").unwrap_or_default();
+        Self::new(endpoint, api_key, model, language, prompt).map(Some)
+    }
+
+    pub(super) fn new(
+        endpoint: String,
+        api_key: String,
+        model: String,
+        language: String,
+        prompt: String,
+    ) -> Result<Self, String> {
+        let endpoint =
+            Url::parse(&endpoint).map_err(|error| format!("invalid STT URL: {error}"))?;
+        let is_loopback = match endpoint.host_str() {
+            Some("localhost") => true,
+            Some(host) => host
+                .parse::<IpAddr>()
+                .is_ok_and(|address| address.is_loopback()),
+            None => false,
+        };
+        if endpoint.scheme() != "http" || !is_loopback {
+            return Err("OpenAI-compatible STT endpoint must use HTTP on loopback".into());
+        }
+        if api_key.is_empty() || model.is_empty() || language.is_empty() {
+            return Err("OpenAI-compatible STT key, model, and language are required".into());
+        }
+        Ok(Self {
+            endpoint,
+            api_key,
+            model,
+            language,
+            prompt,
+        })
+    }
+}
+
+pub(super) fn is_configured() -> Result<bool, String> {
+    Ok(OpenAiSttConfig::from_env()?.is_some())
+}
+
+pub(super) struct OpenAiSttDecoder {
+    client: Client,
+    config: OpenAiSttConfig,
+}
+
+#[derive(Deserialize)]
+struct TranscriptionResponse {
+    text: String,
+}
+
+impl OpenAiSttDecoder {
+    pub(super) fn new(config: OpenAiSttConfig) -> Result<Self, String> {
+        Self::new_with_timeout(config, DECODE_TIMEOUT)
+    }
+
+    fn new_with_timeout(config: OpenAiSttConfig, timeout: Duration) -> Result<Self, String> {
+        let client = Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|error| format!("failed to create STT HTTP client: {error}"))?;
+        Ok(Self { client, config })
+    }
+
+    pub(super) fn decode(&self, speech: &[f32]) -> Result<String, String> {
+        let file = multipart::Part::bytes(encode_pcm16_wav(speech))
+            .file_name("huddle.wav")
+            .mime_str("audio/wav")
+            .map_err(|error| format!("failed to create STT audio part: {error}"))?;
+        let mut form = multipart::Form::new()
+            .part("file", file)
+            .text("model", self.config.model.clone())
+            .text("language", self.config.language.clone());
+        if !self.config.prompt.is_empty() {
+            form = form.text("prompt", self.config.prompt.clone());
+        }
+        let response = self
+            .client
+            .post(self.config.endpoint.clone())
+            .bearer_auth(&self.config.api_key)
+            .multipart(form)
+            .send()
+            .map_err(|error| format!("STT request failed: {error}"))?
+            .error_for_status()
+            .map_err(|error| format!("STT endpoint rejected request: {error}"))?
+            .json::<TranscriptionResponse>()
+            .map_err(|error| format!("invalid STT response: {error}"))?;
+        Ok(response.text.trim().to_string())
+    }
+}
+
+fn encode_pcm16_wav(speech: &[f32]) -> Vec<u8> {
+    let data_length = speech.len().saturating_mul(2).min(u32::MAX as usize) as u32;
+    let mut wav = Vec::with_capacity(44 + data_length as usize);
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&(36_u32.saturating_add(data_length)).to_le_bytes());
+    wav.extend_from_slice(b"WAVEfmt ");
+    wav.extend_from_slice(&16_u32.to_le_bytes());
+    wav.extend_from_slice(&1_u16.to_le_bytes());
+    wav.extend_from_slice(&1_u16.to_le_bytes());
+    wav.extend_from_slice(&16_000_u32.to_le_bytes());
+    wav.extend_from_slice(&32_000_u32.to_le_bytes());
+    wav.extend_from_slice(&2_u16.to_le_bytes());
+    wav.extend_from_slice(&16_u16.to_le_bytes());
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_length.to_le_bytes());
+    for sample in speech.iter().take((data_length / 2) as usize) {
+        let pcm = (sample.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16;
+        wav.extend_from_slice(&pcm.to_le_bytes());
+    }
+    wav
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OpenAiSttConfig, OpenAiSttDecoder};
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        sync::mpsc,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    #[test]
+    fn sends_turkish_pcm_to_loopback_openai_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let (request_tx, request_rx) = mpsc::channel();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let read = stream.read(&mut buffer).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let header_end = request
+                        .windows(4)
+                        .position(|window| window == b"\r\n\r\n")
+                        .expect("header terminator")
+                        + 4;
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.to_ascii_lowercase()
+                                .strip_prefix("content-length: ")
+                                .and_then(|value| value.trim().parse::<usize>().ok())
+                        })
+                        .expect("content length");
+                    if request.len() >= header_end + content_length {
+                        break;
+                    }
+                }
+            }
+            request_tx.send(request).expect("capture request");
+            let body = r#"{"text":"Ananı sikerim, amına koyayım"}"#.as_bytes();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write response headers");
+            stream.write_all(body).expect("write response body");
+        });
+
+        let config = OpenAiSttConfig::new(
+            format!("http://{address}/v1/audio/transcriptions"),
+            "test-key".into(),
+            "whisper-large-v3-turbo-asr-fp16".into(),
+            "tr".into(),
+            "amına koyayım, ananı sikerim, ibne".into(),
+        )
+        .expect("valid loopback config");
+        let decoder = OpenAiSttDecoder::new(config).expect("decoder");
+
+        let text = decoder
+            .decode(&vec![0.25; 16_000])
+            .expect("transcription response");
+
+        assert_eq!(text, "Ananı sikerim, amına koyayım");
+        let request = request_rx.recv().expect("captured request");
+        let request = String::from_utf8_lossy(&request);
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-key"));
+        assert!(request.contains("whisper-large-v3-turbo-asr-fp16"));
+        assert!(request.contains("name=\"language\""));
+        assert!(request.contains("\r\n\r\ntr\r\n"));
+        assert!(request.contains("amına koyayım, ananı sikerim, ibne"));
+        assert!(request
+            .as_bytes()
+            .windows(4)
+            .any(|window| window == b"RIFF"));
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    fn rejects_non_loopback_endpoint() {
+        let result = OpenAiSttConfig::new(
+            "https://api.openai.com/v1/audio/transcriptions".into(),
+            "test-key".into(),
+            "whisper-large-v3-turbo-asr-fp16".into(),
+            "tr".into(),
+            String::new(),
+        );
+        let error = match result {
+            Ok(_) => panic!("remote audio endpoint must be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("loopback"));
+    }
+
+    #[test]
+    fn runaway_decode_times_out_without_blocking_the_worker() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = [0_u8; 4096];
+            let _ = stream.read(&mut buffer);
+            thread::sleep(Duration::from_millis(200));
+            let body = br#"{"text":"late transcript"}"#;
+            let _ = write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(body);
+        });
+        let config = OpenAiSttConfig::new(
+            format!("http://{address}/v1/audio/transcriptions"),
+            "test-key".into(),
+            "whisper-large-v3-turbo-asr-fp16".into(),
+            "tr".into(),
+            String::new(),
+        )
+        .expect("valid loopback config");
+        let decoder =
+            OpenAiSttDecoder::new_with_timeout(config, Duration::from_millis(50)).expect("decoder");
+
+        let started = Instant::now();
+        let error = decoder
+            .decode(&vec![0.25; 16_000])
+            .expect_err("slow decode must time out");
+
+        assert!(started.elapsed() < Duration::from_millis(150));
+        assert!(error.contains("STT request failed"), "{error}");
+        server.join().expect("server thread");
+    }
+}

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -19,6 +19,7 @@ use crate::app_state::AppState;
 use crate::events;
 
 use super::models;
+use super::openai_stt::{self, OpenAiSttConfig};
 use super::relay_api::{self, fetch_channel_members, parse_channel_uuid};
 use super::state::{HuddlePhase, HuddleState, VoiceInputMode};
 use super::stt;
@@ -88,7 +89,10 @@ pub async fn check_pipeline_hotstart(state: State<'_, AppState>) -> Result<(), S
             eprintln!("buzz-desktop: TTS hotstart failed: {e}");
         }
     }
-    if transcription_enabled && !has_stt && (stt_ready || models::is_stt_ready()) {
+    if transcription_enabled
+        && !has_stt
+        && (openai_stt::is_configured()? || stt_ready || models::is_stt_ready())
+    {
         if let Some(eph_id) = &ephemeral_channel_id {
             if let Err(e) = maybe_start_stt_pipeline(&state, eph_id).await {
                 eprintln!("buzz-desktop: STT hotstart failed: {e}");
@@ -226,7 +230,7 @@ pub(crate) async fn post_connect_setup(
     // explicit user choices remain authoritative.
     if let Some(mgr) = models::global_model_manager() {
         mgr.start_tts_download(state.http_client.clone());
-        if state.huddle()?.transcription_enabled {
+        if state.huddle()?.transcription_enabled && !openai_stt::is_configured()? {
             mgr.start_stt_download(state.http_client.clone());
         }
     }
@@ -292,10 +296,15 @@ pub(crate) async fn maybe_start_stt_pipeline(
         hs.huddle_generation
     };
 
-    if !models::is_stt_ready() {
-        return Ok(false); // Models not downloaded yet — voice-only mode.
-    }
-    let model_dir = models::stt_model_dir().ok_or("STT model directory not found")?;
+    let openai_config = OpenAiSttConfig::from_env()?;
+    let model_dir = if openai_config.is_none() {
+        if !models::is_stt_ready() {
+            return Ok(false);
+        }
+        Some(models::stt_model_dir().ok_or("STT model directory not found")?)
+    } else {
+        None
+    };
 
     let channel_uuid = parse_channel_uuid(ephemeral_channel_id)?;
 
@@ -361,14 +370,21 @@ pub(crate) async fn maybe_start_stt_pipeline(
     // Drop the old pipeline OUTSIDE the lock — thread join happens here.
     drop(old_stt);
 
-    let constructed = tokio::task::spawn_blocking(move || {
-        stt::SttPipeline::new(
-            model_dir,
+    let constructed = tokio::task::spawn_blocking(move || match openai_config {
+        Some(config) => stt::SttPipeline::new_openai(
+            config,
             ptt_active_for_stt,
             manual_mic_unmuted_for_stt,
             human_floor,
             output_device,
-        )
+        ),
+        None => stt::SttPipeline::new(
+            model_dir.ok_or("STT model directory not found")?,
+            ptt_active_for_stt,
+            manual_mic_unmuted_for_stt,
+            human_floor,
+            output_device,
+        ),
     })
     .await;
     let (pipeline, text_rx) = match constructed {
@@ -406,8 +422,17 @@ pub(crate) async fn maybe_start_stt_pipeline(
 
 /// Start STT after agent presence automatically enables transcription.
 pub(crate) async fn start_auto_enabled_transcription(state: &AppState, ephemeral_channel_id: &str) {
-    if let Some(manager) = models::global_model_manager() {
-        manager.start_stt_download(state.http_client.clone());
+    let openai_configured = match openai_stt::is_configured() {
+        Ok(configured) => configured,
+        Err(error) => {
+            tracing::warn!(error = %error, "automatic STT start rejected invalid configuration");
+            return;
+        }
+    };
+    if !openai_configured {
+        if let Some(manager) = models::global_model_manager() {
+            manager.start_stt_download(state.http_client.clone());
+        }
     }
     if let Err(error) = maybe_start_stt_pipeline(state, ephemeral_channel_id).await {
         eprintln!("buzz-desktop: auto-enabled STT failed to start: {error}");
@@ -619,6 +644,69 @@ pub(crate) fn sign_and_guard_stt_body(
     Ok(body_bytes)
 }
 
+#[derive(Default)]
+struct TranscriptPublicationFilter {
+    previous: Option<String>,
+}
+
+impl TranscriptPublicationFilter {
+    fn should_publish(&mut self, text: &str) -> bool {
+        let normalized = normalize_transcript(text);
+        if normalized.is_empty()
+            || is_caption_hallucination(&normalized)
+            || is_pathological_repetition(&normalized)
+            || self.previous.as_deref() == Some(normalized.as_str())
+        {
+            return false;
+        }
+        self.previous = Some(normalized);
+        true
+    }
+}
+
+fn normalize_transcript(text: &str) -> String {
+    text.chars()
+        .flat_map(|character| match character {
+            'İ' => 'i'.to_lowercase(),
+            'I' => 'ı'.to_lowercase(),
+            character => character.to_lowercase(),
+        })
+        .map(|character| {
+            if character.is_alphanumeric() {
+                character
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn is_caption_hallucination(normalized: &str) -> bool {
+    [
+        "abone ol",
+        "izlediğiniz için teşekkür ederim",
+        "altyazı m k",
+    ]
+    .iter()
+    .any(|phrase| normalized.contains(&normalize_transcript(phrase)))
+}
+
+fn is_pathological_repetition(normalized: &str) -> bool {
+    let words: Vec<&str> = normalized.split_whitespace().collect();
+    if words.len() < 8 {
+        return false;
+    }
+    let most_repeated = words
+        .iter()
+        .map(|candidate| words.iter().filter(|word| *word == candidate).count())
+        .max()
+        .unwrap_or_default();
+    most_repeated * 10 >= words.len() * 7
+}
+
 /// Spawn a tokio task that reads text_rx and posts kind:9 events.
 ///
 /// Fix 1: `agent_pubkeys_arc` is an `Arc<Mutex<Vec<String>>>` cloned from
@@ -645,10 +733,11 @@ pub(crate) fn spawn_transcription_task(
     let relay_base_url = crate::relay::relay_api_base_url_with_override(state);
 
     tauri::async_runtime::spawn(async move {
+        let mut publication_filter = TranscriptPublicationFilter::default();
         // recv().await yields (not blocks) until text arrives or sender is dropped.
         // When the STT worker exits and drops its Sender, recv() returns None → loop ends.
         while let Some(t) = text_rx.recv().await {
-            if t.is_empty() {
+            if !publication_filter.should_publish(&t) {
                 continue;
             }
 
@@ -877,5 +966,45 @@ mod tts_start_race_tests {
             .expect("huddle state")
             .tts_starting
             .load(Ordering::Acquire));
+    }
+}
+
+#[cfg(test)]
+mod transcript_publication_filter_tests {
+    use super::TranscriptPublicationFilter;
+
+    #[test]
+    fn rejects_common_caption_hallucinations() {
+        let mut filter = TranscriptPublicationFilter::default();
+
+        assert!(!filter.should_publish("abone ol"));
+        assert!(!filter.should_publish("Abone ol, videoyu beğen."));
+        assert!(!filter.should_publish("İzlediğiniz için teşekkür ederim."));
+    }
+
+    #[test]
+    fn rejects_pathological_token_repetition() {
+        let mut filter = TranscriptPublicationFilter::default();
+
+        assert!(!filter.should_publish("iki iki iki iki iki iki iki iki"));
+    }
+
+    #[test]
+    fn rejects_only_consecutive_duplicates() {
+        let mut filter = TranscriptPublicationFilter::default();
+
+        assert!(filter.should_publish("Sorunu önce netleştirelim."));
+        assert!(!filter.should_publish("Sorunu önce netleştirelim."));
+        assert!(filter.should_publish("Sonra issue açalım."));
+        assert!(filter.should_publish("Sorunu önce netleştirelim."));
+    }
+
+    #[test]
+    fn preserves_real_turkish_slang() {
+        let mut filter = TranscriptPublicationFilter::default();
+
+        assert!(filter.should_publish(
+            "Kubilay bu iş böyle olmaz, amına koyayım. Önce problemi netleştirelim."
+        ));
     }
 }

--- a/desktop/src-tauri/src/huddle/stt.rs
+++ b/desktop/src-tauri/src/huddle/stt.rs
@@ -32,13 +32,22 @@ use std::{
 
 use tokio::sync::mpsc as tokio_mpsc;
 
-use super::{human_floor::HumanFloor, local_barge_in};
+use super::{
+    human_floor::HumanFloor,
+    local_barge_in,
+    openai_stt::{OpenAiSttConfig, OpenAiSttDecoder},
+};
 
 // ── Public pipeline handle ────────────────────────────────────────────────────
 
 /// Bounded audio queue capacity.
 /// 100 ms batches at 48 kHz ≈ 19 KB each → 50 slots ≈ 5 s / ~1 MB max backlog.
 const AUDIO_QUEUE_DEPTH: usize = 50;
+
+/// OpenAI-compatible decoders run independently from microphone capture.
+/// Sixteen 30-second utterances occupy at most about 31 MB of PCM while a
+/// slow local model catches up.
+const OPENAI_UTTERANCE_QUEUE_DEPTH: usize = 16;
 
 /// Maximum speech buffer size: 30 seconds at 16 kHz.
 /// Prevents OOM if VAD stays in speech mode (noisy environment).
@@ -73,6 +82,11 @@ enum SttAudioOrigin {
     RemoteHuman,
 }
 
+enum SttBackend {
+    Parakeet(PathBuf),
+    OpenAi(OpenAiSttConfig),
+}
+
 impl SttPipeline {
     /// Spawn the pipeline thread.
     ///
@@ -102,6 +116,38 @@ impl SttPipeline {
         human_floor: HumanFloor,
         output_device: Option<String>,
     ) -> Result<(Self, tokio_mpsc::Receiver<String>), String> {
+        Self::spawn(
+            SttBackend::Parakeet(model_dir),
+            ptt_active,
+            manual_mic_unmuted,
+            human_floor,
+            output_device,
+        )
+    }
+
+    pub(super) fn new_openai(
+        config: OpenAiSttConfig,
+        ptt_active: Option<Arc<AtomicBool>>,
+        manual_mic_unmuted: Option<Arc<AtomicBool>>,
+        human_floor: HumanFloor,
+        output_device: Option<String>,
+    ) -> Result<(Self, tokio_mpsc::Receiver<String>), String> {
+        Self::spawn(
+            SttBackend::OpenAi(config),
+            ptt_active,
+            manual_mic_unmuted,
+            human_floor,
+            output_device,
+        )
+    }
+
+    fn spawn(
+        backend: SttBackend,
+        ptt_active: Option<Arc<AtomicBool>>,
+        manual_mic_unmuted: Option<Arc<AtomicBool>>,
+        human_floor: HumanFloor,
+        output_device: Option<String>,
+    ) -> Result<(Self, tokio_mpsc::Receiver<String>), String> {
         let (audio_tx, audio_rx) = mpsc::sync_channel::<SttAudioInput>(AUDIO_QUEUE_DEPTH);
         let (text_tx, text_rx) = tokio_mpsc::channel::<String>(64);
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -113,7 +159,7 @@ impl SttPipeline {
             .name("stt-worker".into())
             .spawn(move || {
                 stt_worker(
-                    model_dir,
+                    backend,
                     audio_rx,
                     text_tx,
                     shutdown_worker,
@@ -373,6 +419,103 @@ fn stt_speculative_decode() -> bool {
     std::env::var("BUZZ_STT_SPECULATIVE").is_ok_and(|v| v == "1")
 }
 
+trait SpeechDecoder {
+    fn decode(&self, speech: &[f32]) -> Result<DecodeOutcome, String>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DecodeOutcome {
+    Transcript(String),
+    Queued,
+}
+
+struct QueuedDecoder {
+    utterance_tx: SyncSender<Vec<f32>>,
+}
+
+impl SpeechDecoder for QueuedDecoder {
+    fn decode(&self, speech: &[f32]) -> Result<DecodeOutcome, String> {
+        self.utterance_tx
+            .try_send(speech.to_vec())
+            .map_err(|error| format!("STT utterance queue unavailable: {error}"))?;
+        Ok(DecodeOutcome::Queued)
+    }
+}
+
+fn spawn_openai_decoder(
+    config: OpenAiSttConfig,
+    text_tx: tokio_mpsc::Sender<String>,
+    shutdown: Arc<AtomicBool>,
+) -> Result<Box<dyn SpeechDecoder>, String> {
+    let decoder = OpenAiSttDecoder::new(config)?;
+    let (utterance_tx, utterance_rx) = mpsc::sync_channel::<Vec<f32>>(OPENAI_UTTERANCE_QUEUE_DEPTH);
+    thread::Builder::new()
+        .name("stt-openai-decoder".into())
+        .spawn(move || loop {
+            if shutdown.load(Ordering::Acquire) {
+                break;
+            }
+            let speech = match utterance_rx.recv_timeout(RECV_TIMEOUT) {
+                Ok(speech) => speech,
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            };
+            let Some(text) = decode_speech(&decoder, &speech) else {
+                continue;
+            };
+            if shutdown.load(Ordering::Acquire) {
+                break;
+            }
+            send_transcript(text, &text_tx);
+        })
+        .map_err(|error| format!("failed to spawn OpenAI STT decoder thread: {error}"))?;
+    Ok(Box::new(QueuedDecoder { utterance_tx }))
+}
+
+struct ParakeetDecoder {
+    recognizer: sherpa_onnx::OfflineRecognizer,
+}
+
+impl ParakeetDecoder {
+    fn new(model_dir: PathBuf) -> Result<Self, String> {
+        use sherpa_onnx::{OfflineRecognizer, OfflineRecognizerConfig};
+
+        let tokens_path = model_dir.join("tokens.txt");
+        let model_path = model_dir.join("model.int8.onnx");
+        if !tokens_path.exists() || !model_path.exists() {
+            return Err(format!("STT model not found at {}", model_dir.display()));
+        }
+        let mut config = OfflineRecognizerConfig::default();
+        config.model_config.nemo_ctc.model = Some(model_path.to_string_lossy().into_owned());
+        config.model_config.tokens = Some(tokens_path.to_string_lossy().into_owned());
+        config.model_config.num_threads = stt_num_threads();
+        config.model_config.debug = false;
+        let recognizer =
+            OfflineRecognizer::create(&config).ok_or("OfflineRecognizer::create returned None")?;
+        Ok(Self { recognizer })
+    }
+}
+
+impl SpeechDecoder for ParakeetDecoder {
+    fn decode(&self, speech: &[f32]) -> Result<DecodeOutcome, String> {
+        let stream = self.recognizer.create_stream();
+        stream.accept_waveform(16_000, speech);
+        self.recognizer.decode(&stream);
+        Ok(DecodeOutcome::Transcript(
+            stream
+                .get_result()
+                .map(|result| result.text.trim().to_string())
+                .unwrap_or_default(),
+        ))
+    }
+}
+
+impl SpeechDecoder for OpenAiSttDecoder {
+    fn decode(&self, speech: &[f32]) -> Result<DecodeOutcome, String> {
+        OpenAiSttDecoder::decode(self, speech).map(DecodeOutcome::Transcript)
+    }
+}
+
 struct SttStreamState {
     resampler: rubato::Fft<f32>,
     chunk_in: usize,
@@ -417,21 +560,18 @@ fn run_stt_receive_loop(
     let mut local_barge_in_state = local_barge_in::WorkerLocalBargeIn::new(human_floor);
 
     loop {
-        // Check shutdown flag before blocking.
         if shutdown.load(Ordering::Acquire) {
             break;
         }
 
         process(SttLoopInput::Tick, &mut local_barge_in_state);
 
-        // Use recv_timeout so we can periodically check the shutdown flag.
         let input = match audio_rx.recv_timeout(RECV_TIMEOUT) {
             Ok(input) => input,
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
-            Err(mpsc::RecvTimeoutError::Disconnected) => break, // Sender dropped.
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
         };
 
-        // Drain any additional pending messages to batch-process.
         let mut batch = vec![input];
         while let Ok(input) = audio_rx.try_recv() {
             batch.push(input);
@@ -442,7 +582,7 @@ fn run_stt_receive_loop(
 
 #[allow(clippy::too_many_arguments)]
 fn stt_worker(
-    model_dir: PathBuf,
+    backend: SttBackend,
     audio_rx: Receiver<SttAudioInput>,
     text_tx: tokio_mpsc::Sender<String>,
     shutdown: Arc<AtomicBool>,
@@ -451,40 +591,24 @@ fn stt_worker(
     human_floor: HumanFloor,
     output_device: Option<String>,
 ) {
-    // ── 1. Initialise sherpa-onnx recognizer ─────────────────────────────────
-    //
-    // Parakeet TDT-CTC 110M ships as a single `model.int8.onnx` (CTC head) plus
-    // `tokens.txt`. sherpa-onnx infers the model family from which inner config
-    // has a `model` path set, so we don't need to set `model_type` explicitly.
-    // (See rust-api-examples/parakeet_tdt_ctc_simulate_streaming_microphone.rs
-    // in k2-fsa/sherpa-onnx.)
-    use sherpa_onnx::{OfflineRecognizer, OfflineRecognizerConfig};
-
-    let tokens_path = model_dir.join("tokens.txt");
-    let model_path = model_dir.join("model.int8.onnx");
-    if !tokens_path.exists() || !model_path.exists() {
-        eprintln!(
-            "buzz-desktop: STT model not found at {} — STT disabled",
-            model_dir.display()
-        );
-        drain_until_shutdown(audio_rx, &shutdown);
-        return;
-    }
-
-    let mut cfg = OfflineRecognizerConfig::default();
-    cfg.model_config.nemo_ctc.model = Some(model_path.to_string_lossy().into_owned());
-    cfg.model_config.tokens = Some(tokens_path.to_string_lossy().into_owned());
-    cfg.model_config.num_threads = stt_num_threads();
-    // Explicit — defaults are not part of the API contract, and noisy debug
-    // logging in release builds would be expensive on every VAD chunk.
-    cfg.model_config.debug = false;
-
-    let recognizer = match OfflineRecognizer::create(&cfg) {
-        Some(r) => r,
-        None => {
-            eprintln!("buzz-desktop: OfflineRecognizer::create returned None — STT disabled");
-            drain_until_shutdown(audio_rx, &shutdown);
-            return;
+    let decoder: Box<dyn SpeechDecoder> = match backend {
+        SttBackend::Parakeet(model_dir) => match ParakeetDecoder::new(model_dir) {
+            Ok(decoder) => Box::new(decoder),
+            Err(error) => {
+                tracing::warn!(error = %error, "STT disabled");
+                drain_until_shutdown(audio_rx, &shutdown);
+                return;
+            }
+        },
+        SttBackend::OpenAi(config) => {
+            match spawn_openai_decoder(config, text_tx.clone(), Arc::clone(&shutdown)) {
+                Ok(decoder) => decoder,
+                Err(error) => {
+                    tracing::warn!(error = %error, "STT disabled");
+                    drain_until_shutdown(audio_rx, &shutdown);
+                    return;
+                }
+            }
         }
     };
 
@@ -535,7 +659,7 @@ fn stt_worker(
                         flush_to_stt(
                             &local_stream.endpoint.speech_buf,
                             local_stream.endpoint.voiced_frames,
-                            &recognizer,
+                            decoder.as_ref(),
                             &text_tx,
                         );
                         local_stream.endpoint.reset_segment();
@@ -560,7 +684,7 @@ fn stt_worker(
                         stream,
                         &input.pcm_bytes,
                         speculative_enabled,
-                        &recognizer,
+                        decoder.as_ref(),
                         &text_tx,
                         ptt_gate,
                         manual_gate,
@@ -584,7 +708,7 @@ fn process_stt_input(
     stream: &mut SttStreamState,
     pcm_bytes: &[u8],
     speculative_enabled: bool,
-    recognizer: &sherpa_onnx::OfflineRecognizer,
+    decoder: &dyn SpeechDecoder,
     text_tx: &tokio_mpsc::Sender<String>,
     ptt_active: Option<&Arc<AtomicBool>>,
     manual_mic_unmuted: Option<&Arc<AtomicBool>>,
@@ -607,7 +731,7 @@ fn process_stt_input(
             &mut stream.endpoint,
             SILENCE_FLUSH_FRAMES,
             (speculative_enabled, &mut stream.speculative),
-            recognizer,
+            decoder,
             text_tx,
             ptt_active,
             manual_mic_unmuted,
@@ -664,7 +788,7 @@ fn process_16k_samples(
     endpoint: &mut VadEndpoint,
     flush_frames: usize,
     speculative: (bool, &mut Option<(String, usize)>),
-    recognizer: &sherpa_onnx::OfflineRecognizer,
+    decoder: &dyn SpeechDecoder,
     text_tx: &tokio_mpsc::Sender<String>,
     ptt_active: Option<&Arc<AtomicBool>>,
     manual_mic_unmuted: Option<&Arc<AtomicBool>>,
@@ -724,10 +848,9 @@ fn process_16k_samples(
                     && flush_allowed
                     && has_enough_voiced_audio(endpoint.voiced_frames)
                 {
-                    speculative.replace((
-                        decode_speech(recognizer, &endpoint.speech_buf),
-                        endpoint.voiced_frames,
-                    ));
+                    if let Some(text) = decode_speech(decoder, &endpoint.speech_buf) {
+                        speculative.replace((text, endpoint.voiced_frames));
+                    }
                 }
             }
             VadFrameAction::Flush => {
@@ -738,7 +861,7 @@ fn process_16k_samples(
                     _ => flush_to_stt(
                         &endpoint.speech_buf,
                         endpoint.voiced_frames,
-                        recognizer,
+                        decoder,
                         text_tx,
                     ),
                 }
@@ -755,7 +878,7 @@ fn process_16k_samples(
             flush_to_stt(
                 &endpoint.speech_buf,
                 endpoint.voiced_frames,
-                recognizer,
+                decoder,
                 text_tx,
             );
             endpoint.reset_segment();
@@ -774,7 +897,7 @@ fn process_16k_samples(
 fn flush_to_stt(
     speech_buf: &[f32],
     voiced_frames: usize,
-    recognizer: &sherpa_onnx::OfflineRecognizer,
+    decoder: &dyn SpeechDecoder,
     text_tx: &tokio_mpsc::Sender<String>,
 ) {
     if speech_buf.is_empty() {
@@ -786,19 +909,20 @@ fn flush_to_stt(
         );
         return;
     }
-    send_transcript(decode_speech(recognizer, speech_buf), text_tx);
+    if let Some(text) = decode_speech(decoder, speech_buf) {
+        send_transcript(text, text_tx);
+    }
 }
 
-/// Run the Parakeet decode on a speech buffer and return the trimmed text.
-fn decode_speech(recognizer: &sherpa_onnx::OfflineRecognizer, speech_buf: &[f32]) -> String {
-    let stream = recognizer.create_stream();
-    stream.accept_waveform(16_000, speech_buf);
-    recognizer.decode(&stream);
-
-    stream
-        .get_result()
-        .map(|r| r.text.trim().to_string())
-        .unwrap_or_default()
+fn decode_speech(decoder: &dyn SpeechDecoder, speech_buf: &[f32]) -> Option<String> {
+    match decoder.decode(speech_buf) {
+        Ok(DecodeOutcome::Transcript(text)) => Some(text.trim().to_string()),
+        Ok(DecodeOutcome::Queued) => None,
+        Err(error) => {
+            tracing::warn!(error = %error, "STT decode failed");
+            None
+        }
+    }
 }
 
 fn send_transcript(text: String, text_tx: &tokio_mpsc::Sender<String>) {

--- a/desktop/src-tauri/src/huddle/stt_tests.rs
+++ b/desktop/src-tauri/src/huddle/stt_tests.rs
@@ -1,10 +1,28 @@
-use std::sync::{atomic::AtomicBool, mpsc, Arc, Barrier};
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc, Barrier,
+    },
+    thread,
+    time::{Duration, Instant},
+};
 
 use super::{
-    has_enough_voiced_audio, run_stt_receive_loop, vad_flush_allowed, HumanFloor, SttAudioInput,
+    flush_to_stt, has_enough_voiced_audio, run_stt_receive_loop, spawn_openai_decoder,
+    vad_flush_allowed, DecodeOutcome, HumanFloor, OpenAiSttConfig, SpeechDecoder, SttAudioInput,
     SttAudioOrigin, SttLoopInput, VadEndpoint, VadFrameAction, MIN_VOICED_FRAMES,
     SILENCE_FLUSH_FRAMES, VAD_FRAME_SAMPLES, VAD_ONSET_FRAMES, VAD_PRE_ROLL_FRAMES,
 };
+
+struct FailingDecoder;
+
+impl SpeechDecoder for FailingDecoder {
+    fn decode(&self, _speech: &[f32]) -> Result<DecodeOutcome, String> {
+        Err("endpoint unavailable".into())
+    }
+}
 
 #[derive(Clone, Copy)]
 enum WorkerExit {
@@ -257,4 +275,79 @@ fn held_push_to_talk_never_silence_flushes() {
     assert!(!vad_flush_allowed(true, true, true));
     // Manually open mic with the shortcut up: normal VAD behavior.
     assert!(vad_flush_allowed(true, true, false));
+}
+
+#[test]
+fn decoder_failure_does_not_publish_transcript() {
+    let (text_tx, mut text_rx) = tokio::sync::mpsc::channel(1);
+
+    flush_to_stt(
+        &[0.25; 16_000],
+        MIN_VOICED_FRAMES,
+        &FailingDecoder,
+        &text_tx,
+    );
+
+    assert!(text_rx.try_recv().is_err());
+}
+
+#[test]
+fn slow_openai_decode_does_not_block_later_utterance_capture() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    let address = listener.local_addr().expect("test server address");
+    let server = thread::spawn(move || {
+        for text in ["ilk bölüm", "ikinci bölüm"] {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_millis(20)))
+                .expect("read timeout");
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            while let Ok(read) = stream.read(&mut buffer) {
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+            }
+            assert!(!request.is_empty());
+            thread::sleep(Duration::from_millis(100));
+            let body = format!(r#"{{"text":"{text}"}}"#);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        }
+    });
+
+    let config = OpenAiSttConfig::new(
+        format!("http://{address}/v1/audio/transcriptions"),
+        "test-key".into(),
+        "whisper-large-v3-turbo-asr-fp16".into(),
+        "tr".into(),
+        String::new(),
+    )
+    .expect("valid loopback config");
+    let (text_tx, mut text_rx) = tokio::sync::mpsc::channel(2);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let decoder =
+        spawn_openai_decoder(config, text_tx, Arc::clone(&shutdown)).expect("decoder worker");
+
+    let started = Instant::now();
+    assert_eq!(
+        decoder.decode(&[0.25; 16_000]).expect("queue first"),
+        DecodeOutcome::Queued
+    );
+    assert_eq!(
+        decoder.decode(&[0.25; 16_000]).expect("queue second"),
+        DecodeOutcome::Queued
+    );
+    assert!(started.elapsed() < Duration::from_millis(50));
+    assert_eq!(text_rx.blocking_recv().as_deref(), Some("ilk bölüm"));
+    assert_eq!(text_rx.blocking_recv().as_deref(), Some("ikinci bölüm"));
+
+    shutdown.store(true, Ordering::Release);
+    server.join().expect("server thread");
 }

--- a/desktop/src-tauri/src/huddle/transcription.rs
+++ b/desktop/src-tauri/src/huddle/transcription.rs
@@ -2,7 +2,7 @@ use tauri::State;
 
 use crate::app_state::AppState;
 
-use super::{models, pipeline::maybe_start_stt_pipeline};
+use super::{models, openai_stt, pipeline::maybe_start_stt_pipeline};
 
 /// Start the STT pipeline for the active huddle.
 ///
@@ -61,8 +61,10 @@ pub async fn set_huddle_transcription_enabled(
     drop(old_stt);
 
     if enabled {
-        if let Some(manager) = models::global_model_manager() {
-            manager.start_stt_download(state.http_client.clone());
+        if !openai_stt::is_configured()? {
+            if let Some(manager) = models::global_model_manager() {
+                manager.start_stt_download(state.http_client.clone());
+            }
         }
         if let Err(e) = maybe_start_stt_pipeline(&state, &ephemeral_channel_id).await {
             eprintln!("buzz-desktop: STT transcript start failed: {e}");


### PR DESCRIPTION
## Summary

- add a loopback-only OpenAI-compatible STT backend for local servers such as oMLX Whisper
- preserve the native Parakeet fallback and current remote-human/barge-in behavior
- keep audio capture responsive with a bounded decoder queue
- default the optional transcription prompt to blank and suppress common caption hallucinations/repetition without censoring real Turkish speech
- document endpoint, model, language, and prompt environment configuration

## Safety

The endpoint must resolve to loopback. The backend is considered ready only when its configuration is complete. No relay, external send, production data, or hosted model is involved.

## Verification

- full just ci passed on macOS after rebasing onto 1c8321cd08feb597f8bcff5195c21148fb3e98ed
- desktop JavaScript: 5,881 passed
- desktop Rust workspace: 3,065 passed, 19 ignored
- mobile Flutter: 2,019 passed
- focused huddle suite: 204 passed, 1 ignored
- cargo Clippy with warnings denied: passed
- GitNexus compare: low risk, 0 affected processes

## Context

Related to #3720 and #2478. This is backend behavior only, so there is no UI screenshot.
