### PR TITLE
feat(desktop): manage Project related channels

### DIFF
--- a/desktop/src/features/projects/projectEnumeration.test.mjs
+++ b/desktop/src/features/projects/projectEnumeration.test.mjs
@@ -6,6 +6,7 @@ import {
   buildProjectHomeFromFetcher,
   buildProjectsFromFetcher,
 } from "./projectEnumeration.ts";
+import { projectRelatedChannelSnapshotD } from "./projectRelatedChannelSnapshot.ts";
 
 function relayEvent(id, createdAt) {
   return {
@@ -63,6 +64,7 @@ test("buildProjectHomeFromFetcher scopes startup lookup to the active channel", 
     ],
   };
   const calls = [];
+  const snapshotCalls = [];
   const fetchExhaustively = async (kinds, extraFilter) => {
     calls.push({ kinds, extraFilter });
     if (kinds.includes(30621)) return [projectEvent];
@@ -73,7 +75,13 @@ test("buildProjectHomeFromFetcher scopes startup lookup to the active channel", 
   const project = await buildProjectHomeFromFetcher(
     fetchExhaustively,
     channelId,
-    { viewerPubkey: owner },
+    {
+      fetchRelatedChannelSnapshots: async (addresses) => {
+        snapshotCalls.push(addresses);
+        return [];
+      },
+      viewerPubkey: owner,
+    },
   );
 
   assert.equal(project?.projectChannelId, channelId);
@@ -89,6 +97,217 @@ test("buildProjectHomeFromFetcher scopes startup lookup to the active channel", 
     kinds: [5],
     extraFilter: { "#a": [`30621:${owner}:relay`, repositoryAddress] },
   });
+  assert.equal(calls.length, 3);
+  assert.deepEqual(snapshotCalls, [[`30621:${owner}:relay`]]);
+});
+
+test("buildProjectsFromFetcher overlays a matching relay snapshot", async () => {
+  const owner = "a".repeat(64);
+  const projectAddress = `30621:${owner}:relay`;
+  const homeId = "11111111-1111-4111-8111-111111111111";
+  const relatedId = "22222222-2222-4222-8222-222222222222";
+  const projectEvent = {
+    id: "1".repeat(64),
+    kind: 30621,
+    pubkey: owner,
+    created_at: 200,
+    content: "",
+    tags: [
+      ["d", "relay"],
+      ["name", "Relay"],
+      ["buzz-channel", homeId],
+    ],
+  };
+  assert.equal(
+    await projectRelatedChannelSnapshotD(projectAddress),
+    "85aa287457e4ad0ba0a5f9fbc9a3c3b643a388d1115b4342c7e4f934d602d995",
+  );
+  const snapshot = {
+    id: "2".repeat(64),
+    kind: 30623,
+    pubkey: owner,
+    created_at: 201,
+    content: "",
+    tags: [
+      ["d", await projectRelatedChannelSnapshotD(projectAddress)],
+      ["a", projectAddress],
+      ["c", relatedId],
+    ],
+  };
+  const snapshotFilters = [];
+  const projects = await buildProjectsFromFetcher(
+    async (kinds) => {
+      if (kinds.includes(30621)) return [projectEvent];
+      return [];
+    },
+    {
+      fetchRelatedChannelSnapshots: async (addresses) => {
+        snapshotFilters.push(addresses);
+        return [snapshot];
+      },
+      viewerPubkey: owner,
+    },
+  );
+
+  assert.deepEqual(projects[0].relatedChannelIds, [relatedId]);
+  assert.deepEqual(snapshotFilters, [[projectAddress]]);
+});
+
+test("buildProjectsFromFetcher fails closed for an invalid snapshot without retrying", async () => {
+  const owner = "a".repeat(64);
+  const projectAddress = `30621:${owner}:relay`;
+  const legacyChannelId = "22222222-2222-4222-8222-222222222222";
+  const projectEvent = {
+    id: "1".repeat(64),
+    kind: 30621,
+    pubkey: owner,
+    created_at: 200,
+    content: "",
+    tags: [
+      ["d", "relay"],
+      ["name", "Relay"],
+      ["buzz-related-channel", legacyChannelId],
+    ],
+  };
+  const invalidSnapshot = {
+    id: "2".repeat(64),
+    kind: 30623,
+    pubkey: owner,
+    created_at: 201,
+    content: "",
+    tags: [
+      ["d", await projectRelatedChannelSnapshotD(projectAddress)],
+      ["a", projectAddress],
+      ["c", "33333333-3333-4333-8333-333333333333", "unexpected"],
+    ],
+  };
+  let snapshotFetches = 0;
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(message);
+  try {
+    const projects = await buildProjectsFromFetcher(
+      async (kinds) => {
+        if (kinds.includes(30621)) return [projectEvent];
+        return [];
+      },
+      {
+        fetchRelatedChannelSnapshots: async () => {
+          snapshotFetches += 1;
+          return [invalidSnapshot];
+        },
+        viewerPubkey: owner,
+      },
+    );
+    assert.deepEqual(projects[0].relatedChannelIds, []);
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.equal(snapshotFetches, 1);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /snapshot.*invalid/i);
+});
+
+test("snapshot reads stay within bounded Project chunks", async () => {
+  const owner = "a".repeat(64);
+  const projectEvents = Array.from({ length: 101 }, (_, index) => ({
+    id: (index + 1).toString(16).padStart(64, "0"),
+    kind: 30621,
+    pubkey: owner,
+    created_at: 200 + index,
+    content: "",
+    tags: [
+      ["d", `project-${index}`],
+      ["name", `Project ${index}`],
+    ],
+  }));
+  const snapshotsByAddress = new Map(
+    await Promise.all(
+      projectEvents.map(async (event) => {
+        const projectAddress = `30621:${owner}:${event.tags[0][1]}`;
+        return [
+          projectAddress,
+          {
+            id: `f${event.id.slice(1)}`,
+            kind: 30623,
+            pubkey: "b".repeat(64),
+            created_at: event.created_at + 1,
+            content: "",
+            tags: [
+              ["d", await projectRelatedChannelSnapshotD(projectAddress)],
+              ["a", projectAddress],
+            ],
+          },
+        ];
+      }),
+    ),
+  );
+  const snapshotCalls = [];
+  await buildProjectsFromFetcher(
+    async (kinds) => (kinds.includes(30621) ? projectEvents : []),
+    {
+      fetchRelatedChannelSnapshots: async (addresses) => {
+        snapshotCalls.push(addresses);
+        return addresses.map((address) => snapshotsByAddress.get(address));
+      },
+      viewerPubkey: owner,
+    },
+  );
+
+  assert.deepEqual(
+    snapshotCalls.map((addresses) => addresses.length),
+    [100, 1],
+  );
+});
+
+test("buildProjectsFromFetcher accepts a canonical bounded snapshot", async () => {
+  const owner = "a".repeat(64);
+  const projectAddress = `30621:${owner}:relay`;
+  const homeId = "11111111-1111-4111-8111-111111111111";
+  const channelIds = Array.from({ length: 64 }, (_, index) => {
+    const suffix = (index + 1).toString(16).padStart(12, "0");
+    return `22222222-2222-4222-8222-${suffix}`;
+  });
+  const projectEvent = {
+    id: "1".repeat(64),
+    kind: 30621,
+    pubkey: owner,
+    created_at: 200,
+    content: "",
+    tags: [
+      ["d", "relay"],
+      ["name", "Relay"],
+      ["buzz-channel", homeId.toUpperCase()],
+      ["buzz-related-channel", homeId],
+    ],
+  };
+  const snapshot = {
+    id: "2".repeat(64),
+    kind: 30623,
+    pubkey: owner,
+    created_at: 201,
+    content: "",
+    tags: [
+      ["d", await projectRelatedChannelSnapshotD(projectAddress)],
+      ["a", projectAddress],
+      ...channelIds.map((channelId) => ["c", channelId]),
+    ],
+  };
+
+  const projects = await buildProjectsFromFetcher(
+    async (kinds) => {
+      if (kinds.includes(30621)) return [projectEvent];
+      return [];
+    },
+    {
+      fetchRelatedChannelSnapshots: async () => [snapshot],
+      viewerPubkey: owner,
+    },
+  );
+
+  assert.equal(projects[0].projectChannelId, homeId);
+  assert.equal(projects[0].relatedChannelIds.length, 64);
+  assert.deepEqual(projects[0].relatedChannelIds, channelIds);
 });
 
 test("enumerateProjectEvents drains a tied boundary second before advancing", async () => {

--- a/desktop/src/features/projects/projectEnumeration.ts
+++ b/desktop/src/features/projects/projectEnumeration.ts
@@ -3,17 +3,20 @@ import type { RelayEvent } from "@/shared/api/types";
 import {
   KIND_DELETION,
   KIND_PROJECT_ANNOUNCEMENT,
+  KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT,
   KIND_REPO_ANNOUNCEMENT,
 } from "@/shared/constants/kinds";
 import { absorbStandaloneProjectRepositories } from "./lib/projectCollection";
 import { findProjectHomeByChannelId } from "./lib/projectHomeSelection";
 import { buildProjectReadModels, type Project } from "./projectModels";
+import { parseProjectRelatedChannelSnapshot } from "./projectRelatedChannelSnapshot";
 
 const PROJECT_ENUMERATION_PAGE_SIZE = 500;
 
 // Relays commonly cap filter tag-value lists; chunk `#a` scoping well below
 // any such cap.
 const TOMBSTONE_COORDINATE_CHUNK_SIZE = 100;
+const RELATED_CHANNEL_COORDINATE_CHUNK_SIZE = 100;
 
 /** Additional server-side scoping merged into every enumeration page. */
 export type ProjectEventExtraFilter = {
@@ -31,6 +34,11 @@ type ProjectEventFilter = ProjectEventExtraFilter & {
 export type FetchProjectEventsExhaustively = (
   kinds: number[],
   extraFilter?: ProjectEventExtraFilter,
+) => Promise<RelayEvent[]>;
+
+/** One bounded relay read for the current snapshots of these Projects. */
+export type FetchProjectRelatedChannelSnapshots = (
+  projectAddresses: string[],
 ) => Promise<RelayEvent[]>;
 
 type FetchProjectEventPage = (
@@ -161,6 +169,88 @@ async function fetchScopedDeletionEvents(
   return pages.flat();
 }
 
+async function fetchRelatedChannelSnapshots(
+  fetchSnapshotPage: FetchProjectRelatedChannelSnapshots,
+  projectAddresses: string[],
+): Promise<RelayEvent[]> {
+  const pages: RelayEvent[][] = [];
+  for (
+    let index = 0;
+    index < projectAddresses.length;
+    index += RELATED_CHANNEL_COORDINATE_CHUNK_SIZE
+  ) {
+    pages.push(
+      await fetchSnapshotPage(
+        projectAddresses.slice(
+          index,
+          index + RELATED_CHANNEL_COORDINATE_CHUNK_SIZE,
+        ),
+      ),
+    );
+  }
+  return pages.flat();
+}
+
+function snapshotsByProjectAddress(
+  snapshots: RelayEvent[],
+): Map<string, RelayEvent[]> {
+  const grouped = new Map<string, RelayEvent[]>();
+  for (const snapshot of snapshots) {
+    if (snapshot.kind !== KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT) continue;
+    for (const tag of snapshot.tags) {
+      if (tag[0] !== "a" || !tag[1]) continue;
+      const matches = grouped.get(tag[1]) ?? [];
+      matches.push(snapshot);
+      grouped.set(tag[1], matches);
+    }
+  }
+  return grouped;
+}
+
+async function overlayRelatedChannels(
+  projects: Project[],
+  snapshots: RelayEvent[],
+): Promise<Project[]> {
+  const initialSnapshotsByAddress = snapshotsByProjectAddress(snapshots);
+  const resolved = new Map<string, string[]>();
+  const invalidSnapshots = new Set<string>();
+
+  for (const project of projects) {
+    if (project.legacy) continue;
+    const matches = initialSnapshotsByAddress.get(project.projectAddress) ?? [];
+    if (matches.length === 0) continue;
+    const relatedChannelIds =
+      matches.length === 1
+        ? await parseProjectRelatedChannelSnapshot(
+            matches[0],
+            project.projectAddress,
+          )
+        : null;
+    if (relatedChannelIds) {
+      resolved.set(project.projectAddress, relatedChannelIds);
+    } else {
+      invalidSnapshots.add(project.projectAddress);
+      console.warn(
+        `[projects] Ignoring legacy related-channel tags because the relay snapshot for ${project.projectAddress} is invalid.`,
+      );
+    }
+  }
+
+  return projects.map((project) => {
+    const relatedChannelIds = resolved.get(project.projectAddress);
+    if (!relatedChannelIds && !invalidSnapshots.has(project.projectAddress)) {
+      return project;
+    }
+    const normalizedHomeChannelId = project.projectChannelId?.toLowerCase();
+    return {
+      ...project,
+      relatedChannelIds: (relatedChannelIds ?? []).filter(
+        (channelId) => channelId !== normalizedHomeChannelId,
+      ),
+    };
+  });
+}
+
 /**
  * Core fetch-and-build logic for `fetchProjects`, extracted for testability.
  *
@@ -174,6 +264,7 @@ async function fetchScopedDeletionEvents(
 export async function buildProjectsFromFetcher(
   fetchExhaustively: FetchProjectEventsExhaustively,
   options: {
+    fetchRelatedChannelSnapshots?: FetchProjectRelatedChannelSnapshots;
     relayOrigin?: string | null;
     hiddenAddresses?: ReadonlySet<string>;
     viewerPubkey?: string | null;
@@ -204,7 +295,7 @@ export async function buildProjectsFromFetcher(
     );
   }
 
-  return absorbStandaloneProjectRepositories(
+  const projects = absorbStandaloneProjectRepositories(
     buildProjectReadModels({
       projectEvents,
       repositoryEvents,
@@ -214,6 +305,17 @@ export async function buildProjectsFromFetcher(
       viewerPubkey: options.viewerPubkey,
     }),
   ).sort((a, b) => b.createdAt - a.createdAt);
+  const projectAddresses = projects
+    .filter((project) => !project.legacy)
+    .map((project) => project.projectAddress);
+  if (projectAddresses.length === 0) return projects;
+  if (!options.fetchRelatedChannelSnapshots) return projects;
+
+  const snapshots = await fetchRelatedChannelSnapshots(
+    options.fetchRelatedChannelSnapshots,
+    projectAddresses,
+  );
+  return overlayRelatedChannels(projects, snapshots);
 }
 
 /**
@@ -224,20 +326,20 @@ export async function buildProjectHomeFromFetcher(
   fetchExhaustively: FetchProjectEventsExhaustively,
   channelId: string,
   options: {
+    fetchRelatedChannelSnapshots?: FetchProjectRelatedChannelSnapshots;
     relayOrigin?: string | null;
     hiddenAddresses?: ReadonlySet<string>;
     viewerPubkey?: string | null;
   } = {},
 ): Promise<Project | null> {
-  const projects = await buildProjectsFromFetcher(
-    (kinds, extraFilter) =>
-      fetchExhaustively(
-        kinds,
-        kinds.includes(KIND_DELETION)
-          ? extraFilter
-          : { ...extraFilter, "#buzz-channel": [channelId] },
-      ),
-    options,
-  );
+  const projects = await buildProjectsFromFetcher((kinds, extraFilter) => {
+    const needsChannelScope = !kinds.includes(KIND_DELETION);
+    return fetchExhaustively(
+      kinds,
+      needsChannelScope
+        ? { ...extraFilter, "#buzz-channel": [channelId] }
+        : extraFilter,
+    );
+  }, options);
   return findProjectHomeByChannelId(channelId, projects);
 }

--- a/desktop/src/features/projects/projectFetch.ts
+++ b/desktop/src/features/projects/projectFetch.ts
@@ -1,15 +1,41 @@
+import { getRelaySelf } from "@/features/moderation/lib/relaySelf";
+import { relayClient } from "@/shared/api/relayClient";
+import { KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT } from "@/shared/constants/kinds";
 import { getCachedRelayOrigin } from "@/shared/lib/mediaUrl";
 import { getIdentity } from "@/shared/api/tauriIdentity";
 import {
   buildProjectHomeFromFetcher,
   buildProjectsFromFetcher,
   type FetchProjectEventsExhaustively,
+  type FetchProjectRelatedChannelSnapshots,
   fetchProjectEventsExhaustively,
 } from "./projectEnumeration";
 import type { Project } from "./projectModels";
+import { projectRelatedChannelSnapshotD } from "./projectRelatedChannelSnapshot";
 import { markProjectDataAuthoritative } from "./projectSnapshot";
 
 const HIDDEN_PROJECT_CARDS_KEY = "buzz.projects.hidden-cards.v1";
+
+async function trustedSnapshotFetcher(
+  signal?: AbortSignal,
+): Promise<FetchProjectRelatedChannelSnapshots | undefined> {
+  signal?.throwIfAborted();
+  const relaySelf = await getRelaySelf();
+  if (!relaySelf) return undefined;
+  return async (projectAddresses) => {
+    signal?.throwIfAborted();
+    const snapshotDTags = await Promise.all(
+      projectAddresses.map(projectRelatedChannelSnapshotD),
+    );
+    signal?.throwIfAborted();
+    return relayClient.fetchEvents({
+      kinds: [KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT],
+      authors: [relaySelf],
+      "#d": snapshotDTags,
+      limit: projectAddresses.length,
+    });
+  };
+}
 
 function readHiddenProjectCards(): string[] {
   if (typeof window === "undefined") {
@@ -43,7 +69,11 @@ export async function fetchProjects(
     fetchExhaustively ??
     ((kinds, extraFilter) =>
       fetchProjectEventsExhaustively(kinds, extraFilter, undefined, signal));
+  const fetchRelatedChannelSnapshots = fetchExhaustively
+    ? undefined
+    : await trustedSnapshotFetcher(signal);
   const projects = await buildProjectsFromFetcher(fetcher, {
+    fetchRelatedChannelSnapshots,
     relayOrigin: getCachedRelayOrigin(),
     hiddenAddresses: new Set(readHiddenProjectCards()),
     viewerPubkey,
@@ -66,6 +96,7 @@ export async function fetchProjectHomeForChannel(
       fetchProjectEventsExhaustively(kinds, extraFilter, undefined, signal),
     channelId,
     {
+      fetchRelatedChannelSnapshots: await trustedSnapshotFetcher(signal),
       relayOrigin: getCachedRelayOrigin(),
       hiddenAddresses: new Set(readHiddenProjectCards()),
       viewerPubkey,

--- a/desktop/src/features/projects/projectModels.ts
+++ b/desktop/src/features/projects/projectModels.ts
@@ -363,13 +363,16 @@ export function eventToExplicitProject(
     rawVisibility === "unlisted" ? ("unlisted" as const) : ("listed" as const);
   const channel = getTag(event, "buzz-channel");
   const projectChannelId =
-    channel && isValidProjectChannelId(channel) ? channel : null;
+    channel && isValidProjectChannelId(channel) ? channel.toLowerCase() : null;
   const relatedChannelIds = [
     ...new Set(
-      getAllTags(event, PROJECT_RELATED_CHANNEL_TAG).filter(
-        (channelId) =>
-          isValidProjectChannelId(channelId) && channelId !== projectChannelId,
-      ),
+      getAllTags(event, PROJECT_RELATED_CHANNEL_TAG).flatMap((channelId) => {
+        if (!isValidProjectChannelId(channelId)) return [];
+        const normalizedChannelId = channelId.toLowerCase();
+        return normalizedChannelId === projectChannelId
+          ? []
+          : [normalizedChannelId];
+      }),
     ),
   ].slice(0, MAX_PROJECT_RELATED_CHANNELS);
   return {

--- a/desktop/src/features/projects/projectRelatedChannelCommands.test.mjs
+++ b/desktop/src/features/projects/projectRelatedChannelCommands.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { setProjectRelatedChannel } from "./projectRelatedChannelCommands.ts";
+
+const CHANNEL_ID = "11111111-1111-4111-8111-111111111111";
+const PROJECT_ADDRESS = `30621:${"a".repeat(64)}:demo`;
+
+function relayEvent({ id, kind, tags }) {
+  return {
+    id,
+    pubkey: "a".repeat(64),
+    created_at: 1,
+    kind,
+    tags,
+    content: "",
+    sig: "0".repeat(128),
+  };
+}
+
+test("desired-state write signs and publishes one canonical command", async () => {
+  const signed = [];
+  let publishes = 0;
+  await setProjectRelatedChannel(
+    {
+      channelId: CHANNEL_ID,
+      linked: false,
+      projectAddress: PROJECT_ADDRESS,
+    },
+    {
+      signEvent: async (input) => {
+        signed.push(input);
+        return relayEvent({
+          id: String(signed.length).repeat(64),
+          kind: input.kind,
+          tags: input.tags,
+        });
+      },
+      publishEvent: async () => {
+        publishes += 1;
+      },
+    },
+  );
+  assert.deepEqual(signed[0].tags, [
+    ["a", PROJECT_ADDRESS],
+    ["op", "remove"],
+    ["d", CHANNEL_ID],
+  ]);
+  assert.equal(signed.length, 1);
+  assert.equal(publishes, 1);
+});
+
+test("relay rejections are not retried", async () => {
+  let signs = 0;
+  let publishes = 0;
+  await assert.rejects(
+    setProjectRelatedChannel(
+      {
+        channelId: CHANNEL_ID,
+        linked: true,
+        projectAddress: PROJECT_ADDRESS,
+      },
+      {
+        signEvent: async (input) => {
+          signs += 1;
+          return relayEvent({
+            id: "f".repeat(64),
+            kind: input.kind,
+            tags: input.tags,
+          });
+        },
+        publishEvent: async () => {
+          publishes += 1;
+          throw new Error("relay rejected command");
+        },
+      },
+    ),
+    /relay rejected command/,
+  );
+  assert.equal(signs, 1);
+  assert.equal(publishes, 1);
+});
+
+for (const [relayMessage, expected] of [
+  ["restricted: not a Project administrator", /don't have permission/i],
+  ["invalid: target channel is archived", /channel can't be linked/i],
+]) {
+  test(`maps ${relayMessage.split(":")[0]} relay failures to concise copy`, async () => {
+    await assert.rejects(
+      setProjectRelatedChannel(
+        {
+          channelId: CHANNEL_ID,
+          linked: true,
+          projectAddress: PROJECT_ADDRESS,
+        },
+        {
+          signEvent: async (input) =>
+            relayEvent({
+              id: "f".repeat(64),
+              kind: input.kind,
+              tags: input.tags,
+            }),
+          publishEvent: async () => {
+            throw new Error(relayMessage);
+          },
+        },
+      ),
+      expected,
+    );
+  });
+}

--- a/desktop/src/features/projects/projectRelatedChannelCommands.ts
+++ b/desktop/src/features/projects/projectRelatedChannelCommands.ts
@@ -1,0 +1,71 @@
+import { relayClient } from "@/shared/api/relayClient";
+import { signRelayEvent } from "@/shared/api/tauri";
+import { KIND_PROJECT_RELATED_CHANNEL } from "@/shared/constants/kinds";
+import { isValidProjectChannelId } from "./projectModels";
+
+function validateProjectCoordinate(projectAddress: string): void {
+  if (!/^30621:[0-9a-f]{64}:.+$/.test(projectAddress)) {
+    throw new Error("Invalid Project coordinate.");
+  }
+}
+
+function userFacingWriteError(error: unknown, linked: boolean): unknown {
+  if (!(error instanceof Error)) return error;
+  if (error.message.startsWith("restricted:")) {
+    return new Error(
+      `You don't have permission to ${linked ? "link" : "unlink"} channels for this Project.`,
+    );
+  }
+  if (
+    error.message.startsWith("invalid:") &&
+    /(?:channel|target)/i.test(error.message)
+  ) {
+    return new Error(
+      `This channel can't be ${linked ? "linked to" : "unlinked from"} the Project.`,
+    );
+  }
+  return error;
+}
+
+type SetStateDependencies = {
+  publishEvent?: typeof relayClient.publishEvent;
+  signEvent?: typeof signRelayEvent;
+};
+
+/** Submit one desired-state command. The relay serializes the projection. */
+export async function setProjectRelatedChannel(
+  input: { channelId: string; linked: boolean; projectAddress: string },
+  deps: SetStateDependencies = {},
+): Promise<void> {
+  const channelId = input.channelId.toLowerCase();
+  if (!isValidProjectChannelId(channelId)) {
+    throw new Error("Channel id must be a canonical UUID.");
+  }
+  validateProjectCoordinate(input.projectAddress);
+  const signEvent = deps.signEvent ?? signRelayEvent;
+  const publishEvent =
+    deps.publishEvent ?? relayClient.publishEvent.bind(relayClient);
+
+  try {
+    const event = await signEvent({
+      kind: KIND_PROJECT_RELATED_CHANNEL,
+      content: "",
+      tags: [
+        ["a", input.projectAddress],
+        ["op", input.linked ? "add" : "remove"],
+        ["d", channelId],
+      ],
+    });
+    await publishEvent(
+      event,
+      input.linked
+        ? "Timed out while linking the channel."
+        : "Timed out while unlinking the channel.",
+      input.linked
+        ? "Failed to link the channel."
+        : "Failed to unlink the channel.",
+    );
+  } catch (error) {
+    throw userFacingWriteError(error, input.linked);
+  }
+}

--- a/desktop/src/features/projects/projectRelatedChannelSnapshot.ts
+++ b/desktop/src/features/projects/projectRelatedChannelSnapshot.ts
@@ -1,0 +1,59 @@
+import type { RelayEvent } from "@/shared/api/types";
+import { KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT } from "@/shared/constants/kinds";
+import {
+  isValidProjectChannelId,
+  MAX_PROJECT_RELATED_CHANNELS,
+} from "./projectModels";
+
+const SNAPSHOT_D_PREFIX = "buzz:project-related-channels:v1";
+
+export async function projectRelatedChannelSnapshotD(
+  projectAddress: string,
+): Promise<string> {
+  const prefix = new TextEncoder().encode(SNAPSHOT_D_PREFIX);
+  const address = new TextEncoder().encode(projectAddress);
+  const bytes = new Uint8Array(prefix.length + 1 + address.length);
+  bytes.set(prefix);
+  bytes.set(address, prefix.length + 1);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (value) =>
+    value.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/** Parse one trusted relay snapshot with its canonical deterministic envelope. */
+export async function parseProjectRelatedChannelSnapshot(
+  event: RelayEvent,
+  projectAddress: string,
+): Promise<string[] | null> {
+  const expectedD = await projectRelatedChannelSnapshotD(projectAddress);
+  if (
+    event.kind !== KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT ||
+    event.content !== "" ||
+    event.tags[0]?.length !== 2 ||
+    event.tags[0]?.[0] !== "d" ||
+    event.tags[0]?.[1] !== expectedD ||
+    event.tags[1]?.length !== 2 ||
+    event.tags[1]?.[0] !== "a" ||
+    event.tags[1]?.[1] !== projectAddress
+  ) {
+    return null;
+  }
+
+  const channelIds: string[] = [];
+  for (const tag of event.tags.slice(2)) {
+    if (
+      tag.length !== 2 ||
+      tag[0] !== "c" ||
+      !tag[1] ||
+      !isValidProjectChannelId(tag[1]) ||
+      tag[1] !== tag[1].toLowerCase() ||
+      (channelIds.at(-1) ?? "") >= tag[1]
+    ) {
+      return null;
+    }
+    channelIds.push(tag[1]);
+  }
+  if (channelIds.length > MAX_PROJECT_RELATED_CHANNELS) return null;
+  return channelIds;
+}

--- a/desktop/src/features/projects/ui/LinkProjectChannelDialog.tsx
+++ b/desktop/src/features/projects/ui/LinkProjectChannelDialog.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+
+import type { Channel } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
+import { Dialog } from "@/shared/ui/dialog";
+
+export function LinkProjectChannelDialog({
+  channels,
+  isPending,
+  onLink,
+  onOpenChange,
+  open,
+  projectName,
+}: {
+  channels: Channel[];
+  isPending: boolean;
+  onLink: (channelId: string) => Promise<void>;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  projectName: string;
+}) {
+  const [selectedChannelId, setSelectedChannelId] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+  const selectRef = React.useRef<HTMLSelectElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setSelectedChannelId("");
+    setError(null);
+    const timer = globalThis.setTimeout(() => selectRef.current?.focus(), 50);
+    return () => globalThis.clearTimeout(timer);
+  }, [open]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedChannelId) return;
+    setError(null);
+    try {
+      await onLink(selectedChannelId);
+      onOpenChange(false);
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "Could not link the channel.",
+      );
+    }
+  }
+
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && isPending) return;
+        onOpenChange(nextOpen);
+      }}
+      open={open}
+    >
+      <ChooserDialogContent
+        className="max-w-md"
+        contentClassName="pt-3"
+        data-testid="link-project-channel-dialog"
+        footer={
+          <Button
+            data-testid="link-project-channel-submit"
+            disabled={isPending || !selectedChannelId}
+            form="link-project-channel-form"
+            type="submit"
+          >
+            {isPending ? "Linking…" : "Link channel"}
+          </Button>
+        }
+        footerClassName="justify-end"
+        headerSubtitle={`Choose an existing channel to add to ${projectName}.`}
+        title="Link a channel"
+      >
+        <form
+          id="link-project-channel-form"
+          onSubmit={(event) => void handleSubmit(event)}
+        >
+          {channels.length > 0 ? (
+            <div className="space-y-1.5">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="link-project-channel-select"
+              >
+                Channel
+              </label>
+              <select
+                className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+                data-testid="link-project-channel-select"
+                disabled={isPending}
+                id="link-project-channel-select"
+                onChange={(event) => {
+                  setSelectedChannelId(event.target.value);
+                  setError(null);
+                }}
+                ref={selectRef}
+                required
+                value={selectedChannelId}
+              >
+                <option value="">Select a channel</option>
+                {channels.map((channel) => (
+                  <option key={channel.id} value={channel.id}>
+                    #{channel.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Every active channel you belong to is already linked.
+            </p>
+          )}
+          {error ? (
+            <p className="mt-3 text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </form>
+      </ChooserDialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectChannelManagement.tsx
+++ b/desktop/src/features/projects/ui/ProjectChannelManagement.tsx
@@ -1,49 +1,50 @@
-import { Plus } from "lucide-react";
+import { Link2, Plus } from "lucide-react";
 import * as React from "react";
 import { toast } from "sonner";
 
-import { useIsManagedAgent } from "@/features/agent-memory/hooks";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
-import { useUsersBatchQuery } from "@/features/profile/hooks";
-import { ownsAuthorAgent } from "@/features/profile/lib/identity";
 import type { Project } from "@/features/projects/hooks";
 import { useAddProjectChannelMutation } from "@/features/projects/useAddProjectChannel";
+import { useCanManageProjectChannels } from "@/features/projects/useCanManageProjectChannels";
+import { useSetProjectRelatedChannelMutation } from "@/features/projects/useProjectRelatedChannels";
 import { CreateChannelDialog } from "@/features/sidebar/ui/CreateChannelDialog";
+import type { Channel } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
+import { LinkProjectChannelDialog } from "./LinkProjectChannelDialog";
 
 export function ProjectChannelManagement({
+  channels,
   identityPubkey,
   project,
+  relatedChannelIds,
 }: {
+  channels: Channel[];
   identityPubkey?: string;
   project: Project;
+  relatedChannelIds: readonly string[];
 }) {
   const { goChannel } = useAppNavigation();
   const [createOpen, setCreateOpen] = React.useState(false);
+  const [linkOpen, setLinkOpen] = React.useState(false);
   const createMutation = useAddProjectChannelMutation();
-  const ownerProfileQuery = useUsersBatchQuery([project.owner], {
-    enabled: Boolean(identityPubkey),
+  const linkMutation = useSetProjectRelatedChannelMutation(project);
+  const { canCreate, canManage, ownerControlAgentPubkey } =
+    useCanManageProjectChannels(project, channels, identityPubkey);
+  const relatedIds = new Set(relatedChannelIds.map((id) => id.toLowerCase()));
+  const normalizedHomeChannelId = project.projectChannelId?.toLowerCase();
+  const eligibleChannels = channels.filter((channel) => {
+    const channelId = channel.id.toLowerCase();
+    return (
+      channel.archivedAt === null &&
+      channel.isMember &&
+      channelId !== normalizedHomeChannelId &&
+      !relatedIds.has(channelId)
+    );
   });
-  const projectOwnerProfile =
-    ownerProfileQuery.data?.profiles[project.owner.toLowerCase()];
-  const projectOwnerIsManaged = useIsManagedAgent(project.owner) === true;
-  const viewerIsProjectOwner =
-    identityPubkey?.toLowerCase() === project.owner.toLowerCase();
-  const viewerOwnsProjectAgent = ownsAuthorAgent(
-    projectOwnerProfile,
-    identityPubkey,
-  );
-  const canEdit =
-    !project.legacy &&
-    (viewerIsProjectOwner || projectOwnerIsManaged || viewerOwnsProjectAgent);
-  const ownerControlAgentPubkey =
-    viewerOwnsProjectAgent && !projectOwnerIsManaged && !viewerIsProjectOwner
-      ? project.owner
-      : undefined;
 
   return (
     <>
-      {canEdit ? (
+      {canCreate ? (
         <CreateChannelDialog
           channelKind={createOpen ? "stream" : null}
           description="Add another stream to this project. A template can keep the same canvas and agents."
@@ -62,15 +63,47 @@ export function ProjectChannelManagement({
           title="Create a project channel"
         />
       ) : null}
+      {canManage ? (
+        <LinkProjectChannelDialog
+          channels={eligibleChannels}
+          isPending={linkMutation.isPending}
+          onLink={async (channelId) => {
+            await linkMutation.mutateAsync({ channelId, linked: true });
+            const linked = channels.find((channel) => channel.id === channelId);
+            toast.success(
+              linked ? `Channel "#${linked.name}" linked.` : "Channel linked.",
+            );
+          }}
+          onOpenChange={setLinkOpen}
+          open={linkOpen}
+          projectName={project.name}
+        />
+      ) : null}
+      {canManage ? (
+        <Button
+          aria-label="Link existing channel"
+          className="h-6 w-6 shrink-0 rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+          data-testid="link-project-channel"
+          onClick={() => setLinkOpen(true)}
+          size="icon"
+          title="Link existing channel"
+          type="button"
+          variant="ghost"
+        >
+          <Link2 className="h-4 w-4" />
+        </Button>
+      ) : null}
       <Button
-        aria-label="Add channel"
+        aria-label="Create channel"
         className="h-6 w-6 shrink-0 rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
         data-testid="add-project-channel"
-        disabled={!canEdit}
+        disabled={!canCreate}
         onClick={() => setCreateOpen(true)}
         size="icon"
         title={
-          canEdit ? "Add channel" : "Only the project owner can add channels"
+          canCreate
+            ? "Create channel"
+            : "Only the project owner can create channels"
         }
         type="button"
         variant="ghost"

--- a/desktop/src/features/projects/ui/ProjectHomeContextPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectHomeContextPanel.tsx
@@ -6,9 +6,11 @@ import {
   GitCommitHorizontal,
   GitPullRequest,
   Hash,
+  Unlink,
   Users,
 } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 
 import { presentContextCount } from "@/features/projects/lib/projectHomeSummary";
 import type { ProjectHomeWorkspaceSheetTab } from "@/features/projects/lib/projectHomeWorkspaceSheet";
@@ -21,11 +23,15 @@ import {
   type Project,
 } from "@/features/projects/hooks";
 import { ProjectChannelIcon } from "@/features/projects/ui/ProjectChannelIcon";
+import { useCanManageProjectChannels } from "@/features/projects/useCanManageProjectChannels";
+import { useSetProjectRelatedChannelMutation } from "@/features/projects/useProjectRelatedChannels";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import type { EntityLinkTab } from "@/shared/lib/entityLink";
 import { Button } from "@/shared/ui/button";
+import { DropdownMenuItem } from "@/shared/ui/dropdown-menu";
 import { ProjectChannelManagement } from "./ProjectChannelManagement";
+import { ProjectListRowMenu } from "./ProjectListRowMenu";
 import { ProjectRepositoryManagement } from "./ProjectRepositoryManagement";
 import { SECTION_ACTION_VISIBILITY_CLASS } from "@/features/sidebar/ui/sidebarSectionStyles";
 
@@ -151,29 +157,71 @@ function ContextNavButton({
 
 function ChannelContextRow({
   channel,
+  channelId,
   onClick,
+  onUnlink,
   projectHome,
   testId,
 }: {
-  channel: Channel;
+  channel: Channel | null;
+  channelId: string;
   onClick?: () => void;
+  onUnlink?: () => void;
   projectHome?: boolean;
   testId: string;
 }) {
   const Icon = projectHome ? ProjectChannelIcon : Hash;
-  if (onClick) {
+  const label =
+    channel?.name ?? `Unavailable channel (${channelId.slice(0, 8)}…)`;
+  if (onClick && channel) {
     return (
-      <ContextNavButton icon={<Icon />} onClick={onClick} testId={testId}>
-        {channel.name}
-      </ContextNavButton>
+      <div
+        className="group/channel-row flex min-w-0 items-center"
+        data-testid={testId}
+      >
+        <ContextNavButton icon={<Icon />} onClick={onClick}>
+          {label}
+        </ContextNavButton>
+        {onUnlink ? (
+          <span className="-ml-9 opacity-0 transition-opacity group-hover/channel-row:opacity-100 group-focus-within/channel-row:opacity-100">
+            <ProjectListRowMenu label={`More options for #${label}`}>
+              <DropdownMenuItem
+                data-testid={`unlink-project-channel-${channelId}`}
+                onSelect={onUnlink}
+              >
+                <Unlink />
+                Remove from Project
+              </DropdownMenuItem>
+            </ProjectListRowMenu>
+          </span>
+        ) : null}
+      </div>
     );
   }
   return (
     <div
-      className={`${PROJECT_HOME_SIDEBAR_ROW_CLASS} pointer-events-none flex items-center`}
+      className="group/channel-row flex min-w-0 items-center"
       data-testid={testId}
     >
-      <ContextRowContent icon={<Icon />}>{channel.name}</ContextRowContent>
+      <div
+        className={`${PROJECT_HOME_SIDEBAR_ROW_CLASS} pointer-events-none flex min-w-0 items-center`}
+        title={channel ? undefined : channelId}
+      >
+        <ContextRowContent icon={<Icon />}>{label}</ContextRowContent>
+      </div>
+      {onUnlink ? (
+        <span className="-ml-9 opacity-0 transition-opacity group-hover/channel-row:opacity-100 group-focus-within/channel-row:opacity-100">
+          <ProjectListRowMenu label={`More options for #${label}`}>
+            <DropdownMenuItem
+              data-testid={`unlink-project-channel-${channelId}`}
+              onSelect={onUnlink}
+            >
+              <Unlink />
+              Remove from Project
+            </DropdownMenuItem>
+          </ProjectListRowMenu>
+        </span>
+      ) : null}
     </div>
   );
 }
@@ -203,6 +251,13 @@ export function ProjectHomeContextPanel({
   project: Project;
   projects: Project[];
 }) {
+  const setRelatedChannelMutation =
+    useSetProjectRelatedChannelMutation(project);
+  const { canManage } = useCanManageProjectChannels(
+    project,
+    channels,
+    identityPubkey,
+  );
   const firstRepository = project.repositories[0] ?? null;
   const addRepositoryTitle = firstRepository
     ? undefined
@@ -237,14 +292,16 @@ export function ProjectHomeContextPanel({
   const channelsById = new Map(
     channels.map((candidate) => [candidate.id, candidate]),
   );
-  const boundChannels = listProjectBoundChannels(project).flatMap((binding) => {
-    const boundChannel = channelsById.get(binding.channelId);
-    if (!boundChannel) return [];
-    return [{ ...binding, channel: boundChannel }];
-  });
+  const boundChannels = listProjectBoundChannels(project).map((binding) => ({
+    ...binding,
+    channel: channelsById.get(binding.channelId) ?? null,
+  }));
+  const visibleBoundChannels = boundChannels.filter(
+    (binding) => binding.channel || canManage,
+  );
   const listedChannels =
-    boundChannels.length > 0
-      ? boundChannels
+    visibleBoundChannels.length > 0
+      ? visibleBoundChannels
       : channel
         ? [
             {
@@ -325,8 +382,10 @@ export function ProjectHomeContextPanel({
         collapsible
         headerAction={
           <ProjectChannelManagement
+            channels={channels}
             identityPubkey={identityPubkey}
             project={project}
+            relatedChannelIds={project.relatedChannelIds}
           />
         }
         testId="project-home-context-channel"
@@ -338,17 +397,45 @@ export function ProjectHomeContextPanel({
             return (
               <ChannelContextRow
                 channel={binding.channel}
-                key={`${binding.role}:${binding.channel.id}`}
+                channelId={binding.channelId}
+                key={`${binding.role}:${binding.channelId}`}
                 onClick={
-                  isHome || !onOpenChannel
+                  isHome || !binding.channel || !onOpenChannel
                     ? undefined
-                    : () => onOpenChannel(binding.channel.id)
+                    : () => onOpenChannel(binding.channelId)
+                }
+                onUnlink={
+                  !isHome &&
+                  canManage &&
+                  project.relatedChannelIds.includes(binding.channelId)
+                    ? () => {
+                        void setRelatedChannelMutation
+                          .mutateAsync({
+                            channelId: binding.channelId,
+                            linked: false,
+                          })
+                          .then(() => {
+                            toast.success(
+                              binding.channel
+                                ? `Channel "#${binding.channel.name}" removed.`
+                                : "Channel removed from Project.",
+                            );
+                          })
+                          .catch((error: unknown) => {
+                            toast.error(
+                              error instanceof Error
+                                ? error.message
+                                : "Could not remove the channel.",
+                            );
+                          });
+                      }
+                    : undefined
                 }
                 projectHome={isHome}
                 testId={
                   isHome
                     ? "project-home-context-home-channel"
-                    : `project-home-context-channel-${binding.channel.name}`
+                    : `project-home-context-channel-${binding.channel?.name ?? binding.channelId}`
                 }
               />
             );

--- a/desktop/src/features/projects/useCanManageProjectChannels.test.mjs
+++ b/desktop/src/features/projects/useCanManageProjectChannels.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveProjectChannelManagement } from "./useCanManageProjectChannels.ts";
+
+const base = {
+  activeHomeChannel: true,
+  homeCanManage: false,
+  projectIsLegacy: false,
+  projectOwner: "a".repeat(64),
+  projectOwnerIsManaged: false,
+  viewerIsProjectOwner: false,
+  viewerOwnsProjectAgent: false,
+};
+
+test("an active home-channel administrator can manage related channels", () => {
+  const capabilities = resolveProjectChannelManagement({
+    ...base,
+    homeCanManage: true,
+  });
+  assert.equal(capabilities.canManage, true);
+  assert.equal(capabilities.canCreate, false);
+});
+
+test("an ordinary home-channel member cannot manage related channels", () => {
+  const capabilities = resolveProjectChannelManagement(base);
+  assert.equal(capabilities.canManage, false);
+});
+
+test("channel authority is unavailable without an active Project home", () => {
+  const capabilities = resolveProjectChannelManagement({
+    ...base,
+    activeHomeChannel: false,
+    homeCanManage: true,
+  });
+  assert.equal(capabilities.canManage, false);
+});
+
+test("the Project owner can manage without a home channel", () => {
+  const capabilities = resolveProjectChannelManagement({
+    ...base,
+    activeHomeChannel: false,
+    viewerIsProjectOwner: true,
+  });
+  assert.equal(capabilities.canManage, true);
+  assert.equal(capabilities.canCreate, true);
+});

--- a/desktop/src/features/projects/useCanManageProjectChannels.ts
+++ b/desktop/src/features/projects/useCanManageProjectChannels.ts
@@ -1,0 +1,76 @@
+import { useIsManagedAgent } from "@/features/agent-memory/hooks";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { useChannelModerationCapabilities } from "@/features/channels/ui/ChannelManagementModerationActions";
+import type { Project } from "@/features/projects/projectModels";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { ownsAuthorAgent } from "@/features/profile/lib/identity";
+import type { Channel } from "@/shared/api/types";
+
+export function resolveProjectChannelManagement(input: {
+  activeHomeChannel: boolean;
+  homeCanManage: boolean;
+  projectIsLegacy: boolean;
+  projectOwner: string;
+  projectOwnerIsManaged: boolean;
+  viewerIsProjectOwner: boolean;
+  viewerOwnsProjectAgent: boolean;
+}) {
+  const canControlOwnerProject =
+    input.viewerIsProjectOwner ||
+    input.projectOwnerIsManaged ||
+    input.viewerOwnsProjectAgent;
+  return {
+    canCreate: !input.projectIsLegacy && canControlOwnerProject,
+    canManage:
+      !input.projectIsLegacy &&
+      (canControlOwnerProject ||
+        (input.activeHomeChannel && input.homeCanManage)),
+    ownerControlAgentPubkey:
+      input.viewerOwnsProjectAgent &&
+      !input.projectOwnerIsManaged &&
+      !input.viewerIsProjectOwner
+        ? input.projectOwner
+        : undefined,
+  };
+}
+
+export function useCanManageProjectChannels(
+  project: Project,
+  channels: Channel[],
+  identityPubkey?: string,
+) {
+  const ownerProfileQuery = useUsersBatchQuery([project.owner], {
+    enabled: Boolean(identityPubkey),
+  });
+  const projectOwnerProfile =
+    ownerProfileQuery.data?.profiles[project.owner.toLowerCase()];
+  const projectOwnerIsManaged = useIsManagedAgent(project.owner) === true;
+  const viewerIsProjectOwner =
+    identityPubkey?.toLowerCase() === project.owner.toLowerCase();
+  const viewerOwnsProjectAgent = ownsAuthorAgent(
+    projectOwnerProfile,
+    identityPubkey,
+  );
+  const activeHomeChannel = channels.find(
+    (channel) =>
+      channel.id === project.projectChannelId && channel.archivedAt === null,
+  );
+  const homeMembersQuery = useChannelMembersQuery(
+    activeHomeChannel?.id ?? null,
+    Boolean(identityPubkey && activeHomeChannel),
+  );
+  const homeCapabilities = useChannelModerationCapabilities(
+    homeMembersQuery.data,
+    identityPubkey,
+    Boolean(identityPubkey && activeHomeChannel),
+  );
+  return resolveProjectChannelManagement({
+    activeHomeChannel: Boolean(activeHomeChannel),
+    homeCanManage: homeCapabilities.canManageChannel,
+    projectIsLegacy: project.legacy,
+    projectOwner: project.owner,
+    projectOwnerIsManaged,
+    viewerIsProjectOwner,
+    viewerOwnsProjectAgent,
+  });
+}

--- a/desktop/src/features/projects/useProjectRelatedChannels.ts
+++ b/desktop/src/features/projects/useProjectRelatedChannels.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { projectsQueryKey } from "@/features/projects/projectDeletionMutation";
+import type { Project } from "@/features/projects/projectModels";
+import { setProjectRelatedChannel } from "@/features/projects/projectRelatedChannelCommands";
+
+export function useSetProjectRelatedChannelMutation(project: Project) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { channelId: string; linked: boolean }) =>
+      setProjectRelatedChannel({
+        ...input,
+        projectAddress: project.projectAddress,
+      }),
+    onSuccess: (_result, input) => {
+      queryClient.setQueryData<Project[]>(projectsQueryKey, (current = []) =>
+        current.map((candidate) => {
+          if (candidate.projectAddress !== project.projectAddress) {
+            return candidate;
+          }
+          const relatedChannelIds = new Set(candidate.relatedChannelIds);
+          if (input.linked) {
+            relatedChannelIds.add(input.channelId);
+          } else {
+            relatedChannelIds.delete(input.channelId);
+          }
+          return { ...candidate, relatedChannelIds: [...relatedChannelIds] };
+        }),
+      );
+      void queryClient.invalidateQueries({ queryKey: projectsQueryKey });
+    },
+  });
+}

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -70,6 +70,9 @@ export const KIND_REPO_ANNOUNCEMENT = 30617;
 export const KIND_REPO_STATE = 30618;
 // NIP-MP: project grouping above NIP-34 repositories.
 export const KIND_PROJECT_ANNOUNCEMENT = 30621;
+// Actor-signed, relay-authorized Project related-channel command.
+export const KIND_PROJECT_RELATED_CHANNEL = 47010;
+export const KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT = 30623;
 export const KIND_GIT_PATCH = 1617;
 export const KIND_GIT_PULL_REQUEST = 1618;
 export const KIND_GIT_PR_UPDATE = 1619;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -68,6 +68,8 @@ import {
   KIND_MEMBER_REMOVED_NOTIFICATION,
   KIND_PERSONA,
   KIND_PROJECT_ANNOUNCEMENT,
+  KIND_PROJECT_RELATED_CHANNEL,
+  KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT,
   KIND_REPO_ANNOUNCEMENT,
   KIND_REPO_STATE,
   KIND_STREAM_MESSAGE_EDIT,
@@ -76,6 +78,7 @@ import {
   KIND_TEAM_CATALOG,
   KIND_USER_STATUS,
 } from "@/shared/constants/kinds";
+import { projectRelatedChannelSnapshotD } from "@/features/projects/projectRelatedChannelSnapshot";
 import type {
   RawAcpAuthMethodsResult,
   RawConnectAcpRuntimeResult,
@@ -6065,6 +6068,8 @@ const MOCK_PROJECT_SUBJECTS = [
 
 const MOCK_PROJECT_KINDS = new Set<number>([
   KIND_PROJECT_ANNOUNCEMENT,
+  KIND_PROJECT_RELATED_CHANNEL,
+  KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT,
   KIND_REPO_ANNOUNCEMENT,
   KIND_REPO_STATE,
   KIND_GIT_PATCH,
@@ -6279,10 +6284,79 @@ function isMockProjectScopedEvent(event: RelayEvent): boolean {
   const hasRepoAddressTag = event.tags.some(
     (tag) => tag[0] === "a" && (tag[1] ?? "").startsWith("30617:"),
   );
+  const hasProjectAddressTag = event.tags.some(
+    (tag) => tag[0] === "a" && (tag[1] ?? "").startsWith("30621:"),
+  );
   return (
-    (event.kind === KIND_REPO_ANNOUNCEMENT || hasRepoAddressTag) &&
+    (event.kind === KIND_REPO_ANNOUNCEMENT ||
+      hasRepoAddressTag ||
+      hasProjectAddressTag) &&
     (event.kind === 1 || MOCK_PROJECT_KINDS.has(event.kind))
   );
+}
+
+function mockProjectCoordinate(event: RelayEvent): string | null {
+  const dtag = event.tags.find((tag) => tag[0] === "d")?.[1];
+  return dtag ? `${event.kind}:${event.pubkey.toLowerCase()}:${dtag}` : null;
+}
+
+async function updateMockProjectRelatedChannelSnapshot(
+  command: RelayEvent,
+): Promise<void> {
+  const projectAddress = command.tags.find((tag) => tag[0] === "a")?.[1];
+  if (!projectAddress) return;
+  const store = getMockProjectEventStore();
+  const project = store
+    .filter(
+      (candidate) =>
+        candidate.kind === KIND_PROJECT_ANNOUNCEMENT &&
+        mockProjectCoordinate(candidate) === projectAddress,
+    )
+    .sort((left, right) => right.created_at - left.created_at)[0];
+  if (!project) return;
+
+  const relatedChannelIds = new Set<string>();
+  for (const tag of project.tags) {
+    if (tag[0] === "buzz-related-channel" && tag[1]) {
+      relatedChannelIds.add(tag[1].toLowerCase());
+    }
+  }
+  for (const event of store) {
+    if (
+      event.kind !== KIND_PROJECT_RELATED_CHANNEL ||
+      !event.tags.some((tag) => tag[0] === "a" && tag[1] === projectAddress)
+    ) {
+      continue;
+    }
+    const channelId = event.tags.find((tag) => tag[0] === "d")?.[1];
+    const operation = event.tags.find((tag) => tag[0] === "op")?.[1];
+    if (!channelId || !operation) continue;
+    const normalizedChannelId = channelId.toLowerCase();
+    if (operation === "add") relatedChannelIds.add(normalizedChannelId);
+    if (operation === "remove") relatedChannelIds.delete(normalizedChannelId);
+  }
+
+  const tags = [
+    ["d", await projectRelatedChannelSnapshotD(projectAddress)],
+    ["a", projectAddress],
+    ...[...relatedChannelIds]
+      .sort((left, right) => left.localeCompare(right))
+      .map((channelId) => ["c", channelId]),
+  ];
+  const relayPubkey = getConfig()?.mock?.relaySelf ?? project.pubkey;
+  const snapshot = createMockEvent(
+    KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT,
+    "",
+    tags,
+    relayPubkey,
+  );
+  const existingIndex = store.findIndex(
+    (event) =>
+      event.kind === KIND_PROJECT_RELATED_CHANNEL_SNAPSHOT &&
+      event.tags.some((tag) => tag[0] === "a" && tag[1] === projectAddress),
+  );
+  if (existingIndex >= 0) store.splice(existingIndex, 1);
+  store.push(snapshot);
 }
 
 function filterMockProjectEvents(filter: MockFilter): RelayEvent[] {
@@ -10654,7 +10728,7 @@ async function sendToRealSocket(args: {
   }
 }
 
-function sendToMockSocket(args: {
+async function sendToMockSocket(args: {
   id: number;
   message?: {
     type: "Text" | "Close";
@@ -11116,6 +11190,9 @@ function sendToMockSocket(args: {
         return;
       }
       getMockProjectEventStore().push(event);
+      if (event.kind === KIND_PROJECT_RELATED_CHANNEL) {
+        await updateMockProjectRelatedChannelSnapshot(event);
+      }
       const acceptedProjectEvents =
         window.__BUZZ_E2E_ACCEPTED_PROJECT_EVENTS__ ?? [];
       acceptedProjectEvents.push({

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -258,7 +258,7 @@ test("top-level project lists show metadata and overflow actions", async ({
 
 test("creating a project opens its channel conversation", async ({ page }) => {
   await enableProjectsFeature(page);
-  await installMockBridge(page);
+  await installMockBridge(page, { relaySelf: "f".repeat(64) });
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await page.getByTestId("open-projects-view").click();
   await openCreateProjectDialog(page);
@@ -344,6 +344,74 @@ test("creating a project opens its channel conversation", async ({ page }) => {
     page.getByTestId("project-home-context-channel"),
   ).not.toContainText("people in this channel");
   const channelSection = page.getByTestId("project-home-context-channel");
+  await channelSection.hover();
+  const snapshotQueriesBeforeLink = await page.evaluate(
+    () =>
+      window.__BUZZ_E2E_PROJECT_QUERY_FILTERS__?.filter((filter) =>
+        filter.kinds?.includes(30623),
+      ).length ?? 0,
+  );
+  await page.getByTestId("link-project-channel").click();
+  await expect(page.getByTestId("link-project-channel-dialog")).toBeVisible();
+  await page
+    .getByTestId("link-project-channel-select")
+    .selectOption({ label: "#engineering" });
+  await page.getByTestId("link-project-channel-submit").click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_PROJECT_QUERY_FILTERS__?.filter((filter) =>
+            filter.kinds?.includes(30623),
+          ).length ?? 0,
+      ),
+    )
+    .toBeGreaterThan(snapshotQueriesBeforeLink);
+  const snapshotQueriesBeforeUnlink = await page.evaluate(
+    () =>
+      window.__BUZZ_E2E_PROJECT_QUERY_FILTERS__?.filter((filter) =>
+        filter.kinds?.includes(30623),
+      ).length ?? 0,
+  );
+  const linkedEngineering = page.getByTestId(
+    "project-home-context-channel-engineering",
+  );
+  await expect(linkedEngineering).toBeVisible();
+  await linkedEngineering.hover();
+  await linkedEngineering
+    .getByRole("button", { name: "More options for #engineering" })
+    .click();
+  await page
+    .getByTestId("unlink-project-channel-1c7e1c02-87bb-5e88-b2da-5a7a9432d0c9")
+    .click();
+  await expect(linkedEngineering).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_PROJECT_QUERY_FILTERS__?.filter((filter) =>
+            filter.kinds?.includes(30623),
+          ).length ?? 0,
+      ),
+    )
+    .toBeGreaterThan(snapshotQueriesBeforeUnlink);
+  const relatedChannelCommands = await page.evaluate(() =>
+    (window.__BUZZ_E2E_ACCEPTED_PROJECT_EVENTS__ ?? [])
+      .filter((event) => event.kind === 47010)
+      .map((event) => event.tags),
+  );
+  expect(relatedChannelCommands).toHaveLength(2);
+  expect(
+    relatedChannelCommands.map((tags) => tags.map((tag) => tag[0])),
+  ).toEqual([
+    ["a", "op", "d"],
+    ["a", "op", "d"],
+  ]);
+  expect(
+    relatedChannelCommands.map(
+      (tags) => tags.find((tag) => tag[0] === "op")?.[1],
+    ),
+  ).toEqual(["add", "remove"]);
   const channelSectionToggle = channelSection.getByRole("button", {
     name: "Channels",
     exact: true,


### PR DESCRIPTION
## Summary

Adds the Desktop workflow for managing a Project's existing related channels through the relay-backed Project membership contract.

- Project owners and home-channel admins can open **Link existing channel**, choose an eligible channel, and link it to the Project.
- Linked channels appear in the Project home context panel and can be removed from their overflow menu.
- Ordinary members do not receive the management controls.
- Project reads overlay the relay-signed related-channel snapshot, with legacy Project tags retained when no snapshot exists.
- Successful mutations update only related-channel state in the Project cache, preserving concurrent metadata and repository refreshes.

### Related issue

None found.

### Testing

The Desktop Playwright workflow creates a Project, opens **Link existing channel**, selects `#engineering`, verifies the linked channel appears after a snapshot refresh, removes it from the channel overflow menu, and verifies the exact add/remove command tags accepted by the mock relay. The focused run passed on the production React controls, as did the complete 5,892-test Desktop suite and Tauri workspace checks.

A real isolated Tauri build also completed onboarding, relay connection, Projects enablement, Project discovery, and sidebar addition against the disposable relay. The real-build link/unlink mutation was not completed because that fixture opened on an unavailable-repository route and the remaining navigation was not available through non-pointer automation.

## Screenshots

### Link an existing channel

An eligible Project manager can open the existing-channel chooser from the Project home.

![Link an existing channel](https://raw.githubusercontent.com/block/buzz/abe9feeb0ba21249fb5f04ce797e5f6c49d893fb/pr-7257--01-link-channel-dialog.png)

### Linked channel on the Project home

The accepted relation appears in the Project's Channels section.

![Linked channel on the Project home](https://raw.githubusercontent.com/block/buzz/abe9feeb0ba21249fb5f04ce797e5f6c49d893fb/pr-7257--02-linked-channel.png)
