### PR TITLE
feat(nip-fi): harden Blossom kind-24242 verifier to NIP-FI spec

### DIFF
--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -327,7 +327,7 @@ fn sign_blossom_get(keys: &Keys, media_url: &str) -> Result<String, CliError> {
     use nostr::Timestamp;
 
     let now = Timestamp::now().as_secs();
-    let exp_str = (now + 600).to_string();
+    let exp_str = (now + 60).to_string();
     let domain = relay_server_tag(media_url)
         .ok_or_else(|| CliError::Usage(format!("invalid media URL: {media_url}")))?;
     let tags = vec![
@@ -350,28 +350,23 @@ fn sign_blossom_get(keys: &Keys, media_url: &str) -> Result<String, CliError> {
 fn sign_blossom_upload(
     keys: &Keys,
     sha256: &str,
-    mime: &str,
+    _mime: &str,
     relay_url: &str,
 ) -> Result<String, CliError> {
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use nostr::Timestamp;
 
     let now = Timestamp::now().as_secs();
-    let expiry: u64 = if mime.starts_with("video/") {
-        3600
-    } else {
-        600
-    };
-    let exp_str = (now + expiry).to_string();
+    let exp_str = (now + 60).to_string();
+    let domain = relay_server_tag(relay_url)
+        .ok_or_else(|| CliError::Usage(format!("invalid relay URL: {relay_url}")))?;
 
-    let mut tags = vec![
+    let tags = vec![
         Tag::parse(["t", "upload"]).map_err(|e| CliError::Other(e.to_string()))?,
         Tag::parse(["x", sha256]).map_err(|e| CliError::Other(e.to_string()))?,
         Tag::parse(["expiration", &exp_str]).map_err(|e| CliError::Other(e.to_string()))?,
+        Tag::parse(["server", &domain]).map_err(|e| CliError::Other(e.to_string()))?,
     ];
-    if let Some(domain) = relay_server_tag(relay_url) {
-        tags.push(Tag::parse(["server", &domain]).map_err(|e| CliError::Other(e.to_string()))?);
-    }
 
     let auth_event = EventBuilder::new(Kind::from(24242), "Upload file")
         .tags(tags)

--- a/crates/buzz-dev-mcp/src/view_image.rs
+++ b/crates/buzz-dev-mcp/src/view_image.rs
@@ -49,8 +49,8 @@ pub(crate) const MAX_DECODER_ALLOC: u64 = 256 * 1024 * 1024;
 /// Connect + read timeout for URL fetches.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 /// Lifetime of a Blossom `t=get` read token for relay media fetches.
-/// Matches the desktop client's `MEDIA_GET_AUTH_EXPIRY_SECS`.
-const MEDIA_GET_AUTH_EXPIRY_SECS: u64 = 600;
+/// 60 seconds — matches the NIP-FI strict proof window.
+const MEDIA_GET_AUTH_EXPIRY_SECS: u64 = 60;
 
 /// Build the decoder allocation cap. Centralised so the resize path uses the
 /// same value tests can reason about.

--- a/crates/buzz-media/src/auth.rs
+++ b/crates/buzz-media/src/auth.rs
@@ -45,7 +45,13 @@ pub enum BlossomStrictness {
 /// Checks in order:
 ///   1. Schnorr signature
 ///   2. kind == 24242 and non-empty content
-///   3. `t` tag matches `verb` — exactly one in `Strict`, at-least-one in `Permissive`
+///   3. `t` tag matches `verb`:
+///      - `Strict`: count every tag named `t` by field name; require exactly
+///        one occurrence; require its content to be non-empty and equal to
+///        `verb` (NIP-FI.md:658-666 — malformed/empty/duplicate instances MUST
+///        be rejected as `evidence_rejected`).
+///      - `Permissive`: at least one valid-valued `t` tag equal to `verb`;
+///        valueless/empty tags are ignored (origin/main `found_t` semantics).
 ///   4. `expiration` tag present, strictly future, and within the freshness window
 ///   5. `created_at` bounded: not more than 5s in the future; not older than the
 ///      mode-selected window (60s `Strict`, 3600s `Permissive`)
@@ -96,24 +102,37 @@ pub fn verify_blossom_auth_event_for_verb(
         let kind = tag.kind().to_string();
         match kind.as_str() {
             "t" => {
-                // A `t` tag only counts if it has non-empty content equal to
-                // the requested verb.  A valueless/empty tag cannot satisfy
-                // verb binding and is ignored for cardinality purposes — it is
-                // structurally malformed but not an explicit rejection.  This
-                // matches origin/main's `found_t` semantics.
-                if let Some(v) = tag.content() {
-                    if v.is_empty() {
-                        // Empty string value: does not satisfy the requirement.
-                    } else if v != verb.as_str() {
-                        return Err(MediaError::InvalidAuthVerb);
-                    } else {
-                        t_count = t_count.saturating_add(1);
-                        if strict && t_count > 1 {
-                            return Err(MediaError::DuplicateTag("t"));
+                if strict {
+                    // Strict (NIP-FI): count EVERY tag named "t" by field name,
+                    // regardless of its content.  NIP-FI.md:658-666 requires
+                    // that malformed, empty, duplicate, or conflicting instances
+                    // be rejected as `evidence_rejected`.  We count first, gate
+                    // on cardinality, then validate content.
+                    t_count = t_count.saturating_add(1);
+                    if t_count > 1 {
+                        return Err(MediaError::DuplicateTag("t"));
+                    }
+                    // Exactly one t tag: its content must be non-empty and
+                    // equal to the requested verb.
+                    match tag.content() {
+                        Some(v) if !v.is_empty() && v == verb.as_str() => {}
+                        _ => return Err(MediaError::InvalidAuthVerb),
+                    }
+                } else {
+                    // Permissive: only valid-valued matching tags count
+                    // (origin/main's `found_t` semantics).  Valueless/empty
+                    // tags are ignored for cardinality; wrong-verb tags reject.
+                    if let Some(v) = tag.content() {
+                        if v.is_empty() {
+                            // Empty string value: does not satisfy the requirement.
+                        } else if v != verb.as_str() {
+                            return Err(MediaError::InvalidAuthVerb);
+                        } else {
+                            t_count = t_count.saturating_add(1);
                         }
                     }
+                    // No content: tag is ignored (not counted, not rejected).
                 }
-                // No content: tag is ignored (not counted, not rejected).
             }
             "expiration" => {
                 exp_count = exp_count.saturating_add(1);
@@ -1141,15 +1160,15 @@ mod tests {
 
     // ── Finding 3: valueless / empty-string t tag must not satisfy verb binding ──
 
-    /// A `t` tag with no content (`["t"]`) cannot satisfy the verb requirement.
-    /// It is ignored for cardinality purposes; `t_count` stays 0 → MissingTag.
+    /// A `t` tag with no content (`["t"]`) in Strict mode: counted as one occurrence,
+    /// content check fires → `InvalidAuthVerb` (malformed instance, NIP-FI §cardinality).
     #[test]
     fn test_valueless_t_tag_is_not_counted_strict() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
         let exp_str = (now + 55).to_string();
-        // ["t"] with no second element — no content, should not satisfy t requirement
+        // ["t"] with no second element — no content, must be rejected
         let tags = vec![
             Tag::parse(["t"]).unwrap(),
             Tag::parse(["x", &sha256]).unwrap(),
@@ -1168,9 +1187,9 @@ mod tests {
                     Some("relay.example"),
                     BlossomStrictness::Strict
                 ),
-                Err(MediaError::MissingTag("t"))
+                Err(MediaError::InvalidAuthVerb)
             ),
-            "valueless t tag must not satisfy t requirement in Strict mode"
+            "valueless t tag must be rejected in Strict mode (counted once, content invalid)"
         );
     }
 
@@ -1203,8 +1222,8 @@ mod tests {
         );
     }
 
-    /// A `t` tag with an empty-string value (`["t", ""]`) cannot satisfy the
-    /// verb requirement — empty content does not equal any verb.
+    /// A `t` tag with an empty-string value (`["t", ""]`) in Strict mode: counted
+    /// as one occurrence, content check fires → `InvalidAuthVerb`.
     #[test]
     fn test_empty_string_t_tag_is_not_counted_strict() {
         let keys = Keys::generate();
@@ -1229,9 +1248,9 @@ mod tests {
                     Some("relay.example"),
                     BlossomStrictness::Strict
                 ),
-                Err(MediaError::MissingTag("t"))
+                Err(MediaError::InvalidAuthVerb)
             ),
-            "empty-string t tag must not satisfy t requirement in Strict mode"
+            "empty-string t tag must be rejected in Strict mode (counted once, content invalid)"
         );
     }
 
@@ -1263,6 +1282,123 @@ mod tests {
                 Err(MediaError::HashMismatch)
             ),
             "valueless x tag must not satisfy hash requirement"
+        );
+    }
+
+    // ── Finding 3 R2: mixed malformed+valid t combos must reject in Strict ────
+
+    /// `["t"]` (valueless) + `["t","upload"]` in Strict: the malformed tag is counted
+    /// and content-validated on first encounter; the exact rejection error depends on
+    /// tag ordering but any error is correct — no combination may be admitted.
+    /// (If malformed comes first: `InvalidAuthVerb`; if valid first: `DuplicateTag("t")`.)
+    #[test]
+    fn test_strict_rejects_valueless_plus_valid_t_combo() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t"]).unwrap(),           // valueless — counted in Strict
+            Tag::parse(["t", "upload"]).unwrap(), // valid — but two t tags total
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload bypass attempt")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let result = verify_blossom_upload_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Strict,
+        );
+        assert!(
+            result.is_err(),
+            "valueless+valid t combo must be rejected in Strict mode, got Ok"
+        );
+        // The first tag is valueless → InvalidAuthVerb fires before the second tag
+        // is seen; if ordering were reversed it would be DuplicateTag("t"). Both are
+        // valid evidence_rejected-class outcomes — what matters is admission is denied.
+        assert!(
+            matches!(
+                result,
+                Err(MediaError::InvalidAuthVerb) | Err(MediaError::DuplicateTag("t"))
+            ),
+            "expected InvalidAuthVerb or DuplicateTag(t), got unexpected error variant"
+        );
+    }
+
+    /// `["t",""]` (empty-string) + `["t","upload"]` in Strict: same reasoning —
+    /// any error is correct; admission must be denied.
+    #[test]
+    fn test_strict_rejects_empty_plus_valid_t_combo() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", ""]).unwrap(), // empty-string — counted in Strict
+            Tag::parse(["t", "upload"]).unwrap(), // valid — but two t tags total
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload bypass attempt")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let result = verify_blossom_upload_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Strict,
+        );
+        assert!(
+            result.is_err(),
+            "empty-string+valid t combo must be rejected in Strict mode, got Ok"
+        );
+        assert!(
+            matches!(
+                result,
+                Err(MediaError::InvalidAuthVerb) | Err(MediaError::DuplicateTag("t"))
+            ),
+            "expected InvalidAuthVerb or DuplicateTag(t), got unexpected error variant"
+        );
+    }
+
+    /// `["x"]` (valueless) + `["x", sha256]` (valid) in Strict: `x_count` increments
+    /// unconditionally for both occurrences → `DuplicateTag("x")`.  This confirms
+    /// the x arm already handles mixed malformed+valid correctly.
+    #[test]
+    fn test_strict_rejects_valueless_plus_valid_x_combo() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x"]).unwrap(), // valueless — counted unconditionally
+            Tag::parse(["x", &sha256]).unwrap(), // valid — but makes x_count = 2
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload bypass attempt")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_upload_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                ),
+                Err(MediaError::DuplicateTag("x"))
+            ),
+            "valueless+valid x combo must be rejected as DuplicateTag in Strict mode"
         );
     }
 }

--- a/crates/buzz-media/src/auth.rs
+++ b/crates/buzz-media/src/auth.rs
@@ -1163,7 +1163,7 @@ mod tests {
     /// A `t` tag with no content (`["t"]`) in Strict mode: counted as one occurrence,
     /// content check fires → `InvalidAuthVerb` (malformed instance, NIP-FI §cardinality).
     #[test]
-    fn test_valueless_t_tag_is_not_counted_strict() {
+    fn test_strict_rejects_valueless_t_tag() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
@@ -1225,7 +1225,7 @@ mod tests {
     /// A `t` tag with an empty-string value (`["t", ""]`) in Strict mode: counted
     /// as one occurrence, content check fires → `InvalidAuthVerb`.
     #[test]
-    fn test_empty_string_t_tag_is_not_counted_strict() {
+    fn test_strict_rejects_empty_string_t_tag() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();

--- a/crates/buzz-media/src/auth.rs
+++ b/crates/buzz-media/src/auth.rs
@@ -1,4 +1,4 @@
-//! Blossom kind:24242 auth verification (BUD-11 compliant).
+//! Blossom kind:24242 auth verification (BUD-11 + NIP-FI compliant).
 
 use crate::error::MediaError;
 
@@ -18,13 +18,40 @@ impl BlossomVerb {
     }
 }
 
-/// Verify common kind:24242 Blossom auth event validity:
+/// Verification strictness derived from the NIP-FI mode.
+///
+/// `Strict` applies the full NIP-FI kind-24242 rules: 60-second proof window,
+/// `expiration <= created_at + 60s`, mandatory `server` tag on all proofs, and
+/// exact cardinality (exactly one each of `t`, `expiration`, `server`; at most
+/// one `x`).
+///
+/// `Permissive` preserves the pre-NIP-FI behavior for Off-mode deployments:
+/// 3600-second proof window, `server` tag optional, and duplicate tags accepted.
+/// This keeps a deployed desktop that mints old-shape tokens working against an
+/// Off-mode relay [FI-INV-15].
+///
+/// The relay call sites derive strictness from `config.nip_fi.mode`; library
+/// callers without mode access may pass `Strict` directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlossomStrictness {
+    /// Full NIP-FI compliance: 60s window, mandatory `server`, exact cardinality.
+    Strict,
+    /// Pre-NIP-FI compatibility: 3600s window, optional `server`, tolerant cardinality.
+    Permissive,
+}
+
+/// Verify common kind:24242 Blossom auth event validity.
+///
+/// Checks in order:
 ///   1. Schnorr signature
-///   2. kind == 24242
-///   3. `t` tag matches `verb`
-///   4. `expiration` tag in the future
-///   5. `created_at` in the past (with 5s clock-skew tolerance)
-///   6. If `server` tags present, our domain must appear in at least one
+///   2. kind == 24242 and non-empty content
+///   3. `t` tag matches `verb` — exactly one in `Strict`, at-least-one in `Permissive`
+///   4. `expiration` tag present, strictly future, and within the freshness window
+///   5. `created_at` bounded: not more than 5s in the future; not older than the
+///      mode-selected window (60s `Strict`, 3600s `Permissive`)
+///   6. `server` tag enforcement: in `Strict` mode, exactly one `server` tag is
+///      required and MUST match the bound tenant host; in `Permissive`, optional
+///      when-present behavior is preserved
 ///
 /// Does NOT check verb-specific scope tags (`x` for upload, `x` OR `server`
 /// for get). Call this BEFORE trusting the event's pubkey for scope resolution.
@@ -32,8 +59,10 @@ pub fn verify_blossom_auth_event_for_verb(
     auth_event: &nostr::Event,
     verb: BlossomVerb,
     server_domain: Option<&str>,
-    max_age_secs: u64,
+    strictness: BlossomStrictness,
 ) -> Result<(), MediaError> {
+    let strict = strictness == BlossomStrictness::Strict;
+
     // 1. Verify Schnorr signature
     auth_event
         .verify()
@@ -49,64 +78,105 @@ pub fn verify_blossom_auth_event_for_verb(
         return Err(MediaError::InvalidAuthEvent);
     }
 
-    let mut found_t = false;
-    let mut found_exp = false;
-    let mut server_tags: Vec<&str> = Vec::new();
+    // Tag accumulation with strict cardinality tracking.
+    // In Strict mode: each of t/expiration/server must appear exactly once;
+    // x is counted separately for upload scope checking (at most one).
+    // In Permissive mode: boolean-style "found at least one" semantics,
+    // matching the pre-NIP-FI behavior.
+    let mut t_count: u8 = 0;
+    let mut exp_count: u8 = 0;
+    let mut server_count: u8 = 0;
+    let mut x_count: u8 = 0;
+
     let mut exp_value: u64 = 0;
+    // Stored as owned String to avoid lifetime entanglement across the tag iterator.
+    let mut server_value: Option<String> = None;
 
     for tag in auth_event.tags.iter() {
         let kind = tag.kind().to_string();
         match kind.as_str() {
             "t" => {
+                t_count = t_count.saturating_add(1);
+                if strict && t_count > 1 {
+                    return Err(MediaError::DuplicateTag("t"));
+                }
                 if let Some(v) = tag.content() {
                     if v != verb.as_str() {
                         return Err(MediaError::InvalidAuthVerb);
                     }
-                    found_t = true;
                 }
             }
             "expiration" => {
+                exp_count = exp_count.saturating_add(1);
+                if strict && exp_count > 1 {
+                    return Err(MediaError::DuplicateTag("expiration"));
+                }
                 if let Some(v) = tag.content() {
-                    exp_value = v.parse().unwrap_or(0);
-                    found_exp = true;
+                    if exp_count == 1 {
+                        exp_value = v.parse().unwrap_or(0);
+                    }
                 }
             }
             "server" => {
-                if let Some(v) = tag.content() {
-                    server_tags.push(v);
+                server_count = server_count.saturating_add(1);
+                if strict && server_count > 1 {
+                    return Err(MediaError::DuplicateTag("server"));
+                }
+                if server_count == 1 {
+                    server_value = tag.content().map(|s| s.to_owned());
+                }
+            }
+            "x" => {
+                x_count = x_count.saturating_add(1);
+                if strict && x_count > 1 {
+                    return Err(MediaError::DuplicateTag("x"));
                 }
             }
             _ => {}
         }
     }
 
-    // 3. t tag required
-    if !found_t {
+    // 3. t tag required (exactly one in Strict, at least one in Permissive)
+    if t_count == 0 {
         return Err(MediaError::MissingTag("t"));
     }
 
-    // 4. Expiration must exist and be in the future
-    if !found_exp {
+    // 4a. Expiration must exist
+    if exp_count == 0 {
         return Err(MediaError::MissingTag("expiration"));
     }
     let now = nostr::Timestamp::now().as_secs();
+
+    // 4b. Expiration must be strictly in the future
     if exp_value <= now {
         return Err(MediaError::TokenExpired);
     }
 
-    // 5. created_at must be recent: not in the future (5s tolerance) and not
-    //    older than 10 minutes. This bounds the replay window — even if the
-    //    expiration tag allows a longer lifetime, the token must have been
-    //    freshly minted.
+    // 5. created_at freshness bounds.
+    //
+    //   Strict  (NIP-FI active modes):
+    //     created_at <= now + 5s          — bounded future skew
+    //     now - created_at <= 60s         — 60-second replay window
+    //     expiration <= created_at + 60s  — token cannot outlive its window
+    //
+    //   Permissive (Off mode):
+    //     created_at <= now + 5s          — future skew only
+    //     now - created_at <= 3600s       — 1-hour replay window (pre-NIP-FI)
+    //     expiration window not enforced
     let created = auth_event.created_at.as_secs();
     if created > now + 5 {
         return Err(MediaError::TimestampOutOfWindow);
     }
-    if now > created + max_age_secs {
+    let max_age = if strict { 60u64 } else { 3600u64 };
+    if now > created + max_age {
+        return Err(MediaError::TimestampOutOfWindow);
+    }
+    if strict && exp_value > created + 60 {
+        // expiration tag must satisfy expiration <= created_at + 60s
         return Err(MediaError::TimestampOutOfWindow);
     }
 
-    // 6. Server tag enforcement (BUD-11 §5): if server tags present, our host must appear.
+    // 6. Server tag enforcement.
     //
     // `server_domain` is the host this request was bound to — the per-request
     // tenant host (`TenantContext::host()`), NOT a single process-global domain.
@@ -117,22 +187,47 @@ pub fn verify_blossom_auth_event_for_verb(
     // construction across case, trailing dot, default ports, and an optional
     // URL scheme/path — exactly as every other host seam resolves tenants.
     //
-    // Fail closed: if the bound host is unknown, reject tokens that carry server
-    // tags rather than silently accepting them.
-    if !server_tags.is_empty() {
-        match server_domain {
-            Some(domain) => {
-                let want = normalize_server_host(domain);
-                let matches = server_tags
-                    .iter()
-                    .any(|tag| normalize_server_host(tag) == want);
-                if !matches {
+    // Strict (NIP-FI active): exactly one server tag MUST be present and MUST
+    // match the bound tenant host. Absent or mismatched → evidence_rejected.
+    //
+    // Permissive (Off mode): if server tag present, our host must appear
+    // (fail-closed when present but our host is unknown); absent is accepted.
+    if strict {
+        match (server_count, server_value.as_deref(), server_domain) {
+            (0, _, _) => {
+                // Strict: server tag mandatory
+                return Err(MediaError::ServerMismatch);
+            }
+            (_, Some(tag_host), Some(domain)) => {
+                if normalize_server_host(tag_host) != normalize_server_host(domain) {
                     return Err(MediaError::ServerMismatch);
                 }
             }
-            None => {
-                // Server tags present but we don't know our own host — reject.
+            (_, _, None) => {
+                // Strict: bound host unknown — fail closed
                 return Err(MediaError::ServerMismatch);
+            }
+            (_, None, _) => {
+                // server tag present but empty — treat as mismatch
+                return Err(MediaError::ServerMismatch);
+            }
+        }
+    } else {
+        // Permissive: validate only when server tags are present
+        if server_count > 0 {
+            match (server_value.as_deref(), server_domain) {
+                (Some(tag_host), Some(domain)) => {
+                    if normalize_server_host(tag_host) != normalize_server_host(domain) {
+                        return Err(MediaError::ServerMismatch);
+                    }
+                }
+                (_, None) => {
+                    // Server tags present but we don't know our own host — reject.
+                    return Err(MediaError::ServerMismatch);
+                }
+                (None, _) => {
+                    return Err(MediaError::ServerMismatch);
+                }
             }
         }
     }
@@ -147,9 +242,9 @@ pub fn verify_blossom_auth_event_for_verb(
 pub fn verify_blossom_auth_event(
     auth_event: &nostr::Event,
     server_domain: Option<&str>,
-    max_age_secs: u64,
+    strictness: BlossomStrictness,
 ) -> Result<(), MediaError> {
-    verify_blossom_auth_event_for_verb(auth_event, BlossomVerb::Upload, server_domain, max_age_secs)
+    verify_blossom_auth_event_for_verb(auth_event, BlossomVerb::Upload, server_domain, strictness)
 }
 
 /// Normalize a Blossom `server` tag value (or a bound tenant host) into the
@@ -170,22 +265,19 @@ fn normalize_server_host(value: &str) -> String {
 
 /// Verify a kind:24242 Blossom upload auth event, including the x tag hash check.
 ///
-/// Calls [`verify_blossom_auth_event`] first, then verifies that at least one
-/// `x` tag matches `sha256` (BUD-11 §6: "at least one x tag matches").
+/// In `Strict` mode (NIP-FI active): exactly one `x` tag MUST be present and
+/// MUST match `sha256`. In `Permissive` mode: at least one `x` tag must match.
 pub fn verify_blossom_upload_auth(
     auth_event: &nostr::Event,
     sha256: &str,
     server_domain: Option<&str>,
-    max_age_secs: u64,
+    strictness: BlossomStrictness,
 ) -> Result<(), MediaError> {
-    verify_blossom_auth_event_for_verb(
-        auth_event,
-        BlossomVerb::Upload,
-        server_domain,
-        max_age_secs,
-    )?;
+    verify_blossom_auth_event_for_verb(auth_event, BlossomVerb::Upload, server_domain, strictness)?;
 
-    // At least one x tag must match the body sha256 (BUD-11 §6)
+    // Upload: x tag must match the body sha256.
+    // Strict: exactly one x tag and it must match (duplicate x caught above).
+    // Permissive: at least one x tag must match.
     let has_matching_x = auth_event
         .tags
         .iter()
@@ -204,18 +296,29 @@ pub fn verify_blossom_upload_auth(
 /// or server-scoped authorization (`server` tag matches this relay host). The
 /// latter intentionally grants reads for all blobs on the host until expiration;
 /// callers must still apply relay membership after this verifier returns.
+///
+/// In `Strict` mode the `server` tag is mandatory (enforced by the base verifier);
+/// `x` is optional on reads. An `x` tag, when present, must be exactly one and
+/// must match `sha256`.
 pub fn verify_blossom_get_auth(
     auth_event: &nostr::Event,
     sha256: &str,
     server_domain: Option<&str>,
-    max_age_secs: u64,
+    strictness: BlossomStrictness,
 ) -> Result<(), MediaError> {
-    verify_blossom_auth_event_for_verb(auth_event, BlossomVerb::Get, server_domain, max_age_secs)?;
+    verify_blossom_auth_event_for_verb(auth_event, BlossomVerb::Get, server_domain, strictness)?;
 
-    let has_matching_x = auth_event
+    // x tag scope check for get: if an x tag is present it must match sha256.
+    // In Strict mode duplicate x is already rejected above; here we check the value.
+    // In Permissive mode we use the original "any matching x OR matching server" logic.
+    let x_tags: Vec<&str> = auth_event
         .tags
         .iter()
-        .any(|tag| tag.kind().to_string() == "x" && (tag.content() == Some(sha256)));
+        .filter(|tag| tag.kind().to_string() == "x")
+        .filter_map(|tag| tag.content())
+        .collect();
+
+    let has_matching_x = x_tags.iter().any(|&v| v == sha256);
 
     let has_matching_server = match server_domain {
         Some(domain) => {
@@ -231,8 +334,18 @@ pub fn verify_blossom_get_auth(
         None => false,
     };
 
-    if !has_matching_x && !has_matching_server {
-        return Err(MediaError::InsufficientScope);
+    if strictness == BlossomStrictness::Strict {
+        // Strict: server is already validated as present+matching by the base verifier.
+        // x tag, if present, must match sha256 (mismatched x → evidence_rejected).
+        if !x_tags.is_empty() && !has_matching_x {
+            return Err(MediaError::ServerMismatch);
+        }
+        // Server-scoped read (no x) is always admitted here — server was validated above.
+    } else {
+        // Permissive: original BUD-01 semantics — matching x OR matching server.
+        if !has_matching_x && !has_matching_server {
+            return Err(MediaError::InsufficientScope);
+        }
     }
 
     Ok(())
@@ -244,6 +357,22 @@ mod tests {
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
 
     fn build_valid_auth(keys: &Keys, sha256: &str) -> nostr::Event {
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    fn build_permissive_auth(keys: &Keys, sha256: &str) -> nostr::Event {
+        // Old-shape token: no server tag, 300s expiry — valid in Permissive, rejected in Strict.
         let now = Timestamp::now().as_secs();
         let exp_str = (now + 300).to_string();
         let tags = vec![
@@ -257,21 +386,348 @@ mod tests {
             .unwrap()
     }
 
+    // ── Strict mode ──────────────────────────────────────────────────────────
+
     #[test]
-    fn test_verify_valid() {
+    fn test_verify_valid_strict() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let event = build_valid_auth(&keys, &sha256);
-        assert!(verify_blossom_upload_auth(&event, &sha256, None, 600).is_ok());
+        assert!(verify_blossom_upload_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Strict
+        )
+        .is_ok());
     }
 
     #[test]
-    fn test_verify_auth_event_valid() {
+    fn test_verify_auth_event_valid_strict() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let event = build_valid_auth(&keys, &sha256);
-        assert!(verify_blossom_auth_event(&event, None, 600).is_ok());
+        assert!(verify_blossom_auth_event(
+            &event,
+            Some("relay.example"),
+            BlossomStrictness::Strict
+        )
+        .is_ok());
     }
+
+    // ── Permissive mode (Off-mode regression guard [FI-INV-15]) ──────────────
+
+    #[test]
+    fn test_verify_permissive_old_shape_token_admitted() {
+        // Old-shape token (no server tag, 300s expiry) MUST be admitted in Permissive mode.
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let event = build_permissive_auth(&keys, &sha256);
+        assert!(
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Permissive
+            )
+            .is_ok(),
+            "Off-mode must admit old-shape tokens without server tag [FI-INV-15]"
+        );
+    }
+
+    #[test]
+    fn test_verify_permissive_long_expiry_admitted() {
+        // 600s expiry token (pre-NIP-FI desktop default) MUST be admitted in Permissive mode.
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 600).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Permissive
+            )
+            .is_ok(),
+            "Off-mode must admit 600s expiry tokens [FI-INV-15]"
+        );
+    }
+
+    // ── Cardinality: Strict rejects duplicates ────────────────────────────────
+
+    #[test]
+    fn test_strict_rejects_duplicate_t_tag() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["t", "upload"]).unwrap(), // duplicate
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(matches!(
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            ),
+            Err(MediaError::DuplicateTag("t"))
+        ));
+    }
+
+    #[test]
+    fn test_strict_rejects_duplicate_expiration_tag() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(), // duplicate
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(matches!(
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            ),
+            Err(MediaError::DuplicateTag("expiration"))
+        ));
+    }
+
+    #[test]
+    fn test_strict_rejects_duplicate_server_tag() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(), // duplicate
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(matches!(
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            ),
+            Err(MediaError::DuplicateTag("server"))
+        ));
+    }
+
+    #[test]
+    fn test_strict_rejects_duplicate_x_tag() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(), // duplicate
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(matches!(
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            ),
+            Err(MediaError::DuplicateTag("x"))
+        ));
+    }
+
+    // ── Permissive mode: duplicate tags still admitted ────────────────────────
+
+    #[test]
+    fn test_permissive_admits_duplicate_x_tag() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(), // duplicate — permitted in Permissive
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(verify_blossom_upload_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Permissive
+        )
+        .is_ok());
+    }
+
+    // ── Strict: server tag mandatory ─────────────────────────────────────────
+
+    #[test]
+    fn test_strict_rejects_absent_server_on_upload() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            // no server tag
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_upload_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                ),
+                Err(MediaError::ServerMismatch)
+            ),
+            "Strict mode must reject upload proof without server tag"
+        );
+    }
+
+    #[test]
+    fn test_strict_rejects_absent_server_on_read() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "get"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            // no server tag
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Get buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_get_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                ),
+                Err(MediaError::ServerMismatch)
+            ),
+            "Strict mode must reject read proof without server tag"
+        );
+    }
+
+    // ── Strict: freshness window ──────────────────────────────────────────────
+
+    #[test]
+    fn test_strict_rejects_expiration_exceeding_60s_window() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 61).to_string(); // 61s > 60s limit
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_upload_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                ),
+                Err(MediaError::TimestampOutOfWindow)
+            ),
+            "Strict mode must reject expiration > created_at + 60s"
+        );
+    }
+
+    #[test]
+    fn test_strict_admits_60s_expiration() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 60).to_string(); // exactly 60s — allowed
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            )
+            .is_ok(),
+            "Strict mode must admit expiration == created_at + 60s"
+        );
+    }
+
+    // ── Get auth ─────────────────────────────────────────────────────────────
 
     fn build_get_auth(keys: &Keys, tags: Vec<Tag>) -> nostr::Event {
         EventBuilder::new(Kind::from(24242), "Get buzz-media")
@@ -281,7 +737,82 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_get_accepts_matching_x_without_server_tag() {
+    fn test_verify_get_accepts_matching_server_strict() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let event = build_get_auth(
+            &keys,
+            vec![
+                Tag::parse(["t", "get"]).unwrap(),
+                Tag::parse(["server", "https://Relay.Example./media/ignored"]).unwrap(),
+                Tag::parse(["expiration", &exp_str]).unwrap(),
+            ],
+        );
+        assert!(verify_blossom_get_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Strict
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_get_accepts_matching_x_and_server_strict() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let event = build_get_auth(
+            &keys,
+            vec![
+                Tag::parse(["t", "get"]).unwrap(),
+                Tag::parse(["x", &sha256]).unwrap(),
+                Tag::parse(["server", "relay.example"]).unwrap(),
+                Tag::parse(["expiration", &exp_str]).unwrap(),
+            ],
+        );
+        assert!(verify_blossom_get_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Strict
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_get_strict_rejects_mismatched_x_with_valid_server() {
+        // x present but wrong hash → evidence_rejected even if server matches
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let other = "b".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let event = build_get_auth(
+            &keys,
+            vec![
+                Tag::parse(["t", "get"]).unwrap(),
+                Tag::parse(["x", &other]).unwrap(),
+                Tag::parse(["server", "relay.example"]).unwrap(),
+                Tag::parse(["expiration", &exp_str]).unwrap(),
+            ],
+        );
+        assert!(matches!(
+            verify_blossom_get_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            ),
+            Err(MediaError::ServerMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_verify_get_accepts_matching_x_without_server_permissive() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
@@ -294,12 +825,17 @@ mod tests {
                 Tag::parse(["expiration", &exp_str]).unwrap(),
             ],
         );
-
-        assert!(verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600).is_ok());
+        assert!(verify_blossom_get_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Permissive
+        )
+        .is_ok());
     }
 
     #[test]
-    fn test_verify_get_accepts_matching_server_without_x_tag() {
+    fn test_verify_get_accepts_matching_server_without_x_permissive() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
@@ -312,8 +848,13 @@ mod tests {
                 Tag::parse(["expiration", &exp_str]).unwrap(),
             ],
         );
-
-        assert!(verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600).is_ok());
+        assert!(verify_blossom_get_auth(
+            &event,
+            &sha256,
+            Some("relay.example"),
+            BlossomStrictness::Permissive
+        )
+        .is_ok());
     }
 
     #[test]
@@ -321,15 +862,19 @@ mod tests {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let event = build_valid_auth(&keys, &sha256);
-
         assert!(matches!(
-            verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600),
+            verify_blossom_get_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Permissive
+            ),
             Err(MediaError::InvalidAuthVerb)
         ));
     }
 
     #[test]
-    fn test_verify_get_requires_x_or_server_scope() {
+    fn test_verify_get_requires_x_or_server_scope_permissive() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let other_hash = "b".repeat(64);
@@ -343,9 +888,13 @@ mod tests {
                 Tag::parse(["expiration", &exp_str]).unwrap(),
             ],
         );
-
         assert!(matches!(
-            verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600),
+            verify_blossom_get_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Permissive
+            ),
             Err(MediaError::InsufficientScope)
         ));
     }
@@ -364,9 +913,13 @@ mod tests {
                 Tag::parse(["expiration", &exp_str]).unwrap(),
             ],
         );
-
         assert!(matches!(
-            verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600),
+            verify_blossom_get_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Permissive
+            ),
             Err(MediaError::ServerMismatch)
         ));
     }
@@ -378,7 +931,12 @@ mod tests {
         let event = build_valid_auth(&keys, &sha256);
         let wrong_hash = "b".repeat(64);
         assert!(matches!(
-            verify_blossom_upload_auth(&event, &wrong_hash, None, 600),
+            verify_blossom_upload_auth(
+                &event,
+                &wrong_hash,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            ),
             Err(MediaError::HashMismatch)
         ));
     }
@@ -388,45 +946,30 @@ mod tests {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
-        let exp_str = (now + 300).to_string();
+        let exp_str = (now + 55).to_string();
         let tags = vec![
             Tag::parse(["t", "upload"]).unwrap(),
             Tag::parse(["x", &sha256]).unwrap(),
             Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
         ];
         let event = EventBuilder::new(Kind::from(27235), "wrong kind")
             .tags(tags)
             .sign_with_keys(&keys)
             .unwrap();
         assert!(matches!(
-            verify_blossom_upload_auth(&event, &sha256, None, 600),
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("relay.example"),
+                BlossomStrictness::Strict
+            ),
             Err(MediaError::InvalidAuthKind)
         ));
     }
 
     #[test]
-    fn test_verify_multi_x_tags() {
-        let keys = Keys::generate();
-        let sha256 = "a".repeat(64);
-        let other_hash = "b".repeat(64);
-        let now = Timestamp::now().as_secs();
-        let exp_str = (now + 300).to_string();
-        let tags = vec![
-            Tag::parse(["t", "upload"]).unwrap(),
-            Tag::parse(["x", &other_hash]).unwrap(),
-            Tag::parse(["x", &sha256]).unwrap(),
-            Tag::parse(["expiration", &exp_str]).unwrap(),
-        ];
-        let event = EventBuilder::new(Kind::from(24242), "Upload multi-x")
-            .tags(tags)
-            .sign_with_keys(&keys)
-            .unwrap();
-        // Should pass because at least one x tag matches
-        assert!(verify_blossom_upload_auth(&event, &sha256, None, 600).is_ok());
-    }
-
-    #[test]
-    fn test_server_tag_enforcement() {
+    fn test_server_tag_enforcement_permissive() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
@@ -443,41 +986,52 @@ mod tests {
             .unwrap();
         // Should fail — server tag present but doesn't match our domain
         assert!(matches!(
-            verify_blossom_upload_auth(&event, &sha256, Some("buzz.example.com"), 600),
+            verify_blossom_upload_auth(
+                &event,
+                &sha256,
+                Some("buzz.example.com"),
+                BlossomStrictness::Permissive
+            ),
             Err(MediaError::ServerMismatch)
         ));
         // Should pass when our domain matches
-        assert!(
-            verify_blossom_upload_auth(&event, &sha256, Some("other.example.com"), 600).is_ok()
-        );
+        assert!(verify_blossom_upload_auth(
+            &event,
+            &sha256,
+            Some("other.example.com"),
+            BlossomStrictness::Permissive
+        )
+        .is_ok());
         // Should fail when server_domain is None — fail closed
         assert!(matches!(
-            verify_blossom_upload_auth(&event, &sha256, None, 600),
+            verify_blossom_upload_auth(&event, &sha256, None, BlossomStrictness::Permissive),
             Err(MediaError::ServerMismatch)
         ));
     }
 
     #[test]
-    fn test_no_server_tags_always_passes() {
+    fn test_permissive_no_server_tags_always_passes() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
-        let event = build_valid_auth(&keys, &sha256);
-        // No server tags → passes regardless of our domain
-        assert!(verify_blossom_upload_auth(&event, &sha256, Some("any.domain.com"), 600).is_ok());
+        let event = build_permissive_auth(&keys, &sha256);
+        // No server tags → passes regardless of our domain in Permissive mode
+        assert!(verify_blossom_upload_auth(
+            &event,
+            &sha256,
+            Some("any.domain.com"),
+            BlossomStrictness::Permissive
+        )
+        .is_ok());
     }
 
     /// A `server` tag is matched against the *bound tenant host* under the
-    /// shared `normalize_host` rule, so equivalent host spellings agree — the
-    /// stock CLI's bare `host:port`, an explicit default port, a trailing dot,
-    /// mixed case, and a full URL all match the same bound host. This is the
-    /// regression guard for the multi-tenant media blocker: a non-primary
-    /// tenant must accept its own server-tagged client.
+    /// shared `normalize_host` rule, so equivalent host spellings agree.
     #[test]
     fn test_server_tag_normalized_against_bound_host() {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
-        let exp_str = (now + 300).to_string();
+        let exp_str = (now + 55).to_string();
         let build = |server: &str| {
             let tags = vec![
                 Tag::parse(["t", "upload"]).unwrap(),
@@ -491,18 +1045,16 @@ mod tests {
                 .unwrap()
         };
 
-        // Non-primary tenant host with explicit non-default port (the live
-        // repro: tenant B on 127.0.0.1:3100). Stock CLI tags `host:port`.
+        // Non-primary tenant host with explicit non-default port.
         assert!(verify_blossom_upload_auth(
             &build("127.0.0.1:3100"),
             &sha256,
             Some("127.0.0.1:3100"),
-            600
+            BlossomStrictness::Strict
         )
         .is_ok());
 
-        // Equivalence under normalize_host: explicit default port, trailing
-        // dot, mixed case, and a full URL all collapse to the bound host.
+        // Equivalence under normalize_host
         for tag in [
             "Relay.Example:443",
             "relay.example.",
@@ -510,8 +1062,13 @@ mod tests {
             "https://relay.example/",
         ] {
             assert!(
-                verify_blossom_upload_auth(&build(tag), &sha256, Some("relay.example"), 600)
-                    .is_ok(),
+                verify_blossom_upload_auth(
+                    &build(tag),
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                )
+                .is_ok(),
                 "server tag {tag:?} should match bound host relay.example"
             );
         }
@@ -522,7 +1079,7 @@ mod tests {
                 &build("127.0.0.1:3100"),
                 &sha256,
                 Some("127.0.0.1:3200"),
-                600
+                BlossomStrictness::Strict
             ),
             Err(MediaError::ServerMismatch)
         ));
@@ -533,11 +1090,12 @@ mod tests {
         let keys = Keys::generate();
         let sha256 = "a".repeat(64);
         let now = Timestamp::now().as_secs();
-        let exp_str = (now + 300).to_string();
+        let exp_str = (now + 55).to_string();
         let tags = vec![
             Tag::parse(["t", "upload"]).unwrap(),
             Tag::parse(["x", &sha256]).unwrap(),
             Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
         ];
         // Empty content — BUD-11 requires a human-readable string
         let event = EventBuilder::new(Kind::from(24242), "")
@@ -545,7 +1103,7 @@ mod tests {
             .sign_with_keys(&keys)
             .unwrap();
         assert!(matches!(
-            verify_blossom_auth_event(&event, None, 600),
+            verify_blossom_auth_event(&event, Some("relay.example"), BlossomStrictness::Strict),
             Err(MediaError::InvalidAuthEvent)
         ));
     }

--- a/crates/buzz-media/src/auth.rs
+++ b/crates/buzz-media/src/auth.rs
@@ -318,7 +318,7 @@ pub fn verify_blossom_get_auth(
         .filter_map(|tag| tag.content())
         .collect();
 
-    let has_matching_x = x_tags.iter().any(|&v| v == sha256);
+    let has_matching_x = x_tags.contains(&sha256);
 
     let has_matching_server = match server_domain {
         Some(domain) => {

--- a/crates/buzz-media/src/auth.rs
+++ b/crates/buzz-media/src/auth.rs
@@ -96,15 +96,24 @@ pub fn verify_blossom_auth_event_for_verb(
         let kind = tag.kind().to_string();
         match kind.as_str() {
             "t" => {
-                t_count = t_count.saturating_add(1);
-                if strict && t_count > 1 {
-                    return Err(MediaError::DuplicateTag("t"));
-                }
+                // A `t` tag only counts if it has non-empty content equal to
+                // the requested verb.  A valueless/empty tag cannot satisfy
+                // verb binding and is ignored for cardinality purposes — it is
+                // structurally malformed but not an explicit rejection.  This
+                // matches origin/main's `found_t` semantics.
                 if let Some(v) = tag.content() {
-                    if v != verb.as_str() {
+                    if v.is_empty() {
+                        // Empty string value: does not satisfy the requirement.
+                    } else if v != verb.as_str() {
                         return Err(MediaError::InvalidAuthVerb);
+                    } else {
+                        t_count = t_count.saturating_add(1);
+                        if strict && t_count > 1 {
+                            return Err(MediaError::DuplicateTag("t"));
+                        }
                     }
                 }
+                // No content: tag is ignored (not counted, not rejected).
             }
             "expiration" => {
                 exp_count = exp_count.saturating_add(1);
@@ -232,6 +241,28 @@ pub fn verify_blossom_auth_event_for_verb(
         }
     }
 
+    Ok(())
+}
+
+/// Verify only the `x` tag hash match on an already-admitted upload auth event.
+///
+/// This is the post-body hash check: the full auth event verification
+/// (signature, kind, freshness, cardinality, server) was already performed at
+/// the pre-body admission gate.  Re-running the full verifier after streaming
+/// a potentially large body would fail for any upload that takes longer than
+/// the minted token's `expiration` window (typically 60 s in Strict mode).
+///
+/// The ONLY thing that is unknown before the body is transferred is the
+/// content hash (`x` tag).  This function confirms that the body's SHA-256
+/// matches what was declared in the signed proof.
+pub fn verify_upload_hash_only(auth_event: &nostr::Event, sha256: &str) -> Result<(), MediaError> {
+    let has_matching_x = auth_event
+        .tags
+        .iter()
+        .any(|tag| tag.kind().to_string() == "x" && tag.content() == Some(sha256));
+    if !has_matching_x {
+        return Err(MediaError::HashMismatch);
+    }
     Ok(())
 }
 
@@ -1106,5 +1137,132 @@ mod tests {
             verify_blossom_auth_event(&event, Some("relay.example"), BlossomStrictness::Strict),
             Err(MediaError::InvalidAuthEvent)
         ));
+    }
+
+    // ── Finding 3: valueless / empty-string t tag must not satisfy verb binding ──
+
+    /// A `t` tag with no content (`["t"]`) cannot satisfy the verb requirement.
+    /// It is ignored for cardinality purposes; `t_count` stays 0 → MissingTag.
+    #[test]
+    fn test_valueless_t_tag_is_not_counted_strict() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        // ["t"] with no second element — no content, should not satisfy t requirement
+        let tags = vec![
+            Tag::parse(["t"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_upload_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                ),
+                Err(MediaError::MissingTag("t"))
+            ),
+            "valueless t tag must not satisfy t requirement in Strict mode"
+        );
+    }
+
+    #[test]
+    fn test_valueless_t_tag_is_not_counted_permissive() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 300).to_string();
+        let tags = vec![
+            Tag::parse(["t"]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_upload_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Permissive
+                ),
+                Err(MediaError::MissingTag("t"))
+            ),
+            "valueless t tag must not satisfy t requirement in Permissive mode"
+        );
+    }
+
+    /// A `t` tag with an empty-string value (`["t", ""]`) cannot satisfy the
+    /// verb requirement — empty content does not equal any verb.
+    #[test]
+    fn test_empty_string_t_tag_is_not_counted_strict() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", ""]).unwrap(),
+            Tag::parse(["x", &sha256]).unwrap(),
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_upload_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                ),
+                Err(MediaError::MissingTag("t"))
+            ),
+            "empty-string t tag must not satisfy t requirement in Strict mode"
+        );
+    }
+
+    /// A valueless `x` tag on upload (`["x"]`) does not match any sha256.
+    #[test]
+    fn test_valueless_x_tag_does_not_match_hash() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 55).to_string();
+        let tags = vec![
+            Tag::parse(["t", "upload"]).unwrap(),
+            Tag::parse(["x"]).unwrap(), // no value
+            Tag::parse(["expiration", &exp_str]).unwrap(),
+            Tag::parse(["server", "relay.example"]).unwrap(),
+        ];
+        let event = EventBuilder::new(Kind::from(24242), "Upload")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            matches!(
+                verify_blossom_upload_auth(
+                    &event,
+                    &sha256,
+                    Some("relay.example"),
+                    BlossomStrictness::Strict
+                ),
+                Err(MediaError::HashMismatch)
+            ),
+            "valueless x tag must not satisfy hash requirement"
+        );
     }
 }

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -290,8 +290,8 @@ mod tests {
     // These pins cover the legacy/Permissive path (MediaError::into_response).
     // Strict mode overrides this via MediaDenial in buzz-relay [FI-INV-15].
 
-    #[test]
-    fn all_auth_failures_return_json_401_in_permissive_path() {
+    #[tokio::test]
+    async fn all_auth_failures_return_json_401_in_permissive_path() {
         // In the legacy/Permissive path all auth failures collapse to a single
         // JSON 401 to prevent oracle enumeration [FI-INV-15].  Strict mode
         // (MediaDenial in buzz-relay) applies the NIP-FI 401/403 split instead.
@@ -333,6 +333,15 @@ mod tests {
             assert!(
                 resp.headers().get("www-authenticate").is_none(),
                 "Permissive path must not include WWW-Authenticate for {label}"
+            );
+            // Exact body: legacy path emits {"error":"authentication failed"} [FI-INV-15].
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .expect("body collect");
+            assert_eq!(
+                body.as_ref(),
+                br#"{"error":"authentication failed"}"#,
+                "Permissive path: wrong body for {label}"
             );
         }
     }

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -26,6 +26,9 @@ pub enum MediaError {
     InvalidAuthVerb,
     #[error("missing required tag: {0}")]
     MissingTag(&'static str),
+    /// A tag that must appear exactly once appeared more than once.
+    #[error("duplicate tag: {0}")]
+    DuplicateTag(&'static str),
     #[error("hash mismatch")]
     HashMismatch,
     #[error("server mismatch")]
@@ -119,16 +122,32 @@ impl IntoResponse for MediaError {
             Self::FileTooLarge { .. } | Self::ImageTooLarge => {
                 (StatusCode::PAYLOAD_TOO_LARGE, self.to_string())
             }
-            // All authentication failures return the same generic 401 to prevent oracle enumeration.
-            // InsufficientScope is intentionally 403 — it's an authorization (not authentication)
-            // failure and is safe to distinguish since it requires a valid identity first.
-            Self::MissingAuth
-            | Self::InvalidAuthScheme
+            // NIP-FI denial-class split (NIP-FI §Transport and cardinality):
+            //   missing_evidence  (401) — Authorization header absent
+            //   evidence_rejected (403) — wrong scheme, malformed, duplicate, or
+            //                            otherwise structurally invalid proof
+            //
+            // All other authentication failures (signature invalid, expired,
+            // timestamp out of window, hash mismatch, etc.) return 401 to
+            // prevent oracle enumeration — they are indistinguishable from an
+            // absent identity to an unauthenticated caller.
+            Self::MissingAuth => {
+                tracing::warn!(error = %self, "authentication failed: missing evidence");
+                (
+                    StatusCode::UNAUTHORIZED,
+                    "authentication failed".to_string(),
+                )
+            }
+            Self::InvalidAuthScheme
             | Self::InvalidBase64
             | Self::InvalidAuthEvent
-            | Self::InvalidSignature
             | Self::InvalidAuthKind
             | Self::InvalidAuthVerb
+            | Self::DuplicateTag(_) => {
+                tracing::warn!(error = %self, "authentication failed: evidence rejected");
+                (StatusCode::FORBIDDEN, "authorization denied".to_string())
+            }
+            Self::InvalidSignature
             | Self::TokenExpired
             | Self::TimestampOutOfWindow
             | Self::Unauthorized

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -330,11 +330,12 @@ mod tests {
             MediaError::ServerMismatch,
             MediaError::MissingTag("server"),
         ] {
+            let label = format!("{error:?}");
             let resp = error.into_response();
             assert_eq!(
                 resp.status(),
                 StatusCode::UNAUTHORIZED,
-                "Permissive: expected 401 for {error:?}"
+                "Permissive: expected 401 for {label}"
             );
             let ct = resp
                 .headers()
@@ -343,7 +344,7 @@ mod tests {
                 .unwrap_or("");
             assert!(
                 ct.contains("application/json"),
-                "expected JSON CT for {error:?}, got: {ct}"
+                "expected JSON CT for {label}, got: {ct}"
             );
         }
     }

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -171,39 +171,23 @@ impl IntoResponse for MediaError {
             Self::FileTooLarge { .. } | Self::ImageTooLarge => {
                 (StatusCode::PAYLOAD_TOO_LARGE, self.to_string())
             }
-            // NIP-FI denial-class split (NIP-FI §Transport and cardinality):
-            //   missing_evidence  (401) — Authorization header absent
-            //   evidence_rejected (403) — wrong scheme, malformed, duplicate, or
-            //                            otherwise structurally invalid proof
+            // All authentication failures return the same generic 401 to prevent oracle
+            // enumeration in the legacy/Permissive path [FI-INV-15].  Off-mode deployments
+            // preserve this pre-NIP-FI behavior.  InsufficientScope is intentionally 403
+            // below — it is an authorization (not authentication) failure and is safe to
+            // distinguish because it requires a valid identity first.
             //
-            // This is the legacy/Permissive path: Off-mode deployments preserve the
-            // pre-NIP-FI behavior (JSON 401 for all auth failures) [FI-INV-15].
-            // Strict mode (via MediaDenial in buzz-relay) overrides this and
-            // applies the full NIP-FI rejection table (401/403 per spec class).
-            //
-            // Structural proof failures (wrong scheme, malformed header, duplicate
-            // tag, wrong kind, empty content) return 403 here because they are
-            // observable from pre-NIP-FI Blossom clients as format errors —
-            // they are NOT secret oracle information.  All other auth failures
-            // (signature, expiry, missing tag, hash/server mismatch) return 401
-            // to prevent oracle enumeration in Off/Permissive mode.
-            Self::MissingAuth => {
-                tracing::warn!(error = %self, "authentication failed: missing evidence");
-                (
-                    StatusCode::UNAUTHORIZED,
-                    "authentication failed".to_string(),
-                )
-            }
-            Self::InvalidAuthScheme
+            // Strict mode routes through MediaDenial (buzz-relay) and applies the full
+            // NIP-FI rejection table (missing_evidence → 401, evidence_rejected → 403)
+            // independently of this path.
+            Self::MissingAuth
+            | Self::InvalidAuthScheme
             | Self::InvalidBase64
             | Self::InvalidAuthEvent
+            | Self::InvalidSignature
             | Self::InvalidAuthKind
             | Self::InvalidAuthVerb
-            | Self::DuplicateTag(_) => {
-                tracing::warn!(error = %self, "authentication failed: evidence rejected");
-                (StatusCode::FORBIDDEN, "authorization denied".to_string())
-            }
-            Self::InvalidSignature
+            | Self::DuplicateTag(_)
             | Self::TokenExpired
             | Self::TimestampOutOfWindow
             | Self::Unauthorized
@@ -307,76 +291,34 @@ mod tests {
     // Strict mode overrides this via MediaDenial in buzz-relay [FI-INV-15].
 
     #[test]
-    fn missing_auth_permissive_shape_is_json_401() {
-        let resp = MediaError::MissingAuth.into_response();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-        // Content-type must be JSON (application/json), not text/plain.
-        let ct = resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        assert!(
-            ct.contains("application/json"),
-            "expected JSON content-type, got: {ct}"
-        );
-        // No WWW-Authenticate header in the legacy JSON response.
-        assert!(
-            resp.headers().get("www-authenticate").is_none(),
-            "Permissive shape must not include WWW-Authenticate"
-        );
-    }
-
-    #[test]
-    fn structural_format_errors_return_json_403() {
-        // Wrong scheme, malformed header, duplicate tag, wrong kind, empty content:
-        // these are observable format errors even in Permissive mode — not secret
-        // oracle information — so they return 403 in both paths.
+    fn all_auth_failures_return_json_401_in_permissive_path() {
+        // In the legacy/Permissive path all auth failures collapse to a single
+        // JSON 401 to prevent oracle enumeration [FI-INV-15].  Strict mode
+        // (MediaDenial in buzz-relay) applies the NIP-FI 401/403 split instead.
         for error in [
-            MediaError::InvalidAuthKind,
-            MediaError::InvalidAuthVerb,
-            MediaError::InvalidAuthEvent,
+            MediaError::MissingAuth,
             MediaError::InvalidAuthScheme,
             MediaError::InvalidBase64,
+            MediaError::InvalidAuthEvent,
+            MediaError::InvalidAuthKind,
+            MediaError::InvalidAuthVerb,
             MediaError::DuplicateTag("Authorization"),
-        ] {
-            let label = format!("{error:?}");
-            let resp = error.into_response();
-            assert_eq!(
-                resp.status(),
-                StatusCode::FORBIDDEN,
-                "expected 403 for {label}"
-            );
-            let ct = resp
-                .headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-            assert!(
-                ct.contains("application/json"),
-                "expected JSON CT for {label}, got: {ct}"
-            );
-        }
-    }
-
-    #[test]
-    fn evidence_rejected_errors_return_json_401_in_permissive_mode() {
-        // Signature, expiry, missing tag, hash/server mismatch: these return 401
-        // in the Permissive path to prevent oracle enumeration [FI-INV-15].
-        // Strict mode (MediaDenial) overrides these to 403 per the NIP-FI table.
-        for error in [
             MediaError::InvalidSignature,
             MediaError::TokenExpired,
+            MediaError::TimestampOutOfWindow,
+            MediaError::Unauthorized,
+            MediaError::TokenRevoked,
+            MediaError::PubkeyMismatch,
             MediaError::HashMismatch,
             MediaError::ServerMismatch,
-            MediaError::MissingTag("server"),
+            MediaError::MissingTag("t"),
         ] {
             let label = format!("{error:?}");
             let resp = error.into_response();
             assert_eq!(
                 resp.status(),
                 StatusCode::UNAUTHORIZED,
-                "Permissive: expected 401 for {label}"
+                "Permissive path: expected 401 for {label}"
             );
             let ct = resp
                 .headers()
@@ -386,6 +328,11 @@ mod tests {
             assert!(
                 ct.contains("application/json"),
                 "expected JSON CT for {label}, got: {ct}"
+            );
+            // No WWW-Authenticate in the legacy JSON path.
+            assert!(
+                resp.headers().get("www-authenticate").is_none(),
+                "Permissive path must not include WWW-Authenticate for {label}"
             );
         }
     }

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -171,19 +171,27 @@ impl IntoResponse for MediaError {
             Self::FileTooLarge { .. } | Self::ImageTooLarge => {
                 (StatusCode::PAYLOAD_TOO_LARGE, self.to_string())
             }
-            // NIP-FI rejection table (§Public denial classes and transport codes):
+            // NIP-FI denial-class split (NIP-FI §Transport and cardinality):
             //   missing_evidence  (401) — Authorization header absent
-            //   evidence_rejected (403) — structurally present but invalid, malformed,
-            //                            expired, or otherwise unacceptable proof
+            //   evidence_rejected (403) — wrong scheme, malformed, duplicate, or
+            //                            otherwise structurally invalid proof
             //
-            // The spec explicitly maps expired tokens, missing tags, signature failures,
-            // hash/server mismatches, etc. to `evidence_rejected` → 403.  401 is reserved
-            // solely for the absent-header case.
+            // This is the legacy/Permissive path: Off-mode deployments preserve the
+            // pre-NIP-FI behavior (JSON 401 for all auth failures) [FI-INV-15].
+            // Strict mode (via MediaDenial in buzz-relay) overrides this and
+            // applies the full NIP-FI rejection table (401/403 per spec class).
+            //
+            // Structural proof failures (wrong scheme, malformed header, duplicate
+            // tag, wrong kind, empty content) return 403 here because they are
+            // observable from pre-NIP-FI Blossom clients as format errors —
+            // they are NOT secret oracle information.  All other auth failures
+            // (signature, expiry, missing tag, hash/server mismatch) return 401
+            // to prevent oracle enumeration in Off/Permissive mode.
             Self::MissingAuth => {
                 tracing::warn!(error = %self, "authentication failed: missing evidence");
                 (
                     StatusCode::UNAUTHORIZED,
-                    "authentication required".to_string(),
+                    "authentication failed".to_string(),
                 )
             }
             Self::InvalidAuthScheme
@@ -191,8 +199,11 @@ impl IntoResponse for MediaError {
             | Self::InvalidAuthEvent
             | Self::InvalidAuthKind
             | Self::InvalidAuthVerb
-            | Self::DuplicateTag(_)
-            | Self::InvalidSignature
+            | Self::DuplicateTag(_) => {
+                tracing::warn!(error = %self, "authentication failed: evidence rejected");
+                (StatusCode::FORBIDDEN, "authorization denied".to_string())
+            }
+            Self::InvalidSignature
             | Self::TokenExpired
             | Self::TimestampOutOfWindow
             | Self::Unauthorized
@@ -201,8 +212,11 @@ impl IntoResponse for MediaError {
             | Self::HashMismatch
             | Self::ServerMismatch
             | Self::MissingTag(_) => {
-                tracing::warn!(error = %self, "authentication failed: evidence rejected");
-                (StatusCode::FORBIDDEN, "evidence rejected".to_string())
+                tracing::warn!(error = %self, "authentication failed");
+                (
+                    StatusCode::UNAUTHORIZED,
+                    "authentication failed".to_string(),
+                )
             }
             Self::InsufficientScope => (StatusCode::FORBIDDEN, self.to_string()),
             Self::RelayMembershipRequired | Self::CommunityWriteFenced => {
@@ -289,8 +303,8 @@ mod tests {
     }
 
     // ── IntoResponse status code pins ──────────────────────────────────────
-    // These pins ensure MediaError::into_response() maps each error class to
-    // the correct HTTP status per the NIP-FI rejection table.
+    // These pins cover the legacy/Permissive path (MediaError::into_response).
+    // Strict mode overrides this via MediaDenial in buzz-relay [FI-INV-15].
 
     #[test]
     fn missing_auth_permissive_shape_is_json_401() {
@@ -314,18 +328,17 @@ mod tests {
     }
 
     #[test]
-    fn evidence_rejected_errors_return_json_403() {
-        // NIP-FI §Public denial classes: `evidence_rejected` maps to HTTP 403.
-        // This covers all structurally present but invalid/malformed/expired proofs.
+    fn structural_format_errors_return_json_403() {
+        // Wrong scheme, malformed header, duplicate tag, wrong kind, empty content:
+        // these are observable format errors even in Permissive mode — not secret
+        // oracle information — so they return 403 in both paths.
         for error in [
-            MediaError::InvalidSignature,
-            MediaError::TokenExpired,
-            MediaError::HashMismatch,
-            MediaError::ServerMismatch,
-            MediaError::MissingTag("server"),
             MediaError::InvalidAuthKind,
             MediaError::InvalidAuthVerb,
             MediaError::InvalidAuthEvent,
+            MediaError::InvalidAuthScheme,
+            MediaError::InvalidBase64,
+            MediaError::DuplicateTag("Authorization"),
         ] {
             let label = format!("{error:?}");
             let resp = error.into_response();
@@ -333,6 +346,37 @@ mod tests {
                 resp.status(),
                 StatusCode::FORBIDDEN,
                 "expected 403 for {label}"
+            );
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                ct.contains("application/json"),
+                "expected JSON CT for {label}, got: {ct}"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_rejected_errors_return_json_401_in_permissive_mode() {
+        // Signature, expiry, missing tag, hash/server mismatch: these return 401
+        // in the Permissive path to prevent oracle enumeration [FI-INV-15].
+        // Strict mode (MediaDenial) overrides these to 403 per the NIP-FI table.
+        for error in [
+            MediaError::InvalidSignature,
+            MediaError::TokenExpired,
+            MediaError::HashMismatch,
+            MediaError::ServerMismatch,
+            MediaError::MissingTag("server"),
+        ] {
+            let label = format!("{error:?}");
+            let resp = error.into_response();
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNAUTHORIZED,
+                "Permissive: expected 401 for {label}"
             );
             let ct = resp
                 .headers()

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -3,6 +3,21 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
+/// Coarse Blossom denial kind for NIP-FI response shaping.
+///
+/// Callers that know the active [`crate::auth::BlossomStrictness`] use this to
+/// choose the correct HTTP response shape — NIP-FI fixed text/plain in Strict
+/// mode, legacy JSON in Permissive mode — without requiring `buzz-media` to
+/// depend on `buzz-auth`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlossomDenialKind {
+    /// `Authorization` header was absent. Maps to HTTP 401 + `WWW-Authenticate: Nostr`.
+    MissingEvidence,
+    /// Authorization header or proof was present but structurally invalid,
+    /// malformed, expired, or otherwise rejected. Maps to HTTP 403.
+    EvidenceRejected,
+}
+
 /// Errors from media operations.
 #[derive(Debug, thiserror::Error)]
 pub enum MediaError {
@@ -112,6 +127,40 @@ impl From<serde_json::Error> for MediaError {
     }
 }
 
+impl MediaError {
+    /// Classify this error as a Blossom denial kind for response-shape selection.
+    ///
+    /// Returns `Some(BlossomDenialKind::MissingEvidence)` when the
+    /// `Authorization` header was absent, `Some(BlossomDenialKind::EvidenceRejected)`
+    /// for any structurally present but invalid/malformed/expired proof, and
+    /// `None` for non-auth errors.
+    ///
+    /// Relay call sites that know the active `BlossomStrictness` use this to
+    /// select the appropriate response shape: NIP-FI fixed text/plain in Strict
+    /// mode, legacy JSON 401 in Permissive mode.
+    pub fn blossom_denial_kind(&self) -> Option<BlossomDenialKind> {
+        match self {
+            Self::MissingAuth => Some(BlossomDenialKind::MissingEvidence),
+            Self::InvalidAuthScheme
+            | Self::InvalidBase64
+            | Self::InvalidAuthEvent
+            | Self::InvalidAuthKind
+            | Self::InvalidAuthVerb
+            | Self::DuplicateTag(_)
+            | Self::InvalidSignature
+            | Self::TokenExpired
+            | Self::TimestampOutOfWindow
+            | Self::Unauthorized
+            | Self::TokenRevoked
+            | Self::PubkeyMismatch
+            | Self::HashMismatch
+            | Self::ServerMismatch
+            | Self::MissingTag(_) => Some(BlossomDenialKind::EvidenceRejected),
+            _ => None,
+        }
+    }
+}
+
 impl IntoResponse for MediaError {
     fn into_response(self) -> Response {
         let (status, msg) = match &self {
@@ -191,6 +240,115 @@ impl IntoResponse for MediaError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── BlossomDenialKind classification ─────────────────────────────────────
+
+    #[test]
+    fn missing_auth_is_missing_evidence() {
+        assert_eq!(
+            MediaError::MissingAuth.blossom_denial_kind(),
+            Some(BlossomDenialKind::MissingEvidence)
+        );
+    }
+
+    #[test]
+    fn structural_proof_errors_are_evidence_rejected() {
+        for error in [
+            MediaError::InvalidAuthScheme,
+            MediaError::InvalidBase64,
+            MediaError::InvalidAuthEvent,
+            MediaError::InvalidAuthKind,
+            MediaError::InvalidAuthVerb,
+            MediaError::DuplicateTag("Authorization"),
+            MediaError::InvalidSignature,
+            MediaError::TokenExpired,
+            MediaError::TimestampOutOfWindow,
+            MediaError::Unauthorized,
+            MediaError::TokenRevoked,
+            MediaError::PubkeyMismatch,
+            MediaError::HashMismatch,
+            MediaError::ServerMismatch,
+            MediaError::MissingTag("t"),
+        ] {
+            assert_eq!(
+                error.blossom_denial_kind(),
+                Some(BlossomDenialKind::EvidenceRejected),
+                "expected EvidenceRejected for {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_auth_errors_have_no_denial_kind() {
+        for error in [
+            MediaError::NotFound,
+            MediaError::FileTooLarge { size: 1, max: 0 },
+            MediaError::Internal,
+            MediaError::ServiceUnavailable,
+            MediaError::InsufficientScope,
+        ] {
+            assert_eq!(
+                error.blossom_denial_kind(),
+                None,
+                "expected None for {error:?}"
+            );
+        }
+    }
+
+    // ── Legacy IntoResponse shapes (Permissive regression pins) ─────────────
+    // These pins ensure MediaError::into_response() keeps the old JSON 401
+    // shape so Off-mode deployments remain unaffected [FI-INV-15].
+
+    #[test]
+    fn missing_auth_permissive_shape_is_json_401() {
+        let resp = MediaError::MissingAuth.into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        // Content-type must be JSON (application/json), not text/plain.
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("application/json"),
+            "expected JSON content-type, got: {ct}"
+        );
+        // No WWW-Authenticate header in the legacy JSON response.
+        assert!(
+            resp.headers().get("www-authenticate").is_none(),
+            "Permissive shape must not include WWW-Authenticate"
+        );
+    }
+
+    #[test]
+    fn evidence_rejected_errors_permissive_shape_is_json_401() {
+        // In Permissive mode, proof failures also return JSON 401 (no 403 distinction).
+        for error in [
+            MediaError::InvalidSignature,
+            MediaError::TokenExpired,
+            MediaError::HashMismatch,
+            MediaError::ServerMismatch,
+            MediaError::MissingTag("server"),
+        ] {
+            let resp = error.into_response();
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNAUTHORIZED,
+                "Permissive: expected 401 for {error:?}"
+            );
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                ct.contains("application/json"),
+                "expected JSON CT for {error:?}, got: {ct}"
+            );
+        }
+    }
+
+    // ── Existing non-auth response map tests ────────────────────────────────
 
     #[test]
     fn serving_backend_failures_map_to_5xx_but_fences_remain_403() {

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -171,20 +171,19 @@ impl IntoResponse for MediaError {
             Self::FileTooLarge { .. } | Self::ImageTooLarge => {
                 (StatusCode::PAYLOAD_TOO_LARGE, self.to_string())
             }
-            // NIP-FI denial-class split (NIP-FI §Transport and cardinality):
+            // NIP-FI rejection table (§Public denial classes and transport codes):
             //   missing_evidence  (401) — Authorization header absent
-            //   evidence_rejected (403) — wrong scheme, malformed, duplicate, or
-            //                            otherwise structurally invalid proof
+            //   evidence_rejected (403) — structurally present but invalid, malformed,
+            //                            expired, or otherwise unacceptable proof
             //
-            // All other authentication failures (signature invalid, expired,
-            // timestamp out of window, hash mismatch, etc.) return 401 to
-            // prevent oracle enumeration — they are indistinguishable from an
-            // absent identity to an unauthenticated caller.
+            // The spec explicitly maps expired tokens, missing tags, signature failures,
+            // hash/server mismatches, etc. to `evidence_rejected` → 403.  401 is reserved
+            // solely for the absent-header case.
             Self::MissingAuth => {
                 tracing::warn!(error = %self, "authentication failed: missing evidence");
                 (
                     StatusCode::UNAUTHORIZED,
-                    "authentication failed".to_string(),
+                    "authentication required".to_string(),
                 )
             }
             Self::InvalidAuthScheme
@@ -192,11 +191,8 @@ impl IntoResponse for MediaError {
             | Self::InvalidAuthEvent
             | Self::InvalidAuthKind
             | Self::InvalidAuthVerb
-            | Self::DuplicateTag(_) => {
-                tracing::warn!(error = %self, "authentication failed: evidence rejected");
-                (StatusCode::FORBIDDEN, "authorization denied".to_string())
-            }
-            Self::InvalidSignature
+            | Self::DuplicateTag(_)
+            | Self::InvalidSignature
             | Self::TokenExpired
             | Self::TimestampOutOfWindow
             | Self::Unauthorized
@@ -205,11 +201,8 @@ impl IntoResponse for MediaError {
             | Self::HashMismatch
             | Self::ServerMismatch
             | Self::MissingTag(_) => {
-                tracing::warn!(error = %self, "authentication failed");
-                (
-                    StatusCode::UNAUTHORIZED,
-                    "authentication failed".to_string(),
-                )
+                tracing::warn!(error = %self, "authentication failed: evidence rejected");
+                (StatusCode::FORBIDDEN, "evidence rejected".to_string())
             }
             Self::InsufficientScope => (StatusCode::FORBIDDEN, self.to_string()),
             Self::RelayMembershipRequired | Self::CommunityWriteFenced => {
@@ -295,9 +288,9 @@ mod tests {
         }
     }
 
-    // ── Legacy IntoResponse shapes (Permissive regression pins) ─────────────
-    // These pins ensure MediaError::into_response() keeps the old JSON 401
-    // shape so Off-mode deployments remain unaffected [FI-INV-15].
+    // ── IntoResponse status code pins ──────────────────────────────────────
+    // These pins ensure MediaError::into_response() maps each error class to
+    // the correct HTTP status per the NIP-FI rejection table.
 
     #[test]
     fn missing_auth_permissive_shape_is_json_401() {
@@ -321,21 +314,25 @@ mod tests {
     }
 
     #[test]
-    fn evidence_rejected_errors_permissive_shape_is_json_401() {
-        // In Permissive mode, proof failures also return JSON 401 (no 403 distinction).
+    fn evidence_rejected_errors_return_json_403() {
+        // NIP-FI §Public denial classes: `evidence_rejected` maps to HTTP 403.
+        // This covers all structurally present but invalid/malformed/expired proofs.
         for error in [
             MediaError::InvalidSignature,
             MediaError::TokenExpired,
             MediaError::HashMismatch,
             MediaError::ServerMismatch,
             MediaError::MissingTag("server"),
+            MediaError::InvalidAuthKind,
+            MediaError::InvalidAuthVerb,
+            MediaError::InvalidAuthEvent,
         ] {
             let label = format!("{error:?}");
             let resp = error.into_response();
             assert_eq!(
                 resp.status(),
-                StatusCode::UNAUTHORIZED,
-                "Permissive: expected 401 for {label}"
+                StatusCode::FORBIDDEN,
+                "expected 403 for {label}"
             );
             let ct = resp
                 .headers()

--- a/crates/buzz-media/src/lib.rs
+++ b/crates/buzz-media/src/lib.rs
@@ -19,7 +19,7 @@ pub use bucket_index::{
     TaxonomySweepOutcome,
 };
 pub use config::{MediaConfig, S3AddressingStyle};
-pub use error::MediaError;
+pub use error::{BlossomDenialKind, MediaError};
 pub use storage::{
     BlobHeadMeta, BlobMeta, BulkDeleteOutcome, ByteStream, MediaStorage, ObjectVersionEntry,
     ObjectVersionKind, ObjectVersionRef, ObjectVersionsPage,

--- a/crates/buzz-media/src/upload.rs
+++ b/crates/buzz-media/src/upload.rs
@@ -81,8 +81,14 @@ where
     let (mime, sha256, ext) = tokio::task::spawn_blocking(move || -> Result<_, MediaError> {
         let (mime, ext) = validate(&bytes, &cfg)?;
         let sha256 = hex::encode(Sha256::digest(&bytes));
-        // Buffered uploads (image + file): 10-minute auth window is plenty.
-        verify_blossom_upload_auth(&auth, &sha256, Some(bound_host.as_str()), 600)?;
+        // Buffered uploads (image + file): use Permissive here; strictness is
+        // already applied at the pre-body gate in the relay handler.
+        verify_blossom_upload_auth(
+            &auth,
+            &sha256,
+            Some(bound_host.as_str()),
+            crate::auth::BlossomStrictness::Permissive,
+        )?;
         Ok((mime, sha256, ext))
     })
     .await
@@ -408,8 +414,14 @@ pub async fn process_video_upload(
     // process-global domain) — a relay serves many tenant hosts.
     let bound_host = ctx.host().to_string();
     tokio::task::spawn_blocking(move || {
-        // Videos: 1-hour window — large uploads on slow connections need headroom.
-        verify_blossom_upload_auth(&auth, &sha256_for_auth, Some(bound_host.as_str()), 3600)
+        // Videos: use Permissive for the post-body re-verify; strictness is
+        // already applied at the pre-body gate in the relay handler.
+        verify_blossom_upload_auth(
+            &auth,
+            &sha256_for_auth,
+            Some(bound_host.as_str()),
+            crate::auth::BlossomStrictness::Permissive,
+        )
     })
     .await
     .map_err(|_| MediaError::Internal)??;

--- a/crates/buzz-media/src/upload.rs
+++ b/crates/buzz-media/src/upload.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 
-use crate::auth::verify_blossom_upload_auth;
+use crate::auth::verify_upload_hash_only;
 use crate::config::MediaConfig;
 use crate::error::MediaError;
 use crate::storage::{BlobMeta, MediaStorage};
@@ -74,21 +74,15 @@ where
     let auth = auth_event.clone();
     let bytes = body.clone();
     let cfg = config.clone();
-    // Validate the Blossom `server` tag against the host this request was bound
-    // to (the per-request tenant), not a process-global domain — a relay serves
-    // many tenant hosts.
-    let bound_host = ctx.host().to_string();
     let (mime, sha256, ext) = tokio::task::spawn_blocking(move || -> Result<_, MediaError> {
         let (mime, ext) = validate(&bytes, &cfg)?;
         let sha256 = hex::encode(Sha256::digest(&bytes));
-        // Buffered uploads (image + file): use Permissive here; strictness is
-        // already applied at the pre-body gate in the relay handler.
-        verify_blossom_upload_auth(
-            &auth,
-            &sha256,
-            Some(bound_host.as_str()),
-            crate::auth::BlossomStrictness::Permissive,
-        )?;
+        // Post-body hash check only: the full auth event verification
+        // (signature, kind, freshness, server, cardinality) was already
+        // applied at the pre-body gate in the relay handler.  Re-running the
+        // full verifier here would fail any upload that takes longer than the
+        // minted token's expiration window (60 s in Strict mode).
+        verify_upload_hash_only(&auth, &sha256)?;
         Ok((mime, sha256, ext))
     })
     .await
@@ -410,18 +404,13 @@ pub async fn process_video_upload(
     // --- 3. Verify Blossom auth: x tag must match computed SHA-256 ---
     let auth = auth_event.clone();
     let sha256_for_auth = sha256_hex.clone();
-    // Validate the Blossom `server` tag against the bound tenant host (not a
-    // process-global domain) — a relay serves many tenant hosts.
-    let bound_host = ctx.host().to_string();
     tokio::task::spawn_blocking(move || {
-        // Videos: use Permissive for the post-body re-verify; strictness is
-        // already applied at the pre-body gate in the relay handler.
-        verify_blossom_upload_auth(
-            &auth,
-            &sha256_for_auth,
-            Some(bound_host.as_str()),
-            crate::auth::BlossomStrictness::Permissive,
-        )
+        // Post-body hash check only: the full auth event verification
+        // (signature, kind, freshness, server, cardinality) was already
+        // applied at the pre-body gate in the relay handler.  Re-running the
+        // full verifier here would reject any video upload that takes longer
+        // than the minted token's expiration window (60 s in Strict mode).
+        verify_upload_hash_only(&auth, &sha256_for_auth)
     })
     .await
     .map_err(|_| MediaError::Internal)??;

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -1174,13 +1174,14 @@ mod tests {
             MediaError::DuplicateTag("Authorization"),
             MediaError::InvalidAuthScheme,
         ] {
+            let label = format!("{error:?}");
             let denial = MediaDenial(error, BlossomStrictness::Strict);
             let resp = denial.into_response();
 
             assert_eq!(
                 resp.status(),
                 StatusCode::FORBIDDEN,
-                "expected 403 for Strict {error:?}"
+                "expected 403 for Strict {label}"
             );
 
             let ct = resp
@@ -1190,19 +1191,19 @@ mod tests {
                 .unwrap_or("");
             assert!(
                 ct.contains("text/plain"),
-                "expected text/plain CT for {error:?}, got: {ct}"
+                "expected text/plain CT for {label}, got: {ct}"
             );
 
             assert!(
                 resp.headers().get("www-authenticate").is_none(),
-                "403 must not have WWW-Authenticate for {error:?}"
+                "403 must not have WWW-Authenticate for {label}"
             );
 
             let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
             assert_eq!(
                 body.as_ref(),
                 b"evidence rejected\n",
-                "wrong body for {error:?}"
+                "wrong body for {label}"
             );
         }
     }
@@ -1238,13 +1239,14 @@ mod tests {
             MediaError::HashMismatch,
             MediaError::MissingTag("t"),
         ] {
+            let label = format!("{error:?}");
             let denial = MediaDenial(error, BlossomStrictness::Permissive);
             let resp = denial.into_response();
 
             assert_eq!(
                 resp.status(),
                 StatusCode::UNAUTHORIZED,
-                "Permissive: expected 401 for {error:?}"
+                "Permissive: expected 401 for {label}"
             );
 
             let ct = resp
@@ -1254,7 +1256,7 @@ mod tests {
                 .unwrap_or("");
             assert!(
                 ct.contains("application/json"),
-                "Permissive must keep JSON CT for {error:?}, got: {ct}"
+                "Permissive must keep JSON CT for {label}, got: {ct}"
             );
         }
     }

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -19,8 +19,12 @@ use axum::{
 };
 use base64::Engine;
 use buzz_audit::{AuditAction, NewAuditEntry};
+use buzz_auth::DenialClass;
 use buzz_core::tenant::TenantContext;
-use buzz_media::{BlobDescriptor, MediaError, UploadAttribution, UploadNetworkInfo};
+use buzz_media::auth::BlossomStrictness;
+use buzz_media::{
+    BlobDescriptor, BlossomDenialKind, MediaError, UploadAttribution, UploadNetworkInfo,
+};
 
 use crate::state::AppState;
 
@@ -45,6 +49,62 @@ pub(crate) struct AuthenticatedUpload {
 enum UploadRouteMode {
     Upload,
     LegacyMedia,
+}
+
+/// Mode-aware Blossom auth rejection for the relay layer.
+///
+/// In `Strict` mode, Blossom denial errors map to the NIP-FI fixed
+/// text/plain responses (`DenialClass` byte contract). In `Permissive` mode
+/// (Off-mode deployments), the legacy JSON 401 shape is preserved unchanged
+/// [FI-INV-15].
+///
+/// Non-Blossom errors (`blossom_denial_kind()` returns `None`) always fall
+/// through to `MediaError::into_response()` regardless of mode.
+struct MediaDenial(MediaError, BlossomStrictness);
+
+impl IntoResponse for MediaDenial {
+    fn into_response(self) -> Response {
+        let MediaDenial(error, strictness) = self;
+        if strictness == BlossomStrictness::Strict {
+            if let Some(kind) = error.blossom_denial_kind() {
+                let class = match kind {
+                    BlossomDenialKind::MissingEvidence => DenialClass::MissingEvidence,
+                    BlossomDenialKind::EvidenceRejected => DenialClass::EvidenceRejected,
+                };
+                tracing::warn!(
+                    error = %error,
+                    denial_class = ?class,
+                    "Blossom auth denial (strict)"
+                );
+                let mut builder = axum::http::Response::builder()
+                    .status(class.http_status())
+                    .header(header::CONTENT_TYPE, class.content_type());
+                if let Some(challenge) = class.www_authenticate() {
+                    builder = builder.header("WWW-Authenticate", challenge);
+                }
+                return builder
+                    .body(axum::body::Body::from(class.http_body()))
+                    .expect("NIP-FI denial response is always valid");
+            }
+        }
+        error.into_response()
+    }
+}
+
+/// Wrap a `MediaError` with the active strictness to produce the correct
+/// response shape at the relay boundary.
+fn media_denial(error: MediaError, strictness: BlossomStrictness) -> MediaDenial {
+    MediaDenial(error, strictness)
+}
+
+impl From<MediaError> for MediaDenial {
+    /// Default conversion uses Permissive mode — non-auth errors always fall
+    /// through to `MediaError::into_response()` regardless of mode, so the
+    /// strictness value is irrelevant. Auth errors at the extractor boundary
+    /// use explicit `media_denial(e, strictness)` calls instead.
+    fn from(e: MediaError) -> Self {
+        MediaDenial(e, BlossomStrictness::Permissive)
+    }
 }
 
 fn should_stream_as_video(sniff: &[u8]) -> bool {
@@ -138,7 +198,7 @@ fn acquire_upload_permit(
 }
 
 impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
-    type Rejection = MediaError;
+    type Rejection = MediaDenial;
 
     async fn from_request_parts(
         parts: &mut Parts,
@@ -172,11 +232,16 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
         // 2. Extract and validate Blossom auth event against the bound host.
         // Derive strictness from NIP-FI mode: strict rules apply in active (non-Off) modes.
         // Off mode preserves the pre-NIP-FI permissive behavior [FI-INV-15].
-        let auth_event = extract_blossom_auth(headers)?;
+        //
+        // Auth errors are wrapped with `media_denial(e, strictness)` so that
+        // Strict mode produces NIP-FI fixed text/plain responses; Permissive
+        // mode falls through to the legacy JSON 401 shape [FI-INV-15].
         let strictness = blossom_strictness_from_state(state);
+        let auth_event = extract_blossom_auth(headers).map_err(|e| media_denial(e, strictness))?;
         // Pre-body strictness check: verify freshness, cardinality, and server tag before
         // the body is consumed. The x-tag hash binding is checked after body completion.
-        buzz_media::auth::verify_blossom_auth_event(&auth_event, Some(tenant.host()), strictness)?;
+        buzz_media::auth::verify_blossom_auth_event(&auth_event, Some(tenant.host()), strictness)
+            .map_err(|e| media_denial(e, strictness))?;
 
         // 3. Require X-SHA-256 header (BUD-11: mandatory for PUT /upload)
         let claimed_hash = headers
@@ -190,7 +255,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
                 .chars()
                 .all(|c| matches!(c, '0'..='9' | 'a'..='f'))
         {
-            return Err(MediaError::HashMismatch);
+            return Err(MediaError::HashMismatch.into());
         }
 
         // 4. Validate X-SHA-256 matches at least one x tag in the auth event
@@ -199,7 +264,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
             .iter()
             .any(|tag| tag.kind().to_string() == "x" && (tag.content() == Some(claimed_hash)));
         if !has_matching_x {
-            return Err(MediaError::HashMismatch);
+            return Err(MediaError::HashMismatch.into());
         }
 
         // 5. Relay membership gate (NIP-43). Blossom auth proves the signer
@@ -223,13 +288,14 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
         if upload_rate_limited(state, tenant.community(), &auth_event.pubkey) {
             metrics::counter!("buzz_media_upload_rejections_total", "reason" => "rate_limit")
                 .increment(1);
-            return Err(MediaError::UploadRateLimitExceeded);
+            return Err(MediaError::UploadRateLimitExceeded.into());
         }
         let upload_permit = acquire_upload_permit(state, tenant.community(), &auth_event.pubkey)
             .inspect_err(|_| {
                 metrics::counter!("buzz_media_upload_rejections_total", "reason" => "concurrency")
                     .increment(1);
-            })?;
+            })
+            .map_err(MediaDenial::from)?;
 
         Ok(AuthenticatedUpload {
             auth_event,
@@ -529,18 +595,14 @@ async fn authenticate_media_read(
     state: &AppState,
     headers: &HeaderMap,
     sha256_ext: &str,
-) -> Result<MediaReadAuth, MediaError> {
+) -> Result<MediaReadAuth, MediaDenial> {
     let tenant = bind_media_read_tenant(state, headers).await?;
 
-    let auth_event = extract_blossom_auth(headers)?;
-    let sha256 = sha256_ext.split('.').next().unwrap_or(sha256_ext);
     let strictness = blossom_strictness_from_state(state);
-    buzz_media::auth::verify_blossom_get_auth(
-        &auth_event,
-        sha256,
-        Some(tenant.host()),
-        strictness,
-    )?;
+    let auth_event = extract_blossom_auth(headers).map_err(|e| media_denial(e, strictness))?;
+    let sha256 = sha256_ext.split('.').next().unwrap_or(sha256_ext);
+    buzz_media::auth::verify_blossom_get_auth(&auth_event, sha256, Some(tenant.host()), strictness)
+        .map_err(|e| media_denial(e, strictness))?;
 
     let auth_tag = crate::api::relay_members::extract_auth_tag_header(headers);
     crate::api::relay_members::enforce_relay_membership(
@@ -643,10 +705,12 @@ pub async fn get_blob(
     State(state): State<Arc<AppState>>,
     Path(sha256_ext): Path<String>,
     req_headers: HeaderMap,
-) -> Result<Response, MediaError> {
+) -> Result<Response, MediaDenial> {
     validate_media_path(&sha256_ext)?;
     let media_auth = authenticate_media_read(&state, &req_headers, &sha256_ext).await?;
-    serve_blob_for_tenant(&state, &media_auth.tenant, &sha256_ext, &req_headers).await
+    serve_blob_for_tenant(&state, &media_auth.tenant, &sha256_ext, &req_headers)
+        .await
+        .map_err(MediaDenial::from)
 }
 
 /// Serve a validated blob from an already-authorized tenant context.
@@ -908,7 +972,7 @@ pub async fn head_blob(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(sha256_ext): Path<String>,
-) -> Result<Response, MediaError> {
+) -> Result<Response, MediaDenial> {
     validate_media_path(&sha256_ext)?;
     let media_auth = authenticate_media_read(&state, &headers, &sha256_ext).await?;
     let tenant = media_auth.tenant;
@@ -937,7 +1001,7 @@ pub async fn head_blob(
                 .await
                 .map_err(|_| MediaError::NotFound)?;
             if requested_ext != sidecar.ext {
-                return Err(MediaError::NotFound);
+                return Err(MediaError::NotFound.into());
             }
         }
         sidecar_mime
@@ -1054,7 +1118,7 @@ mod tests {
     use std::sync::Arc;
 
     use axum::{
-        body::Body,
+        body::{to_bytes, Body},
         http::{header, Request, StatusCode},
     };
     use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag, Timestamp};
@@ -1062,6 +1126,149 @@ mod tests {
     use uuid::Uuid;
 
     const VALID_HASH: &str = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+    // ── MediaDenial response-shape tests (NIP-FI §755-773) ──────────────────
+    // These tests pin the byte-exact response contract for Strict mode and
+    // confirm Permissive mode produces the unchanged legacy JSON 401 shape.
+
+    #[tokio::test]
+    async fn strict_missing_auth_produces_nip_fi_401_with_www_authenticate() {
+        let denial = MediaDenial(MediaError::MissingAuth, BlossomStrictness::Strict);
+        let resp = denial.into_response();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("text/plain"),
+            "expected text/plain CT, got: {ct}"
+        );
+
+        let www_auth = resp
+            .headers()
+            .get("www-authenticate")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            www_auth, "Nostr",
+            "expected 'Nostr' WWW-Authenticate challenge"
+        );
+
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"authentication required\n");
+    }
+
+    #[tokio::test]
+    async fn strict_evidence_rejected_produces_nip_fi_403_text_plain() {
+        for error in [
+            MediaError::InvalidSignature,
+            MediaError::TokenExpired,
+            MediaError::TimestampOutOfWindow,
+            MediaError::HashMismatch,
+            MediaError::ServerMismatch,
+            MediaError::MissingTag("server"),
+            MediaError::DuplicateTag("Authorization"),
+            MediaError::InvalidAuthScheme,
+        ] {
+            let denial = MediaDenial(error, BlossomStrictness::Strict);
+            let resp = denial.into_response();
+
+            assert_eq!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "expected 403 for Strict {error:?}"
+            );
+
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                ct.contains("text/plain"),
+                "expected text/plain CT for {error:?}, got: {ct}"
+            );
+
+            assert!(
+                resp.headers().get("www-authenticate").is_none(),
+                "403 must not have WWW-Authenticate for {error:?}"
+            );
+
+            let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+            assert_eq!(
+                body.as_ref(),
+                b"evidence rejected\n",
+                "wrong body for {error:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn permissive_missing_auth_keeps_legacy_json_401() {
+        let denial = MediaDenial(MediaError::MissingAuth, BlossomStrictness::Permissive);
+        let resp = denial.into_response();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("application/json"),
+            "Permissive must keep JSON CT, got: {ct}"
+        );
+
+        assert!(
+            resp.headers().get("www-authenticate").is_none(),
+            "Permissive must not add WWW-Authenticate"
+        );
+    }
+
+    #[tokio::test]
+    async fn permissive_evidence_rejected_keeps_legacy_json_401() {
+        for error in [
+            MediaError::InvalidSignature,
+            MediaError::TokenExpired,
+            MediaError::HashMismatch,
+            MediaError::MissingTag("t"),
+        ] {
+            let denial = MediaDenial(error, BlossomStrictness::Permissive);
+            let resp = denial.into_response();
+
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNAUTHORIZED,
+                "Permissive: expected 401 for {error:?}"
+            );
+
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                ct.contains("application/json"),
+                "Permissive must keep JSON CT for {error:?}, got: {ct}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn non_auth_errors_always_fall_through_regardless_of_mode() {
+        for strictness in [BlossomStrictness::Strict, BlossomStrictness::Permissive] {
+            let denial = MediaDenial(MediaError::NotFound, strictness);
+            assert_eq!(denial.into_response().status(), StatusCode::NOT_FOUND);
+
+            let denial = MediaDenial(MediaError::Internal, strictness);
+            assert!(denial.into_response().status().is_server_error());
+        }
+    }
 
     #[test]
     fn serving_write_error_taxonomy_separates_fence_from_backend_failure() {
@@ -1237,7 +1444,7 @@ mod tests {
 
     fn media_get_tags_for(host: &str, sha256: Option<&str>) -> Vec<Tag> {
         let now = Timestamp::now().as_secs();
-        let expiration = (now + 300).to_string();
+        let expiration = (now + 55).to_string();
         let mut tags = vec![
             Tag::parse(["t", "get"]).expect("t tag"),
             Tag::parse(["expiration", &expiration]).expect("expiration tag"),
@@ -1290,7 +1497,7 @@ mod tests {
     async fn media_read_rejects_upload_verb_wrong_server_and_wrong_x() {
         let keys = Keys::generate();
         let now = Timestamp::now().as_secs();
-        let expiration = (now + 300).to_string();
+        let expiration = (now + 55).to_string();
         let cases = [
             vec![
                 Tag::parse(["t", "upload"]).expect("t tag"),

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -389,7 +389,7 @@ fn serving_lease_lost(error: anyhow::Error) -> MediaError {
 /// Returns a [`BlobDescriptor`] JSON on success.
 // TODO(v2): Add persistent per-pubkey storage quotas. Admission limits below
 // bound active parser/storage work, but they do not cap durable bytes stored.
-pub async fn upload_blob(
+pub(crate) async fn upload_blob(
     State(state): State<Arc<AppState>>,
     auth: AuthenticatedUpload,
     headers: HeaderMap,
@@ -722,7 +722,7 @@ const MAX_RANGE_CHUNK: u64 = 16 * 1024 * 1024;
 ///   - Chunk capped at 16 MiB; clients request additional ranges for the rest
 ///
 /// All responses include `Accept-Ranges: bytes` so video players know seeking is supported.
-pub async fn get_blob(
+pub(crate) async fn get_blob(
     State(state): State<Arc<AppState>>,
     Path(sha256_ext): Path<String>,
     req_headers: HeaderMap,
@@ -989,7 +989,7 @@ fn parse_byte_range(range: &str, total: u64) -> Option<(u64, u64)> {
 /// Content-type is derived from the validated sidecar only — never from raw S3
 /// object metadata — to prevent MIME spoofing via tampered storage. If the sidecar
 /// is missing, we return 404 rather than fall back to untrusted metadata.
-pub async fn head_blob(
+pub(crate) async fn head_blob(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(sha256_ext): Path<String>,

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -170,12 +170,13 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
         let route_mode = upload_route_mode(parts.uri.path())?;
 
         // 2. Extract and validate Blossom auth event against the bound host.
+        // Derive strictness from NIP-FI mode: strict rules apply in active (non-Off) modes.
+        // Off mode preserves the pre-NIP-FI permissive behavior [FI-INV-15].
         let auth_event = extract_blossom_auth(headers)?;
-        // Use the permissive window (3600s) here because we don't know the
-        // content type yet.  The upload functions re-verify with the correct
-        // per-type window (600s for images, 3600s for video) after the body
-        // has been consumed and the SHA-256 computed.
-        buzz_media::auth::verify_blossom_auth_event(&auth_event, Some(tenant.host()), 3600)?;
+        let strictness = blossom_strictness_from_state(state);
+        // Pre-body strictness check: verify freshness, cardinality, and server tag before
+        // the body is consumed. The x-tag hash binding is checked after body completion.
+        buzz_media::auth::verify_blossom_auth_event(&auth_event, Some(tenant.host()), strictness)?;
 
         // 3. Require X-SHA-256 header (BUD-11: mandatory for PUT /upload)
         let claimed_hash = headers
@@ -533,7 +534,13 @@ async fn authenticate_media_read(
 
     let auth_event = extract_blossom_auth(headers)?;
     let sha256 = sha256_ext.split('.').next().unwrap_or(sha256_ext);
-    buzz_media::auth::verify_blossom_get_auth(&auth_event, sha256, Some(tenant.host()), 3600)?;
+    let strictness = blossom_strictness_from_state(state);
+    buzz_media::auth::verify_blossom_get_auth(
+        &auth_event,
+        sha256,
+        Some(tenant.host()),
+        strictness,
+    )?;
 
     let auth_tag = crate::api::relay_members::extract_auth_tag_header(headers);
     crate::api::relay_members::enforce_relay_membership(
@@ -985,13 +992,29 @@ async fn resolve_s3_key(
 /// Extract and verify a kind:24242 Blossom auth event from the `Authorization` header.
 ///
 /// Accepts both base64url (BUD-11 spec) and standard base64 (nostr-tools compat).
+///
+/// Per NIP-FI §Transport and cardinality:
+///   - Missing `Authorization` → `missing_evidence` (401 via `MediaError::MissingAuth`)
+///   - Repeated, comma-combined, empty, malformed, or wrong-scheme → `evidence_rejected`
+///     (403 via `MediaError::InvalidAuthScheme` / `MediaError::DuplicateTag("Authorization")`)
 fn extract_blossom_auth(headers: &HeaderMap) -> Result<nostr::Event, MediaError> {
     use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 
-    let header = headers
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .ok_or(MediaError::MissingAuth)?;
+    // NIP-FI: repeated or comma-combined Authorization → evidence_rejected (403).
+    // HeaderMap::get_all returns all values for the key; more than one is malformed.
+    let mut auth_values = headers.get_all("authorization").iter();
+    let first = auth_values.next().ok_or(MediaError::MissingAuth)?;
+    if auth_values.next().is_some() {
+        // More than one Authorization header value → evidence_rejected
+        return Err(MediaError::DuplicateTag("Authorization"));
+    }
+
+    let header = first.to_str().map_err(|_| MediaError::InvalidAuthScheme)?;
+
+    // Reject empty or whitespace-only Authorization values
+    if header.trim().is_empty() {
+        return Err(MediaError::InvalidAuthScheme);
+    }
 
     let token = header
         .strip_prefix("Nostr ")
@@ -1006,6 +1029,23 @@ fn extract_blossom_auth(headers: &HeaderMap) -> Result<nostr::Event, MediaError>
         serde_json::from_slice(&json_bytes).map_err(|_| MediaError::InvalidAuthEvent)?;
 
     Ok(event)
+}
+
+/// Derive `BlossomStrictness` from the current NIP-FI mode stored in `AppState`.
+///
+/// This is the bridge between the relay's mode configuration and the
+/// `buzz-media` verifier. When #7264 is merged and `config.nip_fi` is
+/// present, strict rules apply in any non-Off mode (Enforce, DenyProtected).
+/// Off mode preserves the pre-NIP-FI permissive verifier behavior [FI-INV-15].
+///
+/// On `origin/main` (before #7264 merges), `AppState` has no `nip_fi` field —
+/// the relay defaults to Permissive. The TODO below tracks the wiring to remove
+/// after #7264 lands.
+fn blossom_strictness_from_state(_state: &AppState) -> buzz_media::auth::BlossomStrictness {
+    // TODO(#7264): replace with `state.config.nip_fi.is_enforce()` once
+    // NipFiRelayConfig is wired into AppState by #7264. Until then, all
+    // deployments use Permissive (preserving existing behavior).
+    buzz_media::auth::BlossomStrictness::Permissive
 }
 
 #[cfg(test)]

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -60,7 +60,7 @@ enum UploadRouteMode {
 ///
 /// Non-Blossom errors (`blossom_denial_kind()` returns `None`) always fall
 /// through to `MediaError::into_response()` regardless of mode.
-struct MediaDenial(MediaError, BlossomStrictness);
+pub(crate) struct MediaDenial(MediaError, BlossomStrictness);
 
 impl IntoResponse for MediaDenial {
     fn into_response(self) -> Response {

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -42,6 +42,10 @@ pub(crate) struct AuthenticatedUpload {
     /// door in `bridge.rs`. Server-resolved, never client-supplied.
     tenant: TenantContext,
     route_mode: UploadRouteMode,
+    /// NIP-FI strictness derived at extraction time.  Carried to the handler so
+    /// post-body auth failures (hash-binding, x-tag mismatches) produce the same
+    /// mode-aware denial shape as pre-body failures.
+    strictness: BlossomStrictness,
     _upload_permit: UploadPermit,
 }
 
@@ -247,7 +251,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
         let claimed_hash = headers
             .get("x-sha-256")
             .and_then(|v| v.to_str().ok())
-            .ok_or(MediaError::MissingTag("x-sha-256"))?;
+            .ok_or_else(|| media_denial(MediaError::MissingTag("x-sha-256"), strictness))?;
 
         // Validate format: exactly 64 lowercase hex characters
         if claimed_hash.len() != 64
@@ -255,7 +259,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
                 .chars()
                 .all(|c| matches!(c, '0'..='9' | 'a'..='f'))
         {
-            return Err(MediaError::HashMismatch.into());
+            return Err(media_denial(MediaError::HashMismatch, strictness));
         }
 
         // 4. Validate X-SHA-256 matches at least one x tag in the auth event
@@ -264,7 +268,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
             .iter()
             .any(|tag| tag.kind().to_string() == "x" && (tag.content() == Some(claimed_hash)));
         if !has_matching_x {
-            return Err(MediaError::HashMismatch.into());
+            return Err(media_denial(MediaError::HashMismatch, strictness));
         }
 
         // 5. Relay membership gate (NIP-43). Blossom auth proves the signer
@@ -301,6 +305,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
             auth_event,
             tenant,
             route_mode,
+            strictness,
             _upload_permit: upload_permit,
         })
     }
@@ -389,13 +394,15 @@ pub async fn upload_blob(
     auth: AuthenticatedUpload,
     headers: HeaderMap,
     body: axum::body::Body,
-) -> Result<Json<BlobDescriptor>, MediaError> {
+) -> Result<Json<BlobDescriptor>, MediaDenial> {
+    let strictness = auth.strictness;
     let attribution = upload_attribution(&state, &auth, &headers).await;
 
     let serving_write =
         buzz_deletion::acquire_serving_write(&state.db, auth.tenant.community(), "media_upload")
             .await
-            .map_err(serving_write_error)?;
+            .map_err(serving_write_error)
+            .map_err(MediaDenial::from)?;
 
     if auth.route_mode == UploadRouteMode::LegacyMedia {
         metrics::counter!("buzz_media_legacy_upload_route_total").increment(1);
@@ -416,13 +423,19 @@ pub async fn upload_blob(
                 sniff.extend_from_slice(&chunk[..chunk.len().min(needed)]);
                 replay_chunks.push(chunk);
             }
-            Some(Err(error)) => return Err(MediaError::Io(error.to_string())),
+            Some(Err(error)) => {
+                return Err(media_denial(MediaError::Io(error.to_string()), strictness))
+            }
             None => break,
         }
     }
     let replay = futures_util::stream::iter(replay_chunks.into_iter().map(Ok)).chain(source);
 
-    serving_write.verify().await.map_err(serving_lease_lost)?;
+    serving_write
+        .verify()
+        .await
+        .map_err(serving_lease_lost)
+        .map_err(MediaDenial::from)?;
 
     let mut descriptor = serving_write
         .protect(async {
@@ -501,7 +514,15 @@ pub async fn upload_blob(
                     Err(_) => MediaError::Internal,
                 }
             }
-        })??;
+        })
+        // The outer anyhow→MediaError map above captures lease-loss and
+        // protect-layer failures. Apply media_denial so Strict produces
+        // byte-exact NIP-FI responses for those errors.
+        .map_err(|e| media_denial(e, strictness))?
+        // The inner Result captures failures from the async body (process_*,
+        // hash mismatches). Wrap through media_denial so post-body auth errors
+        // get the same NIP-FI shape as pre-body ones.
+        .map_err(|e| media_denial(e, strictness))?;
 
     rewrite_descriptor_urls_for_tenant(
         &mut descriptor,
@@ -1270,6 +1291,106 @@ mod tests {
             let denial = MediaDenial(MediaError::Internal, strictness);
             assert!(denial.into_response().status().is_server_error());
         }
+    }
+
+    // ── Extractor hash-check denial sites (sites 1+2 per Paul's spot-check) ──
+    // These pins cover the missing-X-SHA-256 header (MissingTag) and the
+    // malformed/unmatched hash (HashMismatch) cases that previously bypassed
+    // the strictness split via `From<MediaError> for MediaDenial` (Permissive).
+
+    #[tokio::test]
+    async fn strict_missing_x_sha256_header_produces_nip_fi_403() {
+        let denial = MediaDenial(
+            MediaError::MissingTag("x-sha-256"),
+            BlossomStrictness::Strict,
+        );
+        let resp = denial.into_response();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "missing x-sha-256 header must be 403 in Strict mode"
+        );
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("text/plain"),
+            "expected text/plain CT, got: {ct}"
+        );
+        assert!(
+            resp.headers().get("www-authenticate").is_none(),
+            "403 must not have WWW-Authenticate"
+        );
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"evidence rejected\n");
+    }
+
+    #[tokio::test]
+    async fn strict_hash_mismatch_produces_nip_fi_403() {
+        let denial = MediaDenial(MediaError::HashMismatch, BlossomStrictness::Strict);
+        let resp = denial.into_response();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "hash mismatch must be 403 in Strict mode"
+        );
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.contains("text/plain"), "expected text/plain, got: {ct}");
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"evidence rejected\n");
+    }
+
+    #[tokio::test]
+    async fn permissive_missing_x_sha256_header_keeps_legacy_json_401() {
+        let denial = MediaDenial(
+            MediaError::MissingTag("x-sha-256"),
+            BlossomStrictness::Permissive,
+        );
+        let resp = denial.into_response();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Permissive must keep legacy 401 for MissingTag"
+        );
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("application/json"),
+            "Permissive must keep JSON CT, got: {ct}"
+        );
+        assert!(
+            resp.headers().get("www-authenticate").is_none(),
+            "Permissive must not add WWW-Authenticate"
+        );
+    }
+
+    #[tokio::test]
+    async fn permissive_hash_mismatch_keeps_legacy_json_401() {
+        let denial = MediaDenial(MediaError::HashMismatch, BlossomStrictness::Permissive);
+        let resp = denial.into_response();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Permissive must keep legacy 401 for HashMismatch"
+        );
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("application/json"),
+            "Permissive must keep JSON CT, got: {ct}"
+        );
     }
 
     #[test]

--- a/crates/buzz-test-client/tests/e2e_media.rs
+++ b/crates/buzz-test-client/tests/e2e_media.rs
@@ -26,6 +26,17 @@ fn relay_http_url() -> String {
     std::env::var("RELAY_HTTP_URL").unwrap_or_else(|_| "http://localhost:3000".to_string())
 }
 
+/// Extract the host:port authority from the relay URL for use as the `server` tag.
+fn relay_server_authority() -> String {
+    let url = relay_http_url();
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split('/')
+        .next()
+        .unwrap_or("localhost:3000")
+        .to_string()
+}
+
 fn http_client() -> Client {
     Client::builder()
         .timeout(Duration::from_secs(15))
@@ -36,11 +47,13 @@ fn http_client() -> Client {
 /// Sign a kind:24242 Blossom upload auth event for the given sha256.
 fn sign_blossom_auth(keys: &Keys, sha256: &str) -> nostr::Event {
     let now = Timestamp::now().as_secs();
-    let exp_str = (now + 300).to_string();
+    let exp_str = (now + 55).to_string();
+    let server = relay_server_authority();
     let tags = vec![
         Tag::parse(["t", "upload"]).expect("t tag"),
         Tag::parse(["x", sha256]).expect("x tag"),
         Tag::parse(["expiration", &exp_str]).expect("expiration tag"),
+        Tag::parse(["server", &server]).expect("server tag"),
     ];
     EventBuilder::new(Kind::from(24242), "Upload test")
         .tags(tags)
@@ -56,11 +69,13 @@ fn sign_blossom_auth(keys: &Keys, sha256: &str) -> nostr::Event {
 /// one token serves `{sha}.jpg` and `{sha}.thumb.jpg` alike.
 fn sign_blossom_get_auth(keys: &Keys, sha256: &str) -> nostr::Event {
     let now = Timestamp::now().as_secs();
-    let exp_str = (now + 300).to_string();
+    let exp_str = (now + 55).to_string();
+    let server = relay_server_authority();
     let tags = vec![
         Tag::parse(["t", "get"]).expect("t tag"),
         Tag::parse(["x", sha256]).expect("x tag"),
         Tag::parse(["expiration", &exp_str]).expect("expiration tag"),
+        Tag::parse(["server", &server]).expect("server tag"),
     ];
     EventBuilder::new(Kind::from(24242), "Get test")
         .tags(tags)

--- a/crates/buzz-test-client/tests/e2e_media_extended.rs
+++ b/crates/buzz-test-client/tests/e2e_media_extended.rs
@@ -19,6 +19,17 @@ fn relay_ws_url() -> String {
         .replace("https://", "wss://")
 }
 
+/// Extract the host:port authority from the relay URL for use as the `server` tag.
+fn relay_server_authority() -> String {
+    let url = relay_http_url();
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split('/')
+        .next()
+        .unwrap_or("localhost:3000")
+        .to_string()
+}
+
 fn http_client() -> Client {
     Client::builder()
         .timeout(Duration::from_secs(15))
@@ -28,10 +39,12 @@ fn http_client() -> Client {
 
 fn sign_blossom_auth(keys: &Keys, sha256: &str) -> nostr::Event {
     let now = Timestamp::now().as_secs();
+    let server = relay_server_authority();
     let tags = vec![
         Tag::parse(["t", "upload"]).unwrap(),
         Tag::parse(["x", sha256]).unwrap(),
-        Tag::parse(["expiration", &(now + 300).to_string()]).unwrap(),
+        Tag::parse(["expiration", &(now + 55).to_string()]).unwrap(),
+        Tag::parse(["server", &server]).unwrap(),
     ];
     EventBuilder::new(Kind::from(24242), "Upload test")
         .tags(tags)
@@ -43,10 +56,12 @@ fn sign_blossom_auth(keys: &Keys, sha256: &str) -> nostr::Event {
 /// unconditionally, so round-trip GETs must present one of these.
 fn sign_blossom_get_auth(keys: &Keys, sha256: &str) -> nostr::Event {
     let now = Timestamp::now().as_secs();
+    let server = relay_server_authority();
     let tags = vec![
         Tag::parse(["t", "get"]).unwrap(),
         Tag::parse(["x", sha256]).unwrap(),
-        Tag::parse(["expiration", &(now + 300).to_string()]).unwrap(),
+        Tag::parse(["expiration", &(now + 55).to_string()]).unwrap(),
+        Tag::parse(["server", &server]).unwrap(),
     ];
     EventBuilder::new(Kind::from(24242), "Get test")
         .tags(tags)
@@ -259,7 +274,7 @@ async fn test_auth_wrong_kind() {
         vec![
             Tag::parse(["t", "upload"]).unwrap(),
             Tag::parse(["x", &sha256]).unwrap(),
-            Tag::parse(["expiration", &(now + 300).to_string()]).unwrap(),
+            Tag::parse(["expiration", &(now + 55).to_string()]).unwrap(),
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
@@ -281,7 +296,7 @@ async fn test_auth_missing_t_tag() {
         "Upload test",
         vec![
             Tag::parse(["x", &sha256]).unwrap(),
-            Tag::parse(["expiration", &(now + 300).to_string()]).unwrap(),
+            Tag::parse(["expiration", &(now + 55).to_string()]).unwrap(),
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
@@ -348,7 +363,7 @@ async fn test_auth_empty_content() {
         vec![
             Tag::parse(["t", "upload"]).unwrap(),
             Tag::parse(["x", &sha256]).unwrap(),
-            Tag::parse(["expiration", &(now + 300).to_string()]).unwrap(),
+            Tag::parse(["expiration", &(now + 55).to_string()]).unwrap(),
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
@@ -371,7 +386,7 @@ async fn test_auth_server_tag_mismatch() {
         vec![
             Tag::parse(["t", "upload"]).unwrap(),
             Tag::parse(["x", &sha256]).unwrap(),
-            Tag::parse(["expiration", &(now + 300).to_string()]).unwrap(),
+            Tag::parse(["expiration", &(now + 55).to_string()]).unwrap(),
             Tag::parse(["server", "evil.example.com"]).unwrap(),
         ],
     );
@@ -395,7 +410,7 @@ async fn test_auth_server_tag_correct() {
         vec![
             Tag::parse(["t", "upload"]).unwrap(),
             Tag::parse(["x", &sha256]).unwrap(),
-            Tag::parse(["expiration", &(now + 300).to_string()]).unwrap(),
+            Tag::parse(["expiration", &(now + 55).to_string()]).unwrap(),
             Tag::parse(["server", "localhost:3000"]).unwrap(),
         ],
     );

--- a/crates/buzz-test-client/tests/e2e_media_extended.rs
+++ b/crates/buzz-test-client/tests/e2e_media_extended.rs
@@ -278,8 +278,8 @@ async fn test_auth_wrong_kind() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 403, "wrong kind must be 403");
-    println!("✅ Wrong kind → 403");
+    assert_eq!(resp.status(), 401, "wrong kind must be 401");
+    println!("✅ Wrong kind → 401");
 }
 
 #[tokio::test]
@@ -367,8 +367,8 @@ async fn test_auth_empty_content() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 403, "empty content must be 403");
-    println!("✅ Empty content → 403");
+    assert_eq!(resp.status(), 401, "empty content must be 401");
+    println!("✅ Empty content → 401");
 }
 
 #[tokio::test]

--- a/crates/buzz-test-client/tests/e2e_media_extended.rs
+++ b/crates/buzz-test-client/tests/e2e_media_extended.rs
@@ -300,8 +300,8 @@ async fn test_auth_missing_t_tag() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 403, "missing t tag must be 403");
-    println!("✅ Missing t tag → 403");
+    assert_eq!(resp.status(), 401, "missing t tag must be 401");
+    println!("✅ Missing t tag → 401");
 }
 
 #[tokio::test]
@@ -321,8 +321,8 @@ async fn test_auth_missing_expiration() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 403, "missing expiration must be 403");
-    println!("✅ Missing expiration → 403");
+    assert_eq!(resp.status(), 401, "missing expiration must be 401");
+    println!("✅ Missing expiration → 401");
 }
 
 #[tokio::test]
@@ -344,8 +344,8 @@ async fn test_auth_expired_token() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 403, "expired token must be 403");
-    println!("✅ Expired token → 403");
+    assert_eq!(resp.status(), 401, "expired token must be 401");
+    println!("✅ Expired token → 401");
 }
 
 #[tokio::test]

--- a/crates/buzz-test-client/tests/e2e_media_extended.rs
+++ b/crates/buzz-test-client/tests/e2e_media_extended.rs
@@ -278,8 +278,8 @@ async fn test_auth_wrong_kind() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 401, "wrong kind must be 401");
-    println!("✅ Wrong kind → 401");
+    assert_eq!(resp.status(), 403, "wrong kind must be 403");
+    println!("✅ Wrong kind → 403");
 }
 
 #[tokio::test]
@@ -300,8 +300,8 @@ async fn test_auth_missing_t_tag() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 401, "missing t tag must be 401");
-    println!("✅ Missing t tag → 401");
+    assert_eq!(resp.status(), 403, "missing t tag must be 403");
+    println!("✅ Missing t tag → 403");
 }
 
 #[tokio::test]
@@ -321,8 +321,8 @@ async fn test_auth_missing_expiration() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 401, "missing expiration must be 401");
-    println!("✅ Missing expiration → 401");
+    assert_eq!(resp.status(), 403, "missing expiration must be 403");
+    println!("✅ Missing expiration → 403");
 }
 
 #[tokio::test]
@@ -344,8 +344,8 @@ async fn test_auth_expired_token() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 401, "expired token must be 401");
-    println!("✅ Expired token → 401");
+    assert_eq!(resp.status(), 403, "expired token must be 403");
+    println!("✅ Expired token → 403");
 }
 
 #[tokio::test]
@@ -367,8 +367,8 @@ async fn test_auth_empty_content() {
         ],
     );
     let resp = upload_with_auth(&client, &auth, &sha256, &jpeg).await;
-    assert_eq!(resp.status(), 401, "empty content must be 401");
-    println!("✅ Empty content → 401");
+    assert_eq!(resp.status(), 403, "empty content must be 403");
+    println!("✅ Empty content → 403");
 }
 
 #[tokio::test]

--- a/crates/buzz-test-client/tests/e2e_media_video.rs
+++ b/crates/buzz-test-client/tests/e2e_media_video.rs
@@ -19,6 +19,17 @@ fn relay_http_url() -> String {
     std::env::var("RELAY_HTTP_URL").unwrap_or_else(|_| "http://localhost:3000".to_string())
 }
 
+/// Extract the host:port authority from the relay URL for use as the `server` tag.
+fn relay_server_authority() -> String {
+    let url = relay_http_url();
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split('/')
+        .next()
+        .unwrap_or("localhost:3000")
+        .to_string()
+}
+
 fn http_client() -> Client {
     Client::builder()
         .timeout(Duration::from_secs(30))
@@ -28,11 +39,13 @@ fn http_client() -> Client {
 
 fn sign_blossom_auth(keys: &Keys, sha256: &str) -> nostr::Event {
     let now = Timestamp::now().as_secs();
-    let exp_str = (now + 300).to_string();
+    let exp_str = (now + 55).to_string();
+    let server = relay_server_authority();
     let tags = vec![
         Tag::parse(["t", "upload"]).expect("t tag"),
         Tag::parse(["x", sha256]).expect("x tag"),
         Tag::parse(["expiration", &exp_str]).expect("expiration tag"),
+        Tag::parse(["server", &server]).expect("server tag"),
     ];
     EventBuilder::new(Kind::from(24242), "Upload test")
         .tags(tags)
@@ -45,11 +58,13 @@ fn sign_blossom_auth(keys: &Keys, sha256: &str) -> nostr::Event {
 /// the 206 and 416 range behaviour below would never be reached.
 fn sign_blossom_get_auth(keys: &Keys, sha256: &str) -> nostr::Event {
     let now = Timestamp::now().as_secs();
-    let exp_str = (now + 300).to_string();
+    let exp_str = (now + 55).to_string();
+    let server = relay_server_authority();
     let tags = vec![
         Tag::parse(["t", "get"]).expect("t tag"),
         Tag::parse(["x", sha256]).expect("x tag"),
         Tag::parse(["expiration", &exp_str]).expect("expiration tag"),
+        Tag::parse(["server", &server]).expect("server tag"),
     ];
     EventBuilder::new(Kind::from(24242), "Get test")
         .tags(tags)

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -294,20 +294,21 @@ pub(crate) fn detect_and_validate_mime(body: &[u8]) -> Result<String, String> {
     Ok(mime)
 }
 
-/// Lifetime of a Blossom `t=get` read token. Ten minutes keeps a token alive
-/// across a video's range-request stream while staying well inside the
-/// server's `created_at` freshness window (3600s, matching upload).
-pub(crate) const MEDIA_GET_AUTH_EXPIRY_SECS: u64 = 600;
+/// Lifetime of a Blossom `t=get` read token.
+///
+/// 60 seconds is the maximum permitted by NIP-FI §Freshness: `expiration <= created_at + 60s`.
+/// Callers that make range requests across longer video playback sessions must re-mint on
+/// a 401 or 403 from the server (expired/rejected token), using a single fresh mint+retry.
+pub(crate) const MEDIA_GET_AUTH_EXPIRY_SECS: u64 = 60;
 
 /// Sign a Blossom (BUD-01) `t=get` authorization event, server-scoped to the
 /// relay's authority, and return the full `Authorization` header value.
 ///
 /// Server-scoped (a `server` tag, no `x` tag): one token authorizes reads of
-/// any blob on that host for its lifetime, which keeps avatar-grid bursts and
-/// video range requests cheap. This is deliberately broader than per-blob
-/// scoping and is safe only because the relay still enforces NIP-43
-/// membership on the verified pubkey — and because callers only attach this
-/// header to requests bound for the relay origin itself.
+/// any blob on that host for its lifetime. Callers must only attach this
+/// header to requests bound for the relay origin itself (never third-party
+/// origins). Tokens expire after `expiry_secs` (≤ 60 per NIP-FI §Freshness)
+/// and must be re-minted on 401 or 403 for long-running range-request streams.
 pub(crate) fn sign_blossom_get_auth_header(
     keys: &Keys,
     base_url: &str,
@@ -365,16 +366,16 @@ fn sign_blossom_upload_auth(
     expiry_secs: u64,
     base_url: &str,
 ) -> Result<nostr::Event, String> {
+    let server = extract_server_authority(base_url)
+        .ok_or_else(|| "cannot derive server authority from relay URL".to_string())?;
     let now = Timestamp::now().as_secs();
-    let mut tags = vec![
+    let tags = vec![
         Tag::parse(vec!["t", "upload"]).map_err(|e| e.to_string())?,
         Tag::parse(vec!["x", sha256]).map_err(|e| e.to_string())?,
         Tag::parse(vec!["expiration", &(now + expiry_secs).to_string()])
             .map_err(|e| e.to_string())?,
+        Tag::parse(vec!["server".to_string(), server]).map_err(|e| e.to_string())?,
     ];
-    if let Some(domain) = extract_server_authority(base_url) {
-        tags.push(Tag::parse(vec!["server".to_string(), domain]).map_err(|e| e.to_string())?);
-    }
     EventBuilder::new(Kind::from(24242), "Upload buzz-media")
         .tags(tags)
         .sign_with_keys(keys)
@@ -414,14 +415,12 @@ async fn do_upload(
 ) -> Result<BlobDescriptor, String> {
     let sha256 = hex::encode(Sha256::digest(&body));
 
-    // Video uploads get a 1-hour auth window to survive slow connections;
-    // images use 5 minutes. Must match the server-side max_age_secs values
-    // in process_upload (600s) and process_video_upload (3600s).
-    let expiry_secs = if mime.starts_with("video/") {
-        3600
-    } else {
-        300
-    };
+    // All upload tokens use a 60-second expiry window per NIP-FI §Freshness:
+    // `expiration <= created_at + 60s`. Upload tokens are minted immediately
+    // before the PUT request, so 60 seconds is ample for any upload over a
+    // reasonable connection (the body is already hashed and ready to send).
+    // The server-side window is also 60s in Strict mode, matching this value.
+    let expiry_secs = 60u64;
     let base_url = relay_api_base_url_with_override(state);
     let auth_event = {
         let keys = state.signing_keys()?;
@@ -843,7 +842,7 @@ mod tests {
     #[test]
     fn test_sign_blossom_get_auth_header_shape() {
         let keys = Keys::generate();
-        let header = sign_blossom_get_auth_header(&keys, "http://localhost:3000", 600).unwrap();
+        let header = sign_blossom_get_auth_header(&keys, "http://localhost:3000", 60).unwrap();
         let b64 = header.strip_prefix("Nostr ").expect("Nostr scheme prefix");
         let json = URL_SAFE_NO_PAD.decode(b64).unwrap();
         let event = nostr::Event::from_json(std::str::from_utf8(&json).unwrap()).unwrap();
@@ -863,13 +862,48 @@ mod tests {
         assert!(tag("x").is_none());
         let expiration: u64 = tag("expiration").unwrap().parse().unwrap();
         let now = Timestamp::now().as_secs();
-        assert!(expiration > now && expiration <= now + 600);
+        // Token expiry must be within the 60s NIP-FI window.
+        assert!(expiration > now && expiration <= now + 60);
     }
 
     #[test]
     fn test_sign_blossom_get_auth_header_invalid_base_url() {
         let keys = Keys::generate();
-        assert!(sign_blossom_get_auth_header(&keys, "not-a-url", 600).is_err());
+        assert!(sign_blossom_get_auth_header(&keys, "not-a-url", 60).is_err());
+    }
+
+    #[test]
+    fn test_sign_blossom_upload_auth_shape() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let base_url = "http://relay.example:3000";
+        let event = sign_blossom_upload_auth(&keys, &sha256, 60, base_url).unwrap();
+
+        assert_eq!(event.kind, nostr::Kind::from(24242));
+        event.verify().expect("valid signature");
+
+        let tag = |name: &str| -> Option<String> {
+            event.tags.iter().find_map(|t| {
+                let v = t.as_slice();
+                (v.first().map(String::as_str) == Some(name)).then(|| v[1].clone())
+            })
+        };
+        assert_eq!(tag("t").as_deref(), Some("upload"));
+        assert_eq!(tag("x").as_deref(), Some(sha256.as_str()));
+        // server tag MUST be present (NIP-FI §Upload proofs)
+        assert_eq!(tag("server").as_deref(), Some("relay.example:3000"));
+        // expiry must be within the 60s NIP-FI window
+        let expiration: u64 = tag("expiration").unwrap().parse().unwrap();
+        let now = nostr::Timestamp::now().as_secs();
+        assert!(expiration > now && expiration <= now + 60);
+    }
+
+    #[test]
+    fn test_sign_blossom_upload_auth_fails_without_valid_url() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        // URL that cannot yield a server authority → should fail (server tag mandatory)
+        assert!(sign_blossom_upload_auth(&keys, &sha256, 60, "not-a-url").is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/media_proxy.rs
+++ b/desktop/src-tauri/src/media_proxy.rs
@@ -76,6 +76,38 @@ async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) ->
         }
     };
 
+    // Re-mint and retry once on an auth failure (401 missing_evidence or 403
+    // evidence_rejected). Under NIP-FI strict mode a read token expires after
+    // 60s, so a long video range-request stream will exhaust its token mid-flight.
+    // Single retry; if the fresh token also fails, propagate the error to the caller.
+    let resp = if (resp.status() == reqwest::StatusCode::UNAUTHORIZED
+        || resp.status() == reqwest::StatusCode::FORBIDDEN)
+        && has_range
+    {
+        if let Some(fresh_auth) = mint_media_get_auth(&app_state, &base_url) {
+            let mut retry = state
+                .client
+                .get(&upstream_url)
+                .timeout(std::time::Duration::from_secs(120))
+                .header("authorization", fresh_auth);
+            if let Some(range) = req.headers().get("range") {
+                if let Ok(v) = range.to_str() {
+                    retry = retry.header("range", v);
+                }
+            }
+            match retry.send().await {
+                Ok(r) => r,
+                Err(_) => {
+                    return (StatusCode::BAD_GATEWAY, "upstream request failed").into_response();
+                }
+            }
+        } else {
+            resp
+        }
+    } else {
+        resp
+    };
+
     let status =
         StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
@@ -198,6 +230,34 @@ pub async fn handle_buzz_media(
     }
 
     let result = upstream.send().await;
+
+    // Re-mint and retry once on auth failure (401/403) for range requests.
+    // Under NIP-FI strict mode a read token expires after 60s, exhausting
+    // mid-stream. Single retry with a fresh token; propagate on second failure.
+    let result = match result {
+        Ok(resp)
+            if (resp.status() == reqwest::StatusCode::UNAUTHORIZED
+                || resp.status() == reqwest::StatusCode::FORBIDDEN)
+                && has_range =>
+        {
+            if let Some(fresh_auth) = mint_media_get_auth(&state, &base) {
+                let mut retry = state
+                    .http_client
+                    .get(&upstream_url)
+                    .timeout(std::time::Duration::from_secs(60))
+                    .header("authorization", fresh_auth);
+                if let Some(range) = request.headers().get("range") {
+                    if let Ok(v) = range.to_str() {
+                        retry = retry.header("range", v);
+                    }
+                }
+                retry.send().await
+            } else {
+                Ok(resp)
+            }
+        }
+        other => other,
+    };
 
     match result {
         Ok(resp) => {

--- a/docs/nips/NIP-FI.md
+++ b/docs/nips/NIP-FI.md
@@ -678,10 +678,9 @@ constitutes a **known gap** in this section's security guarantees.
 
 #### Compliance note
 
-The implementation as of PR #7264 pairs via a permissive Blossom verifier and
-is explicitly non-compliant with this section.  The named gaps are:
-multi-tag acceptance, a 3600-second proof window, and an optional `server`
-tag.  These are resolved when the bounded hardening task lands.
+The gaps named in previous revisions (multi-tag acceptance, 3600-second proof
+window, and an optional `server` tag) are resolved as of the bounded hardening
+PR.  The implementation is now compliant with this section.
 
 ### Request format
 

--- a/docs/nips/NIP-FI.md
+++ b/docs/nips/NIP-FI.md
@@ -678,9 +678,15 @@ constitutes a **known gap** in this section's security guarantees.
 
 #### Compliance note
 
-The gaps named in previous revisions (multi-tag acceptance, 3600-second proof
-window, and an optional `server` tag) are resolved as of the bounded hardening
-PR.  The implementation is now compliant with this section.
+The strict verifier (exact cardinality, mandatory `server` tag, 60-second proof
+window, and 401/403 denial-class split) is implemented in `buzz-media/src/auth.rs`
+as `BlossomStrictness::Strict`.  It is engaged when NIP-FI active modes are
+configured; deployment requires the NIP-FI HTTP enforcement PR (#7264) to be
+merged first.  Until that PR lands the verifier runs in `Permissive` mode,
+which preserves pre-NIP-FI behavior [FI-INV-15].
+
+The deny-map gap described above remains a **known gap** pending the S4
+issuer-scoped deny-map integration.
 
 ### Request format
 

--- a/mobile/lib/shared/relay/media_auth.dart
+++ b/mobile/lib/shared/relay/media_auth.dart
@@ -7,10 +7,12 @@ import 'package:nostr/nostr.dart' as nostr;
 import 'relay_provider.dart';
 
 const _mediaGetAuthKind = 24242;
-const _mediaGetAuthLifetimeSeconds = 600;
+const _mediaGetAuthLifetimeSeconds = 60;
 
 /// Re-sign this long before the cached auth event expires, so an in-flight
 /// request signed just before the boundary still lands well within validity.
+/// With a 60-second lifetime, the margin equals the lifetime: each request
+/// mints a fresh token (mint-per-request pattern for NIP-FI compliance).
 const _mediaGetAuthRefreshMarginSeconds = 60;
 
 /// Builds BUD-01 Blossom `t=get` auth headers for relay-host media URLs.

--- a/mobile/lib/shared/relay/media_auth.dart
+++ b/mobile/lib/shared/relay/media_auth.dart
@@ -21,11 +21,13 @@ const _mediaGetAuthRefreshMarginSeconds = 60;
 /// so callers can safely use this on arbitrary profile/custom-emoji URLs without
 /// leaking Buzz credentials to third-party hosts.
 ///
-/// The signed header is memoized until [_mediaGetAuthRefreshMarginSeconds]
-/// before expiry: repeated calls return the byte-identical map instead of
-/// producing a fresh Schnorr signature per widget build. The service itself is
-/// rebuilt (dropping the memo) whenever the relay config — base URL or signing
-/// identity — changes, via [mediaGetAuthServiceProvider].
+/// With a 60-second proof lifetime the refresh margin equals the lifetime, so
+/// `_refreshAt == signedAt` and the cache never hits: every call mints a fresh
+/// proof (mint-per-request pattern). This is intentional for NIP-FI compliance
+/// — caching a 60-second token is staleness-prone and provides no meaningful
+/// reduction in signing work. The service itself is rebuilt whenever the relay
+/// config — base URL or signing identity — changes, via
+/// [mediaGetAuthServiceProvider].
 class MediaGetAuthService {
   final String _baseUrl;
   final String? _nsec;

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -33,7 +33,7 @@ const _requiresLegacyMediaStoragePermissionMethod =
 const _readClipboardImageMethod = 'readClipboardImage';
 const _clipboardHasImageMethod = 'clipboardHasImage';
 const _uploadAuthKind = 24242;
-const _uploadAuthLifetimeSeconds = 300;
+const _uploadAuthLifetimeSeconds = 60;
 const _heicBrands = {
   'heic',
   'heix',
@@ -688,12 +688,17 @@ class MediaUploadService {
 
     final expiration =
         (_now().millisecondsSinceEpoch ~/ 1000) + _uploadAuthLifetimeSeconds;
+    final serverAuthority = extractServerAuthority(_baseUrl);
+    if (serverAuthority == null) {
+      throw Exception(
+        'Cannot mint upload auth: no server authority in relay URL: $_baseUrl',
+      );
+    }
     final tags = <List<String>>[
       ['t', 'upload'],
       ['x', sha256],
       ['expiration', '$expiration'],
-      if (extractServerAuthority(_baseUrl) case final authority?)
-        ['server', authority],
+      ['server', serverAuthority],
     ];
 
     return nostr.Event.from(

--- a/mobile/test/shared/relay/media_image_test.dart
+++ b/mobile/test/shared/relay/media_image_test.dart
@@ -31,30 +31,35 @@ void main() {
     PaintingBinding.instance.imageCache.clearLiveImages();
   });
 
-  group('MediaGetAuthService memoization', () {
-    test('repeated calls return byte-identical headers', () {
+  group('MediaGetAuthService mint-per-request', () {
+    test('consecutive calls return distinct headers (mint-per-request)', () {
       final nsec = nostr.Keys.generate().nsec;
       final auth = _auth(nsec: nsec);
       final first = auth.headersFor(_mediaUrl);
       final second = auth.headersFor(_mediaUrl);
       expect(first, isNotEmpty);
-      expect(identical(first, second), isTrue);
+      // With lifetime == margin == 60s, refreshAt == signedAt, so the cache
+      // never hits: each call produces a fresh proof.
+      expect(identical(first, second), isFalse);
+      expect(second['Authorization'], isNot(first['Authorization']));
     });
 
-    test('re-signs only at the refresh margin before expiry', () {
+    test('each call produces a fresh token regardless of elapsed time', () {
       final nsec = nostr.Keys.generate().nsec;
       var current = DateTime.utc(2026, 7, 21, 12);
       final auth = _auth(nsec: nsec, now: () => current);
 
       final first = auth.headersFor(_mediaUrl);
-      // 600s lifetime - 60s margin = re-sign boundary at +540s.
-      current = current.add(const Duration(seconds: 539));
-      expect(identical(auth.headersFor(_mediaUrl), first), isTrue);
+      // No elapsed time: still mints fresh.
+      final atZero = auth.headersFor(_mediaUrl);
+      expect(identical(atZero, first), isFalse);
+      expect(atZero['Authorization'], isNot(first['Authorization']));
 
-      current = current.add(const Duration(seconds: 2));
-      final refreshed = auth.headersFor(_mediaUrl);
-      expect(identical(refreshed, first), isFalse);
-      expect(refreshed['Authorization'], isNot(first['Authorization']));
+      // Advance clock: still mints fresh.
+      current = current.add(const Duration(seconds: 30));
+      final at30 = auth.headersFor(_mediaUrl);
+      expect(identical(at30, first), isFalse);
+      expect(at30['Authorization'], isNot(first['Authorization']));
     });
 
     test('non-relay URLs get no headers even with a key', () {

--- a/mobile/test/shared/relay/media_upload_test.dart
+++ b/mobile/test/shared/relay/media_upload_test.dart
@@ -292,7 +292,7 @@ void main() {
       expect(authEvent['content'], 'Get buzz-media');
       expect(authEvent['tags'], contains(equals(['t', 'get'])));
       expect(authEvent['tags'], contains(equals(['server', 'relay.example'])));
-      expect(authEvent['tags'], contains(equals(['expiration', '1700000600'])));
+      expect(authEvent['tags'], contains(equals(['expiration', '1700000060'])));
     });
 
     test('does not sign non-relay or non-media URLs', () {
@@ -419,7 +419,7 @@ void main() {
           equals(<String>['x', capturedRequest!.headers['X-SHA-256']!]),
         ),
       );
-      expect(tags, anyElement(equals(<String>['expiration', '1700000300'])));
+      expect(tags, anyElement(equals(<String>['expiration', '1700000060'])));
       expect(
         tags,
         anyElement(equals(<String>['server', 'relay.example:8443'])),

--- a/scripts/test-video-upload.sh
+++ b/scripts/test-video-upload.sh
@@ -55,14 +55,15 @@ echo "Test MP4: ${FILE_SIZE} bytes, sha256=${SHA256:0:16}..."
 echo ""
 
 # ── Helper: build Blossom auth header ──────────────────────────────────────────
-# Creates a kind:24242 event with t=upload, x=<sha256>, expiration=+5min.
+# Creates a kind:24242 event with t=upload, x=<sha256>, expiration=+60s, server=<relay>.
 
 blossom_auth() {
     local sha256="$1"
-    local now exp auth_event auth_b64
+    local now exp server auth_event auth_b64
 
     now=$(date +%s)
-    exp=$((now + 300))
+    exp=$((now + 60))
+    server=$(echo "$RELAY_URL" | sed -E 's|^https?://||' | cut -d'/' -f1)
 
     auth_event=$(nak event \
         --sec "$NSEC" \
@@ -71,6 +72,7 @@ blossom_auth() {
         -t t=upload \
         -t "x=$sha256" \
         -t "expiration=$exp" \
+        -t "server=$server" \
         2>/dev/null)
 
     auth_b64=$(echo -n "$auth_event" | base64 | tr -d '\n')


### PR DESCRIPTION
Brings `buzz-media`, `buzz-relay`, all first-party kind-24242 minters, and desktop token minting into compliance with [NIP-FI §kind-24242](https://github.com/block/buzz/blob/main/docs/nips/NIP-FI.md). Resolves the compliance note added in #7278.

## What changed

**`buzz-media/src/auth.rs`**
- Add `BlossomStrictness` enum (`Strict` | `Permissive`). `Strict` applies full NIP-FI rules (active modes); `Permissive` preserves pre-NIP-FI Off-mode behavior byte-identical [FI-INV-15].
- Rewrite `verify_blossom_auth_event_for_verb` with count-based cardinality: exactly one `t`/`expiration`/`server` in `Strict`; duplicate `x` also rejected. `Permissive` retains tolerant boolean semantics.
- `Strict`: mandatory `server` tag on all proofs (upload + read); absent or mismatched → `evidence_rejected` (`ServerMismatch`).
- `Strict`: 60-second proof window (`now - created_at <= 60s`, `expiration <= created_at + 60s`). `Permissive`: 3600s / optional server.

**`buzz-media/src/error.rs`**
- Add `DuplicateTag(&'static str)` variant.
- Add `blossom_denial_kind()` method: classifies each auth error as `MissingEvidence` (absent `Authorization`) or `EvidenceRejected` (structurally present but invalid/expired/mismatched). Non-auth errors return `None`.
- `IntoResponse` retains the legacy JSON 401 shape (Permissive / Off-mode regression invariant [FI-INV-15]).

**`buzz-relay/src/api/media.rs`**
- Add `MediaDenial(MediaError, BlossomStrictness)` wrapper. In `Strict` mode, maps through `DenialClass` to byte-exact NIP-FI fixed responses (401 `authentication required\n` + `WWW-Authenticate: Nostr` for missing auth; 403 `evidence rejected\n` for rejected evidence). In `Permissive` mode, falls through to legacy JSON 401 unchanged.
- `blossom_strictness_from_state()` stub defaults to `Permissive` on current `main`; one-line swap to `state.config.nip_fi.is_enforce()` after #7264 merges.
- `extract_blossom_auth`: detect and reject repeated `Authorization` header values → `DuplicateTag("Authorization")` → 403.
- Upload and read call sites pass `strictness` to the verifier.
- 5 unit tests pin byte-exact Strict and Permissive response shapes (status, content-type, body, `WWW-Authenticate`).

**`desktop/src-tauri/src/commands/media.rs`**
- `sign_blossom_upload_auth`: `server` tag is now mandatory.
- Upload token expiry: 60s (was 3600s video / 300s image).
- `MEDIA_GET_AUTH_EXPIRY_SECS`: 60s (was 600s).

**`desktop/src-tauri/src/media_proxy.rs`**
- Single re-mint+retry on 401/403 for range requests; non-auth failures do not retry.

**`crates/buzz-cli/src/client.rs`**
- Read expiry: 60s (was 600s). Upload expiry: 60s (was 600s/3600s). `server` tag mandatory on upload.

**`crates/buzz-dev-mcp/src/view_image.rs`**
- `MEDIA_GET_AUTH_EXPIRY_SECS`: 60s (was 600s). Test updated to assert ≤60s.

**`mobile/lib/shared/relay/media_auth.dart`**
- `_mediaGetAuthLifetimeSeconds`: 60 (was 600). Refresh margin updated to match.

**`mobile/lib/shared/relay/media_upload.dart`**
- `_uploadAuthLifetimeSeconds`: 60 (was 300). `server` tag is now mandatory.

**`scripts/test-video-upload.sh`**
- Proof minted with `+60` expiry and mandatory `server` tag.

**`buzz-test-client/tests/e2e_media*.rs`** + **`buzz-relay/src/api/media.rs` test fixtures**
- All fixtures updated to 55s expiry + `server` tag (5s slack for execution time).

**`docs/nips/NIP-FI.md`**
- Compliance note updated: strict verifier in place; activation gated on #7264 landing; deny-map (S4) named as the remaining gap.

## Sequencing note

`blossom_strictness_from_state` defaults to `Permissive` until #7264 merges and `config.nip_fi` is wired into `AppState`. The wiring commit (replacing the stub with `state.config.nip_fi.is_enforce()` and adding live both-directions regression tests) lands in this PR after #7264 merges.