### PR TITLE
fix(desktop): stop rendering relay system events as Inbox messages

### DIFF
--- a/desktop/src/features/home/useHomeInboxContextMessages.test.mjs
+++ b/desktop/src/features/home/useHomeInboxContextMessages.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Regression for #7234: the Inbox conversation pane rendered relay system
+ * events (kind 40099) as ordinary message bubbles, so a `dm_created` payload
+ * showed up as raw JSON authored by a truncated hex pubkey. The channel
+ * timeline routes the same event to `SystemMessageRow` and shows nothing for a
+ * payload it has no copy for; the Inbox now matches.
+ */
+
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+});
+
+after(() => dom.window.close());
+
+const CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const AUTHOR = "a".repeat(64);
+const RELAY = "f".repeat(64);
+
+const CHANNEL = {
+  id: CHANNEL_ID,
+  name: "general",
+  channelType: "stream",
+  archivedAt: null,
+};
+
+function event(overrides) {
+  return {
+    id: overrides.id,
+    kind: overrides.kind ?? 9,
+    pubkey: overrides.pubkey ?? AUTHOR,
+    content: overrides.content ?? "hello",
+    created_at: overrides.created_at ?? 1_700_000_000,
+    tags: overrides.tags ?? [["h", CHANNEL_ID]],
+    sig: "0".repeat(128),
+  };
+}
+
+const SYSTEM_EVENT = event({
+  id: "system-1",
+  kind: 40099,
+  pubkey: RELAY,
+  content: JSON.stringify({
+    actor: AUTHOR,
+    participants: [AUTHOR, "b".repeat(64)],
+    type: "dm_created",
+  }),
+  created_at: 1_700_000_100,
+});
+
+async function renderContextMessages(events) {
+  const { renderHook } = await import("@testing-library/react");
+  const { useHomeInboxContextMessages } = await import(
+    "./useHomeInboxContextMessages.ts"
+  );
+
+  const view = renderHook(() =>
+    useHomeInboxContextMessages({
+      currentPubkey: AUTHOR,
+      events,
+      profiles: {},
+      reactionEvents: [],
+      selectedChannel: CHANNEL,
+      selectedEventId: "root-1",
+      selectedItem: { id: "root-1", item: { pubkey: AUTHOR } },
+    }),
+  );
+  return view.result.current;
+}
+
+test("inbox context drops relay system events", async () => {
+  const messages = await renderContextMessages([
+    event({ id: "root-1", content: "Please review the release checklist." }),
+    SYSTEM_EVENT,
+  ]);
+
+  assert.equal(messages.length, 1, "only the real message survives");
+  assert.equal(messages[0].id, "root-1");
+  assert.ok(
+    !messages.some((message) => message.body?.includes("dm_created")),
+    "no raw system payload reaches the Inbox",
+  );
+  assert.ok(
+    !messages.some((message) => message.rawPubkey === RELAY),
+    "the relay signer is never surfaced as an Inbox author",
+  );
+});
+
+test("inbox context keeps ordinary messages untouched", async () => {
+  const messages = await renderContextMessages([
+    event({ id: "root-1", content: "first" }),
+    event({ id: "reply-1", content: "second", created_at: 1_700_000_200 }),
+  ]);
+
+  assert.deepEqual(
+    messages.map((message) => message.id),
+    ["root-1", "reply-1"],
+  );
+});

--- a/desktop/src/features/home/useHomeInboxContextMessages.ts
+++ b/desktop/src/features/home/useHomeInboxContextMessages.ts
@@ -8,7 +8,7 @@ import {
 import { formatTimelineMessages } from "@/features/messages/lib/formatTimelineMessages";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel, RelayEvent } from "@/shared/api/types";
-import { KIND_REACTION } from "@/shared/constants/kinds";
+import { KIND_REACTION, KIND_SYSTEM_MESSAGE } from "@/shared/constants/kinds";
 
 type UseHomeInboxContextMessagesOptions = {
   channelMessages?: RelayEvent[];
@@ -66,13 +66,25 @@ export function useHomeInboxContextMessages({
       ownerProfiles,
     );
 
-    return timelineMessages.map((message) =>
-      toInboxContextMessage(message, {
-        eventById,
-        fallbackAuthorPubkey: selectedItem.item.pubkey,
-        profiles,
-        selectedItemId: selectedEventId ?? selectedItem.id,
-      }),
+    return (
+      timelineMessages
+        // Relay system events (kind 40099) carry a JSON payload, not prose, and
+        // are signed by the relay rather than a member. The channel timeline
+        // routes them to `SystemMessageRow`; the Inbox has no such row, so an
+        // unhandled one renders as a message bubble with the raw JSON as its
+        // body and a truncated hex pubkey as its author. Drop them here so the
+        // Inbox matches the channel, which shows nothing for a payload it has no
+        // copy for. They stay in `formatTimelineMessages`' input because it
+        // harvests their `actor`/`target` pubkeys for profile lookups.
+        .filter((message) => message.kind !== KIND_SYSTEM_MESSAGE)
+        .map((message) =>
+          toInboxContextMessage(message, {
+            eventById,
+            fallbackAuthorPubkey: selectedItem.item.pubkey,
+            profiles,
+            selectedItemId: selectedEventId ?? selectedItem.id,
+          }),
+        )
     );
   }, [
     channelMessages,


### PR DESCRIPTION
## Why

Fixes #7234. The Home Inbox conversation pane renders every timeline event
through `InboxMessageRow`, which has no branch for relay system events
(kind 40099). A `dm_created` payload therefore arrives as an ordinary message
bubble: body = raw JSON, author = truncated hex pubkey, avatar = initials
derived from that hex.

## Root cause

`useHomeInboxContextMessages` hands the output of `formatTimelineMessages`
straight to `toInboxContextMessage`. Nothing under
`desktop/src/features/home/` references `KIND_SYSTEM_MESSAGE`.

The channel timeline does have that branch — `timelineItems.ts` classifies the
event as `"system"` and routes it to `SystemMessageRow` — so the same event is
handled in a channel and unhandled in the Inbox.

I checked the channel's actual behaviour for this payload rather than assuming
it: emitting the same kind 40099 `dm_created` event into a channel renders
nothing at all (`systemEventCopy` has copy for joins/topic/purpose, not
`dm_created`). This change makes the Inbox match that.

## What

Filter `KIND_SYSTEM_MESSAGE` out of the Inbox timeline **after**
`formatTimelineMessages`, not before it: that function harvests `actor` and
`target` pubkeys from system events for profile lookups
(`extractSystemMessagePubkeys`), so the events still need to reach its input.

## Before / after

Home → Inbox → open a conversation, with a kind 40099 `dm_created` event in the
thread.

**Before** — raw JSON body, `ffffffff…ffff` author, `FF` avatar:

![before](https://raw.githubusercontent.com/PresentJay/buzz/ac7a04e8f8fb7df42b4772966e9f0fc3f07cdbeb/pr-7234--01-before.png)

**After** — the system event is gone, matching the channel:

![after](https://raw.githubusercontent.com/PresentJay/buzz/ac7a04e8f8fb7df42b4772966e9f0fc3f07cdbeb/pr-7234--02-after.png)

Note the header also changes from *Thread in #general* to *Message in #general*:
the spurious event was being counted as a reply, so the conversation was
presented as a thread. That falls out of the same fix.

## Tests

`useHomeInboxContextMessages.test.mjs` renders the hook with a real message plus
a `dm_created` system event and asserts the system event is dropped, no raw
payload reaches the Inbox, and the relay signer never surfaces as an author. A
second case pins that ordinary messages are untouched. The first fails on
`main` (`only the real message survives`) and passes here.

Fork PRs need maintainer approval before CI runs, so local results for
`4d175898e` (branched from `origin/main`), via the repo's Hermit toolchain:

```
pnpm typecheck  ✔  tsc --noEmit
pnpm check      ✔  biome + check:px-text + check:pubkey-truncation
pnpm test       ✔  5966 pass / 0 fail
```