### PR TITLE
Lowercase hex pubkeys before authors filters

### DIFF
--- a/crates/buzz-cli/src/commands/projects.rs
+++ b/crates/buzz-cli/src/commands/projects.rs
@@ -255,10 +255,7 @@ async fn fetch_project(
     owner: Option<&str>,
 ) -> Result<Option<Event>, CliError> {
     let pubkey = match owner {
-        Some(pk) => {
-            crate::validate::validate_hex64(pk)?;
-            pk.to_string()
-        }
+        Some(pk) => crate::validate::canonicalize_hex64(pk)?,
         None => client.keys().public_key().to_hex(),
     };
     let filter = serde_json::json!({
@@ -488,10 +485,7 @@ pub async fn cmd_list(
     limit: Option<u32>,
 ) -> Result<(), CliError> {
     let pubkey = match owner {
-        Some(pk) => {
-            crate::validate::validate_hex64(pk)?;
-            pk.to_string()
-        }
+        Some(pk) => crate::validate::canonicalize_hex64(pk)?,
         None => client.keys().public_key().to_hex(),
     };
     let mut filter = serde_json::json!({

--- a/crates/buzz-cli/src/commands/repos.rs
+++ b/crates/buzz-cli/src/commands/repos.rs
@@ -293,7 +293,7 @@ pub async fn cmd_get_repo(
     // If owner specified, filter by author pubkey; otherwise return any match.
     // Note: without --owner, multiple repos with the same name (different owners) may be returned.
     if let Some(pk) = owner {
-        crate::validate::validate_hex64(pk)?;
+        let pk = crate::validate::canonicalize_hex64(pk)?;
         filter["authors"] = serde_json::json!([pk]);
     }
 
@@ -309,10 +309,7 @@ pub async fn cmd_list_repos(
 ) -> Result<(), CliError> {
     // Default to self if no owner specified.
     let pubkey = match owner {
-        Some(pk) => {
-            crate::validate::validate_hex64(pk)?;
-            pk.to_string()
-        }
+        Some(pk) => crate::validate::canonicalize_hex64(pk)?,
         None => client.keys().public_key().to_hex(),
     };
 

--- a/crates/buzz-cli/src/commands/social.rs
+++ b/crates/buzz-cli/src/commands/social.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::client::{normalize_write_response, BuzzClient};
 use crate::error::CliError;
-use crate::validate::{parse_event_id, validate_hex64};
+use crate::validate::{canonicalize_hex64, parse_event_id, validate_hex64};
 
 /// A single contact entry (CLI-local, not from buzz-sdk).
 #[derive(Debug, Deserialize)]
@@ -87,10 +87,11 @@ pub async fn cmd_get_user_notes(
     before: Option<i64>,
     before_id: Option<&str>,
 ) -> Result<(), CliError> {
-    validate_hex64(pubkey)?;
-    if let Some(bid) = before_id {
-        validate_hex64(bid)?;
-    }
+    let pubkey = canonicalize_hex64(pubkey)?;
+    let before_id = match before_id {
+        Some(bid) => Some(canonicalize_hex64(bid)?),
+        None => None,
+    };
     let limit = limit.unwrap_or(50).min(100);
 
     let mut filter = serde_json::json!({
@@ -113,7 +114,7 @@ pub async fn cmd_get_user_notes(
 
 /// Get a user's contact list (kind:3) by pubkey.
 pub async fn cmd_get_contact_list(client: &BuzzClient, pubkey: &str) -> Result<(), CliError> {
-    validate_hex64(pubkey)?;
+    let pubkey = canonicalize_hex64(pubkey)?;
     let filter = serde_json::json!({
         "kinds": [3],
         "authors": [pubkey],
@@ -187,7 +188,7 @@ pub async fn cmd_get_list(
     kind: u32,
     d_tag: Option<&str>,
 ) -> Result<(), CliError> {
-    validate_hex64(pubkey)?;
+    let pubkey = canonicalize_hex64(pubkey)?;
     validate_social_list_kind(kind)?;
     if !is_parameterized_social_list_kind(kind) && d_tag.is_some() {
         return Err(CliError::Usage(format!(

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -35,6 +35,12 @@ pub fn validate_hex64(s: &str) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Validate a 64-hex pubkey/event id and return lowercase for relay filters.
+pub fn canonicalize_hex64(s: &str) -> Result<String, CliError> {
+    validate_hex64(s)?;
+    Ok(s.to_ascii_lowercase())
+}
+
 /// Validate a git repo identifier: `[a-zA-Z0-9._-]{1,64}`, no leading dots, no `..`.
 pub fn validate_repo_id(s: &str) -> Result<(), CliError> {
     if s.is_empty() || s.len() > 64 {
@@ -226,6 +232,12 @@ mod tests {
     fn validate_hex64_valid() {
         let hex = "a".repeat(64);
         assert!(validate_hex64(&hex).is_ok());
+    }
+
+    #[test]
+    fn canonicalize_hex64_lowercases() {
+        let hex = "A".repeat(64);
+        assert_eq!(super::canonicalize_hex64(&hex).unwrap(), "a".repeat(64));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `validate_hex64` accepts `A-F`, but relays index `authors` as lowercase
- uppercase social/project/repo queries returned empty results
- canonicalize pubkeys to lowercase after validation

## Test plan
- [x] `cargo test -p buzz-cli --lib canonicalize_hex64`
