### PR TITLE
fix(mobile): recover agent activity observer after terminal close

### DIFF
--- a/mobile/lib/features/channels/agent_activity/agent_activity_sheet.dart
+++ b/mobile/lib/features/channels/agent_activity/agent_activity_sheet.dart
@@ -124,8 +124,7 @@ class AgentActivitySheet extends HookConsumerWidget {
                       child: _EmptyState(
                         connection: connection,
                         errorMessage: observerState.errorMessage,
-                        onRetry:
-                            connection == ObserverConnectionState.error
+                        onRetry: connection == ObserverConnectionState.error
                             ? () => ref
                                   .read(observerRelayProvider.notifier)
                                   .retry()
@@ -158,7 +157,11 @@ class _EmptyState extends StatelessWidget {
   final String? errorMessage;
   final VoidCallback? onRetry;
 
-  const _EmptyState({required this.connection, this.errorMessage, this.onRetry});
+  const _EmptyState({
+    required this.connection,
+    this.errorMessage,
+    this.onRetry,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/features/channels/agent_activity/agent_activity_sheet.dart
+++ b/mobile/lib/features/channels/agent_activity/agent_activity_sheet.dart
@@ -124,6 +124,12 @@ class AgentActivitySheet extends HookConsumerWidget {
                       child: _EmptyState(
                         connection: connection,
                         errorMessage: observerState.errorMessage,
+                        onRetry:
+                            connection == ObserverConnectionState.error
+                            ? () => ref
+                                  .read(observerRelayProvider.notifier)
+                                  .retry()
+                            : null,
                       ),
                     )
                   : ListView.builder(
@@ -150,8 +156,9 @@ class AgentActivitySheet extends HookConsumerWidget {
 class _EmptyState extends StatelessWidget {
   final ObserverConnectionState connection;
   final String? errorMessage;
+  final VoidCallback? onRetry;
 
-  const _EmptyState({required this.connection, this.errorMessage});
+  const _EmptyState({required this.connection, this.errorMessage, this.onRetry});
 
   @override
   Widget build(BuildContext context) {
@@ -169,6 +176,14 @@ class _EmptyState extends StatelessWidget {
               ),
               textAlign: TextAlign.center,
             ),
+            if (onRetry != null) ...[
+              const SizedBox(height: Grid.xxs),
+              FilledButton.tonalIcon(
+                onPressed: onRetry,
+                icon: const Icon(LucideIcons.rotateCcw, size: 16),
+                label: const Text('Try again'),
+              ),
+            ],
           ],
         ),
       );

--- a/mobile/lib/features/channels/agent_activity/observer_subscription.dart
+++ b/mobile/lib/features/channels/agent_activity/observer_subscription.dart
@@ -107,6 +107,26 @@ class ObserverRelayNotifier extends Notifier<ObserverRelayState> {
     return _startFuture!;
   }
 
+  /// Re-attempts the observer subscription after a terminal error.
+  ///
+  /// The `build()` method only re-runs when the relay config or session
+  /// changes, so an error emitted by the `onClosed` relay callback (where the
+  /// session itself stays connected) previously dead-ended the UI with no
+  /// re-entry point. This method is the user-driven re-entry: it invalidates
+  /// any in-flight subscribe via the epoch guard, clears the stale error, and
+  /// re-enters the existing [_ensureSubscribed] seam with the same filter
+  /// shape. Safe to call repeatedly; a no-op when already subscribed.
+  Future<void> retry() {
+    if (_disposed) return Future.value();
+    if (_unsubscribe != null) return Future.value();
+
+    _subscriptionEpoch += 1;
+    _startFuture = null;
+    _errorMessage = null;
+    _emit(connection: ObserverConnectionState.connecting);
+    return _ensureSubscribed();
+  }
+
   Future<void> _subscribe(int epoch) async {
     try {
       if (_disposed || epoch != _subscriptionEpoch) {

--- a/mobile/test/features/channels/agent_activity/agent_activity_sheet_test.dart
+++ b/mobile/test/features/channels/agent_activity/agent_activity_sheet_test.dart
@@ -1,0 +1,274 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/misc.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+import 'package:buzz/features/channels/agent_activity/agent_activity_sheet.dart';
+import 'package:buzz/shared/crypto/nip44.dart';
+import 'package:buzz/shared/profile/user_cache_provider.dart';
+import 'package:buzz/shared/profile/user_profile.dart';
+import 'package:buzz/shared/relay/relay.dart';
+
+import '../../../helpers/widget_helpers.dart';
+
+void main() {
+  testWidgets('01 error state shows retry affordance', (tester) async {
+    final ownerKeychain = nostr.Keys.generate();
+    final agentKeychain = nostr.Keys.generate();
+    final session = _ScriptedRelaySession();
+
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: _overrides(
+          session: session,
+          nsec: ownerKeychain.nsec,
+          agentPubkey: agentKeychain.public,
+        ),
+        child: AgentActivitySheet(
+          channelId: 'test-channel',
+          agentPubkey: agentKeychain.public,
+        ),
+      ),
+    );
+    // Let the initial subscription microtask run and settle to open.
+    await tester.pump();
+    await tester.pump();
+
+    // The relay closes the observer subscription while the session stays
+    // connected — the terminal dead end this item fixes.
+    session.closeAll('boom');
+    await tester.pump();
+
+    expect(find.byIcon(LucideIcons.circleX), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+    expect(find.byIcon(LucideIcons.rotateCcw), findsOneWidget);
+  });
+
+  testWidgets('02 tapping retry re-subscribes and streams live frames again', (
+    tester,
+  ) async {
+    final ownerKeychain = nostr.Keys.generate();
+    final agentKeychain = nostr.Keys.generate();
+    final session = _ScriptedRelaySession();
+
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: _overrides(
+          session: session,
+          nsec: ownerKeychain.nsec,
+          agentPubkey: agentKeychain.public,
+        ),
+        child: AgentActivitySheet(
+          channelId: 'test-channel',
+          agentPubkey: agentKeychain.public,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    // Terminal error via onClosed.
+    session.closeAll('boom');
+    await tester.pump();
+    expect(find.text('Try again'), findsOneWidget);
+
+    // The retry attempt hangs on a gate so the connecting state is observable.
+    session.gateNextSubscribe = true;
+    await tester.tap(find.text('Try again'));
+    await tester.pump();
+    expect(find.byIcon(LucideIcons.circleX), findsNothing);
+
+    // Complete the re-subscribe: filter re-sent, connection opens. (This fake
+    // keeps closed subscriptions in `filters`, so 2 = initial + retry.)
+    session.releaseSubscribe(0);
+    await tester.pump();
+    expect(session.filters, hasLength(2));
+    expect(session.filters.last.kinds, [EventKind.agentObserverFrame]);
+    expect(find.text('Try again'), findsNothing);
+
+    // A live frame arrives on the NEW subscription; the transcript resumes.
+    session.emit(
+      _observerEvent(
+        ownerKeychain: ownerKeychain,
+        agentKeychain: agentKeychain,
+        payload: _observerFrameJson(seq: 1),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(ListView), findsOneWidget);
+    expect(find.text('Try again'), findsNothing);
+  });
+
+  testWidgets('03 no retry affordance while healthy or connecting', (
+    tester,
+  ) async {
+    final ownerKeychain = nostr.Keys.generate();
+    final agentKeychain = nostr.Keys.generate();
+    final session = _ScriptedRelaySession();
+
+    // Gate the FIRST subscribe so the sheet sits in connecting, not open.
+    session.gateNextSubscribe = true;
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: _overrides(
+          session: session,
+          nsec: ownerKeychain.nsec,
+          agentPubkey: agentKeychain.public,
+        ),
+        child: AgentActivitySheet(
+          channelId: 'test-channel',
+          agentPubkey: agentKeychain.public,
+        ),
+      ),
+    );
+    await tester.pump();
+    // Still connecting — no affordance.
+    expect(find.text('Try again'), findsNothing);
+    session.releaseSubscribe(0);
+    await tester.pump();
+    // Open and healthy — still no affordance, just the waiting empty state.
+    expect(find.text('Try again'), findsNothing);
+    expect(find.text('Waiting for activity…'), findsOneWidget);
+  });
+}
+
+List<Override> _overrides({
+  required _ScriptedRelaySession session,
+  required String nsec,
+  required String agentPubkey,
+}) {
+  return [
+    relaySessionProvider.overrideWith(() => session),
+    relayConfigProvider.overrideWith(() => _FakeRelayConfigNotifier(nsec)),
+    userCacheProvider.overrideWith(
+      () => _SeededUserCacheNotifier({
+        agentPubkey.toLowerCase(): UserProfile(
+          pubkey: agentPubkey,
+          displayName: 'Test Agent',
+        ),
+      }),
+    ),
+  ];
+}
+
+Map<String, dynamic> _observerFrameJson({required int seq}) => {
+  'seq': seq,
+  'timestamp': '2026-09-03T09:00:0$seq.000Z',
+  'kind': 'turn_started',
+  'channelId': 'test-channel',
+  'turnId': 'turn-1',
+  'payload': {
+    'triggeringEventIds': ['$seq'],
+  },
+};
+
+NostrEvent _observerEvent({
+  required nostr.Keys ownerKeychain,
+  required nostr.Keys agentKeychain,
+  required Map<String, dynamic> payload,
+}) {
+  final conversationKey = getConversationKey(
+    agentKeychain.secret,
+    ownerKeychain.public,
+  );
+  final event = nostr.Event.from(
+    kind: EventKind.agentObserverFrame,
+    content: nip44Encrypt(conversationKey, jsonEncode(payload)),
+    tags: [
+      ['p', ownerKeychain.public],
+      ['agent', agentKeychain.public],
+      ['frame', 'telemetry'],
+    ],
+    secretKey: agentKeychain.secret,
+    verify: false,
+  );
+  return NostrEvent.fromJson(event.toMap());
+}
+
+/// Relay session fake mirroring `_RecordingRelaySession` from the notifier's
+/// unit test, plus a gate so a subscribe can be held in-flight.
+class _ScriptedRelaySession extends RelaySessionNotifier {
+  final List<NostrFilter> filters = [];
+  final List<void Function(NostrEvent)> _listeners = [];
+  final List<void Function(String message)> _closedListeners = [];
+  final List<Completer<void>> _subscribeGates = [];
+  bool gateNextSubscribe = false;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async {
+    filters.add(filter);
+    if (gateNextSubscribe) {
+      gateNextSubscribe = false;
+      final gate = Completer<void>();
+      _subscribeGates.add(gate);
+      await gate.future;
+    }
+    _listeners.add(onEvent);
+    if (onClosed != null) {
+      _closedListeners.add(onClosed);
+    }
+    return () {
+      filters.remove(filter);
+      _listeners.remove(onEvent);
+      if (onClosed != null) {
+        _closedListeners.remove(onClosed);
+      }
+    };
+  }
+
+  void emit(NostrEvent event) {
+    for (final listener in List.of(_listeners)) {
+      listener(event);
+    }
+  }
+
+  void closeAll(String message) {
+    for (final listener in List.of(_closedListeners)) {
+      listener(message);
+    }
+    _listeners.clear();
+    _closedListeners.clear();
+  }
+
+  void releaseSubscribe(int index) {
+    final gate = _subscribeGates[index];
+    if (!gate.isCompleted) {
+      gate.complete();
+    }
+  }
+}
+
+class _FakeRelayConfigNotifier extends RelayConfigNotifier {
+  final String? _nsec;
+
+  _FakeRelayConfigNotifier(this._nsec);
+
+  @override
+  RelayConfig build() =>
+      RelayConfig(baseUrl: 'http://localhost:3000', nsec: _nsec);
+}
+
+/// Skips the relay-backed batch loader; the sheet only needs a label.
+class _SeededUserCacheNotifier extends UserCacheNotifier {
+  final Map<String, UserProfile> _seed;
+
+  _SeededUserCacheNotifier(this._seed);
+
+  @override
+  Map<String, UserProfile> build() => _seed;
+
+  @override
+  Future<bool> preload(List<String> pubkeys) async => true;
+}

--- a/mobile/test/features/channels/agent_activity/observer_subscription_test.dart
+++ b/mobile/test/features/channels/agent_activity/observer_subscription_test.dart
@@ -516,6 +516,104 @@ void main() {
       expect(state.framesByAgent[agentKeychain.public], isNull);
     },
   );
+
+  test('retry() re-subscribes with the same filter after an onClosed error', () async {
+    final userKeychain = nostr.Keys.generate();
+    final agentKeychain = nostr.Keys.generate();
+    final relaySession = _RecordingRelaySession();
+    final container = ProviderContainer(
+      overrides: [
+        relaySessionProvider.overrideWith(() => relaySession),
+        relayConfigProvider.overrideWith(
+          () => _FakeRelayConfigNotifier(nsec: userKeychain.nsec),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final key = (channelId: 'test-channel', agentPubkey: agentKeychain.public);
+    container.read(observerSubscriptionProvider(key));
+    await Future<void>.delayed(Duration.zero);
+
+    // Terminal error while the session stays connected.
+    relaySession.closeAll('restricted: p-gated events require #p');
+    expect(
+      container.read(observerSubscriptionProvider(key)).connection,
+      ObserverConnectionState.error,
+    );
+
+    // Retry emits connecting and re-enters subscribe.
+    final retryFuture = container
+        .read(observerRelayProvider.notifier)
+        .retry();
+    expect(
+      container.read(observerSubscriptionProvider(key)).connection,
+      ObserverConnectionState.connecting,
+    );
+
+    await retryFuture;
+    await Future<void>.delayed(Duration.zero);
+
+    // closeAll cleared the recorded filters; the retried subscribe is the only
+    // live entry, and it must repeat the exact filter shape.
+    expect(relaySession.filters, hasLength(1));
+    final retriedFilter = relaySession.filters.last;
+    expect(retriedFilter.kinds, [EventKind.agentObserverFrame]);
+    expect(retriedFilter.limit, 0);
+    expect(retriedFilter.tags['#p'], contains(userKeychain.public));
+    expect(
+      container.read(observerSubscriptionProvider(key)).connection,
+      ObserverConnectionState.open,
+    );
+    expect(
+      container.read(observerSubscriptionProvider(key)).errorMessage,
+      isNull,
+    );
+  });
+
+  test('retry() is repeatable and idempotent while subscribed', () async {
+    final userKeychain = nostr.Keys.generate();
+    final agentKeychain = nostr.Keys.generate();
+    final relaySession = _RecordingRelaySession();
+    final container = ProviderContainer(
+      overrides: [
+        relaySessionProvider.overrideWith(() => relaySession),
+        relayConfigProvider.overrideWith(
+          () => _FakeRelayConfigNotifier(nsec: userKeychain.nsec),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final key = (channelId: 'test-channel', agentPubkey: agentKeychain.public);
+    container.read(observerSubscriptionProvider(key));
+    await Future<void>.delayed(Duration.zero);
+
+    // Fail, then retry to open.
+    relaySession.closeAll('boom');
+    await container.read(observerRelayProvider.notifier).retry();
+    await Future<void>.delayed(Duration.zero);
+    expect(relaySession.filters, hasLength(1));
+
+    // While subscribed, retry() is a no-op: no extra filter, no churn.
+    await container.read(observerRelayProvider.notifier).retry();
+    await Future<void>.delayed(Duration.zero);
+    expect(relaySession.filters, hasLength(1));
+
+    // A second full error/retry cycle still works (repeatable).
+    relaySession.closeAll('closed by relay');
+    expect(
+      container.read(observerSubscriptionProvider(key)).connection,
+      ObserverConnectionState.error,
+    );
+    await container.read(observerRelayProvider.notifier).retry();
+    await Future<void>.delayed(Duration.zero);
+    expect(relaySession.filters, hasLength(1));
+    expect(
+      container.read(observerSubscriptionProvider(key)).connection,
+      ObserverConnectionState.open,
+    );
+  });
 }
 
 Map<String, dynamic> _observerFrameJson({

--- a/mobile/test/features/channels/agent_activity/observer_subscription_test.dart
+++ b/mobile/test/features/channels/agent_activity/observer_subscription_test.dart
@@ -517,59 +517,65 @@ void main() {
     },
   );
 
-  test('retry() re-subscribes with the same filter after an onClosed error', () async {
-    final userKeychain = nostr.Keys.generate();
-    final agentKeychain = nostr.Keys.generate();
-    final relaySession = _RecordingRelaySession();
-    final container = ProviderContainer(
-      overrides: [
-        relaySessionProvider.overrideWith(() => relaySession),
-        relayConfigProvider.overrideWith(
-          () => _FakeRelayConfigNotifier(nsec: userKeychain.nsec),
-        ),
-      ],
-    );
-    addTearDown(container.dispose);
+  test(
+    'retry() re-subscribes with the same filter after an onClosed error',
+    () async {
+      final userKeychain = nostr.Keys.generate();
+      final agentKeychain = nostr.Keys.generate();
+      final relaySession = _RecordingRelaySession();
+      final container = ProviderContainer(
+        overrides: [
+          relaySessionProvider.overrideWith(() => relaySession),
+          relayConfigProvider.overrideWith(
+            () => _FakeRelayConfigNotifier(nsec: userKeychain.nsec),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
 
-    final key = (channelId: 'test-channel', agentPubkey: agentKeychain.public);
-    container.read(observerSubscriptionProvider(key));
-    await Future<void>.delayed(Duration.zero);
+      final key = (
+        channelId: 'test-channel',
+        agentPubkey: agentKeychain.public,
+      );
+      container.read(observerSubscriptionProvider(key));
+      await Future<void>.delayed(Duration.zero);
 
-    // Terminal error while the session stays connected.
-    relaySession.closeAll('restricted: p-gated events require #p');
-    expect(
-      container.read(observerSubscriptionProvider(key)).connection,
-      ObserverConnectionState.error,
-    );
+      // Terminal error while the session stays connected.
+      relaySession.closeAll('restricted: p-gated events require #p');
+      expect(
+        container.read(observerSubscriptionProvider(key)).connection,
+        ObserverConnectionState.error,
+      );
 
-    // Retry emits connecting and re-enters subscribe.
-    final retryFuture = container
-        .read(observerRelayProvider.notifier)
-        .retry();
-    expect(
-      container.read(observerSubscriptionProvider(key)).connection,
-      ObserverConnectionState.connecting,
-    );
+      // Retry emits connecting and re-enters subscribe.
+      final retryFuture = container
+          .read(observerRelayProvider.notifier)
+          .retry();
+      expect(
+        container.read(observerSubscriptionProvider(key)).connection,
+        ObserverConnectionState.connecting,
+      );
 
-    await retryFuture;
-    await Future<void>.delayed(Duration.zero);
+      await retryFuture;
+      await Future<void>.delayed(Duration.zero);
 
-    // closeAll cleared the recorded filters; the retried subscribe is the only
-    // live entry, and it must repeat the exact filter shape.
-    expect(relaySession.filters, hasLength(1));
-    final retriedFilter = relaySession.filters.last;
-    expect(retriedFilter.kinds, [EventKind.agentObserverFrame]);
-    expect(retriedFilter.limit, 0);
-    expect(retriedFilter.tags['#p'], contains(userKeychain.public));
-    expect(
-      container.read(observerSubscriptionProvider(key)).connection,
-      ObserverConnectionState.open,
-    );
-    expect(
-      container.read(observerSubscriptionProvider(key)).errorMessage,
-      isNull,
-    );
-  });
+      // closeAll cleared the recorded filters; the retried subscribe is the only
+      // live entry, and it must repeat the exact filter shape.
+      expect(relaySession.filters, hasLength(1));
+      final retriedFilter = relaySession.filters.last;
+      expect(retriedFilter.kinds, [EventKind.agentObserverFrame]);
+      expect(retriedFilter.limit, 0);
+      expect(retriedFilter.tags['#p'], contains(userKeychain.public));
+      expect(
+        container.read(observerSubscriptionProvider(key)).connection,
+        ObserverConnectionState.open,
+      );
+      expect(
+        container.read(observerSubscriptionProvider(key)).errorMessage,
+        isNull,
+      );
+    },
+  );
 
   test('retry() is repeatable and idempotent while subscribed', () async {
     final userKeychain = nostr.Keys.generate();


### PR DESCRIPTION
## What changed
- add a user-driven `Try again` affordance when the agent-activity observer reaches a terminal error
- retry bumps the subscription epoch, clears stale error state, and re-enters the existing subscription path
- add unit and golden coverage for error, connecting, healthy, and repeatable retry states

## Evidence
- `flutter test test/features/channels/agent_activity/` — 20 passed
- Full merged-tree suite: 2352 passed; 15 failures identical to untouched upstream baseline (no regressions)
- Golden evidence: `evidence/2026-09-03-hw014/`

Sensitive paths: none (no schema, identity, authorization, security, or relay protocol changes).

Authored locally by Michael Feth; Signed-off-by preserved.