### PR TITLE
fix(desktop): order same-name agents using your recent choices

### DIFF
--- a/desktop/src/features/channels/mentionAdmissionJourney.test.mjs
+++ b/desktop/src/features/channels/mentionAdmissionJourney.test.mjs
@@ -1,3 +1,7 @@
+import {
+  getMentionSelectionHistory,
+  resetMentionSelectionHistory,
+} from "../messages/lib/mentionSelectionHistory.ts";
 // Admission against existing root query evidence, without membership freshness production.
 // Real mention and picker hooks; Tauri policy/classification are fixture evidence.
 import assert from "node:assert/strict";
@@ -246,6 +250,7 @@ async function setup(overrides = {}) {
 }
 afterEach(async () => {
   if (root) await act(async () => root.unmount());
+  resetMentionSelectionHistory();
   client?.clear();
   document.body.replaceChildren();
 });
@@ -326,6 +331,7 @@ test("retained explicit pin rejects latest policy denial without draft effects",
   assert.equal(rows().length, 1, "denial does not move the displayed row");
   await act(async () => oldPin(row));
   assert.deepEqual(effects, []);
+  assert.deepEqual(getMentionSelectionHistory(VIEWER, CHANNEL), []);
   assert.deepEqual(mention.knownNames, []);
 });
 
@@ -349,6 +355,7 @@ for (const returnToOrigin of [false, true]) {
       edit = oldInsert(row, 1);
     });
     assert.deepEqual(effects, []);
+    assert.deepEqual(getMentionSelectionHistory(VIEWER, CHANNEL), []);
     assert.equal(edit.insertText, "");
     assert.deepEqual(mention.knownNames, []);
   });
@@ -592,6 +599,9 @@ test("background membership/search updates leave visible same-name rows and Tab 
     mention.getDraftMentionRefs(edit.insertText)[0].pubkey,
     selected.pubkey,
   );
+  assert.deepEqual(getMentionSelectionHistory(VIEWER, CHANNEL), [
+    selected.pubkey,
+  ]);
   await act(async () => mention.updateMentionQuery("@Scou", 5));
   await settle();
   assert.equal(mention.suggestions.length, 3);
@@ -719,6 +729,7 @@ for (const condition of ["denied", "missing", "failed", "cold-failed"]) {
       assert.equal(outcome.suggestion, undefined);
     }
     assert.deepEqual(effects, []);
+    assert.deepEqual(getMentionSelectionHistory(VIEWER, CHANNEL), []);
     assert.deepEqual(mention.knownNames, []);
   });
 }

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -1,3 +1,4 @@
+import { resetMentionSelectionHistory } from "@/features/messages/lib/mentionSelectionHistory";
 import { useEffect, useRef, useState } from "react";
 import { isTauri } from "@tauri-apps/api/core";
 import { isMacPlatform } from "@/shared/lib/platform";
@@ -58,6 +59,7 @@ async function resetCommunityState({
   resetAvatarState: boolean;
 }): Promise<void> {
   relayClient.disconnect();
+  resetMentionSelectionHistory();
   await resetNavigationDeepLinkDrain();
   resetRateLimitGate();
   clearAllDrafts();

--- a/desktop/src/features/messages/lib/mentionPresentation.test.mjs
+++ b/desktop/src/features/messages/lib/mentionPresentation.test.mjs
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildMentionCandidates } from "./buildMentionCandidates.ts";
+import { rankMentionCandidates } from "./mentionRanking.ts";
 import { getMentionMemberPubkeys } from "./mentionMemberPubkeys.ts";
+import {
+  getMentionSelectionHistory,
+  rememberMentionSelection,
+  resetMentionSelectionHistory,
+} from "./mentionSelectionHistory.ts";
 
 const A = "a".repeat(64),
   B = "b".repeat(64),
+  C = "c".repeat(64),
   VIEWER = "f".repeat(64);
 function input(overrides = {}) {
   return {
@@ -160,4 +167,100 @@ test("relay presence and verified ownership are independent of local stopped sta
     }),
   );
   assert.equal(stale.presence, "unknown");
+});
+const candidate = (pubkey, extra = {}) => ({
+  kind: "identity",
+  pubkey,
+  displayName: "Scout",
+  isAgent: true,
+  isMember: true,
+  action: "mention",
+  ...extra,
+});
+test("collision order is explicit recent, owned, Online > Away > unknown/Offline, then exact key", () => {
+  const rows = [
+    candidate(A, { presence: "online" }),
+    candidate(B, { isOwned: true, presence: "offline" }),
+    candidate(C, { presence: "away" }),
+  ];
+  const keys = (items, history = []) =>
+    rankMentionCandidates(items, "", new Set(), history).map(
+      (x) => x.candidate.pubkey,
+    );
+  assert.deepEqual(keys(rows), [B, A, C]);
+  assert.deepEqual(keys(rows, [C]), [C, B, A]);
+  for (const permutation of [
+    rows,
+    [...rows].reverse(),
+    [rows[1], rows[0], rows[2]],
+    [rows[2], rows[0], rows[1]],
+  ])
+    assert.deepEqual(keys(permutation), [B, A, C]);
+  assert.deepEqual(
+    keys([
+      candidate(B, { presence: "unknown" }),
+      candidate(A, { presence: "offline" }),
+    ]),
+    [A, B],
+  );
+  assert.deepEqual(
+    keys([
+      candidate(B, { action: "unavailable" }),
+      candidate(A, { isMember: false, action: "invite" }),
+    ]),
+    [A, B],
+  );
+});
+test("unrelated text/kind slots do not participate in conditional-comparator cycles", () => {
+  const rows = [
+    candidate(B),
+    candidate(C, { displayName: "Someone", isAgent: false }),
+    candidate(A),
+  ];
+  assert.deepEqual(
+    rankMentionCandidates(rows, "").map((x) => x.candidate.pubkey),
+    [A, C, B],
+  );
+});
+test("explicit history is channel/user scoped, bounded and cleared at community reset", () => {
+  resetMentionSelectionHistory();
+  rememberMentionSelection(VIEWER, "room", A);
+  rememberMentionSelection(VIEWER, "room", B);
+  assert.deepEqual(getMentionSelectionHistory(VIEWER, "room"), [B, A]);
+  assert.deepEqual(getMentionSelectionHistory(A, "room"), []);
+  assert.deepEqual(getMentionSelectionHistory(VIEWER, "other"), []);
+  resetMentionSelectionHistory();
+  assert.deepEqual(getMentionSelectionHistory(VIEWER, "room"), []);
+});
+
+test("history normalizes keys and evicts excess entries and scopes", () => {
+  resetMentionSelectionHistory();
+  for (let i = 0; i < 55; i++)
+    rememberMentionSelection(VIEWER, "room", i.toString(16).padStart(64, "0"));
+  assert.equal(getMentionSelectionHistory(VIEWER, "room").length, 50);
+  rememberMentionSelection(VIEWER.toUpperCase(), "room", A.toUpperCase());
+  assert.equal(getMentionSelectionHistory(VIEWER, "room")[0], A);
+  for (let i = 0; i < 100; i++)
+    rememberMentionSelection(VIEWER, `room-${i}`, A);
+  assert.deepEqual(getMentionSelectionHistory(VIEWER, "room"), []);
+  resetMentionSelectionHistory();
+});
+
+test("ranking before the visible slice preserves persona and team slots", () => {
+  const rows = [
+    candidate(B, { isMember: false, personaId: "active" }),
+    candidate(undefined, {
+      kind: "persona",
+      isMember: false,
+      personaId: "active",
+    }),
+    candidate(undefined, { kind: "team", isMember: false }),
+    candidate(A, { isMember: false, personaId: "active", isOwned: true }),
+  ];
+  const rank = (history = []) =>
+    rankMentionCandidates(rows, "Scout", new Set(["active"]), history)
+      .slice(0, 3)
+      .map((item) => item.candidate);
+  assert.deepEqual(rank(), [rows[3], rows[1], rows[2]]);
+  assert.deepEqual(rank([B]), [rows[0], rows[1], rows[2]]);
 });

--- a/desktop/src/features/messages/lib/mentionRanking.ts
+++ b/desktop/src/features/messages/lib/mentionRanking.ts
@@ -1,9 +1,15 @@
-import { isMentionActionable, type MentionAction } from "./mentionPresentation";
+import {
+  isMentionActionable,
+  type MentionAction,
+  type MentionPresence,
+} from "./mentionPresentation";
 import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
 
 export type MentionCandidateForRanking = {
   displayName: string | null;
   action?: MentionAction;
+  isOwned?: boolean;
+  presence?: MentionPresence;
   isAgent: boolean;
   isActiveAgent?: boolean;
   isMember: boolean;
@@ -116,10 +122,11 @@ export function rankMentionCandidates<T extends MentionCandidateForRanking>(
   candidates: readonly T[],
   query: string,
   activePersonaIds: ReadonlySet<string> = new Set(),
+  recentExplicitPubkeys: readonly string[] = [],
 ): RankedMentionCandidate<T>[] {
   const lowerQuery = query.toLowerCase();
 
-  return candidates
+  const ranked = candidates
     .map((candidate, order) => {
       const pubkeyLower = candidate.pubkey
         ? normalizePubkey(candidate.pubkey)
@@ -160,4 +167,43 @@ export function rankMentionCandidates<T extends MentionCandidateForRanking>(
       (a, b) =>
         a.groupRank - b.groupRank || a.score - b.score || a.order - b.order,
     );
+  // Reorder only comparable same-name agent slots. A conditional pairwise
+  // comparator against unrelated rows creates cycles (A<B, B<C, C<A).
+  const groups = new Map<string, number[]>();
+  ranked.forEach((item, index) => {
+    if (
+      item.candidate.kind !== "identity" ||
+      !item.candidate.pubkey ||
+      !item.candidate.isAgent ||
+      !isMentionActionable(item.candidate)
+    )
+      return;
+    const group = `${item.groupRank}:${item.score}:${item.label.trim().toLowerCase()}`;
+    groups.set(group, [...(groups.get(group) ?? []), index]);
+  });
+  const recent = new Map(
+    recentExplicitPubkeys.map((key, index) => [normalizePubkey(key), index]),
+  );
+  const presenceRank = (value?: MentionPresence) =>
+    value === "online" ? 0 : value === "away" ? 1 : 2;
+  for (const indexes of groups.values()) {
+    if (indexes.length < 2) continue;
+    const sorted = indexes
+      .map((index) => ranked[index])
+      .sort((a, b) => {
+        const left = a.candidate,
+          right = b.candidate;
+        return (
+          (recent.get(normalizePubkey(left.pubkey ?? "")) ?? Infinity) -
+            (recent.get(normalizePubkey(right.pubkey ?? "")) ?? Infinity) ||
+          Number(right.isOwned === true) - Number(left.isOwned === true) ||
+          presenceRank(left.presence) - presenceRank(right.presence) ||
+          (left.pubkey ?? "").localeCompare(right.pubkey ?? "")
+        );
+      });
+    indexes.forEach((index, i) => {
+      ranked[index] = sorted[i];
+    });
+  }
+  return ranked;
 }

--- a/desktop/src/features/messages/lib/mentionSelectionHistory.ts
+++ b/desktop/src/features/messages/lib/mentionSelectionHistory.ts
@@ -1,0 +1,44 @@
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+// Community lifetime is owned by resetCommunityState. Keys additionally isolate
+// identities/channels; this is selection intent, never authorization or pins.
+const history = new Map<string, string[]>();
+const scopeKey = (viewer: string, channel: string) =>
+  `${normalizePubkey(viewer)}:${channel}`;
+
+/** Clear selection intent when the community changes. */
+export function resetMentionSelectionHistory() {
+  history.clear();
+}
+
+/** Read recent successful insertions for this viewer and channel only. */
+export function getMentionSelectionHistory(
+  viewer: string | null,
+  channel: string | null,
+): readonly string[] {
+  return viewer && channel
+    ? (history.get(scopeKey(viewer, channel)) ?? [])
+    : [];
+}
+
+/** Record a successful exact-key insertion without creating permission or a pin. */
+export function rememberMentionSelection(
+  viewer: string | null,
+  channel: string | null,
+  pubkey: string,
+) {
+  if (!viewer || !channel) return;
+  const scope = scopeKey(viewer, channel);
+  const key = normalizePubkey(pubkey);
+  const previous = history.get(scope) ?? [];
+  history.delete(scope);
+  history.set(
+    scope,
+    [key, ...previous.filter((item) => item !== key)].slice(0, 50),
+  );
+  while (history.size > 100) {
+    const oldest = history.keys().next().value;
+    if (oldest === undefined) break;
+    history.delete(oldest);
+  }
+}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -3,6 +3,10 @@ import {
   markMentionCollisions,
 } from "./mentionPresentation";
 import { useCanAddChannelMembers } from "@/features/channels/useCanAddChannelMembers";
+import {
+  getMentionSelectionHistory,
+  rememberMentionSelection,
+} from "./mentionSelectionHistory";
 import { useMentionEvidence } from "./useMentionEvidence";
 import * as React from "react";
 import {
@@ -420,6 +424,7 @@ export function useMentions(
       mentionCandidatesWithTeams,
       mentionQuery,
       activePersonaIds,
+      getMentionSelectionHistory(currentPubkey, channelId),
     )
       .slice(0, MENTION_SUGGESTION_LIMIT)
       .map(({ candidate, label }) => ({
@@ -438,6 +443,7 @@ export function useMentions(
     activePersonaIds,
     agentDirectoriesReady,
     retryMention,
+    channelId,
     currentPubkey,
     mentionCandidatesWithTeams,
     mentionQuery,
@@ -592,6 +598,8 @@ export function useMentions(
           replaceToOffset: selectionEnd,
           insertText: "",
         };
+      if (suggestion.pubkey)
+        rememberMentionSelection(currentPubkey, channelId, suggestion.pubkey);
       const [boundSuggestion] = selectedMentionLabels(
         [suggestion],
         mentionMapRef.current,
@@ -666,6 +674,8 @@ export function useMentions(
       knownAgentPubkeys,
       query,
       suggestions,
+      currentPubkey,
+      channelId,
     ],
   );
   const registerMentionPubkey = React.useCallback(

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -476,6 +476,116 @@ test.describe("community rail", () => {
       .toBe(COMMUNITY_B.id);
   });
 
+  test("community round trip clears mention ranking for the same viewer and channel", async ({
+    page,
+  }) => {
+    const first = "11".repeat(32);
+    const chosen = "22".repeat(32);
+    const channelId = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+    await seedCommunities(page, [COMMUNITY_A, COMMUNITY_B], COMMUNITY_A.id);
+    await installMockBridge(
+      page,
+      {
+        managedAgents: [],
+        relayAgents: [first, chosen].map((pubkey) => ({
+          pubkey,
+          name: "Scout",
+          ownerPubkey: OWNER_PUBKEY,
+          respondTo: "anyone",
+          status: "offline",
+          channelNames: ["general"],
+        })),
+        searchProfiles: [first, chosen].map((pubkey) => ({
+          pubkey,
+          displayName: "Scout",
+          isAgent: true,
+        })),
+      },
+      { skipCommunitySeed: true },
+    );
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await page.evaluate(
+      async ({ channelId, keys }) => {
+        await window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("add_channel_members", {
+          channelId,
+          pubkeys: keys,
+          role: "bot",
+        });
+        await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+          queryKey: ["channels"],
+        });
+        await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+          queryKey: ["relay-agents"],
+        });
+      },
+      { channelId, keys: [first, chosen] },
+    );
+    const input = page.getByTestId("message-input");
+    const rows = page.locator("[data-mention-suggestion-index]");
+    const rowIds = () =>
+      rows.evaluateAll((items) =>
+        items.map((row) => row.getAttribute("data-testid")),
+      );
+    const baseline = [first, chosen].map((key) => `mention-suggestion-${key}`);
+    await input.fill("@Scout");
+    await expect.poll(rowIds).toEqual(baseline);
+    await input.press("ArrowDown");
+    await input.press("Tab");
+    await expect(input).toHaveText("@Scout ");
+    await page.keyboard.type("ranking choice");
+    await page.getByTestId("send-message").click();
+    const publication = (content: string) =>
+      page.evaluate(
+        (text) =>
+          (window.__BUZZ_E2E_SIGNED_EVENTS__ ?? [])
+            .filter((event) => event.content === text)
+            .map((event) => ({
+              viewer: (
+                window.__BUZZ_E2E_QUERY_CLIENT__?.getQueryState(["identity"]) as
+                  | { data?: { pubkey: string } }
+                  | undefined
+              )?.data?.pubkey,
+              channel: event.tags.find((tag) => tag[0] === "h")?.[1],
+              recipients: event.tags
+                .filter((tag) => tag[0] === "p")
+                .map((tag) => tag[1]),
+            })),
+        content,
+      );
+    await expect
+      .poll(() => publication("@Scout ranking choice"))
+      .toEqual([
+        { viewer: OWNER_PUBKEY, channel: channelId, recipients: [chosen] },
+      ]);
+    // Positive control: this exact choice really affects the next snapshot.
+    await input.fill("@Scout");
+    await expect.poll(rowIds).toEqual([...baseline].reverse());
+    await input.press("Escape");
+    await input.fill("");
+
+    // Real rail navigation remounts the community without reloading the page.
+    for (const community of [COMMUNITY_B, COMMUNITY_A]) {
+      await page.getByTestId(`community-rail-button-${community.id}`).click();
+      await expect(
+        page.getByTestId(`community-rail-button-${community.id}`),
+      ).toHaveAttribute("aria-current", "true");
+      await page.getByTestId("channel-general").click();
+      await expect(page.getByTestId("chat-title")).toHaveText("general");
+    }
+    // The identity query used by useMentions and the publication channel bind
+    // the returned composer to the original scope;
+    // changing viewer/channel must not masquerade as clearing its history.
+    await input.fill("ranking returned");
+    await page.getByTestId("send-message").click();
+    await expect
+      .poll(() => publication("ranking returned"))
+      .toEqual([{ viewer: OWNER_PUBKEY, channel: channelId, recipients: [] }]);
+    await input.fill("@Scout");
+    await expect.poll(rowIds).toEqual(baseline);
+  });
+
   test("community switch cancels a send after its link preview settles", async ({
     page,
   }) => {

--- a/desktop/tests/e2e/mention-picker.spec.ts
+++ b/desktop/tests/e2e/mention-picker.spec.ts
@@ -76,7 +76,12 @@ test("collision distinction, deliberate key choice, and exact publication", asyn
   const rowIds = await page
     .locator("[data-mention-suggestion-index]")
     .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-testid")));
+  expect(rowIds).toEqual([
+    `mention-suggestion-${A}`,
+    `mention-suggestion-${B}`,
+  ]);
   const first = rowIds[1]?.endsWith(A) ? A : B;
+  const second = first === A ? B : A;
   await input.press("ArrowDown");
   // Membership/presence changes affect the next request, not the visible order.
   await page.evaluate(() => {
@@ -122,6 +127,17 @@ test("collision distinction, deliberate key choice, and exact publication", asyn
       ),
     )
     .toEqual([[first]]);
+  await input.fill("@Scout");
+  await expect
+    .poll(() =>
+      page
+        .locator("[data-mention-suggestion-index]")
+        .evaluateAll((rows) =>
+          rows.map((row) => row.getAttribute("data-testid")),
+        ),
+    )
+    .toEqual([`mention-suggestion-${first}`, `mention-suggestion-${second}`]);
+  await capture(page, "next-open-ranking");
 });
 
 test("Escape discards delayed picker results across navigation", async ({


### PR DESCRIPTION
🤖
## Summary
Your recent @ mention choices now rank first the next time you search — without ever reordering a list you're already looking at.

- **Only real choices are remembered.** A mention counts only when it is actually inserted and passes the live admission check from #7196; denied or stale selections record nothing.
- **Recent choices rank first on the next search.** When several same-name agents tie for a slot, the one you chose most recently comes first — even above an agent you own. Before, the agent you own always won that tie, no matter what you had just chosen.
- **An open list never moves.** New choices only affect the next snapshot; they never reorder the identities, labels, or selection of a list that is already open.
- **History is bounded and scoped.** The record is capped in size, kept per viewer and per channel, and cleared when you switch communities.

Part of the mention-chooser stack on the shared #7190 recovery prerequisite: #7190 → #7196 → #7323 → #7197 → #7239 → #7240. This feature stack remains separate from #7191 → #7192. This PR builds directly on #7239.

### Related issue
Continues the merged mention-editor work from #7124 (authorize remote mentions at publication) and #7128 (preserve spacing after multi-word mentions). No separate tracking issue for this slice.

### Testing

<!-- accepted-replay-3a062ea7 -->
#### Current accepted replay (2026-09-09)

Published head `ed502a18b941786a187fb69a54cab47e31c93de5`, tree `f01223931881fb2a2981deaa7d7b3dae85d6a1a7`, base `479bbe0f17d7635c48e00b5f7280350b1d8b2dba`. Only #7239, #7240 and #7542 were advanced in one atomic exact-lease push; the other six stack heads are unchanged.

Closes the shared community-reset coverage finding in reviews 5159942011 and 5159947440. The community-rail regression records a real admitted choice and proves its next-open promotion, drives actual A→B→A community navigation through the production reset seam, binds the returned viewer/channel, and verifies baseline ranking instead of calling the history reset helper directly. The two-review duplicate is one issue, not two independent defects.

Reconciled local evidence (not rerun for publication): 6,153/6,153 Desktop package and 102/102 focused on composed production; TypeScript and actual desktop-check passed; exact per-PR base/tree size gates passed. Broad Chromium/mock-bridge run remains 233/234 before the test-only formatting correction, followed by the full affected 66/66. Final test-only B1 delta passed full remote-owned-mentions 20/20 and real lifecycle/authority 16/16. Production/dependencies/build/every served file are equivalent across those test-only deltas. No fresh 234/234, union total, repository-wide just ci, live-relay, native Tauri/WebKit/IME/VoiceOver certification, or current-head CI success is claimed. Historical c98 draft failure remains unattributed, not proof of autofocus causation and not a permanent gate after the accepted present-invariant proof. Existing standalone-stack limitations remain. Source evidence: OUTBOX/MENTION_10055/REPORT.md and OUTBOX/MENTION_C0F1/REPORT.md (the latter supersedes only the former B1 blocker disposition).

Current-head CI and fresh review are pending verification, not covered by old approvals. The evidence and head-specific CI statements below are preserved historical records, superseded by this block for the current head.

- Unit tests: `mentionPresentation.test.mjs` additions and the new `mentionSelectionHistory` logic cover bounded per-viewer/per-channel history, clearing on community switch, admitted choices only, and ranking applied to the next snapshot; `mentionAdmissionJourney.test.mjs` adds the ranking journey.
- Browser tests: `mention-picker.spec.ts` covers choosing a same-name row via ArrowDown→Tab, publishing its sole exact recipient, then seeing that choice promoted above the initially owned row on the next search — while an open list never moves.

## Historical capture state (not these heads)
The following original captions/links are retained as historical capture evidence only; none is relabeled as this restack.

## Preserved recent-choice comparison
Historical mock-bridge captures from PR6 `22b1d536` and the PR7 production-equivalent build through `bce92ee1`. These illustrate the ranking preference (the new stable-list lifecycle is different), not a new-head capture or delivery proof.

### Before — ownership still ranks first after choosing B
At PR6, the owned Scout stays above the other Scout after the other Scout is selected.
![before-recent-choice](https://raw.githubusercontent.com/block/buzz/a35d9a96bbf884f4256daa779e43b4ae20e83cfa/pr-7240--before-recent-choice.png)

### After — the recent explicit choice ranks first
At PR7, choosing the other Scout moves that exact identity above the owned Scout on the next comparable search. The selected recipient does not change.
![after-recent-choice](https://raw.githubusercontent.com/block/buzz/a35d9a96bbf884f4256daa779e43b4ae20e83cfa/pr-7240--after-recent-choice.png)


## Integrated stable-picker visuals
[Captured integrated f638b9cb](https://github.com/block/buzz/pull/7240#issuecomment-5518822403) — **not standalone PR5 and not a capture of this correction**. These still illustrate stable rows, action labels and next-open ranking; the earlier correction changed null-destination readiness and fixtures, not those pictured channel states. The duplicate-row image is before Tab, as captioned. No image proves access or delivery.
- Earlier independent-root evidence is historical; current shared-recovery composition validation is recorded below.


### Extraction validation update
- This stack builds on the shared #7190 recovery baseline, separately from #7191 → #7192. Chooser, cold-error settlement and ranking production behavior are unchanged by the fixture repairs.
- Desktop lint/format, TypeScript, explicit shared-base file-size checks and E2E builds pass. Targeted send-flow/mention-presentation checks pass. Earlier package **6035/6035** and isolated browser **8/8** remain historical evidence for unchanged semantic inputs, not fresh runs of this composition.
- The fresh composition probe passed **7/8** initially. The Welcome failure was traced to mock parity: create dropped the starter team ID, and add-members omitted the normal membership event. The fixture now preserves team ID, deliberately seeds a same-name collision and delivers that event. Exactly three starter creates prove reuse. The original ambiguous-submit error, retained draft, no-publication and exact-current-starter completion assertions remain.
- Welcome now passes separately on the earliest owning #7196 prefix and final descendant with matching E2E builds. Removing only the fixture membership event fails the roster precondition; restoring it passes. This is not one combined clean eight-test run and does not establish a production freshness dependency on lane B.
- Earlier full browser sweep remains **138/141**, with separate separator corrections **2/2** and editor **4/4**. No fresh full-suite or all-prefix runtime claim.
- The initial-directory authorization test now holds the actual mock directory response until Loading and no-Quinn assertions finish, rather than spending a one-second delay during navigation. Releasing it passes; withholding release fails eventual visibility. Existing assertions and timeouts are unchanged.
- Independent Welcome fixture review passed; independent held-directory fixture review also passed; earlier helper/shared-base and semantic reviews are retained.
- Fixed the historical profile-hover CI timing failure in separate commit [3825f894](https://github.com/block/buzz/commit/3825f894d08acb5a12d609fbb100da7d982274f2), inherited by #7240. The test now uses the existing animation helper after each hover, before sampling/comparing settled surfaces; exact CSS equality, screenshot and timeouts remain unchanged. Fresh real-browser complete spec **2/2** passed; a disposable wrong-profile-color probe still failed that equality, and a controlled in-flight channel transition reproduced the old .03-versus-.04 failure. Probes removed; no production styling changed. Desktop check/typecheck and fresh E2E build passed. This tiny delta was self-reviewed, not independently re-reviewed.
- Historical pre-workflow-repair CI: [run 34271016267](https://github.com/block/buzz/actions/runs/34271016267) **SUCCESS** at `9778b2b200fd33592e17d53fd6d7545ab5cdbd37`; all applicable jobs passed, including Core, all four smoke shards and both integration shards. DCO passed and GitHub reports no merge conflict. Earlier automatic superseded-run cancellations are not current-run failures. Base #7239's workflow-controls Smoke 4 failure was repaired by 27593788 (that suite passed on the terminal run), and its Smoke 1 toast flake was repaired by be1d594f4 (Smoke 1 green on #7239's current run); base #7239's remaining gate is an unrelated Smoke 2 flake recorded below. No whole-stack ready/merge claim.
- Authorized workflow fixture repair is a separate, independently revertible commit [27593788](https://github.com/block/buzz/commit/27593788c4f21a74b1ccb994b2e926bf69b5cfcd), retaining the hover fix unchanged. It targets the actual message textarea during trigger-inspector exit, samples operator boxes together after bounded geometry settlement, and checks the original persisted trigger expression and message text before reopen. Original geometry relations, screenshots, trigger/message semantics and timeouts remain; no production code or snapshot changes. Self-reviewed small test-only delta (+39/-4).
- Reused bounded local proof: corrected diagnostic **1/1** with executed saved-original-content and 416px geometry evidence; wrong-layout and wrong-saved-content controls each fail meaningful assertions (the earlier inert wrapper control is not counted). Affected full browser spec **11/12**, not clean: Darwin template-variable snapshot differs by 438 pixels. Lint and application types pass; expanded fixture types show baseline-only errors. No repeat full-suite or controls.
- Screenshot attribution: **one executed unchanged-published-fixture control** on #7239's prior `3825f894d08acb5a12d609fbb100da7d982274f2`, same Darwin Playwright configuration and same production served artifact, also fails by 438 pixels. Actual, expected and diff PNGs are each byte-identical to candidate fullspec artifacts. This screenshot test does not call the modified helper and its setup/capture is unchanged. Local HTTP content was verified against all 459 JS/CSS/index files; repair tree is exactly the tested `2a8f9068e9748f7a908b77097c98097b6c91fc7f`. This is an inherited Darwin baseline limitation, separate from target repair proof; official Linux CI remains the intended gate. No baseline update, threshold relaxation or icon hiding.
- Prior exact-head CI: [run 34276688671](https://github.com/block/buzz/actions/runs/34276688671) **SUCCESS** (terminal) at `3fa953a7fdb4190eb5dea71c9f068a1b65524c96` — Desktop Core, all four smoke shards (including `channels.spec.ts:1005`, which failed only on #7239's run) and both integration shards passed. DCO passes; GitHub reports MERGEABLE. Base #7239's terminal run failed only that unrelated Smoke 1 flake; no whole-stack ready/merge claim.
- Toast fixture repair inheritance: #7239's authorized test-only toast repair [be1d594f](https://github.com/block/buzz/commit/be1d594f466434cdaeabd6aa4999b25b0a6a027b) is replayed beneath this PR unchanged; head `7795b7d5fedf5963dccdb9564e464afd09fd9da1` differs from the prior `3fa953a7fdb4190eb5dea71c9f068a1b65524c96` only by that nine-line channels.spec.ts hunk — no production delta.
- Prior exact-head CI: [run 34363497199](https://github.com/block/buzz/actions/runs/34363497199) **SUCCESS** (terminal) at `7795b7d5fedf5963dccdb9564e464afd09fd9da1` — Desktop Core, all four smoke shards (including the repaired toast test) and both integration shards passed. DCO passes; GitHub reports MERGEABLE. Base #7239's current run [34363489121](https://github.com/block/buzz/actions/runs/34363489121) failed only the unrelated Smoke 2 `mentions.spec.ts:1885` retry-luck flake (attribution on #7239); no whole-stack ready/merge claim.
- Mention fixture repair inheritance: base #7239's authorized test-only explicit-picker fixture repair [f1af1b8](https://github.com/block/buzz/commit/f1af1b88c6458d40080529e8d71a0bdec1868a78) is replayed beneath this PR; head `7d06bf5bebbe75d23132eb6d581557797f55c545` differs from the prior `7795b7d5fedf5963dccdb9564e464afd09fd9da1` only by that eight-line `mentions.spec.ts` setup hunk — no production delta. The 2/2 zero-retry local proof ran on this exact tree (prior head plus the fixture patch; verified by diff).
- Current exact-head CI: **registered, in progress — not observed to completion** at `7d06bf5bebbe75d23132eb6d581557797f55c545`: [run 34371493916](https://github.com/block/buzz/actions/runs/34371493916) (CI, 15:37:50Z) and [run 34371490600](https://github.com/block/buzz/actions/runs/34371490600) (CI, 15:37:48Z). The prior terminal SUCCESS [34363497199](https://github.com/block/buzz/actions/runs/34363497199) at `7795b7d5fedf5963dccdb9564e464afd09fd9da1` remains the last completed run. No whole-stack ready/merge claim.
