### PR TITLE
feat(observer): share managed-agent activity with channel members

### DIFF
--- a/VISION_ACTIVITY.md
+++ b/VISION_ACTIVITY.md
@@ -8,13 +8,19 @@ We wanted a feed you supervise the way you supervise a capable teammate: skim fo
 
 ## Who It Serves
 
-A developer supervising a delegate. They are not watching for entertainment; they are deciding whether to intervene. Every item in the feed earns its pixels by answering one of three questions:
+A channel member supervising a delegate. They are not watching for entertainment; they are deciding whether to intervene. Every item in the feed earns its pixels by answering one of three questions:
 
 - **Comprehension** — *what is it doing, and why?*
 - **Confidence** — *is it going well, or is it stuck or wrong?*
 - **Control** — *do I need to step in, and where?*
 
 A feed that answers these instantly converts a stream of events into a sense of trajectory. A feed that does not is just noise with a scrollbar.
+
+Visibility follows the team boundary. The controlling owner retains existing
+oversight; other observers must be authenticated direct relay members who
+currently share the event's channel. Telemetry is encrypted for the named
+viewers. Channel membership never grants observer controls, agent memory, or
+secret access.
 
 ## The Governing Frame: Verb, Object, Outcome
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -28,7 +28,7 @@ use buzz_core::kind::{
     KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
-    decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
+    decrypt_observer_payload, encrypt_observer_payload, encrypt_observer_payload_for_recipients,
     OBSERVER_MAX_PLAINTEXT_LEN,
 };
 use clap::Parser;
@@ -45,7 +45,7 @@ use pool::{
 };
 use pool_lifecycle::PoolLifecycle;
 use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
-use relay::{HarnessRelay, RelayEventPublisher};
+use relay::{HarnessRelay, RelayEventPublisher, RestClient};
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
@@ -1097,12 +1097,83 @@ fn batch_envelope(events: &[observer::ObserverEvent]) -> observer::ObserverEvent
     }
 }
 
+const OBSERVER_RECIPIENT_CACHE_TTL: Duration = Duration::from_secs(30);
+const OBSERVER_RECIPIENT_CACHE_MAX_CHANNELS: usize = 1_024;
+const OBSERVER_RECIPIENT_FETCH_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Default)]
+struct ObserverRecipientCache {
+    by_channel: HashMap<uuid::Uuid, (tokio::time::Instant, Vec<PublicKey>)>,
+}
+
+impl ObserverRecipientCache {
+    fn insert(
+        &mut self,
+        channel_id: uuid::Uuid,
+        fetched_at: tokio::time::Instant,
+        recipients: Vec<PublicKey>,
+    ) {
+        if !self.by_channel.contains_key(&channel_id)
+            && self.by_channel.len() >= OBSERVER_RECIPIENT_CACHE_MAX_CHANNELS
+        {
+            if let Some(oldest_channel) = self
+                .by_channel
+                .iter()
+                .min_by_key(|(_, (cached_at, _))| *cached_at)
+                .map(|(channel_id, _)| *channel_id)
+            {
+                self.by_channel.remove(&oldest_channel);
+            }
+        }
+        self.by_channel.insert(channel_id, (fetched_at, recipients));
+    }
+
+    async fn resolve(
+        &mut self,
+        rest: &RestClient,
+        channel_id: uuid::Uuid,
+        owner: PublicKey,
+        agent: PublicKey,
+    ) -> Vec<PublicKey> {
+        if let Some((fetched_at, recipients)) = self.by_channel.get(&channel_id) {
+            if fetched_at.elapsed() < OBSERVER_RECIPIENT_CACHE_TTL {
+                return recipients.clone();
+            }
+        }
+
+        match tokio::time::timeout(
+            OBSERVER_RECIPIENT_FETCH_TIMEOUT,
+            rest.shared_observer_recipients(channel_id, owner, agent),
+        )
+        .await
+        {
+            Ok(Ok(recipients)) => {
+                self.insert(channel_id, tokio::time::Instant::now(), recipients.clone());
+                recipients
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    %channel_id,
+                    "shared observer audience unavailable; publishing owner-only: {error}"
+                );
+                vec![owner]
+            }
+            Err(_) => {
+                tracing::warn!(
+                    %channel_id,
+                    "shared observer audience query timed out; publishing owner-only"
+                );
+                vec![owner]
+            }
+        }
+    }
+}
+
 fn spawn_relay_observer_publisher(
     observer: observer::ObserverHandle,
     publisher: RelayEventPublisher,
+    rest: RestClient,
     keys: nostr::Keys,
-    agent_pubkey_hex: String,
-    owner_pubkey_hex: String,
     owner_pubkey: PublicKey,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -1112,16 +1183,7 @@ fn spawn_relay_observer_publisher(
         // high-water `seq` (monotonic, assigned at emit).
         let rx = observer.subscribe();
         let snapshot = observer.snapshot();
-        run_relay_observer_publisher(
-            snapshot,
-            rx,
-            publisher,
-            keys,
-            agent_pubkey_hex,
-            owner_pubkey_hex,
-            owner_pubkey,
-        )
-        .await;
+        run_relay_observer_publisher(snapshot, rx, publisher, Some(rest), keys, owner_pubkey).await;
     })
 }
 
@@ -1129,12 +1191,12 @@ async fn run_relay_observer_publisher(
     snapshot: Vec<observer::ObserverEvent>,
     mut rx: tokio::sync::broadcast::Receiver<observer::ObserverEvent>,
     publisher: RelayEventPublisher,
+    rest: Option<RestClient>,
     keys: nostr::Keys,
-    agent_pubkey_hex: String,
-    owner_pubkey_hex: String,
     owner_pubkey: PublicKey,
 ) {
     let mut queue = ObserverPublishQueue::default();
+    let mut recipient_cache = ObserverRecipientCache::default();
     let max_snapshot_seq = snapshot.iter().map(|event| event.seq).max().unwrap_or(0);
     for event in snapshot {
         queue.ingest(event);
@@ -1150,6 +1212,9 @@ async fn run_relay_observer_publisher(
         OBSERVER_PUBLISH_TICK,
     );
     publish_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let agent_pubkey = keys.public_key();
+    let agent_pubkey_hex = agent_pubkey.to_hex();
+    let owner_pubkey_hex = owner_pubkey.to_hex();
     let mut closed = false;
     loop {
         tokio::select! {
@@ -1177,10 +1242,28 @@ async fn run_relay_observer_publisher(
             }
             _ = publish_tick.tick() => {
                 if let Some(frame) = queue.next_frame() {
+                    let channel_id = frame
+                        .channel_id
+                        .as_deref()
+                        .and_then(|value| uuid::Uuid::parse_str(value).ok());
+                    let recipients = match (channel_id, rest.as_ref()) {
+                        (Some(channel_id), Some(rest)) => {
+                            recipient_cache
+                                .resolve(rest, channel_id, owner_pubkey, agent_pubkey)
+                                .await
+                        }
+                        _ => vec![owner_pubkey],
+                    };
                     publish_relay_observer_event(
-                        &publisher, &keys, &agent_pubkey_hex,
-                        &owner_pubkey_hex, &owner_pubkey, frame,
-                    ).await;
+                        &publisher,
+                        &keys,
+                        &agent_pubkey_hex,
+                        &owner_pubkey_hex,
+                        recipients,
+                        channel_id,
+                        frame,
+                    )
+                    .await;
                 }
                 if closed && queue.is_empty() {
                     break;
@@ -1522,23 +1605,31 @@ async fn publish_relay_observer_event(
     keys: &nostr::Keys,
     agent_pubkey_hex: &str,
     owner_pubkey_hex: &str,
-    owner_pubkey: &PublicKey,
+    recipients: Vec<PublicKey>,
+    channel_id: Option<uuid::Uuid>,
     mut event: observer::ObserverEvent,
 ) {
-    // Trim oversized frames to fit the plaintext cap rather than letting
-    // encrypt_observer_payload reject and drop them whole (silent telemetry loss).
+    // Trim oversized frames before encryption so one oversized leaf cannot
+    // drop the whole telemetry frame.
     fit_observer_event_to_budget(&mut event);
-    let encrypted = match encrypt_observer_payload(keys, owner_pubkey, &event) {
+    let encrypted = if recipients.len() == 1 {
+        encrypt_observer_payload(keys, &recipients[0], &event)
+    } else {
+        encrypt_observer_payload_for_recipients(keys, &recipients, &event)
+    };
+    let encrypted = match encrypted {
         Ok(encrypted) => encrypted,
         Err(error) => {
             tracing::warn!("failed to encrypt relay observer event: {error}");
             return;
         }
     };
-    let builder = match buzz_sdk::build_agent_observer_frame(
+    let recipient_pubkeys: Vec<String> = recipients.iter().map(PublicKey::to_hex).collect();
+    let builder = match buzz_sdk::build_agent_observer_telemetry_frame(
         owner_pubkey_hex,
+        &recipient_pubkeys,
         agent_pubkey_hex,
-        OBSERVER_FRAME_TELEMETRY,
+        channel_id,
         &encrypted,
     ) {
         Ok(builder) => builder,
@@ -2565,9 +2656,8 @@ async fn tokio_main() -> Result<()> {
                     relay_observer_publisher = Some((
                         observer,
                         relay.event_publisher(),
+                        relay.rest_client(),
                         config.keys.clone(),
-                        pubkey_hex.clone(),
-                        owner_pubkey_hex,
                         owner_pubkey,
                     ));
                     relay
@@ -2648,16 +2738,9 @@ async fn tokio_main() -> Result<()> {
         }
     }
 
-    if let Some((observer, publisher, keys, agent_pubkey, owner_pubkey, owner)) =
-        relay_observer_publisher.take()
-    {
+    if let Some((observer, publisher, rest, keys, owner)) = relay_observer_publisher.take() {
         relay_observer_publisher_task = Some(spawn_relay_observer_publisher(
-            observer,
-            publisher,
-            keys,
-            agent_pubkey,
-            owner_pubkey,
-            owner,
+            observer, publisher, rest, keys, owner,
         ));
     }
 
@@ -7812,9 +7895,8 @@ mod observer_snapshot_race_tests {
             snapshot,
             rx,
             publisher,
+            None,
             agent_keys.clone(),
-            agent_keys.public_key().to_hex(),
-            owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
         )
         .await;
@@ -7848,6 +7930,33 @@ mod observer_snapshot_race_tests {
 #[cfg(test)]
 mod observer_publish_queue_tests {
     use super::*;
+    #[test]
+    fn observer_recipient_cache_evicts_oldest_channel_at_capacity() {
+        let mut cache = ObserverRecipientCache::default();
+        let started_at = tokio::time::Instant::now();
+        let oldest_channel = uuid::Uuid::from_u128(1);
+        for index in 0..OBSERVER_RECIPIENT_CACHE_MAX_CHANNELS {
+            cache.insert(
+                uuid::Uuid::from_u128(index as u128 + 1),
+                started_at + Duration::from_millis(index as u64),
+                Vec::new(),
+            );
+        }
+
+        let newest_channel = uuid::Uuid::from_u128(u128::MAX);
+        cache.insert(
+            newest_channel,
+            started_at + Duration::from_secs(60),
+            Vec::new(),
+        );
+
+        assert_eq!(
+            cache.by_channel.len(),
+            OBSERVER_RECIPIENT_CACHE_MAX_CHANNELS
+        );
+        assert!(!cache.by_channel.contains_key(&oldest_channel));
+        assert!(cache.by_channel.contains_key(&newest_channel));
+    }
 
     fn event(seq: u64, kind: &str, channel: Option<&str>) -> observer::ObserverEvent {
         observer::ObserverEvent {
@@ -8468,6 +8577,74 @@ mod observer_publish_queue_tests {
 }
 
 #[cfg(test)]
+mod shared_observer_publish_tests {
+    use super::*;
+    use buzz_core::observer::{OBSERVER_FRAME_TELEMETRY, OBSERVER_OWNER_TAG};
+    use nostr::Keys;
+
+    #[tokio::test]
+    async fn one_shared_frame_is_decryptable_by_owner_and_channel_employee() {
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let employee = Keys::generate();
+        let outsider = Keys::generate();
+        let channel_id = uuid::Uuid::new_v4();
+        let (publisher, mut published_rx) = RelayEventPublisher::test_pair();
+        let frame = observer::ObserverEvent {
+            seq: 1,
+            timestamp: "2026-04-29T04:00:00Z".into(),
+            kind: "acp_read".into(),
+            agent_index: Some(0),
+            channel_id: Some(channel_id.to_string()),
+            session_id: Some("session-1".into()),
+            turn_id: Some("turn-1".into()),
+            started_at: None,
+            payload: serde_json::json!({"marker": "shared"}),
+        };
+
+        publish_relay_observer_event(
+            &publisher,
+            &agent,
+            &agent.public_key().to_hex(),
+            &owner.public_key().to_hex(),
+            vec![owner.public_key(), employee.public_key()],
+            Some(channel_id),
+            frame,
+        )
+        .await;
+        let event = published_rx.recv().await.expect("published observer frame");
+        let tags: Vec<Vec<String>> = event
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+        assert!(tags
+            .iter()
+            .any(|tag| tag == &["p", &owner.public_key().to_hex()]));
+        assert!(tags
+            .iter()
+            .any(|tag| tag == &["p", &employee.public_key().to_hex()]));
+        assert!(tags
+            .iter()
+            .any(|tag| tag == &[OBSERVER_OWNER_TAG, &owner.public_key().to_hex()]));
+        assert!(tags
+            .iter()
+            .any(|tag| tag == &["h", &channel_id.to_string()]));
+        assert!(tags
+            .iter()
+            .any(|tag| tag == &["frame", OBSERVER_FRAME_TELEMETRY]));
+
+        let owner_payload: serde_json::Value =
+            decrypt_observer_payload(&owner, &event).expect("owner decrypts");
+        let employee_payload: serde_json::Value =
+            decrypt_observer_payload(&employee, &event).expect("employee decrypts");
+        assert_eq!(owner_payload["payload"]["marker"], "shared");
+        assert_eq!(employee_payload, owner_payload);
+        assert!(decrypt_observer_payload::<serde_json::Value>(&outsider, &event).is_err());
+    }
+}
+
+#[cfg(test)]
 mod observer_publish_cadence_tests {
     use super::*;
     use nostr::Keys;
@@ -8536,9 +8713,8 @@ mod observer_publish_cadence_tests {
             snapshot,
             rx,
             publisher,
+            None,
             agent_keys.clone(),
-            agent_keys.public_key().to_hex(),
-            owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
         ));
 
@@ -8615,9 +8791,8 @@ mod observer_publish_cadence_tests {
             snapshot,
             rx,
             publisher,
+            None,
             agent_keys.clone(),
-            agent_keys.public_key().to_hex(),
-            owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
         ));
 
@@ -8681,9 +8856,8 @@ mod observer_publish_cadence_tests {
             snapshot,
             rx,
             publisher,
+            None,
             agent_keys.clone(),
-            agent_keys.public_key().to_hex(),
-            owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
         ));
         settle().await;

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -118,10 +118,11 @@ use std::time::Instant;
 
 use buzz_core::kind::{
     KIND_AGENT_OBSERVER_FRAME, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
-    KIND_TYPING_INDICATOR,
+    KIND_NIP29_GROUP_MEMBERS, KIND_NIP43_MEMBERSHIP_LIST, KIND_TYPING_INDICATOR,
 };
+use buzz_core::observer::OBSERVER_MAX_RECIPIENTS;
 use futures_util::{SinkExt, StreamExt};
-use nostr::{Event, EventBuilder, Keys, Kind, RelayUrl, Tag};
+use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, RelayUrl, Tag};
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
@@ -492,6 +493,36 @@ impl RestClient {
             .map_err(|e| RelayError::Http(e.to_string()))
     }
 
+    /// Resolve the direct relay members who may observe one channel's agent work.
+    ///
+    /// The channel's kind-39002 roster supplies the access scope. Intersecting
+    /// it with the kind-13534 relay roster excludes owner-delegated agent keys.
+    /// The controlling owner remains first and always receives the frame.
+    pub async fn shared_observer_recipients(
+        &self,
+        channel_id: Uuid,
+        owner: PublicKey,
+        agent: PublicKey,
+    ) -> Result<Vec<PublicKey>, RelayError> {
+        use nostr::{Alphabet, SingleLetterTag};
+
+        let channel_id = channel_id.to_string();
+        let filters = [
+            nostr::Filter::new()
+                .kind(Kind::Custom(KIND_NIP29_GROUP_MEMBERS as u16))
+                .custom_tags(
+                    SingleLetterTag::lowercase(Alphabet::D),
+                    [channel_id.as_str()],
+                )
+                .limit(1),
+            nostr::Filter::new()
+                .kind(Kind::Custom(KIND_NIP43_MEMBERSHIP_LIST as u16))
+                .limit(1),
+        ];
+        let events = self.query(&filters).await?;
+        resolve_shared_observer_recipients(&events, &channel_id, owner, agent)
+    }
+
     /// Query events via `POST /query` with a raw NIP-01 filter document.
     ///
     /// `nostr::Filter` only encodes single-letter generic tags. Project home
@@ -626,6 +657,95 @@ impl From<nostr::event::builder::Error> for RelayError {
     fn from(e: nostr::event::builder::Error) -> Self {
         RelayError::AuthFailed(e.to_string())
     }
+}
+
+fn json_tag_values<'a>(event: &'a Value, tag_name: &str) -> Result<Vec<&'a str>, RelayError> {
+    let tags = event
+        .get("tags")
+        .and_then(Value::as_array)
+        .ok_or_else(|| RelayError::Http("observer roster event has no tags array".into()))?;
+    let mut values = Vec::new();
+    for tag in tags {
+        let Some(parts) = tag.as_array() else {
+            return Err(RelayError::Http(
+                "observer roster event contains a non-array tag".into(),
+            ));
+        };
+        if parts.first().and_then(Value::as_str) != Some(tag_name) {
+            continue;
+        }
+        let value = parts.get(1).and_then(Value::as_str).ok_or_else(|| {
+            RelayError::Http(format!(
+                "observer roster {tag_name} tag has no string value"
+            ))
+        })?;
+        values.push(value);
+    }
+    Ok(values)
+}
+
+fn resolve_shared_observer_recipients(
+    events: &Value,
+    channel_id: &str,
+    owner: PublicKey,
+    agent: PublicKey,
+) -> Result<Vec<PublicKey>, RelayError> {
+    let events = events
+        .as_array()
+        .ok_or_else(|| RelayError::Http("observer roster query response is not an array".into()))?;
+    let newest = |kind: u32, required_tag: Option<(&str, &str)>| {
+        events
+            .iter()
+            .filter(|event| event.get("kind").and_then(Value::as_u64) == Some(kind as u64))
+            .filter(|event| {
+                let Some((name, value)) = required_tag else {
+                    return true;
+                };
+                json_tag_values(event, name)
+                    .map(|values| values.contains(&value))
+                    .unwrap_or(false)
+            })
+            .max_by_key(|event| event.get("created_at").and_then(Value::as_u64).unwrap_or(0))
+    };
+
+    let channel_roster = newest(KIND_NIP29_GROUP_MEMBERS, Some(("d", channel_id)))
+        .ok_or_else(|| RelayError::Http("channel member roster is unavailable".into()))?;
+    let relay_roster = newest(KIND_NIP43_MEMBERSHIP_LIST, None)
+        .ok_or_else(|| RelayError::Http("relay member roster is unavailable".into()))?;
+
+    let mut direct_members = HashSet::new();
+    for value in json_tag_values(relay_roster, "member")? {
+        let pubkey = PublicKey::from_hex(value)
+            .map_err(|_| RelayError::Http("relay member roster has an invalid pubkey".into()))?;
+        direct_members.insert(pubkey.to_bytes());
+    }
+
+    let owner_bytes = owner.to_bytes();
+    let agent_bytes = agent.to_bytes();
+    let mut employee_pubkeys = Vec::new();
+    let mut seen = HashSet::new();
+    for value in json_tag_values(channel_roster, "p")? {
+        let pubkey = PublicKey::from_hex(value)
+            .map_err(|_| RelayError::Http("channel member roster has an invalid pubkey".into()))?;
+        let bytes = pubkey.to_bytes();
+        if bytes == owner_bytes || bytes == agent_bytes || !direct_members.contains(&bytes) {
+            continue;
+        }
+        if seen.insert(bytes) {
+            employee_pubkeys.push(pubkey);
+        }
+    }
+    employee_pubkeys.sort_by_key(PublicKey::to_hex);
+    if employee_pubkeys.len() + 1 > OBSERVER_MAX_RECIPIENTS {
+        return Err(RelayError::Http(format!(
+            "shared observer audience exceeds {OBSERVER_MAX_RECIPIENTS} recipients"
+        )));
+    }
+
+    let mut recipients = Vec::with_capacity(employee_pubkeys.len() + 1);
+    recipients.push(owner);
+    recipients.extend(employee_pubkeys);
+    Ok(recipients)
 }
 
 /// A parsed NIP-01 relay message.
@@ -4281,6 +4401,63 @@ mod tests {
         (client, requests, server)
     }
 
+    #[test]
+    fn shared_observer_audience_is_channel_members_intersected_with_direct_members() {
+        let owner = Keys::generate().public_key();
+        let employee = Keys::generate().public_key();
+        let delegated_agent = Keys::generate().public_key();
+        let external_guest = Keys::generate().public_key();
+        let employee_outside_channel = Keys::generate().public_key();
+        let channel_id = Uuid::new_v4().to_string();
+        let events = serde_json::json!([
+            {
+                "kind": KIND_NIP29_GROUP_MEMBERS,
+                "created_at": 10,
+                "tags": [
+                    ["d", channel_id],
+                    ["p", owner.to_hex()],
+                    ["p", employee.to_hex()],
+                    ["p", delegated_agent.to_hex()],
+                    ["p", external_guest.to_hex()]
+                ]
+            },
+            {
+                "kind": KIND_NIP43_MEMBERSHIP_LIST,
+                "created_at": 11,
+                "tags": [
+                    ["member", owner.to_hex(), "member"],
+                    ["member", employee.to_hex(), "member"],
+                    ["member", delegated_agent.to_hex(), "agent"],
+                    ["member", employee_outside_channel.to_hex(), "member"]
+                ]
+            }
+        ]);
+
+        let recipients =
+            resolve_shared_observer_recipients(&events, &channel_id, owner, delegated_agent)
+                .expect("resolve shared observer recipients");
+
+        assert_eq!(recipients, vec![owner, employee]);
+    }
+
+    #[test]
+    fn shared_observer_audience_fails_closed_without_direct_member_roster() {
+        let owner = Keys::generate().public_key();
+        let agent = Keys::generate().public_key();
+        let channel_id = Uuid::new_v4().to_string();
+        let events = serde_json::json!([{
+            "kind": KIND_NIP29_GROUP_MEMBERS,
+            "created_at": 10,
+            "tags": [["d", channel_id], ["p", owner.to_hex()]]
+        }]);
+
+        let error = resolve_shared_observer_recipients(&events, &channel_id, owner, agent)
+            .expect_err("missing relay roster must fail closed");
+        assert!(error
+            .to_string()
+            .contains("relay member roster is unavailable"));
+    }
+
     #[tokio::test]
     async fn relay_self_reads_and_normalizes_standard_root_document() {
         let uppercase = "AB".repeat(32);
@@ -6346,10 +6523,12 @@ mod tests {
             &json!({"type": "test"}),
         )
         .expect("encrypt test observer payload");
-        buzz_sdk::build_agent_observer_frame(
-            &recipient.public_key().to_hex(),
+        let recipient_hex = recipient.public_key().to_hex();
+        buzz_sdk::build_agent_observer_telemetry_frame(
+            &recipient_hex,
+            std::slice::from_ref(&recipient_hex),
             &keys.public_key().to_hex(),
-            "telemetry",
+            None,
             &encrypted,
         )
         .expect("build test observer frame")

--- a/crates/buzz-cli/src/agent_management.rs
+++ b/crates/buzz-cli/src/agent_management.rs
@@ -1,6 +1,6 @@
 //! Owner-reviewed agent draft requests published through Buzz observer frames.
 
-use buzz_core::observer::{encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY};
+use buzz_core::observer::encrypt_observer_payload;
 use nostr::{Event, Keys, PublicKey};
 use serde::Serialize;
 
@@ -107,6 +107,8 @@ fn build<T: Serialize>(
     action: &'static str,
     request: T,
 ) -> Result<BuiltDraftRequest, CliError> {
+    let channel_uuid = uuid::Uuid::parse_str(&channel_id)
+        .map_err(|_| CliError::Usage(format!("invalid channel UUID: {channel_id}")))?;
     let request_id = uuid::Uuid::new_v4().to_string();
     let payload = ObserverEvent {
         seq: 0,
@@ -125,10 +127,12 @@ fn build<T: Serialize>(
     };
     let encrypted = encrypt_observer_payload(keys, owner, &payload)
         .map_err(|error| CliError::Other(format!("could not encrypt draft request: {error}")))?;
-    let event = buzz_sdk::build_agent_observer_frame(
-        &owner.to_hex(),
+    let owner_hex = owner.to_hex();
+    let event = buzz_sdk::build_agent_observer_telemetry_frame(
+        &owner_hex,
+        std::slice::from_ref(&owner_hex),
         &keys.public_key().to_hex(),
-        OBSERVER_FRAME_TELEMETRY,
+        Some(channel_uuid),
         &encrypted,
     )
     .map_err(|error| CliError::Other(format!("could not build draft request: {error}")))?
@@ -254,7 +258,9 @@ pub fn build_project_channel(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use buzz_core::observer::{decrypt_observer_payload, OBSERVER_AGENT_TAG, OBSERVER_FRAME_TAG};
+    use buzz_core::observer::{
+        decrypt_observer_payload, OBSERVER_AGENT_TAG, OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY,
+    };
 
     const CHANNEL: &str = "7c07e659-3610-42f4-9a5e-1e9973c09da9";
 
@@ -289,9 +295,7 @@ mod tests {
         assert!(tags
             .iter()
             .any(|tag| tag == &[OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY]));
-        assert!(!tags
-            .iter()
-            .any(|tag| tag.first().map(String::as_str) == Some("h")));
+        assert!(tags.iter().any(|tag| tag == &["h", CHANNEL]));
 
         let payload: serde_json::Value = decrypt_observer_payload(&owner, &built.event).unwrap();
         assert_eq!(payload["kind"], AGENT_REQUEST_KIND);

--- a/crates/buzz-core/src/observer.rs
+++ b/crates/buzz-core/src/observer.rs
@@ -1,16 +1,21 @@
 //! Agent observer frame helpers.
 //!
-//! Observer frames are transient, owner-scoped agent telemetry/control messages.
-//! They use a Buzz ephemeral event kind and carry NIP-44 encrypted JSON in the
-//! event content so relays can route frames without reading ACP internals.
+//! Observer frames are transient encrypted agent telemetry/control messages.
+//! Owner-only frames use direct NIP-44. Shared telemetry encrypts the payload
+//! once to an ephemeral key and NIP-44-wraps that key for each authorized
+//! channel member, so adding viewers does not duplicate the full payload.
 
-use nostr::{nips::nip44, Event, Keys, PublicKey};
-use serde::{de::DeserializeOwned, Serialize};
+use std::collections::HashSet;
+
+use nostr::{nips::nip44, Event, Keys, PublicKey, SecretKey};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::Zeroize;
 
 /// Tag name that identifies the agent pubkey the observer frame belongs to.
 pub const OBSERVER_AGENT_TAG: &str = "agent";
+/// Tag name that identifies the managed agent's controlling owner.
+pub const OBSERVER_OWNER_TAG: &str = "owner";
 /// Tag name that identifies the cleartext frame direction.
 pub const OBSERVER_FRAME_TAG: &str = "frame";
 /// Frame value for agent-to-owner observer telemetry.
@@ -23,6 +28,17 @@ pub const NIP44_MIN_CONTENT_LEN: usize = 132;
 pub const NIP44_MAX_CONTENT_LEN: usize = 87_472;
 /// Maximum observer plaintext JSON size accepted by helpers.
 pub const OBSERVER_MAX_PLAINTEXT_LEN: usize = 65_535;
+/// Maximum recipients carried by one shared observer frame.
+pub const OBSERVER_MAX_RECIPIENTS: usize = 128;
+const OBSERVER_ENVELOPE_VERSION: u8 = 1;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ObserverPayloadEnvelope {
+    version: u8,
+    ciphertext: String,
+    wrapped_keys: Vec<String>,
+}
 
 /// Errors returned by observer payload encryption/decryption helpers.
 #[derive(Debug, Error)]
@@ -51,7 +67,64 @@ pub enum ObserverPayloadError {
 
 /// Returns true when `content` fits the NIP-44 v2 ciphertext length envelope.
 pub fn content_looks_like_nip44(content: &str) -> bool {
-    (NIP44_MIN_CONTENT_LEN..=NIP44_MAX_CONTENT_LEN).contains(&content.len())
+    !content.starts_with('{')
+        && (NIP44_MIN_CONTENT_LEN..=NIP44_MAX_CONTENT_LEN).contains(&content.len())
+}
+
+fn parse_observer_envelope(content: &str) -> Result<ObserverPayloadEnvelope, ObserverPayloadError> {
+    let envelope: ObserverPayloadEnvelope = serde_json::from_str(content)?;
+    if envelope.version != OBSERVER_ENVELOPE_VERSION {
+        return Err(ObserverPayloadError::InvalidPayload(format!(
+            "unsupported observer envelope version {}",
+            envelope.version
+        )));
+    }
+    if envelope.wrapped_keys.is_empty() || envelope.wrapped_keys.len() > OBSERVER_MAX_RECIPIENTS {
+        return Err(ObserverPayloadError::InvalidPayload(format!(
+            "observer envelope must carry 1..={OBSERVER_MAX_RECIPIENTS} wrapped keys"
+        )));
+    }
+    if !content_looks_like_nip44(&envelope.ciphertext)
+        || envelope
+            .wrapped_keys
+            .iter()
+            .any(|wrapped| !content_looks_like_nip44(wrapped))
+    {
+        return Err(ObserverPayloadError::InvalidPayload(
+            "observer envelope contains invalid NIP-44 ciphertext".into(),
+        ));
+    }
+    Ok(envelope)
+}
+
+/// Return how many recipients an encrypted observer payload targets.
+///
+/// Direct NIP-44 payloads target one recipient. Shared envelopes carry one
+/// wrapped content key per ordered `p` tag.
+pub fn observer_payload_recipient_count(content: &str) -> Result<usize, ObserverPayloadError> {
+    if content.starts_with('{') {
+        return Ok(parse_observer_envelope(content)?.wrapped_keys.len());
+    }
+    if content_looks_like_nip44(content) {
+        return Ok(1);
+    }
+    Err(ObserverPayloadError::InvalidCiphertextLength(content.len()))
+}
+
+/// Returns true for either direct NIP-44 or a valid shared observer envelope.
+pub fn content_looks_like_observer_payload(content: &str) -> bool {
+    observer_payload_recipient_count(content).is_ok()
+}
+
+fn serialize_observer_payload<T: Serialize>(payload: &T) -> Result<String, ObserverPayloadError> {
+    let plaintext = serde_json::to_string(payload)?;
+    if plaintext.len() > OBSERVER_MAX_PLAINTEXT_LEN {
+        return Err(ObserverPayloadError::PlaintextTooLarge {
+            max: OBSERVER_MAX_PLAINTEXT_LEN,
+            got: plaintext.len(),
+        });
+    }
+    Ok(plaintext)
 }
 
 /// Serialize and NIP-44 encrypt an observer payload for `recipient`.
@@ -60,42 +133,81 @@ pub fn encrypt_observer_payload<T: Serialize>(
     recipient: &PublicKey,
     payload: &T,
 ) -> Result<String, ObserverPayloadError> {
-    let mut plaintext = serde_json::to_string(payload)?;
-    if plaintext.len() > OBSERVER_MAX_PLAINTEXT_LEN {
-        let got = plaintext.len();
-        plaintext.zeroize();
-        return Err(ObserverPayloadError::PlaintextTooLarge {
-            max: OBSERVER_MAX_PLAINTEXT_LEN,
-            got,
-        });
-    }
-
+    let mut plaintext = serialize_observer_payload(payload)?;
     let encrypted = nip44::encrypt(
         sender_keys.secret_key(),
         recipient,
         &plaintext,
         nip44::Version::V2,
-    )?;
+    );
     plaintext.zeroize();
-    Ok(encrypted)
+    Ok(encrypted?)
 }
 
-/// NIP-44 decrypt and deserialize an observer payload from `event`.
-pub fn decrypt_observer_payload<T: DeserializeOwned>(
-    recipient_keys: &Keys,
-    event: &Event,
-) -> Result<T, ObserverPayloadError> {
-    if !content_looks_like_nip44(&event.content) {
-        return Err(ObserverPayloadError::InvalidCiphertextLength(
-            event.content.len(),
+/// Encrypt one observer payload for multiple ordered recipients.
+///
+/// The payload is encrypted once to a fresh ephemeral key. That key is then
+/// NIP-44 encrypted independently for each recipient, in the same order as the
+/// frame's `p` tags.
+pub fn encrypt_observer_payload_for_recipients<T: Serialize>(
+    sender_keys: &Keys,
+    recipients: &[PublicKey],
+    payload: &T,
+) -> Result<String, ObserverPayloadError> {
+    if recipients.is_empty() || recipients.len() > OBSERVER_MAX_RECIPIENTS {
+        return Err(ObserverPayloadError::InvalidPayload(format!(
+            "observer recipient count must be 1..={OBSERVER_MAX_RECIPIENTS}"
+        )));
+    }
+    let mut seen = HashSet::with_capacity(recipients.len());
+    if recipients
+        .iter()
+        .any(|recipient| !seen.insert(recipient.to_bytes()))
+    {
+        return Err(ObserverPayloadError::InvalidPayload(
+            "observer recipients must be unique".into(),
         ));
     }
 
-    let mut plaintext = nip44::decrypt(
-        recipient_keys.secret_key(),
-        &event.pubkey,
-        event.content.as_str(),
-    )?;
+    let mut plaintext = serialize_observer_payload(payload)?;
+    let ephemeral_keys = Keys::generate();
+    let ciphertext = nip44::encrypt(
+        sender_keys.secret_key(),
+        &ephemeral_keys.public_key(),
+        &plaintext,
+        nip44::Version::V2,
+    );
+    plaintext.zeroize();
+    let ciphertext = ciphertext?;
+
+    let mut ephemeral_secret = ephemeral_keys.secret_key().to_secret_hex();
+    let mut wrapped_keys = Vec::with_capacity(recipients.len());
+    for recipient in recipients {
+        match nip44::encrypt(
+            sender_keys.secret_key(),
+            recipient,
+            &ephemeral_secret,
+            nip44::Version::V2,
+        ) {
+            Ok(wrapped) => wrapped_keys.push(wrapped),
+            Err(error) => {
+                ephemeral_secret.zeroize();
+                return Err(error.into());
+            }
+        }
+    }
+    ephemeral_secret.zeroize();
+
+    Ok(serde_json::to_string(&ObserverPayloadEnvelope {
+        version: OBSERVER_ENVELOPE_VERSION,
+        ciphertext,
+        wrapped_keys,
+    })?)
+}
+
+fn deserialize_observer_plaintext<T: DeserializeOwned>(
+    mut plaintext: String,
+) -> Result<T, ObserverPayloadError> {
     if plaintext.len() > OBSERVER_MAX_PLAINTEXT_LEN {
         let got = plaintext.len();
         plaintext.zeroize();
@@ -104,10 +216,91 @@ pub fn decrypt_observer_payload<T: DeserializeOwned>(
             got,
         });
     }
-
     let result = serde_json::from_str(&plaintext);
     plaintext.zeroize();
     Ok(result?)
+}
+
+/// NIP-44 decrypt and deserialize a direct or shared observer payload.
+pub fn decrypt_observer_payload<T: DeserializeOwned>(
+    recipient_keys: &Keys,
+    event: &Event,
+) -> Result<T, ObserverPayloadError> {
+    if event.content.starts_with('{') {
+        return decrypt_shared_observer_payload(recipient_keys, event);
+    }
+    if !content_looks_like_nip44(&event.content) {
+        return Err(ObserverPayloadError::InvalidCiphertextLength(
+            event.content.len(),
+        ));
+    }
+    let plaintext = nip44::decrypt(
+        recipient_keys.secret_key(),
+        &event.pubkey,
+        event.content.as_str(),
+    )?;
+    deserialize_observer_plaintext(plaintext)
+}
+
+fn decrypt_shared_observer_payload<T: DeserializeOwned>(
+    recipient_keys: &Keys,
+    event: &Event,
+) -> Result<T, ObserverPayloadError> {
+    let envelope = parse_observer_envelope(&event.content)?;
+    let recipient_hex = recipient_keys.public_key().to_hex();
+    let mut recipient_index = None;
+    let mut p_count = 0usize;
+    for tag in event.tags.iter() {
+        let values = tag.as_slice();
+        if values.first().map(String::as_str) != Some("p") {
+            continue;
+        }
+        p_count += 1;
+        let tagged = values.get(1).ok_or_else(|| {
+            ObserverPayloadError::InvalidPayload("observer frame has an empty p tag".into())
+        })?;
+        PublicKey::from_hex(tagged).map_err(|_| {
+            ObserverPayloadError::InvalidPayload(
+                "observer frame p tag must contain a hex pubkey".into(),
+            )
+        })?;
+        if tagged.eq_ignore_ascii_case(&recipient_hex)
+            && recipient_index.replace(p_count - 1).is_some()
+        {
+            return Err(ObserverPayloadError::InvalidPayload(
+                "observer frame repeats the recipient p tag".into(),
+            ));
+        }
+    }
+    if p_count != envelope.wrapped_keys.len() {
+        return Err(ObserverPayloadError::InvalidPayload(
+            "observer p-tag count does not match wrapped-key count".into(),
+        ));
+    }
+    let index = recipient_index.ok_or_else(|| {
+        ObserverPayloadError::InvalidPayload(
+            "observer frame has no wrapped key for this recipient".into(),
+        )
+    })?;
+
+    let mut ephemeral_secret = nip44::decrypt(
+        recipient_keys.secret_key(),
+        &event.pubkey,
+        &envelope.wrapped_keys[index],
+    )?;
+    let parsed_secret = SecretKey::from_hex(&ephemeral_secret).map_err(|_| {
+        ObserverPayloadError::InvalidPayload(
+            "observer envelope wrapped an invalid content key".into(),
+        )
+    });
+    ephemeral_secret.zeroize();
+    let ephemeral_keys = Keys::new(parsed_secret?);
+    let plaintext = nip44::decrypt(
+        ephemeral_keys.secret_key(),
+        &event.pubkey,
+        &envelope.ciphertext,
+    )?;
+    deserialize_observer_plaintext(plaintext)
 }
 
 #[cfg(test)]
@@ -137,6 +330,90 @@ mod tests {
         let decrypted: serde_json::Value =
             decrypt_observer_payload(&recipient, &event).expect("decrypt payload");
         assert_eq!(decrypted, payload);
+    }
+
+    #[test]
+    fn shared_observer_payload_round_trips_for_each_recipient() {
+        let sender = Keys::generate();
+        let first = Keys::generate();
+        let second = Keys::generate();
+        let outsider = Keys::generate();
+        let recipients = [first.public_key(), second.public_key()];
+        let payload = serde_json::json!({
+            "type": "tool_call",
+            "channelId": "0dd6ba71-0304-4e50-8100-4e9d1224ebd1"
+        });
+        let encrypted = encrypt_observer_payload_for_recipients(&sender, &recipients, &payload)
+            .expect("encrypt shared payload");
+        assert!(!content_looks_like_nip44(&encrypted));
+        assert!(content_looks_like_observer_payload(&encrypted));
+        assert_eq!(
+            observer_payload_recipient_count(&encrypted).expect("recipient count"),
+            2
+        );
+
+        let event = EventBuilder::new(
+            Kind::Custom(crate::kind::KIND_AGENT_OBSERVER_FRAME as u16),
+            encrypted,
+        )
+        .tags([
+            Tag::public_key(first.public_key()),
+            Tag::public_key(second.public_key()),
+        ])
+        .sign_with_keys(&sender)
+        .expect("sign event");
+
+        for recipient in [&first, &second] {
+            let decrypted: serde_json::Value =
+                decrypt_observer_payload(recipient, &event).expect("decrypt shared payload");
+            assert_eq!(decrypted, payload);
+        }
+        assert!(matches!(
+            decrypt_observer_payload::<serde_json::Value>(&outsider, &event),
+            Err(ObserverPayloadError::InvalidPayload(message))
+                if message.contains("no wrapped key")
+        ));
+    }
+
+    #[test]
+    fn shared_observer_payload_binds_wrapped_keys_to_ordered_p_tags() {
+        let sender = Keys::generate();
+        let first = Keys::generate();
+        let second = Keys::generate();
+        let encrypted = encrypt_observer_payload_for_recipients(
+            &sender,
+            &[first.public_key(), second.public_key()],
+            &serde_json::json!({"type": "turn_started"}),
+        )
+        .expect("encrypt shared payload");
+        let event = EventBuilder::new(
+            Kind::Custom(crate::kind::KIND_AGENT_OBSERVER_FRAME as u16),
+            encrypted,
+        )
+        .tags([
+            Tag::public_key(second.public_key()),
+            Tag::public_key(first.public_key()),
+        ])
+        .sign_with_keys(&sender)
+        .expect("sign event");
+
+        assert!(decrypt_observer_payload::<serde_json::Value>(&first, &event).is_err());
+        assert!(decrypt_observer_payload::<serde_json::Value>(&second, &event).is_err());
+    }
+
+    #[test]
+    fn shared_observer_payload_rejects_duplicate_recipients() {
+        let sender = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        assert!(matches!(
+            encrypt_observer_payload_for_recipients(
+                &sender,
+                &[recipient, recipient],
+                &serde_json::json!({"type": "turn_started"}),
+            ),
+            Err(ObserverPayloadError::InvalidPayload(message))
+                if message.contains("unique")
+        ));
     }
 
     #[test]

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -1,6 +1,9 @@
 //! EVENT handler — WS dispatcher → ingest pipeline → fan-out.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use axum::body::Bytes;
 use tracing::{debug, error, info, warn};
@@ -11,8 +14,9 @@ use buzz_core::kind::{
     KIND_AGENT_OBSERVER_FRAME, KIND_GIFT_WRAP, KIND_PRESENCE_UPDATE,
 };
 use buzz_core::observer::{
-    content_looks_like_nip44, OBSERVER_AGENT_TAG, OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG,
-    OBSERVER_FRAME_TELEMETRY,
+    content_looks_like_nip44, observer_payload_recipient_count, OBSERVER_AGENT_TAG,
+    OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY, OBSERVER_MAX_RECIPIENTS,
+    OBSERVER_OWNER_TAG,
 };
 use buzz_core::tenant::TenantContext;
 use buzz_core::verification::verify_event;
@@ -173,6 +177,43 @@ pub async fn filter_fanout_by_access(
     } else {
         matches
     };
+
+    // Observer telemetry stays globally indexed by p-tag so the desktop can
+    // keep one identity subscription. Shared frames still re-check channel
+    // membership at this final send chokepoint, including Redis cross-node
+    // delivery, so a stale subscription cannot outlive channel removal.
+    if event_kind_u32(&stored_event.event) == KIND_AGENT_OBSERVER_FRAME {
+        let route = match agent_observer_route(&stored_event.event) {
+            Ok(Some(route)) => route,
+            _ => return Vec::new(),
+        };
+        if route.direction == AgentObserverDirection::Telemetry && route.recipients.len() > 1 {
+            let Some(channel_id) = route.channel_id else {
+                return Vec::new();
+            };
+            let mut allowed = Vec::with_capacity(matches.len());
+            for (conn_id, sub_id) in matches {
+                let Some(pubkey) = state.conn_manager.pubkey_for_conn(conn_id) else {
+                    continue;
+                };
+                if pubkey == route.owner.to_bytes() {
+                    allowed.push((conn_id, sub_id));
+                    continue;
+                }
+                match state
+                    .is_member_cached(community_id, channel_id, &pubkey)
+                    .await
+                {
+                    Ok(true) => allowed.push((conn_id, sub_id)),
+                    Ok(false) => {}
+                    Err(error) => {
+                        warn!(%channel_id, "observer fan-out membership check failed: {error}");
+                    }
+                }
+            }
+            return allowed;
+        }
+    }
 
     let Some(channel_id) = stored_event.channel_id else {
         return matches;
@@ -911,10 +952,12 @@ enum AgentObserverDirection {
     Control,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct AgentObserverRoute {
     agent: PublicKey,
     owner: PublicKey,
+    recipients: Vec<PublicKey>,
+    channel_id: Option<uuid::Uuid>,
     direction: AgentObserverDirection,
 }
 
@@ -1060,6 +1103,83 @@ async fn handle_agent_observer_event(
         return;
     }
 
+    if route.direction == AgentObserverDirection::Telemetry && route.recipients.len() > 1 {
+        let channel_id = route
+            .channel_id
+            .expect("shared observer route must include a channel");
+        for recipient in route
+            .recipients
+            .iter()
+            .filter(|recipient| **recipient != route.owner)
+        {
+            match state
+                .is_member_cached(conn.tenant.community(), channel_id, &recipient.to_bytes())
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    reject("auth");
+                    conn.send(RelayMessage::ok(
+                        event_id_hex,
+                        false,
+                        "restricted: observer recipient is not a channel member",
+                    ));
+                    return;
+                }
+                Err(error) => {
+                    warn!(
+                        conn_id = %conn_id,
+                        event_id = %event_id_hex,
+                        %channel_id,
+                        "observer recipient membership check failed: {error}"
+                    );
+                    conn.send(RelayMessage::ok(
+                        event_id_hex,
+                        false,
+                        "error: internal server error",
+                    ));
+                    return;
+                }
+            }
+        }
+    }
+
+    if route.direction == AgentObserverDirection::Telemetry && route.recipients.len() > 1 {
+        let relay_members = match state.db.list_relay_members(conn.tenant.community()).await {
+            Ok(members) => members
+                .into_iter()
+                .map(|member| member.pubkey)
+                .collect::<HashSet<_>>(),
+            Err(error) => {
+                warn!(
+                    conn_id = %conn_id,
+                    event_id = %event_id_hex,
+                    "observer relay membership check failed: {error}"
+                );
+                conn.send(RelayMessage::ok(
+                    event_id_hex,
+                    false,
+                    "error: internal server error",
+                ));
+                return;
+            }
+        };
+        if route
+            .recipients
+            .iter()
+            .filter(|recipient| **recipient != route.owner)
+            .any(|recipient| !relay_members.contains(&recipient.to_hex()))
+        {
+            reject("auth");
+            conn.send(RelayMessage::ok(
+                event_id_hex,
+                false,
+                "restricted: observer recipient is not a direct relay member",
+            ));
+            return;
+        }
+    }
+
     // Rate limit telemetry frames only (100/sec per agent).
     // Control frames (owner → agent) bypass the limiter — they are rare and must not
     // be starved by bursty telemetry from the agent.
@@ -1101,21 +1221,57 @@ async fn handle_agent_observer_event(
 }
 
 fn agent_observer_route(event: &Event) -> Result<Option<AgentObserverRoute>, String> {
-    if !content_looks_like_nip44(&event.content) {
-        return Err("invalid: observer content must be NIP-44 encrypted".into());
-    }
-
-    let recipient = parse_single_pubkey_tag(event, "p")?;
+    let recipients = parse_pubkey_tags(event, "p")?;
     let agent = parse_single_pubkey_tag(event, OBSERVER_AGENT_TAG)?;
     let frame = single_tag_content(event, OBSERVER_FRAME_TAG)?;
+    let owner_tag = optional_single_tag_content(event, OBSERVER_OWNER_TAG)?
+        .map(|value| {
+            PublicKey::from_hex(value)
+                .map_err(|_| "invalid: observer owner tag must be a hex pubkey".to_string())
+        })
+        .transpose()?;
+    let channel_id = optional_single_tag_content(event, "h")?
+        .map(|value| {
+            uuid::Uuid::parse_str(value)
+                .map_err(|_| "invalid: observer h tag must be a channel UUID".to_string())
+        })
+        .transpose()?;
 
-    let (owner, direction, expected_frame) = if event.pubkey == agent && recipient != agent {
+    let payload_recipients = observer_payload_recipient_count(&event.content)
+        .map_err(|error| format!("invalid: observer content must be NIP-44 encrypted: {error}"))?;
+    if payload_recipients != recipients.len() {
+        return Err("invalid: observer recipient tags do not match encrypted payload".into());
+    }
+
+    let (owner, direction, expected_frame) = if event.pubkey == agent {
+        if recipients.contains(&agent) {
+            return Err("invalid: observer telemetry cannot target the agent".into());
+        }
+        let owner = match owner_tag {
+            Some(owner) => owner,
+            None if recipients.len() == 1 => recipients[0],
+            None => {
+                return Err("invalid: shared observer telemetry requires an owner tag".into());
+            }
+        };
+        if !recipients.contains(&owner) {
+            return Err("invalid: observer owner must be a recipient".into());
+        }
+        if recipients.len() > 1 && channel_id.is_none() {
+            return Err("invalid: shared observer telemetry requires an h tag".into());
+        }
         (
-            recipient,
+            owner,
             AgentObserverDirection::Telemetry,
             OBSERVER_FRAME_TELEMETRY,
         )
-    } else if recipient == agent && event.pubkey != agent {
+    } else if recipients.len() == 1 && recipients[0] == agent {
+        if !content_looks_like_nip44(&event.content) {
+            return Err("invalid: observer control content must be direct NIP-44".into());
+        }
+        if owner_tag.is_some_and(|owner| owner != event.pubkey) {
+            return Err("invalid: observer control owner tag must match its author".into());
+        }
         (
             event.pubkey,
             AgentObserverDirection::Control,
@@ -1123,7 +1279,7 @@ fn agent_observer_route(event: &Event) -> Result<Option<AgentObserverRoute>, Str
         )
     } else {
         return Err(
-            "invalid: observer frame must be agent-to-owner telemetry or owner-to-agent control"
+            "invalid: observer frame must be agent-to-viewer telemetry or owner-to-agent control"
                 .into(),
         );
     };
@@ -1136,8 +1292,42 @@ fn agent_observer_route(event: &Event) -> Result<Option<AgentObserverRoute>, Str
     Ok(Some(AgentObserverRoute {
         agent,
         owner,
+        recipients,
+        channel_id,
         direction,
     }))
+}
+
+fn parse_pubkey_tags(event: &Event, tag_name: &str) -> Result<Vec<PublicKey>, String> {
+    let values: Vec<&str> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.kind().to_string() == tag_name)
+        .filter_map(|tag| tag.content())
+        .collect();
+    if values.is_empty() {
+        return Err(format!("invalid: observer frame missing {tag_name} tag"));
+    }
+    if values.len() > OBSERVER_MAX_RECIPIENTS {
+        return Err(format!(
+            "invalid: observer frame exceeds {OBSERVER_MAX_RECIPIENTS} recipients"
+        ));
+    }
+
+    let mut seen = HashSet::with_capacity(values.len());
+    values
+        .into_iter()
+        .map(|value| {
+            let pubkey = PublicKey::from_hex(value)
+                .map_err(|_| format!("invalid: observer {tag_name} tag must be a hex pubkey"))?;
+            if !seen.insert(pubkey.to_bytes()) {
+                return Err(format!(
+                    "invalid: observer frame has duplicate {tag_name} tags"
+                ));
+            }
+            Ok(pubkey)
+        })
+        .collect()
 }
 
 fn parse_single_pubkey_tag(event: &Event, tag_name: &str) -> Result<PublicKey, String> {
@@ -1146,21 +1336,27 @@ fn parse_single_pubkey_tag(event: &Event, tag_name: &str) -> Result<PublicKey, S
         .map_err(|_| format!("invalid: observer {tag_name} tag must be a hex pubkey"))
 }
 
-fn single_tag_content<'a>(event: &'a Event, tag_name: &str) -> Result<&'a str, String> {
+fn optional_single_tag_content<'a>(
+    event: &'a Event,
+    tag_name: &str,
+) -> Result<Option<&'a str>, String> {
     let mut values = event
         .tags
         .iter()
         .filter(|tag| tag.kind().to_string() == tag_name)
         .filter_map(|tag| tag.content());
-    let Some(value) = values.next() else {
-        return Err(format!("invalid: observer frame missing {tag_name} tag"));
-    };
+    let value = values.next();
     if values.next().is_some() {
         return Err(format!(
             "invalid: observer frame has multiple {tag_name} tags"
         ));
     }
     Ok(value)
+}
+
+fn single_tag_content<'a>(event: &'a Event, tag_name: &str) -> Result<&'a str, String> {
+    optional_single_tag_content(event, tag_name)?
+        .ok_or_else(|| format!("invalid: observer frame missing {tag_name} tag"))
 }
 
 #[cfg(test)]
@@ -1174,8 +1370,8 @@ mod tests {
         KIND_FORUM_VOTE, KIND_PRESENCE_UPDATE, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_DIFF,
     };
     use buzz_core::observer::{
-        encrypt_observer_payload, OBSERVER_AGENT_TAG, OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG,
-        OBSERVER_FRAME_TELEMETRY,
+        encrypt_observer_payload, encrypt_observer_payload_for_recipients, OBSERVER_AGENT_TAG,
+        OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY, OBSERVER_OWNER_TAG,
     };
     use nostr::{EventBuilder, Keys, Kind, Tag};
     use tokio::sync::{mpsc, Mutex, RwLock};
@@ -1272,6 +1468,95 @@ mod tests {
         assert_eq!(route.agent, agent.public_key());
         assert_eq!(route.owner, owner.public_key());
         assert_eq!(route.direction, super::AgentObserverDirection::Telemetry);
+    }
+
+    #[test]
+    fn agent_observer_route_accepts_channel_scoped_shared_telemetry() {
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let employee = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let recipients = [owner.public_key(), employee.public_key()];
+        let encrypted = encrypt_observer_payload_for_recipients(
+            &agent,
+            &recipients,
+            &serde_json::json!({"type": "acp_read"}),
+        )
+        .expect("encrypt shared observer payload");
+        let event = EventBuilder::new(Kind::Custom(KIND_AGENT_OBSERVER_FRAME as u16), encrypted)
+            .tags([
+                Tag::parse(["p", &owner.public_key().to_hex()]).expect("owner p tag"),
+                Tag::parse(["p", &employee.public_key().to_hex()]).expect("employee p tag"),
+                Tag::parse([OBSERVER_OWNER_TAG, &owner.public_key().to_hex()]).expect("owner tag"),
+                Tag::parse([OBSERVER_AGENT_TAG, &agent.public_key().to_hex()]).expect("agent tag"),
+                Tag::parse([OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY]).expect("frame tag"),
+                Tag::parse(["h", &channel_id.to_string()]).expect("channel tag"),
+            ])
+            .sign_with_keys(&agent)
+            .expect("sign event");
+
+        let route = super::agent_observer_route(&event)
+            .expect("observer route")
+            .expect("route should be Some");
+        assert_eq!(route.agent, agent.public_key());
+        assert_eq!(route.owner, owner.public_key());
+        assert_eq!(route.recipients, recipients);
+        assert_eq!(route.channel_id, Some(channel_id));
+        assert_eq!(route.direction, super::AgentObserverDirection::Telemetry);
+    }
+
+    #[test]
+    fn agent_observer_route_rejects_shared_telemetry_without_channel() {
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let employee = Keys::generate();
+        let recipients = [owner.public_key(), employee.public_key()];
+        let encrypted = encrypt_observer_payload_for_recipients(
+            &agent,
+            &recipients,
+            &serde_json::json!({"type": "acp_read"}),
+        )
+        .expect("encrypt shared observer payload");
+        let event = EventBuilder::new(Kind::Custom(KIND_AGENT_OBSERVER_FRAME as u16), encrypted)
+            .tags([
+                Tag::parse(["p", &owner.public_key().to_hex()]).expect("owner p tag"),
+                Tag::parse(["p", &employee.public_key().to_hex()]).expect("employee p tag"),
+                Tag::parse([OBSERVER_OWNER_TAG, &owner.public_key().to_hex()]).expect("owner tag"),
+                Tag::parse([OBSERVER_AGENT_TAG, &agent.public_key().to_hex()]).expect("agent tag"),
+                Tag::parse([OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY]).expect("frame tag"),
+            ])
+            .sign_with_keys(&agent)
+            .expect("sign event");
+
+        let error = super::agent_observer_route(&event).expect_err("missing h must fail");
+        assert!(error.contains("requires an h tag"));
+    }
+
+    #[test]
+    fn agent_observer_route_rejects_recipient_envelope_mismatch() {
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let employee = Keys::generate();
+        let recipients = [owner.public_key(), employee.public_key()];
+        let encrypted = encrypt_observer_payload_for_recipients(
+            &agent,
+            &recipients,
+            &serde_json::json!({"type": "acp_read"}),
+        )
+        .expect("encrypt shared observer payload");
+        let event = EventBuilder::new(Kind::Custom(KIND_AGENT_OBSERVER_FRAME as u16), encrypted)
+            .tags([
+                Tag::parse(["p", &owner.public_key().to_hex()]).expect("owner p tag"),
+                Tag::parse([OBSERVER_OWNER_TAG, &owner.public_key().to_hex()]).expect("owner tag"),
+                Tag::parse([OBSERVER_AGENT_TAG, &agent.public_key().to_hex()]).expect("agent tag"),
+                Tag::parse([OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY]).expect("frame tag"),
+                Tag::parse(["h", &Uuid::new_v4().to_string()]).expect("channel tag"),
+            ])
+            .sign_with_keys(&agent)
+            .expect("sign event");
+
+        let error = super::agent_observer_route(&event).expect_err("mismatch must fail");
+        assert!(error.contains("do not match encrypted payload"));
     }
 
     #[test]
@@ -1432,6 +1717,95 @@ mod tests {
         assert_eq!(
             frame[3],
             "restricted: observer frame is not authorized for this agent owner"
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_observer_publish_rejects_non_member_recipient() {
+        let state = fanout_access::test_state().await;
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let non_member = Keys::generate();
+        let community_id = buzz_core::CommunityId::from_uuid(Uuid::new_v4());
+        let channel_id = Uuid::new_v4();
+        let recipients = [owner.public_key(), non_member.public_key()];
+        state.observer_owner_cache.insert(
+            (
+                community_id,
+                agent.public_key().to_bytes().to_vec(),
+                owner.public_key().to_bytes().to_vec(),
+            ),
+            true,
+        );
+        state.membership_cache.insert(
+            (
+                community_id,
+                channel_id,
+                non_member.public_key().to_bytes().to_vec(),
+            ),
+            false,
+        );
+        let encrypted = encrypt_observer_payload_for_recipients(
+            &agent,
+            &recipients,
+            &serde_json::json!({"channelId": channel_id}),
+        )
+        .expect("encrypt shared observer payload");
+        let event = EventBuilder::new(Kind::Custom(KIND_AGENT_OBSERVER_FRAME as u16), encrypted)
+            .tags([
+                Tag::parse(["p", &owner.public_key().to_hex()]).expect("owner p tag"),
+                Tag::parse(["p", &non_member.public_key().to_hex()]).expect("non-member p tag"),
+                Tag::parse([OBSERVER_OWNER_TAG, &owner.public_key().to_hex()]).expect("owner tag"),
+                Tag::parse([OBSERVER_AGENT_TAG, &agent.public_key().to_hex()]).expect("agent tag"),
+                Tag::parse([OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY]).expect("frame tag"),
+                Tag::parse(["h", &channel_id.to_string()]).expect("channel tag"),
+            ])
+            .sign_with_keys(&agent)
+            .expect("sign observer event");
+
+        let (send_tx, mut send_rx) = mpsc::channel(1);
+        let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
+        let conn = Arc::new(crate::connection::ConnectionState {
+            conn_id: Uuid::new_v4(),
+            tenant: buzz_core::TenantContext::resolved(community_id, "relay.example"),
+            remote_addr: "127.0.0.1:1234".parse().expect("socket addr"),
+            auth_state: RwLock::new(crate::connection::AuthState::Authenticated(
+                buzz_auth::AuthContext {
+                    pubkey: agent.public_key(),
+                    scopes: vec![],
+                    channel_ids: None,
+                    auth_method: buzz_auth::AuthMethod::Nip42,
+                    agent_owner_pubkey: None,
+                },
+            )),
+            subscriptions: Arc::new(Mutex::new(HashMap::new())),
+            send_tx,
+            ctrl_tx,
+            cancel: CancellationToken::new(),
+            backpressure_count: Arc::new(AtomicU8::new(0)),
+            grace_limit: 3,
+        });
+
+        super::handle_agent_observer_event(
+            event.clone(),
+            conn.conn_id,
+            &event.id.to_hex(),
+            conn,
+            state,
+        )
+        .await;
+
+        let axum::extract::ws::Message::Text(text) =
+            send_rx.try_recv().expect("observer rejection sent")
+        else {
+            panic!("expected text relay message");
+        };
+        let frame: serde_json::Value = serde_json::from_str(&text).expect("relay frame JSON");
+        assert_eq!(frame[0], "OK");
+        assert_eq!(frame[2], false);
+        assert_eq!(
+            frame[3],
+            "restricted: observer recipient is not a channel member"
         );
     }
 
@@ -1996,7 +2370,7 @@ mod tests {
         use std::sync::Arc;
 
         use buzz_core::StoredEvent;
-        use nostr::{EventBuilder, Keys, Kind};
+        use nostr::{EventBuilder, Keys, Kind, Tag};
         use tokio::sync::{mpsc, Mutex};
         use tokio_util::sync::CancellationToken;
         use uuid::Uuid;
@@ -2126,6 +2500,89 @@ mod tests {
                 .sign_with_keys(&Keys::generate())
                 .expect("sign event");
             StoredEvent::new(event, channel_id)
+        }
+
+        fn shared_observer_event(
+            channel_id: Uuid,
+            agent: &Keys,
+            owner: &Keys,
+            employee: &Keys,
+        ) -> StoredEvent {
+            let recipients = [owner.public_key(), employee.public_key()];
+            let encrypted = buzz_core::observer::encrypt_observer_payload_for_recipients(
+                agent,
+                &recipients,
+                &serde_json::json!({"channelId": channel_id}),
+            )
+            .expect("encrypt shared observer payload");
+            let event = EventBuilder::new(
+                Kind::Custom(buzz_core::kind::KIND_AGENT_OBSERVER_FRAME as u16),
+                encrypted,
+            )
+            .tags([
+                Tag::parse(["p", &owner.public_key().to_hex()]).expect("owner p tag"),
+                Tag::parse(["p", &employee.public_key().to_hex()]).expect("employee p tag"),
+                Tag::parse([
+                    buzz_core::observer::OBSERVER_OWNER_TAG,
+                    &owner.public_key().to_hex(),
+                ])
+                .expect("owner tag"),
+                Tag::parse([
+                    buzz_core::observer::OBSERVER_AGENT_TAG,
+                    &agent.public_key().to_hex(),
+                ])
+                .expect("agent tag"),
+                Tag::parse([
+                    buzz_core::observer::OBSERVER_FRAME_TAG,
+                    buzz_core::observer::OBSERVER_FRAME_TELEMETRY,
+                ])
+                .expect("frame tag"),
+                Tag::parse(["h", &channel_id.to_string()]).expect("channel tag"),
+            ])
+            .sign_with_keys(agent)
+            .expect("sign observer frame");
+            StoredEvent::new(event, None)
+        }
+
+        #[tokio::test]
+        async fn shared_observer_fanout_keeps_owner_and_current_channel_member_only() {
+            let state = test_state().await;
+            let channel_id = Uuid::new_v4();
+            let community_id = buzz_core::tenant::CommunityId::from_uuid(Uuid::nil());
+            let agent = Keys::generate();
+            let owner = Keys::generate();
+            let employee = Keys::generate();
+            let former_member = Keys::generate();
+            let employee_bytes = employee.public_key().to_bytes().to_vec();
+            let former_member_bytes = former_member.public_key().to_bytes().to_vec();
+            state
+                .membership_cache
+                .insert((community_id, channel_id, employee_bytes.clone()), true);
+            state.membership_cache.insert(
+                (community_id, channel_id, former_member_bytes.clone()),
+                false,
+            );
+
+            let owner_conn = register_conn(&state, Some(owner.public_key().to_bytes().to_vec()));
+            let employee_conn = register_conn(&state, Some(employee_bytes));
+            let former_member_conn = register_conn(&state, Some(former_member_bytes));
+            let matches = vec![
+                (owner_conn, "owner".to_string()),
+                (employee_conn, "employee".to_string()),
+                (former_member_conn, "former".to_string()),
+            ];
+            let event = shared_observer_event(channel_id, &agent, &owner, &employee);
+
+            let allowed =
+                filter_fanout_by_access(&state, community_id, &event, matches, None).await;
+
+            assert_eq!(
+                allowed,
+                vec![
+                    (owner_conn, "owner".to_string()),
+                    (employee_conn, "employee".to_string()),
+                ]
+            );
         }
 
         #[tokio::test]

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -15,8 +15,9 @@ use buzz_core::{
         KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
     },
     observer::{
-        content_looks_like_nip44, OBSERVER_AGENT_TAG, OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG,
-        OBSERVER_FRAME_TELEMETRY,
+        content_looks_like_nip44, content_looks_like_observer_payload,
+        observer_payload_recipient_count, OBSERVER_AGENT_TAG, OBSERVER_FRAME_CONTROL,
+        OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY, OBSERVER_MAX_RECIPIENTS, OBSERVER_OWNER_TAG,
     },
 };
 use nostr::{EventBuilder, Kind, Tag};
@@ -244,34 +245,111 @@ pub fn build_message(
         .allow_self_tagging())
 }
 
-/// Build an encrypted agent observer frame (kind 24200).
+/// Build encrypted agent-to-viewer observer telemetry (kind 24200).
 ///
-/// `recipient_pubkey` is the cleartext `p` tag used by the relay for owner-only
-/// routing. `agent_pubkey` identifies the managed agent whose observer stream
-/// this frame belongs to. `encrypted_content` must be NIP-44 v2 ciphertext.
-pub fn build_agent_observer_frame(
-    recipient_pubkey: &str,
+/// `recipient_pubkeys` and the payload's wrapped keys have the same order.
+/// The controlling owner must be one recipient. More than one recipient
+/// requires a channel so the relay can enforce shared-channel visibility.
+pub fn build_agent_observer_telemetry_frame(
+    owner_pubkey: &str,
+    recipient_pubkeys: &[String],
     agent_pubkey: &str,
-    frame: &str,
+    channel_id: Option<Uuid>,
     encrypted_content: &str,
 ) -> Result<EventBuilder, SdkError> {
-    if frame != OBSERVER_FRAME_TELEMETRY && frame != OBSERVER_FRAME_CONTROL {
+    if recipient_pubkeys.is_empty() || recipient_pubkeys.len() > OBSERVER_MAX_RECIPIENTS {
         return Err(SdkError::InvalidInput(format!(
-            "observer frame must be {OBSERVER_FRAME_TELEMETRY:?} or {OBSERVER_FRAME_CONTROL:?}"
+            "observer frame must have 1..={OBSERVER_MAX_RECIPIENTS} recipients"
         )));
     }
-    if !content_looks_like_nip44(encrypted_content) {
+    if !content_looks_like_observer_payload(encrypted_content) {
         return Err(SdkError::InvalidInput(
-            "observer frame content must be NIP-44 v2 ciphertext".into(),
+            "observer telemetry content must be encrypted".into(),
+        ));
+    }
+    let wrapped_key_count = observer_payload_recipient_count(encrypted_content)
+        .map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    if wrapped_key_count != recipient_pubkeys.len() {
+        return Err(SdkError::InvalidInput(
+            "observer recipient count must match encrypted payload".into(),
+        ));
+    }
+    if recipient_pubkeys.len() > 1 && channel_id.is_none() {
+        return Err(SdkError::InvalidInput(
+            "shared observer telemetry requires a channel".into(),
         ));
     }
 
-    let recipient_pubkey = check_pubkey_hex(recipient_pubkey, "recipient_pubkey")?;
+    let owner_pubkey = check_pubkey_hex(owner_pubkey, "owner_pubkey")?;
     let agent_pubkey = check_pubkey_hex(agent_pubkey, "agent_pubkey")?;
+    if owner_pubkey == agent_pubkey {
+        return Err(SdkError::InvalidInput(
+            "observer owner and agent must differ".into(),
+        ));
+    }
+
+    let mut recipients = Vec::with_capacity(recipient_pubkeys.len());
+    for recipient in recipient_pubkeys {
+        let recipient = check_pubkey_hex(recipient, "recipient_pubkey")?;
+        if recipient == agent_pubkey {
+            return Err(SdkError::InvalidInput(
+                "observer telemetry cannot target its author".into(),
+            ));
+        }
+        if recipients.contains(&recipient) {
+            return Err(SdkError::InvalidInput(
+                "observer recipients must be unique".into(),
+            ));
+        }
+        recipients.push(recipient);
+    }
+    if !recipients.contains(&owner_pubkey) {
+        return Err(SdkError::InvalidInput(
+            "observer telemetry recipients must include the owner".into(),
+        ));
+    }
+
+    let mut tags = Vec::with_capacity(recipients.len() + 4);
+    for recipient in &recipients {
+        tags.push(tag(&["p", recipient])?);
+    }
+    tags.push(tag(&[OBSERVER_OWNER_TAG, &owner_pubkey])?);
+    tags.push(tag(&[OBSERVER_AGENT_TAG, &agent_pubkey])?);
+    tags.push(tag(&[OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY])?);
+    if let Some(channel_id) = channel_id {
+        tags.push(tag(&["h", &channel_id.to_string()])?);
+    }
+
+    Ok(EventBuilder::new(
+        Kind::Custom(KIND_AGENT_OBSERVER_FRAME as u16),
+        encrypted_content,
+    )
+    .tags(tags))
+}
+
+/// Build an encrypted owner-to-agent observer control frame (kind 24200).
+pub fn build_agent_observer_control_frame(
+    owner_pubkey: &str,
+    agent_pubkey: &str,
+    encrypted_content: &str,
+) -> Result<EventBuilder, SdkError> {
+    if !content_looks_like_nip44(encrypted_content) {
+        return Err(SdkError::InvalidInput(
+            "observer control content must be NIP-44 v2 ciphertext".into(),
+        ));
+    }
+    let owner_pubkey = check_pubkey_hex(owner_pubkey, "owner_pubkey")?;
+    let agent_pubkey = check_pubkey_hex(agent_pubkey, "agent_pubkey")?;
+    if owner_pubkey == agent_pubkey {
+        return Err(SdkError::InvalidInput(
+            "observer owner and agent must differ".into(),
+        ));
+    }
     let tags = vec![
-        tag(&["p", &recipient_pubkey])?,
+        tag(&["p", &agent_pubkey])?,
+        tag(&[OBSERVER_OWNER_TAG, &owner_pubkey])?,
         tag(&[OBSERVER_AGENT_TAG, &agent_pubkey])?,
-        tag(&[OBSERVER_FRAME_TAG, frame])?,
+        tag(&[OBSERVER_FRAME_TAG, OBSERVER_FRAME_CONTROL])?,
     ];
 
     Ok(EventBuilder::new(
@@ -2434,43 +2512,82 @@ mod tests {
     }
 
     #[test]
-    fn agent_observer_frame_happy_path() {
-        let sender = keys();
-        let recipient = keys();
+    fn agent_observer_telemetry_frame_binds_shared_recipients_and_channel() {
+        let owner = keys();
+        let viewer = keys();
         let agent = keys();
-        let encrypted = buzz_core::observer::encrypt_observer_payload(
-            &sender,
-            &recipient.public_key(),
+        let channel = uuid();
+        let recipients = vec![owner.public_key().to_hex(), viewer.public_key().to_hex()];
+        let encrypted = buzz_core::observer::encrypt_observer_payload_for_recipients(
+            &agent,
+            &[owner.public_key(), viewer.public_key()],
             &serde_json::json!({"type": "acp_read"}),
         )
         .unwrap();
-        let ev = sign(
-            build_agent_observer_frame(
-                &recipient.public_key().to_hex(),
-                &agent.public_key().to_hex(),
-                OBSERVER_FRAME_TELEMETRY,
-                &encrypted,
-            )
-            .unwrap(),
-        );
+        let ev = build_agent_observer_telemetry_frame(
+            &owner.public_key().to_hex(),
+            &recipients,
+            &agent.public_key().to_hex(),
+            Some(channel),
+            &encrypted,
+        )
+        .unwrap()
+        .sign_with_keys(&agent)
+        .unwrap();
 
         assert_eq!(ev.kind.as_u16(), KIND_AGENT_OBSERVER_FRAME as u16);
         assert_eq!(ev.content, encrypted);
-        assert!(has_tag(&ev, "p", &recipient.public_key().to_hex()));
+        assert!(has_tag(&ev, "p", &owner.public_key().to_hex()));
+        assert!(has_tag(&ev, "p", &viewer.public_key().to_hex()));
+        assert!(has_tag(
+            &ev,
+            OBSERVER_OWNER_TAG,
+            &owner.public_key().to_hex()
+        ));
         assert!(has_tag(
             &ev,
             OBSERVER_AGENT_TAG,
             &agent.public_key().to_hex()
         ));
         assert!(has_tag(&ev, OBSERVER_FRAME_TAG, OBSERVER_FRAME_TELEMETRY));
+        assert!(has_tag(&ev, "h", &channel.to_string()));
     }
 
     #[test]
-    fn agent_observer_frame_rejects_plaintext_content() {
-        let err = build_agent_observer_frame(
+    fn agent_observer_control_frame_targets_agent_only() {
+        let owner = keys();
+        let agent = keys();
+        let encrypted = buzz_core::observer::encrypt_observer_payload(
+            &owner,
+            &agent.public_key(),
+            &serde_json::json!({"type": "cancel_turn"}),
+        )
+        .unwrap();
+        let ev = build_agent_observer_control_frame(
+            &owner.public_key().to_hex(),
+            &agent.public_key().to_hex(),
+            &encrypted,
+        )
+        .unwrap()
+        .sign_with_keys(&owner)
+        .unwrap();
+
+        assert!(has_tag(&ev, "p", &agent.public_key().to_hex()));
+        assert!(has_tag(
+            &ev,
+            OBSERVER_OWNER_TAG,
+            &owner.public_key().to_hex()
+        ));
+        assert!(has_tag(&ev, OBSERVER_FRAME_TAG, OBSERVER_FRAME_CONTROL));
+    }
+
+    #[test]
+    fn shared_agent_observer_frame_rejects_plaintext_content() {
+        let err = build_agent_observer_telemetry_frame(
             &"a".repeat(64),
+            &["a".repeat(64), "c".repeat(64)],
             &"b".repeat(64),
-            OBSERVER_FRAME_TELEMETRY,
+            Some(uuid()),
             "not encrypted",
         )
         .unwrap_err();

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
+use buzz_core::observer::{decrypt_observer_payload, encrypt_observer_payload_for_recipients};
+use buzz_sdk::{build_agent_observer_telemetry_frame, nip_oa};
 use buzz_test_client::{BuzzTestClient, RelayMessage, TestClientError};
 use nostr::{Alphabet, EventBuilder, Filter, Keys, Kind, SingleLetterTag, Tag};
 use sha2::{Digest, Sha256};
@@ -3202,5 +3204,169 @@ async fn test_nip29_relay_rejects_last_owner_self_demotion() {
             .as_deref(),
         Some("owner"),
         "the last owner must keep their role"
+    );
+}
+
+/// Channel members named by a shared observer frame receive and decrypt it;
+/// authenticated outsiders do not.
+#[tokio::test]
+#[ignore]
+async fn test_shared_agent_observer_frame_reaches_channel_employee_only() {
+    let url = relay_url();
+    let owner = Keys::generate();
+    let employee = Keys::generate();
+    let agent = Keys::generate();
+    let outsider = Keys::generate();
+    let delegated_agent = Keys::generate();
+    let relay_url = url::Url::parse(&url).expect("parse relay URL");
+    let relay_host = format!(
+        "{}:{}",
+        relay_url.host_str().expect("relay URL host"),
+        relay_url.port_or_known_default().expect("relay URL port")
+    );
+    seed_relay_member(&relay_host, &employee, "member").await;
+
+    let mut owner_client = BuzzTestClient::connect(&url, &owner)
+        .await
+        .expect("connect owner");
+    let channel_id = create_private_channel_ws(&mut owner_client, &owner).await;
+    for member in [&employee, &agent, &delegated_agent] {
+        let (accepted, message) = add_member_ws(
+            &mut owner_client,
+            &channel_id,
+            &member.public_key().to_hex(),
+            &owner,
+        )
+        .await;
+        assert!(accepted, "add channel member failed: {message}");
+    }
+
+    let auth_tag_json = nip_oa::compute_auth_tag(&owner, &agent.public_key(), "kind=24200")
+        .expect("compute observer NIP-OA tag");
+    let auth_tag = nip_oa::parse_auth_tag(&auth_tag_json).expect("parse observer NIP-OA tag");
+    let mut agent_client = BuzzTestClient::connect_unauthenticated(&url)
+        .await
+        .expect("connect agent");
+    agent_client
+        .authenticate_with_nip_oa(&agent, &auth_tag)
+        .await
+        .expect("authenticate managed agent");
+
+    let mut employee_client = BuzzTestClient::connect(&url, &employee)
+        .await
+        .expect("connect employee");
+    let mut outsider_client = BuzzTestClient::connect(&url, &outsider)
+        .await
+        .expect("connect outsider");
+
+    for (client, name, viewer) in [
+        (&mut owner_client, "observer-owner", &owner),
+        (&mut employee_client, "observer-employee", &employee),
+        (&mut outsider_client, "observer-outsider", &outsider),
+    ] {
+        let sid = sub_id(name);
+        let viewer_hex = viewer.public_key().to_hex();
+        let filter = Filter::new()
+            .kind(Kind::Custom(24_200))
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::P), viewer_hex.as_str());
+        client
+            .subscribe(&sid, vec![filter])
+            .await
+            .expect("subscribe to observer frames");
+        client
+            .collect_until_eose(&sid, Duration::from_secs(5))
+            .await
+            .expect("observer subscription EOSE");
+    }
+
+    let recipients = [owner.public_key(), employee.public_key()];
+    let payload = serde_json::json!({
+        "type": "acp_read",
+        "channelId": channel_id,
+        "path": "VISION.md",
+    });
+    let encrypted = encrypt_observer_payload_for_recipients(&agent, &recipients, &payload)
+        .expect("encrypt shared observer payload");
+    let recipient_hexes = recipients
+        .iter()
+        .map(|recipient| recipient.to_hex())
+        .collect::<Vec<_>>();
+    let event = build_agent_observer_telemetry_frame(
+        &owner.public_key().to_hex(),
+        &recipient_hexes,
+        &agent.public_key().to_hex(),
+        Some(channel_id.parse().expect("channel UUID")),
+        &encrypted,
+    )
+    .expect("build shared observer frame")
+    .sign_with_keys(&agent)
+    .expect("sign shared observer frame");
+    let ok = agent_client
+        .send_event(event)
+        .await
+        .expect("publish shared observer frame");
+    assert!(
+        ok.accepted,
+        "shared observer frame rejected: {}",
+        ok.message
+    );
+
+    for (client, viewer, name) in [
+        (&mut owner_client, &owner, "owner"),
+        (&mut employee_client, &employee, "employee"),
+    ] {
+        let message = client
+            .recv_event(Duration::from_secs(5))
+            .await
+            .unwrap_or_else(|error| panic!("{name} did not receive observer frame: {error}"));
+        let RelayMessage::Event { event, .. } = message else {
+            panic!("{name} received unexpected relay message: {message:?}");
+        };
+        let decrypted: serde_json::Value =
+            decrypt_observer_payload(viewer, &event).expect("decrypt shared observer frame");
+        assert_eq!(
+            decrypted, payload,
+            "{name} decrypted wrong observer payload"
+        );
+    }
+
+    match outsider_client.recv_event(Duration::from_millis(500)).await {
+        Err(TestClientError::Timeout) => {}
+        Ok(RelayMessage::Event { event, .. }) => {
+            panic!("outsider received observer frame {}", event.id)
+        }
+        Ok(other) => panic!("outsider received unexpected relay message: {other:?}"),
+        Err(error) => panic!("outsider observer wait failed unexpectedly: {error}"),
+    }
+
+    let delegated_recipients = [owner.public_key(), delegated_agent.public_key()];
+    let delegated_content =
+        encrypt_observer_payload_for_recipients(&agent, &delegated_recipients, &payload)
+            .expect("encrypt delegated-agent observer payload");
+    let delegated_recipient_hexes = delegated_recipients
+        .iter()
+        .map(|recipient| recipient.to_hex())
+        .collect::<Vec<_>>();
+    let delegated_event = build_agent_observer_telemetry_frame(
+        &owner.public_key().to_hex(),
+        &delegated_recipient_hexes,
+        &agent.public_key().to_hex(),
+        Some(channel_id.parse().expect("channel UUID")),
+        &delegated_content,
+    )
+    .expect("build delegated-agent observer frame")
+    .sign_with_keys(&agent)
+    .expect("sign delegated-agent observer frame");
+    let rejected = agent_client
+        .send_event(delegated_event)
+        .await
+        .expect("publish delegated-agent observer frame");
+    assert!(
+        !rejected.accepted
+            && rejected
+                .message
+                .contains("observer recipient is not a direct relay member"),
+        "channel-only delegated agent must not become an observer: {}",
+        rejected.message
     );
 }

--- a/desktop/src-tauri/src/archive/mod.rs
+++ b/desktop/src-tauri/src/archive/mod.rs
@@ -13,9 +13,10 @@
 //!
 //! **Ephemeral scope** (`owner_p`, kind 24200 observer frames): the relay
 //! never stores these, so `/query` cannot verify them. The relay's REQ-time
-//! `#p == authed reader` gate is the access control; local per-frame
-//! validation (sig/id + kind + p-tag + agent tag + frame=telemetry + author
-//! == agent) is applied fail-closed.
+//! `#p == authenticated reader` gate is the access control; local per-frame
+//! validation (sig/id + kind + matching p-tag + agent tag + frame=telemetry
+//! + author == agent) is applied fail-closed. Shared frames remain encrypted
+//!   and are only addressed to direct relay members who share the turn's channel.
 
 mod agent_usage;
 mod archive_db;

--- a/desktop/src-tauri/src/archive/mod_tests.rs
+++ b/desktop/src-tauri/src/archive/mod_tests.rs
@@ -483,6 +483,69 @@ fn test_ephemeral_path_persists_valid_frame() {
 }
 
 #[test]
+fn test_ephemeral_path_persists_and_indexes_shared_frame_for_employee() {
+    let conn = in_memory();
+    let owner_keys = Keys::generate();
+    let employee_keys = Keys::generate();
+    let agent_keys = Keys::generate();
+    let employee_pk = employee_keys.public_key().to_hex();
+    let relay_url = "wss://relay.example";
+    let channel_id = Uuid::new_v4().to_string();
+    add_sub(
+        &conn,
+        &employee_pk,
+        relay_url,
+        "owner_p",
+        &employee_pk,
+        "[24200]",
+    );
+
+    let recipients = [owner_keys.public_key(), employee_keys.public_key()];
+    let encrypted = buzz_core_pkg::observer::encrypt_observer_payload_for_recipients(
+        &agent_keys,
+        &recipients,
+        &serde_json::json!({
+            "kind": "acp_read",
+            "channelId": channel_id,
+            "payload": {"marker": "employee-visible"}
+        }),
+    )
+    .expect("encrypt shared observer payload");
+    let event = EventBuilder::new(Kind::Custom(24200), encrypted)
+        .tags([
+            Tag::parse(["p", &owner_keys.public_key().to_hex()]).unwrap(),
+            Tag::parse(["p", &employee_pk]).unwrap(),
+            Tag::parse(["owner", &owner_keys.public_key().to_hex()]).unwrap(),
+            Tag::parse(["agent", &agent_keys.public_key().to_hex()]).unwrap(),
+            Tag::parse(["frame", OBSERVER_FRAME_TELEMETRY]).unwrap(),
+            Tag::parse(["h", &channel_id]).unwrap(),
+        ])
+        .sign_with_keys(&agent_keys)
+        .unwrap();
+    let candidates = vec![candidate(&event, ScopeType::OwnerP, &employee_pk)];
+
+    let result = run_batch_sync_with_keys(
+        candidates,
+        &employee_pk,
+        relay_url,
+        &conn,
+        vec![],
+        &employee_keys,
+    );
+
+    assert_eq!(result.persisted, 1);
+    assert_eq!(result.dropped, 0);
+    let indexed_channel: Option<String> = conn
+        .query_row(
+            "SELECT channel_id FROM observer_channel_index WHERE id = ?1",
+            [&event.id.to_hex()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(indexed_channel.as_deref(), Some(channel_id.as_str()));
+}
+
+#[test]
 fn test_ephemeral_path_drops_kind_not_in_subscription() {
     let conn = in_memory();
     let owner_keys = Keys::generate();

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -174,10 +174,9 @@ pub fn build_observer_control_event(
     let encrypted =
         buzz_core_pkg::observer::encrypt_observer_payload(&keys, &agent_pubkey, &payload)
             .map_err(|error| format!("encrypt observer control failed: {error}"))?;
-    let builder = buzz_sdk_pkg::build_agent_observer_frame(
+    let builder = buzz_sdk_pkg::build_agent_observer_control_frame(
+        &keys.public_key().to_hex(),
         &agent_pubkey_hex,
-        &agent_pubkey_hex,
-        buzz_core_pkg::observer::OBSERVER_FRAME_CONTROL,
         &encrypted,
     )
     .map_err(|error| format!("build observer control failed: {error}"))?;

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -195,8 +195,8 @@ export function AppShell() {
   useAgentsDataRefresh();
   // Chunk F: auto-restart drifted idle agents (per-agent opt-out, default ON).
   useAutoRestartPolicy();
-  // Owner-global observer ingestion: receives + decrypts agent observer
-  // frames and keeps derived active-turn liveness in sync app-wide, so no
+  // App-global observer ingestion: receives + decrypts owner and channel-shared
+  // agent frames and keeps derived active-turn liveness in sync, so no
   // individual screen/panel has to mount its own bridge for ingestion.
   // Intentionally mounted without a `startupReady`/identity guard: before
   // `currentPubkey` resolves the hook ingests managed agents only, and

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -284,6 +284,16 @@ with a TypeScript lookup table or an id comparison in a component.
 
 17. **Databricks model discovery has one shared catalog authority.** Desktop and ACP call the shared `buzz-agent` discovery library; Desktop passes the effective merged `DATABRICKS_MODEL_FILTER` explicitly, and the library applies it to raw workspace endpoint IDs and Unity Catalog model-service FQNs after the additive union. A successful filtered-empty catalog is authoritative: it stays empty, disables switching, and never falls through to configured or known-model fallback. UC FQNs are catalog data and always use the MLflow Chat Completions route, regardless of family-looking text in their components. Global Defaults preserves the discovered model ID as the selected value while its closed trigger renders the provider-scoped display label; do not force the raw persisted ID over that label.
 
+18. **Observer telemetry is channel-shared; observer control remains
+    owner-only.** The controlling owner keeps existing telemetry visibility.
+    Additional viewers must be direct relay members, current members of the
+    event's channel, and explicit encrypted `p`-tag recipients. The relay
+    revalidates membership before publication and delivery. Relay-only agents,
+    former channel members, unauthenticated clients, and non-recipient
+    subscribers must never receive or decrypt the frame. Discover relay agents
+    for ingestion through the current identity's visible channels, but do not
+    infer management or control authority from visibility.
+
 ## Channel-only runtime controls
 
 Desktop observer controls identify a channel, not a thread session. The harness

--- a/desktop/src/features/agents/useAgentObserverIngestion.test.mjs
+++ b/desktop/src/features/agents/useAgentObserverIngestion.test.mjs
@@ -3,14 +3,11 @@ import { describe, it } from "node:test";
 
 import { combineObserverIngestionAgents } from "./useAgentObserverIngestion.ts";
 
-const ME = "aaaa1234aaaa1234aaaa1234aaaa1234aaaa1234aaaa1234aaaa1234aaaa1234";
-const OTHER =
-  "bbbb4321bbbb4321bbbb4321bbbb4321bbbb4321bbbb4321bbbb4321bbbb4321";
 const AGENT_LOCAL =
   "cccc1111cccc1111cccc1111cccc1111cccc1111cccc1111cccc1111cccc1111";
 const AGENT_REMOTE =
   "dddd2222dddd2222dddd2222dddd2222dddd2222dddd2222dddd2222dddd2222";
-const AGENT_FOREIGN =
+const AGENT_CHANNEL =
   "eeee3333eeee3333eeee3333eeee3333eeee3333eeee3333eeee3333eeee3333";
 
 describe("combineObserverIngestionAgents", () => {
@@ -18,71 +15,34 @@ describe("combineObserverIngestionAgents", () => {
     const result = combineObserverIngestionAgents(
       [{ pubkey: AGENT_LOCAL, status: "running" }],
       [],
-      new Map(),
-      ME,
     );
     assert.deepEqual(result, [{ pubkey: AGENT_LOCAL, status: "running" }]);
   });
 
-  it("adds declared-owned relay agents as deployed", () => {
+  it("registers every channel-visible relay agent for shared ingestion", () => {
     const result = combineObserverIngestionAgents(
       [],
-      [AGENT_REMOTE],
-      new Map([[AGENT_REMOTE, ME]]),
-      ME,
+      [AGENT_REMOTE, AGENT_CHANNEL],
     );
-    assert.deepEqual(result, [{ pubkey: AGENT_REMOTE, status: "deployed" }]);
+    assert.deepEqual(result, [
+      { pubkey: AGENT_REMOTE, status: "deployed" },
+      { pubkey: AGENT_CHANNEL, status: "deployed" },
+    ]);
   });
 
-  it("excludes relay agents owned by someone else", () => {
-    const result = combineObserverIngestionAgents(
-      [],
-      [AGENT_FOREIGN],
-      new Map([[AGENT_FOREIGN, OTHER]]),
-      ME,
-    );
-    assert.deepEqual(result, []);
-  });
-
-  it("excludes relay agents with no declared owner", () => {
-    const result = combineObserverIngestionAgents(
-      [],
-      [AGENT_REMOTE],
-      new Map(),
-      ME,
-    );
-    assert.deepEqual(result, []);
-  });
-
-  it("does not duplicate an agent that is both managed and on the relay", () => {
+  it("does not duplicate an agent present locally and on the relay", () => {
     const result = combineObserverIngestionAgents(
       [{ pubkey: AGENT_LOCAL, status: "stopped" }],
-      [AGENT_LOCAL],
-      new Map([[AGENT_LOCAL, ME]]),
-      ME,
+      [AGENT_LOCAL.toUpperCase()],
     );
     assert.deepEqual(result, [{ pubkey: AGENT_LOCAL, status: "stopped" }]);
   });
 
-  it("matches ownership case-insensitively", () => {
+  it("deduplicates relay discovery case-insensitively", () => {
     const result = combineObserverIngestionAgents(
       [],
-      [AGENT_REMOTE.toUpperCase()],
-      new Map([[AGENT_REMOTE, ME.toUpperCase()]]),
-      ME,
+      [AGENT_REMOTE, AGENT_REMOTE.toUpperCase()],
     );
-    assert.deepEqual(result, [
-      { pubkey: AGENT_REMOTE.toUpperCase(), status: "deployed" },
-    ]);
-  });
-
-  it("returns only managed agents when identity is not resolved yet", () => {
-    const result = combineObserverIngestionAgents(
-      [{ pubkey: AGENT_LOCAL, status: "running" }],
-      [AGENT_REMOTE],
-      new Map([[AGENT_REMOTE, ME]]),
-      undefined,
-    );
-    assert.deepEqual(result, [{ pubkey: AGENT_LOCAL, status: "running" }]);
+    assert.deepEqual(result, [{ pubkey: AGENT_REMOTE, status: "deployed" }]);
   });
 });

--- a/desktop/src/features/agents/useAgentObserverIngestion.ts
+++ b/desktop/src/features/agents/useAgentObserverIngestion.ts
@@ -6,77 +6,50 @@ import {
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
-import { useUsersBatchQuery } from "@/features/profile/hooks";
-import { useIdentityQuery } from "@/shared/api/hooks";
 import type { ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 type IngestionAgent = Pick<ManagedAgent, "pubkey" | "status">;
 
 /**
- * Combine locally managed agents with relay agents the current identity
- * declared-owns (NIP-OA `ownerPubkey == me`) into one ingestion list.
+ * Combine locally managed agents with every relay agent discoverable through
+ * the current identity's channel memberships.
  *
- * Managed agents keep their real status; owned relay agents that are not
- * managed locally are treated as `deployed` so the observer subscription
- * starts and their frames decrypt. Registering non-owned agents would be
- * pointless — observer frames are `#p`-addressed to the owner, so frames for
- * agents we do not own never arrive on our subscription in the first place.
+ * Managed agents keep their real status. Relay-only agents are treated as
+ * deployed so the app-level observer subscription starts and shared frames
+ * addressed to this identity are accepted. The relay still enforces the
+ * p-tag and current channel membership before delivery.
  */
 export function combineObserverIngestionAgents(
   managedAgents: readonly IngestionAgent[],
   relayAgentPubkeys: readonly string[],
-  ownerByPubkey: ReadonlyMap<string, string>,
-  currentPubkey: string | null | undefined,
 ): IngestionAgent[] {
-  const managed = managedAgents.map((agent) => ({
+  const combined = managedAgents.map((agent) => ({
     pubkey: agent.pubkey,
     status: agent.status,
   }));
-  if (!currentPubkey) {
-    return managed;
-  }
-
-  const managedSet = new Set(
-    managed.map((agent) => normalizePubkey(agent.pubkey)),
-  );
-  const me = normalizePubkey(currentPubkey);
-  const owned: IngestionAgent[] = [];
+  const known = new Set(combined.map((agent) => normalizePubkey(agent.pubkey)));
   for (const pubkey of relayAgentPubkeys) {
     const key = normalizePubkey(pubkey);
-    if (managedSet.has(key)) {
+    if (known.has(key)) {
       continue;
     }
-    const owner = ownerByPubkey.get(key);
-    if (owner && normalizePubkey(owner) === me) {
-      owned.push({ pubkey, status: "deployed" as const });
-    }
+    known.add(key);
+    combined.push({ pubkey, status: "deployed" });
   }
-  return [...managed, ...owned];
+  return combined;
 }
 
 /**
- * App-level owner-global observer ingestion.
+ * App-level channel-scoped observer ingestion.
  *
  * Mounted once in AppShell so observer frames (kind 24200) are received,
  * decrypted, and folded into the derived active-turns store regardless of
- * which screen or panel happens to be open. Individual surfaces read from the
- * stores; none of them need to mount their own bridge for ingestion to work.
- *
- * This is the product invariant: if the current identity owns an agent (local
- * managed agent or declared-owned relay agent), its turn activity is ingested
- * app-wide — not only while a panel that happens to mount a bridge is open.
- *
- * Mounts before identity resolves by design: while `currentPubkey` is still
- * `undefined`, `combineObserverIngestionAgents` returns managed agents only,
- * and relay-owned agents are folded in on the render after identity arrives.
- * Do not gate this hook on identity/startup readiness — that would drop
- * managed-agent observer coverage during startup.
+ * which screen or panel happens to be open. Relay agent discovery is already
+ * scoped to channels visible to the current identity; registering all of those
+ * agents lets employees ingest shared frames without granting control rights.
  */
 export function useAgentObserverIngestion() {
-  const identityQuery = useIdentityQuery();
-  const currentPubkey = identityQuery.data?.pubkey;
-
   const managedAgentsQuery = useManagedAgentsQuery();
   const managedAgents = managedAgentsQuery.data;
 
@@ -86,30 +59,11 @@ export function useAgentObserverIngestion() {
     [relayAgentsQuery.data],
   );
 
-  const profilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
-    enabled: Boolean(currentPubkey) && relayAgentPubkeys.length > 0,
-  });
-  const profiles = profilesQuery.data?.profiles;
-
-  const ingestionAgents = React.useMemo(() => {
-    const ownerByPubkey = new Map<string, string>();
-    for (const [pubkey, summary] of Object.entries(profiles ?? {})) {
-      if (summary.ownerPubkey) {
-        // Store both key and value normalized so lookups and ownership
-        // comparisons never depend on the casing the relay happened to send.
-        ownerByPubkey.set(
-          normalizePubkey(pubkey),
-          normalizePubkey(summary.ownerPubkey),
-        );
-      }
-    }
-    return combineObserverIngestionAgents(
-      managedAgents ?? [],
-      relayAgentPubkeys,
-      ownerByPubkey,
-      currentPubkey,
-    );
-  }, [currentPubkey, managedAgents, profiles, relayAgentPubkeys]);
+  const ingestionAgents = React.useMemo(
+    () =>
+      combineObserverIngestionAgents(managedAgents ?? [], relayAgentPubkeys),
+    [managedAgents, relayAgentPubkeys],
+  );
 
   useManagedAgentObserverBridge(ingestionAgents);
   useActiveAgentTurnsBridge(ingestionAgents);


### PR DESCRIPTION
## Summary
Share managed-agent activity telemetry with authenticated employees who currently share the agent turn's channel. Observer payloads remain encrypted: the harness encrypts each payload once, wraps its ephemeral key for the ordered recipients, and the relay revalidates agent ownership, direct relay membership, and channel membership before fan-out. Existing owner-only telemetry and owner-to-agent controls remain direct NIP-44; Desktop now ingests observer frames for relay agents visible through the signed-in identity's channels.

## Key decisions
- The audience is the intersection of the channel's NIP-29 roster and the relay's direct NIP-43 roster. This excludes delegated/hosted agent keys even when those agents share the channel.
- One shared envelope carries one payload ciphertext plus a wrapped key per viewer. This preserves the global one-frame-per-second observer pacer instead of duplicating the full frame for every employee.
- Audience lookup is bounded to 128 recipients and a 1,024-channel/30-second cache. Lookup failure or overflow falls back to the controlling owner only; the relay independently fails closed on stale membership.
- Shared-envelope decoding is additive, but emission must roll out after compatible Desktop/core readers. Relay validation should precede harness emission; control frames remain owner-only throughout.

## Review guide
**Part 1 (review first — confidentiality boundary).** Start at `RestClient::shared_observer_recipients` in `crates/buzz-acp/src/relay.rs` when the observer publisher drains a channel-scoped event. Follow `ObserverRecipientCache::resolve` → `encrypt_observer_payload_for_recipients` → `build_agent_observer_telemetry_frame` → `handle_agent_observer_event` → `filter_fanout_by_access`. The path stops at relay-local/Redis ephemeral fan-out: no observer event storage or database schema changes. State machine: the existing observer frame lifecycle (queued → encrypted → authorized → delivered/dropped); recipient authorization adds guarded edges without changing turn states. This is a security fix — attack recipient ordering, duplicate tags, non-direct members, removed channel members, cross-tenant state, and lookup failures.

**Part 2.** Start at `useAgentObserverIngestion` in `desktop/src/features/agents/useAgentObserverIngestion.ts` when AppShell initializes observer ingestion. It reaches channel-visible relay-agent discovery, the existing kind-24200 subscription/decryption path, and Rust archive indexing, then stops before activity-feed projection and rendering. State machine: the existing Desktop observer ingestion lifecycle; the registered agent set expands from locally managed agents to channel-visible relay agents while statuses and downstream projections remain unchanged. This is an improvement/evolution of the existing ingestion machine — verify visibility does not imply management or control authority.

**Part 3.** Start at `decrypt_observer_payload` in `crates/buzz-core/src/observer.rs` for wire compatibility. Direct NIP-44 follows the existing branch; shared JSON envelopes select an ordered wrapped key and then deserialize through the same plaintext budget. The path stops at the typed observer payload; event semantics are unchanged. No lifecycle state changes; this is a protectionist/defensive protocol extension.

## Test plan
- `just ci` — repository-wide formatting, clippy, unit tests, Desktop/Tauri/mobile checks, and builds.
- `cargo test -p buzz-relay observer --lib` — publication parsing, owner authorization, channel membership, and live fan-out gates.
- `cargo test -p buzz-acp observer --lib` — bounded audience resolution, encryption, cadence, and owner-only fallback behavior.
- `RELAY_URL=ws://127.0.0.1:3033 DATABASE_URL=postgres://buzz:buzz_dev@127.0.0.1:55432/buzz_observer_employees cargo test -p buzz-test-client --test e2e_relay test_shared_agent_observer_frame_reaches_channel_employee_only -- --ignored --exact --nocapture` — running relay delivers/decrypts for owner and direct employee, withholds from an outsider, and rejects a channel-only delegated-agent recipient.
