### PR TITLE
fix(deps): trust OS-installed CAs for WebSocket connections (workspace crates)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9906,6 +9906,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,25 @@ moka    = { version = "0.12", features = ["sync"] }
 futures-util = "0.3"
 
 # WebSocket client (test client)
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+# WSS trust: OS trust store *in addition to* the compiled-in Mozilla bundle.
+# `webpki-roots` alone bakes the Mozilla list into the binary, so a
+# TLS-terminating proxy — which re-signs every certificate with a private CA
+# that administrators install into the *system* store — fails every WSS
+# handshake with `invalid peer certificate: UnknownIssuer`, while reqwest
+# (rustls-platform-verifier) keeps working. Same class of failure the MCP env
+# passthrough already calls out (crates/buzz-agent/src/mcp.rs) and the same
+# store this repo's own Dockerfile writes its extra proxy CA into.
+#
+# Both features are enabled deliberately. tokio-tungstenite's `tls.rs` writes
+# native roots and webpki roots into the *same* `RootCertStore` (:117 and
+# :122), so they union rather than conflict — and its "no native root CA
+# certificates found" hard error is gated on `rustls-tls-webpki-roots` being
+# absent (:109-112). Enabling native-roots *alone* would therefore turn an
+# empty platform store — reachable via a stale SSL_CERT_FILE / SSL_CERT_DIR,
+# which rustls-native-certs prefers over system paths, or an image without
+# ca-certificates — into a hard failure on every wss:// connection. Keeping
+# webpki as a floor trades no availability for the trust fix.
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots", "rustls-tls-webpki-roots"] }
 url = "2"
 
 # Property-based testing (dev-only)


### PR DESCRIPTION
## Summary

`tokio-tungstenite` is pinned to `rustls-tls-webpki-roots`, which compiles the Mozilla root list into the binary and never consults the platform store. Behind a TLS-terminating proxy — one that re-signs certificates with a private CA administrators install into the system trust store — every WSS handshake fails with `invalid peer certificate: UnknownIssuer`. Installing the CA into the OS trust store does not help, and neither does `SSL_CERT_FILE`.

The failure is partial, which is what makes it hard to isolate. `reqwest` 0.13 verifies through `rustls-platform-verifier`, so REST keeps working while the WebSocket dies in the same process: an agent authenticates, discovers channels, then cannot open the relay socket. The obvious remedies change nothing, which sends you looking in the wrong place.

This is the companion to #5148, which fixes `desktop/src-tauri`. This change applies the same fix to the workspace root, which governs the seven other crates that open WSS connections — `buzz-acp`, `buzz-ws-client`, `buzz-cli`, `buzz-relay`, `buzz-test-client`, `buzz-pair-relay`, and `buzz-pairing-cli`. All declare `tokio-tungstenite = { workspace = true }` with no per-crate feature override, so the workspace declaration is the entire policy for them. The error above comes from `buzz-acp`, which #5148 does not reach. The two PRs touch disjoint files and merge in either order.

Both root stores are enabled rather than swapped, for the reason #5148 gives. `tokio-tungstenite`'s `tls.rs` writes native roots and webpki roots into the same `RootCertStore`, and its "no native root CA certificates found" hard error is gated on `rustls-tls-webpki-roots` being absent. Enabling native-roots alone would turn an empty platform store — reachable through a stale `SSL_CERT_FILE`, which `rustls-native-certs` prefers over system paths, or an image without `ca-certificates` — into a hard failure on every `wss://` connection. Credit to @abipalli for catching that.

No source changes and no new crates. `rustls-native-certs` was already in the lockfile transitively, so the lock diff is a single additive line and `webpki-roots` is retained.

### Related issue

Fixes the workspace-crate half of #5197, which lists this exact change as its first suggested resolution. Also #2940. Companion to #5148 — happy to close this in favour of folding the root change into that PR if you would rather have one.

### Testing

`cargo check -p buzz-ws-client -p buzz-acp -p buzz-relay` passes. `cargo tree -p tokio-tungstenite@0.29.0` shows both `rustls-native-certs` and `webpki-roots` resolved, confirming the features union rather than replace. `cargo metadata --locked` passes for the workspace and for `desktop/src-tauri`.

Not run: `just ci`, and a live handshake behind a TLS-terminating proxy. The check that matters most there is the negative control — removing the private CA's trust from the OS store must make the handshake fail again; if it still succeeds, verification has been redirected into nothing rather than at the OS store. #5197's reporter is already running the equivalent patch as a fork and could exercise that faster than I can.
