### PR TITLE
fix(desktop): default missing channel participant arrays at the Tauri boundary

### DIFF
--- a/desktop/src/features/messages/lib/channelWindowResponse.test.mjs
+++ b/desktop/src/features/messages/lib/channelWindowResponse.test.mjs
@@ -169,3 +169,26 @@ test("drops malformed or mistargeted live thread summaries", () => {
     null,
   );
 });
+
+test("live thread summary defaults missing participants to []", () => {
+  const rootId = "a".padEnd(64, "0");
+  const push = event(
+    "s",
+    39005,
+    700,
+    JSON.stringify({
+      reply_count: 4,
+      descendant_count: 6,
+      last_reply_at: 650,
+    }),
+    [["e", rootId]],
+  );
+  const parsed = parseLiveThreadSummary(push);
+  assert.equal(parsed.rootId, rootId);
+  assert.deepEqual(parsed.live.summary, {
+    replyCount: 4,
+    descendantCount: 6,
+    lastReplyAt: 650,
+    participantPubkeys: [],
+  });
+});

--- a/desktop/src/features/messages/lib/channelWindowResponse.ts
+++ b/desktop/src/features/messages/lib/channelWindowResponse.ts
@@ -21,7 +21,7 @@ type SummaryPayload = {
   reply_count: number;
   descendant_count: number;
   last_reply_at: number | null;
-  participants: string[];
+  participants?: string[];
 };
 
 function targetId(event: RelayEvent, tagName: "d" | "e") {
@@ -43,7 +43,7 @@ const mapSummary = (payload: SummaryPayload): ChannelWindowThreadSummary => ({
   replyCount: payload.reply_count,
   descendantCount: payload.descendant_count,
   lastReplyAt: payload.last_reply_at,
-  participantPubkeys: payload.participants,
+  participantPubkeys: payload.participants ?? [],
 });
 
 /**

--- a/desktop/src/shared/api/tauriChannels.test.mjs
+++ b/desktop/src/shared/api/tauriChannels.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { fromRawChannel, fromRawChannelDetail } = await import(
+  "./tauriChannels.ts"
+);
+
+function rawChannel(overrides = {}) {
+  return {
+    id: "chan-1",
+    name: "General",
+    channel_type: "stream",
+    visibility: "open",
+    description: "",
+    topic: null,
+    purpose: null,
+    member_count: 3,
+    member_pubkeys: ["a".repeat(64), "b".repeat(64)],
+    last_message_at: null,
+    archived_at: null,
+    participants: ["Alice", "Bob"],
+    participant_pubkeys: ["a".repeat(64), "b".repeat(64)],
+    is_member: true,
+    ttl_seconds: null,
+    ttl_deadline: null,
+    ...overrides,
+  };
+}
+
+function rawDetail(overrides = {}) {
+  return {
+    ...rawChannel(overrides),
+    created_by: "a".repeat(64),
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    topic_set_by: null,
+    topic_set_at: null,
+    purpose_set_by: null,
+    purpose_set_at: null,
+    topic_required: false,
+    max_members: null,
+    nip29_group_id: null,
+  };
+}
+
+test("fromRawChannel maps participants and participantPubkeys", () => {
+  const channel = fromRawChannel(rawChannel());
+  assert.deepEqual(channel.participants, ["Alice", "Bob"]);
+  assert.deepEqual(channel.participantPubkeys, [
+    "a".repeat(64),
+    "b".repeat(64),
+  ]);
+});
+
+test("fromRawChannel defaults missing participants to empty arrays", () => {
+  const channel = fromRawChannel(
+    rawChannel({ participants: undefined, participant_pubkeys: undefined }),
+  );
+  assert.deepEqual(
+    channel.participants,
+    [],
+    "missing participants must default to []",
+  );
+  assert.deepEqual(
+    channel.participantPubkeys,
+    [],
+    "missing participantPubkeys must default to []",
+  );
+});
+
+test("fromRawChannelDetail defaults missing participants to empty arrays", () => {
+  const detail = fromRawChannelDetail(
+    rawDetail({ participants: undefined, participant_pubkeys: undefined }),
+  );
+  assert.deepEqual(detail.participants, []);
+  assert.deepEqual(detail.participantPubkeys, []);
+});

--- a/desktop/src/shared/api/tauriChannels.ts
+++ b/desktop/src/shared/api/tauriChannels.ts
@@ -24,8 +24,8 @@ export type RawChannel = {
   member_pubkeys: string[];
   last_message_at: string | null;
   archived_at: string | null;
-  participants: string[];
-  participant_pubkeys: string[];
+  participants?: string[];
+  participant_pubkeys?: string[];
   is_member?: boolean;
   ttl_seconds: number | null;
   ttl_deadline: string | null;
@@ -86,8 +86,8 @@ export function fromRawChannel(channel: RawChannel): Channel {
     memberPubkeys: channel.member_pubkeys ?? [],
     lastMessageAt: channel.last_message_at,
     archivedAt: channel.archived_at,
-    participants: channel.participants,
-    participantPubkeys: channel.participant_pubkeys,
+    participants: channel.participants ?? [],
+    participantPubkeys: channel.participant_pubkeys ?? [],
     isMember: channel.is_member ?? true,
     ttlSeconds: channel.ttl_seconds,
     ttlDeadline: channel.ttl_deadline,


### PR DESCRIPTION
## Summary

`fromRawChannel` and `mapSummary` left `participants` / `participantPubkeys` as `undefined` when the Rust wire response omitted the snake_case arrays. Any downstream `.map()` / `.filter()` on those fields then crashed with the `participantPubkeys.map is not a function` error reported in Buzz Desktop 0.5.19.

## Changes

- Make `RawChannel.participants` and `RawChannel.participant_pubkeys` optional to reflect the wire contract.
- Default both to `[]` in `fromRawChannel` and `fromRawChannelDetail`.
- Default `SummaryPayload.participants` to `[]` in `mapSummary`.
- Add regression tests for `fromRawChannel` and `parseLiveThreadSummary`.

## Validation

- `just desktop-typecheck` passes
- `just desktop-test` passes (6048 tests)
- `just desktop-check` passes
- `just desktop-build` passes

## Risk zone

None.

— Devin (SWE-1.7 Max)
