### PR TITLE
fix(desktop): default participantPubkeys to [] when relay omits it

### DIFF
--- a/desktop/src/shared/api/tauriChannels.test.mjs
+++ b/desktop/src/shared/api/tauriChannels.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const { fromRawChannel } = await import("@/shared/api/tauriChannels.ts");
+
+function rawChannel(overrides = {}) {
+  return {
+    id: "channel-1",
+    name: "DM",
+    channel_type: "dm",
+    visibility: "private",
+    description: "",
+    topic: null,
+    purpose: null,
+    member_count: 2,
+    member_pubkeys: ["a", "b"],
+    last_message_at: null,
+    archived_at: null,
+    participants: [],
+    participant_pubkeys: ["a", "b"],
+    ttl_seconds: null,
+    ttl_deadline: null,
+    ...overrides,
+  };
+}
+
+test("fromRawChannel defaults participantPubkeys to [] when the relay omits it", () => {
+  const raw = rawChannel();
+  delete raw.participant_pubkeys;
+
+  const channel = fromRawChannel(raw);
+
+  assert.deepEqual(channel.participantPubkeys, []);
+});
+
+test("fromRawChannel preserves participantPubkeys when present", () => {
+  const channel = fromRawChannel(rawChannel({ participant_pubkeys: ["a", "b"] }));
+
+  assert.deepEqual(channel.participantPubkeys, ["a", "b"]);
+});

--- a/desktop/src/shared/api/tauriChannels.ts
+++ b/desktop/src/shared/api/tauriChannels.ts
@@ -87,7 +87,7 @@ export function fromRawChannel(channel: RawChannel): Channel {
     lastMessageAt: channel.last_message_at,
     archivedAt: channel.archived_at,
     participants: channel.participants,
-    participantPubkeys: channel.participant_pubkeys,
+    participantPubkeys: channel.participant_pubkeys ?? [],
     isMember: channel.is_member ?? true,
     ttlSeconds: channel.ttl_seconds,
     ttlDeadline: channel.ttl_deadline,


### PR DESCRIPTION
Malformed DM channel records (missing participant p-tags) leave participant_pubkeys undefined, which then hits an unguarded .map() in the sidebar (resolveChannelDisplayLabel / useDmSidebarMetadata) and crashes the desktop app on load. member_pubkeys already has this fallback; participant_pubkeys was missing it.

## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
