### PR TITLE
fix(projects): preserve page state across history and reload

### DIFF
--- a/desktop/src/app/routes/projects.$projectId.tsx
+++ b/desktop/src/app/routes/projects.$projectId.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { createFileRoute, useLocation } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { parseProjectDetailSearch } from "@/features/projects/lib/projectDetailSearch";
 import { usePreviewFeatureWarning } from "@/shared/features";
@@ -18,23 +18,22 @@ export const Route = createFileRoute("/projects/$projectId")({
 function ProjectDetailRouteComponent() {
   usePreviewFeatureWarning("projects");
   const { projectId } = Route.useParams();
-  const { commitHash, filePath, pullRequestId, issueId, repositoryId, tab } =
-    Route.useSearch();
-  const entityNavigationId = useLocation({
-    select: (location) => {
-      const value = (
-        location.state as { entityNavigationId?: unknown } | undefined
-      )?.entityNavigationId;
-      return typeof value === "string" ? value : undefined;
-    },
-  });
+  const {
+    commitHash,
+    filePath,
+    homeTab,
+    pullRequestId,
+    issueId,
+    repositoryId,
+    tab,
+  } = Route.useSearch();
 
   return (
     <React.Suspense fallback={<ViewLoadingFallback kind="projects" />}>
       <ProjectDetailScreen
         commitHash={commitHash}
-        entityNavigationId={entityNavigationId}
         filePath={filePath}
+        homeTab={homeTab}
         issueId={issueId}
         projectId={projectId}
         pullRequestId={pullRequestId}

--- a/desktop/src/features/projects/lib/projectDetailSearch.test.mjs
+++ b/desktop/src/features/projects/lib/projectDetailSearch.test.mjs
@@ -8,6 +8,7 @@ import {
 
 test("parseProjectDetailSearch keeps forge params and channel panel params", () => {
   const search = parseProjectDetailSearch({
+    homeTab: "files",
     repositoryId: "30617:owner:buzz",
     tab: "files",
     filePath: "src/main.ts",
@@ -17,6 +18,7 @@ test("parseProjectDetailSearch keeps forge params and channel panel params", () 
     extra: "dropped",
   });
 
+  assert.equal(search.homeTab, "files");
   assert.equal(search.repositoryId, "30617:owner:buzz");
   assert.equal(search.tab, "files");
   assert.equal(search.filePath, "src/main.ts");
@@ -31,17 +33,31 @@ test("parseProjectDetailSearch drops empty channel panel params", () => {
     thread: "",
     messageId: "",
     tab: "not-a-tab",
+    homeTab: "not-a-home-tab",
   });
 
   assert.equal(search.thread, undefined);
   assert.equal(search.messageId, undefined);
   assert.equal(search.tab, undefined);
+  assert.equal(search.homeTab, undefined);
 });
 
 test("wantsProjectRepositorySurface is false for channel-first project home", () => {
   assert.equal(
     wantsProjectRepositorySurface({
       projectId: "30621:owner:platform",
+    }),
+    false,
+  );
+});
+
+test("home workspace params do not request the repository surface", () => {
+  assert.equal(
+    wantsProjectRepositorySurface({
+      filePath: "src/main.ts",
+      homeTab: "files",
+      projectId: "30621:owner:platform",
+      repositoryId: "30617:owner:buzz",
     }),
     false,
   );

--- a/desktop/src/features/projects/lib/projectDetailSearch.ts
+++ b/desktop/src/features/projects/lib/projectDetailSearch.ts
@@ -1,4 +1,8 @@
 import {
+  isProjectHomeWorkspaceSheetTab,
+  type ProjectHomeWorkspaceSheetTab,
+} from "@/features/projects/lib/projectHomeWorkspaceSheet";
+import {
   parseProfilePanelTab,
   parseProfilePanelView,
 } from "@/features/profile/ui/UserProfilePanelUtils";
@@ -23,6 +27,11 @@ export function parseProjectDetailSearch(search: Record<string, unknown>) {
   return {
     commitHash: optionalSearchString(search.commitHash),
     filePath: optionalSearchString(search.filePath),
+    homeTab: isProjectHomeWorkspaceSheetTab(
+      optionalSearchString(search.homeTab),
+    )
+      ? (search.homeTab as ProjectHomeWorkspaceSheetTab)
+      : undefined,
     pullRequestId: optionalSearchString(search.pullRequestId),
     issueId: optionalSearchString(search.issueId),
     repositoryId: optionalSearchString(search.repositoryId),
@@ -48,12 +57,14 @@ export function parseProjectDetailSearch(search: Record<string, unknown>) {
 export function wantsProjectRepositorySurface(input: {
   commitHash?: string;
   filePath?: string;
+  homeTab?: ProjectHomeWorkspaceSheetTab;
   issueId?: string;
   projectId: string;
   pullRequestId?: string;
   repositoryId?: string;
   tab?: string;
 }): boolean {
+  if (input.homeTab) return false;
   if (
     input.repositoryId ||
     input.tab ||

--- a/desktop/src/features/projects/ui/ProjectChannelHome.tsx
+++ b/desktop/src/features/projects/ui/ProjectChannelHome.tsx
@@ -18,6 +18,7 @@ import { useHealProjectHomeRepositories } from "@/features/projects/useHealProje
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { RelayEvent } from "@/shared/api/types";
 import type { EntityLinkTab } from "@/shared/lib/entityLink";
+import { useHistorySearchState } from "@/shared/hooks/useHistorySearchState";
 import { useThreadPanelWidth } from "@/shared/hooks/useThreadPanelWidth";
 import { SIDEBAR_WIDTH_MIN } from "@/shared/layout/sidebarLayout";
 import { cn } from "@/shared/lib/cn";
@@ -26,6 +27,7 @@ import { DrawerPanelIcon } from "@/shared/ui/DrawerPanelIcon";
 import { useOptionalSidebar } from "@/shared/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
+import { PROJECT_REPOSITORY_SEARCH_KEYS } from "./projectDetailHelpers";
 import { ProjectContextRail } from "./ProjectContextRail";
 import { ProjectDetailChrome } from "./ProjectDetailChrome";
 import { ProjectHomeColumn } from "./ProjectHomeColumn";
@@ -87,15 +89,27 @@ function ProjectHomeHeaderToggle({
 export function ProjectChannelHome({
   allowRepositoryHealing,
   autoSendDraftKey,
+  commitHash,
+  filePath,
+  homeTab,
+  issueId,
   project,
   projects,
+  pullRequestId,
+  repositoryId,
   targetMessageEvents = EMPTY_TARGET_MESSAGE_EVENTS,
   targetMessageId,
 }: {
   allowRepositoryHealing: boolean;
   autoSendDraftKey?: string | null;
+  commitHash?: string;
+  filePath?: string;
+  homeTab?: ProjectHomeWorkspaceSheetTab;
+  issueId?: string;
   project: Project;
   projects: Project[];
+  pullRequestId?: string;
+  repositoryId?: string;
   targetMessageEvents?: RelayEvent[];
   targetMessageId?: string | null;
 }) {
@@ -110,11 +124,11 @@ export function ProjectChannelHome({
   };
   const [summaryOpen, setSummaryOpen] = React.useState(true);
   const [addRepositoryOpen, setAddRepositoryOpen] = React.useState(false);
-  const [workspaceSheetTab, setWorkspaceSheetTab] =
-    React.useState<ProjectHomeWorkspaceSheetTab | null>(null);
-  const [workspaceRepositoryId, setWorkspaceRepositoryId] = React.useState<
-    string | null
-  >(null);
+  const { applyPatch: applyWorkspaceSearch } = useHistorySearchState(
+    PROJECT_REPOSITORY_SEARCH_KEYS,
+  );
+  const workspaceSheetTab = homeTab ?? null;
+  const workspaceRepositoryId = repositoryId ?? null;
   const [workspaceCreateAction, setWorkspaceCreateAction] =
     React.useState<ProjectHomeWorkspaceCreateAction | null>(null);
   const [workspaceDetail, setWorkspaceDetail] =
@@ -145,21 +159,37 @@ export function ProjectChannelHome({
   const summaryVisible = summaryOpen && !workspaceSheetOpen;
 
   const openWorkspaceSheet = React.useCallback(
-    (tab: ProjectHomeWorkspaceSheetTab, repositoryId?: string) => {
-      if (repositoryId) {
-        setWorkspaceRepositoryId(repositoryId);
-      }
+    (nextTab: ProjectHomeWorkspaceSheetTab, nextRepositoryId?: string) => {
       setWorkspaceCreateAction(null);
       setWorkspaceDetail(null);
-      setWorkspaceSheetTab((current) => (current === tab ? null : tab));
+      applyWorkspaceSearch({
+        commitHash: null,
+        filePath: null,
+        homeTab: workspaceSheetTab === nextTab ? null : nextTab,
+        issueId: null,
+        pullRequestId: null,
+        repositoryId:
+          workspaceSheetTab === nextTab
+            ? null
+            : (nextRepositoryId ?? workspaceRepository?.id ?? null),
+        tab: null,
+      });
     },
-    [],
+    [applyWorkspaceSearch, workspaceRepository?.id, workspaceSheetTab],
   );
   const closeWorkspaceSheet = React.useCallback(() => {
     setWorkspaceCreateAction(null);
     setWorkspaceDetail(null);
-    setWorkspaceSheetTab(null);
-  }, []);
+    applyWorkspaceSearch({
+      commitHash: null,
+      filePath: null,
+      homeTab: null,
+      issueId: null,
+      pullRequestId: null,
+      repositoryId: null,
+      tab: null,
+    });
+  }, [applyWorkspaceSearch]);
   const handleOpenWorkspace = React.useCallback(
     (repositoryId: string, tab?: EntityLinkTab) => {
       if (!isProjectHomeWorkspaceSheetTab(tab)) {
@@ -182,19 +212,35 @@ export function ProjectChannelHome({
   const handleAddFiles = React.useCallback(() => {
     setAddRepositoryOpen(true);
   }, []);
-  const handleFilesAdded = React.useCallback((repositoryId: string) => {
-    setWorkspaceCreateAction(null);
-    setWorkspaceDetail(null);
-    setWorkspaceRepositoryId(repositoryId);
-    setWorkspaceSheetTab("files");
-  }, []);
-  const handleWorkspaceRepositoryChange = React.useCallback(
-    (repositoryId: string) => {
+  const handleFilesAdded = React.useCallback(
+    (nextRepositoryId: string) => {
       setWorkspaceCreateAction(null);
       setWorkspaceDetail(null);
-      setWorkspaceRepositoryId(repositoryId);
+      applyWorkspaceSearch({
+        commitHash: null,
+        filePath: null,
+        homeTab: "files",
+        issueId: null,
+        pullRequestId: null,
+        repositoryId: nextRepositoryId,
+        tab: null,
+      });
     },
-    [],
+    [applyWorkspaceSearch],
+  );
+  const handleWorkspaceRepositoryChange = React.useCallback(
+    (nextRepositoryId: string) => {
+      setWorkspaceCreateAction(null);
+      setWorkspaceDetail(null);
+      applyWorkspaceSearch({
+        commitHash: null,
+        filePath: null,
+        issueId: null,
+        pullRequestId: null,
+        repositoryId: nextRepositoryId,
+      });
+    },
+    [applyWorkspaceSearch],
   );
   useHealProjectHomeRepositories(
     project,
@@ -234,6 +280,10 @@ export function ProjectChannelHome({
       <ProjectHomeWorkspaceSheet
         key={`${workspaceSheetTab}:${workspaceRepository.id}`}
         identityPubkey={identityQuery.data?.pubkey}
+        initialCommitHash={commitHash}
+        initialFilePath={filePath}
+        initialIssueId={issueId}
+        initialPullRequestId={pullRequestId}
         onCreateActionChange={setWorkspaceCreateAction}
         onDetailChange={setWorkspaceDetail}
         onOpenCommit={handleOpenCommit}

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -34,7 +34,10 @@ import {
   projectBranchOptionsFromSync,
   resolveProjectDefaultBranch,
 } from "@/features/projects/lib/projectBranches";
-import { workspaceTabForShareTab } from "@/features/projects/lib/projectShareLinks";
+import {
+  shareTabForWorkspaceTab,
+  workspaceTabForShareTab,
+} from "@/features/projects/lib/projectShareLinks";
 import {
   buildProjectDetailAgentContext,
   type ProjectDetailAgentContext,
@@ -52,7 +55,6 @@ import { isProjectRelayValidated } from "@/features/projects/projectSnapshot";
 import { ProjectSelectionProvider } from "@/features/projects/lib/useProjectSelection";
 import { useMemberChannelIds } from "@/features/projects/useRepositoryAccess";
 import { KIND_REPO_ANNOUNCEMENT } from "@/shared/constants/kinds";
-import type { EntityLinkTab } from "@/shared/lib/entityLink";
 import { useProjectRepoPresentation } from "@/features/projects/useProjectRepoHost";
 import { WorkspaceTabs } from "./ProjectWorkspaceTabs";
 import type { RepoSourceHeaderControls } from "./ProjectRepositorySource";
@@ -87,8 +89,8 @@ import {
 export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   const {
     commitHash,
-    entityNavigationId,
     filePath,
+    homeTab,
     projectId,
     pullRequestId,
     issueId,
@@ -137,56 +139,69 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
     });
   const activeTag =
     repoStateQuery.data?.tags.find((tag) => tag.name === selectedTag) ?? null;
-  const [selectedPullRequestId, setSelectedPullRequestId] = React.useState<
-    string | null
-  >(pullRequestId ?? null);
-  const [selectedIssueId, setSelectedIssueId] = React.useState<string | null>(
-    issueId ?? null,
-  );
+  const selectedPullRequestId = pullRequestId ?? null;
+  const selectedIssueId = issueId ?? null;
   const [createIssueRequestKey, setCreateIssueRequestKey] = React.useState(0);
   const [createPullRequestRequestKey, setCreatePullRequestRequestKey] =
     React.useState(0);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the transient request ID deliberately reapplies an unchanged entity selection.
-  React.useEffect(() => {
-    setSelectedPullRequestId(pullRequestId ?? null);
-    setSelectedIssueId(issueId ?? null);
-  }, [entityNavigationId, issueId, pullRequestId]);
-  const [selectedCommitHash, setSelectedCommitHash] = React.useState<
-    string | null
-  >(commitHash ?? null);
-  React.useEffect(
-    () => setSelectedCommitHash(commitHash ?? null),
-    [commitHash],
-  );
-  const [tabsResetKey, setTabsResetKey] = React.useState(0);
-  const [requestedTab, setRequestedTab] = React.useState<
-    EntityLinkTab | undefined
-  >(tab);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the transient request ID deliberately reapplies an unchanged share-link tab.
-  React.useEffect(() => setRequestedTab(tab), [entityNavigationId, tab]);
-  const [activeTab, setActiveTab] = React.useState("overview");
+  const selectedCommitHash = commitHash ?? null;
+  const activeTab = pullRequestId
+    ? "prs"
+    : issueId
+      ? "issues"
+      : commitHash
+        ? "activity"
+        : tab
+          ? workspaceTabForShareTab(tab)
+          : "overview";
   const [filesContext, setFilesContext] =
     React.useState<ProjectDetailAgentContext["file"]>(null);
   const handleSelectedPullRequestIdChange = React.useCallback(
     (id: string | null) => {
-      setSelectedPullRequestId(id);
-      if (id) setSelectedCommitHash(null);
+      const nextTab = id ? "prs" : tab === "prs" || pullRequestId ? "prs" : tab;
+      applyRepositorySearch({
+        commitHash: null,
+        filePath: null,
+        issueId: null,
+        pullRequestId: id,
+        tab: nextTab,
+      });
     },
-    [],
+    [applyRepositorySearch, pullRequestId, tab],
   );
-  const handleSelectedIssueIdChange = React.useCallback((id: string | null) => {
-    setSelectedIssueId(id);
-    if (id) setSelectedCommitHash(null);
-  }, []);
+  const handleSelectedIssueIdChange = React.useCallback(
+    (id: string | null) => {
+      const nextTab = id
+        ? "issues"
+        : tab === "issues" || issueId
+          ? "issues"
+          : tab;
+      applyRepositorySearch({
+        commitHash: null,
+        filePath: null,
+        issueId: id,
+        pullRequestId: null,
+        tab: nextTab,
+      });
+    },
+    [applyRepositorySearch, issueId, tab],
+  );
   const handleSelectedCommitHashChange = React.useCallback(
     (hash: string | null) => {
-      setSelectedCommitHash(hash);
-      if (hash) {
-        setSelectedPullRequestId(null);
-        setSelectedIssueId(null);
-      }
+      const nextTab = hash
+        ? "commits"
+        : tab === "commits" || commitHash
+          ? "commits"
+          : tab;
+      applyRepositorySearch({
+        commitHash: hash,
+        filePath: null,
+        issueId: null,
+        pullRequestId: null,
+        tab: nextTab,
+      });
     },
-    [],
+    [applyRepositorySearch, commitHash, tab],
   );
   const issuesQuery = useProjectIssuesQuery(repository);
   const {
@@ -445,13 +460,18 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   });
   const projectPending = projectQuery.isPending;
   React.useEffect(() => {
-    if (!repository) {
-      if (projectPending) return;
-      setSelectedPullRequestId(null);
-      setSelectedIssueId(null);
-      setSelectedCommitHash(null);
+    if (!repository && !projectPending) {
+      applyRepositorySearch(
+        {
+          commitHash: null,
+          filePath: null,
+          issueId: null,
+          pullRequestId: null,
+        },
+        { replace: true },
+      );
     }
-  }, [projectPending, repository]);
+  }, [applyRepositorySearch, projectPending, repository]);
   React.useEffect(() => {
     if (selectedTag) {
       if (repoSource !== "remote") setRepoSource("remote");
@@ -570,10 +590,15 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
       }
       if (createdRepository.id === repository?.id) {
         await pullRequestsQuery.refetch();
-      } else {
-        applyRepositorySearch({ repositoryId: createdRepository.id });
       }
-      setSelectedPullRequestId(pullRequestId);
+      applyRepositorySearch({
+        commitHash: null,
+        filePath: null,
+        issueId: null,
+        pullRequestId,
+        repositoryId: createdRepository.id,
+        tab: "prs",
+      });
     },
     [
       applyRepositorySearch,
@@ -588,9 +613,9 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
       const issueId = await createIssueMutation.mutateAsync(input);
       toast.success("Task created.");
       await issuesQuery.refetch();
-      setSelectedIssueId(issueId);
+      handleSelectedIssueIdChange(issueId);
     },
-    [createIssueMutation, issuesQuery],
+    [createIssueMutation, handleSelectedIssueIdChange, issuesQuery],
   );
   const handleUpdatePullRequest = React.useCallback(async () => {
     const commit = repoSyncStatusQuery.data?.remoteHead;
@@ -685,6 +710,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
     !wantsProjectRepositorySurface({
       commitHash,
       filePath,
+      homeTab,
       issueId,
       projectId,
       pullRequestId,
@@ -695,8 +721,14 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
     return (
       <ProjectChannelHome
         allowRepositoryHealing={isProjectRelayValidated(project)}
+        commitHash={commitHash}
+        filePath={filePath}
+        homeTab={homeTab}
+        issueId={issueId}
         project={project}
         projects={projectsQuery.data ?? [project]}
+        pullRequestId={pullRequestId}
+        repositoryId={repositoryId}
       />
     );
   }
@@ -741,15 +773,24 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
       commit: selectedCommit,
       issue: selectedIssue,
       pullRequest: selectedPullRequest,
-      setRequestedTab,
-      setSelectedCommitHash,
-      setSelectedIssueId,
-      setSelectedPullRequestId,
-      setTabsResetKey,
+      setRequestedTab: (nextTab) =>
+        applyRepositorySearch({ tab: nextTab ?? null }),
+      setSelectedCommitHash: handleSelectedCommitHashChange,
+      setSelectedIssueId: handleSelectedIssueIdChange,
+      setSelectedPullRequestId: handleSelectedPullRequestIdChange,
+      setTabsResetKey: () => undefined,
     });
   const goChannelHome = () => {
     if (project.projectChannelId) {
-      void goProject(project.id);
+      applyRepositorySearch({
+        commitHash: null,
+        filePath: null,
+        homeTab: null,
+        issueId: null,
+        pullRequestId: null,
+        repositoryId: null,
+        tab: null,
+      });
       return;
     }
     handleGoToProjectHome();
@@ -781,16 +822,14 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   const handleRepositoryChange = (nextRepositoryId: string) => {
     applyRepositorySearch({
       repositoryId: nextRepositoryId,
+      homeTab: null,
+      tab: null,
+      filePath: null,
       issueId: null,
       pullRequestId: null,
       commitHash: null,
     });
-    setSelectedPullRequestId(null);
-    setSelectedIssueId(null);
-    setSelectedCommitHash(null);
-    setRequestedTab(undefined);
     setRepoSource("remote");
-    setTabsResetKey((key) => key + 1);
   };
   return (
     <ProjectSelectionProvider
@@ -884,14 +923,9 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                     taller page when content already overflows. */}
                 <div className="flex min-h-full w-full flex-col space-y-3">
                   <WorkspaceTabs
-                    key={`${project.id}:${repository.id}:${tabsResetKey}`}
-                    initialTab={
-                      requestedTab
-                        ? workspaceTabForShareTab(requestedTab)
-                        : undefined
-                    }
+                    key={`${project.id}:${repository.id}`}
+                    selectedTab={activeTab}
                     initialFilePath={filePath}
-                    initialTabRequestKey={entityNavigationId}
                     fileContentSource={fileContentSource}
                     commitDiff={commitDiffQuery.data}
                     commitDiffError={commitDiffQuery.error}
@@ -926,6 +960,9 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                     localSnapshotError={localRepoSnapshotQuery.error}
                     localSnapshotLoading={localRepoSnapshotQuery.isLoading}
                     onFilesContextChange={setFilesContext}
+                    onFilePathChange={(path) =>
+                      applyRepositorySearch({ filePath: path })
+                    }
                     onOpenMergeRecoveryTerminal={
                       handleOpenMergeRecoveryTerminal
                     }
@@ -934,7 +971,16 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                     onSelectedPullRequestIdChange={
                       handleSelectedPullRequestIdChange
                     }
-                    onSelectedTabChange={setActiveTab}
+                    onSelectedTabChange={(nextTab) =>
+                      applyRepositorySearch({
+                        commitHash: null,
+                        filePath:
+                          nextTab === "files" ? (filePath ?? null) : null,
+                        issueId: null,
+                        pullRequestId: null,
+                        tab: shareTabForWorkspaceTab(nextTab) ?? null,
+                      })
+                    }
                     onBack={goChannelHome}
                     profiles={profiles}
                     project={repository}

--- a/desktop/src/features/projects/ui/ProjectHomeCodebasePanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectHomeCodebasePanel.tsx
@@ -20,7 +20,9 @@ import { useRepositoryFileContentSource } from "./useRepositoryFileContentSource
 
 export function ProjectHomeCodebasePanel({
   identityPubkey,
+  initialPath,
   onFilesContextChange,
+  onPathChange,
   onOpenCommit,
   onRepositoryAdded,
   onSelectRepository,
@@ -29,11 +31,13 @@ export function ProjectHomeCodebasePanel({
   repository,
 }: {
   identityPubkey?: string;
+  initialPath?: string;
   onFilesContextChange?: (context: {
     kind: "file" | "folder";
     onBack?: () => void;
     path: string;
   }) => void;
+  onPathChange?: (path: string | null) => void;
   onOpenCommit?: (commitHash: string) => void;
   onRepositoryAdded: (repositoryId: string) => void;
   onSelectRepository: (repositoryId: string) => void;
@@ -122,8 +126,10 @@ export function ProjectHomeCodebasePanel({
           fallbackAuthorPubkey={repository.owner}
           fileContentSource={fileContentSource}
           files={files}
+          initialPath={initialPath}
           isLoading={snapshotQuery.isPending}
           onContextChange={onFilesContextChange}
+          onPathChange={onPathChange}
           onOpenCommit={onOpenCommit}
           snapshot={snapshot}
         />

--- a/desktop/src/features/projects/ui/ProjectHomeWorkspaceSheet.tsx
+++ b/desktop/src/features/projects/ui/ProjectHomeWorkspaceSheet.tsx
@@ -14,6 +14,8 @@ import { resolveProjectDefaultBranch } from "@/features/projects/lib/projectBran
 import type { ProjectHomeWorkspaceSheetTab } from "@/features/projects/lib/projectHomeWorkspaceSheet";
 import { useProjectCommitDiffQuery } from "@/features/projects/useProjectCommitDiff";
 import { useProjectRepositorySnapshots } from "@/features/projects/useProjectRepositorySnapshots";
+import { useHistorySearchState } from "@/shared/hooks/useHistorySearchState";
+import { PROJECT_REPOSITORY_SEARCH_KEYS } from "./projectDetailHelpers";
 import { CreateProjectIssueDialog } from "./CreateProjectIssueDialog";
 import { CreatePullRequestDialog } from "./CreatePullRequestDialog";
 import { ProjectCommitDetailPanel } from "./ProjectCommitDetailPanel";
@@ -46,6 +48,10 @@ export type ProjectHomeWorkspaceDetail = {
 
 export function ProjectHomeWorkspaceSheet({
   identityPubkey,
+  initialCommitHash,
+  initialFilePath,
+  initialIssueId,
+  initialPullRequestId,
   onCreateActionChange,
   onDetailChange,
   onOpenCommit,
@@ -57,6 +63,10 @@ export function ProjectHomeWorkspaceSheet({
   tab,
 }: {
   identityPubkey?: string;
+  initialCommitHash?: string;
+  initialFilePath?: string;
+  initialIssueId?: string;
+  initialPullRequestId?: string;
   onCreateActionChange?: (
     action: ProjectHomeWorkspaceCreateAction | null,
   ) => void;
@@ -70,16 +80,19 @@ export function ProjectHomeWorkspaceSheet({
   tab: ProjectHomeWorkspaceSheetTab;
 }) {
   const { goProject } = useAppNavigation();
+  const { applyPatch: applyWorkspaceSearch } = useHistorySearchState(
+    PROJECT_REPOSITORY_SEARCH_KEYS,
+  );
   const { activeCommunity } = useCommunities();
   const [selectedIssueId, setSelectedIssueId] = React.useState<string | null>(
-    null,
+    initialIssueId ?? null,
   );
   const [selectedPullRequestId, setSelectedPullRequestId] = React.useState<
     string | null
-  >(null);
+  >(initialPullRequestId ?? null);
   const [selectedCommitHash, setSelectedCommitHash] = React.useState<
     string | null
-  >(null);
+  >(initialCommitHash ?? null);
   const [selectedCommitRepositoryId, setSelectedCommitRepositoryId] =
     React.useState<string | null>(null);
   const [filesContext, setFilesContext] = React.useState<{
@@ -90,6 +103,56 @@ export function ProjectHomeWorkspaceSheet({
   const [createIssueOpen, setCreateIssueOpen] = React.useState(false);
   const [createPullRequestOpen, setCreatePullRequestOpen] =
     React.useState(false);
+
+  React.useEffect(() => {
+    setSelectedIssueId(initialIssueId ?? null);
+  }, [initialIssueId]);
+  React.useEffect(() => {
+    setSelectedPullRequestId(initialPullRequestId ?? null);
+  }, [initialPullRequestId]);
+  React.useEffect(() => {
+    setSelectedCommitHash(initialCommitHash ?? null);
+    if (!initialCommitHash) setSelectedCommitRepositoryId(null);
+  }, [initialCommitHash]);
+
+  const selectIssue = React.useCallback(
+    (id: string | null) => {
+      setSelectedIssueId(id);
+      applyWorkspaceSearch({
+        commitHash: null,
+        filePath: null,
+        issueId: id,
+        pullRequestId: null,
+      });
+    },
+    [applyWorkspaceSearch],
+  );
+  const selectPullRequest = React.useCallback(
+    (id: string | null) => {
+      setSelectedPullRequestId(id);
+      applyWorkspaceSearch({
+        commitHash: null,
+        filePath: null,
+        issueId: null,
+        pullRequestId: id,
+      });
+    },
+    [applyWorkspaceSearch],
+  );
+  const selectCommit = React.useCallback(
+    (hash: string | null, nextRepositoryId?: string) => {
+      setSelectedCommitHash(hash);
+      setSelectedCommitRepositoryId(hash ? (nextRepositoryId ?? null) : null);
+      applyWorkspaceSearch({
+        commitHash: hash,
+        filePath: null,
+        issueId: null,
+        pullRequestId: null,
+        repositoryId: nextRepositoryId,
+      });
+    },
+    [applyWorkspaceSearch],
+  );
 
   const projectScope = React.useMemo(() => [project], [project]);
   const workItemsQuery = useProjectsWorkItemsQuery(projectScope);
@@ -181,9 +244,9 @@ export function ProjectHomeWorkspaceSheet({
         return;
       }
       await workItemsQuery.refetch();
-      setSelectedIssueId(issueId);
+      selectIssue(issueId);
     },
-    [goProject, project.id, workItemsQuery],
+    [goProject, project.id, selectIssue, workItemsQuery],
   );
   const handlePullRequestCreated = React.useCallback(
     async (
@@ -202,7 +265,7 @@ export function ProjectHomeWorkspaceSheet({
         onSelectRepository(createdRepository.id);
       }
       await pullRequestsQuery.refetch();
-      setSelectedPullRequestId(pullRequestId);
+      selectPullRequest(pullRequestId);
     },
     [
       goProject,
@@ -210,6 +273,7 @@ export function ProjectHomeWorkspaceSheet({
       project.id,
       pullRequestsQuery,
       repository.id,
+      selectPullRequest,
     ],
   );
   const detail = React.useMemo<ProjectHomeWorkspaceDetail | null>(() => {
@@ -220,14 +284,14 @@ export function ProjectHomeWorkspaceSheet({
           issueId: selectedIssueId,
           repositoryId: selectedIssueItem?.project.id,
         },
-        onBack: () => setSelectedIssueId(null),
+        onBack: () => selectIssue(null),
       };
     }
     if (tab === "prs" && selectedPullRequestId) {
       return {
         backLabel: "Back to Reviews",
         navigation: { pullRequestId: selectedPullRequestId },
-        onBack: () => setSelectedPullRequestId(null),
+        onBack: () => selectPullRequest(null),
       };
     }
     if (tab === "commits" && selectedCommitHash) {
@@ -237,10 +301,7 @@ export function ProjectHomeWorkspaceSheet({
           commitHash: selectedCommitHash,
           repositoryId: selectedCommitRepository.id,
         },
-        onBack: () => {
-          setSelectedCommitHash(null);
-          setSelectedCommitRepositoryId(null);
-        },
+        onBack: () => selectCommit(null),
       };
     }
     if (tab === "files" && filesContext?.onBack) {
@@ -253,6 +314,9 @@ export function ProjectHomeWorkspaceSheet({
     return null;
   }, [
     filesContext,
+    selectCommit,
+    selectIssue,
+    selectPullRequest,
     selectedCommitHash,
     selectedCommitRepository.id,
     selectedIssueId,
@@ -311,7 +375,7 @@ export function ProjectHomeWorkspaceSheet({
           error={workItemsQuery.error}
           isLoading={workItemsQuery.isLoading}
           issueItems={issueItems}
-          onSelectedIssueIdChange={setSelectedIssueId}
+          onSelectedIssueIdChange={selectIssue}
           profiles={people.profiles}
           project={selectedCommitRepository}
           selectedIssueId={selectedIssueId}
@@ -323,7 +387,7 @@ export function ProjectHomeWorkspaceSheet({
         <PullRequestsPanel
           error={pullRequestsQuery.error}
           isLoading={pullRequestsQuery.isLoading}
-          onSelectedPullRequestIdChange={setSelectedPullRequestId}
+          onSelectedPullRequestIdChange={selectPullRequest}
           profiles={people.profiles}
           project={repository}
           pullRequests={pullRequests}
@@ -346,8 +410,7 @@ export function ProjectHomeWorkspaceSheet({
       ) : (
         <ProjectHomeCommitsPanel
           onSelectCommit={(commit, commitRepository) => {
-            setSelectedCommitRepositoryId(commitRepository.id);
-            setSelectedCommitHash(commit.hash);
+            selectCommit(commit.hash, commitRepository.id);
           }}
           profiles={people.profiles}
           projectId={project.id}
@@ -361,7 +424,9 @@ export function ProjectHomeWorkspaceSheet({
       body = (
         <ProjectHomeCodebasePanel
           identityPubkey={identityPubkey}
+          initialPath={initialFilePath}
           onFilesContextChange={setFilesContext}
+          onPathChange={(path) => applyWorkspaceSearch({ filePath: path })}
           onOpenCommit={onOpenCommit}
           onRepositoryAdded={onRepositoryAdded}
           onSelectRepository={onSelectRepository}

--- a/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
@@ -621,6 +621,7 @@ export function RepositoryFilesPanel({
   profiles,
   fallbackAuthorPubkey,
   onContextChange,
+  onPathChange,
   onOpenCommit,
   sourceControls,
   unavailableMessage,
@@ -634,6 +635,7 @@ export function RepositoryFilesPanel({
   profiles?: UserProfileLookup;
   fallbackAuthorPubkey?: string;
   onContextChange?: (context: RepositoryFilesContext) => void;
+  onPathChange?: (path: string | null) => void;
   onOpenCommit?: (commitHash: string) => void;
   /** Branch picker + remote/local toggle rendered in the panel header. */
   sourceControls?: RepoSourceHeaderControls;
@@ -650,6 +652,7 @@ export function RepositoryFilesPanel({
     files,
     initialPath,
     onContextChange,
+    onPathChange,
     pageSize: REPOSITORY_ENTRY_PAGE_SIZE,
   });
   const entries = React.useMemo(

--- a/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
@@ -94,9 +94,8 @@ export function WorkspaceTabs({
   createPullRequestAction,
   createPullRequestRequestKey,
   updatePullRequestAction,
-  initialTab,
+  selectedTab,
   initialFilePath,
-  initialTabRequestKey,
   fileContentSource,
   localSnapshot,
   localSnapshotError,
@@ -115,6 +114,7 @@ export function WorkspaceTabs({
   pullRequestsError,
   pullRequestsLoading,
   onSelectedCommitHashChange,
+  onFilePathChange,
   onFilesContextChange,
   onSelectedIssueIdChange,
   onSelectedPullRequestIdChange,
@@ -141,12 +141,10 @@ export function WorkspaceTabs({
   createPullRequestAction?: CreatePullRequestAction;
   createPullRequestRequestKey?: number;
   updatePullRequestAction?: UpdatePullRequestAction;
-  /** Tab to open on mount (workspace vocabulary), e.g. from a share link. */
-  initialTab?: string;
+  /** Active workspace tab controlled by route search state. */
+  selectedTab: string;
   /** File or folder to open when entering the repository Files tab. */
   initialFilePath?: string;
-  /** Changes for every entity-link activation, including repeated links. */
-  initialTabRequestKey?: string;
   fileContentSource?: RepositoryFileContentSource;
   localSnapshot: ProjectLocalRepoSnapshot | null | undefined;
   localSnapshotError: unknown;
@@ -165,6 +163,7 @@ export function WorkspaceTabs({
   pullRequestsError: unknown;
   pullRequestsLoading: boolean;
   onSelectedCommitHashChange: (hash: string | null) => void;
+  onFilePathChange?: (path: string | null) => void;
   onFilesContextChange?: (context: {
     kind: "file" | "folder";
     path: string;
@@ -261,15 +260,6 @@ export function WorkspaceTabs({
   const isDetailSelected = Boolean(
     selectedPullRequestId || selectedIssueId || selectedCommitHash,
   );
-  const [selectedTab, setSelectedTab] = React.useState(
-    initialTab ?? "overview",
-  );
-  // Follow later share-link navigations to the same project (the search
-  // param changes without a remount).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: request key intentionally retriggers an unchanged tab.
-  React.useEffect(() => {
-    if (initialTab) setSelectedTab(initialTab);
-  }, [initialTab, initialTabRequestKey]);
   const [pullRequestCommentTarget, setPullRequestCommentTarget] =
     React.useState<{
       anchor: ProjectPullRequestCommentAnchor;
@@ -300,46 +290,11 @@ export function WorkspaceTabs({
     setCreatePullRequestOpen(true);
   }, [createPullRequestRequestKey]);
 
-  React.useEffect(() => {
-    onSelectedTabChange?.(selectedTab);
-  }, [onSelectedTabChange, selectedTab]);
-
-  React.useEffect(() => {
-    if (isPullRequestSelected) {
-      setSelectedTab("prs");
-    }
-  }, [isPullRequestSelected]);
-
-  React.useEffect(() => {
-    if (selectedIssueId) {
-      setSelectedTab("issues");
-    }
-  }, [selectedIssueId]);
-
-  React.useEffect(() => {
-    if (selectedCommitHash) {
-      setSelectedTab("activity");
-    }
-  }, [selectedCommitHash]);
-
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
-      setSelectedTab(nextTab);
-      if (nextTab !== "prs") {
-        onSelectedPullRequestIdChange(null);
-      }
-      if (nextTab !== "issues") {
-        onSelectedIssueIdChange(null);
-      }
-      if (nextTab !== "activity") {
-        onSelectedCommitHashChange(null);
-      }
+      onSelectedTabChange?.(nextTab);
     },
-    [
-      onSelectedCommitHashChange,
-      onSelectedIssueIdChange,
-      onSelectedPullRequestIdChange,
-    ],
+    [onSelectedTabChange],
   );
   const handleOpenPullRequestComment = React.useCallback(
     (anchor: ProjectPullRequestCommentAnchor) => {
@@ -587,6 +542,7 @@ export function WorkspaceTabs({
                 initialPath={initialFilePath}
                 isLoading={displayedSnapshotLoading}
                 onContextChange={onFilesContextChange}
+                onPathChange={onFilePathChange}
                 onOpenCommit={onSelectedCommitHashChange}
                 profiles={profiles}
                 snapshot={displayedSnapshot}

--- a/desktop/src/features/projects/ui/projectDetailHelpers.ts
+++ b/desktop/src/features/projects/ui/projectDetailHelpers.ts
@@ -2,11 +2,14 @@ import type {
   ProjectRepoSnapshot,
   Repository as Project,
 } from "@/features/projects/hooks";
+import type { ProjectHomeWorkspaceSheetTab } from "@/features/projects/lib/projectHomeWorkspaceSheet";
 import type { EntityLinkTab } from "@/shared/lib/entityLink";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export const PROJECT_REPOSITORY_SEARCH_KEYS = [
   "repositoryId",
+  "tab",
+  "homeTab",
   "issueId",
   "pullRequestId",
   "commitHash",
@@ -24,8 +27,8 @@ export const PROJECT_TAB_CRUMB_LABELS: Record<string, string> = {
 
 export type ProjectDetailScreenProps = {
   commitHash?: string;
-  entityNavigationId?: string;
   filePath?: string;
+  homeTab?: ProjectHomeWorkspaceSheetTab;
   projectId: string;
   pullRequestId?: string;
   issueId?: string;

--- a/desktop/src/features/projects/ui/useRepositoryFilesNavigation.ts
+++ b/desktop/src/features/projects/ui/useRepositoryFilesNavigation.ts
@@ -12,11 +12,13 @@ export function useRepositoryFilesNavigation({
   files,
   initialPath,
   onContextChange,
+  onPathChange,
   pageSize,
 }: {
   files: ProjectRepoFile[];
   initialPath?: string;
   onContextChange?: (context: RepositoryFilesContext) => void;
+  onPathChange?: (path: string | null) => void;
   pageSize: number;
 }) {
   const [currentPath, setCurrentPath] = React.useState("");
@@ -28,17 +30,25 @@ export function useRepositoryFilesNavigation({
       setCurrentPath(path);
       setSelectedFile(null);
       setVisibleEntryCount(pageSize);
+      onPathChange?.(path || null);
     },
-    [pageSize],
+    [onPathChange, pageSize],
+  );
+  const selectFile = React.useCallback(
+    (file: ProjectRepoFile | null) => {
+      setSelectedFile(file);
+      onPathChange?.(file?.path ?? (currentPath || null));
+    },
+    [currentPath, onPathChange],
   );
   const contextBack = React.useMemo(() => {
-    if (selectedFile) return () => setSelectedFile(null);
+    if (selectedFile) return () => selectFile(null);
     if (!currentPath) return undefined;
     return () => {
       const segments = currentPath.split("/");
       openPath(segments.slice(0, -1).join("/"));
     };
-  }, [currentPath, openPath, selectedFile]);
+  }, [currentPath, openPath, selectedFile, selectFile]);
 
   React.useEffect(() => {
     onContextChange?.({
@@ -73,7 +83,7 @@ export function useRepositoryFilesNavigation({
     currentPath,
     openPath,
     selectedFile,
-    setSelectedFile,
+    setSelectedFile: selectFile,
     setVisibleEntryCount,
     visibleEntryCount,
   };

--- a/desktop/src/features/projects/ui/useRetainedProjectGitViews.test.mjs
+++ b/desktop/src/features/projects/ui/useRetainedProjectGitViews.test.mjs
@@ -326,7 +326,7 @@ async function renderWorkspaceReviews(initialProps) {
     setPanelProps = setProps;
     return React.createElement(WorkspaceTabs, {
       ...workspaceTabsStub,
-      initialTab: "prs",
+      selectedTab: "prs",
       project: repository,
       pullRequests: props.pullRequests,
       pullRequestsError: null,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -6214,6 +6214,14 @@ function buildMockProjectEvents(): RelayEvent[] {
             : roll < 0.85
               ? KIND_GIT_PULL_REQUEST
               : KIND_GIT_ISSUE;
+        const eventId = `f00d${projectIndex
+          .toString(16)
+          .padStart(2, "0")}${dayOffset.toString(16).padStart(4, "0")}${index
+          .toString(16)
+          .padStart(4, "0")}${kind.toString(16).padStart(4, "0")}`.padEnd(
+          64,
+          "0",
+        );
         const tags = [
           ["a", repoAddress],
           ["subject", subject],
@@ -6227,7 +6235,9 @@ function buildMockProjectEvents(): RelayEvent[] {
             : []),
         ];
 
-        events.push(createMockEvent(kind, subject, tags, author, createdAt));
+        events.push(
+          createMockEvent(kind, subject, tags, author, createdAt, eventId),
+        );
       }
     }
   }

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -1226,6 +1226,82 @@ test("project home task sheet expands into the repository Tasks view", async ({
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 });
 
+test("project navigation survives history traversal and reload", async ({
+  page,
+}) => {
+  await enableProjectsFeature(page);
+  await installMockBridge(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-projects-view").click();
+  await page.getByTestId("projects-section-projects").click();
+  await page
+    .locator(
+      '[data-testid="project-card-buzz"], [data-testid="project-row-buzz"]',
+    )
+    .first()
+    .click();
+
+  await page.getByTestId("project-home-context-tasks").click();
+  await expect(page).toHaveURL(/homeTab=issues/);
+  const sheet = page.getByTestId("project-home-workspace-sheet");
+  const taskRow = sheet.getByTestId("project-issue-row").first();
+  await taskRow.locator('[data-projects-text-priority="primary"]').click();
+  await expect(sheet.getByTestId("project-issue-detail")).toBeVisible();
+  await expect(page).toHaveURL(/issueId=/);
+
+  await page.goBack();
+  await expect(sheet.getByTestId("project-issue-detail")).toHaveCount(0);
+  await expect(taskRow).toBeVisible();
+  await page.goForward();
+  await expect(sheet.getByTestId("project-issue-detail")).toBeVisible();
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(
+    page
+      .getByTestId("project-home-workspace-sheet")
+      .getByTestId("project-issue-detail"),
+  ).toBeVisible();
+
+  await page
+    .getByTestId("focus-thread-drawer")
+    .getByTestId("auxiliary-panel-close")
+    .click();
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(page).not.toHaveURL(/homeTab=|repositoryId=|issueId=/);
+
+  await page.getByTestId("project-home-context-repo-buzz").click();
+  await page.getByRole("tab", { name: "Commits" }).click();
+  await expect(page).toHaveURL(/tab=commits/);
+  await page.getByTestId("project-activity-feed-item").first().click();
+  await expect(page.getByTestId("project-commit-detail")).toBeVisible();
+  await expect(page).toHaveURL(/commitHash=/);
+
+  await page.goBack();
+  await expect(
+    page.getByTestId("project-activity-feed-item").first(),
+  ).toBeVisible();
+  await page.goForward();
+  await expect(page.getByTestId("project-commit-detail")).toBeVisible();
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("project-commit-detail")).toBeVisible();
+
+  await page.getByTestId("project-detail-chrome").getByText("Commits").click();
+  await page.getByRole("tab", { name: "Files" }).click();
+  const entry = page.getByTestId("project-repository-entry-row").first();
+  await entry.click();
+  await expect(page).toHaveURL(/filePath=/);
+  const hashSearch = new URL(page.url()).hash.split("?")[1] ?? "";
+  const selectedFilePath = new URLSearchParams(hashSearch).get("filePath");
+  expect(selectedFilePath).toBeTruthy();
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/filePath=/);
+  await expect(
+    page
+      .locator("[data-project-detail-panel]")
+      .getByText(selectedFilePath?.split("/").at(-1) ?? "", { exact: true })
+      .first(),
+  ).toBeVisible();
+});
+
 test("project discussion row opens its channel thread in context", async ({
   page,
 }) => {


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** Project pages now reopen the same sheet, repository tab, work item, commit, or file after refresh and respond correctly to browser Back and Forward.

**Problem:** Project navigation was split between URL search state and component-local state, so the visible page diverged from the browser history and refresh restored the wrong surface. **Solution:** Make project navigation route-owned, with an explicit `homeTab` discriminator for project-home sheets and atomic history updates for repository tabs and nested selections.

## Changes

<details>
<summary>File changes</summary>

**desktop/src/app/routes/projects.$projectId.tsx**
Passes validated project-home sheet state from the route into the project detail screen.

**desktop/src/features/projects/lib/projectDetailSearch.test.mjs**
Covers valid and invalid `homeTab` parsing and verifies home-sheet URLs do not select the full repository surface.

**desktop/src/features/projects/lib/projectDetailSearch.ts**
Validates `homeTab` and uses it to distinguish project-home sheets from repository routes.

**desktop/src/features/projects/ui/ProjectChannelHome.tsx**
Moves project-home sheet tab, repository, and nested detail navigation into atomic URL history patches.

**desktop/src/features/projects/ui/ProjectDetailScreen.tsx**
Derives repository tab and nested selections from route state, clears incompatible fields together, and writes explicit user navigation to history.

**desktop/src/features/projects/ui/ProjectHomeCodebasePanel.tsx**
Accepts the route-owned file path and reports file navigation through an explicit callback.

**desktop/src/features/projects/ui/ProjectHomeWorkspaceSheet.tsx**
Restores issue, review, commit, and file detail from route state and updates history from user actions.

**desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx**
Threads explicit file-path changes into repository file navigation.

**desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx**
Makes the active repository tab controlled by route state instead of component-local state.

**desktop/src/features/projects/ui/projectDetailHelpers.ts**
Adds the project-home tab to the shared route-state keys and project detail props.

**desktop/src/features/projects/ui/useRepositoryFilesNavigation.ts**
Reports directory, breadcrumb, file, and back navigation without writing history during asynchronous hydration.

**desktop/src/features/projects/ui/useRetainedProjectGitViews.test.mjs**
Updates the workspace test seam for controlled tab selection.

**desktop/src/testing/e2eBridge.ts**
Makes generated project issue and pull-request IDs deterministic so detail URLs remain valid across fixture regeneration on reload.

**desktop/tests/e2e/project-commit-detail.spec.ts**
Adds end-to-end coverage for home-sheet and repository detail Back/Forward behavior, reload restoration, sheet close, and file-path reload.

</details>

## Reproduction Steps

1. Open a channel-first project and open a Tasks workspace sheet.
2. Select a task, then use browser Back and Forward; the list and detail should restore with the URL.
3. Reload on the task detail, then close the sheet; the task detail should survive reload and close should return to project home without opening repository detail.
4. Open a repository, switch to Commits, select a commit, and repeat Back, Forward, and reload.
5. Switch to Files, open an entry, and reload; the selected file or folder should remain rendered.

## Validation

- `pnpm -C desktop typecheck`
- `pnpm -C desktop check` (passes with existing warnings outside this diff)
- `pnpm -C desktop test` — 5,965 passed
- `pnpm -C desktop build:e2e`
- `pnpm -C desktop exec playwright test tests/e2e/project-commit-detail.spec.ts --project=smoke` — 17 passed
- Focused history/reload scenario rerun after rebasing onto `origin/main` — 1 passed
