### PR TITLE
fix(acp): hold batches through provider usage limits instead of dead-lettering them

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -14,6 +14,7 @@ mod relay;
 mod scope;
 mod setup_mode;
 mod usage;
+mod usage_limit;
 
 pub use usage::TurnUsage;
 
@@ -4497,7 +4498,112 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
     message.contains("Re-authenticate") || message.contains("API Error: 401")
 }
 
-/// Spawn a task that posts a user-visible failure notice to the relay.
+/// Extract the provider usage-limit error behind a failed prompt, if that is
+/// what failed it. See [`usage_limit`] for the classification and why such
+/// errors are held rather than retried with backoff.
+fn usage_limit_from_outcome(outcome: &PromptOutcome) -> Option<usage_limit::UsageLimit> {
+    match outcome {
+        PromptOutcome::Error(acp::AcpError::AgentError { message, .. }) => {
+            usage_limit::detect(message)
+        }
+        _ => None,
+    }
+}
+
+/// Maximum characters of an event's content quoted in a failure notice.
+const NOTICE_EXCERPT_CHARS: usize = 80;
+
+/// Describe the events of a failed batch for a channel notice: which agent
+/// and turn they belonged to, and one `buzz://message` deep link per event
+/// with its author, time and an excerpt of what was asked.
+///
+/// A bare "please re-send" leaves the reader guessing *what* was lost —
+/// during a fleet-wide usage-limit outage a dozen agents each drop a different
+/// request into the same channel. The deep link resolves the original event
+/// in Buzz Desktop even when the notice cannot be threaded under it.
+fn describe_batch_events(batch: &FlushBatch, turn_id: &str, config: &Config) -> String {
+    let mut out = format!(
+        "Affected: {} event(s) for {}, turn `{turn_id}`",
+        batch.events.len(),
+        agent_label(config)
+    );
+    for be in &batch.events {
+        let event = &be.event;
+        let mut link = format!(
+            "buzz://message?channel={}&id={}",
+            batch.channel_id,
+            event.id.to_hex()
+        );
+        if let Some(root) = queue::parse_thread_tags(event).root_event_id {
+            link.push_str("&thread=");
+            link.push_str(&root);
+        }
+        let author: String = nostr::ToBech32::to_bech32(&event.pubkey)
+            .unwrap_or_else(|_| event.pubkey.to_hex())
+            .chars()
+            .take(12)
+            .collect();
+        let when =
+            chrono::TimeZone::timestamp_opt(&chrono::Utc, event.created_at.as_secs() as i64, 0)
+                .single()
+                .map(|t| {
+                    t.with_timezone(&chrono::Local)
+                        .format("%Y-%m-%d %H:%M (%:z)")
+                        .to_string()
+                })
+                .unwrap_or_else(|| event.created_at.as_secs().to_string());
+        let excerpt = notice_excerpt(&event.content);
+        out.push_str(&format!("\n• {link} — {author}… at {when}: “{excerpt}”"));
+    }
+    out
+}
+
+/// The agent's display name from `BUZZ_ACP_DISPLAY_NAME` (the same contract
+/// forwarded to dev-mcp for git authorship), falling back to its npub.
+fn agent_label(config: &Config) -> String {
+    match std::env::var("BUZZ_ACP_DISPLAY_NAME") {
+        Ok(name) if !name.trim().is_empty() => name.trim().to_string(),
+        _ => nostr::ToBech32::to_bech32(&config.keys.public_key())
+            .unwrap_or_else(|_| config.keys.public_key().to_hex()),
+    }
+}
+
+/// First non-empty line of `content`, whitespace-collapsed, capped at
+/// [`NOTICE_EXCERPT_CHARS`] characters with an ellipsis.
+fn notice_excerpt(content: &str) -> String {
+    let line = content
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    let collapsed = line.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = collapsed.chars();
+    let head: String = chars.by_ref().take(NOTICE_EXCERPT_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
+/// Spawn a task that posts a user-visible notice to the relay, threaded per
+/// `thread_tags` (empty tags → top-level channel post).
+fn spawn_notice(
+    rest_client: Option<&relay::RestClient>,
+    channel_id: Uuid,
+    thread_tags: queue::ThreadTags,
+    content: String,
+) {
+    if let Some(rest) = rest_client {
+        let rest = rest.clone();
+        tokio::spawn(async move {
+            pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
+        });
+    }
+}
+
+/// Spawn a task that posts a user-visible failure notice to the relay, in the
+/// thread of the batch's last event.
 ///
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
 /// dead-letter path so neither duplicates the tokio::spawn block.
@@ -4506,18 +4612,12 @@ fn spawn_failure_notice(
     batch: &FlushBatch,
     content: String,
 ) {
-    if let Some(rest) = rest_client {
-        let thread_tags = batch
-            .events
-            .last()
-            .map(|be| queue::parse_thread_tags(&be.event))
-            .unwrap_or_default();
-        let rest = rest.clone();
-        let channel_id = batch.channel_id;
-        tokio::spawn(async move {
-            pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
-        });
-    }
+    let thread_tags = batch
+        .events
+        .last()
+        .map(|be| queue::parse_thread_tags(&be.event))
+        .unwrap_or_default();
+    spawn_notice(rest_client, batch.channel_id, thread_tags, content);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4580,6 +4680,9 @@ fn handle_prompt_result(
         // Don't requeue batches for channels the agent was removed from —
         // those events are stale and should be silently dropped.
         if !removed_channels.contains(&batch.channel_id) {
+            // Computed up front: every notice below quotes the batch, and the
+            // requeue/hold branches consume it.
+            let details = describe_batch_events(&batch, &result.turn_id, config);
             if matches!(
                 result.outcome,
                 PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
@@ -4613,7 +4716,7 @@ fn handle_prompt_result(
                     batch.events.len(),
                 );
                 let content = format!(
-                    "⚠️ I couldn't process the last request (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.",
+                    "⚠️ I couldn't process the last request (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.\n\n{details}",
                     config.max_turn_duration_secs
                 );
                 spawn_failure_notice(rest_client, &batch, content);
@@ -4631,13 +4734,54 @@ fn handle_prompt_result(
                 );
                 if let Some(dead) = queue.requeue(batch) {
                     let content = format!(
-                        "⚠️ I couldn't process the last request after multiple retries (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.",
+                        "⚠️ I couldn't process the last request after multiple retries (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.\n\n{details}",
                         config.max_turn_duration_secs
                     );
                     spawn_failure_notice(rest_client, &dead, content);
                     hard_timeout_fate_suffix = Some(" — dead-lettered (retry budget exhausted)");
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
+                }
+            } else if let Some(limit) = usage_limit_from_outcome(&result.outcome) {
+                // Provider usage limit: deterministic until the window resets,
+                // so hold the batch until then rather than burning the retry
+                // budget and discarding the event. Observed 2026-09-03: a
+                // five-hour account limit failed 183 turns across 15 agents;
+                // every pending batch was dead-lettered within ~20 minutes and
+                // nothing resumed once the limit lifted.
+                let delay = limit.hold_delay(chrono::Local::now());
+                let resets = limit.reset_label();
+                tracing::warn!(
+                    channel_id = %batch.channel_id,
+                    events = batch.events.len(),
+                    hold_secs = delay.as_secs(),
+                    resets_at = resets.as_deref().unwrap_or("unknown"),
+                    "usage limit hit — holding batch until it resets"
+                );
+                let channel_id = batch.channel_id;
+                let thread_tags = batch
+                    .events
+                    .last()
+                    .map(|be| queue::parse_thread_tags(&be.event))
+                    .unwrap_or_default();
+                let first_hold = queue.usage_limit_holds(&batch.scope) == 0;
+                if let Some(dead) = queue.requeue_held(batch, delay) {
+                    let content = format!(
+                        "⚠️ I couldn't process the last request: the provider usage limit was still in force after {} waits for it to reset. Please re-send if it's still needed.\n\n{details}",
+                        queue::MAX_USAGE_LIMIT_HOLDS
+                    );
+                    spawn_failure_notice(rest_client, &dead, content);
+                } else if first_hold {
+                    // Tell the channel once per hold series why the agent has
+                    // gone quiet and that nothing needs re-sending.
+                    let when = match &resets {
+                        Some(at) => format!("once it resets at {at}"),
+                        None => format!("in about {} minutes", delay.as_secs().div_ceil(60)),
+                    };
+                    let content = format!(
+                        "⏳ The provider usage limit was hit, so I couldn't process the last request yet. I'll retry it automatically {when} — no need to re-send.\n\n{details}"
+                    );
+                    spawn_notice(rest_client, channel_id, thread_tags, content);
                 }
             } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_auth_error(e)) {
                 // Auth errors are non-retryable: the token won't self-repair
@@ -4649,10 +4793,11 @@ fn handle_prompt_result(
                     events = batch.events.len(),
                     "dead-lettering batch immediately — non-retryable auth error"
                 );
-                let content = "⚠️ I couldn't process the last request: authentication failed. \
+                let content = format!(
+                    "⚠️ I couldn't process the last request: authentication failed. \
                     Please re-authenticate the CLI (e.g. run `claude /login` or `codex login`) \
-                    and then re-send."
-                    .to_string();
+                    and then re-send.\n\n{details}"
+                );
                 spawn_failure_notice(rest_client, &batch, content);
             } else if let Some(dead) = queue.requeue(batch) {
                 let reason = match &result.outcome {
@@ -4666,7 +4811,7 @@ fn handle_prompt_result(
                     _ => "repeated failures".to_string(),
                 };
                 let content = format!(
-                    "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
+                    "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed.\n\n{details}"
                 );
                 spawn_failure_notice(rest_client, &dead, content);
             }
@@ -10745,6 +10890,208 @@ mod error_outcome_emission_tests {
             0,
             "auth error must dead-letter immediately — no events should be pending"
         );
+    }
+
+    // ── usage-limit hold behavior ─────────────────────────────────────────
+
+    /// The exact message observed in the 2026-09-03 fleet incident.
+    const LIMIT_MSG: &str =
+        "Internal error: You've hit your session limit · resets 3:10am (Asia/Seoul)";
+
+    fn limit_error() -> AcpError {
+        AcpError::AgentError {
+            code: -32603,
+            message: LIMIT_MSG.to_string(),
+        }
+    }
+
+    fn one_event_batch(channel_id: uuid::Uuid, content: &str) -> FlushBatch {
+        let keys = nostr::Keys::generate();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), content)
+            .sign_with_keys(&keys)
+            .unwrap();
+        FlushBatch {
+            channel_id,
+            scope: scope::SessionScope::Conversation { channel_id },
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        }
+    }
+
+    /// Drive `handle_prompt_result` with an error outcome for `batch` against
+    /// `queue`, no observer and no relay — the queue state afterwards is the
+    /// observable.
+    async fn run_error_outcome(
+        queue: &mut EventQueue,
+        channel_id: uuid::Uuid,
+        batch: FlushBatch,
+        error: AcpError,
+    ) {
+        let agent = dummy_agent(0).await;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: None,
+                scope: None,
+                turn_id: "test-turn-id".to_string(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let removed_channels = std::collections::HashSet::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+        let result = PromptResult {
+            agent,
+            source: PromptSource::Channel(scope::SessionScope::Conversation { channel_id }),
+            turn_id: "test-turn-id".to_string(),
+            outcome: PromptOutcome::Error(error),
+            batch: Some(batch),
+        };
+        handle_prompt_result(
+            &mut pool,
+            queue,
+            &config,
+            result,
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+        );
+    }
+
+    /// A usage-limit `PromptOutcome::Error` (Claude Code "hit your session
+    /// limit · resets …") must hold the batch until the reset instead of
+    /// entering the backoff/dead-letter path: the event stays queued, the
+    /// scope is throttled for the time until reset, and the retry budget is
+    /// untouched.
+    #[tokio::test]
+    async fn usage_limit_error_holds_batch_without_consuming_retry_budget() {
+        let channel_id = uuid::Uuid::new_v4();
+        let batch = one_event_batch(channel_id, "please deploy the release");
+        let event_id = batch.events[0].event.id;
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+
+        run_error_outcome(&mut queue, channel_id, batch, limit_error()).await;
+
+        assert_eq!(
+            queue.queued_event_count(channel_id),
+            1,
+            "held batch must stay queued, not be dead-lettered"
+        );
+        assert_eq!(
+            queue.retry_count_for_test(channel_id),
+            0,
+            "a usage-limit hold must not consume the retry budget"
+        );
+        assert_eq!(queue.usage_limit_holds(channel_id), 1);
+        let remaining = queue
+            .retry_after_remaining_for_test(channel_id)
+            .expect("scope throttled until the reset");
+        let buffer = std::time::Duration::from_secs(usage_limit::RESET_BUFFER_SECS);
+        // "resets 3:10am" is at most a day away, and always a real wait
+        // (buffer included) rather than a backoff-sized delay.
+        assert!(
+            remaining > buffer && remaining <= std::time::Duration::from_secs(24 * 3600) + buffer,
+            "unexpected hold {remaining:?}"
+        );
+        assert!(
+            queue.flush_next().is_none(),
+            "held scope must not flush before the reset"
+        );
+        assert_eq!(queue.queued_event_ids_for_test(channel_id), vec![event_id]);
+    }
+
+    /// Past [`queue::MAX_USAGE_LIMIT_HOLDS`] consecutive holds the batch is
+    /// dead-lettered like an exhausted retry budget, so a permanently
+    /// exhausted account cannot pin a scope forever.
+    #[tokio::test]
+    async fn usage_limit_holds_past_the_cap_dead_letter() {
+        let channel_id = uuid::Uuid::new_v4();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        queue.set_usage_limit_holds_for_test(channel_id, queue::MAX_USAGE_LIMIT_HOLDS);
+
+        run_error_outcome(
+            &mut queue,
+            channel_id,
+            one_event_batch(channel_id, "x"),
+            limit_error(),
+        )
+        .await;
+
+        assert_eq!(queue.queued_event_count(channel_id), 0);
+        assert_eq!(queue.pending_channels(), 0);
+        assert_eq!(queue.usage_limit_holds(channel_id), 0);
+    }
+
+    /// Only `AgentError`s that read as a usage limit take the hold path; auth
+    /// and other application errors keep their existing classification.
+    #[test]
+    fn usage_limit_is_recognised_only_for_limit_errors() {
+        assert!(usage_limit_from_outcome(&PromptOutcome::Error(limit_error())).is_some());
+        for message in [
+            "API Error: 401 OAuth access token has expired. Re-authenticate to continue.",
+            "Usage credits required for 1M context",
+        ] {
+            let outcome = PromptOutcome::Error(AcpError::AgentError {
+                code: -32000,
+                message: message.to_string(),
+            });
+            assert!(usage_limit_from_outcome(&outcome).is_none(), "{message}");
+        }
+        assert!(usage_limit_from_outcome(&PromptOutcome::AgentExited).is_none());
+    }
+
+    /// The failure/hold notice names the turn and deep-links every affected
+    /// event with an excerpt, so a reader can find what was dropped.
+    #[test]
+    fn notice_details_link_the_original_event_with_an_excerpt() {
+        let channel_id = uuid::Uuid::new_v4();
+        let batch = one_event_batch(
+            channel_id,
+            "@agent please deploy the release to staging\nand ignore this second line",
+        );
+        let event = &batch.events[0].event;
+        let details = describe_batch_events(&batch, "turn-42", &test_config());
+
+        let link = format!(
+            "buzz://message?channel={channel_id}&id={}",
+            event.id.to_hex()
+        );
+        assert!(details.contains(&link), "{details}");
+        assert!(details.contains("turn `turn-42`"), "{details}");
+        assert!(details.contains("1 event(s)"), "{details}");
+        assert!(
+            details.contains("“@agent please deploy the release to staging”"),
+            "{details}"
+        );
+        assert!(!details.contains("second line"), "{details}");
+
+        let long = "x".repeat(NOTICE_EXCERPT_CHARS + 20);
+        let excerpt = notice_excerpt(&format!("  {long}  "));
+        assert_eq!(excerpt.chars().count(), NOTICE_EXCERPT_CHARS + 1);
+        assert!(excerpt.ends_with('…'));
+        assert_eq!(notice_excerpt("\n\n  spaced   out  \n"), "spaced out");
     }
 
     /// A non-auth application error (e.g. usage credits) must still follow the

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -83,6 +83,17 @@ const MAX_BATCH_EVENTS: usize = 50;
 /// Maximum retry attempts before a batch is dead-lettered.
 pub(crate) const MAX_RETRIES: u32 = 10;
 
+/// Maximum consecutive usage-limit holds per scope before the batch is
+/// dead-lettered anyway.
+///
+/// A hold ([`EventQueue::requeue_held`]) lasts until the provider's parsed
+/// reset time (or [`crate::usage_limit::FALLBACK_HOLD_SECS`] without one) and
+/// does not consume the [`MAX_RETRIES`] budget. This cap bounds a scope that
+/// keeps hitting the limit at every reset — a misparsed time or a permanently
+/// exhausted account — so it cannot be held forever. Holds reset on the
+/// scope's next successful turn, like `retry_counts`.
+pub(crate) const MAX_USAGE_LIMIT_HOLDS: u32 = 24;
+
 /// Base retry delay in seconds (doubled each attempt).
 const BASE_RETRY_DELAY_SECS: u64 = 5;
 
@@ -162,6 +173,7 @@ pub struct FlushBatch {
 ///   in_flight_deadlines:  Map<channel_id, Instant>                (auto-expire after in_flight_deadline)
 ///   retry_after:          Map<channel_id, Instant>
 ///   retry_counts:         Map<channel_id, u32>                    (dead-letter after MAX_RETRIES)
+///   usage_limit_holds:    Map<channel_id, u32>                    (dead-letter after MAX_USAGE_LIMIT_HOLDS)
 ///   dedup_mode:           DedupMode
 ///
 /// Transitions:
@@ -189,12 +201,18 @@ pub struct FlushBatch {
 ///     in_flight_channels.remove(channel_id)
 ///     in_flight_deadlines.remove(channel_id)
 ///     retry_counts.remove(channel_id)
+///     usage_limit_holds.remove(channel_id)
 ///     clean up expired retry_after entry if present
 ///
 ///   requeue(batch):
 ///     increment retry_counts[channel]
 ///     if retry_counts[channel] > MAX_RETRIES: dead-letter (log ERROR, return batch to caller)
 ///     else: push_front with original received_at, set exponential backoff retry_after with jitter
+///
+///   requeue_held(batch, delay):            (provider usage limit — see crate::usage_limit)
+///     increment usage_limit_holds[channel]  (retry_counts untouched)
+///     if usage_limit_holds[channel] > MAX_USAGE_LIMIT_HOLDS: dead-letter (log ERROR, return batch to caller)
+///     else: push_front with original received_at, set retry_after = now + delay (the limit's reset)
 /// ```
 pub struct EventQueue {
     queues: HashMap<SessionScope, VecDeque<QueuedEvent>>,
@@ -206,6 +224,11 @@ pub struct EventQueue {
     retry_after: HashMap<SessionScope, Instant>,
     /// Per-scope retry attempt counter for exponential backoff / dead-lettering.
     retry_counts: HashMap<SessionScope, u32>,
+    /// Per-scope count of consecutive usage-limit holds (see
+    /// [`requeue_held`](Self::requeue_held)); dead-letter after
+    /// [`MAX_USAGE_LIMIT_HOLDS`]. Kept apart from `retry_counts` so a hold
+    /// never eats into the transient-failure budget.
+    usage_limit_holds: HashMap<SessionScope, u32>,
     dedup_mode: DedupMode,
     /// Events from cancelled batches, keyed by channel. Merged into the next
     /// `FlushBatch` for that channel as `cancelled_events` so `format_prompt()`
@@ -246,6 +269,7 @@ impl EventQueue {
             in_flight_batch_sizes: HashMap::new(),
             retry_after: HashMap::new(),
             retry_counts: HashMap::new(),
+            usage_limit_holds: HashMap::new(),
             dedup_mode,
             cancelled_batches: HashMap::new(),
             cancel_reasons: HashMap::new(),
@@ -518,9 +542,11 @@ impl EventQueue {
             Some(_) => {
                 self.retry_after.remove(&scope);
                 self.retry_counts.remove(&scope);
+                self.usage_limit_holds.remove(&scope);
             }
             None => {
                 self.retry_counts.remove(&scope);
+                self.usage_limit_holds.remove(&scope);
             }
         }
     }
@@ -561,6 +587,7 @@ impl EventQueue {
                 batch.events.len(),
             );
             self.retry_counts.remove(&scope);
+            self.usage_limit_holds.remove(&scope);
             // Also clear retry_after so fresh traffic on this scope isn't
             // throttled by stale backoff from the discarded poison batch.
             self.retry_after.remove(&scope);
@@ -615,6 +642,73 @@ impl EventQueue {
         self.retry_after.insert(scope, Instant::now() + delay);
         self.enforce_channel_cap(channel_id);
         None
+    }
+
+    /// Re-queue a batch whose prompt failed on a provider usage limit, holding
+    /// the scope for `delay` — until the limit's parsed reset, see
+    /// [`crate::usage_limit`].
+    ///
+    /// Unlike [`requeue`](Self::requeue) this does **not** consume the retry
+    /// budget: the failure is deterministic until the window resets, so
+    /// counting it dead-letters every batch that outlives ten backoff steps
+    /// (≈ 20 minutes) and discards the event exactly when it could finally
+    /// run. Consecutive holds are counted separately and capped at
+    /// [`MAX_USAGE_LIMIT_HOLDS`]; past the cap the batch is dead-lettered and
+    /// returned to the caller, like an exhausted retry budget. Returns `None`
+    /// when the batch was held.
+    ///
+    /// The whole batch is restored via
+    /// [`requeue_preserve_timestamps`](Self::requeue_preserve_timestamps), so
+    /// an interrupted turn's cancelled carryover survives the hold too.
+    ///
+    /// Note: does NOT remove from `in_flight_scopes` — caller must call
+    /// `mark_complete` separately (which keeps both counters while the hold
+    /// is active, exactly as for a backoff requeue).
+    pub fn requeue_held(&mut self, batch: FlushBatch, delay: Duration) -> Option<FlushBatch> {
+        let channel_id = batch.channel_id;
+        let scope = batch.scope.clone();
+        let hold = {
+            let count = self.usage_limit_holds.entry(scope.clone()).or_insert(0);
+            *count += 1;
+            *count
+        };
+
+        if hold > MAX_USAGE_LIMIT_HOLDS {
+            tracing::error!(
+                channel_id = %channel_id,
+                hold,
+                events = batch.events.len(),
+                "dead-lettering batch after {} usage-limit holds — discarding {} events",
+                MAX_USAGE_LIMIT_HOLDS,
+                batch.events.len(),
+            );
+            self.usage_limit_holds.remove(&scope);
+            self.retry_counts.remove(&scope);
+            self.retry_after.remove(&scope);
+            return Some(batch);
+        }
+
+        tracing::warn!(
+            channel_id = %channel_id,
+            scope = %scope.telemetry_label(),
+            hold,
+            max = MAX_USAGE_LIMIT_HOLDS,
+            delay_secs = delay.as_secs(),
+            events = batch.events.len(),
+            "holding batch until the usage limit resets"
+        );
+        self.requeue_preserve_timestamps(batch);
+        self.retry_after.insert(scope, Instant::now() + delay);
+        None
+    }
+
+    /// Number of consecutive usage-limit holds recorded for `scope` since its
+    /// last successful turn (0 when none).
+    pub fn usage_limit_holds<K: IntoScope>(&self, scope: K) -> u32 {
+        self.usage_limit_holds
+            .get(&scope.into_scope())
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Re-queue a **complete** flushed batch preserving original `received_at`
@@ -799,6 +893,40 @@ impl EventQueue {
         self.retry_counts.insert(scope.into_scope(), count);
     }
 
+    /// Current retry-attempt counter for a scope (0 when absent). Test-only.
+    #[cfg(test)]
+    pub fn retry_count_for_test<K: IntoScope>(&self, scope: K) -> u32 {
+        self.retry_counts
+            .get(&scope.into_scope())
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Force a scope's usage-limit hold counter, simulating `count` prior
+    /// holds so a test can hit [`MAX_USAGE_LIMIT_HOLDS`] directly. Test-only.
+    #[cfg(test)]
+    pub fn set_usage_limit_holds_for_test<K: IntoScope>(&mut self, scope: K, count: u32) {
+        self.usage_limit_holds.insert(scope.into_scope(), count);
+    }
+
+    /// Remaining `retry_after` throttle for a scope, if one is set. Test-only.
+    #[cfg(test)]
+    pub fn retry_after_remaining_for_test<K: IntoScope>(&self, scope: K) -> Option<Duration> {
+        self.retry_after
+            .get(&scope.into_scope())
+            .map(|t| t.saturating_duration_since(Instant::now()))
+    }
+
+    /// Ids of the queued (not in-flight) events for a scope, head first.
+    /// Test-only.
+    #[cfg(test)]
+    pub fn queued_event_ids_for_test<K: IntoScope>(&self, scope: K) -> Vec<nostr::EventId> {
+        self.queues
+            .get(&scope.into_scope())
+            .map(|q| q.iter().map(|e| e.event.id).collect())
+            .unwrap_or_default()
+    }
+
     /// Drop all queued (non-in-flight) events for a channel.
     ///
     /// Used when the agent is removed from a channel — any pending events
@@ -828,6 +956,8 @@ impl EventQueue {
         // Also purge side-tables for every scope of this channel.
         self.retry_after.retain(|s, _| s.channel_id() != channel_id);
         self.retry_counts
+            .retain(|s, _| s.channel_id() != channel_id);
+        self.usage_limit_holds
             .retain(|s, _| s.channel_id() != channel_id);
         self.cancelled_batches
             .retain(|s, _| s.channel_id() != channel_id);
@@ -1029,6 +1159,12 @@ impl EventQueue {
         // queued events, AND no in-flight prompt — they completed their
         // retry cycle and are truly idle.
         self.retry_counts.retain(|scope, _| {
+            self.retry_after.contains_key(scope)
+                || self.queues.get(scope).is_some_and(|q| !q.is_empty())
+                || self.in_flight_scopes.contains(scope)
+        });
+        // Same idleness rule for usage-limit hold counters.
+        self.usage_limit_holds.retain(|scope, _| {
             self.retry_after.contains_key(scope)
                 || self.queues.get(scope).is_some_and(|q| !q.is_empty())
                 || self.in_flight_scopes.contains(scope)
@@ -6577,5 +6713,123 @@ mod tests {
             !prompt.contains("Description:"),
             "unresolved metadata must not render a Description field; got: {prompt}"
         );
+    }
+
+    // ── usage-limit hold ──────────────────────────────────────────────────
+
+    /// A hold keeps the batch queued, throttles the scope for the given delay
+    /// and leaves `retry_counts` untouched — the transient-failure budget must
+    /// not be spent on a deterministic limit.
+    #[test]
+    fn test_requeue_held_keeps_events_without_consuming_retry_budget() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        queue.set_retry_count_for_test(channel_id, 3);
+        queue.push(make_queued(channel_id, "held"));
+        let batch = queue.flush_next().expect("batch");
+        let original_id = batch.events[0].event.id;
+
+        assert!(queue
+            .requeue_held(batch, Duration::from_secs(3600))
+            .is_none());
+        queue.mark_complete(channel_id);
+
+        assert_eq!(
+            queue.retry_count_for_test(channel_id),
+            3,
+            "a hold must not touch retry_counts"
+        );
+        assert_eq!(queue.usage_limit_holds(channel_id), 1);
+        assert_eq!(queue.queued_event_count(channel_id), 1);
+        let remaining = queue
+            .retry_after_remaining_for_test(channel_id)
+            .expect("scope throttled");
+        assert!(remaining > Duration::from_secs(3500), "{remaining:?}");
+        assert!(
+            queue.flush_next().is_none(),
+            "held scope must not flush before the delay elapses"
+        );
+        // Still the same event, at the head.
+        assert_eq!(
+            queue.queued_event_ids_for_test(channel_id),
+            vec![original_id]
+        );
+    }
+
+    /// Once the delay elapses the very same events flush again, in order, and
+    /// the subsequent successful completion clears the hold counter.
+    #[test]
+    fn test_requeue_held_releases_the_same_events_after_the_delay() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        queue.push(make_queued(channel_id, "first"));
+        queue.push(make_queued(channel_id, "second"));
+        let batch = queue.flush_next().expect("batch");
+        let ids: Vec<_> = batch.events.iter().map(|e| e.event.id).collect();
+        assert_eq!(ids.len(), 2);
+
+        assert!(queue
+            .requeue_held(batch, Duration::from_millis(60))
+            .is_none());
+        queue.mark_complete(channel_id);
+        assert!(queue.flush_next().is_none(), "held");
+
+        std::thread::sleep(Duration::from_millis(80));
+        let again = queue.flush_next().expect("released after the hold");
+        let again_ids: Vec<_> = again.events.iter().map(|e| e.event.id).collect();
+        assert_eq!(again_ids, ids, "same events, same order");
+        queue.mark_complete(channel_id);
+        assert_eq!(
+            queue.usage_limit_holds(channel_id),
+            0,
+            "a successful turn clears the hold counter"
+        );
+        assert_eq!(queue.retry_count_for_test(channel_id), 0);
+    }
+
+    /// Consecutive holds keep counting while retry_counts stays put; past the
+    /// cap the batch is dead-lettered and all throttle state is cleared.
+    #[test]
+    fn test_requeue_held_dead_letters_past_the_hold_cap() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        queue.set_usage_limit_holds_for_test(channel_id, MAX_USAGE_LIMIT_HOLDS - 1);
+        queue.push(make_queued(channel_id, "doomed"));
+
+        // Hold number MAX is still a hold …
+        let batch = queue.flush_next().expect("batch");
+        assert!(queue
+            .requeue_held(batch, Duration::from_millis(1))
+            .is_none());
+        queue.mark_complete(channel_id);
+        assert_eq!(queue.usage_limit_holds(channel_id), MAX_USAGE_LIMIT_HOLDS);
+        assert_eq!(queue.retry_count_for_test(channel_id), 0);
+        std::thread::sleep(Duration::from_millis(5));
+
+        // … and the next one dead-letters.
+        let batch = queue.flush_next().expect("batch after hold");
+        let dead = queue
+            .requeue_held(batch, Duration::from_secs(60))
+            .expect("dead-lettered past the cap");
+        assert_eq!(dead.events.len(), 1);
+        queue.mark_complete(channel_id);
+        assert_eq!(queue.queued_event_count(channel_id), 0);
+        assert_eq!(queue.usage_limit_holds(channel_id), 0);
+        assert!(queue.retry_after_remaining_for_test(channel_id).is_none());
+    }
+
+    /// `drain_channel` (agent removed from the channel) forgets hold state
+    /// along with the other per-scope side tables.
+    #[test]
+    fn test_drain_channel_clears_usage_limit_holds() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        queue.push(make_queued(channel_id, "x"));
+        let batch = queue.flush_next().expect("batch");
+        assert!(queue.requeue_held(batch, Duration::from_secs(60)).is_none());
+        queue.mark_complete(channel_id);
+        assert_eq!(queue.usage_limit_holds(channel_id), 1);
+        queue.drain_channel(channel_id);
+        assert_eq!(queue.usage_limit_holds(channel_id), 0);
     }
 }

--- a/crates/buzz-acp/src/usage_limit.rs
+++ b/crates/buzz-acp/src/usage_limit.rs
@@ -1,0 +1,339 @@
+//! Recognise provider usage-limit errors and work out when they lift.
+//!
+//! When the account behind the agent CLI exhausts a usage window, every
+//! `session/prompt` fails with a JSON-RPC error whose message names the reset
+//! time, e.g. (Claude Code via claude-agent-acp, code `-32603`):
+//!
+//! ```text
+//! Internal error: You've hit your session limit · resets 3:10am (Asia/Seoul)
+//! ```
+//!
+//! Such a failure is deterministic until the window resets: exponential
+//! backoff cannot outlast a multi-hour window, so treating it like a transient
+//! error burns the whole retry budget in ~20 minutes and dead-letters the batch
+//! — the triggering event is discarded, and nothing resumes once the limit
+//! lifts. This module classifies these errors and parses the reset time so the
+//! queue can hold the batch until then instead
+//! ([`EventQueue::requeue_held`](crate::queue::EventQueue::requeue_held)).
+//!
+//! # Timezone
+//!
+//! The reset time is interpreted in the harness process's local timezone. The
+//! agent CLI is a child of this process on the same host, so the zone it
+//! prints (`(Asia/Seoul)` above) is the same one `chrono::Local` resolves to;
+//! the zone label itself is not parsed.
+
+use chrono::{DateTime, Datelike, Days, Local, NaiveDate, TimeZone};
+use std::time::Duration;
+
+/// Slack added after the parsed reset instant so the retry lands once the
+/// provider has actually rolled the window over, not a second before.
+pub(crate) const RESET_BUFFER_SECS: u64 = 90;
+
+/// Hold applied when the error is a usage limit but no reset time could be
+/// parsed from it. Long enough to avoid a tight retry loop, short enough that
+/// a five-hour window is not overshot by much.
+pub(crate) const FALLBACK_HOLD_SECS: u64 = 30 * 60;
+
+/// Upper bound on a single hold. Weekly limits reset up to seven days out;
+/// anything longer is a parse artefact and is clamped.
+pub(crate) const MAX_HOLD_SECS: u64 = 8 * 24 * 60 * 60;
+
+/// A usage-limit error extracted from a failed prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UsageLimit {
+    /// Reset instant parsed from the message, in local time. `None` when the
+    /// message names no parseable time.
+    pub resets_at: Option<DateTime<Local>>,
+}
+
+impl UsageLimit {
+    /// How long to hold the batch before retrying, measured from `now`.
+    ///
+    /// With a parsed reset: time until the reset plus [`RESET_BUFFER_SECS`],
+    /// clamped to [`MAX_HOLD_SECS`]. Without one: [`FALLBACK_HOLD_SECS`].
+    pub(crate) fn hold_delay(&self, now: DateTime<Local>) -> Duration {
+        match self.resets_at {
+            Some(at) => {
+                // A reset in the past (clock skew, parse edge) yields a zero
+                // wait; the buffer alone then spaces the retry.
+                let until = (at - now).to_std().unwrap_or_default();
+                (until + Duration::from_secs(RESET_BUFFER_SECS))
+                    .min(Duration::from_secs(MAX_HOLD_SECS))
+            }
+            None => Duration::from_secs(FALLBACK_HOLD_SECS),
+        }
+    }
+
+    /// Human-readable reset time for notices and logs, e.g. `03:10 (+09:00)`.
+    pub(crate) fn reset_label(&self) -> Option<String> {
+        self.resets_at
+            .map(|at| at.format("%H:%M (%:z)").to_string())
+    }
+}
+
+/// Classify `message` (the `AgentError` text) as a usage-limit error and, if
+/// it is one, parse its reset time relative to the current local time.
+pub(crate) fn detect(message: &str) -> Option<UsageLimit> {
+    detect_at(message, Local::now())
+}
+
+/// [`detect`] with an injectable `now` for deterministic tests.
+pub(crate) fn detect_at(message: &str, now: DateTime<Local>) -> Option<UsageLimit> {
+    if !is_usage_limit_message(message) {
+        return None;
+    }
+    Some(UsageLimit {
+        resets_at: parse_reset_time(message, now),
+    })
+}
+
+/// Whether `message` describes an exhausted account usage window.
+///
+/// Matches the "You've hit your … limit" family (session / weekly / usage
+/// limit, Claude Code) and the generic "usage limit" phrase. Rate-limit
+/// (HTTP 429) messages from the API say "rate limit" without "hit your" and
+/// are deliberately left to ordinary backoff. A false positive here only
+/// delays a retry (the batch is held, never dropped), so the patterns lean
+/// towards recall rather than the precision required of
+/// [`is_auth_error`](crate::is_auth_error).
+pub(crate) fn is_usage_limit_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    (lower.contains("hit your") && lower.contains("limit")) || lower.contains("usage limit")
+}
+
+/// Parse the reset time named after the word `reset`/`resets` in `message`.
+///
+/// Understands `3:10am`, `3am`, `11pm`, `15:30`, an optional `Sep 8` /
+/// `September 8` date, and `today` / `tomorrow`. A bare clock time earlier
+/// than `now` means the next day. Returns `None` when no time is named.
+pub(crate) fn parse_reset_time(message: &str, now: DateTime<Local>) -> Option<DateTime<Local>> {
+    let lower = message.to_ascii_lowercase();
+    let idx = lower.find("reset")?;
+    // Join "3:10 am" → "3:10am" so a detached meridiem still parses.
+    let rest = lower[idx..].replace(" am", "am").replace(" pm", "pm");
+
+    let mut time: Option<(u32, u32)> = None;
+    let mut date: Option<NaiveDate> = None;
+    let mut day_offset: Option<u64> = None;
+    let mut pending_month: Option<u32> = None;
+
+    let tokens = rest
+        .split(|c: char| c.is_whitespace() || c == ',' || c == '·')
+        .map(|t| t.trim_matches(|c| c == '(' || c == ')' || c == '.'))
+        .filter(|t| !t.is_empty())
+        .skip(1) // the reset word itself
+        .take(8);
+    for tok in tokens {
+        if matches!(tok, "at" | "on" | "in" | "the") {
+            continue;
+        }
+        if time.is_none() {
+            if let Some(t) = parse_clock(tok) {
+                time = Some(t);
+                continue;
+            }
+        }
+        match tok {
+            "today" => day_offset = Some(0),
+            "tomorrow" => day_offset = Some(1),
+            _ => {
+                if let Some(m) = month_number(tok) {
+                    pending_month = Some(m);
+                } else if let (Some(m), Ok(d)) = (pending_month, tok.parse::<u32>()) {
+                    date = NaiveDate::from_ymd_opt(now.year(), m, d);
+                    pending_month = None;
+                }
+            }
+        }
+    }
+
+    let (hour, minute) = time?;
+    let today = now.date_naive();
+    let base = match (date, day_offset) {
+        (Some(d), _) => d,
+        (None, Some(off)) => today.checked_add_days(Days::new(off))?,
+        (None, None) => today,
+    };
+    let candidate = local_at(base, hour, minute)?;
+    if candidate > now {
+        return Some(candidate);
+    }
+    match (date, day_offset) {
+        // Explicit date already in the past: only possible across a year
+        // boundary (e.g. "resets Jan 2" parsed in late December).
+        (Some(d), _) => local_at(d.with_year(now.year() + 1)?, hour, minute),
+        // "today"/"tomorrow" in the past: take it at face value.
+        (None, Some(_)) => Some(candidate),
+        // Bare clock time already passed today → next occurrence.
+        (None, None) => local_at(base.checked_add_days(Days::new(1))?, hour, minute),
+    }
+}
+
+fn local_at(date: NaiveDate, hour: u32, minute: u32) -> Option<DateTime<Local>> {
+    let naive = date.and_hms_opt(hour, minute, 0)?;
+    // `earliest` picks the first valid instant across a DST gap/overlap.
+    Local.from_local_datetime(&naive).earliest()
+}
+
+/// Parse `3:10am`, `3am`, `12pm`, `15:30` into a 24h `(hour, minute)`.
+/// A bare number without a meridiem is not a clock time.
+fn parse_clock(tok: &str) -> Option<(u32, u32)> {
+    let (body, pm) = if let Some(b) = tok.strip_suffix("am") {
+        (b, Some(false))
+    } else if let Some(b) = tok.strip_suffix("pm") {
+        (b, Some(true))
+    } else {
+        (tok, None)
+    };
+    let (hour, minute) = match body.split_once(':') {
+        Some((h, m)) => (h.parse::<u32>().ok()?, m.parse::<u32>().ok()?),
+        None => (body.parse::<u32>().ok().filter(|_| pm.is_some())?, 0),
+    };
+    if minute > 59 {
+        return None;
+    }
+    let hour = match pm {
+        Some(pm) => {
+            if !(1..=12).contains(&hour) {
+                return None;
+            }
+            (hour % 12) + if pm { 12 } else { 0 }
+        }
+        None => {
+            if hour > 23 {
+                return None;
+            }
+            hour
+        }
+    };
+    Some((hour, minute))
+}
+
+fn month_number(tok: &str) -> Option<u32> {
+    if tok.len() < 3 || !tok.chars().all(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    const MONTHS: [&str; 12] = [
+        "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+    ];
+    MONTHS
+        .iter()
+        .position(|m| tok.starts_with(m))
+        .map(|i| i as u32 + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Timelike;
+
+    const INCIDENT_MSG: &str =
+        "Internal error: You've hit your session limit · resets 3:10am (Asia/Seoul)";
+
+    /// 2026-09-03 00:47:46 local — the first failed turn of the incident.
+    fn incident_now() -> DateTime<Local> {
+        Local
+            .with_ymd_and_hms(2026, 9, 3, 0, 47, 46)
+            .single()
+            .expect("unambiguous local time")
+    }
+
+    #[test]
+    fn detects_the_incident_message_and_parses_its_reset() {
+        let limit = detect_at(INCIDENT_MSG, incident_now()).expect("usage limit");
+        let at = limit.resets_at.expect("reset time");
+        assert_eq!(
+            at.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 9, 3).unwrap()
+        );
+        assert_eq!((at.hour(), at.minute()), (3, 10));
+        let delay = limit.hold_delay(incident_now());
+        // 2h22m14s until reset, plus the buffer.
+        assert_eq!(
+            delay,
+            Duration::from_secs(2 * 3600 + 22 * 60 + 14 + RESET_BUFFER_SECS)
+        );
+    }
+
+    #[test]
+    fn clock_time_already_passed_today_rolls_to_tomorrow() {
+        let now = incident_now(); // 00:47
+        let at = parse_reset_time("hit your limit · resets 12:30am", now).unwrap();
+        assert_eq!(
+            at.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 9, 4).unwrap()
+        );
+        assert_eq!((at.hour(), at.minute()), (0, 30));
+    }
+
+    #[test]
+    fn parses_hour_only_meridiem_and_24h_forms() {
+        let now = incident_now();
+        let pm = parse_reset_time("resets 11pm (America/Los_Angeles)", now).unwrap();
+        assert_eq!((pm.hour(), pm.minute()), (23, 0));
+        let noon = parse_reset_time("resets 12pm", now).unwrap();
+        assert_eq!(noon.hour(), 12);
+        let midnight = parse_reset_time("resets 12am", now).unwrap();
+        assert_eq!(midnight.hour(), 0);
+        let h24 = parse_reset_time("resets at 15:30", now).unwrap();
+        assert_eq!((h24.hour(), h24.minute()), (15, 30));
+        let spaced = parse_reset_time("resets 3:10 am", now).unwrap();
+        assert_eq!((spaced.hour(), spaced.minute()), (3, 10));
+    }
+
+    #[test]
+    fn parses_an_explicit_date_for_weekly_limits() {
+        let now = incident_now();
+        let at =
+            parse_reset_time("You've hit your weekly limit · resets Sep 8 at 3pm", now).unwrap();
+        assert_eq!(
+            at.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 9, 8).unwrap()
+        );
+        assert_eq!(at.hour(), 15);
+        let tomorrow = parse_reset_time("resets tomorrow at 9am", now).unwrap();
+        assert_eq!(
+            tomorrow.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 9, 4).unwrap()
+        );
+    }
+
+    #[test]
+    fn unparseable_reset_falls_back_to_the_default_hold() {
+        let limit = detect_at("You've hit your usage limit.", incident_now()).unwrap();
+        assert_eq!(limit.resets_at, None);
+        assert_eq!(
+            limit.hold_delay(incident_now()),
+            Duration::from_secs(FALLBACK_HOLD_SECS)
+        );
+        assert!(parse_reset_time("resets soon", incident_now()).is_none());
+        // A clock time without the `reset` keyword is not a reset time.
+        assert!(parse_reset_time("try again after 3:10am", incident_now()).is_none());
+    }
+
+    #[test]
+    fn hold_is_clamped_and_never_negative() {
+        let now = incident_now();
+        let far = UsageLimit {
+            resets_at: Some(now + chrono::Duration::days(30)),
+        };
+        assert_eq!(far.hold_delay(now), Duration::from_secs(MAX_HOLD_SECS));
+        let past = UsageLimit {
+            resets_at: Some(now - chrono::Duration::hours(1)),
+        };
+        assert_eq!(past.hold_delay(now), Duration::from_secs(RESET_BUFFER_SECS));
+    }
+
+    #[test]
+    fn ignores_errors_that_are_not_usage_limits() {
+        for msg in [
+            "API Error: 401 OAuth access token has expired. Re-authenticate to continue.",
+            "Usage credits required for 1M context",
+            "rate_limit_error: This request would exceed your organization's rate limit",
+            "Internal error: something else",
+        ] {
+            assert!(detect_at(msg, incident_now()).is_none(), "{msg}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When the account behind the agent CLI exhausts its usage window, every `session/prompt` fails with a deterministic error until the window resets — for Claude Code via claude-agent-acp:

```
Agent reported error (code -32603): Internal error: You've hit your session limit · resets 3:10am (Asia/Seoul)
```

`buzz-acp` treated this like any transient failure: exponential backoff, ten attempts (≈20 minutes), then `dead-lettering batch after 10 retries — discarding N events`. The triggering event was discarded and nothing resumed when the limit lifted. Observed 2026-09-03 on a 25-harness host: 183 failed turns across 15 harnesses in 54 minutes, every pending batch dead-lettered, three projects silently stalled until a human noticed 35 hours later.

This PR makes the harness **hold** such batches until the limit resets, and makes every dead-letter notice say **what** was dropped.

- New `usage_limit` module recognises "hit your … limit" / "usage limit" agent errors and parses the reset time named after `resets` (`3:10am`, `11pm`, `15:30`, optional `Sep 8` / `tomorrow`; interpreted in the harness's local timezone, which the child CLI shares). No time → 30 min fallback hold.
- `EventQueue::requeue_held(batch, delay)`: restores the whole batch (via `requeue_preserve_timestamps`, so cancelled carryover survives) and sets `retry_after = now + delay` **without touching `retry_counts`**. Consecutive holds are counted separately and capped at `MAX_USAGE_LIMIT_HOLDS = 24`; past the cap the batch is dead-lettered as before, so a permanently exhausted account cannot pin a scope forever. `mark_complete`, `drain_channel` and `compact_expired_state` clear the hold counter under the same rules as `retry_counts`.
- `handle_prompt_result`: a usage-limit `AgentError` takes the hold path (before the auth-error check). On the first hold of a series the channel gets one notice — "⏳ … I'll retry it automatically once it resets at 03:10 (+09:00) — no need to re-send" — so readers know why the agent went quiet.
- Every dead-letter notice (hard-cap, retries exhausted, auth, hold cap) now appends `describe_batch_events`: agent label (`BUZZ_ACP_DISPLAY_NAME`, else npub), turn id, and one `buzz://message?channel=…&id=…[&thread=…]` deep link per event with author, time and an 80-char excerpt. A bare "please re-send" was not actionable when a dozen agents each dropped a different request into the same channel.

Hold and dead-letter log lines keep the existing `channel_id=` / `events=` shape:

```
WARN buzz_acp: usage limit hit — holding batch until it resets channel_id=… events=1 hold_secs=8624 resets_at="03:10 (+09:00)"
WARN buzz_acp::queue: holding batch until the usage limit resets channel_id=… scope=conversation hold=1 max=24 delay_secs=8624 events=1
ERROR buzz_acp::queue: dead-lettering batch after 24 usage-limit holds — discarding 1 events channel_id=… hold=25 events=1
```

## Test plan

- [x] `cargo test -p buzz-acp` — new: `usage_limit::tests` (incident message, am/pm/24h/date forms, rollover, fallback, clamp, negatives), `queue::tests::test_requeue_held_*` (budget untouched, same events released after the delay, cap → dead-letter, `drain_channel`), `error_outcome_emission_tests::usage_limit_*` (hold via `handle_prompt_result`, cap, classification) and `notice_details_link_the_original_event_with_an_excerpt`.
- [x] `cargo clippy -p buzz-acp --all-targets -- -D warnings`, `cargo fmt --check`
- [ ] Fleet rollout on the affected host is gated separately (operator approval).

Not changed: `MAX_RETRIES`/backoff for other errors, the auth-error fast path, `agent_returned` respawn/return semantics (a usage-limit error is still an application error — the agent goes back to the pool).
