### PR TITLE
fix(acp): publish completed streamed replies

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -45,10 +45,14 @@ impl TurnReplyCapture {
 
     fn push_chunk(&mut self, update: &serde_json::Value) {
         if let Some(message_id) = update.get("messageId").and_then(|value| value.as_str()) {
-            if self.message_id.as_deref() != Some(message_id) {
+            if self
+                .message_id
+                .as_deref()
+                .is_some_and(|current| current != message_id)
+            {
                 self.reset();
-                self.message_id = Some(message_id.to_owned());
             }
+            self.message_id = Some(message_id.to_owned());
         }
 
         let Some(text) = update

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -22,6 +22,70 @@ use crate::usage::{
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
 
+/// Maximum ACP assistant text retained for harness-side reply publication.
+/// Matches the channel-message content bound enforced by `buzz-sdk`.
+const MAX_TURN_REPLY_BYTES: usize = 64 * 1024;
+
+/// Final publishable assistant segment captured from one `session/prompt`.
+#[derive(Default)]
+struct TurnReplyCapture {
+    content: String,
+    message_id: Option<String>,
+    overflowed: bool,
+}
+
+impl TurnReplyCapture {
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    fn clear_for_tool_call(&mut self) {
+        self.reset();
+    }
+
+    fn push_chunk(&mut self, update: &serde_json::Value) {
+        if let Some(message_id) = update.get("messageId").and_then(|value| value.as_str()) {
+            if self.message_id.as_deref() != Some(message_id) {
+                self.reset();
+                self.message_id = Some(message_id.to_owned());
+            }
+        }
+
+        let Some(text) = update
+            .get("content")
+            .and_then(|content| content.get("text"))
+            .and_then(|value| value.as_str())
+        else {
+            return;
+        };
+        if self.overflowed {
+            return;
+        }
+        if self
+            .content
+            .len()
+            .checked_add(text.len())
+            .is_none_or(|size| size > MAX_TURN_REPLY_BYTES)
+        {
+            self.content.clear();
+            self.overflowed = true;
+            return;
+        }
+        self.content.push_str(text);
+    }
+}
+
+/// Assistant output retained from a completed ACP turn.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum CapturedTurnReply {
+    /// The final assistant segment contained publishable text.
+    Text(String),
+    /// The final assistant segment was empty.
+    Empty,
+    /// The final assistant segment exceeded the channel-message limit.
+    Overflow,
+}
+
 /// An MCP server configuration passed to `session/new`.
 ///
 /// Corresponds to the `McpServerStdio` variant in the ACP schema.
@@ -214,6 +278,8 @@ pub struct AcpClient {
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
     standard_adapter: Option<StandardAdapterKind>,
+    /// Bounded final assistant segment for harness-side reply publication.
+    turn_reply_capture: TurnReplyCapture,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -563,6 +629,7 @@ impl AcpClient {
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
+            turn_reply_capture: TurnReplyCapture::default(),
         })
     }
 
@@ -781,6 +848,9 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        // A new prompt must never inherit output from an initial-message prompt
+        // or a previous turn on this long-lived ACP process.
+        self.turn_reply_capture.reset();
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -1755,11 +1825,16 @@ impl AcpClient {
         match update_type {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
+                    self.turn_reply_capture.push_chunk(update);
                     tracing::info!(target: "acp::stream", "{text}");
                 }
                 false
             }
             "tool_call" => {
+                // Assistant text before a tool request is commentary, not the
+                // final visible response. Retain only text emitted after the
+                // last tool call in the turn.
+                self.turn_reply_capture.clear_for_tool_call();
                 let title = update
                     .get("title")
                     .and_then(|v| v.as_str())
@@ -1850,6 +1925,18 @@ impl AcpClient {
                 tracing::debug!(target: "acp::update", "session/update: {other}");
                 false
             }
+        }
+    }
+
+    /// Take the final assistant segment emitted by the current prompt.
+    pub(crate) fn take_turn_reply(&mut self) -> CapturedTurnReply {
+        let capture = std::mem::take(&mut self.turn_reply_capture);
+        if capture.overflowed {
+            CapturedTurnReply::Overflow
+        } else if capture.content.trim().is_empty() {
+            CapturedTurnReply::Empty
+        } else {
+            CapturedTurnReply::Text(capture.content)
         }
     }
 
@@ -5026,5 +5113,60 @@ mod tests {
             msg.contains("sandbox_workspace_write"),
             "error must mention sandbox_workspace_write"
         );
+    }
+
+    #[tokio::test]
+    async fn turn_reply_capture_keeps_only_the_final_model_segment() {
+        let mut client = spawn_inert_client().await;
+        let update = |value| {
+            serde_json::json!({
+                "params": { "update": value }
+            })
+        };
+
+        client.handle_session_update(&update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "messageId": "first",
+            "content": { "text": "I will inspect that." }
+        })));
+        client.handle_session_update(&update(serde_json::json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "tool-1",
+            "title": "inspect",
+            "kind": "read"
+        })));
+        client.handle_session_update(&update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "messageId": "final",
+            "content": { "text": "The " }
+        })));
+        client.handle_session_update(&update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "messageId": "final",
+            "content": { "text": "answer." }
+        })));
+
+        assert_eq!(
+            client.take_turn_reply(),
+            CapturedTurnReply::Text("The answer.".to_string())
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn turn_reply_capture_fails_closed_after_cumulative_overflow() {
+        let mut client = spawn_inert_client().await;
+        let chunk = "x".repeat(MAX_TURN_REPLY_BYTES / 2 + 1);
+        for _ in 0..2 {
+            client.handle_session_update(&serde_json::json!({
+                "params": { "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": { "text": chunk.as_str() }
+                }}
+            }));
+        }
+
+        assert_eq!(client.take_turn_reply(), CapturedTurnReply::Overflow);
+        client.shutdown().await;
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -31,8 +31,8 @@ use uuid::Uuid;
 
 use crate::acp::{
     extract_model_config_options, extract_model_state, extract_thought_level_config_id,
-    model_in_catalog, resolve_model_switch_method, AcpClient, AcpError, EnvVar, McpServer,
-    ModelSwitchMethod, StopReason, SystemPromptTransport,
+    model_in_catalog, resolve_model_switch_method, AcpClient, AcpError, CapturedTurnReply, EnvVar,
+    McpServer, ModelSwitchMethod, StopReason, SystemPromptTransport,
 };
 use crate::config::{compose_scoped_session_title, DedupMode, PermissionMode};
 use crate::observer;
@@ -271,6 +271,19 @@ pub struct OwnedAgent {
     pub goose_system_prompt_supported: Option<bool>,
     /// Protocol version reported by the agent in its initialize response.
     pub protocol_version: u32,
+}
+
+/// Harness-owned destination for publishing a completed ACP response.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReplyFallbackContext {
+    /// Channel receiving the signed kind-9 response.
+    pub channel_id: Uuid,
+    /// NIP-10 root tag, absent for an unthreaded top-level DM.
+    pub thread_root: Option<String>,
+    /// NIP-10 reply tag, absent for an unthreaded top-level DM.
+    pub thread_parent: Option<String>,
+    /// Coarse lower timestamp bound for duplicate detection.
+    pub turn_started_at_secs: u64,
 }
 
 /// Package name reported by `claude-agent-acp` in its `initialize` response.
@@ -2045,6 +2058,7 @@ pub async fn run_prompt_task(
         None => PromptSource::Heartbeat,
     };
     let observer_channel_id = source.channel_id();
+    let turn_started_at_secs = nostr::Timestamp::now().as_secs();
     let turn_started_at = chrono::Utc::now().to_rfc3339();
     agent.acp.set_observer_context(observer::context_for_turn(
         observer_channel_id,
@@ -2605,6 +2619,7 @@ pub async fn run_prompt_task(
     // (`prompt[0].text.startsWith("/")`) fires; the wrapped Buzz context
     // follows as a second block.
     let mut slash_command: Option<String> = None;
+    let mut reply_fallback: Option<ReplyFallbackContext> = None;
     // Event IDs represented by this prompt. Commit only after ACP reports a
     // successful turn; failed/cancelled prompts must be retryable without loss.
     let mut pending_delivered_event_ids = HashSet::new();
@@ -2669,6 +2684,18 @@ pub async fn run_prompt_task(
 
         let profile_lookup =
             fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client).await;
+
+        reply_fallback = crate::queue::reply_destination_for_batch(
+            b,
+            channel_info.as_ref(),
+            profile_lookup.as_ref(),
+        )
+        .map(|destination| ReplyFallbackContext {
+            channel_id: b.channel_id,
+            thread_root: destination.thread_root,
+            thread_parent: destination.thread_parent,
+            turn_started_at_secs,
+        });
 
         let known_names: Vec<&str> = profile_lookup
             .iter()
@@ -2919,6 +2946,12 @@ pub async fn run_prompt_task(
                             );
                         }
                         log_stop_reason(&source, &StopReason::EndTurn);
+                        finish_turn_reply_fallback(
+                            &mut agent,
+                            &ctx.rest_client,
+                            reply_fallback.as_ref(),
+                        )
+                        .await;
                         if let PromptSource::Channel(scope) = &source {
                             let standing_sent = !agent.has_system_prompt_support();
                             record_scope_delivery_success(
@@ -2961,6 +2994,18 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+
+            if matches!(stop_reason, StopReason::EndTurn) {
+                finish_turn_reply_fallback(
+                    &mut agent,
+                    &ctx.rest_client,
+                    reply_fallback.as_ref(),
+                )
+                .await;
+            } else {
+                // Never publish partial, refused, limited, or cancelled output.
+                let _ = agent.acp.take_turn_reply();
+            }
 
             if let PromptSource::Channel(scope) = &source {
                 let standing_sent = !agent.has_system_prompt_support();
@@ -4967,6 +5012,205 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum ReplyFallbackOutcome {
+    ExistingReply,
+    Published(String),
+}
+
+fn is_explicit_silence(content: &str) -> bool {
+    let marker = content
+        .trim()
+        .trim_matches(|character: char| matches!(character, '`' | '.' | '!' | ':' | ';'))
+        .trim();
+    ["NO_REPLY", "ANNOUNCE_SKIP", "REPLY_SKIP"]
+        .iter()
+        .any(|candidate| marker.eq_ignore_ascii_case(candidate))
+}
+
+async fn finish_turn_reply_fallback(
+    agent: &mut OwnedAgent,
+    rest: &crate::relay::RestClient,
+    context: Option<&ReplyFallbackContext>,
+) {
+    let content = match agent.acp.take_turn_reply() {
+        CapturedTurnReply::Empty => return,
+        CapturedTurnReply::Overflow => {
+            tracing::warn!(
+                "reply fallback suppressed: final ACP response exceeded the 64 KiB message limit"
+            );
+            agent.acp.observe(
+                "delivery_fallback_failed",
+                serde_json::json!({ "reason": "final response exceeded 64 KiB" }),
+            );
+            return;
+        }
+        CapturedTurnReply::Text(content) => content,
+    };
+    if is_explicit_silence(&content) {
+        tracing::debug!("reply fallback suppressed for explicit silence marker");
+        return;
+    }
+    let Some(context) = context else {
+        return;
+    };
+
+    match post_agent_reply_fallback(rest, context, &content).await {
+        Ok(ReplyFallbackOutcome::ExistingReply) => tracing::debug!(
+            channel = %context.channel_id,
+            "agent already published during turn — suppressing reply fallback"
+        ),
+        Ok(ReplyFallbackOutcome::Published(event_id)) => {
+            tracing::warn!(
+                channel = %context.channel_id,
+                event_id,
+                "content-delivery fallback published the ACP final response"
+            );
+            agent.acp.observe(
+                "delivery_fallback",
+                serde_json::json!({ "eventId": event_id }),
+            );
+        }
+        Err(reason) => {
+            tracing::warn!(
+                channel = %context.channel_id,
+                "content-delivery fallback failed: {reason}"
+            );
+            agent.acp.observe(
+                "delivery_fallback_failed",
+                serde_json::json!({ "reason": reason }),
+            );
+        }
+    }
+}
+
+async fn fallback_event_persisted(
+    rest: &crate::relay::RestClient,
+    event_id: nostr::EventId,
+) -> Result<bool, String> {
+    let filter = nostr::Filter::new()
+        .id(event_id)
+        .kinds([
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_V2 as u16),
+        ])
+        .limit(1);
+    let value = tokio::time::timeout(Duration::from_secs(5), rest.query(&[filter]))
+        .await
+        .map_err(|_| "event-ID reconciliation timed out".to_string())?
+        .map_err(|error| format!("event-ID reconciliation failed: {error}"))?;
+    value
+        .as_array()
+        .map(|events| !events.is_empty())
+        .ok_or_else(|| "event-ID reconciliation returned malformed data".to_string())
+}
+
+/// Publish the final ACP response only when the agent did not already send a
+/// reply during this turn. Relay reads fail closed to prevent duplicate sends.
+async fn post_agent_reply_fallback(
+    rest: &crate::relay::RestClient,
+    context: &ReplyFallbackContext,
+    content: &str,
+) -> Result<ReplyFallbackOutcome, String> {
+    use nostr::{Alphabet, SingleLetterTag};
+
+    let content = content.trim();
+    if content.is_empty() {
+        return Ok(ReplyFallbackOutcome::ExistingReply);
+    }
+
+    let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+    let e_tag = SingleLetterTag::lowercase(Alphabet::E);
+    let channel = context.channel_id.to_string();
+    let mut filter = nostr::Filter::new()
+        .kinds([
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_V2 as u16),
+        ])
+        .author(rest.keys.public_key())
+        .custom_tags(h_tag, [channel.as_str()])
+        .since(nostr::Timestamp::from(context.turn_started_at_secs))
+        .limit(1);
+    if let Some(root) = context.thread_root.as_deref() {
+        filter = filter.custom_tags(e_tag, [root]);
+    }
+
+    let existing = tokio::time::timeout(
+        Duration::from_secs(5),
+        rest.query(std::slice::from_ref(&filter)),
+    )
+    .await
+    .map_err(|_| "duplicate check timed out".to_string())?
+    .map_err(|error| format!("duplicate check failed: {error}"))?
+    .as_array()
+    .map(|events| !events.is_empty())
+    .ok_or_else(|| "duplicate check returned malformed data".to_string())?;
+    if existing {
+        return Ok(ReplyFallbackOutcome::ExistingReply);
+    }
+
+    let thread_ref = match (
+        context.thread_root.as_deref(),
+        context.thread_parent.as_deref(),
+    ) {
+        (None, None) => None,
+        (Some(root), Some(parent)) => Some(buzz_sdk::ThreadRef {
+            root_event_id: nostr::EventId::from_hex(root)
+                .map_err(|error| format!("invalid reply root: {error}"))?,
+            parent_event_id: nostr::EventId::from_hex(parent)
+                .map_err(|error| format!("invalid reply parent: {error}"))?,
+        }),
+        _ => return Err("incomplete reply thread destination".to_string()),
+    };
+    let builder = buzz_sdk::build_message(
+        context.channel_id,
+        content,
+        thread_ref.as_ref(),
+        &[],
+        false,
+        &[],
+    )
+    .map_err(|error| format!("build failed: {error}"))?;
+    let event = builder
+        .sign_with_keys(&rest.keys)
+        .map_err(|error| format!("sign failed: {error}"))?;
+    let event_id = event.id.clone();
+    let event_id_hex = event_id.to_hex();
+
+    let uncertain_reason = match tokio::time::timeout(
+        Duration::from_secs(5),
+        rest.submit_event(&event),
+    )
+    .await
+    {
+        Ok(Ok(response))
+            if response.get("accepted").and_then(|value| value.as_bool()) == Some(true) =>
+        {
+            return Ok(ReplyFallbackOutcome::Published(event_id_hex));
+        }
+        Ok(Ok(response))
+            if response.get("accepted").and_then(|value| value.as_bool()) == Some(false) =>
+        {
+            let message = response
+                .get("message")
+                .and_then(|value| value.as_str())
+                .unwrap_or("relay rejected the event");
+            return Err(format!("relay rejected the event: {message}"));
+        }
+        Ok(Ok(_)) => "relay returned no acceptance decision".to_string(),
+        Ok(Err(error)) => format!("publish request failed: {error}"),
+        Err(_) => "publish acknowledgement timed out".to_string(),
+    };
+
+    match fallback_event_persisted(rest, event_id).await {
+        Ok(true) => Ok(ReplyFallbackOutcome::Published(event_id_hex)),
+        Ok(false) => Err(uncertain_reason),
+        Err(reconciliation_error) => Err(format!(
+            "{uncertain_reason}; {reconciliation_error}"
+        )),
+    }
+}
+
 /// Best-effort: post a visible failure notice (kind:9) to a channel after a
 /// batch is dead-lettered. Replies into the thread of `thread_tags` when the
 /// triggering event was threaded. Errors are logged and swallowed — the
@@ -5136,6 +5380,170 @@ mod tests {
     /// (equivalent to the pre-thread-scoping channel key).
     fn conv(channel_id: Uuid) -> SessionScope {
         SessionScope::Conversation { channel_id }
+    }
+
+    async fn read_test_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt;
+
+        let mut bytes = Vec::new();
+        loop {
+            let mut chunk = [0_u8; 4096];
+            let count = socket.read(&mut chunk).await.expect("read test request");
+            if count == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&chunk[..count]);
+            let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n")
+            else {
+                continue;
+            };
+            let header_end = header_end + 4;
+            let headers = String::from_utf8_lossy(&bytes[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            if bytes.len() >= header_end + content_length {
+                break;
+            }
+        }
+        String::from_utf8(bytes).expect("UTF-8 test request")
+    }
+
+    async fn write_test_http_json(socket: &mut tokio::net::TcpStream, body: &str) {
+        use tokio::io::AsyncWriteExt;
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write test response");
+    }
+
+    #[test]
+    fn explicit_silence_markers_are_not_publishable() {
+        for marker in ["NO_REPLY", "`announce_skip`", " reply_skip. "] {
+            assert!(is_explicit_silence(marker));
+        }
+        assert!(!is_explicit_silence("No reply was received."));
+    }
+
+    #[tokio::test]
+    async fn reply_fallback_requires_relay_acceptance() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let base_url = format!("http://{}", listener.local_addr().expect("test address"));
+        let server = tokio::spawn(async move {
+            let (mut query, _) = listener.accept().await.expect("accept duplicate query");
+            let _ = read_test_http_request(&mut query).await;
+            write_test_http_json(&mut query, "[]").await;
+
+            let (mut submit, _) = listener.accept().await.expect("accept submit");
+            let _ = read_test_http_request(&mut submit).await;
+            write_test_http_json(
+                &mut submit,
+                r#"{"accepted":false,"message":"blocked by policy"}"#,
+            )
+            .await;
+        });
+        let rest = RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        };
+        let context = ReplyFallbackContext {
+            channel_id: Uuid::new_v4(),
+            thread_root: None,
+            thread_parent: None,
+            turn_started_at_secs: Timestamp::now().as_secs(),
+        };
+
+        let result = post_agent_reply_fallback(&rest, &context, "reply").await;
+        assert!(
+            result
+                .expect_err("relay rejection must fail")
+                .contains("blocked by policy")
+        );
+        server.await.expect("test server");
+    }
+
+    #[tokio::test]
+    async fn reply_fallback_reconciles_an_uncertain_ack_by_event_id() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let base_url = format!("http://{}", listener.local_addr().expect("test address"));
+        let (submitted_tx, submitted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let mut submitted_tx = Some(submitted_tx);
+            for (index, body) in ["[]", "{}", "[{}]"].into_iter().enumerate() {
+                let (mut socket, _) = listener.accept().await.expect("accept request");
+                let request = read_test_http_request(&mut socket).await;
+                if index == 1 {
+                    let body = request
+                        .split_once("\r\n\r\n")
+                        .expect("HTTP request has a body")
+                        .1
+                        .to_string();
+                    submitted_tx
+                        .take()
+                        .expect("submit sender available")
+                        .send(body)
+                        .expect("capture submitted event");
+                }
+                write_test_http_json(&mut socket, body).await;
+            }
+        });
+        let rest = RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        };
+        let channel_id = Uuid::new_v4();
+        let root = "a".repeat(64);
+        let parent = "b".repeat(64);
+        let context = ReplyFallbackContext {
+            channel_id,
+            thread_root: Some(root.clone()),
+            thread_parent: Some(parent.clone()),
+            turn_started_at_secs: Timestamp::now().as_secs(),
+        };
+
+        assert!(matches!(
+            post_agent_reply_fallback(&rest, &context, "reply").await,
+            Ok(ReplyFallbackOutcome::Published(_))
+        ));
+        let event: serde_json::Value = serde_json::from_str(
+            &submitted_rx.await.expect("submitted event body"),
+        )
+        .expect("submitted event JSON");
+        assert_eq!(event["kind"], json!(9));
+        assert_eq!(event["content"], json!("reply"));
+        let tags = event["tags"].as_array().expect("event tags");
+        assert!(tags.iter().any(|tag| tag == &json!(["h", channel_id])));
+        assert!(tags.iter().any(|tag| {
+            tag.as_array().is_some_and(|parts| {
+                parts.first() == Some(&json!("e")) && parts.get(1) == Some(&json!(root))
+            })
+        }));
+        assert!(tags.iter().any(|tag| {
+            tag.as_array().is_some_and(|parts| {
+                parts.first() == Some(&json!("e")) && parts.get(1) == Some(&json!(parent))
+            })
+        }));
+        server.await.expect("test server");
     }
 
     fn test_mcp_server() -> McpServer {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2946,12 +2946,10 @@ pub async fn run_prompt_task(
                             );
                         }
                         log_stop_reason(&source, &StopReason::EndTurn);
-                        finish_turn_reply_fallback(
-                            &mut agent,
-                            &ctx.rest_client,
-                            reply_fallback.as_ref(),
-                        )
-                        .await;
+                        // The prompt future was dropped, so its actual stop reason
+                        // (end_turn, max_tokens, refusal, etc.) is unavailable.
+                        // Fail closed rather than risk publishing partial output.
+                        let _ = agent.acp.take_turn_reply();
                         if let PromptSource::Channel(scope) = &source {
                             let standing_sent = !agent.has_system_prompt_support();
                             record_scope_delivery_success(
@@ -5174,7 +5172,7 @@ async fn post_agent_reply_fallback(
     let event = builder
         .sign_with_keys(&rest.keys)
         .map_err(|error| format!("sign failed: {error}"))?;
-    let event_id = event.id.clone();
+    let event_id = event.id;
     let event_id_hex = event_id.to_hex();
 
     let uncertain_reason = match tokio::time::timeout(

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1441,6 +1441,58 @@ fn resolve_reply_anchor(
     )
 }
 
+/// Human-facing destination for a reply produced by the current turn.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReplyDestination {
+    /// Event ID passed as the ordinary reply anchor. A top-level DM is
+    /// human-facing but deliberately has no anchor.
+    pub reply_to: Option<String>,
+    /// Root tag for direct harness publication.
+    pub thread_root: Option<String>,
+    /// Immediate parent tag for direct harness publication.
+    pub thread_parent: Option<String>,
+}
+
+/// Resolve whether a batch expects a human-facing reply and, if so, its anchor.
+///
+/// This is shared by prompt rendering and harness-side publication so the two
+/// paths cannot disagree about agent-only turns, channel threads, or DMs.
+pub(crate) fn reply_destination_for_batch(
+    batch: &FlushBatch,
+    channel_info: Option<&PromptChannelInfo>,
+    profile_lookup: Option<&PromptProfileLookup>,
+) -> Option<ReplyDestination> {
+    let last_event = batch.events.last()?;
+    let thread_tags = parse_thread_tags(&last_event.event);
+    let is_dm = channel_info
+        .map(|info| info.channel_type == "dm")
+        .unwrap_or(false);
+
+    if is_dm {
+        let root = thread_tags.root_event_id.clone();
+        return Some(ReplyDestination {
+            reply_to: root.as_ref().map(|_| last_event.event.id.to_hex()),
+            thread_root: root,
+            thread_parent: thread_tags
+                .root_event_id
+                .as_ref()
+                .map(|_| last_event.event.id.to_hex()),
+        });
+    }
+
+    resolve_reply_anchor(
+        &last_event.event.pubkey.to_hex(),
+        &thread_tags,
+        &last_event.event.id.to_hex(),
+        profile_lookup,
+    )
+    .map(|reply_to| ReplyDestination {
+        thread_root: Some(reply_to.clone()),
+        thread_parent: Some(reply_to.clone()),
+        reply_to: Some(reply_to),
+    })
+}
+
 /// Maximum length (in characters) of a channel description rendered into `<context>`.
 ///
 /// Limits prompt bloat from unusually long descriptions. Multi-line
@@ -2015,20 +2067,8 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     //   - top-level     → anchor to the triggering event (it becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
     // there. DMs are always 1:1 with a human, so they always anchor.
-    let sender_pubkey = last_event.event.pubkey.to_hex();
-    let reply_anchor = if is_dm {
-        thread_tags
-            .root_event_id
-            .is_some()
-            .then(|| last_event.event.id.to_hex())
-    } else {
-        resolve_reply_anchor(
-            &sender_pubkey,
-            &thread_tags,
-            &last_event.event.id.to_hex(),
-            args.profile_lookup,
-        )
-    };
+    let reply_anchor = reply_destination_for_batch(batch, args.channel_info, args.profile_lookup)
+        .and_then(|destination| destination.reply_to);
     sections.push(format_context_hints(
         &batch.scope,
         args.channel_info,
@@ -3996,6 +4036,26 @@ mod tests {
                         description: None,
                         project: None,
                     };
+                    let destination = reply_destination_for_batch(&batch, Some(&ci), None)
+                        .expect("human-facing turn has a reply destination");
+                    if is_dm && !is_reply {
+                        assert_eq!(destination.reply_to, None);
+                        assert_eq!(destination.thread_root, None);
+                        assert_eq!(destination.thread_parent, None);
+                    } else if is_dm {
+                        assert_eq!(destination.reply_to, Some(reply.id.to_hex()));
+                        assert_eq!(destination.thread_root, Some(root.to_uppercase()));
+                        assert_eq!(destination.thread_parent, Some(reply.id.to_hex()));
+                    } else {
+                        let expected = if is_reply {
+                            root.to_uppercase()
+                        } else {
+                            root.clone()
+                        };
+                        assert_eq!(destination.reply_to, Some(expected.clone()));
+                        assert_eq!(destination.thread_root, Some(expected.clone()));
+                        assert_eq!(destination.thread_parent, Some(expected));
+                    }
                     // Session scope must remain visible on every turn, even
                     // after standing context was sent or via modern ACP.
                     for modern in [false, true] {

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -2066,7 +2066,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     //   - in a thread  → anchor to the thread ROOT (no depth-2 nesting)
     //   - top-level     → anchor to the triggering event (it becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
-    // there. DMs are always 1:1 with a human, so they always anchor.
+    // there. Top-level DMs remain unthreaded; DM replies preserve their thread.
     let reply_anchor = reply_destination_for_batch(batch, args.channel_info, args.profile_lookup)
         .and_then(|destination| destination.reply_to);
     sections.push(format_context_hints(


### PR DESCRIPTION
## Summary

- capture the final assistant text emitted through ACP `agent_message_chunk` updates
- publish that text with the harness identity when an `end_turn` completes without an existing agent-authored reply
- preserve DM, human-facing thread, and agent-only routing semantics
- bound captured output to 64 KiB, suppress explicit silence markers, and fail closed when duplicate detection is uncertain
- require a positive relay acceptance decision and reconcile ambiguous acknowledgements by immutable event ID

## Root cause

`buzz-acp` consumed ACP assistant chunks only for tracing. Agents such as Hermes can complete a turn with `stopReason: end_turn` but cannot use the Buzz CLI because the terminal environment intentionally omits `BUZZ_*` credentials. Their completed text therefore never became a kind-9 reply.

The harness already owns the signing keys, so this change adds a delivery fallback at that existing credential boundary. It runs only for successfully completed human-facing turns and checks the relay for an agent-authored reply before publishing, avoiding duplicate replies from agents that did use the normal tool path.

## Tests

Added regression coverage for:

- retaining only the final post-tool assistant segment
- cumulative capture overflow
- DM/channel/thread destination mapping
- explicit silence markers
- relay rejection
- ambiguous acknowledgement reconciliation and kind-9 thread tags

Static whitespace validation passed with `git diff --check`. The local scratch environment did not contain the repository toolchain, so `cargo fmt`, Clippy, and unit tests are delegated to this PR's CI.

No UI changes.

## Related work

Closest overlapping implementation: #5811. This PR incorporates its review feedback by bounding memory, publishing only on `end_turn`, checking for an existing reply, preserving routing, requiring relay acceptance, reconciling uncertain sends by event ID, and never rerunning the model/tool turn.

Also reviewed #3883 and the closed #2681 while investigating the recurrence.

Fixes #4923