### PR TITLE
test(desktop): await Bestie drag and profile hover endpoints

### DIFF
--- a/desktop/tests/e2e/bestie.spec.ts
+++ b/desktop/tests/e2e/bestie.spec.ts
@@ -223,6 +223,12 @@ test("assigns from an agent profile, reopens, drags, and offers the message acti
   await expect(page.getByTestId("bestie-activity-dot").last()).toBeVisible();
   await page.getByRole("button", { name: "Close Bestie" }).click();
   await waitForAnimations(page);
+  // The Motion close morph can outlive the CSS/Web animations above. Wait for
+  // the closed, untranslated shell before measuring the drag's starting point.
+  const closedBloom = floatingAvatar.getByTestId("bestie-bloom-container");
+  await expect(closedBloom).toHaveCSS("width", "48px");
+  await expect(closedBloom).toHaveCSS("height", "48px");
+  await expect(closedBloom).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 0)");
   const beforeDrag = await floatingAvatar.boundingBox();
   const collapsedAvatar = floatingAvatar.getByTestId("bestie-trigger-avatar");
   const collapsedAvatarBeforeDrag = await collapsedAvatar.boundingBox();

--- a/desktop/tests/e2e/message-feedback-snapshots.spec.ts
+++ b/desktop/tests/e2e/message-feedback-snapshots.spec.ts
@@ -100,11 +100,20 @@ test("profile hover uses the channel hover surface", async ({ page }) => {
 
   const profile = page.getByTestId("sidebar-profile-card");
   const channel = page.getByTestId("channel-random");
+  const hoverSurface = await channel.evaluate((element) => {
+    const probe = document.createElement("span");
+    probe.style.backgroundColor = "var(--buzz-hover-surface)";
+    element.append(probe);
+    const color = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    return color;
+  });
+  // Equal unfinished (transparent) surfaces must not satisfy hover parity.
+  expect(hoverSurface).not.toMatch(/^(transparent|rgba\(.*,\s*0\))$/);
   await channel.hover();
-  // Wait for the CSS transition to settle before capturing the hover color so
-  // a mid-transition sample does not produce a value the profile card (which
-  // uses the same token) can never match.
-  await waitForAnimations(page);
+  // Observe the semantic endpoint, not an intermediate transition sample or
+  // the shared animation helper's timeout-as-success ceiling.
+  await expect(channel).toHaveCSS("background-color", hoverSurface);
   const channelHoverColor = await channel.evaluate(
     (element) => getComputedStyle(element).backgroundColor,
   );

--- a/desktop/tests/e2e/message-feedback-snapshots.spec.ts
+++ b/desktop/tests/e2e/message-feedback-snapshots.spec.ts
@@ -100,6 +100,7 @@ test("profile hover uses the channel hover surface", async ({ page }) => {
 
   const profile = page.getByTestId("sidebar-profile-card");
   const channel = page.getByTestId("channel-random");
+  await expect(page.locator("html")).toHaveAttribute("data-buzz-sidebar", "");
   const hoverSurface = await channel.evaluate((element) => {
     const probe = document.createElement("span");
     probe.style.backgroundColor = "var(--buzz-hover-surface)";


### PR DESCRIPTION
## Summary

Repair two demonstrated animation observation boundaries, without changing runtime behavior, CSS, the shared helper, or assertion tolerances:

- **Bestie collapsed drag:** wait for the inner Bloom shell's closed 48×48/untranslated endpoint before capturing the baseline. The original six-line fix, mouse events, immediate post-mouse-up measurements, and both `<1px` assertions remain unchanged.
- **Profile hover:** wait for ThemeProvider’s production `data-buzz-sidebar` marker, then resolve the real `--buzz-hover-surface` token under the channel, reject transparency, and wait for the channel to reach that exact endpoint before recording its color. Keep the original exact profile/channel equality and screenshot wait. #7270 already added a helper wait here; this replaces that timeout-as-success boundary, rather than duplicating the stale proposed helper calls.

Both repairs establish the intended precondition before an unchanged strict oracle. The bounded Bestie sibling audit demonstrated no additional defect, so there are no speculative sibling changes.

### Related work / scope

Closest related PRs: #7124 and #7125 (smoke gates exposed unchanged-base failures), #7279 (same Bestie failure reported), #7270 (prior smoke waits), and #7133 (profile-hover diagnosis). The separate mention-address flake is excluded: no demonstrated common cause.

Base remains `88687876f7808a2fd742b7eb2e4b9f87d999ad8d`. Expanded head: `c385a1d1278b700b88a33e2e05175f4cc6d0b013`. Profile-only range: `ee67e59d2ec87460685443f57eb6de9666dc6e67..c385a1d1278b700b88a33e2e05175f4cc6d0b013` (one spec, +14/-4). Focused review correction: `d6d7498a..c385a1d1` adds only the theme-ready precondition.

Human-authorized expansion in this same PR; no original-eight branch updates, rebase, merge, waiver, or new human-review outreach. The successor was applied in a separate worktree; the old reviewed checkout and served bundle remain unchanged. Old-head review/CI do not certify this expansion.

Work discussion: buzz://message?channel=088a082d-4e63-45c8-b043-bfa96d596d1d&id=d661e25d28c747f7f9d68aac848a3d6e7381f92af71fb24d30a83f6396a17c99

## Focused review correction

Independent review found one P2 readiness race: the channel may exist before the asynchronous GitHub Light theme import sets `data-buzz-sidebar`. With a 1.5s theme-asset delay, the previous candidate rejected a healthy initializing page as transparent in 662ms. Added the reviewer’s minimal bounded `toHaveAttribute("data-buzz-sidebar", "")` precondition before resolving the token. No guard, color comparison or strict assertion changed. No other actionable profile-delta finding.

PR stays **Draft** by owner instruction; no mark-ready or formal-review outreach is authorized.

## Validation

### Final applied candidate — fresh full affected-package checks

- Desktop units: **6,110/6,110 PASS**, no failed/cancelled/skipped tests.
- TypeScript `--noEmit`: **PASS**.
- Full Desktop Biome: **PASS**, 2,618 files, no fixes; 4 existing warnings / 5 infos.
- px-text, pubkey-truncation and repository file-size gates: **PASS**.
- E2E production build: **PASS**, isolated output.
- Production OSS/internal protected-feature artifact matrix: **PASS**, successor-local output separate from all served bundles.

Hermit activated; existing dependency tree has byte-identical lockfile and Desktop package manifest. No install, dependency/config/credential workaround, or peer-output mutation. First file-size invocation used the wrong root script path and failed `MODULE_NOT_FOUND`; retained verbatim, corrected to the actual `just file-size-check` recipe, which passed.

### Corrected-source browser validation and reused causal evidence

- Final corrected full message-feedback spec: **6/6 PASS**, two tests × three repetitions; final corrected profile with **1500ms GitHub Light asset delay: 3/3 PASS**. Chromium, one worker, zero retries, own port 43991, successor-only E2E build. Traces embed the exact applied source after import substitution (delay hook is diagnostic only).
- Full package checks above were run again once after this correction; all passed. Frozen Bestie/transition-control evidence is reused because its assertions and runtime source are unchanged.


- Message-feedback spec: **6/6 PASS** (two tests × three repetitions), Chromium, one worker, zero retries. All six prepared traces match the initial applied d6d7498a source after import-path normalization; fresh corrected traces above match c385a1d1.
- Bestie bounded sibling audit: **3/3 PASS**; original complete repaired workflow also **3/3 PASS**. The Bestie file is byte-identical to the reviewed old head.
- Deliberately slowed real CSS transition: old helper reads alpha `.024` versus the intended `.04`; candidate waits for `.04`. Frozen channel/profile and transparent-token controls are rejected. Old equality can pass while both surfaces remain transparent.
- The initial prepared candidate matched d6d7498a (SHA-256 `0918ab551938274a4e359fd2a38dacf10f722e26c27e02e53fcbb902ceb2718b`); final c385a1d1 adds only the reviewed theme-readiness assertion. Fresh final traces cover that correction. All **547 frozen bundle hashes** independently rechecked: zero mismatches. Production source has not changed.
- Expected-negative probes are explicitly diagnostic, not production tests hidden behind expected-failure markers. Earlier delay probes that rounded to `.04` remain preserved and do not establish a natural old-head failure.

Prior matched Bestie diagnosis is reused: original tests failed on both base and branch, while settled experiments passed 2/2 on each frozen build with the strict drag assertions intact. No diagnosis rerun.

### Limits / remaining gates

Full `just ci` is **not green**: prior attempt was interrupted during unrelated Rust dependency/clippy work; normal pnpm gates stopped with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. These limits remain disclosed; no install/config workaround was used. Direct package checks above are not full-repository, native, relay, or cross-browser certification.

Corrected-head hosted checks and confirmation of the focused review correction remain pending; independent review already assessed the profile delta with only the now-addressed readiness finding. Old-head technical review covers only the Bestie six-line repair. Required `Security` path-skipping is not security clearance; Codex authorization/review contexts are advisory under the live rules, and skipped review jobs are not a completed review. No authorization comment or waiver has been posted.

Durable local evidence: `WORK_LOGS/BESTIE_APPLY_A99913BD/corrected/` (final patch, exact-source/hash verification, fresh checks and browser traces, identity and lease publication evidence), `WORK_LOGS/BESTIE_DELTA_REVIEW_F50A5F79/` (review reproduction and recommended correction), `WORK_LOGS/BESTIE_EXPANSION_40574694/` (prepared browser traces and controls), `WORK_LOGS/BESTIE_REPAIR_1840976C/` (original candidate), and `WORK_LOGS/BESTIE_CAUSAL_4FC0911C/` (matched diagnosis).
