### PR TITLE
fix(buzz-cli): support stdin content for messages edit

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -993,7 +993,11 @@ pub async fn dispatch(
             )
             .await
         }
-        MessagesCmd::Edit { event, content } => cmd_edit_message(client, &event, &content).await,
+        MessagesCmd::Edit { event, content } => {
+            // Allow '-' to read content from stdin, matching Send behavior.
+            let content = read_or_stdin(&content)?;
+            cmd_edit_message(client, &event, &content).await
+        }
         MessagesCmd::Delete {
             event,
             action_id,

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -443,7 +443,7 @@ pub enum MessagesCmd {
         /// Event ID of the message to edit (64-char hex)
         #[arg(long)]
         event: String,
-        /// New message content
+        /// New message content (use '-' to read from stdin)
         #[arg(long)]
         content: String,
     },


### PR DESCRIPTION
## Summary

`buzz messages send --content -` reads the message body from stdin via `read_or_stdin`, but `buzz messages edit --content -` stores the literal dash as the new content.

Any caller that streams edits through stdin silently replaces the message with `-`. We hit this with a gateway adapter that streams replies by repeatedly editing one message: every edit (kind 40003) landed on the relay with content `-`, so clients rendered an empty markdown bullet and the original message stayed frozen at its first partial chunk.

## Reproduction

```
$ buzz messages send --channel <UUID> --content "original"
{"accepted":true,"event_id":"9d3382..."}
$ echo "edited content" | buzz messages edit --event 9d3382... --content -
{"accepted":true,"event_id":"9cc428..."}
$ buzz messages get --channel <UUID> --kinds 40003 --limit 1
# → edit event content is the literal "-", not "edited content"
```

## Fix

Route the `MessagesCmd::Edit` dispatch through `read_or_stdin`, matching `Send` (which already documents `-` as the stdin sentinel), and document `-` in the `--content` help text.

Verified against a live relay: after the fix the kind 40003 edit event carries the full stdin content, including multiline/UTF-8 bodies.