### PR TITLE
fix(desktop): preserve membership refresh during an in-flight channel fetch

### DIFF
--- a/desktop/src/features/channels/useMembershipNotifications.test.mjs
+++ b/desktop/src/features/channels/useMembershipNotifications.test.mjs
@@ -1,5 +1,15 @@
+/**
+ * Tests for the membership-notification channel-list refresh gate.
+ *
+ * These run against a real QueryClient and drive the 500ms trailing debounce
+ * with node:test fake timers, so there are no wall-clock sleeps. `isFetching`
+ * is deliberately never stubbed: the behaviour under test is which queries the
+ * gate's filter matches, and a wholesale stub would answer that question for
+ * the seam instead of exercising it.
+ */
+
 import assert from "node:assert/strict";
-import { after, before, test } from "node:test";
+import { after, before, mock, test } from "node:test";
 
 import { JSDOM } from "jsdom";
 
@@ -18,7 +28,33 @@ before(() => {
 
 after(() => dom.window.close());
 
-test("membership refresh survives an in-flight channel fetch", async () => {
+const CHANNEL_ID = "new-channel";
+const VIEWER = "viewer-pubkey";
+/** Mirrors CHANNELS_INVALIDATE_DEBOUNCE_MS in useMembershipNotifications.ts. */
+const DEBOUNCE_MS = 500;
+
+/**
+ * Park a real query in `fetching` until `settle()` is called. The fetch promise
+ * is kept so the test can await it before teardown: a query still in flight
+ * when the client is cleared leaves that promise pending forever.
+ */
+function startDeferredQuery(queryClient, queryKey) {
+  let release;
+  const pending = new Promise((resolve) => {
+    release = resolve;
+  });
+  const fetched = queryClient
+    .fetchQuery({ queryKey, queryFn: () => pending })
+    .catch(() => {});
+  return {
+    settle: async (value = []) => {
+      release(value);
+      await fetched;
+    },
+  };
+}
+
+async function mountHook() {
   const React = await import("react");
   const { act, cleanup, renderHook } = await import("@testing-library/react");
   const { QueryClient, QueryClientProvider } = await import(
@@ -40,62 +76,174 @@ test("membership refresh survives an in-flight channel fetch", async () => {
   };
 
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    // An infinite gcTime schedules no collection timer at all. A finite one is
+    // armed on the mocked clock when a query settles and is still owed when the
+    // clock is restored, which leaves the test runner waiting on it.
+    defaultOptions: {
+      queries: { gcTime: Number.POSITIVE_INFINITY, retry: false },
+    },
   });
-  const invalidations = [];
-  queryClient.invalidateQueries = async ({ queryKey }) => {
-    invalidations.push(queryKey);
+  // Wrap rather than replace, so real invalidation still runs while the keys
+  // are recorded.
+  const invalidated = [];
+  const realInvalidateQueries = queryClient.invalidateQueries.bind(queryClient);
+  queryClient.invalidateQueries = (filters, options) => {
+    invalidated.push(filters?.queryKey);
+    return realInvalidateQueries(filters, options);
   };
-  let fetching = 1;
-  queryClient.isFetching = () => fetching;
+
   const wrapper = ({ children }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 
-  try {
-    renderHook(() => useMembershipNotifications("viewer-pubkey"), { wrapper });
-    await act(async () => new Promise((resolve) => setImmediate(resolve)));
+  renderHook(() => useMembershipNotifications(VIEWER), { wrapper });
+  await act(async () => new Promise((resolve) => setImmediate(resolve)));
 
-    await act(async () => {
-      listener({
-        id: "membership",
-        pubkey: "relay",
-        created_at: 1,
-        kind: KIND_MEMBER_ADDED_NOTIFICATION,
-        tags: [
-          ["p", "viewer-pubkey"],
-          ["h", "new-channel"],
-        ],
-        content: "",
-        sig: "sig",
+  return {
+    queryClient,
+    invalidated,
+    /** Only the bare ["channels"] list key; detail/members are 3 segments. */
+    listRefreshes: () => invalidated.filter((key) => key.length === 1),
+    emitMembershipEvent: async () => {
+      await act(async () => {
+        listener({
+          id: "membership",
+          pubkey: "relay",
+          created_at: 1,
+          kind: KIND_MEMBER_ADDED_NOTIFICATION,
+          tags: [
+            ["p", VIEWER],
+            ["h", CHANNEL_ID],
+          ],
+          content: "",
+          sig: "sig",
+        });
       });
-    });
+    },
+    flush: async () => {
+      await act(async () => new Promise((resolve) => setImmediate(resolve)));
+    },
+    dispose: () => {
+      cleanup();
+      queryClient.clear();
+      relayClient.subscribeLive = originalSubscribeLive;
+    },
+  };
+}
 
-    assert.deepEqual(invalidations, [
-      ["channels", "new-channel", "detail"],
-      ["channels", "new-channel", "members"],
+test("an in-flight members fetch does not hold back the channel list refresh", async () => {
+  const harness = await mountHook();
+  const { queryClient } = harness;
+  try {
+    // The list query is present and idle; only a sibling members fetch is in
+    // flight — the exact shape this handler creates when it kicks detail and
+    // members before the debounce fires.
+    queryClient.setQueryData(["channels"], [{ id: "seed" }]);
+    const members = startDeferredQuery(queryClient, [
+      "channels",
+      CHANNEL_ID,
+      "members",
     ]);
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
+    // Fixture sanity: the prefix and exact filters must genuinely disagree
+    // here, or this test would pass whichever one the gate uses.
     assert.equal(
-      invalidations.filter((key) => key.length === 1).length,
+      queryClient.isFetching({ queryKey: ["channels"] }),
+      1,
+      "fixture: a prefix match counts the in-flight members fetch",
+    );
+    assert.equal(
+      queryClient.isFetching({ queryKey: ["channels"], exact: true }),
       0,
+      "fixture: an exact match sees the list query itself as idle",
+    );
+
+    mock.timers.enable({ apis: ["setTimeout"] });
+    await harness.emitMembershipEvent();
+    assert.deepEqual(
+      harness.listRefreshes(),
+      [],
+      "the list refresh is debounced, never immediate",
+    );
+
+    mock.timers.tick(DEBOUNCE_MS);
+    assert.deepEqual(
+      harness.listRefreshes(),
+      [["channels"]],
+      "the list refresh lands even though a members fetch is still in flight",
+    );
+
+    // The members fetch really was still in flight when the refresh landed.
+    assert.equal(
+      queryClient.isFetching({ queryKey: ["channels"] }),
+      1,
+      "the members fetch outlived the list refresh it must not have blocked",
+    );
+    await members.settle();
+  } finally {
+    mock.timers.reset();
+    harness.dispose();
+  }
+});
+
+test("membership refresh survives an in-flight channel fetch", async () => {
+  const harness = await mountHook();
+  const { queryClient } = harness;
+  try {
+    const list = startDeferredQuery(queryClient, ["channels"]);
+    assert.equal(
+      queryClient.isFetching({ queryKey: ["channels"], exact: true }),
+      1,
+      "fixture: get_channels itself is in flight",
+    );
+
+    mock.timers.enable({ apis: ["setTimeout"] });
+    await harness.emitMembershipEvent();
+    assert.deepEqual(
+      harness.invalidated,
+      [
+        ["channels", CHANNEL_ID, "detail"],
+        ["channels", CHANNEL_ID, "members"],
+      ],
+      "detail and members refresh immediately",
+    );
+
+    mock.timers.tick(DEBOUNCE_MS);
+    assert.deepEqual(
+      harness.listRefreshes(),
+      [],
       "must not invalidate the channel list while get_channels is in flight",
     );
 
-    fetching = 0;
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
-    assert.deepEqual(invalidations, [
-      ["channels", "new-channel", "detail"],
-      ["channels", "new-channel", "members"],
-      ["channels"],
-    ]);
+    // Still parked several debounce windows later: the gate re-arms rather
+    // than dropping the dirty signal.
+    mock.timers.tick(DEBOUNCE_MS * 4);
+    assert.deepEqual(
+      harness.listRefreshes(),
+      [],
+      "the deferred refresh stays armed instead of firing early",
+    );
+
+    // get_channels settles; the next quiet window lets the refresh land.
+    await list.settle();
+    await harness.flush();
+    assert.equal(
+      queryClient.isFetching({ queryKey: ["channels"], exact: true }),
+      0,
+      "fixture: the list query really did go idle",
+    );
+
+    mock.timers.tick(DEBOUNCE_MS);
+    assert.deepEqual(
+      harness.invalidated,
+      [
+        ["channels", CHANNEL_ID, "detail"],
+        ["channels", CHANNEL_ID, "members"],
+        ["channels"],
+      ],
+      "the deferred list refresh lands once the fetch is idle",
+    );
   } finally {
-    cleanup();
-    queryClient.clear();
-    relayClient.subscribeLive = originalSubscribeLive;
+    mock.timers.reset();
+    harness.dispose();
   }
 });

--- a/desktop/src/features/channels/useMembershipNotifications.test.mjs
+++ b/desktop/src/features/channels/useMembershipNotifications.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+after(() => dom.window.close());
+
+test("membership refresh survives an in-flight channel fetch", async () => {
+  const React = await import("react");
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { QueryClient, QueryClientProvider } = await import(
+    "@tanstack/react-query"
+  );
+  const { relayClient } = await import("@/shared/api/relayClient");
+  const { KIND_MEMBER_ADDED_NOTIFICATION } = await import(
+    "@/shared/constants/kinds"
+  );
+  const { useMembershipNotifications } = await import(
+    "./useMembershipNotifications.ts"
+  );
+
+  const originalSubscribeLive = relayClient.subscribeLive;
+  let listener;
+  relayClient.subscribeLive = async (_filter, nextListener) => {
+    listener = nextListener;
+    return async () => {};
+  };
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const invalidations = [];
+  queryClient.invalidateQueries = async ({ queryKey }) => {
+    invalidations.push(queryKey);
+  };
+  let fetching = 1;
+  queryClient.isFetching = () => fetching;
+  const wrapper = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  try {
+    renderHook(() => useMembershipNotifications("viewer-pubkey"), { wrapper });
+    await act(async () => new Promise((resolve) => setImmediate(resolve)));
+
+    await act(async () => {
+      listener({
+        id: "membership",
+        pubkey: "relay",
+        created_at: 1,
+        kind: KIND_MEMBER_ADDED_NOTIFICATION,
+        tags: [
+          ["p", "viewer-pubkey"],
+          ["h", "new-channel"],
+        ],
+        content: "",
+        sig: "sig",
+      });
+    });
+
+    assert.deepEqual(invalidations, [
+      ["channels", "new-channel", "detail"],
+      ["channels", "new-channel", "members"],
+    ]);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+    assert.equal(
+      invalidations.filter((key) => key.length === 1).length,
+      0,
+      "must not invalidate the channel list while get_channels is in flight",
+    );
+
+    fetching = 0;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+    assert.deepEqual(invalidations, [
+      ["channels", "new-channel", "detail"],
+      ["channels", "new-channel", "members"],
+      ["channels"],
+    ]);
+  } finally {
+    cleanup();
+    queryClient.clear();
+    relayClient.subscribeLive = originalSubscribeLive;
+  }
+});

--- a/desktop/src/features/channels/useMembershipNotifications.ts
+++ b/desktop/src/features/channels/useMembershipNotifications.ts
@@ -26,8 +26,12 @@ export function useMembershipNotifications(currentPubkey?: string) {
   if (channelsInvalidateRef.current === null) {
     channelsInvalidateRef.current = createTrailingDebounce(() => {
       refreshChannelsWhenIdle({
+        // Scope the gate to the list query itself. A prefix match would also
+        // count ["channels", id, "detail"] and ["channels", id, "members"] —
+        // the very fetches this handler kicks off — so the list refresh would
+        // be held closed by its own siblings and re-armed indefinitely.
         isFetching: () =>
-          queryClient.isFetching({ queryKey: channelsQueryKey }),
+          queryClient.isFetching({ queryKey: channelsQueryKey, exact: true }),
         invalidate: () => {
           void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
         },

--- a/desktop/src/features/channels/useMembershipNotifications.ts
+++ b/desktop/src/features/channels/useMembershipNotifications.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { channelsQueryKey } from "@/features/channels/hooks";
+import { refreshChannelsWhenIdle } from "@/features/channels/refreshChannelsWhenIdle";
 import { getChannelIdFromTags } from "@/features/messages/lib/threading";
 import { relayClient } from "@/shared/api/relayClient";
 import type { RelayEvent } from "@/shared/api/types";
@@ -9,19 +10,37 @@ import {
   KIND_MEMBER_ADDED_NOTIFICATION,
   KIND_MEMBER_REMOVED_NOTIFICATION,
 } from "@/shared/constants/kinds";
+import {
+  createTrailingDebounce,
+  type TrailingDebounce,
+} from "@/shared/lib/trailingDebounce";
 
 const MEMBERSHIP_NOTIFICATION_RETRY_BASE_MS = 1_000;
 const MEMBERSHIP_NOTIFICATION_RETRY_MAX_MS = 30_000;
+const CHANNELS_INVALIDATE_DEBOUNCE_MS = 500;
 
 export function useMembershipNotifications(currentPubkey?: string) {
   const queryClient = useQueryClient();
   const normalizedCurrentPubkey = currentPubkey?.trim().toLowerCase() ?? "";
+  const channelsInvalidateRef = React.useRef<TrailingDebounce | null>(null);
+  if (channelsInvalidateRef.current === null) {
+    channelsInvalidateRef.current = createTrailingDebounce(() => {
+      refreshChannelsWhenIdle({
+        isFetching: () =>
+          queryClient.isFetching({ queryKey: channelsQueryKey }),
+        invalidate: () => {
+          void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+        },
+        reArm: () => channelsInvalidateRef.current?.trigger(),
+      });
+    }, CHANNELS_INVALIDATE_DEBOUNCE_MS);
+  }
 
   const handleMembershipNotification = React.useEffectEvent(
     (event: RelayEvent) => {
       const channelId = getChannelIdFromTags(event.tags);
 
-      void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+      channelsInvalidateRef.current?.trigger();
       if (!channelId) {
         return;
       }
@@ -99,6 +118,7 @@ export function useMembershipNotifications(currentPubkey?: string) {
       if (retryTimeout !== undefined) {
         window.clearTimeout(retryTimeout);
       }
+      channelsInvalidateRef.current?.cancel();
       if (dispose) {
         void dispose().catch(() => {});
       }


### PR DESCRIPTION
## Summary

Keep the Desktop joined-channel list live when a membership notification
arrives while `get_channels` is already in flight.

- Route kind `44100` / `44101` channel-list invalidation through the existing
  `refreshChannelsWhenIdle` helper.
- Coalesce bursts with the existing trailing-debounce utility.
- Re-arm while the channel query is fetching, then invalidate exactly once
  after it becomes idle.
- Keep the affected channel's detail and member-list invalidations immediate.
- Cancel the pending debounce when the identity-scoped hook unmounts.

## Problem

`useMembershipNotifications` currently invalidates `channelsQueryKey`
immediately. If an older `get_channels` request is already running, the
membership signal can lose this ordering:

1. `get_channels` starts and reads the pre-membership list.
2. A kind `44100` or `44101` arrives and invalidates the query.
3. The older request settles with pre-event data and clears the dirty state.
4. The Channels / Forums sidebar remains stale until the next polling,
   browse, or reconnect refresh.

The repository already documents and solves this race for ordinary live
channel traffic in `refreshChannelsWhenIdle`. This change applies the same
boundary to membership-driven discovery.

## Scope

This is intentionally client-only and narrow. It does not:

- change relay membership or NIP-29 event emission;
- add a global kind `39002` subscription (those discovery events are
  channel-scoped);
- change terminal `CLOSED` retry policy;
- restore broad focus-triggered query refetch; or
- add a second manual refresh control.

## User impact

When another member adds or removes the signed-in user, the Desktop channel
navigation converges immediately after any already-running channel fetch
settles instead of remaining stale for up to the next one-minute poll. The same
shared cache update also refreshes downstream channel-bound subscriptions,
search/reference resolution, unread state, and navigation labels.

## Testing

- [x] Regression: deliver a membership event while the channel query reports
      one active fetch; prove channel detail and member-list keys invalidate
      immediately while the channel-list invalidation waits for idle, then
      lands exactly once.
- [x] Full Desktop unit suite.
- [x] Desktop typecheck.
- [x] Sidebar channel-list E2E suite.
- [x] Biome check for the changed source and regression test.
- [x] `git diff --check`.

Related: #6713
