### PR TITLE
fix(desktop): explain an unreachable pairing relay instead of showing a dead recovery QR

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -141,6 +141,7 @@ export default defineConfig({
         "**/appearance-previews.spec.ts",
         "**/channel-sort.spec.ts",
         "**/identity-lost.spec.ts",
+        "**/identity-recovery-local-relay.spec.ts",
         "**/deep-link-invite.spec.ts",
         "**/invite-link-copy.spec.ts",
         "**/global-agent-config-screenshots.spec.ts",

--- a/desktop/src/features/onboarding/lib/identityRecoveryErrors.test.mjs
+++ b/desktop/src/features/onboarding/lib/identityRecoveryErrors.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { recoveryErrorMessage } = await import("./identityRecoveryErrors.ts");
+
+const EXPIRED =
+  "This pairing code expired or lost its connection. Create a new code and try again.";
+
+test("connection failures name the pairing relay when it is known", () => {
+  for (const backendMessage of [
+    "relay connection closed",
+    "WebSocket handshake failed: Connection refused (os error 111)",
+    "failed to connect to relay",
+  ]) {
+    const message = recoveryErrorMessage(backendMessage, "ws://localhost:3000");
+    assert.match(message, /ws:\/\/localhost:3000/, backendMessage);
+    assert.match(message, /community address/, backendMessage);
+    assert.doesNotMatch(message, /expired/, backendMessage);
+  }
+});
+
+test("connection failures without a known relay keep the expired wording", () => {
+  assert.equal(recoveryErrorMessage("relay connection closed"), EXPIRED);
+  assert.equal(recoveryErrorMessage("websocket error", null), EXPIRED);
+});
+
+test("expiry, timeouts and SAS-confirm failures are unchanged, relay or not", () => {
+  for (const backendMessage of [
+    "pairing session expired",
+    "sas-confirm rejected by peer",
+    "request timed out",
+  ]) {
+    assert.equal(recoveryErrorMessage(backendMessage), EXPIRED);
+    assert.equal(
+      recoveryErrorMessage(backendMessage, "wss://pairing.buzz.xyz"),
+      EXPIRED,
+    );
+  }
+});
+
+test("unrecognised backend messages pass through verbatim", () => {
+  assert.equal(
+    recoveryErrorMessage("invalid relay URL: empty host", "ws://x"),
+    "invalid relay URL: empty host",
+  );
+});

--- a/desktop/src/features/onboarding/lib/identityRecoveryErrors.ts
+++ b/desktop/src/features/onboarding/lib/identityRecoveryErrors.ts
@@ -1,0 +1,36 @@
+/**
+ * Maps backend pairing failures to copy the user can act on.
+ *
+ * Connection failures are called out with the relay address when it is known:
+ * a fresh desktop still pointed at the built-in `ws://localhost:3000` default
+ * fails this way instantly (block/buzz#5236), and a generic "expired" message
+ * sends people looking at the wrong thing. Everything else keeps the existing
+ * expired/lost-connection wording.
+ */
+export function recoveryErrorMessage(
+  message: string,
+  pairingRelayUrl: string | null = null,
+): string {
+  const normalized = message.toLowerCase();
+  if (isConnectionFailure(normalized) && pairingRelayUrl) {
+    return `Could not connect to the pairing relay at ${pairingRelayUrl}. Check the community address this desktop is configured with, then create a new code.`;
+  }
+  if (
+    normalized.includes("sas-confirm") ||
+    isConnectionFailure(normalized) ||
+    normalized.includes("expired") ||
+    normalized.includes("timed out")
+  ) {
+    return "This pairing code expired or lost its connection. Create a new code and try again.";
+  }
+  return message;
+}
+
+function isConnectionFailure(normalized: string): boolean {
+  return (
+    normalized.includes("relay connection closed") ||
+    normalized.includes("websocket") ||
+    normalized.includes("connection refused") ||
+    normalized.includes("failed to connect")
+  );
+}

--- a/desktop/src/features/onboarding/lib/pairingRelayReachability.test.mjs
+++ b/desktop/src/features/onboarding/lib/pairingRelayReachability.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const {
+  classifyPairingQrUri,
+  classifyPairingRelay,
+  localOnlyPairingRelayMessage,
+  pairingRelayFromQrUri,
+} = await import("./pairingRelayReachability.ts");
+
+// The code a fresh desktop emits when no community relay is configured: the
+// built-in dev default from src-tauri/src/relay.rs, percent-encoded by the
+// Rust side.
+const DEFAULT_RELAY_RECOVERY_URI =
+  "nostrpair://bb02eb1cf24d3590b344a514e2477dc335fd018f799d99161a6a965078a058e8" +
+  "?secret=cdb535bf5d3402a4c178bc395d5200c7d230e1ad77f218afa020346be31da380" +
+  "&relay=ws%3A%2F%2Flocalhost%3A3000&v=1&mode=recover";
+
+// Same shape once the desktop is pointed at a real community: the relay's
+// NIP-11 document advertises a public pairing relay. Dots arrive as `%2E`.
+const PUBLIC_RELAY_RECOVERY_URI =
+  "nostrpair://59e937d51a4755be8255813f867d32ef3219cd7563999ca5905fa707e5ecacd2" +
+  "?secret=602d497bb8c71d483694ff386c28dd9601621c4b447f667a42b5b96228afb4ff" +
+  "&relay=wss%3A%2F%2Fpairing%2Ebuzz%2Exyz&v=1&mode=recover";
+
+test("extracts and decodes the relay the code asks the phone to join", () => {
+  assert.equal(
+    pairingRelayFromQrUri(DEFAULT_RELAY_RECOVERY_URI),
+    "ws://localhost:3000",
+  );
+  assert.equal(
+    pairingRelayFromQrUri(PUBLIC_RELAY_RECOVERY_URI),
+    "wss://pairing.buzz.xyz",
+  );
+  assert.equal(pairingRelayFromQrUri("nostrpair://abc?secret=1&v=1"), null);
+  assert.equal(pairingRelayFromQrUri("not a uri"), null);
+});
+
+test("the unconfigured default relay is flagged as local-only", () => {
+  const result = classifyPairingQrUri(DEFAULT_RELAY_RECOVERY_URI);
+  assert.equal(result.kind, "local-only");
+  assert.equal(result.host, "localhost");
+  assert.equal(result.reason, "loopback");
+  assert.equal(result.relayUrl, "ws://localhost:3000");
+});
+
+test("a public pairing relay is reachable", () => {
+  const result = classifyPairingQrUri(PUBLIC_RELAY_RECOVERY_URI);
+  assert.equal(result.kind, "reachable");
+  assert.equal(result.host, "pairing.buzz.xyz");
+});
+
+test("loopback, unspecified and *.localhost hosts are local-only", () => {
+  for (const url of [
+    "ws://127.0.0.1:3000",
+    "ws://[::1]:3000",
+    "ws://0.0.0.0:3000",
+    "ws://relay.localhost",
+    "wss://LOCALHOST",
+  ]) {
+    const result = classifyPairingRelay(url);
+    assert.equal(result.kind, "local-only", url);
+  }
+});
+
+test("RFC 1918 and link-local IPv4 ranges are local-only — the phone rejects them too", () => {
+  for (const url of [
+    "ws://10.0.0.5:3000",
+    "ws://172.16.0.1:3000",
+    "ws://172.31.255.254:3000",
+    "ws://192.168.1.20:3000",
+    "ws://169.254.10.10:3000",
+  ]) {
+    const result = classifyPairingRelay(url);
+    assert.equal(result.kind, "local-only", url);
+    assert.equal(result.reason, "private-network", url);
+  }
+});
+
+test("public IPv4 and hostnames are reachable; 172.x outside /12 is public", () => {
+  for (const url of [
+    "wss://pairing.buzz.xyz",
+    "wss://nas-dum.communities.buzz.xyz",
+    "ws://8.8.8.8:3000",
+    "ws://172.15.0.1:3000",
+    "ws://172.32.0.1:3000",
+    "ws://11.0.0.1",
+  ]) {
+    assert.equal(classifyPairingRelay(url).kind, "reachable", url);
+  }
+});
+
+test("garbage input is unknown rather than a false positive either way", () => {
+  assert.equal(classifyPairingRelay("").kind, "unknown");
+  assert.equal(classifyPairingRelay("::::").kind, "unknown");
+  assert.equal(classifyPairingQrUri("nostrpair://abc?v=1").kind, "unknown");
+});
+
+test("the local-only message names the offending address and the fix", () => {
+  const result = classifyPairingRelay("ws://localhost:3000");
+  assert.equal(result.kind, "local-only");
+  const message = localOnlyPairingRelayMessage(result);
+  assert.match(message, /ws:\/\/localhost:3000/);
+  assert.match(message, /this computer only/);
+  assert.match(message, /invite link or relay address/);
+
+  const lan = classifyPairingRelay("ws://192.168.1.20:3000");
+  assert.equal(lan.kind, "local-only");
+  assert.match(localOnlyPairingRelayMessage(lan), /private network address/);
+});

--- a/desktop/src/features/onboarding/lib/pairingRelayReachability.ts
+++ b/desktop/src/features/onboarding/lib/pairingRelayReachability.ts
@@ -1,0 +1,111 @@
+/**
+ * Reachability triage for the relay a `nostrpair://` code asks the *other*
+ * device to connect to.
+ *
+ * A fresh desktop with no community configured falls back to the built-in
+ * development relay (`ws://localhost:3000`, see `src-tauri/src/relay.rs`).
+ * That address is embedded verbatim in the recovery QR, so a phone scanning it
+ * tries to reach *itself* and reports "Could not reach the pairing relay",
+ * while the desktop's own connection attempt fails and surfaces as "expired
+ * or lost its connection". Neither message points at the actual cause. The
+ * mobile client also refuses loopback and private-network relays outright in
+ * release builds, so the same triage here mirrors what the phone will reject.
+ */
+
+export type PairingRelayReachability =
+  | { kind: "reachable"; relayUrl: string; host: string }
+  | {
+      kind: "local-only";
+      relayUrl: string;
+      host: string;
+      reason: "loopback" | "private-network" | "unspecified";
+    }
+  | { kind: "unknown" };
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const UNSPECIFIED_HOSTS = new Set(["0.0.0.0", "::", "[::]"]);
+
+/**
+ * Extract the `relay` the pairing code instructs the scanning device to join.
+ * Returns `null` when the URI does not carry one (or cannot be parsed).
+ */
+export function pairingRelayFromQrUri(qrUri: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(qrUri);
+  } catch {
+    return null;
+  }
+  const relay = parsed.searchParams.get("relay");
+  return relay && relay.trim().length > 0 ? relay.trim() : null;
+}
+
+function isPrivateIpv4(host: string): boolean {
+  const parts = host.split(".");
+  if (parts.length !== 4) return false;
+  const octets = parts.map((part) =>
+    /^\d{1,3}$/.test(part) ? Number(part) : NaN,
+  );
+  if (octets.some((octet) => Number.isNaN(octet) || octet > 255)) return false;
+  const [a, b] = octets as [number, number, number, number];
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+
+/**
+ * Classify whether another device on another network could plausibly reach
+ * `relayUrl`. Loopback, unspecified, `*.localhost`, and RFC 1918 / link-local
+ * addresses are local to the machine (or LAN) that produced the code.
+ */
+export function classifyPairingRelay(
+  relayUrl: string,
+): PairingRelayReachability {
+  let parsed: URL;
+  try {
+    parsed = new URL(relayUrl);
+  } catch {
+    return { kind: "unknown" };
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!host) return { kind: "unknown" };
+
+  if (LOOPBACK_HOSTS.has(host) || host.endsWith(".localhost")) {
+    return { kind: "local-only", relayUrl, host, reason: "loopback" };
+  }
+  if (UNSPECIFIED_HOSTS.has(host)) {
+    return { kind: "local-only", relayUrl, host, reason: "unspecified" };
+  }
+  if (isPrivateIpv4(host)) {
+    return { kind: "local-only", relayUrl, host, reason: "private-network" };
+  }
+  return { kind: "reachable", relayUrl, host };
+}
+
+/** Triage the relay embedded in a `nostrpair://` code in one step. */
+export function classifyPairingQrUri(qrUri: string): PairingRelayReachability {
+  const relay = pairingRelayFromQrUri(qrUri);
+  return relay ? classifyPairingRelay(relay) : { kind: "unknown" };
+}
+
+/**
+ * Human-readable explanation for a code whose relay another device cannot
+ * reach. Names the address so the user can see *what* the desktop is pointed
+ * at, and says what to do about it.
+ */
+export function localOnlyPairingRelayMessage(
+  reachability: Extract<PairingRelayReachability, { kind: "local-only" }>,
+): string {
+  const where =
+    reachability.reason === "private-network"
+      ? "a private network address"
+      : "this computer only";
+  return (
+    `This desktop isn't connected to a community yet, so the pairing code ` +
+    `points at ${reachability.relayUrl} — a relay reachable from ${where}. ` +
+    `A phone scanning it can't get there. Join your community first (paste ` +
+    `its invite link or relay address), then create a new code.`
+  );
+}

--- a/desktop/src/features/onboarding/ui/IdentityRecoveryPairing.tsx
+++ b/desktop/src/features/onboarding/ui/IdentityRecoveryPairing.tsx
@@ -15,26 +15,27 @@ import { startIdentityRecoveryPairing } from "@/shared/api/tauriPairing";
 import { writeTextToClipboard } from "@/shared/lib/clipboard";
 import { Button } from "@/shared/ui/button";
 import { StyledQrCode } from "@/shared/ui/styled-qr-code";
+import { recoveryErrorMessage } from "../lib/identityRecoveryErrors";
+import {
+  classifyPairingQrUri,
+  localOnlyPairingRelayMessage,
+  pairingRelayFromQrUri,
+} from "../lib/pairingRelayReachability";
 
-type Step = "loading" | "qr" | "sas" | "receiving" | "done" | "error";
+export type IdentityRecoveryPairingStep =
+  | "loading"
+  | "qr"
+  | "local-relay"
+  | "sas"
+  | "receiving"
+  | "done"
+  | "error";
+
+type Step = IdentityRecoveryPairingStep;
 
 // Refresh before the pairing relay's two-minute connection cap so Desktop never
 // leaves a code on screen after its publishing channel has closed.
 const QR_REFRESH_MS = 90_000;
-
-function recoveryErrorMessage(message: string): string {
-  const normalized = message.toLowerCase();
-  if (
-    normalized.includes("sas-confirm") ||
-    normalized.includes("relay connection closed") ||
-    normalized.includes("websocket") ||
-    normalized.includes("expired") ||
-    normalized.includes("timed out")
-  ) {
-    return "This pairing code expired or lost its connection. Create a new code and try again.";
-  }
-  return message;
-}
 
 export function IdentityRecoveryPairing({
   onRecovered,
@@ -50,28 +51,49 @@ export function IdentityRecoveryPairing({
   const [copied, setCopied] = React.useState(false);
   const active = React.useRef(true);
   const copyTimer = React.useRef<number | null>(null);
+  // The relay the current code asks the phone to join, for error copy.
+  const pairingRelayRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     onStepChange?.(step);
   }, [onStepChange, step]);
 
-  const start = React.useCallback(async () => {
-    active.current = true;
-    setStep("loading");
-    setError(null);
-    setSas(null);
-    setQrUri(null);
-    setCopied(false);
-    try {
-      setQrUri(await startIdentityRecoveryPairing());
-      setStep("qr");
-    } catch (cause) {
-      setError(
-        cause instanceof Error ? cause.message : "Could not start recovery.",
-      );
-      setStep("error");
-    }
-  }, []);
+  const start = React.useCallback(
+    async ({ allowLocalRelay = false }: { allowLocalRelay?: boolean } = {}) => {
+      active.current = true;
+      setStep("loading");
+      setError(null);
+      setSas(null);
+      setQrUri(null);
+      setCopied(false);
+      pairingRelayRef.current = null;
+      try {
+        const uri = await startIdentityRecoveryPairing();
+        pairingRelayRef.current = pairingRelayFromQrUri(uri);
+        const reachability = classifyPairingQrUri(uri);
+        if (reachability.kind === "local-only" && !allowLocalRelay) {
+          // The backend has already opened its side of the session against a
+          // relay no phone can reach. Tear it down so its inevitable failure
+          // cannot race in as a misleading "expired" error, and explain the
+          // real cause instead of rendering an unusable code.
+          active.current = false;
+          await cancelPairing().catch(() => {});
+          setQrUri(uri);
+          setError(localOnlyPairingRelayMessage(reachability));
+          setStep("local-relay");
+          return;
+        }
+        setQrUri(uri);
+        setStep("qr");
+      } catch (cause) {
+        setError(
+          cause instanceof Error ? cause.message : "Could not start recovery.",
+        );
+        setStep("error");
+      }
+    },
+    [],
+  );
 
   React.useEffect(() => {
     void start();
@@ -93,7 +115,9 @@ export function IdentityRecoveryPairing({
     listen<{ message: string }>("pairing-error", ({ payload }) => {
       if (!disposed && active.current) {
         active.current = false;
-        setError(recoveryErrorMessage(payload.message));
+        setError(
+          recoveryErrorMessage(payload.message, pairingRelayRef.current),
+        );
         setStep("error");
       }
     }).then((unlisten) => (disposed ? unlisten() : unlisteners.push(unlisten)));
@@ -149,6 +173,7 @@ export function IdentityRecoveryPairing({
           cause instanceof Error
             ? cause.message
             : "Could not confirm recovery.",
+          pairingRelayRef.current,
         ),
       );
       setStep("error");
@@ -217,6 +242,40 @@ export function IdentityRecoveryPairing({
               <Check className="h-6 w-6 text-green-600 dark:text-green-400" />
             </div>
             <p className="text-sm font-medium">Identity received securely</p>
+          </div>
+        ) : step === "local-relay" ? (
+          <div
+            className="flex max-w-56 flex-col items-center gap-3 text-center text-foreground"
+            data-testid="identity-recovery-local-relay"
+          >
+            <TriangleAlert className="h-6 w-6 text-destructive" />
+            <p className="text-sm text-destructive">{error}</p>
+            <div className="flex w-full flex-col gap-2">
+              <Button
+                data-testid="identity-recovery-local-relay-retry"
+                onClick={() => void start()}
+                size="sm"
+                variant="outline"
+              >
+                <RefreshCw className="mr-1.5 h-4 w-4" />
+                Try again
+              </Button>
+              {/*
+                Developers pairing a simulator against a local relay are the one
+                audience this code does work for; never leave them without a way
+                through (a guard that hides the only recovery affordance is a
+                functional failure).
+              */}
+              <Button
+                className="text-xs text-muted-foreground"
+                data-testid="identity-recovery-local-relay-show-anyway"
+                onClick={() => void start({ allowLocalRelay: true })}
+                size="sm"
+                variant="ghost"
+              >
+                Show the code anyway
+              </Button>
+            </div>
           </div>
         ) : step === "error" ? (
           <div className="flex max-w-52 flex-col items-center gap-3 text-center text-foreground">

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -25,7 +25,10 @@ import {
   useEncryptedBackupSession,
 } from "./EncryptedBackupCreator";
 import { IdentityKeyHelpDialog } from "./IdentityKeyHelpDialog";
-import { IdentityRecoveryPairing } from "./IdentityRecoveryPairing";
+import {
+  IdentityRecoveryPairing,
+  type IdentityRecoveryPairingStep,
+} from "./IdentityRecoveryPairing";
 import { LandingBees } from "./LandingBees";
 import {
   NostrKeyImportForm,
@@ -98,7 +101,8 @@ export function MachineOnboardingFlow({
   const [keyImportDialog, setKeyImportDialog] = React.useState<
     "backup" | "phone" | null
   >(null);
-  const [phoneRecoveryStep, setPhoneRecoveryStep] = React.useState("loading");
+  const [phoneRecoveryStep, setPhoneRecoveryStep] =
+    React.useState<IdentityRecoveryPairingStep>("loading");
   const [selectedPubkey, setSelectedPubkey] = React.useState<string | null>(
     null,
   );
@@ -486,7 +490,9 @@ export function MachineOnboardingFlow({
                       {phoneRecoveryStep === "loading" ||
                       phoneRecoveryStep === "qr"
                         ? "Scan this code with a signed-in Buzz phone."
-                        : "Confirm the code before sharing your identity."}
+                        : phoneRecoveryStep === "local-relay"
+                          ? "This desktop isn't connected to a community yet."
+                          : "Confirm the code before sharing your identity."}
                     </DialogDescription>
                     <div className="mt-5">
                       <IdentityRecoveryPairing

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -514,6 +514,13 @@ type E2eConfig = {
     /** Delay (ms) applied to `start_pairing` so pairing loading UI is observable. */
     pairingStartDelayMs?: number;
     /**
+     * Relay embedded in the `nostrpair://` codes returned by `start_pairing`
+     * and `start_identity_recovery_pairing`. Defaults to a public relay; set
+     * to e.g. `ws://localhost:3000` to reproduce the unconfigured-desktop
+     * default that a phone cannot reach.
+     */
+    pairingRelayUrl?: string;
+    /**
      * Sequenced results for `confirm_team_snapshot_import`. String = throw
      * with that message; null = succeed. Call N uses results[N]; last entry
      * repeats when exhausted. Follows the `nsecErrors` precedent.
@@ -14583,14 +14590,14 @@ export function maybeInstallE2eTauriMocks() {
         if (delayMs > 0) {
           await new Promise((resolve) => window.setTimeout(resolve, delayMs));
         }
-        return "nostrpair://8f4b8db31967ce14fef970a1ff1e8eecf19a430aa1c83875e2f5be68dcac0f1a?relay=wss%3A%2F%2Frelay.example.com&secret=87d5a8cfd5807a0cb44f728b67d88d6dcb8daf99be137c158f21a50c1e913c0a&v=1";
+        return `nostrpair://8f4b8db31967ce14fef970a1ff1e8eecf19a430aa1c83875e2f5be68dcac0f1a?relay=${encodeURIComponent(activeConfig?.mock?.pairingRelayUrl ?? "wss://relay.example.com")}&secret=87d5a8cfd5807a0cb44f728b67d88d6dcb8daf99be137c158f21a50c1e913c0a&v=1`;
       }
       case "start_identity_recovery_pairing": {
         const delayMs = activeConfig?.mock?.pairingStartDelayMs ?? 0;
         if (delayMs > 0) {
           await new Promise((resolve) => window.setTimeout(resolve, delayMs));
         }
-        return `nostrpair://8f4b8db31967ce14fef970a1ff1e8eecf19a430aa1c83875e2f5be68dcac0f1a?relay=wss%3A%2F%2Frelay.example.com&secret=87d5a8cfd5807a0cb44f728b67d88d6dcb8daf99be137c158f21a50c1e913c0a&v=1&mode=recover`;
+        return `nostrpair://8f4b8db31967ce14fef970a1ff1e8eecf19a430aa1c83875e2f5be68dcac0f1a?relay=${encodeURIComponent(activeConfig?.mock?.pairingRelayUrl ?? "wss://relay.example.com")}&secret=87d5a8cfd5807a0cb44f728b67d88d6dcb8daf99be137c158f21a50c1e913c0a&v=1&mode=recover`;
       }
       case "cancel_pairing":
       case "confirm_pairing_sas":

--- a/desktop/tests/e2e/identity-recovery-local-relay.spec.ts
+++ b/desktop/tests/e2e/identity-recovery-local-relay.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+// A fresh desktop with no community relay configured falls back to the
+// built-in `ws://localhost:3000` dev default and embeds it in the recovery
+// QR. A phone scanning that code tries to reach *itself*. The recovery
+// dialog must say so instead of rendering an unusable code.
+
+test("recovery code pointing at a local-only relay explains the cause instead of showing a QR", async ({
+  page,
+}, testInfo) => {
+  await installMockBridge(
+    page,
+    { identityLost: true, pairingRelayUrl: "ws://localhost:3000" },
+    { skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+
+  await page.getByTestId("nostr-import-phone-link").click();
+  const card = page.getByTestId("identity-recovery-pairing");
+  await expect(card).toBeVisible();
+
+  const notice = card.getByTestId("identity-recovery-local-relay");
+  await expect(notice).toBeVisible();
+  await expect(notice).toContainText("ws://localhost:3000");
+  await expect(notice).toContainText("A phone scanning it can't get there");
+  await expect(
+    page.getByText("This desktop isn't connected to a community yet."),
+  ).toBeVisible();
+
+  // No unusable code, and nothing to copy.
+  await expect(card.getByTestId("identity-recovery-qr")).toHaveCount(0);
+  await expect(card.getByTestId("copy-identity-recovery-code")).toHaveCount(0);
+
+  // The backend session against the unreachable relay was torn down.
+  const commands = await page.evaluate(
+    () =>
+      (window as Window & { __BUZZ_E2E_COMMANDS__?: string[] })
+        .__BUZZ_E2E_COMMANDS__ ?? [],
+  );
+  expect(commands).toContain("cancel_pairing");
+
+  await page.waitForTimeout(1_000); // Let the onboarding entrance motion settle.
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: testInfo.outputPath("desktop-recovery-local-relay.png"),
+  });
+
+  // Developers pairing a simulator against a local relay keep a way through.
+  await card.getByTestId("identity-recovery-local-relay-show-anyway").click();
+  await expect(card.getByTestId("identity-recovery-qr")).toBeVisible();
+  await expect(card.getByTestId("copy-identity-recovery-code")).toBeVisible();
+  await expect(
+    page.getByText("Scan this code with a signed-in Buzz phone."),
+  ).toBeVisible();
+});
+
+test("recovery code pointing at a public relay still shows the QR", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    { identityLost: true, pairingRelayUrl: "wss://pairing.buzz.xyz" },
+    { skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+
+  await page.getByTestId("nostr-import-phone-link").click();
+  const card = page.getByTestId("identity-recovery-pairing");
+  await expect(card.getByTestId("identity-recovery-qr")).toBeVisible();
+  await expect(card.getByTestId("identity-recovery-local-relay")).toHaveCount(
+    0,
+  );
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -428,6 +428,11 @@ type MockBridgeOptions = {
   /** Delay (ms) applied to `start_pairing` so pairing loading UI is observable. */
   pairingStartDelayMs?: number;
   /**
+   * Relay embedded in mock `nostrpair://` codes. Defaults to a public relay;
+   * `ws://localhost:3000` reproduces the unconfigured-desktop default.
+   */
+  pairingRelayUrl?: string;
+  /**
    * Sequenced results for `confirm_team_snapshot_import`. String = throw
    * with that message; null = succeed. Call N uses results[N]; last entry
    * repeats when exhausted. Follows the `nsecErrors` precedent.


### PR DESCRIPTION
## Summary

A fresh desktop with no community configured falls back to the built-in development relay (`ws://localhost:3000`, `src-tauri/src/relay.rs`) and embeds it verbatim in the identity-recovery QR / `nostrpair://` code. A phone scanning that code tries to reach *itself* and reports *"Could not reach the pairing relay"*, while the desktop's own connection attempt fails and surfaces as *"This pairing code expired or lost its connection."* Neither message points at the cause, and nothing on the recovery screen shows which relay the code is pointing at. The only way to discover it today is to copy the code and read the `relay=` parameter.

Real-world repro (Windows 11, Buzz 0.5.20 unsigned alpha, signed-in Android phone): the copied code was
`nostrpair://…&relay=ws%3A%2F%2Flocalhost%3A3000&v=1&mode=recover`. Setting `BUZZ_RELAY_URL` to the community relay made the code point at `wss://pairing.buzz.xyz` (advertised via NIP-11 `pairing_relay_url`) and recovery succeeded first try.

This PR makes the desktop say so before rendering an unusable code:

- **Reachability triage** (`onboarding/lib/pairingRelayReachability.ts`): parse the `relay` in the returned URI and classify loopback, unspecified, `*.localhost` and RFC 1918 / link-local addresses as local-only — the same set the mobile client refuses outright in release builds (`_validateRelayUrl`), so the desktop check mirrors what the phone would reject anyway.
- **Dedicated state in `IdentityRecoveryPairing`** (`local-relay`): names the address, says a phone cannot get there, and tells the user to join their community first (invite link / relay address). The backend session opened against the unreachable relay is cancelled immediately so its inevitable failure cannot race in as a misleading "expired" error. Developers pairing a simulator against a local relay keep a **"Show the code anyway"** path — the guard never removes the only way through (review rule 6).
- **Actionable connection errors** (`onboarding/lib/identityRecoveryErrors.ts`): when a connection failure does reach the error state and the relay is known, the message names it ("Could not connect to the pairing relay at …") instead of the generic expired wording. Expiry / timeout / SAS-confirm wording is unchanged.
- **Dialog copy**: the phone-recovery dialog description reads *"This desktop isn't connected to a community yet."* in the new state.
- **E2E infrastructure**: `pairingRelayUrl` knob on the mock bridge (`e2eBridge.ts`, `tests/helpers/bridge.ts`), defaulting to the existing `wss://relay.example.com` so no current spec changes behaviour.

Not in this PR (follow-up): the mobile client could validate the QR's relay up front and replace *"Could not reach the pairing relay"* with the same explanation; and the recovery dialog could offer the community relay/invite input inline rather than pointing at the welcome step.

### Related issue

Likely the same failure as #5236 (macOS, immediate "expired or lost its connection" on a fresh desktop, no outbound connection observed) — the reporter suspected a default relay but had no way to see it. Also related in spirit to #7132 (local-relay onboarding). No existing PR found.

### Testing

- New e2e spec `tests/e2e/identity-recovery-local-relay.spec.ts` (registered in the `smoke` project): local-only relay → notice with the address, no QR, no copy button, `cancel_pairing` invoked, then "Show the code anyway" → QR; public relay → QR as before. Ran together with `identity-lost.spec.ts`: **17 passed**.
- Unit tests: `pairingRelayReachability.test.mjs` (8) and `identityRecoveryErrors.test.mjs` (4); `features/onboarding/**` + `features/notifications/**`: 250 passed.
- `tsc --noEmit` clean (also via `pnpm build:e2e`), Biome clean, `check:px-text` clean.

### Screenshot

New state (mock bridge with `pairingRelayUrl: "ws://localhost:3000"`) — screenshot attached in a comment below.