### PR TITLE
Canonicalize channel UUIDs in CLI project and repo bindings

### DIFF
--- a/crates/buzz-cli/src/commands/project_channel.rs
+++ b/crates/buzz-cli/src/commands/project_channel.rs
@@ -14,7 +14,7 @@ use crate::commands::projects::{
     PROJECT_QUERY_EVENT_BOUND,
 };
 use crate::error::CliError;
-use crate::validate::{validate_repo_id, validate_uuid};
+use crate::validate::{canonicalize_uuid, validate_repo_id};
 
 pub struct ChannelProjectRepo {
     pub repo_owner: String,
@@ -26,10 +26,10 @@ pub async fn resolve_or_ensure_repo_for_channel(
     client: &BuzzClient,
     channel: &str,
 ) -> Result<ChannelProjectRepo, CliError> {
-    validate_uuid(channel)?;
-    let projects = fetch_projects_for_channel(client, channel).await?;
-    let repos = fetch_channel_repos(client, channel).await?;
-    let project = pick_authoritative_project(&projects, &repos, channel)?;
+    let channel = canonicalize_uuid(channel)?;
+    let projects = fetch_projects_for_channel(client, &channel).await?;
+    let repos = fetch_channel_repos(client, &channel).await?;
+    let project = pick_authoritative_project(&projects, &repos, &channel)?;
     if let Some((_, repo)) = project {
         return Ok(repo);
     }
@@ -40,10 +40,10 @@ pub async fn resolve_or_ensure_repo_for_channel(
             .pubkey
             .to_hex()
             .eq_ignore_ascii_case(&caller)
-            .then(|| repo_from_announcement(event, channel))
+            .then(|| repo_from_announcement(event, &channel))
             .flatten()
     }) {
-        let _ = try_add_own_repo_to_channel_project(client, channel, &repo.repo_id).await;
+        let _ = try_add_own_repo_to_channel_project(client, &channel, &repo.repo_id).await;
         return Ok(repo);
     }
 
@@ -54,7 +54,7 @@ pub async fn resolve_or_ensure_repo_for_channel(
             "this channel is not a project home; pass --repo-owner and --repo-id".into(),
         ));
     };
-    ensure_default_repo(client, channel, event).await
+    ensure_default_repo(client, &channel, event).await
 }
 
 fn project_is_unlisted(event: &Event) -> bool {
@@ -99,7 +99,8 @@ fn repo_authorizes_project(repo: &Event, project: &Event) -> bool {
 fn repo_from_announcement(event: &Event, channel: &str) -> Option<ChannelProjectRepo> {
     if event.kind.as_u16() != KIND_GIT_REPO_ANNOUNCEMENT as u16
         || repo_is_unlisted(event)
-        || first_tag_value(event, "buzz-channel") != Some(channel)
+        || !first_tag_value(event, "buzz-channel")
+            .is_some_and(|bound| channel_ids_equal(bound, channel))
     {
         return None;
     }
@@ -161,9 +162,10 @@ fn repo_is_unlisted(event: &Event) -> bool {
 }
 
 async fn fetch_channel_repos(client: &BuzzClient, channel: &str) -> Result<Vec<Event>, CliError> {
+    let channel = canonicalize_uuid(channel)?;
     let filter = serde_json::json!({
         "kinds": [KIND_GIT_REPO_ANNOUNCEMENT],
-        "#buzz-channel": [channel],
+        "#buzz-channel": [&channel],
     });
     client
         .query_all_bounded(filter, PROJECT_QUERY_EVENT_BOUND)
@@ -177,9 +179,16 @@ async fn fetch_channel_repos(client: &BuzzClient, channel: &str) -> Result<Vec<E
         .collect()
 }
 
+fn channel_ids_equal(a: &str, b: &str) -> bool {
+    match (uuid::Uuid::parse_str(a), uuid::Uuid::parse_str(b)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => a == b,
+    }
+}
+
 pub(crate) fn require_repo_channel_binding(event: &Event, channel: &str) -> Result<(), CliError> {
     match first_tag_value(event, "buzz-channel") {
-        Some(bound) if bound == channel => Ok(()),
+        Some(bound) if channel_ids_equal(bound, channel) => Ok(()),
         Some(bound) => Err(CliError::Conflict(format!(
             "repository {:?} is already bound to channel {bound}; pass --repo-owner and --repo-id",
             first_tag_value(event, "d").unwrap_or("<unknown>")

--- a/crates/buzz-cli/src/commands/projects.rs
+++ b/crates/buzz-cli/src/commands/projects.rs
@@ -113,8 +113,17 @@ fn parse_events(json: &str) -> Result<Vec<Event>, CliError> {
 
 /// Fetch listed kind:30621 heads whose `buzz-channel` is `channel`.
 fn project_tags_match_channel<'a>(tags: impl IntoIterator<Item = &'a Tag>, channel: &str) -> bool {
-    tags.into_iter()
-        .any(|tag| tag_name(tag) == Some("buzz-channel") && tag_value(tag) == Some(channel))
+    tags.into_iter().any(|tag| {
+        tag_name(tag) == Some("buzz-channel")
+            && tag_value(tag).is_some_and(|value| channel_ids_equal(value, channel))
+    })
+}
+
+fn channel_ids_equal(a: &str, b: &str) -> bool {
+    match (uuid::Uuid::parse_str(a), uuid::Uuid::parse_str(b)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => a == b,
+    }
 }
 
 pub(crate) const PROJECT_QUERY_EVENT_BOUND: u32 = 10_000;
@@ -131,9 +140,10 @@ async fn fetch_projects_for_channel_bounded(
     channel: &str,
     max_events: u32,
 ) -> Result<Vec<Event>, CliError> {
+    let channel = crate::validate::canonicalize_uuid(channel)?;
     let filter = serde_json::json!({
         "kinds": [KIND_PROJECT],
-        "#buzz-channel": [channel],
+        "#buzz-channel": [&channel],
     });
     let events: Vec<Event> = client
         .query_all_bounded(filter, max_events)
@@ -146,7 +156,7 @@ async fn fetch_projects_for_channel_bounded(
         .collect::<Result<_, _>>()?;
     Ok(events
         .into_iter()
-        .filter(|event| project_tags_match_channel(event.tags.iter(), channel))
+        .filter(|event| project_tags_match_channel(event.tags.iter(), &channel))
         .collect())
 }
 
@@ -396,9 +406,10 @@ pub async fn cmd_create(
     }
 
     // Validate optional metadata (early, before any network call).
-    if let Some(ch) = channel {
-        crate::validate::validate_uuid(ch)?;
-    }
+    let channel = match channel {
+        Some(ch) => Some(crate::validate::canonicalize_uuid(ch)?),
+        None => None,
+    };
     if let Some(vis) = visibility {
         validate_visibility(vis)?;
     }
@@ -417,7 +428,7 @@ pub async fn cmd_create(
             "project {slug:?} already exists; use 'buzz projects update' to modify it"
         )));
     }
-    if let Some(channel) = channel {
+    if let Some(ref channel) = channel {
         if let Some(existing) = fetch_projects_for_channel(client, channel)
             .await?
             .into_iter()
@@ -434,7 +445,7 @@ pub async fn cmd_create(
     }
 
     if members.is_empty() {
-        let home = channel.ok_or_else(|| {
+        let home = channel.as_deref().ok_or_else(|| {
             CliError::Usage(
                 "pass --channel to create a default repository, or --repo to attach an existing one"
                     .into(),
@@ -445,7 +456,7 @@ pub async fn cmd_create(
     }
 
     // ── Build via Layer B (enforces all writer policy) ────────────────────
-    let builder = build_project(slug, name, description, &members, channel, visibility)
+    let builder = build_project(slug, name, description, &members, channel.as_deref(), visibility)
         .map_err(|e| CliError::Usage(e.to_string()))?;
 
     // Slugs wider than the link charset stay linkless rather than emitting a
@@ -619,9 +630,10 @@ pub async fn cmd_update(
     }
 
     validate_project_slug(slug)?;
-    if let Some(ch) = channel {
-        crate::validate::validate_uuid(ch)?;
-    }
+    let channel = match channel {
+        Some(ch) => Some(crate::validate::canonicalize_uuid(ch)?),
+        None => None,
+    };
     if let Some(vis) = visibility {
         validate_visibility(vis)?;
     }
@@ -669,7 +681,7 @@ pub async fn cmd_update(
     if let Some(d) = description {
         tags.push(make_tag(&["description", d])?);
     }
-    if let Some(ch) = channel {
+    if let Some(ref ch) = channel {
         tags.push(make_tag(&["buzz-channel", ch])?);
     }
     if let Some(vis) = visibility {

--- a/crates/buzz-cli/src/commands/repos.rs
+++ b/crates/buzz-cli/src/commands/repos.rs
@@ -111,7 +111,7 @@ fn build_updated_repo_announcement(
             (Some(pattern), false, None)
         }
         RepoChange::BindChannel(channel) => {
-            crate::validate::validate_uuid(&channel)?;
+            let channel = crate::validate::canonicalize_uuid(&channel)?;
             let tag = Tag::parse(["buzz-channel", channel.as_str()]).map_err(tag_error)?;
             (None, true, Some(tag))
         }
@@ -234,8 +234,8 @@ pub(crate) fn build_create_announcement(
     .map_err(|e| CliError::Other(format!("build_repo_announcement failed: {e}")))?;
 
     if let Some(channel) = channel {
-        crate::validate::validate_uuid(channel)?;
-        builder = builder.tag(Tag::parse(["buzz-channel", channel]).map_err(tag_error)?);
+        let channel = crate::validate::canonicalize_uuid(channel)?;
+        builder = builder.tag(Tag::parse(["buzz-channel", channel.as_str()]).map_err(tag_error)?);
     }
     Ok(builder)
 }

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -19,6 +19,11 @@ pub fn parse_uuid(s: &str) -> Result<uuid::Uuid, CliError> {
     uuid::Uuid::parse_str(s).map_err(|e| CliError::Usage(format!("invalid UUID: {e}")))
 }
 
+/// Parse a UUID and return its hyphenated lowercase form for tags and filters.
+pub fn canonicalize_uuid(s: &str) -> Result<String, CliError> {
+    Ok(parse_uuid(s)?.hyphenated().to_string())
+}
+
 /// Validate UUID string. Returns CliError::Usage on failure.
 pub fn validate_uuid(s: &str) -> Result<(), CliError> {
     uuid::Uuid::parse_str(s).map_err(|_| CliError::Usage(format!("invalid UUID: {s}")))?;
@@ -412,6 +417,12 @@ mod tests {
     #[test]
     fn parse_uuid_valid() {
         assert!(super::parse_uuid("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn canonicalize_uuid_lowercases_and_hyphenates() {
+        let out = super::canonicalize_uuid("550E8400E29B41D4A716446655440000").unwrap();
+        assert_eq!(out, "550e8400-e29b-41d4-a716-446655440000");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- repos/projects wrote and queried raw `buzz-channel` UUID spellings
- canonicalize to hyphenated lowercase on write and in filters
- compare channel ids by UUID so mixed spellings still match

## Test plan
- [x] `cargo test -p buzz-cli --lib canonicalize_uuid`
- [x] `cargo check -p buzz-cli`
