### PR TITLE
fix(desktop): keep channel-sections scoped to the active community

### DIFF
--- a/desktop/src/features/sidebar/lib/channelSectionsHelpers.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSectionsHelpers.test.mjs
@@ -1,11 +1,82 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { swapSectionOrder } from "./channelSectionsHelpers.ts";
+import {
+  isChannelSectionsAllowlistReady,
+  scopeChannelSectionsToKnownChannels,
+  swapSectionOrder,
+} from "./channelSectionsHelpers.ts";
 
 function makeStore(sections, assignments = {}) {
   return { version: 1, sections, assignments };
 }
+
+test("isChannelSectionsAllowlistReady: explicit ready wins over empty set", () => {
+  assert.equal(isChannelSectionsAllowlistReady(new Set(), true), true);
+  assert.equal(isChannelSectionsAllowlistReady(new Set(["a"]), false), false);
+  assert.equal(isChannelSectionsAllowlistReady(new Set(["a"])), true);
+  assert.equal(isChannelSectionsAllowlistReady(new Set()), false);
+});
+
+test("scopeChannelSectionsToKnownChannels: strips foreign channel ids", () => {
+  const store = makeStore([{ id: "s1", name: "One", order: 0 }], {
+    "chan-a": "s1",
+    "chan-b-foreign": "s1",
+  });
+  const filtered = scopeChannelSectionsToKnownChannels(
+    store,
+    new Set(["chan-a"]),
+  );
+  assert.deepEqual(filtered.assignments, { "chan-a": "s1" });
+  assert.equal(filtered.sections.length, 1);
+  assert.equal(filtered.sections[0].id, "s1");
+});
+
+test("scopeChannelSectionsToKnownChannels: drops sections that only held foreign channels", () => {
+  const store = makeStore(
+    [
+      { id: "s-local", name: "Local", order: 0 },
+      { id: "s-foreign", name: "From B", order: 1 },
+      { id: "s-empty", name: "Empty", order: 2 },
+    ],
+    {
+      "chan-a": "s-local",
+      "chan-b-foreign": "s-foreign",
+    },
+  );
+  const scoped = scopeChannelSectionsToKnownChannels(
+    store,
+    new Set(["chan-a"]),
+  );
+  assert.deepEqual(scoped.assignments, { "chan-a": "s-local" });
+  assert.deepEqual(
+    scoped.sections.map((s) => s.id),
+    ["s-local", "s-empty"],
+  );
+});
+
+test("scopeChannelSectionsToKnownChannels: empty allowlist is a no-op until channelsReady", () => {
+  const store = makeStore([{ id: "s1", name: "One", order: 0 }], {
+    "chan-a": "s1",
+  });
+  assert.equal(scopeChannelSectionsToKnownChannels(store, new Set()), store);
+  assert.equal(scopeChannelSectionsToKnownChannels(store, null), store);
+  assert.equal(scopeChannelSectionsToKnownChannels(store, undefined), store);
+  assert.deepEqual(
+    scopeChannelSectionsToKnownChannels(store, new Set(), true).assignments,
+    {},
+  );
+});
+
+test("scopeChannelSectionsToKnownChannels: returns same reference when nothing stripped", () => {
+  const store = makeStore([{ id: "s1", name: "One", order: 0 }], {
+    "chan-a": "s1",
+  });
+  assert.equal(
+    scopeChannelSectionsToKnownChannels(store, new Set(["chan-a", "chan-b"])),
+    store,
+  );
+});
 
 function makeSection(id, name, order) {
   return { id, name, order };

--- a/desktop/src/features/sidebar/lib/channelSectionsHelpers.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsHelpers.ts
@@ -1,5 +1,75 @@
 import type { ChannelSectionStore } from "./channelSectionsStorage";
 
+/**
+ * Whether the active community's channel list has settled enough to scope
+ * section assignments. An explicit `channelsReady` flag distinguishes
+ * "loaded, zero channels" from "still loading" (both present as an empty Set).
+ * Without the flag, a non-empty allowlist is treated as ready for callers that
+ * only pass known ids (unit tests).
+ */
+export function isChannelSectionsAllowlistReady(
+  knownChannelIds: ReadonlySet<string> | null | undefined,
+  channelsReady?: boolean,
+): boolean {
+  if (channelsReady === true) return true;
+  if (channelsReady === false) return false;
+  return Boolean(knownChannelIds && knownChannelIds.size > 0);
+}
+
+/**
+ * Drop assignments whose channel id is not in the active community, and drop
+ * section folders that only referenced those foreign channels.
+ *
+ * Used before local persist / relay publish so a stale in-memory store from a
+ * previous workspace cannot write foreign channel UUIDs (or the section objects
+ * that only existed to hold them) into another community's `kind:30078` blob
+ * (#7207). When the allowlist is not ready, returns `store` unchanged so a
+ * still-loading channel list cannot wipe every assignment.
+ *
+ * Intentionally empty sections (no assignments at all) are kept — they cannot
+ * be distinguished from user-created empty folders on the active community.
+ */
+export function scopeChannelSectionsToKnownChannels(
+  store: ChannelSectionStore,
+  knownChannelIds: ReadonlySet<string> | null | undefined,
+  channelsReady?: boolean,
+): ChannelSectionStore {
+  if (!isChannelSectionsAllowlistReady(knownChannelIds, channelsReady)) {
+    return store;
+  }
+  const allow = knownChannelIds ?? new Set<string>();
+  let assignmentsChanged = false;
+  const assignments: Record<string, string> = {};
+  for (const [channelId, sectionId] of Object.entries(store.assignments)) {
+    if (allow.has(channelId)) {
+      assignments[channelId] = sectionId;
+    } else {
+      assignmentsChanged = true;
+    }
+  }
+
+  const retainedSectionIds = new Set(Object.values(assignments));
+  const previouslyAssignedSectionIds = new Set(
+    Object.values(store.assignments),
+  );
+  const sections = store.sections.filter((section) => {
+    if (retainedSectionIds.has(section.id)) return true;
+    // Drop sections that only held foreign-channel assignments.
+    if (previouslyAssignedSectionIds.has(section.id)) return false;
+    return true;
+  });
+  const sectionsChanged = sections.length !== store.sections.length;
+
+  if (!assignmentsChanged && !sectionsChanged) {
+    return store;
+  }
+  return {
+    ...store,
+    sections,
+    assignments,
+  };
+}
+
 export function swapSectionOrder(
   prev: ChannelSectionStore,
   sectionId: string,

--- a/desktop/src/features/sidebar/lib/useChannelSections.test.mjs
+++ b/desktop/src/features/sidebar/lib/useChannelSections.test.mjs
@@ -18,61 +18,411 @@ before(() => {
 
 after(() => dom.window.close());
 
+async function withMockedRelay(run) {
+  const { relayClient } = await import("@/shared/api/relayClient");
+  const originalFetchEvents = relayClient.fetchEvents;
+  const originalSubscribeLive = relayClient.subscribeLive;
+  const originalSubscribeToReconnects = relayClient.subscribeToReconnects;
+  const originalPublishEvent = relayClient.publishEvent;
+  const publishCalls = [];
+  relayClient.fetchEvents = async () => [];
+  relayClient.subscribeLive = async () => async () => {};
+  relayClient.subscribeToReconnects = () => () => {};
+  relayClient.publishEvent = async (...args) => {
+    publishCalls.push(args);
+  };
+  try {
+    return await run({ publishCalls, relayClient });
+  } finally {
+    relayClient.fetchEvents = originalFetchEvents;
+    relayClient.subscribeLive = originalSubscribeLive;
+    relayClient.subscribeToReconnects = originalSubscribeToReconnects;
+    relayClient.publishEvent = originalPublishEvent;
+  }
+}
+
 test("assignChannel refreshes an existing assignment before the next eviction", async () => {
   const { act, cleanup, renderHook } = await import("@testing-library/react");
-  const { relayClient } = await import("@/shared/api/relayClient");
   const { MAX_CHANNEL_SECTION_ASSIGNMENTS, storageKey } = await import(
     "./channelSectionsStorage.ts"
   );
   const { useChannelSections } = await import("./useChannelSections.ts");
 
-  const originalFetchEvents = relayClient.fetchEvents;
-  const originalSubscribeLive = relayClient.subscribeLive;
-  const originalSubscribeToReconnects = relayClient.subscribeToReconnects;
-  relayClient.fetchEvents = async () => [];
-  relayClient.subscribeLive = async () => async () => {};
-  relayClient.subscribeToReconnects = () => () => {};
-
-  const pubkey = "pk-at-capacity";
-  const relayUrl = "wss://relay.example";
-  const assignments = Object.fromEntries(
-    Array.from({ length: MAX_CHANNEL_SECTION_ASSIGNMENTS }, (_, index) => [
-      `chan-${String(index).padStart(4, "0")}`,
-      "section-1",
-    ]),
-  );
-  window.localStorage.setItem(
-    storageKey(pubkey, relayUrl),
-    JSON.stringify({
-      version: 1,
-      sections: [
-        { id: "section-1", name: "One", order: 0 },
-        { id: "section-2", name: "Two", order: 1 },
-      ],
-      assignments,
-    }),
-  );
-
-  try {
-    const { result, unmount } = renderHook(() =>
-      useChannelSections(pubkey, relayUrl),
+  await withMockedRelay(async () => {
+    const pubkey = "pk-at-capacity";
+    const relayUrl = "wss://relay.example";
+    const assignments = Object.fromEntries(
+      Array.from({ length: MAX_CHANNEL_SECTION_ASSIGNMENTS }, (_, index) => [
+        `chan-${String(index).padStart(4, "0")}`,
+        "section-1",
+      ]),
+    );
+    window.localStorage.setItem(
+      storageKey(pubkey, relayUrl),
+      JSON.stringify({
+        version: 1,
+        sections: [
+          { id: "section-1", name: "One", order: 0 },
+          { id: "section-2", name: "Two", order: 1 },
+        ],
+        assignments,
+      }),
     );
 
-    act(() => result.current.assignChannel("chan-0000", "section-2"));
-    act(() => result.current.assignChannel("chan-new", "section-1"));
+    try {
+      const { result, unmount } = renderHook(() =>
+        useChannelSections(pubkey, relayUrl),
+      );
 
-    assert.equal(result.current.assignments["chan-0000"], "section-2");
-    assert.equal(result.current.assignments["chan-new"], "section-1");
-    assert.equal(result.current.assignments["chan-0001"], undefined);
-    assert.equal(
-      Object.keys(result.current.assignments).length,
-      MAX_CHANNEL_SECTION_ASSIGNMENTS,
+      act(() => result.current.assignChannel("chan-0000", "section-2"));
+      act(() => result.current.assignChannel("chan-new", "section-1"));
+
+      assert.equal(result.current.assignments["chan-0000"], "section-2");
+      assert.equal(result.current.assignments["chan-new"], "section-1");
+      assert.equal(result.current.assignments["chan-0001"], undefined);
+      assert.equal(
+        Object.keys(result.current.assignments).length,
+        MAX_CHANNEL_SECTION_ASSIGNMENTS,
+      );
+      unmount();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// Regression for #7207: switching the active relay must not persist the
+// previous community's section assignment map under the new community's key,
+// and must not queue a publish payload containing foreign channel ids.
+test("relayUrl switch resets in-memory store and never writes prior community assignments into the new scope", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { storageKey } = await import("./channelSectionsStorage.ts");
+  const { ChannelSectionSyncManager } = await import(
+    "./channelSectionsSync.ts"
+  );
+  const { useChannelSections } = await import("./useChannelSections.ts");
+
+  await withMockedRelay(async () => {
+    const pubkey = "pk-7207";
+    const relayB = "wss://relay-b.example";
+    const relayA = "wss://relay-a.example";
+    const sectionB = { id: "section-b", name: "From B", order: 0 };
+    const channelOnlyOnB = "channel-only-on-b";
+    const queuedPublishes = [];
+    const originalPublishSections =
+      ChannelSectionSyncManager.prototype.publishSections;
+    ChannelSectionSyncManager.prototype.publishSections =
+      function publishSections(store) {
+        queuedPublishes.push({
+          relayUrl: this.relayUrl,
+          assignments: { ...store.assignments },
+          sectionIds: store.sections.map((section) => section.id),
+        });
+        return originalPublishSections.call(this, store);
+      };
+
+    window.localStorage.setItem(
+      storageKey(pubkey, relayB),
+      JSON.stringify({
+        version: 1,
+        sections: [sectionB],
+        assignments: { [channelOnlyOnB]: sectionB.id },
+      }),
     );
-    unmount();
-  } finally {
-    cleanup();
-    relayClient.fetchEvents = originalFetchEvents;
-    relayClient.subscribeLive = originalSubscribeLive;
-    relayClient.subscribeToReconnects = originalSubscribeToReconnects;
-  }
+    window.localStorage.setItem(
+      storageKey(pubkey, relayA),
+      JSON.stringify({
+        version: 1,
+        sections: [],
+        assignments: {},
+      }),
+    );
+
+    try {
+      const { result, rerender, unmount } = renderHook(
+        ({ relayUrl, known, ready }) =>
+          useChannelSections(pubkey, relayUrl, known, ready),
+        {
+          initialProps: {
+            relayUrl: relayB,
+            known: new Set([channelOnlyOnB]),
+            ready: true,
+          },
+        },
+      );
+
+      assert.equal(result.current.assignments[channelOnlyOnB], sectionB.id);
+      assert.equal(result.current.sections[0]?.id, sectionB.id);
+
+      // Switch to community A. The same-render scope reset must drop B's
+      // layout before any A-scoped persist/publish can see it.
+      act(() => {
+        rerender({
+          relayUrl: relayA,
+          known: new Set(["channel-only-on-a"]),
+          ready: true,
+        });
+      });
+
+      assert.deepEqual(result.current.assignments, {});
+      assert.deepEqual(result.current.sections, []);
+
+      const rawA = window.localStorage.getItem(storageKey(pubkey, relayA));
+      assert.ok(rawA);
+      const parsedA = JSON.parse(rawA);
+      assert.equal(parsedA.assignments[channelOnlyOnB], undefined);
+      assert.deepEqual(parsedA.assignments, {});
+
+      const publishesBeforeMutation = queuedPublishes.length;
+
+      // A post-switch mutation must only persist/publish A's known channels.
+      act(() => {
+        const section = result.current.createSection("A section");
+        assert.ok(section);
+        result.current.assignChannel(channelOnlyOnB, section.id);
+        result.current.assignChannel("channel-only-on-a", section.id);
+      });
+
+      assert.equal(result.current.assignments[channelOnlyOnB], undefined);
+      assert.equal(
+        result.current.assignments["channel-only-on-a"],
+        result.current.sections[0]?.id,
+      );
+
+      const rawAAfter = JSON.parse(
+        window.localStorage.getItem(storageKey(pubkey, relayA)),
+      );
+      assert.equal(rawAAfter.assignments[channelOnlyOnB], undefined);
+      assert.equal(
+        rawAAfter.assignments["channel-only-on-a"],
+        result.current.sections[0]?.id,
+      );
+
+      // B's scoped store must remain untouched by the A-side edits.
+      const rawB = JSON.parse(
+        window.localStorage.getItem(storageKey(pubkey, relayB)),
+      );
+      assert.equal(rawB.assignments[channelOnlyOnB], sectionB.id);
+
+      const publishesForA = queuedPublishes.slice(publishesBeforeMutation);
+      assert.ok(
+        publishesForA.length > 0,
+        "post-switch mutations must queue at least one publish",
+      );
+      for (const publish of publishesForA) {
+        assert.equal(publish.relayUrl, relayA);
+        assert.equal(
+          publish.assignments[channelOnlyOnB],
+          undefined,
+          "publish queued for A must not carry B-only channel ids",
+        );
+        assert.ok(
+          !publish.sectionIds.includes(sectionB.id),
+          "publish queued for A must not carry B-only section ids",
+        );
+      }
+
+      unmount();
+    } finally {
+      ChannelSectionSyncManager.prototype.publishSections =
+        originalPublishSections;
+      cleanup();
+      window.localStorage.clear();
+    }
+  });
+});
+
+test("defers bootstrap seed-publish until channelsReady and scopes the seeded blob", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { storageKey } = await import("./channelSectionsStorage.ts");
+  const { ChannelSectionSyncManager } = await import(
+    "./channelSectionsSync.ts"
+  );
+  const { useChannelSections } = await import("./useChannelSections.ts");
+
+  await withMockedRelay(async () => {
+    const pubkey = "pk-7207-seed";
+    const relayUrl = "wss://relay-a.example";
+    const foreignChannel = "channel-only-on-b";
+    const localChannel = "channel-only-on-a";
+    const foreignSection = { id: "section-from-b", name: "From B", order: 0 };
+    const bootstrapCalls = [];
+    const queuedPublishes = [];
+    const originalBootstrap = ChannelSectionSyncManager.prototype.bootstrap;
+    const originalPublishSections =
+      ChannelSectionSyncManager.prototype.publishSections;
+    ChannelSectionSyncManager.prototype.bootstrap = async function bootstrap(
+      localStore,
+    ) {
+      bootstrapCalls.push({
+        relayUrl: this.relayUrl,
+        assignments: { ...localStore.assignments },
+        sectionIds: localStore.sections.map((section) => section.id),
+      });
+      return originalBootstrap.call(this, localStore);
+    };
+    ChannelSectionSyncManager.prototype.publishSections =
+      function publishSections(store) {
+        queuedPublishes.push({
+          assignments: { ...store.assignments },
+          sectionIds: store.sections.map((section) => section.id),
+        });
+        return originalPublishSections.call(this, store);
+      };
+
+    // Polluted A local (the issue's post-contamination state) with zero
+    // watermark so first-sync would otherwise seed-publish the dirty blob.
+    window.localStorage.setItem(
+      storageKey(pubkey, relayUrl),
+      JSON.stringify({
+        version: 1,
+        sections: [foreignSection],
+        assignments: { [foreignChannel]: foreignSection.id },
+      }),
+    );
+
+    try {
+      const { result, rerender, unmount } = renderHook(
+        ({ known, ready }) =>
+          useChannelSections(pubkey, relayUrl, known, ready),
+        {
+          initialProps: {
+            known: new Set(),
+            ready: false,
+          },
+        },
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      assert.equal(
+        bootstrapCalls.length,
+        0,
+        "bootstrap must wait until channelsReady",
+      );
+
+      act(() => {
+        rerender({ known: new Set([localChannel]), ready: true });
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      assert.ok(
+        bootstrapCalls.length >= 1,
+        "bootstrap runs once allowlist ready",
+      );
+      for (const call of bootstrapCalls) {
+        assert.equal(call.assignments[foreignChannel], undefined);
+        assert.ok(!call.sectionIds.includes(foreignSection.id));
+      }
+      // Display and healed storage drop the foreign layout.
+      assert.deepEqual(result.current.assignments, {});
+      assert.ok(
+        !result.current.sections.some(
+          (section) => section.id === foreignSection.id,
+        ),
+      );
+      const raw = JSON.parse(
+        window.localStorage.getItem(storageKey(pubkey, relayUrl)),
+      );
+      assert.equal(raw.assignments[foreignChannel], undefined);
+      assert.ok(
+        !raw.sections.some((section) => section.id === foreignSection.id),
+      );
+
+      for (const publish of queuedPublishes) {
+        assert.equal(publish.assignments[foreignChannel], undefined);
+        assert.ok(!publish.sectionIds.includes(foreignSection.id));
+      }
+
+      unmount();
+    } finally {
+      ChannelSectionSyncManager.prototype.bootstrap = originalBootstrap;
+      ChannelSectionSyncManager.prototype.publishSections =
+        originalPublishSections;
+      cleanup();
+      window.localStorage.clear();
+    }
+  });
+});
+
+test("channelsReady heals polluted storage and drops orphan foreign sections", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { storageKey } = await import("./channelSectionsStorage.ts");
+  const { ChannelSectionSyncManager } = await import(
+    "./channelSectionsSync.ts"
+  );
+  const { useChannelSections } = await import("./useChannelSections.ts");
+
+  await withMockedRelay(async () => {
+    const pubkey = "pk-7207-heal";
+    const relayUrl = "wss://relay.example";
+    const queuedPublishes = [];
+    const originalPublishSections =
+      ChannelSectionSyncManager.prototype.publishSections;
+    ChannelSectionSyncManager.prototype.publishSections =
+      function publishSections(store) {
+        queuedPublishes.push({
+          assignments: { ...store.assignments },
+          sectionIds: store.sections.map((section) => section.id),
+        });
+        return originalPublishSections.call(this, store);
+      };
+
+    window.localStorage.setItem(
+      storageKey(pubkey, relayUrl),
+      JSON.stringify({
+        version: 1,
+        sections: [
+          { id: "s-local", name: "Local", order: 0 },
+          { id: "s-foreign", name: "From B", order: 1 },
+        ],
+        assignments: {
+          "chan-local": "s-local",
+          "chan-foreign": "s-foreign",
+        },
+      }),
+    );
+
+    try {
+      const { result, unmount } = renderHook(() =>
+        useChannelSections(pubkey, relayUrl, new Set(["chan-local"]), true),
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      assert.deepEqual(result.current.assignments, { "chan-local": "s-local" });
+      assert.deepEqual(
+        result.current.sections.map((section) => section.id),
+        ["s-local"],
+      );
+      const raw = JSON.parse(
+        window.localStorage.getItem(storageKey(pubkey, relayUrl)),
+      );
+      assert.deepEqual(raw.assignments, { "chan-local": "s-local" });
+      assert.deepEqual(
+        raw.sections.map((section) => section.id),
+        ["s-local"],
+      );
+      assert.ok(
+        queuedPublishes.some(
+          (publish) =>
+            publish.assignments["chan-foreign"] === undefined &&
+            !publish.sectionIds.includes("s-foreign"),
+        ),
+        "heal must publish a cleaned kind:30078 payload",
+      );
+      unmount();
+    } finally {
+      ChannelSectionSyncManager.prototype.publishSections =
+        originalPublishSections;
+      cleanup();
+      window.localStorage.clear();
+    }
+  });
 });

--- a/desktop/src/features/sidebar/lib/useChannelSections.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSections.ts
@@ -10,7 +10,11 @@ import {
 } from "./channelSectionsStorage";
 import { ChannelSectionSyncManager } from "./channelSectionsSync";
 import type { RemoteSections } from "./channelSectionsSync";
-import { swapSectionOrder } from "./channelSectionsHelpers";
+import {
+  isChannelSectionsAllowlistReady,
+  scopeChannelSectionsToKnownChannels,
+  swapSectionOrder,
+} from "./channelSectionsHelpers";
 
 export type { ChannelSection } from "./channelSectionsStorage";
 
@@ -19,9 +23,27 @@ import type {
   ChannelSectionStore,
 } from "./channelSectionsStorage";
 
+function readScopedStore(
+  pubkey: string | undefined,
+  relayUrl: string | undefined,
+): ChannelSectionStore {
+  if (!pubkey) {
+    return DEFAULT_STORE;
+  }
+  return readChannelSectionsStore(pubkey, relayUrl);
+}
+
 export function useChannelSections(
   pubkey: string | undefined,
   relayUrl?: string,
+  knownChannelIds?: ReadonlySet<string> | null,
+  /**
+   * When true, an empty allowlist means "community has no channels" and
+   * foreign assignments are stripped. When false, the allowlist is still
+   * loading and scoping is deferred. When omitted, a non-empty allowlist is
+   * treated as ready (unit-test / legacy callers).
+   */
+  channelsReady?: boolean,
 ): {
   sections: ChannelSection[];
   assignments: Record<string, string>;
@@ -34,25 +56,91 @@ export function useChannelSections(
   assignChannel: (channelId: string, sectionId: string) => void;
   unassignChannel: (channelId: string) => void;
 } {
-  const [store, setStore] = React.useState<ChannelSectionStore>(() => {
-    if (!pubkey) {
-      return DEFAULT_STORE;
-    }
-    return readChannelSectionsStore(pubkey, relayUrl);
-  });
+  const scopeKey = `${pubkey ?? ""}::${relayUrl ?? ""}`;
+  const [store, setStore] = React.useState<ChannelSectionStore>(() =>
+    readScopedStore(pubkey, relayUrl),
+  );
 
+  // Scope fence (#7207): bump generation synchronously so in-flight writers from
+  // the previous community cannot persist/publish under the new relayUrl. Do
+  // NOT call setState during render — that desyncs later hooks in AppSidebar
+  // (invalid hook call / "Should have a queue"). Hydrate from the new scope in
+  // layout; until then derive a display store from localStorage for this scope.
+  const scopeRef = React.useRef({ pubkey, relayUrl });
+  const scopeGenerationRef = React.useRef(0);
+  const storeScopeKeyRef = React.useRef(scopeKey);
   const managerRef = React.useRef<ChannelSectionSyncManager | null>(null);
   const lastAppliedRemoteTs = React.useRef(0);
   const lastAppliedEventId = React.useRef("");
+  const knownChannelIdsRef = React.useRef(knownChannelIds);
+  knownChannelIdsRef.current = knownChannelIds;
+  const channelsReadyRef = React.useRef(channelsReady);
+  channelsReadyRef.current = channelsReady;
+  const allowlistReady = isChannelSectionsAllowlistReady(
+    knownChannelIds,
+    channelsReady,
+  );
+
+  if (
+    scopeRef.current.pubkey !== pubkey ||
+    scopeRef.current.relayUrl !== relayUrl
+  ) {
+    scopeRef.current = { pubkey, relayUrl };
+    scopeGenerationRef.current += 1;
+  }
+
+  React.useLayoutEffect(() => {
+    setStore(readScopedStore(pubkey, relayUrl));
+    storeScopeKeyRef.current = scopeKey;
+    lastAppliedRemoteTs.current = 0;
+    lastAppliedEventId.current = "";
+  }, [scopeKey, pubkey, relayUrl]);
+
+  const effectiveStore =
+    storeScopeKeyRef.current === scopeKey
+      ? store
+      : readScopedStore(pubkey, relayUrl);
+
+  const persistAndPublish = React.useCallback(
+    (
+      next: ChannelSectionStore,
+      generation: number,
+    ): ChannelSectionStore | null => {
+      if (!pubkey) {
+        return null;
+      }
+      if (scopeGenerationRef.current !== generation) {
+        return null;
+      }
+      if (
+        scopeRef.current.pubkey !== pubkey ||
+        scopeRef.current.relayUrl !== relayUrl
+      ) {
+        return null;
+      }
+      const scoped = scopeChannelSectionsToKnownChannels(
+        boundChannelSectionsStore(next),
+        knownChannelIdsRef.current,
+        channelsReadyRef.current,
+      );
+      if (!writeChannelSectionsStore(pubkey, scoped, relayUrl)) {
+        return null;
+      }
+      storeScopeKeyRef.current = `${pubkey}::${relayUrl ?? ""}`;
+      managerRef.current?.publishSections(scoped);
+      return scoped;
+    },
+    [pubkey, relayUrl],
+  );
 
   React.useEffect(() => {
     if (!pubkey || !relayUrl) {
-      setStore(DEFAULT_STORE);
       lastAppliedRemoteTs.current = 0;
       lastAppliedEventId.current = "";
+      managerRef.current?.destroy();
+      managerRef.current = null;
       return;
     }
-    setStore(readChannelSectionsStore(pubkey, relayUrl));
     lastAppliedRemoteTs.current = 0;
     lastAppliedEventId.current = "";
     managerRef.current = new ChannelSectionSyncManager(pubkey, relayUrl);
@@ -83,8 +171,10 @@ export function useChannelSections(
     (
       remote: RemoteSections,
     ): ((prev: ChannelSectionStore) => ChannelSectionStore) => {
+      const generation = scopeGenerationRef.current;
       return (prev) => {
         if (!pubkey) return prev;
+        if (scopeGenerationRef.current !== generation) return prev;
         if (remote.createdAt < lastAppliedRemoteTs.current) return prev;
         if (
           remote.createdAt === lastAppliedRemoteTs.current &&
@@ -94,18 +184,30 @@ export function useChannelSections(
         lastAppliedRemoteTs.current = remote.createdAt;
         lastAppliedEventId.current = remote.eventId;
         managerRef.current?.cancelPendingPublish();
-        if (!writeChannelSectionsStore(pubkey, remote.store, relayUrl))
-          return prev;
-        return remote.store;
+        const scoped = scopeChannelSectionsToKnownChannels(
+          remote.store,
+          knownChannelIdsRef.current,
+          channelsReadyRef.current,
+        );
+        if (!writeChannelSectionsStore(pubkey, scoped, relayUrl)) return prev;
+        storeScopeKeyRef.current = `${pubkey}::${relayUrl ?? ""}`;
+        return scoped;
       };
     },
     [pubkey, relayUrl],
   );
 
+  // Defer bootstrap (including first-sync seed-publish) until the channel
+  // allowlist is ready so a polluted local blob cannot seed-publish foreign
+  // channel ids while channels are still loading (#7207).
   React.useEffect(() => {
-    if (!pubkey || !relayUrl) return;
+    if (!pubkey || !relayUrl || !allowlistReady) return;
     let cancelled = false;
-    const local = readChannelSectionsStore(pubkey, relayUrl);
+    const local = scopeChannelSectionsToKnownChannels(
+      readChannelSectionsStore(pubkey, relayUrl),
+      knownChannelIdsRef.current,
+      true,
+    );
     void managerRef.current?.bootstrap(local).then((result) => {
       if (cancelled) return;
       if (result.action === "apply-remote") {
@@ -117,7 +219,27 @@ export function useChannelSections(
     return () => {
       cancelled = true;
     };
-  }, [pubkey, relayUrl, applyRemote]);
+  }, [pubkey, relayUrl, applyRemote, allowlistReady]);
+
+  // When the allowlist becomes ready (or the known channel set changes), heal
+  // any foreign assignments / orphan section objects already sitting in memory
+  // or localStorage, and publish the cleaned blob so a previously polluted A
+  // does not keep serving B's layout.
+  React.useEffect(() => {
+    if (!pubkey || !allowlistReady) return;
+    const generation = scopeGenerationRef.current;
+    setStore((prev) => {
+      const scoped = scopeChannelSectionsToKnownChannels(
+        prev,
+        knownChannelIds,
+        true,
+      );
+      if (scoped === prev) {
+        return prev;
+      }
+      return persistAndPublish(scoped, generation) ?? prev;
+    });
+  }, [pubkey, allowlistReady, knownChannelIds, persistAndPublish]);
 
   React.useEffect(() => {
     if (!pubkey) return;
@@ -152,7 +274,12 @@ export function useChannelSections(
         }
         const pending = managerRef.current?.getPendingStore();
         if (pending) {
-          managerRef.current?.publishSections(pending);
+          const scoped = scopeChannelSectionsToKnownChannels(
+            pending,
+            knownChannelIdsRef.current,
+            channelsReadyRef.current,
+          );
+          managerRef.current?.publishSections(scoped);
         }
       });
     });
@@ -162,14 +289,27 @@ export function useChannelSections(
     };
   }, [pubkey, applyRemote]);
 
-  const sections = React.useMemo<ChannelSection[]>(
-    () => store.sections.slice().sort((a, b) => a.order - b.order),
-    [store.sections],
+  const displayStore = React.useMemo(
+    () =>
+      scopeChannelSectionsToKnownChannels(
+        effectiveStore,
+        knownChannelIds,
+        channelsReady,
+      ),
+    [effectiveStore, knownChannelIds, channelsReady],
   );
+
+  const sections = React.useMemo<ChannelSection[]>(
+    () => displayStore.sections.slice().sort((a, b) => a.order - b.order),
+    [displayStore.sections],
+  );
+
+  const assignments = displayStore.assignments;
 
   const createSection = React.useCallback(
     (name: string, icon?: string): ChannelSection | null => {
       if (!pubkey) return null;
+      const generation = scopeGenerationRef.current;
       const prev = readChannelSectionsStore(pubkey, relayUrl);
       const maxOrder =
         prev.sections.length > 0
@@ -181,18 +321,22 @@ export function useChannelSections(
         ...(icon ? { icon } : {}),
         order: maxOrder + 1,
       };
+      let created: ChannelSection | null = section;
       setStore((current) => {
-        const next = boundChannelSectionsStore({
+        const next = {
           ...current,
           sections: [...current.sections, section],
-        });
-        if (!writeChannelSectionsStore(pubkey, next, relayUrl)) return current;
-        managerRef.current?.publishSections(next);
-        return next;
+        };
+        const persisted = persistAndPublish(next, generation);
+        if (!persisted) {
+          created = null;
+          return current;
+        }
+        return persisted;
       });
-      return section;
+      return created;
     },
-    [pubkey, relayUrl],
+    [pubkey, relayUrl, persistAndPublish],
   );
 
   const renameSection = React.useCallback(
@@ -200,6 +344,7 @@ export function useChannelSections(
       if (!pubkey) {
         return;
       }
+      const generation = scopeGenerationRef.current;
       setStore((prev) => {
         const next: ChannelSectionStore = {
           ...prev,
@@ -214,14 +359,10 @@ export function useChannelSections(
               : s,
           ),
         };
-        if (!writeChannelSectionsStore(pubkey, next, relayUrl)) {
-          return prev;
-        }
-        managerRef.current?.publishSections(next);
-        return next;
+        return persistAndPublish(next, generation) ?? prev;
       });
     },
-    [pubkey, relayUrl],
+    [pubkey, persistAndPublish],
   );
 
   const deleteSection = React.useCallback(
@@ -229,71 +370,65 @@ export function useChannelSections(
       if (!pubkey) {
         return;
       }
+      const generation = scopeGenerationRef.current;
       setStore((prev) => {
-        const assignments = { ...prev.assignments };
-        for (const channelId of Object.keys(assignments)) {
-          if (assignments[channelId] === sectionId) {
-            delete assignments[channelId];
+        const nextAssignments = { ...prev.assignments };
+        for (const channelId of Object.keys(nextAssignments)) {
+          if (nextAssignments[channelId] === sectionId) {
+            delete nextAssignments[channelId];
           }
         }
         const next: ChannelSectionStore = {
           ...prev,
           sections: prev.sections.filter((s) => s.id !== sectionId),
-          assignments,
+          assignments: nextAssignments,
         };
-        if (!writeChannelSectionsStore(pubkey, next, relayUrl)) {
-          return prev;
-        }
-        managerRef.current?.publishSections(next);
-        return next;
+        return persistAndPublish(next, generation) ?? prev;
       });
     },
-    [pubkey, relayUrl],
+    [pubkey, persistAndPublish],
   );
 
   const moveSectionUp = React.useCallback(
     (sectionId: string) => {
       if (!pubkey) return;
+      const generation = scopeGenerationRef.current;
       setStore((prev) => {
         const next = swapSectionOrder(prev, sectionId, "up");
-        if (!next || !writeChannelSectionsStore(pubkey, next, relayUrl))
-          return prev;
-        managerRef.current?.publishSections(next);
-        return next;
+        if (!next) return prev;
+        return persistAndPublish(next, generation) ?? prev;
       });
     },
-    [pubkey, relayUrl],
+    [pubkey, persistAndPublish],
   );
 
   const moveSectionDown = React.useCallback(
     (sectionId: string) => {
       if (!pubkey) return;
+      const generation = scopeGenerationRef.current;
       setStore((prev) => {
         const next = swapSectionOrder(prev, sectionId, "down");
-        if (!next || !writeChannelSectionsStore(pubkey, next, relayUrl))
-          return prev;
-        managerRef.current?.publishSections(next);
-        return next;
+        if (!next) return prev;
+        return persistAndPublish(next, generation) ?? prev;
       });
     },
-    [pubkey, relayUrl],
+    [pubkey, persistAndPublish],
   );
 
   const reorderSections = React.useCallback(
     (orderedIds: string[]) => {
       if (!pubkey) return;
+      const generation = scopeGenerationRef.current;
       setStore((prev) => {
-        const sections = prev.sections.map((s) => {
+        const nextSections = prev.sections.map((s) => {
           const newOrder = orderedIds.indexOf(s.id);
           return newOrder === -1 ? s : { ...s, order: newOrder };
         });
-        const next: ChannelSectionStore = { ...prev, sections };
-        if (!writeChannelSectionsStore(pubkey, next, relayUrl)) return prev;
-        managerRef.current?.publishSections(next);
-        return next;
+        const next: ChannelSectionStore = { ...prev, sections: nextSections };
+        return persistAndPublish(next, generation) ?? prev;
       });
     },
-    [pubkey, relayUrl],
+    [pubkey, persistAndPublish],
   );
 
   const assignChannel = React.useCallback(
@@ -301,22 +436,19 @@ export function useChannelSections(
       if (!pubkey) {
         return;
       }
+      const generation = scopeGenerationRef.current;
       setStore((prev) => {
-        const assignments = { ...prev.assignments };
-        delete assignments[channelId];
-        assignments[channelId] = sectionId;
-        const next = boundChannelSectionsStore({
+        const nextAssignments = { ...prev.assignments };
+        delete nextAssignments[channelId];
+        nextAssignments[channelId] = sectionId;
+        const next = {
           ...prev,
-          assignments,
-        });
-        if (!writeChannelSectionsStore(pubkey, next, relayUrl)) {
-          return prev;
-        }
-        managerRef.current?.publishSections(next);
-        return next;
+          assignments: nextAssignments,
+        };
+        return persistAndPublish(next, generation) ?? prev;
       });
     },
-    [pubkey, relayUrl],
+    [pubkey, persistAndPublish],
   );
 
   const unassignChannel = React.useCallback(
@@ -324,23 +456,23 @@ export function useChannelSections(
       if (!pubkey) {
         return;
       }
+      const generation = scopeGenerationRef.current;
       setStore((prev) => {
-        const assignments = { ...prev.assignments };
-        delete assignments[channelId];
-        const next: ChannelSectionStore = { ...prev, assignments };
-        if (!writeChannelSectionsStore(pubkey, next, relayUrl)) {
-          return prev;
-        }
-        managerRef.current?.publishSections(next);
-        return next;
+        const nextAssignments = { ...prev.assignments };
+        delete nextAssignments[channelId];
+        const next: ChannelSectionStore = {
+          ...prev,
+          assignments: nextAssignments,
+        };
+        return persistAndPublish(next, generation) ?? prev;
       });
     },
-    [pubkey, relayUrl],
+    [pubkey, persistAndPublish],
   );
 
   return {
     sections,
-    assignments: store.assignments,
+    assignments,
     createSection,
     renameSection,
     deleteSection,

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -249,6 +249,15 @@ export function AppSidebar({
     }));
   }, []);
 
+  const knownChannelIds = React.useMemo(
+    () => new Set(channels.map((channel) => channel.id)),
+    [channels],
+  );
+  // Distinguish "query settled with zero channels" from "still loading" so
+  // section scoping / seed-publish can wait without treating an empty Set as
+  // ready (#7207).
+  const channelsReady = !isLoading;
+
   const {
     sections: channelSections,
     assignments: channelAssignments,
@@ -260,7 +269,12 @@ export function AppSidebar({
     reorderSections,
     assignChannel,
     unassignChannel,
-  } = useChannelSections(currentPubkey, activeCommunity?.relayUrl);
+  } = useChannelSections(
+    currentPubkey,
+    activeCommunity?.relayUrl,
+    knownChannelIds,
+    channelsReady,
+  );
 
   const sectionIds = React.useMemo(
     () => channelSections.map((s) => s.id),

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -476,6 +476,190 @@ test.describe("community rail", () => {
       .toBe(COMMUNITY_B.id);
   });
 
+  test("community switch does not copy channel-sections into the other community (#7207)", async ({
+    page,
+  }) => {
+    // Full issue timeline: organize sidebar sections on Bravo (B), switch to
+    // Alpha (A), and prove B's section layout never lands in A's scoped store
+    // or sidebar. Mirrors https://github.com/block/buzz/issues/7207.
+    const sectionsKey = (relayUrl: string) => {
+      const normalized = relayUrl.trim().replace(/\/+$/, "").toLowerCase();
+      return `buzz-channel-sections.v1:${OWNER_PUBKEY}:${encodeURIComponent(normalized)}`;
+    };
+    const keyA = sectionsKey(COMMUNITY_A.relayUrl);
+    const keyB = sectionsKey(COMMUNITY_B.relayUrl);
+    const sectionName = "Only On Bravo";
+
+    await installMockBridge(page, undefined, { skipCommunitySeed: true });
+    await seedCommunities(page, [COMMUNITY_A, COMMUNITY_B], COMMUNITY_B.id);
+    await page.goto("/");
+    await expect(page.getByTestId("app-sidebar")).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.localStorage.getItem("buzz-active-community-id"),
+        ),
+      )
+      .toBe(COMMUNITY_B.id);
+
+    // Organize on B via the production sidebar context-menu seam.
+    await page.getByTestId("channel-engineering").click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Move to section" }).hover();
+    await page.getByRole("menuitem", { name: "New section..." }).click();
+    const createDialog = page.getByRole("dialog", { name: "Create section" });
+    await expect(createDialog).toBeVisible();
+    await createDialog.getByPlaceholder("Section name").fill(sectionName);
+    await createDialog.getByRole("button", { name: "Create" }).click();
+    await expect(createDialog).toHaveCount(0);
+    await expect(page.getByText(sectionName)).toBeVisible();
+
+    const storeOnB = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as {
+            sections: Array<{ id: string; name: string }>;
+            assignments: Record<string, string>;
+          })
+        : null;
+    }, keyB);
+    expect(storeOnB).not.toBeNull();
+    expect(
+      storeOnB?.sections.some((section) => section.name === sectionName),
+    ).toBe(true);
+    expect(Object.keys(storeOnB?.assignments ?? {}).length).toBeGreaterThan(0);
+    const bChannelIds = Object.keys(storeOnB?.assignments ?? {});
+    const bSectionIds = (storeOnB?.sections ?? []).map((section) => section.id);
+
+    // Snapshot publish log length before the switch so we only inspect
+    // kind:30078 events signed after A becomes active.
+    const publishLogOffset = await page.evaluate(() => {
+      const payloads =
+        (
+          window as Window & {
+            __BUZZ_E2E_COMMAND_PAYLOADS__?: Array<{
+              command: string;
+              payload: unknown;
+            }>;
+          }
+        ).__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [];
+      return payloads.length;
+    });
+
+    // Switch to A — no further edits. The prior community's assignment map
+    // must not be written into A's scoped key or published as A's layout.
+    await page.getByTestId(`community-rail-button-${COMMUNITY_A.id}`).click();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.localStorage.getItem("buzz-active-community-id"),
+        ),
+      )
+      .toBe(COMMUNITY_A.id);
+    await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+    // Give debounce / bootstrap a beat; pollution would land within 2s.
+    await page.waitForTimeout(2500);
+
+    const afterSwitch = await page.evaluate(
+      ({ keyA: aKey, keyB: bKey, offset, bannedSectionIds }) => {
+        const parse = (raw: string | null) =>
+          raw
+            ? (JSON.parse(raw) as {
+                sections: Array<{ id: string; name: string }>;
+                assignments: Record<string, string>;
+              })
+            : null;
+        type PayloadEntry = {
+          command: string;
+          payload: {
+            kind?: number;
+            content?: string;
+            tags?: string[][];
+          } | null;
+        };
+        const payloads =
+          (
+            window as Window & {
+              __BUZZ_E2E_COMMAND_PAYLOADS__?: PayloadEntry[];
+            }
+          ).__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [];
+        const publishedChannelSections = payloads
+          .slice(offset)
+          .filter((entry) => {
+            if (entry.command !== "sign_event") return false;
+            const event = entry.payload;
+            if (event?.kind !== 30078) return false;
+            return event.tags?.some(
+              (tag) => tag[0] === "d" && tag[1] === "channel-sections",
+            );
+          })
+          .map((entry) => {
+            try {
+              return JSON.parse(String(entry.payload?.content ?? "")) as {
+                sections?: Array<{ id: string }>;
+                assignments?: Record<string, string>;
+              };
+            } catch {
+              return null;
+            }
+          })
+          .filter((payload): payload is NonNullable<typeof payload> =>
+            Boolean(payload),
+          );
+        return {
+          a: parse(window.localStorage.getItem(aKey)),
+          b: parse(window.localStorage.getItem(bKey)),
+          publishedChannelSections,
+          // Mock communities share channel UUIDs; the durable leak signal is
+          // B's section objects (or assignments pointing at them) appearing
+          // in an event signed after A became active.
+          leakedSectionIds: publishedChannelSections.flatMap((payload) =>
+            (payload.sections ?? [])
+              .map((section) => section.id)
+              .filter((id) => bannedSectionIds.includes(id)),
+          ),
+          leakedAssignmentTargets: publishedChannelSections.flatMap((payload) =>
+            Object.values(payload.assignments ?? {}).filter((sectionId) =>
+              bannedSectionIds.includes(sectionId),
+            ),
+          ),
+        };
+      },
+      {
+        keyA,
+        keyB,
+        offset: publishLogOffset,
+        bannedSectionIds: bSectionIds,
+      },
+    );
+
+    // B's organized layout remains intact on B.
+    expect(
+      afterSwitch.b?.sections.some((section) => section.name === sectionName),
+    ).toBe(true);
+
+    // A must not receive B's section objects or B's assignment map.
+    for (const sectionId of bSectionIds) {
+      expect(
+        afterSwitch.a?.sections.some((section) => section.id === sectionId),
+      ).toBeFalsy();
+    }
+    for (const channelId of bChannelIds) {
+      // Shared mock channel UUIDs may exist on both communities; the smoking
+      // gun is B's section id being referenced from A's store.
+      const assignedSection = afterSwitch.a?.assignments?.[channelId];
+      if (assignedSection) {
+        expect(bSectionIds).not.toContain(assignedSection);
+      }
+    }
+    // Issue expected #4: any kind:30078 channel-sections event signed after
+    // the switch to A must not carry B's section layout. (Mock nip44 is
+    // plaintext, so content is inspectable.)
+    expect(afterSwitch.leakedSectionIds).toEqual([]);
+    expect(afterSwitch.leakedAssignmentTargets).toEqual([]);
+    await expect(page.getByText(sectionName)).toHaveCount(0);
+  });
+
   test("community switch cancels a send after its link preview settles", async ({
     page,
   }) => {


### PR DESCRIPTION
## Problem

Desktop persists and publishes the channel-sections layout of the
**previously active** community into the **newly active** community after a
workspace switch. Community A's `kind:30078` `d=channel-sections` event (and
the matching localStorage key) can end up with channel UUIDs and section
objects that exist only on community B.

This is a persistence/publish bug, not only a render bug: the wrong assignment
map is written to the other community's relay, so it survives restarts and
follows the user to a new machine.

## Cause

Section state is keyed `…:<pubkey>:<relayUrl>`, but in-memory writers and
first-sync seed-publish were not reliably fenced to the active community
before channels were ready. A stale store (or a polluted local blob) could be
persisted/published under the new relay URL, including while the channel
allowlist was still empty and filtering was a no-op.

## Fix

- Fence persist/publish by community scope generation so prior-community
  writers cannot land under the new `relayUrl`.
- Scope assignments to known channel ids of the active community before
  localStorage write and `kind:30078` publish; drop section folders that only
  held foreign-channel assignments.
- Defer bootstrap seed-publish until the channel list is ready
  (`channelsReady`), then heal already-polluted local state and republish the
  cleaned blob.
- Filter the rendered sections/assignments the same way so a stale payload
  cannot resurrect the symptom.

## Related

- Fixes #7207.
- Desktop counterpart of #5762 (mobile section folders across linked
  workspaces).
- Overlaps file-wise with open #6525 (`fix(sidebar): converge channel sidebar
  state across devices`), which rewrites the same hook for multi-device
  LWW/outbox convergence but does **not** close the cross-community channel-id
  leak. This PR is intentionally narrower and landable on current `main`; if
  #6525 merges first, this will need a rebase.

## Testing

- `pnpm exec node --import ./test-loader.mjs --experimental-strip-types --test`
  on:
  - `desktop/src/features/sidebar/lib/channelSectionsHelpers.test.mjs`
  - `desktop/src/features/sidebar/lib/useChannelSections.test.mjs`
  - `desktop/src/features/sidebar/lib/channelSectionsSync.test.mjs`
  - `desktop/src/features/sidebar/lib/channelSectionsStorage.test.mjs`
  (58 passed)
- Falsifiability: the new #7207 hook tests fail against `origin/main`
  `useChannelSections.ts` and pass with this change
- `pnpm exec playwright test --project=smoke tests/e2e/community-rail.spec.ts -g 7207`
  (1 passed — organize on B, switch to A, assert A's store and post-switch
  `sign_event` payloads carry no B section layout)