### PR TITLE
fix(desktop): stop treating the Windows notification shim's startup "denied" as final

### DIFF
--- a/desktop/src/features/notifications/lib/desktop.ts
+++ b/desktop/src/features/notifications/lib/desktop.ts
@@ -6,7 +6,11 @@ import {
   onAction,
   requestPermission,
 } from "@tauri-apps/plugin-notification";
-import { isLinuxPlatform, isMacPlatform } from "@/shared/lib/platform";
+import {
+  isLinuxPlatform,
+  isMacPlatform,
+  isWindowsPlatform,
+} from "@/shared/lib/platform";
 
 // Backend event emitted when a native Linux notification is clicked or a
 // queued macOS activation becomes available. See src-tauri notification code.
@@ -123,6 +127,21 @@ function dispatchDesktopNotificationTarget(target: DesktopNotificationTarget) {
   );
 }
 
+/**
+ * True when the "denied" currently reported by `window.Notification` is the
+ * placeholder tauri-plugin-notification's Windows init script writes without
+ * consulting the backend (block/buzz#2445), rather than a real OS decision.
+ * Windows has no per-app notification prompt for the desktop backend to lose,
+ * so on Windows under Tauri a shim "denied" is never authoritative.
+ */
+function isWindowsShimDeniedPlaceholder(): boolean {
+  return (
+    isTauri() &&
+    isWindowsPlatform() &&
+    window.Notification.permission === "denied"
+  );
+}
+
 function shouldUseMacDevelopmentFallback(error: unknown): boolean {
   return String(error).includes("not running from an app bundle");
 }
@@ -147,6 +166,18 @@ export async function getDesktopNotificationPermissionState(): Promise<DesktopNo
   }
 
   if (window.Notification.permission !== "default") {
+    // block/buzz#2445 — tauri-plugin-notification replaces
+    // `window.Notification` with a shim whose init script, on Windows only,
+    // compares its own freshly initialised "default" against "granted" instead
+    // of asking the backend, and so stamps "denied" on every launch. The
+    // desktop backend grants unconditionally, so a "denied" read from the shim
+    // carries no information on Windows. Report "default" instead: the
+    // auto-request in `use-feed-desktop-notifications` and the settings toggle
+    // then call `requestPermission()`, which the shim answers by writing the
+    // backend's real "granted" back into its cached state.
+    if (isWindowsShimDeniedPlaceholder()) {
+      return "default";
+    }
     return window.Notification.permission;
   }
 

--- a/desktop/src/features/notifications/lib/desktopWindowsPermission.test.mjs
+++ b/desktop/src/features/notifications/lib/desktopWindowsPermission.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Mirrors the `window.Notification` shim that tauri-plugin-notification's
+// init script installs. On Windows the shim's own `isPermissionGranted()`
+// compares its freshly initialised "default" against "granted" instead of
+// asking the backend, so it stamps "denied" on every launch
+// (block/buzz#2445). `requestPermission()` is the only path that writes the
+// backend's real answer ("granted" on desktop) back into the shim.
+function installShim({ permission }) {
+  let current = permission;
+  const Shim = function ShimNotification() {};
+  Shim.requestPermission = async () => {
+    current = "granted";
+    return "granted";
+  };
+  Object.defineProperty(Shim, "permission", {
+    enumerable: true,
+    get: () => current,
+  });
+  return Shim;
+}
+
+function setPlatform(platform) {
+  // Node ships a getter-only global `navigator`; redefine it per test.
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { platform, userAgent: `Mozilla/5.0 (${platform})` },
+  });
+}
+
+// `isTauri()` from @tauri-apps/api/core reads `globalThis.isTauri`.
+globalThis.isTauri = true;
+globalThis.window = { Notification: installShim({ permission: "denied" }) };
+setPlatform("Win32");
+
+const {
+  getDesktopNotificationPermissionState,
+  requestDesktopNotificationAccess,
+} = await import("./desktop.ts");
+
+test("Windows: the shim's startup 'denied' is reported as 'default' so permission can still be requested", async () => {
+  setPlatform("Win32");
+  window.Notification = installShim({ permission: "denied" });
+
+  assert.equal(await getDesktopNotificationPermissionState(), "default");
+
+  // Requesting flips the shim to the backend's real answer, and from then on
+  // the state is authoritative.
+  assert.equal(await requestDesktopNotificationAccess(), "granted");
+  assert.equal(await getDesktopNotificationPermissionState(), "granted");
+});
+
+test("Windows: a real 'granted' passes through unchanged", async () => {
+  setPlatform("Win32");
+  window.Notification = installShim({ permission: "granted" });
+
+  assert.equal(await getDesktopNotificationPermissionState(), "granted");
+});
+
+test("Linux: 'denied' stays authoritative — the placeholder rewrite is Windows-only", async () => {
+  setPlatform("Linux x86_64");
+  window.Notification = installShim({ permission: "denied" });
+
+  assert.equal(await getDesktopNotificationPermissionState(), "denied");
+});
+
+test("browser (non-Tauri) on Windows: 'denied' is a real user decision and stays 'denied'", async () => {
+  setPlatform("Win32");
+  globalThis.isTauri = false;
+  try {
+    window.Notification = installShim({ permission: "denied" });
+    assert.equal(await getDesktopNotificationPermissionState(), "denied");
+  } finally {
+    globalThis.isTauri = true;
+  }
+});

--- a/desktop/src/shared/lib/platform.ts
+++ b/desktop/src/shared/lib/platform.ts
@@ -12,6 +12,16 @@ export function isMacPlatform(): boolean {
   return /mac|iphone|ipad|ipod/i.test(navigator.platform);
 }
 
+/** Returns true on Windows. */
+export function isWindowsPlatform(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  // Anchored so "Darwin" (which contains "win") never matches.
+  return /^win/i.test(navigator.platform);
+}
+
 /** Returns true on Linux desktops (excludes Android). */
 export function isLinuxPlatform(): boolean {
   if (typeof navigator === "undefined") {


### PR DESCRIPTION
## Summary

On Windows, desktop notifications could never be enabled: the Notifications settings card always showed *"Desktop notifications are blocked. Enable them in your system settings."*, the toggle snapped back off, and Buzz never appeared under Windows Settings → Notifications.

Root cause is in the `window.Notification` shim that `tauri-plugin-notification` (2.3.3, unchanged in 2.4.0) injects at startup. On Windows only, its `isPermissionGranted()` takes a shortcut that compares the shim's own freshly-initialised `"default"` against `"granted"` instead of asking the backend — always false — and stamps `permission = "denied"` on every launch. Buzz trusted that value, so `requestPermission()` was never called (the hooks only request from `"default"`), no toast was ever sent, and Windows never registered the app. Reinstalling cannot help because the value is recomputed on each start.

The desktop backend grants unconditionally on every platform, so a shim `"denied"` carries no information on Windows. This PR reports it as `"default"` there. The existing auto-request in `use-feed-desktop-notifications` (and the settings toggle) then call `requestPermission()`, which the shim answers by writing the backend's real `"granted"` into its cached state. Linux/macOS and non-Tauri browsers are untouched — a real `"denied"` stays authoritative.

Changes:
- `shared/lib/platform.ts`: add `isWindowsPlatform()` (anchored `^win` so `"Darwin"` never matches).
- `notifications/lib/desktop.ts`: `getDesktopNotificationPermissionState()` treats a Windows shim `"denied"` as `"default"`, with the reasoning documented inline.
- `notifications/lib/desktopWindowsPermission.test.mjs`: regression test bound to the production seam — the Windows case fails without the guard; Linux and browser (non-Tauri) cases pin that `"denied"` stays `"denied"` there.

### Related issue

Fixes #2445 (same diagnosis, reporter offered a PR but none was opened).

### Testing

- `desktop` unit tests for `features/notifications/**` and `shared/lib/*`: 422 passed. Removing the guard makes the new Windows test fail (verified).
- `tsc --noEmit` clean, Biome clean, `check:px-text` clean.
- Manual repro of the bug on Windows 11 with Buzz 0.5.20 (unsigned alpha): no Chromium content-setting for notifications exists in the WebView2 profile, no `notifications` entry in `permission_actions`, and Buzz is absent from Windows' per-app notification list — consistent with the shim never asking the OS. Not yet verified end-to-end with a rebuilt Windows binary; happy to do so if a maintainer can point me at the Windows build recipe used for the alpha installers.