### PR TITLE
feat(agents): allow granted direct creation

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -6,7 +6,7 @@ The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ
 
 | Group | Key commands |
 |-------|-------------|
-| `buzz agents` | `draft-create`, `draft-update` |
+| `buzz agents` | `create`, `draft-create`, `draft-update` |
 | `buzz messages` | `send`, `get`, `thread`, `search` |
 | `buzz channels` | `list`, `get`, `create`, `join`, `members` |
 | `buzz canvas` | `get`, `set` |
@@ -23,7 +23,7 @@ The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ
 | `buzz upload` | `file` |
 | `buzz mem` | `set`, `get`, `ls`, `patch`, `rm` |
 
-Run `buzz --help` or `buzz <group> --help` for full usage. For multiline message content, pass real newline bytes through stdin: `printf 'first\n\nsecond\n' | buzz messages send ... --content -`. Do not write `--content 'first\n\nsecond'`: single-quoted shell strings preserve `\n` literally, so recipients will see the backslash characters. `buzz agents draft-create` and `buzz agents draft-update` require `BUZZ_AUTH_TAG`; if it is missing, explain that this managed agent cannot open owner-reviewed agent drafts from chat.
+Run `buzz --help` or `buzz <group> --help` for full usage. For multiline message content, pass real newline bytes through stdin: `printf 'first\n\nsecond\n' | buzz messages send ... --content -`. Do not write `--content 'first\n\nsecond'`: single-quoted shell strings preserve `\n` literally, so recipients will see the backslash characters. `buzz agents create`, `buzz agents draft-create`, and `buzz agents draft-update` require `BUZZ_AUTH_TAG`; if it is missing, explain that this managed agent cannot send owner-addressed agent-management requests from chat.
 
 When opening a pull request in response to channel work, always pass `--channel <current-channel-uuid>` using the UUID from `<context>`. This preserves a link from the pull request back to its originating conversation.
 
@@ -44,7 +44,7 @@ To assign an issue to someone, run `buzz issues assign --issue <event-id> --repo
 
 When someone asks to create an agent, ask for at most two things: its name and what it should do day-to-day. Write the `--system-prompt` yourself. Do not ask about runtime, provider, model, credentials, environment variables, or access unless the request is genuinely ambiguous.
 
-Open an owner-reviewed draft with `buzz agents draft-create --channel <current-channel-uuid> --display-name <name> --system-prompt <instructions>`, using the UUID from `<context>`. Never claim the agent exists until the owner saves it. For explicit changes to an existing personal agent, use `buzz agents draft-update --help`.
+If the owner explicitly authorizes direct creation and has granted this agent that permission in Desktop, run `buzz agents create --channel <current-channel-uuid> --display-name <name> --system-prompt <instructions> [--reply-to <thread-root>]`. This waits for an owner-signed result; claim creation only when it returns `created: true`. On timeout, retry with the same reported `--request-id` to avoid duplicates. Otherwise open an owner-reviewed draft with `buzz agents draft-create --channel <current-channel-uuid> --display-name <name> --system-prompt <instructions>`, and never claim the agent exists until the owner saves it. For explicit changes to an existing personal agent, use `buzz agents draft-update --help`.
 
 ## Communication Patterns
 

--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -86,6 +86,14 @@ buzz mem set <slug> "my-value"
 buzz mem patch <slug> --base-hash <hex> < diff.patch  # or --no-base-hash
 buzz mem rm <slug>
 
+# Agents
+# Requires a revocable per-agent grant in the owner's running Buzz Desktop.
+buzz agents create --channel <uuid> --display-name "Research helper" \
+  --system-prompt "Find reliable sources and summarize them concisely."
+# Retry an acknowledgement timeout without creating a duplicate.
+buzz agents create --channel <uuid> --display-name "Research helper" \
+  --system-prompt - --request-id <uuid> < prompt.md
+
 # Repository protection
 buzz repos protect list --id my-repo
 buzz repos protect set --id my-repo --ref refs/heads/main --push admin --no-force-push --no-delete
@@ -125,6 +133,9 @@ stored rules in `validation_error` so an owner can remove and repair them.
 | | `members` | List channel members |
 | | `add-member` | Add a member |
 | | `remove-member` | Remove a member |
+| `agents` | `create` | Create an owner-only agent through a Desktop grant and wait for signed completion |
+| | `draft-create` | Open an owner-reviewed create-agent draft |
+| | `draft-update` | Open an owner-reviewed update-agent draft |
 | `canvas` | `get` | Get channel canvas |
 | | `set` | Set channel canvas |
 | `reactions` | `add` | React to a message |

--- a/crates/buzz-cli/src/agent_management.rs
+++ b/crates/buzz-cli/src/agent_management.rs
@@ -21,6 +21,16 @@ pub struct CreateAgentDraft {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DirectCreateAgentRequest {
+    pub channel_id: String,
+    pub display_name: String,
+    pub system_prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateAgentDraft {
     pub channel_id: String,
     pub agent_name: String,
@@ -108,6 +118,26 @@ fn build<T: Serialize>(
     request: T,
 ) -> Result<BuiltDraftRequest, CliError> {
     let request_id = uuid::Uuid::new_v4().to_string();
+    build_with_request_id(
+        keys,
+        owner,
+        channel_id,
+        request_kind,
+        action,
+        request,
+        request_id,
+    )
+}
+
+fn build_with_request_id<T: Serialize>(
+    keys: &Keys,
+    owner: &PublicKey,
+    channel_id: String,
+    request_kind: &'static str,
+    action: &'static str,
+    request: T,
+    request_id: String,
+) -> Result<BuiltDraftRequest, CliError> {
     let payload = ObserverEvent {
         seq: 0,
         timestamp: chrono::Utc::now().to_rfc3339(),
@@ -161,6 +191,46 @@ pub fn build_create(
         AGENT_REQUEST_KIND,
         "create",
         request,
+    )
+}
+
+pub fn build_direct_create(
+    keys: &Keys,
+    owner: &PublicKey,
+    request: DirectCreateAgentRequest,
+    request_id: Option<String>,
+) -> Result<BuiltDraftRequest, CliError> {
+    let channel_id = required(request.channel_id, "channel", 128)?;
+    uuid::Uuid::parse_str(&channel_id)
+        .map_err(|_| CliError::Usage(format!("invalid channel UUID: {channel_id}")))?;
+    let request_id = request_id
+        .map(|value| required(value, "request id", 64))
+        .transpose()?
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    uuid::Uuid::parse_str(&request_id)
+        .map_err(|_| CliError::Usage(format!("invalid request UUID: {request_id}")))?;
+    let reply_to = optional(request.reply_to, "reply-to")?;
+    if reply_to.as_deref().is_some_and(|value| {
+        value.len() != 64 || !value.chars().all(|character| character.is_ascii_hexdigit())
+    }) {
+        return Err(CliError::Usage(
+            "reply-to must be a 64-character hex event id".into(),
+        ));
+    }
+    let request = DirectCreateAgentRequest {
+        channel_id: channel_id.clone(),
+        display_name: required(request.display_name, "display name", MAX_NAME_CHARS)?,
+        system_prompt: required(request.system_prompt, "system prompt", MAX_PROMPT_CHARS)?,
+        reply_to,
+    };
+    build_with_request_id(
+        keys,
+        owner,
+        channel_id,
+        AGENT_REQUEST_KIND,
+        "create_direct",
+        request,
+        request_id,
     )
 }
 
@@ -339,6 +409,32 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("invalid channel UUID"));
+    }
+
+    #[test]
+    fn direct_create_preserves_idempotency_key_and_reply_target() {
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let reply_to = "a".repeat(64);
+        let built = build_direct_create(
+            &agent,
+            &owner.public_key(),
+            DirectCreateAgentRequest {
+                channel_id: CHANNEL.into(),
+                display_name: "Operations helper".into(),
+                system_prompt: "Operate safely.".into(),
+                reply_to: Some(reply_to.clone()),
+            },
+            Some(request_id.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(built.request_id, request_id);
+        let payload: serde_json::Value = decrypt_observer_payload(&owner, &built.event).unwrap();
+        assert_eq!(payload["payload"]["action"], "create_direct");
+        assert_eq!(payload["payload"]["requestId"], request_id);
+        assert_eq!(payload["payload"]["request"]["replyTo"], reply_to);
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -1,9 +1,13 @@
 use buzz_core::kind::KIND_IA_ARCHIVED_LIST;
 use buzz_sdk::builders::{build_archive_identity_request, build_unarchive_identity_request};
-use nostr::PublicKey;
+use nostr::{JsonUtil, PublicKey};
 use serde_json::json;
+use std::time::{Duration, Instant};
 
-use crate::agent_management::{build_create, build_update, CreateAgentDraft, UpdateAgentDraft};
+use crate::agent_management::{
+    build_create, build_direct_create, build_update, CreateAgentDraft, DirectCreateAgentRequest,
+    UpdateAgentDraft,
+};
 use crate::client::BuzzClient;
 use crate::error::CliError;
 use crate::validate::{read_or_stdin, validate_hex64};
@@ -11,6 +15,41 @@ use crate::{AgentsCmd, RespondToArg};
 
 pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), CliError> {
     match command {
+        AgentsCmd::Create {
+            channel,
+            display_name,
+            system_prompt,
+            reply_to,
+            request_id,
+            timeout,
+        } => {
+            let owner = require_owner(client)?;
+            let built = build_direct_create(
+                client.keys(),
+                &owner,
+                DirectCreateAgentRequest {
+                    channel_id: channel.clone(),
+                    display_name,
+                    system_prompt: read_or_stdin(&system_prompt)?,
+                    reply_to,
+                },
+                request_id,
+            )?;
+            let request_id = built.request_id.clone();
+            let since = chrono::Utc::now().timestamp().saturating_sub(5);
+            client.publish_ephemeral_event(built.event).await?;
+            let result = wait_for_direct_create_result(
+                client,
+                &channel,
+                &owner.to_hex(),
+                &request_id,
+                since,
+                Duration::from_secs(timeout.clamp(5, 300)),
+            )
+            .await?;
+            println!("{result}");
+            Ok(())
+        }
         AgentsCmd::DraftCreate {
             channel,
             display_name,
@@ -167,8 +206,104 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
     }
 }
 
-/// Require `BUZZ_AUTH_TAG` and parse the owner pubkey from it. Used only by
-/// the `draft-create` and `draft-update` paths.
+async fn wait_for_direct_create_result(
+    client: &BuzzClient,
+    channel: &str,
+    owner_hex: &str,
+    request_id: &str,
+    since: i64,
+    timeout: Duration,
+) -> Result<serde_json::Value, CliError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let filter = json!({
+            "kinds": [9],
+            "authors": [owner_hex],
+            "#h": [channel],
+            "since": since,
+            "limit": 100,
+        });
+        let raw = client.query(&filter).await?;
+        let events: Vec<serde_json::Value> = serde_json::from_str(&raw)
+            .map_err(|error| CliError::Other(format!("invalid create-result response: {error}")))?;
+        for value in events {
+            if value.get("pubkey").and_then(serde_json::Value::as_str) != Some(owner_hex) {
+                continue;
+            }
+            let event = nostr::Event::from_json(value.to_string())
+                .map_err(|error| CliError::Other(format!("invalid result event: {error}")))?;
+            if !event.verify_id() || !event.verify_signature() {
+                continue;
+            }
+            let Some(marker) = parse_direct_create_marker(&event.content, request_id) else {
+                continue;
+            };
+            return match marker.status.as_str() {
+                "created" => Ok(json!({
+                    "event_id": event.id.to_hex(),
+                    "request_id": request_id,
+                    "action": "create",
+                    "created": true,
+                    "agent_pubkey": marker.agent_pubkey,
+                })),
+                "denied" | "failed" => Err(CliError::Other(format!(
+                    "direct agent creation {} (request_id {request_id}); see owner result event {}",
+                    marker.status,
+                    event.id.to_hex(),
+                ))),
+                _ => continue,
+            };
+        }
+        if Instant::now() >= deadline {
+            return Err(CliError::Other(format!(
+                "timed out waiting for the owner's Desktop to create the agent (request_id {request_id}); retry with --request-id {request_id} to avoid duplicates"
+            )));
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+struct DirectCreateMarker {
+    status: String,
+    agent_pubkey: Option<String>,
+}
+
+fn parse_direct_create_marker(content: &str, request_id: &str) -> Option<DirectCreateMarker> {
+    const PREFIX: &str = "<!-- buzz-agent-create-result ";
+    let marker = content.split(PREFIX).nth(1)?.split(" -->").next()?;
+    let mut request = None;
+    let mut status = None;
+    let mut agent_pubkey = None;
+    for part in marker.split_ascii_whitespace() {
+        let (key, value) = part.split_once('=')?;
+        match key {
+            "request" => request = Some(value),
+            "status" => status = Some(value),
+            "pubkey" => agent_pubkey = Some(value.to_owned()),
+            _ => {}
+        }
+    }
+    if request != Some(request_id) {
+        return None;
+    }
+    if !matches!(status, Some("created" | "denied" | "failed")) {
+        return None;
+    }
+    if status == Some("created")
+        && !agent_pubkey.as_deref().is_some_and(|value| {
+            value.len() == 64 && value.chars().all(|character| character.is_ascii_hexdigit())
+        })
+    {
+        return None;
+    }
+    Some(DirectCreateMarker {
+        status: status?.to_owned(),
+        agent_pubkey,
+    })
+}
+
+/// Require `BUZZ_AUTH_TAG` and parse the owner pubkey from it. Used by
+/// owner-addressed agent-management requests.
 fn require_owner(client: &BuzzClient) -> Result<PublicKey, CliError> {
     let hex = client
         .auth_tag_owner_hex()
@@ -540,6 +675,39 @@ mod tests {
 
     fn hex128(c: char) -> String {
         std::iter::repeat_n(c, 128).collect()
+    }
+
+    #[test]
+    fn direct_create_marker_requires_matching_request_and_created_pubkey() {
+        let request_id = "2fd826e1-3958-4f39-afbe-c12a83925334";
+        let pubkey = hex64('a');
+        let content = format!(
+            "Created.\n\n<!-- buzz-agent-create-result request={request_id} status=created pubkey={pubkey} -->"
+        );
+
+        let marker = parse_direct_create_marker(&content, request_id).unwrap();
+        assert_eq!(marker.status, "created");
+        assert_eq!(marker.agent_pubkey.as_deref(), Some(pubkey.as_str()));
+        assert!(parse_direct_create_marker(&content, "another-request").is_none());
+        assert!(parse_direct_create_marker(
+            &format!(
+                "<!-- buzz-agent-create-result request={request_id} status=created pubkey=short -->"
+            ),
+            request_id,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn direct_create_marker_accepts_terminal_failure_without_pubkey() {
+        let request_id = "2fd826e1-3958-4f39-afbe-c12a83925334";
+        let content = format!(
+            "Denied.\n\n<!-- buzz-agent-create-result request={request_id} status=denied -->"
+        );
+
+        let marker = parse_direct_create_marker(&content, request_id).unwrap();
+        assert_eq!(marker.status, "denied");
+        assert_eq!(marker.agent_pubkey, None);
     }
 
     // --- (b) auth-selection matrix: extract_owner_auth_tag ---

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -262,6 +262,27 @@ impl RespondToArg {
 
 #[derive(Subcommand)]
 pub enum AgentsCmd {
+    /// Create an owner-only agent through a standing grant in the owner's running Desktop
+    Create {
+        /// Origin channel UUID; the new agent is added here
+        #[arg(long)]
+        channel: String,
+        /// Agent name
+        #[arg(long)]
+        display_name: String,
+        /// Agent instructions; use '-' to read from stdin
+        #[arg(long)]
+        system_prompt: String,
+        /// Optional thread root for the signed result message
+        #[arg(long)]
+        reply_to: Option<String>,
+        /// Reuse this UUID after an acknowledgement timeout to avoid duplicates
+        #[arg(long)]
+        request_id: Option<String>,
+        /// Seconds to wait for the owner's Desktop result
+        #[arg(long, default_value_t = 60)]
+        timeout: u64,
+    },
     /// Open a prefilled create-agent form in the owner's Buzz Desktop
     DraftCreate {
         /// Current channel UUID; the new agent is added here after save
@@ -2291,6 +2312,7 @@ mod tests {
             vec![
                 "archive",
                 "archived",
+                "create",
                 "draft-create",
                 "draft-update",
                 "unarchive"
@@ -2432,7 +2454,7 @@ mod tests {
     #[test]
     fn subcommand_counts_are_stable() {
         let expected: Vec<(&str, usize)> = vec![
-            ("agents", 5),
+            ("agents", 6),
             ("canvas", 2),
             ("channels", 16),
             ("dms", 4),

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -382,6 +382,7 @@ pub async fn create_managed_agent(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<CreateManagedAgentResponse, String> {
+    let create_scope = CapturedCreateScope::bind(&input, &state)?;
     let name = input.name.trim().to_string();
     let requested_persona_id = input
         .persona_id
@@ -751,7 +752,7 @@ pub async fn create_managed_agent(
     // ── Phase 3b: local spawn (async preflight outside store lock) ───────────
     let mut spawn_error = None;
     let agent = if input.spawn_after_create && input.backend == BackendKind::Local {
-        match start_local_agent_with_preflight(&app, &state, &pubkey, true, None, None).await {
+        match create_scope.start_local(&app, &state, &pubkey).await {
             Ok(agent) => agent,
             Err(error) => {
                 let _store_guard = state
@@ -799,22 +800,9 @@ pub async fn create_managed_agent(
 
     let spawn_error = if input.spawn_after_create && input.backend != BackendKind::Local {
         if let BackendKind::Provider { ref id, ref config } = input.backend {
-            let agent_json = {
-                let _g = state
-                    .managed_agents_store_lock
-                    .lock()
-                    .map_err(|e| e.to_string())?;
-                let records = load_managed_agents(&app)?;
-                let rec = records
-                    .iter()
-                    .find(|r| r.pubkey == pubkey)
-                    .ok_or_else(|| "agent disappeared".to_string())?;
-                build_deploy_payload(&app, &state, rec)?
-            };
-            match deploy_to_provider(
-                &app, &state, &pubkey, id, config, agent_json, None, None, None,
-            )
-            .await
+            match create_scope
+                .deploy_provider(&app, &state, &pubkey, id, config)
+                .await
             {
                 Ok(()) => spawn_error,
                 Err(e) => Some(e),
@@ -1168,7 +1156,10 @@ pub async fn delete_managed_agent(
 #[path = "agents_deploy.rs"]
 mod deploy;
 pub(super) mod provider_access;
+mod create_scope;
 mod provider_deploy;
+
+use create_scope::CapturedCreateScope;
 pub(super) use deploy::build_deploy_payload;
 #[cfg(test)]
 use deploy::{deploy_payload_json, DeployProjections};

--- a/desktop/src-tauri/src/commands/agents/create_scope.rs
+++ b/desktop/src-tauri/src/commands/agents/create_scope.rs
@@ -1,0 +1,87 @@
+use tauri::AppHandle;
+
+use crate::{
+    app_state::AppState,
+    managed_agents::{load_managed_agents, CreateManagedAgentRequest, ManagedAgentSummary},
+};
+
+use super::{
+    build_deploy_payload, deploy_to_provider, start_local_agent_with_preflight,
+    workspace_owner_hex,
+};
+
+pub(super) struct CapturedCreateScope {
+    relay_url: Option<String>,
+    signer_pubkey: Option<String>,
+}
+
+impl CapturedCreateScope {
+    pub(super) fn bind(
+        input: &CreateManagedAgentRequest,
+        state: &AppState,
+    ) -> Result<Self, String> {
+        crate::relay::bind_expected_relay_scope(
+            input.expected_relay_url.as_deref(),
+            crate::relay::relay_ws_url_with_override(state),
+        )?;
+        crate::relay::bind_expected_signer(
+            input.expected_signer_pubkey.as_deref(),
+            workspace_owner_hex(state)?,
+        )?;
+        Ok(Self {
+            relay_url: input.expected_relay_url.clone(),
+            signer_pubkey: input.expected_signer_pubkey.clone(),
+        })
+    }
+
+    pub(super) async fn start_local(
+        &self,
+        app: &AppHandle,
+        state: &AppState,
+        pubkey: &str,
+    ) -> Result<ManagedAgentSummary, String> {
+        start_local_agent_with_preflight(
+            app,
+            state,
+            pubkey,
+            true,
+            self.relay_url.as_deref(),
+            self.signer_pubkey.as_deref(),
+        )
+        .await
+    }
+
+    pub(super) async fn deploy_provider(
+        &self,
+        app: &AppHandle,
+        state: &AppState,
+        pubkey: &str,
+        provider_id: &str,
+        config: &serde_json::Value,
+    ) -> Result<(), String> {
+        let agent_json = {
+            let _guard = state
+                .managed_agents_store_lock
+                .lock()
+                .map_err(|error| error.to_string())?;
+            let records = load_managed_agents(app)?;
+            let record = records
+                .iter()
+                .find(|record| record.pubkey == pubkey)
+                .ok_or_else(|| "agent disappeared".to_string())?;
+            build_deploy_payload(app, state, record)?
+        };
+        deploy_to_provider(
+            app,
+            state,
+            pubkey,
+            provider_id,
+            config,
+            agent_json,
+            None,
+            self.relay_url.as_deref(),
+            self.signer_pubkey.as_deref(),
+        )
+        .await
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -1,7 +1,7 @@
 ---
 name: buzz-cli
 description: >
-  Buzz CLI for relay operations: owner-reviewed agent drafts, messaging,
+  Buzz CLI for relay operations: granted direct creation, owner-reviewed agent drafts, messaging,
   channels, DMs, users, workflows, feed, reactions, canvas, social, repos,
   uploads, and agent memory.
 version: 1
@@ -15,13 +15,27 @@ version: 1
 
 `BUZZ_RELAY_URL` defaults to `http://localhost:3000`. In development, the user may need to set this to a staging or production relay URL.
 
-`BUZZ_AUTH_TAG` is required for `buzz agents draft-create` and `buzz agents draft-update` because those commands send owner-reviewed Desktop drafts. If missing, explain that this managed agent cannot open owner-reviewed agent drafts from chat.
+`BUZZ_AUTH_TAG` is required for `buzz agents create`, `buzz agents draft-create`, and `buzz agents draft-update` because those commands send owner-addressed Desktop requests. If missing, explain that this managed agent cannot send agent-management requests from chat.
 
 Run the bundled CLI with `--help` and `<command> <subcommand> --help` to discover all flags, arguments, and usage. This skill documents only what `--help` cannot tell you.
 
 ## Conversational Agent Management
 
-When someone naturally asks to create an agent, ask for at most two things: the agent's **name** and **what it should do day-to-day**. Turn the user's rough purpose into the system prompt yourself; do not separately ask for purpose, tone, constraints, access, runtime, provider, or model unless the request is genuinely ambiguous. Then run:
+When someone naturally asks to create an agent, ask for at most two things: the agent's **name** and **what it should do day-to-day**. Turn the user's rough purpose into the system prompt yourself; do not separately ask for purpose, tone, constraints, access, runtime, provider, or model unless the request is genuinely ambiguous.
+
+When the owner explicitly authorized direct creation and granted this agent permission in Desktop, run:
+
+```bash
+buzz agents create \
+  --channel <current-channel-uuid> \
+  --display-name "Research helper" \
+  --system-prompt "Find reliable sources and summarize them concisely." \
+  --reply-to <current-thread-root>
+```
+
+The command waits for an owner-signed completion message. Report creation only when it returns `created: true`. If acknowledgement times out, retry with the same `--request-id` printed by the error so Desktop cannot create a duplicate. A direct-created agent uses the owner's saved runtime/provider/model defaults, starts as **Only me**, and is added to the source channel. The grant is per requesting agent and revocable in Desktop Settings.
+
+Without explicit authorization or a direct-creation grant, run:
 
 ```bash
 buzz agents draft-create \
@@ -53,7 +67,7 @@ Output varies by command group — `--help` shows flags but not response shapes.
 
 **Read commands** return JSON arrays. Event reads (`messages get/thread/search`, `feed get`) return normalized, complete signed Nostr events with `{id, pubkey, kind, content, created_at, tags, sig}`. Other reads use command-specific shapes for channels (`{channel_id, name, description, created_at}`), users (kind:0 profile JSON with `pubkey` injected), and workflows (`{workflow_id, content, created_at, pubkey}`).
 
-**Write commands**: all return `{event_id, accepted, message}`. Create commands add the generated entity ID: `channels create` → `channel_id`, `dms open` → `dm_id`, `workflows create` → `workflow_id`. Agent draft commands add `{request_id, action, saved: false}` because they only open an owner-reviewed Desktop draft.
+**Write commands**: all return `{event_id, accepted, message}`. Create commands add the generated entity ID: `channels create` → `channel_id`, `dms open` → `dm_id`, `workflows create` → `workflow_id`. `agents create` returns the owner result event, request ID, and created agent pubkey only after verified completion. Agent draft commands add `{request_id, action, saved: false}` because they only open an owner-reviewed Desktop draft.
 
 **Exceptions to the above patterns:**
 

--- a/desktop/src-tauri/src/managed_agents/types/requests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/requests.rs
@@ -195,6 +195,12 @@ pub struct CreateManagedAgentRequest {
     pub respond_to_allowlist: Vec<String>,
     #[serde(default)]
     pub relay_mesh: Option<RelayMeshConfig>,
+    /// Tenant scope captured by a long-lived caller before its first await.
+    #[serde(default)]
+    pub expected_relay_url: Option<String>,
+    /// Owner identity captured together with the relay scope.
+    #[serde(default)]
+    pub expected_signer_pubkey: Option<String>,
 }
 
 /// Patch request for updating a managed agent's mutable fields.

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -274,6 +274,26 @@ fn create_request_deserializes_camel_case_relay_mesh() {
     );
 }
 
+#[test]
+fn create_request_deserializes_captured_tenant_scope() {
+    let request: CreateManagedAgentRequest = serde_json::from_str(
+        r#"{
+            "name": "scoped-agent",
+            "expectedRelayUrl": "wss://relay.example",
+            "expectedSignerPubkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }"#,
+    )
+    .expect("captured tenant scope from TS should deserialize");
+    assert_eq!(
+        request.expected_relay_url.as_deref(),
+        Some("wss://relay.example")
+    );
+    assert_eq!(
+        request.expected_signer_pubkey.as_deref(),
+        Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
+}
+
 /// Persisted records use snake_case; the camelCase alias must not break
 /// the stored-record round trip.
 #[test]

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -308,7 +308,23 @@ buzz messages send --channel <channel-id> --reply-to <thread-root-id> \
   --mention <agent-pubkey> --content '!cancel'
 ```
 
+## Direct creation grants
+
+`buzz agents create` is a Desktop-mediated privileged operation. Desktop remains
+the authority: accept requests only from a locally managed agent that shares
+the source channel and has an explicit per-agent grant in Settings. Direct
+creation always uses saved owner defaults, forces owner-only response access,
+adds the new agent to the source channel, and reports a signed terminal result
+there. Capture relay and signer scope before the first await and pass that scope
+through membership, start, and acknowledgement calls so community switches
+fail closed. Persist the request ID before creation begins; an incomplete prior
+attempt must stop for inspection rather than risk a duplicate.
+
 ## The tests that enforce this
+
+- `directAgentCreationGrant.test.mjs`, `directAgentCreationJournal.test.mjs`,
+  and `directAgentCreationResult.test.mjs` cover per-agent grant persistence,
+  crash-safe request correlation, and signed-result marker formatting.
 
 - `lib/agentConfigCore.test.mjs` — field model per harness × scope, clearing
   policy. Update when the capability model changes.

--- a/desktop/src/features/agents/agentManagement.test.mjs
+++ b/desktop/src/features/agents/agentManagement.test.mjs
@@ -24,6 +24,14 @@ function createPayload(overrides = {}) {
   };
 }
 
+function directCreatePayload(overrides = {}) {
+  return createPayload({
+    action: "create_direct",
+    requestId: "2fd826e1-3958-4f39-afbe-c12a83925334",
+    ...overrides,
+  });
+}
+
 test("parses the narrow no-secret create request", () => {
   assert.deepEqual(
     parseAgentManagementRequest(createPayload()),
@@ -59,6 +67,29 @@ test("chat creation leaves advanced behavior unset so the form stays collapsed",
     displayName: "Research helper",
     systemPrompt: "Find reliable sources and summarize them.",
   });
+});
+
+test("direct creation accepts only a UUID request and optional hex reply target", () => {
+  const replyTo = "a".repeat(64);
+  const payload = directCreatePayload({
+    request: { ...directCreatePayload().request, replyTo },
+  });
+  assert.deepEqual(parseAgentManagementRequest(payload), payload);
+
+  assert.equal(
+    parseAgentManagementRequest(
+      directCreatePayload({ requestId: "not-a-request-uuid" }),
+    ),
+    null,
+  );
+  assert.equal(
+    parseAgentManagementRequest(
+      directCreatePayload({
+        request: { ...directCreatePayload().request, replyTo: "not-an-event" },
+      }),
+    ),
+    null,
+  );
 });
 
 test("requires the originating channel for profile updates", () => {

--- a/desktop/src/features/agents/agentManagement.ts
+++ b/desktop/src/features/agents/agentManagement.ts
@@ -17,6 +17,18 @@ export type AgentManagementCreateRequest = {
   };
 };
 
+export type AgentManagementDirectCreateRequest = {
+  type: typeof AGENT_MANAGEMENT_REQUEST;
+  action: "create_direct";
+  requestId: string;
+  request: {
+    channelId: string;
+    displayName: string;
+    systemPrompt: string;
+    replyTo?: string;
+  };
+};
+
 export type AgentManagementUpdateRequest = {
   type: typeof AGENT_MANAGEMENT_REQUEST;
   action: "update";
@@ -35,11 +47,16 @@ export type AgentManagementUpdateRequest = {
 
 export type AgentManagementRequest =
   | AgentManagementCreateRequest
+  | AgentManagementDirectCreateRequest
   | AgentManagementUpdateRequest;
 
 function isText(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
+
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const HEX_EVENT_ID = /^[0-9a-f]{64}$/i;
 
 function isRespondTo(value: unknown): value is RespondToMode | undefined {
   return value === undefined || value === "owner-only" || value === "anyone";
@@ -61,7 +78,9 @@ export function parseAgentManagementRequest(
   if (
     payload.type !== AGENT_MANAGEMENT_REQUEST ||
     !isText(payload.requestId) ||
-    (payload.action !== "create" && payload.action !== "update") ||
+    (payload.action !== "create" &&
+      payload.action !== "create_direct" &&
+      payload.action !== "update") ||
     typeof payload.request !== "object" ||
     payload.request === null
   ) {
@@ -69,8 +88,12 @@ export function parseAgentManagementRequest(
   }
   const request = payload.request as Record<string, unknown>;
 
-  if (payload.action === "create") {
-    if (!hasOnlyKeys(request, ["channelId", "displayName", "systemPrompt"])) {
+  if (payload.action === "create" || payload.action === "create_direct") {
+    const allowedKeys =
+      payload.action === "create_direct"
+        ? ["channelId", "displayName", "systemPrompt", "replyTo"]
+        : ["channelId", "displayName", "systemPrompt"];
+    if (!hasOnlyKeys(request, allowedKeys)) {
       return null;
     }
     if (
@@ -80,14 +103,26 @@ export function parseAgentManagementRequest(
     ) {
       return null;
     }
+    if (
+      payload.action === "create_direct" &&
+      (!UUID.test(payload.requestId) ||
+        (request.replyTo !== undefined &&
+          (typeof request.replyTo !== "string" ||
+            !HEX_EVENT_ID.test(request.replyTo))))
+    ) {
+      return null;
+    }
     return {
       type: AGENT_MANAGEMENT_REQUEST,
-      action: "create",
+      action: payload.action,
       requestId: payload.requestId,
       request: {
         channelId: request.channelId,
         displayName: request.displayName,
         systemPrompt: request.systemPrompt,
+        ...(payload.action === "create_direct" && isText(request.replyTo)
+          ? { replyTo: request.replyTo }
+          : {}),
       },
     };
   }
@@ -141,7 +176,10 @@ export function requestTargetsEditablePersona(
 }
 
 export function createInputFromRequest(
-  request: Extract<AgentManagementRequest, { action: "create" }>,
+  request: Extract<
+    AgentManagementRequest,
+    { action: "create" | "create_direct" }
+  >,
 ): CreatePersonaInput {
   return {
     displayName: request.request.displayName,

--- a/desktop/src/features/agents/channelAgents.ts
+++ b/desktop/src/features/agents/channelAgents.ts
@@ -36,6 +36,8 @@ export type AttachManagedAgentToChannelInput = {
   agent: ManagedAgent;
   role?: Exclude<ChannelRole, "owner">;
   ensureRunning?: boolean;
+  expectedRelayUrl?: string;
+  expectedSignerPubkey?: string;
 };
 
 export type AttachManagedAgentToChannelResult = {
@@ -153,6 +155,8 @@ export async function attachManagedAgentToChannel(
     channelId,
     pubkeys: [input.agent.pubkey],
     role,
+    expectedRelayUrl: input.expectedRelayUrl,
+    expectedSignerPubkey: input.expectedSignerPubkey,
   });
   const membershipError = membershipResult.errors.find(
     (error) => normalizePubkey(error.pubkey) === agentPubkey,
@@ -178,14 +182,20 @@ export async function attachManagedAgentToChannel(
     // another community's.
     const isRemote = input.agent.backend.type === "provider";
     if (isRemote && input.agent.status !== "deployed") {
-      agent = await startManagedAgent(input.agent.pubkey);
+      agent = await startManagedAgent(input.agent.pubkey, {
+        expectedRelayUrl: input.expectedRelayUrl,
+        expectedSignerPubkey: input.expectedSignerPubkey,
+      });
       started = true;
     } else if (
       !isRemote &&
       input.agent.status !== "running" &&
       input.agent.status !== "deployed"
     ) {
-      agent = await startManagedAgent(input.agent.pubkey);
+      agent = await startManagedAgent(input.agent.pubkey, {
+        expectedRelayUrl: input.expectedRelayUrl,
+        expectedSignerPubkey: input.expectedSignerPubkey,
+      });
       started = true;
     }
   }

--- a/desktop/src/features/agents/directAgentCreationGrant.test.mjs
+++ b/desktop/src/features/agents/directAgentCreationGrant.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const values = new Map();
+globalThis.localStorage = {
+  getItem: (key) => values.get(key) ?? null,
+  setItem: (key, value) => values.set(key, String(value)),
+};
+
+const grants = await import("./directAgentCreationGrant.ts");
+
+test("parses only normalized unique pubkeys", () => {
+  const upper = "A".repeat(64);
+  assert.deepEqual(
+    grants.parseDirectAgentCreationGrants(
+      JSON.stringify([upper, upper.toLowerCase(), "invalid", 7]),
+    ),
+    [upper.toLowerCase()],
+  );
+  assert.deepEqual(grants.parseDirectAgentCreationGrants("not-json"), []);
+});
+
+test("persists per-agent grants and supports revocation", () => {
+  const owner = "a".repeat(64);
+  const pubkey = "b".repeat(64);
+  grants.setDirectAgentCreationGrant(owner, pubkey, true);
+  assert.equal(grants.hasDirectAgentCreationGrant(owner, pubkey), true);
+  assert.equal(
+    values.get(`${grants.DIRECT_AGENT_CREATION_GRANTS_STORAGE_KEY}.${owner}`),
+    JSON.stringify([pubkey]),
+  );
+
+  grants.setDirectAgentCreationGrant(owner, pubkey, false);
+  assert.equal(grants.hasDirectAgentCreationGrant(owner, pubkey), false);
+});
+
+test("grants do not cross owner identities", () => {
+  const ownerA = "c".repeat(64);
+  const ownerB = "d".repeat(64);
+  const agent = "e".repeat(64);
+  grants.setDirectAgentCreationGrant(ownerA, agent, true);
+
+  assert.equal(grants.hasDirectAgentCreationGrant(ownerA, agent), true);
+  assert.equal(grants.hasDirectAgentCreationGrant(ownerB, agent), false);
+});
+
+test("a failed permission write leaves the prior grant state in force", () => {
+  const owner = "1".repeat(64);
+  const agent = "2".repeat(64);
+  const originalSetItem = globalThis.localStorage.setItem;
+  globalThis.localStorage.setItem = () => {
+    throw new Error("quota denied");
+  };
+  try {
+    grants.setDirectAgentCreationGrant(owner, agent, true);
+  } finally {
+    globalThis.localStorage.setItem = originalSetItem;
+  }
+
+  assert.equal(grants.hasDirectAgentCreationGrant(owner, agent), false);
+});

--- a/desktop/src/features/agents/directAgentCreationGrant.ts
+++ b/desktop/src/features/agents/directAgentCreationGrant.ts
@@ -1,0 +1,113 @@
+import * as React from "react";
+
+export const DIRECT_AGENT_CREATION_GRANTS_STORAGE_KEY =
+  "buzz.agents.directCreationGrants";
+
+const HEX_PUBKEY = /^[0-9a-f]{64}$/;
+const listeners = new Set<() => void>();
+const EMPTY_GRANTS: readonly string[] = [];
+const grantsByOwner = new Map<string, readonly string[]>();
+
+function normalizePubkey(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return HEX_PUBKEY.test(normalized) ? normalized : null;
+}
+
+export function parseDirectAgentCreationGrants(
+  value: string | null | undefined,
+): string[] {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return [
+      ...new Set(
+        parsed.flatMap((item) => {
+          if (typeof item !== "string") return [];
+          const normalized = normalizePubkey(item);
+          return normalized ? [normalized] : [];
+        }),
+      ),
+    ].sort();
+  } catch {
+    return [];
+  }
+}
+
+function storageKey(ownerPubkey: string): string {
+  return `${DIRECT_AGENT_CREATION_GRANTS_STORAGE_KEY}.${ownerPubkey}`;
+}
+
+function readStoredGrants(ownerPubkey: string): string[] {
+  try {
+    return parseDirectAgentCreationGrants(
+      globalThis.localStorage?.getItem(storageKey(ownerPubkey)),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getDirectAgentCreationGrants(
+  ownerPubkey: string,
+): readonly string[] {
+  const owner = normalizePubkey(ownerPubkey);
+  if (!owner) return EMPTY_GRANTS;
+  const cached = grantsByOwner.get(owner);
+  if (cached) return cached;
+  const stored = readStoredGrants(owner);
+  grantsByOwner.set(owner, stored);
+  return stored;
+}
+
+export function hasDirectAgentCreationGrant(
+  ownerPubkey: string,
+  pubkey: string,
+): boolean {
+  const normalized = normalizePubkey(pubkey);
+  return (
+    normalized !== null &&
+    getDirectAgentCreationGrants(ownerPubkey).includes(normalized)
+  );
+}
+
+export function setDirectAgentCreationGrant(
+  ownerPubkey: string,
+  pubkey: string,
+  enabled: boolean,
+): void {
+  const owner = normalizePubkey(ownerPubkey);
+  const normalized = normalizePubkey(pubkey);
+  if (!owner || !normalized) return;
+  const current = getDirectAgentCreationGrants(owner);
+  const next = new Set(current);
+  if (enabled) next.add(normalized);
+  else next.delete(normalized);
+  const sorted = [...next].sort();
+  if (JSON.stringify(sorted) === JSON.stringify(current)) return;
+  try {
+    globalThis.localStorage?.setItem(storageKey(owner), JSON.stringify(sorted));
+  } catch {
+    // Permission mutations fail closed. Keep the prior snapshot so a failed
+    // grant or revocation is visible to the owner instead of pretending it
+    // persisted.
+    return;
+  }
+  grantsByOwner.set(owner, sorted);
+  for (const listener of listeners) listener();
+}
+
+export function useDirectAgentCreationGrants(
+  ownerPubkey: string,
+): readonly string[] {
+  return React.useSyncExternalStore(
+    subscribe,
+    () => getDirectAgentCreationGrants(ownerPubkey),
+    () => EMPTY_GRANTS,
+  );
+}

--- a/desktop/src/features/agents/directAgentCreationJournal.test.mjs
+++ b/desktop/src/features/agents/directAgentCreationJournal.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const values = new Map();
+globalThis.localStorage = {
+  getItem: (key) => values.get(key) ?? null,
+  setItem: (key, value) => values.set(key, String(value)),
+};
+
+const journal = await import("./directAgentCreationJournal.ts");
+const owner = "f".repeat(64);
+
+test("a begun request fails closed instead of running twice", () => {
+  journal.beginDirectAgentCreation(owner, "request-1", "Example Agent");
+
+  assert.deepEqual(journal.getDirectAgentCreationResult(owner, "request-1"), {
+    requestId: "request-1",
+    status: "failed",
+    displayName: "Example Agent",
+    message:
+      "A previous attempt did not record a terminal result. Inspect the agent roster before retrying with a new request ID.",
+  });
+});
+
+test("a terminal result replaces the processing sentinel", () => {
+  journal.beginDirectAgentCreation(owner, "request-2", "Example Agent");
+  const result = {
+    requestId: "request-2",
+    status: "created",
+    displayName: "Example Agent",
+    agentPubkey: "a".repeat(64),
+    message: "created",
+  };
+  journal.recordDirectAgentCreationResult(owner, result);
+
+  assert.deepEqual(
+    journal.getDirectAgentCreationResult(owner, "request-2"),
+    result,
+  );
+});
+
+test("request IDs do not cross owner identities", () => {
+  const otherOwner = "e".repeat(64);
+  journal.beginDirectAgentCreation(owner, "shared-request", "Owner A Agent");
+
+  assert.equal(
+    journal.getDirectAgentCreationResult(otherOwner, "shared-request"),
+    null,
+  );
+});

--- a/desktop/src/features/agents/directAgentCreationJournal.ts
+++ b/desktop/src/features/agents/directAgentCreationJournal.ts
@@ -1,0 +1,103 @@
+import type { DirectAgentCreationResult } from "./directAgentCreationResult";
+
+const STORAGE_KEY = "buzz.agents.directCreationJournal";
+const MAX_ENTRIES = 100;
+
+type ProcessingEntry = {
+  ownerPubkey: string;
+  requestId: string;
+  status: "processing";
+  displayName: string;
+  recordedAt: number;
+};
+type JournalEntry =
+  | (DirectAgentCreationResult & {
+      ownerPubkey: string;
+      recordedAt: number;
+    })
+  | ProcessingEntry;
+
+function readJournal(): JournalEntry[] {
+  try {
+    const parsed: unknown = JSON.parse(
+      globalThis.localStorage?.getItem(STORAGE_KEY) ?? "[]",
+    );
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is JournalEntry =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as JournalEntry).ownerPubkey === "string" &&
+        typeof (entry as JournalEntry).requestId === "string" &&
+        typeof (entry as JournalEntry).recordedAt === "number",
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function getDirectAgentCreationResult(
+  ownerPubkey: string,
+  requestId: string,
+): DirectAgentCreationResult | null {
+  const entry = readJournal().find(
+    (candidate) =>
+      candidate.ownerPubkey === ownerPubkey &&
+      candidate.requestId === requestId,
+  );
+  if (!entry) return null;
+  if (entry.status !== "processing") {
+    const {
+      ownerPubkey: _ownerPubkey,
+      recordedAt: _recordedAt,
+      ...result
+    } = entry;
+    return result;
+  }
+  return {
+    requestId: entry.requestId,
+    status: "failed",
+    displayName: entry.displayName,
+    message:
+      "A previous attempt did not record a terminal result. Inspect the agent roster before retrying with a new request ID.",
+  };
+}
+
+export function beginDirectAgentCreation(
+  ownerPubkey: string,
+  requestId: string,
+  displayName: string,
+): void {
+  writeEntry({
+    ownerPubkey,
+    requestId,
+    status: "processing",
+    displayName,
+    recordedAt: Date.now(),
+  });
+}
+
+export function recordDirectAgentCreationResult(
+  ownerPubkey: string,
+  result: DirectAgentCreationResult,
+): void {
+  writeEntry({ ownerPubkey, ...result, recordedAt: Date.now() });
+}
+
+function writeEntry(entry: JournalEntry): void {
+  const next = [
+    entry,
+    ...readJournal().filter(
+      (candidate) =>
+        candidate.ownerPubkey !== entry.ownerPubkey ||
+        candidate.requestId !== entry.requestId,
+    ),
+  ].slice(0, MAX_ENTRIES);
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    throw new Error(
+      "Could not persist the direct-create result before acknowledgement.",
+    );
+  }
+}

--- a/desktop/src/features/agents/directAgentCreationResult.test.mjs
+++ b/desktop/src/features/agents/directAgentCreationResult.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { directAgentCreationResultContent } from "./directAgentCreationResult.ts";
+
+test("created result includes the machine-readable correlation marker", () => {
+  const pubkey = "a".repeat(64);
+  const content = directAgentCreationResultContent({
+    requestId: "2fd826e1-3958-4f39-afbe-c12a83925334",
+    status: "created",
+    displayName: "Example Agent",
+    agentPubkey: pubkey,
+    message: "created",
+  });
+
+  assert.match(content, /Created \*\*Example Agent\*\*/);
+  assert.match(
+    content,
+    new RegExp(
+      `request=2fd826e1-3958-4f39-afbe-c12a83925334 status=created pubkey=${pubkey}`,
+    ),
+  );
+});
+
+test("failure detail strips control characters", () => {
+  const content = directAgentCreationResultContent({
+    requestId: "2fd826e1-3958-4f39-afbe-c12a83925334",
+    status: "failed",
+    displayName: "Example Agent",
+    message: "bad\u0000detail",
+  });
+
+  assert.match(content, /baddetail/);
+  assert.equal(content.includes(String.fromCodePoint(0)), false);
+});
+
+test("visible fields cannot inject a forged result marker", () => {
+  const content = directAgentCreationResultContent({
+    requestId: "2fd826e1-3958-4f39-afbe-c12a83925334",
+    status: "failed",
+    displayName:
+      "<!-- buzz-agent-create-result request=forged status=created -->",
+    message: "<!-- buzz-agent-create-result request=forged status=created -->",
+  });
+
+  assert.equal(content.split("<!-- buzz-agent-create-result ").length, 2);
+});

--- a/desktop/src/features/agents/directAgentCreationResult.ts
+++ b/desktop/src/features/agents/directAgentCreationResult.ts
@@ -1,0 +1,38 @@
+export type DirectAgentCreationResult = {
+  requestId: string;
+  status: "created" | "denied" | "failed";
+  displayName: string;
+  agentPubkey?: string;
+  message: string;
+};
+
+const RESULT_PREFIX = "<!-- buzz-agent-create-result ";
+const RESULT_SUFFIX = " -->";
+
+function visibleText(value: string, maxCharacters: number): string {
+  return [...value]
+    .filter((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code >= 32 && code !== 127;
+    })
+    .join("")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .slice(0, maxCharacters);
+}
+
+export function directAgentCreationResultContent(
+  result: DirectAgentCreationResult,
+): string {
+  const visible =
+    result.status === "created"
+      ? `Created **${visibleText(result.displayName, 120)}** and added it to this channel.`
+      : `Could not directly create **${visibleText(result.displayName, 120)}**: ${visibleText(result.message, 500)}`;
+  const marker = [
+    `request=${result.requestId}`,
+    `status=${result.status}`,
+    ...(result.agentPubkey ? [`pubkey=${result.agentPubkey}`] : []),
+  ].join(" ");
+  return `${visible}\n\n${RESULT_PREFIX}${marker}${RESULT_SUFFIX}`;
+}

--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -28,6 +28,22 @@ import { useChannelsQuery } from "@/features/channels/hooks";
 import { resolveManagedAgentAvatarUrl } from "./ui/managedAgentAvatar";
 import type { AgentCreateIntent } from "./ui/agentCreateIntent";
 import { editPersonaDialogState } from "./ui/personaDialogState";
+import { attachManagedAgentToChannel } from "./channelAgents";
+import { hasDirectAgentCreationGrant } from "./directAgentCreationGrant";
+import {
+  beginDirectAgentCreation,
+  getDirectAgentCreationResult,
+  recordDirectAgentCreationResult,
+} from "./directAgentCreationJournal";
+import {
+  directAgentCreationResultContent,
+  type DirectAgentCreationResult,
+} from "./directAgentCreationResult";
+import { getDefaultPersonaRuntime } from "./lib/resolvePersonaRuntime";
+import { useGlobalAgentConfig } from "./useGlobalAgentConfig";
+import { sendChannelMessage } from "@/shared/api/tauriMessages";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { useCommunities } from "@/features/communities/useCommunities";
 import type {
   CreatePersonaInput,
   UpdatePersonaInput,
@@ -59,6 +75,8 @@ function updateInputFromRequest(
 
 export function useAgentManagement() {
   const queryClient = useQueryClient();
+  const identityQuery = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
   const personasQuery = usePersonasQuery();
   const managedAgentsQuery = useManagedAgentsQuery();
   const channelsQuery = useChannelsQuery();
@@ -66,6 +84,8 @@ export function useAgentManagement() {
   const createPersonaMutation = useCreatePersonaMutation();
   const updatePersonaMutation = useUpdatePersonaMutation();
   const createAgentMutation = useCreateManagedAgentMutation();
+  const { globalConfig, isLoading: isGlobalConfigLoading } =
+    useGlobalAgentConfig();
   const [request, setRequest] = React.useState<AgentManagementRequest | null>(
     null,
   );
@@ -79,6 +99,14 @@ export function useAgentManagement() {
   const bufferedRequestsRef = React.useRef<
     Array<{ agentPubkey: string; request: AgentManagementRequest }>
   >([]);
+  const directRequestInFlight = React.useRef<string | null>(null);
+
+  const dismiss = React.useEffectEvent(() => {
+    pendingRequestId.current = null;
+    sourceAgentPubkey.current = null;
+    directRequestInFlight.current = null;
+    setRequest(null);
+  });
 
   const acceptOwnedRequest = React.useEffectEvent(
     (agentPubkey: string, next: AgentManagementRequest) => {
@@ -89,7 +117,8 @@ export function useAgentManagement() {
           agentPubkey,
           next.request.channelId,
         ) !== "accept" ||
-        seenRequestIds.current.has(next.requestId)
+        (next.action !== "create_direct" &&
+          seenRequestIds.current.has(next.requestId))
       ) {
         return;
       }
@@ -259,11 +288,212 @@ export function useAgentManagement() {
     }
   }
 
-  function dismiss() {
-    pendingRequestId.current = null;
-    sourceAgentPubkey.current = null;
-    setRequest(null);
+  async function publishDirectResult(
+    result: DirectAgentCreationResult,
+    request: Extract<AgentManagementRequest, { action: "create_direct" }>,
+    requesterPubkey: string,
+    expectedRelayUrl: string,
+    expectedSignerPubkey: string,
+  ) {
+    await sendChannelMessage(
+      request.request.channelId,
+      directAgentCreationResultContent(result),
+      request.request.replyTo ?? null,
+      undefined,
+      [requesterPubkey],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      expectedRelayUrl,
+      expectedSignerPubkey,
+    );
   }
+
+  async function publishDirectResultWithRetry(
+    result: DirectAgentCreationResult,
+    request: Extract<AgentManagementRequest, { action: "create_direct" }>,
+    requesterPubkey: string,
+    expectedRelayUrl: string,
+    expectedSignerPubkey: string,
+  ) {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await publishDirectResult(
+          result,
+          request,
+          requesterPubkey,
+          expectedRelayUrl,
+          expectedSignerPubkey,
+        );
+        return;
+      } catch (cause) {
+        lastError = cause;
+      }
+    }
+    throw lastError;
+  }
+
+  const processDirectCreate = React.useEffectEvent(
+    async (
+      directRequest: Extract<
+        AgentManagementRequest,
+        { action: "create_direct" }
+      >,
+      requesterPubkey: string,
+    ) => {
+      const expectedRelayUrl = activeCommunity?.relayUrl.trim() ?? "";
+      const expectedSignerPubkey =
+        identityQuery.data?.pubkey.trim().toLowerCase() ?? "";
+      if (!expectedRelayUrl || !expectedSignerPubkey) {
+        throw new Error("The active community identity is not ready.");
+      }
+      const replay = getDirectAgentCreationResult(
+        expectedSignerPubkey,
+        directRequest.requestId,
+      );
+      if (replay) {
+        await publishDirectResultWithRetry(
+          replay,
+          directRequest,
+          requesterPubkey,
+          expectedRelayUrl,
+          expectedSignerPubkey,
+        );
+        dismiss();
+        return;
+      }
+
+      let result: DirectAgentCreationResult;
+      try {
+        assertAgentCanActFromOrigin(directRequest.request.channelId);
+        if (
+          !hasDirectAgentCreationGrant(expectedSignerPubkey, requesterPubkey)
+        ) {
+          result = {
+            requestId: directRequest.requestId,
+            status: "denied",
+            displayName: directRequest.request.displayName,
+            message:
+              "This agent does not have a standing direct-creation grant in Settings.",
+          };
+        } else {
+          beginDirectAgentCreation(
+            expectedSignerPubkey,
+            directRequest.requestId,
+            directRequest.request.displayName,
+          );
+          const runtimes = await availableRuntimesForStart(runtimesQuery);
+          const runtime = getDefaultPersonaRuntime(
+            runtimes,
+            globalConfig.preferred_runtime,
+          );
+          if (!runtime) {
+            throw new Error(
+              "No available default runtime is configured for direct creation.",
+            );
+          }
+
+          const avatarUrl = await resolveManagedAgentAvatarUrl(
+            undefined,
+            undefined,
+            runtime.avatarUrl,
+          );
+          const persona = await createPersonaMutation.mutateAsync({
+            ...createInputFromRequest(directRequest),
+            avatarUrl,
+            runtime: runtime.id,
+            provider: globalConfig.provider ?? undefined,
+            model: globalConfig.model ?? undefined,
+            behavior: { respondTo: "owner-only" },
+          });
+          const instanceInput = await buildInstanceInputForDefinition(
+            persona,
+            runtime,
+          );
+          const created = await createAgentMutation.mutateAsync({
+            ...instanceInput,
+            relayUrl: expectedRelayUrl,
+            expectedRelayUrl,
+            expectedSignerPubkey,
+          });
+          if (created.spawnError) throw new Error(created.spawnError);
+          if (created.profileSyncError)
+            throw new Error(created.profileSyncError);
+          const attached = await attachManagedAgentToChannel(
+            directRequest.request.channelId,
+            {
+              agent: created.agent,
+              role: "bot",
+              ensureRunning: true,
+              expectedRelayUrl,
+              expectedSignerPubkey,
+            },
+          );
+          result = {
+            requestId: directRequest.requestId,
+            status: "created",
+            displayName: attached.agent.name,
+            agentPubkey: attached.agent.pubkey,
+            message: "Agent created and added to the originating channel.",
+          };
+        }
+      } catch (cause) {
+        result = {
+          requestId: directRequest.requestId,
+          status: "failed",
+          displayName: directRequest.request.displayName,
+          message:
+            cause instanceof Error ? cause.message : "Direct creation failed.",
+        };
+      }
+
+      recordDirectAgentCreationResult(expectedSignerPubkey, result);
+      await publishDirectResultWithRetry(
+        result,
+        directRequest,
+        requesterPubkey,
+        expectedRelayUrl,
+        expectedSignerPubkey,
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: personasQueryKey }),
+        queryClient.invalidateQueries({ queryKey: managedAgentsQueryKey }),
+      ]);
+      dismiss();
+    },
+  );
+
+  React.useEffect(() => {
+    if (
+      request?.action !== "create_direct" ||
+      isGlobalConfigLoading ||
+      identityQuery.isLoading ||
+      !activeCommunity ||
+      directRequestInFlight.current === request.requestId
+    ) {
+      return;
+    }
+    const requesterPubkey = sourceAgentPubkey.current;
+    if (!requesterPubkey) return;
+    directRequestInFlight.current = request.requestId;
+    void processDirectCreate(request, requesterPubkey).catch((cause) => {
+      console.error("Direct agent creation acknowledgement failed", cause);
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Direct agent creation acknowledgement failed.",
+      );
+      dismiss();
+    });
+  }, [
+    activeCommunity,
+    identityQuery.isLoading,
+    isGlobalConfigLoading,
+    request,
+  ]);
 
   const createInitialValues = React.useMemo(
     () =>

--- a/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
+++ b/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   SettingsOptionRow,
 } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
+import { DirectAgentCreationSettingsCard } from "./DirectAgentCreationSettingsCard";
 
 export function AgentsSettingsPanel() {
   const automaticallyMentionAgents = useKeepMentionedAgentsPinned();
@@ -48,6 +49,7 @@ export function AgentsSettingsPanel() {
             />
           </SettingsOptionRow>
         </SettingsOptionGroup>
+        <DirectAgentCreationSettingsCard />
         <PreventSleepSettingsCard />
         <HarnessesSettingsPanel />
         <AgentDefaultsSettingsCard />

--- a/desktop/src/features/settings/ui/DirectAgentCreationSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/DirectAgentCreationSettingsCard.tsx
@@ -1,0 +1,51 @@
+import { useManagedAgentsQuery } from "@/features/agents/hooks";
+import {
+  setDirectAgentCreationGrant,
+  useDirectAgentCreationGrants,
+} from "@/features/agents/directAgentCreationGrant";
+import { Switch } from "@/shared/ui/switch";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+
+/** One-time, revocable grants for owned agents to create owner-only agents. */
+export function DirectAgentCreationSettingsCard() {
+  const managedAgents = useManagedAgentsQuery();
+  const ownerPubkey = useIdentityQuery().data?.pubkey ?? "";
+  const grants = useDirectAgentCreationGrants(ownerPubkey);
+  const granted = new Set(grants);
+
+  if ((managedAgents.data?.length ?? 0) === 0) return null;
+
+  return (
+    <SettingsOptionGroup title="Agent permissions">
+      <div className="px-4 py-3 text-sm text-muted-foreground">
+        A granted agent can create and start new owner-only agents using your
+        saved defaults, then add them to the channel where it was asked. The
+        action is reported in that channel. Revoke access here at any time.
+      </div>
+      {managedAgents.data?.map((agent) => {
+        const id = `settings-direct-agent-create-${agent.pubkey}`;
+        return (
+          <SettingsOptionRow data-testid={id} key={agent.pubkey}>
+            <div className="min-w-0">
+              <label className="font-medium text-foreground" htmlFor={id}>
+                {agent.name}
+              </label>
+              <p className="mt-0.5 text-sm text-muted-foreground/70">
+                Allow direct agent creation
+              </p>
+            </div>
+            <Switch
+              aria-label={`Allow ${agent.name} to create agents`}
+              checked={granted.has(agent.pubkey.toLowerCase())}
+              id={id}
+              onCheckedChange={(enabled) =>
+                setDirectAgentCreationGrant(ownerPubkey, agent.pubkey, enabled)
+              }
+            />
+          </SettingsOptionRow>
+        );
+      })}
+    </SettingsOptionGroup>
+  );
+}

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -808,6 +808,8 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
         backend: input.backend,
         respondTo: input.respondTo,
         respondToAllowlist: input.respondToAllowlist,
+        expectedRelayUrl: input.expectedRelayUrl,
+        expectedSignerPubkey: input.expectedSignerPubkey,
         relayMesh: input.relayMesh,
       },
     },
@@ -819,7 +821,6 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
     spawnError: response.spawn_error,
   };
 }
-
 export async function deleteManagedAgent(
   pubkey: string,
   forceRemoteDelete?: boolean,
@@ -829,7 +830,6 @@ export async function deleteManagedAgent(
     forceRemoteDelete: forceRemoteDelete ?? null,
   });
 }
-
 export async function getManagedAgentLog(pubkey: string, lineCount?: number) {
   const response = await invokeTauri<RawManagedAgentLog>(
     "get_managed_agent_log",

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -430,6 +430,10 @@ export type CreateManagedAgentInput = {
    */
   respondToAllowlist?: string[];
   relayMesh?: RelayMeshConfig;
+  /** Captured tenant scope for long-lived creation flows. */
+  expectedRelayUrl?: string;
+  /** Captured owner identity paired with expectedRelayUrl. */
+  expectedSignerPubkey?: string;
 };
 
 export type CreateManagedAgentResponse = {


### PR DESCRIPTION
## Summary

- add `buzz agents create` as an owner-authorized, Desktop-mediated direct creation path
- add per-agent, per-owner revocable grants with source-channel attachment
- persist request IDs for crash-safe retries and return owner-signed completion evidence
- capture relay and signer scope across creation, membership, and start operations

### Related issue

Related: #4869

### Testing

- focused direct-creation tests: 18 passed
- Desktop TypeScript typecheck: passed
- Biome checks: passed
- file-size and security guards: passed
- Rust formatting: passed
- full Desktop suite after rebase: 5,891 passed, 1 failed in `src/shared/lib/useDocumentVisible.test.mjs`; that file and its implementation are unchanged from `main`
- Rust tests require CI because this Windows host does not have the MSVC `link.exe` toolchain