### PR TITLE
db: pin application function search paths for restores

### DIFF
--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -702,7 +702,7 @@ mod postgres_tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 44);
+        assert_eq!(migrations.len(), 45);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -2448,6 +2448,75 @@ mod postgres_tests {
 
     #[tokio::test]
     #[ignore = "requires Postgres"]
+    async fn function_search_path_migration_repairs_restore_context() {
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        run_migrations_through(&pool, 44)
+            .await
+            .expect("apply migrations through 44");
+
+        let community = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community)
+            .bind(format!("restore-proof-{}.example", community.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert restore proof community");
+
+        let mut before = pool.acquire().await.expect("pre-migration connection");
+        sqlx::query("BEGIN")
+            .execute(&mut *before)
+            .await
+            .expect("begin pre-migration transaction");
+        sqlx::query("SET LOCAL search_path TO ''")
+            .execute(&mut *before)
+            .await
+            .expect("clear pre-migration search path");
+        let before_error = sqlx::query("SELECT public.assert_community_write_allowed($1)")
+            .bind(community)
+            .execute(&mut *before)
+            .await
+            .expect_err("migration 44 must reproduce restore name-resolution failure");
+        assert_eq!(
+            before_error
+                .as_database_error()
+                .and_then(sqlx::error::DatabaseError::code)
+                .as_deref(),
+            Some("42883")
+        );
+        sqlx::query("ROLLBACK")
+            .execute(&mut *before)
+            .await
+            .expect("rollback pre-migration transaction");
+        drop(before);
+
+        run_migrations(&pool)
+            .await
+            .expect("apply function search-path migration");
+
+        let mut after = pool.acquire().await.expect("post-migration connection");
+        sqlx::query("BEGIN")
+            .execute(&mut *after)
+            .await
+            .expect("begin restore-like transaction");
+        sqlx::query("SET LOCAL search_path TO ''")
+            .execute(&mut *after)
+            .await
+            .expect("clear restore-like search path");
+        sqlx::query("INSERT INTO public.users (community_id, pubkey) VALUES ($1, $2)")
+            .bind(community)
+            .bind(vec![0x41_u8; 32])
+            .execute(&mut *after)
+            .await
+            .expect("restore-like insert must traverse the repaired write fence");
+        sqlx::query("ROLLBACK")
+            .execute(&mut *after)
+            .await
+            .expect("finish restore-like transaction");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn run_migrations_applies_consolidated_initial_schema_on_fresh_database() {
         let pool = connect_test_pool().await;
         reset_public_schema(&pool).await;
@@ -2521,6 +2590,57 @@ mod postgres_tests {
                 .await
                 .expect("insert late-table test community");
         }
+
+        let unpinned_application_functions: i64 = sqlx::query_scalar(
+            "SELECT count(*)::BIGINT \
+               FROM pg_proc AS procedure \
+               JOIN pg_namespace AS namespace \
+                 ON namespace.oid = procedure.pronamespace \
+              WHERE namespace.nspname = 'public' \
+                AND procedure.prokind = 'f' \
+                AND procedure.proowner = (SELECT oid FROM pg_roles WHERE rolname = current_user) \
+                AND NOT EXISTS (\
+                    SELECT 1 FROM pg_depend AS dependency \
+                     WHERE dependency.classid = 'pg_proc'::REGCLASS \
+                       AND dependency.objid = procedure.oid \
+                       AND dependency.deptype = 'e'\
+                ) \
+                AND NOT coalesce(procedure.proconfig, ARRAY[]::TEXT[]) \
+                    @> ARRAY['search_path=public, pg_catalog']",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("inspect application function search paths");
+        assert_eq!(
+            unpinned_application_functions, 0,
+            "every application-owned function must resolve independently of the restore session"
+        );
+
+        let mut restore_connection = pool.acquire().await.expect("restore-like connection");
+        sqlx::query("BEGIN")
+            .execute(&mut *restore_connection)
+            .await
+            .expect("begin restore-like transaction");
+        sqlx::query("SET LOCAL search_path TO ''")
+            .execute(&mut *restore_connection)
+            .await
+            .expect("clear restore-like search path");
+        sqlx::query("SELECT public.assert_community_write_allowed($1)")
+            .bind(active_a)
+            .execute(&mut *restore_connection)
+            .await
+            .expect("write fence must resolve with an empty invoker search path");
+        sqlx::query("INSERT INTO public.users (community_id, pubkey) VALUES ($1, $2)")
+            .bind(active_a)
+            .bind(vec![0x41_u8; 32])
+            .execute(&mut *restore_connection)
+            .await
+            .expect("restore-like insert must traverse the write-fence trigger");
+        sqlx::query("ROLLBACK")
+            .execute(&mut *restore_connection)
+            .await
+            .expect("finish restore-like transaction");
+
         sqlx::query(
             "CREATE TABLE late_created_scoped (\
                  community_id UUID NOT NULL, id BIGINT PRIMARY KEY, value TEXT NOT NULL\

--- a/migrations/0045_function_search_paths.sql
+++ b/migrations/0045_function_search_paths.sql
@@ -1,0 +1,36 @@
+-- PostgreSQL restore sessions deliberately clear search_path. Buzz trigger
+-- functions call other Buzz functions and tables by their unqualified names,
+-- so data-only restores must not inherit name resolution from the invoker.
+-- Pin every application-owned public function while leaving extension-owned
+-- and provider-owned functions untouched.
+
+SET LOCAL search_path TO public, pg_catalog;
+
+DO $$
+DECLARE
+    function_identity REGPROCEDURE;
+BEGIN
+    FOR function_identity IN
+        SELECT procedure.oid::REGPROCEDURE
+          FROM pg_proc AS procedure
+          JOIN pg_namespace AS namespace
+            ON namespace.oid = procedure.pronamespace
+         WHERE namespace.nspname = 'public'
+           AND procedure.prokind = 'f'
+           AND procedure.proowner = (SELECT oid FROM pg_roles WHERE rolname = current_user)
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_depend AS dependency
+                WHERE dependency.classid = 'pg_proc'::REGCLASS
+                  AND dependency.objid = procedure.oid
+                  AND dependency.deptype = 'e'
+           )
+         ORDER BY procedure.oid
+    LOOP
+        EXECUTE format(
+            'ALTER FUNCTION %s SET search_path TO public, pg_catalog',
+            function_identity
+        );
+    END LOOP;
+END
+$$;


### PR DESCRIPTION
## Why

PostgreSQL restore sessions can clear `search_path`. Buzz trigger functions call other Buzz functions and tables by unqualified names, so a data-only restore can fail inside the community write fence even when every restored row is valid.

## Change

Add migration 0045, after the current upstream migration chain, to pin every application-owned function in `public` to `public, pg_catalog`. Extension-owned functions are excluded. The path preserves Buzz functions that intentionally use `current_schema()` while making their name resolution independent of the restore session.

The regression test first migrates through 0044 and proves the restore-like empty path fails, then applies 0045 and proves a write-fence-triggered insert succeeds. The fresh-schema test also fails unless every application-owned function has the pinned path and exercises both direct fence invocation and a trigger-backed insert.

## Evidence

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p buzz-db --lib`: 122 passed, 252 PostgreSQL tests ignored
- live PostgreSQL 17: `function_search_path_migration_repairs_restore_context` passed
- live PostgreSQL 17: `run_migrations_applies_consolidated_initial_schema_on_fresh_database` passed
- `cargo clippy -p buzz-db --all-targets -- -D warnings`

The disposable PostgreSQL container and anonymous data volume used for the live proofs were removed afterward.