### PR TITLE
fix(desktop): route live thread replies to thread caches

### DIFF
--- a/desktop/src/features/channels/useLiveChannelUpdates.test.mjs
+++ b/desktop/src/features/channels/useLiveChannelUpdates.test.mjs
@@ -33,6 +33,7 @@ after(() => dom.window.close());
 
 const CHANNEL_ID = "channel-a";
 const ROOT_ID = "a".repeat(64);
+const PARENT_ID = "1".repeat(64);
 const EXISTING_REPLY_ID = "b".repeat(64);
 const NEW_REPLY_ID = "c".repeat(64);
 const TOP_LEVEL_ID = "d".repeat(64);
@@ -129,6 +130,47 @@ test("non-broadcast replies stay out of channelMessagesKey and merge into an exi
     existingReply,
     reply,
   ]);
+
+  unmount();
+  client.clear();
+});
+
+test("nested non-broadcast replies use the root thread cache instead of the parent cache", async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(channelMessagesKey(CHANNEL_ID), [rootEvent()]);
+  const parentReply = directReplyEvent(PARENT_ID, 101, [], "parent-reply");
+  client.setQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID), [parentReply]);
+
+  const { callback, unmount } = await mountLiveUpdates(client);
+  const nestedReply = event(
+    NEW_REPLY_ID,
+    102,
+    [
+      ["h", CHANNEL_ID],
+      ["e", ROOT_ID, "", "root"],
+      ["e", PARENT_ID, "", "reply"],
+    ],
+    "nested-reply",
+  );
+
+  callback(nestedReply);
+
+  assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
+    rootEvent(),
+  ]);
+  assert.deepEqual(client.getQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID)), [
+    parentReply,
+    nestedReply,
+  ]);
+  assert.equal(
+    client.getQueryCache().find({
+      queryKey: threadRepliesKey(CHANNEL_ID, PARENT_ID),
+      exact: true,
+    }),
+    undefined,
+  );
 
   unmount();
   client.clear();

--- a/desktop/src/features/channels/useLiveChannelUpdates.test.mjs
+++ b/desktop/src/features/channels/useLiveChannelUpdates.test.mjs
@@ -9,6 +9,8 @@ import {
   channelMessagesKey,
   threadRepliesKey,
 } from "@/features/messages/lib/messageQueryKeys.ts";
+import { formatTimelineMessages } from "@/features/messages/lib/formatTimelineMessages.ts";
+import { buildMainTimelineEntries } from "@/features/messages/lib/threadPanel.ts";
 import { relayClient } from "@/shared/api/relayClient.ts";
 import { KIND_STREAM_MESSAGE } from "@/shared/constants/kinds";
 
@@ -105,7 +107,7 @@ async function mountLiveUpdates(client) {
   };
 }
 
-test("non-broadcast replies stay out of channelMessagesKey and merge into an existing thread cache", async () => {
+test("non-broadcast replies feed the raw projection and root thread cache without rendering as timeline rows", async () => {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -123,13 +125,29 @@ test("non-broadcast replies stay out of channelMessagesKey and merge into an exi
 
   callback(reply);
 
-  assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
-    rootEvent(),
-  ]);
+  const rawMessages = client.getQueryData(channelMessagesKey(CHANNEL_ID));
+  assert.deepEqual(rawMessages, [rootEvent(), reply]);
   assert.deepEqual(client.getQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID)), [
     existingReply,
     reply,
   ]);
+  const entries = buildMainTimelineEntries(
+    formatTimelineMessages(rawMessages, channel, undefined, null),
+  );
+  assert.deepEqual(
+    entries.map((entry) => ({
+      id: entry.message.id,
+      summaryThreadHeadId: entry.summary?.threadHeadId ?? null,
+      summaryReplyCount: entry.summary?.replyCount ?? 0,
+    })),
+    [
+      {
+        id: ROOT_ID,
+        summaryThreadHeadId: ROOT_ID,
+        summaryReplyCount: 1,
+      },
+    ],
+  );
 
   unmount();
   client.clear();
@@ -159,6 +177,7 @@ test("nested non-broadcast replies use the root thread cache instead of the pare
 
   assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
     rootEvent(),
+    nestedReply,
   ]);
   assert.deepEqual(client.getQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID)), [
     parentReply,
@@ -192,6 +211,7 @@ test("non-broadcast replies merge into an existing empty thread query", async ()
 
   assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
     rootEvent(),
+    reply,
   ]);
   assert.deepEqual(client.getQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID)), [
     reply,
@@ -214,6 +234,7 @@ test("non-broadcast replies do not create thread cache entries for unopened thre
 
   assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
     rootEvent(),
+    reply,
   ]);
   assert.equal(
     client.getQueryCache().find({

--- a/desktop/src/features/channels/useLiveChannelUpdates.test.mjs
+++ b/desktop/src/features/channels/useLiveChannelUpdates.test.mjs
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { after, afterEach, mock, test } from "node:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { JSDOM } from "jsdom";
+import React from "react";
+
+import { useLiveChannelUpdates } from "./useLiveChannelUpdates.ts";
+import {
+  channelMessagesKey,
+  threadRepliesKey,
+} from "@/features/messages/lib/messageQueryKeys.ts";
+import { relayClient } from "@/shared/api/relayClient.ts";
+import { KIND_STREAM_MESSAGE } from "@/shared/constants/kinds";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+Object.assign(globalThis, {
+  document: dom.window.document,
+  HTMLElement: dom.window.HTMLElement,
+  IS_REACT_ACT_ENVIRONMENT: true,
+  window: dom.window,
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+  mock.restoreAll();
+});
+
+after(() => dom.window.close());
+
+const CHANNEL_ID = "channel-a";
+const ROOT_ID = "a".repeat(64);
+const EXISTING_REPLY_ID = "b".repeat(64);
+const NEW_REPLY_ID = "c".repeat(64);
+const TOP_LEVEL_ID = "d".repeat(64);
+const BROADCAST_REPLY_ID = "e".repeat(64);
+
+const channel = {
+  id: CHANNEL_ID,
+  name: "general",
+  channelType: "stream",
+  visibility: "open",
+  description: "",
+  topic: null,
+  purpose: null,
+  memberCount: 1,
+  memberPubkeys: [],
+  lastMessageAt: null,
+  archivedAt: null,
+  participants: [],
+  participantPubkeys: [],
+  isMember: true,
+  ttlSeconds: null,
+  ttlDeadline: null,
+};
+
+function event(id, createdAt, tags, content = id) {
+  return {
+    id,
+    pubkey: "f".repeat(64),
+    created_at: createdAt,
+    kind: KIND_STREAM_MESSAGE,
+    tags,
+    content,
+    sig: "0".repeat(128),
+  };
+}
+
+function rootEvent() {
+  return event(ROOT_ID, 100, [["h", CHANNEL_ID]], "root");
+}
+
+function directReplyEvent(id, createdAt, extraTags = [], content = id) {
+  return event(
+    id,
+    createdAt,
+    [["h", CHANNEL_ID], ["e", ROOT_ID, "", "reply"], ...extraTags],
+    content,
+  );
+}
+
+async function mountLiveUpdates(client) {
+  let callback = null;
+  mock.method(relayClient, "subscribeToReconnects", () => () => {});
+  mock.method(relayClient, "subscribeLive", async (_filter, onEvent) => {
+    callback = onEvent;
+    return async () => {};
+  });
+
+  const { renderHook, waitFor } = await import("@testing-library/react");
+  const view = renderHook(() => useLiveChannelUpdates([channel], null), {
+    wrapper: ({ children }) =>
+      React.createElement(QueryClientProvider, { client }, children),
+  });
+
+  await waitFor(() => assert.equal(typeof callback, "function"));
+
+  return {
+    callback,
+    unmount: () => view.unmount(),
+  };
+}
+
+test("non-broadcast replies stay out of channelMessagesKey and merge into an existing thread cache", async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(channelMessagesKey(CHANNEL_ID), [rootEvent()]);
+  const existingReply = directReplyEvent(
+    EXISTING_REPLY_ID,
+    101,
+    [],
+    "existing-thread-reply",
+  );
+  client.setQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID), [existingReply]);
+
+  const { callback, unmount } = await mountLiveUpdates(client);
+  const reply = directReplyEvent(NEW_REPLY_ID, 102, [], "new-thread-reply");
+
+  callback(reply);
+
+  assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
+    rootEvent(),
+  ]);
+  assert.deepEqual(client.getQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID)), [
+    existingReply,
+    reply,
+  ]);
+
+  unmount();
+  client.clear();
+});
+
+test("non-broadcast replies merge into an existing empty thread query", async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(channelMessagesKey(CHANNEL_ID), [rootEvent()]);
+  client.getQueryCache().build(client, {
+    queryKey: threadRepliesKey(CHANNEL_ID, ROOT_ID),
+  });
+
+  const { callback, unmount } = await mountLiveUpdates(client);
+  const reply = directReplyEvent(NEW_REPLY_ID, 102, [], "new-thread-reply");
+
+  callback(reply);
+
+  assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
+    rootEvent(),
+  ]);
+  assert.deepEqual(client.getQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID)), [
+    reply,
+  ]);
+
+  unmount();
+  client.clear();
+});
+
+test("non-broadcast replies do not create thread cache entries for unopened threads", async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(channelMessagesKey(CHANNEL_ID), [rootEvent()]);
+
+  const { callback, unmount } = await mountLiveUpdates(client);
+  const reply = directReplyEvent(NEW_REPLY_ID, 102, [], "new-thread-reply");
+
+  callback(reply);
+
+  assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
+    rootEvent(),
+  ]);
+  assert.equal(
+    client.getQueryCache().find({
+      queryKey: threadRepliesKey(CHANNEL_ID, ROOT_ID),
+      exact: true,
+    }),
+    undefined,
+  );
+
+  unmount();
+  client.clear();
+});
+
+test("top-level live messages still merge into channelMessagesKey", async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(channelMessagesKey(CHANNEL_ID), [rootEvent()]);
+
+  const { callback, unmount } = await mountLiveUpdates(client);
+  const topLevel = event(
+    TOP_LEVEL_ID,
+    103,
+    [["h", CHANNEL_ID]],
+    "top-level-message",
+  );
+
+  callback(topLevel);
+
+  assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
+    rootEvent(),
+    topLevel,
+  ]);
+
+  unmount();
+  client.clear();
+});
+
+test("broadcast replies keep the top-level channel write and update an existing thread cache", async () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(channelMessagesKey(CHANNEL_ID), [rootEvent()]);
+  const existingReply = directReplyEvent(
+    EXISTING_REPLY_ID,
+    101,
+    [],
+    "existing-thread-reply",
+  );
+  client.setQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID), [existingReply]);
+
+  const { callback, unmount } = await mountLiveUpdates(client);
+  const broadcastReply = directReplyEvent(
+    BROADCAST_REPLY_ID,
+    104,
+    [["broadcast", "1"]],
+    "broadcast-reply",
+  );
+
+  callback(broadcastReply);
+
+  assert.deepEqual(client.getQueryData(channelMessagesKey(CHANNEL_ID)), [
+    rootEvent(),
+    broadcastReply,
+  ]);
+  assert.deepEqual(client.getQueryData(threadRepliesKey(CHANNEL_ID, ROOT_ID)), [
+    existingReply,
+    broadcastReply,
+  ]);
+
+  unmount();
+  client.clear();
+});

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -342,10 +342,6 @@ export function useLiveChannelUpdates(
           );
         }
       }
-
-      if (isThreadedReply) {
-        return;
-      }
     }
 
     // Merge into the timeline cache for the active channel.

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -4,9 +4,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import { channelsQueryKey } from "@/features/channels/hooks";
 import { updateChannelLastMessageAt } from "@/features/channels/lib/channelRecency";
 import { mergeTimelineCacheMessages } from "@/features/messages/hooks";
-import { channelMessagesKey } from "@/features/messages/lib/messageQueryKeys";
+import {
+  channelMessagesKey,
+  threadRepliesKey,
+} from "@/features/messages/lib/messageQueryKeys";
 import {
   getChannelIdFromTags,
+  getThreadReference,
   isThreadReply,
 } from "@/features/messages/lib/threading";
 import { shouldNotifyForEvent } from "@/features/notifications/lib/shouldNotify";
@@ -280,6 +284,7 @@ export function useLiveChannelUpdates(
         event.id,
         SEEN_NOTIFICATION_EVENT_LIMIT,
       );
+    const threadReference = getThreadReference(event.tags);
     const isThreadedReply = isThreadReply(event.tags);
 
     // DM alerts and every other notification side effect share this delivery
@@ -319,6 +324,27 @@ export function useLiveChannelUpdates(
         ) {
           options.onThreadReplyDesktopNotification?.(channelId, event);
         }
+      }
+    }
+
+    if (threadReference.parentId != null) {
+      const rootId = threadReference.rootId;
+      if (rootId) {
+        const queryKey = threadRepliesKey(channelId, rootId);
+        if (
+          queryClient.getQueryCache().find({
+            queryKey,
+            exact: true,
+          }) !== undefined
+        ) {
+          queryClient.setQueryData<RelayEvent[]>(queryKey, (current = []) =>
+            mergeTimelineCacheMessages(current, event),
+          );
+        }
+      }
+
+      if (isThreadedReply) {
+        return;
       }
     }
 


### PR DESCRIPTION
## Why
The broad live subscription needs to deliver non-broadcast replies to already-open root thread caches without dropping those replies from the raw channel projection. The raw projection feeds local thread summaries, unread derivation, route fallback, and Inbox detail data; visible timeline rows are filtered separately by `buildMainTimelineEntries`, so removing replies from the cache erased required state and made thread access depend on best-effort relay overlays.

## What
- Route live replies into an already-existing root thread cache, including nested replies keyed by the root rather than the parent.
- Preserve replies in the raw channel-message cache for local thread derivation while keeping non-broadcast replies out of rendered timeline message rows.
- Cover the cache-to-render boundary: root summary preservation without kind:39005, no reply timeline row, nested root routing, unopened threads, top-level messages, and broadcast replies.
- Keep the existing projection model instead of adding a summary-only cache or another reconciliation lifecycle.

## Risk Assessment
Moderate risk. The change touches desktop live projection shared by the channel timeline, thread unread state, route fallback, and Inbox detail. The implementation adds no new state model and retains existing idempotent cache merging; focused mutation tests and the affected smoke suites pin the shared boundary.

## References
- [Gate evidence for the missing thread-summary regression](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/7260/thread-summary-after-live-replies.png)
- [Pre-rework live relay view with a thread summary](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/7260/thread-summary-before-live-replies.png)

Generated with Codex
