### PR TITLE
fix(relay): correct pagination and counts for existing private queries

### DIFF
--- a/crates/buzz-db/src/store/event.rs
+++ b/crates/buzz-db/src/store/event.rs
@@ -10,8 +10,8 @@ use sqlx::{PgConnection, PgPool, Postgres, QueryBuilder, Row, Transaction};
 use uuid::Uuid;
 
 use buzz_core::kind::{
-    event_kind_i32, is_ephemeral, is_parameterized_replaceable, KIND_AUTH, KIND_EVENT_REMINDER,
-    KIND_HUDDLE_STARTED, SHARED_GATED_KINDS,
+    event_kind_i32, is_ephemeral, is_parameterized_replaceable, AUTHOR_ONLY_KINDS, KIND_AUTH,
+    KIND_EVENT_REMINDER, KIND_HUDDLE_STARTED, SHARED_GATED_KINDS,
 };
 use buzz_core::{CommunityId, StoredEvent};
 use buzz_datastore_tracing::datastore_span;
@@ -113,6 +113,10 @@ pub struct EventQuery {
     /// SQL pushdown is sound.  Keeping `event_visible_to_reader` as post-filter
     /// defense-in-depth catches any residual mismatch.
     pub shared_gated_reader: Option<Vec<u8>>,
+    /// Author-only visibility reader for [`query_events`]: exclude foreign
+    /// [`AUTHOR_ONLY_KINDS`] before ordering, offset and limit. This does not
+    /// affect `count_events`; callers must retain its existing fallback gate.
+    pub author_only_reader: Option<Vec<u8>>,
 }
 
 impl EventQuery {
@@ -144,6 +148,7 @@ impl EventQuery {
             channel_ids_include_global: true,
             max_limit: None,
             shared_gated_reader: None,
+            author_only_reader: None,
         }
     }
 }
@@ -679,6 +684,19 @@ pub(crate) async fn query_events_on(
         qb.push_bind(reader_bytes.clone());
         qb.push(format!(" OR {col_prefix}tags @> "));
         qb.push_bind(shared_containment);
+        qb.push(")");
+    }
+
+    // Author-only visibility belongs before pagination, just like shared-gated
+    // visibility. Keep relay result checks as defense in depth.
+    if let Some(ref reader_bytes) = q.author_only_reader {
+        qb.push(format!(" AND ({col_prefix}kind NOT IN ("));
+        let mut sep = qb.separated(", ");
+        for kind in AUTHOR_ONLY_KINDS {
+            sep.push_bind(*kind as i32);
+        }
+        qb.push(format!(") OR {col_prefix}pubkey = "));
+        qb.push_bind(reader_bytes.clone());
         qb.push(")");
     }
 

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -146,6 +146,26 @@ pub(crate) fn verify_bridge_auth_with_options(
     Err(api_error(StatusCode::UNAUTHORIZED, "missing Nostr auth"))
 }
 
+/// A declared dev-mode identity is not proof of authorship. Preserve the
+/// public-kind fallback, but require verified NIP-98 for any filter that could
+/// read author-only data, including mixed-kind and known-ID queries.
+fn authorize_author_only_read(
+    filters: &[nostr::Filter],
+    signed_auth_created_at: Option<u64>,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    if signed_auth_created_at.is_none()
+        && filters
+            .iter()
+            .any(crate::handlers::req::filter_can_match_author_only_kinds)
+    {
+        return Err(api_error(
+            StatusCode::UNAUTHORIZED,
+            "auth-required: author-only reads require NIP-98 authentication",
+        ));
+    }
+    Ok(())
+}
+
 /// Check NIP-98 replay and record the event ID atomically.
 ///
 /// The correctness boundary is the shared, community-scoped Redis seen-set on
@@ -1121,6 +1141,8 @@ async fn query_events_authed(
     crate::handlers::req::extract_channel_ids_from_filters_limited(&filters)
         .map_err(|()| api_error(StatusCode::BAD_REQUEST, "too many explicit channels"))?;
 
+    authorize_author_only_read(&filters, signed_auth_created_at)?;
+
     // P-gated kinds (gift wraps, member notifications, observer frames) require
     // the caller's own pubkey in the #p tag — same enforcement as WS REQ handler.
     let authed_pubkey_hex = pubkey.to_hex();
@@ -1654,6 +1676,8 @@ async fn count_events_authed(
         .map_err(|e| api_error(StatusCode::BAD_REQUEST, &format!("invalid filters: {e}")))?;
     crate::handlers::req::extract_channel_ids_from_filters_limited(&filters)
         .map_err(|()| api_error(StatusCode::BAD_REQUEST, "too many explicit channels"))?;
+
+    authorize_author_only_read(&filters, signed_auth_created_at)?;
 
     // P-gated kinds enforcement — same as WS REQ and /query.
     let authed_pubkey_hex = pubkey.to_hex();
@@ -2528,6 +2552,10 @@ fn ban_json(b: &buzz_db::moderation::BanRecord) -> Value {
         "updated_at": b.updated_at,
     })
 }
+
+#[cfg(test)]
+#[path = "private_read_postgres_tests.rs"]
+mod private_read_postgres_tests;
 
 #[cfg(test)]
 mod postgres_tests {
@@ -3839,7 +3867,7 @@ mod postgres_tests {
     /// - Redis pool points at the local dev instance for the admission check.
     ///
     /// Returns `None` when local Postgres is not reachable.
-    async fn bridge_handler_test_state() -> Option<Arc<crate::state::AppState>> {
+    pub(super) async fn bridge_handler_test_state() -> Option<Arc<crate::state::AppState>> {
         let mut config = crate::config::Config::from_env().ok()?;
         config.database_url = crate::test_support::database_url();
         // Use the real local Redis so enforce_http_admission can pass.

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -146,26 +146,6 @@ pub(crate) fn verify_bridge_auth_with_options(
     Err(api_error(StatusCode::UNAUTHORIZED, "missing Nostr auth"))
 }
 
-/// A declared dev-mode identity is not proof of authorship. Preserve the
-/// public-kind fallback, but require verified NIP-98 for any filter that could
-/// read author-only data, including mixed-kind and known-ID queries.
-fn authorize_author_only_read(
-    filters: &[nostr::Filter],
-    signed_auth_created_at: Option<u64>,
-) -> Result<(), (StatusCode, Json<Value>)> {
-    if signed_auth_created_at.is_none()
-        && filters
-            .iter()
-            .any(crate::handlers::req::filter_can_match_author_only_kinds)
-    {
-        return Err(api_error(
-            StatusCode::UNAUTHORIZED,
-            "auth-required: author-only reads require NIP-98 authentication",
-        ));
-    }
-    Ok(())
-}
-
 /// Check NIP-98 replay and record the event ID atomically.
 ///
 /// The correctness boundary is the shared, community-scoped Redis seen-set on
@@ -1141,8 +1121,6 @@ async fn query_events_authed(
     crate::handlers::req::extract_channel_ids_from_filters_limited(&filters)
         .map_err(|()| api_error(StatusCode::BAD_REQUEST, "too many explicit channels"))?;
 
-    authorize_author_only_read(&filters, signed_auth_created_at)?;
-
     // P-gated kinds (gift wraps, member notifications, observer frames) require
     // the caller's own pubkey in the #p tag — same enforcement as WS REQ handler.
     let authed_pubkey_hex = pubkey.to_hex();
@@ -1676,8 +1654,6 @@ async fn count_events_authed(
         .map_err(|e| api_error(StatusCode::BAD_REQUEST, &format!("invalid filters: {e}")))?;
     crate::handlers::req::extract_channel_ids_from_filters_limited(&filters)
         .map_err(|()| api_error(StatusCode::BAD_REQUEST, "too many explicit channels"))?;
-
-    authorize_author_only_read(&filters, signed_auth_created_at)?;
 
     // P-gated kinds enforcement — same as WS REQ and /query.
     let authed_pubkey_hex = pubkey.to_hex();

--- a/crates/buzz-relay/src/api/private_read_postgres_tests.rs
+++ b/crates/buzz-relay/src/api/private_read_postgres_tests.rs
@@ -1,0 +1,327 @@
+//! Existing author-only reads through HTTP and WebSocket storage seams.
+use super::postgres_tests::bridge_handler_test_state;
+use super::*;
+use axum::{body::Body, http::Request};
+use buzz_core::kind::KIND_EVENT_REMINDER;
+use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
+use serde_json::json;
+use tower::ServiceExt;
+
+async fn post(
+    state: &Arc<AppState>,
+    host: &str,
+    path: &str,
+    keys: &Keys,
+    body: Value,
+    signed: bool,
+) -> (StatusCode, Value) {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("host", host);
+    if signed {
+        let proof = EventBuilder::new(Kind::HttpAuth, "")
+            .tags([
+                Tag::parse(["u", &format!("https://{host}{path}")]).unwrap(),
+                Tag::parse(["method", "POST"]).unwrap(),
+            ])
+            .sign_with_keys(keys)
+            .unwrap();
+        request = request.header(
+            "authorization",
+            format!(
+                "Nostr {}",
+                base64::engine::general_purpose::STANDARD
+                    .encode(serde_json::to_vec(&proof).unwrap())
+            ),
+        );
+    } else {
+        request = request.header("x-pubkey", keys.public_key().to_hex());
+    }
+    let response = crate::router::build_router(state.clone())
+        .oneshot(
+            request
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1_048_576)
+        .await
+        .unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+fn drain(rx: &mut tokio::sync::mpsc::Receiver<axum::extract::ws::Message>) -> Vec<Value> {
+    let mut frames = vec![];
+    while let Ok(frame) = rx.try_recv() {
+        let axum::extract::ws::Message::Text(text) = frame else {
+            panic!("text frame")
+        };
+        frames.push(serde_json::from_str(&text).unwrap());
+    }
+    frames
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn existing_private_reads_require_proof_and_preserve_visible_pages() {
+    let mut state = bridge_handler_test_state()
+        .await
+        .expect("test infrastructure");
+    let host = format!("private-read-{}.example", uuid::Uuid::new_v4().simple());
+    let community = state
+        .db
+        .ensure_configured_community(&host)
+        .await
+        .unwrap()
+        .id;
+    let tenant = TenantContext::resolved(community, &host);
+    let owner = Keys::generate();
+    let outsider = Keys::generate();
+    let now = Timestamp::now().as_secs();
+    // Ingest the existing reminder envelope, not a new kind or test-only row.
+    // Terminal reminders may omit not_before; the relay never decrypts content.
+    let ciphertext = nostr::nips::nip44::encrypt(
+        owner.secret_key(),
+        &owner.public_key(),
+        r#"{"status":"done","note":"private reminder"}"#,
+        nostr::nips::nip44::Version::V2,
+    )
+    .unwrap();
+    let reminder = EventBuilder::new(Kind::Custom(KIND_EVENT_REMINDER as u16), &ciphertext)
+        .tags([Tag::parse(["d", &uuid::Uuid::new_v4().to_string()]).unwrap()])
+        .custom_created_at(Timestamp::from(now))
+        .sign_with_keys(&owner)
+        .unwrap();
+    let mut public = vec![];
+    for text in ["first public note", "second public note"] {
+        public.push(
+            EventBuilder::text_note(text)
+                .custom_created_at(Timestamp::from(now - 1))
+                .sign_with_keys(&owner)
+                .unwrap(),
+        );
+    }
+    public.sort_by_key(|event| event.id);
+    for event in std::iter::once(&reminder).chain(public.iter()) {
+        let (status, result) = post(&state, &host, "/events", &owner, json!(event), true).await;
+        assert_eq!(status, StatusCode::OK, "{result}");
+        assert_eq!(result["accepted"], true, "{result}");
+    }
+    let own = json!([{"kinds":[30300], "authors":[owner.public_key().to_hex()]}]);
+    let known = json!([{"ids":[reminder.id.to_hex()]}]);
+    let mixed = json!([{"kinds":[30300,1], "limit":1}]);
+    // Test both the deployed strict-auth branch and the explicit dev fallback.
+    for strict in [false, true] {
+        Arc::make_mut(&mut Arc::get_mut(&mut state).unwrap().config).require_auth_token = strict;
+        for route in ["/query", "/count"] {
+            for filters in [&own, &known, &mixed] {
+                let (status, result) =
+                    post(&state, &host, route, &owner, filters.clone(), false).await;
+                assert_eq!(status, StatusCode::UNAUTHORIZED, "{route}: {result}");
+            }
+            let (status, result) = post(&state, &host, route, &outsider, own.clone(), true).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "{result}");
+            let (status, result) = post(&state, &host, route, &owner, own.clone(), true).await;
+            assert_eq!(status, StatusCode::OK, "{result}");
+            if route == "/query" {
+                assert_eq!(result[0]["id"], reminder.id.to_hex());
+            } else {
+                assert_eq!(result["count"], 1);
+            }
+            let (status, result) = post(
+                &state,
+                &host,
+                route,
+                &outsider,
+                json!([{"kinds":[1]}]),
+                false,
+            )
+            .await;
+            assert_eq!(
+                status,
+                if strict {
+                    StatusCode::UNAUTHORIZED
+                } else {
+                    StatusCode::OK
+                },
+                "{result}"
+            );
+        }
+        for who in [&owner, &outsider] {
+            let (status, rows) = post(
+                &state,
+                &host,
+                "/query",
+                who,
+                json!([{"kinds":[30300,1], "search":"private reminder"}]),
+                true,
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "{rows}");
+            assert!(rows
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|row| row["kind"] != 30300));
+            let is_owner = who.public_key() == owner.public_key();
+            let (status, rows) = post(&state, &host, "/query", who, mixed.clone(), true).await;
+            assert_eq!(status, StatusCode::OK, "{rows}");
+            assert_eq!(rows.as_array().unwrap().len(), 1);
+            assert_eq!(
+                rows[0]["id"],
+                if is_owner {
+                    reminder.id.to_hex()
+                } else {
+                    public[0].id.to_hex()
+                }
+            );
+            // COUNT ignores the page limit, but must count only visible rows.
+            let (status, result) = post(&state, &host, "/count", who, mixed.clone(), true).await;
+            assert_eq!(status, StatusCode::OK, "{result}");
+            assert_eq!(result["count"], if is_owner { 3 } else { 2 });
+            let (status, rows) = post(&state, &host, "/query", who, known.clone(), true).await;
+            assert_eq!(status, StatusCode::OK, "{rows}");
+            assert_eq!(rows.as_array().unwrap().len(), usize::from(is_owner));
+            let (status, result) = post(&state, &host, "/count", who, known.clone(), true).await;
+            assert_eq!(status, StatusCode::OK, "{result}");
+            assert_eq!(result["count"], u64::from(is_owner));
+        }
+    }
+    // Both offset and composite cursors must page over visible records, including ties.
+    for filters in [
+        json!([{"kinds":[30300,1], "limit":1, "page":2}]),
+        json!([{"kinds":[30300,1], "limit":1, "until":now-1, "before_id":public[0].id.to_hex()}]),
+    ] {
+        let (status, rows) = post(&state, &host, "/query", &outsider, filters, true).await;
+        assert_eq!(status, StatusCode::OK, "{rows}");
+        assert_eq!(rows.as_array().unwrap().len(), 1);
+        assert_eq!(rows[0]["id"], public[1].id.to_hex());
+    }
+    // WS uses its existing authenticated principal, never an HTTP dev identity.
+    for who in [&owner, &outsider] {
+        let (mut conn, mut rx) = crate::connection::tests::test_conn_with_auth(
+            crate::connection::AuthState::Authenticated(buzz_auth::AuthContext {
+                pubkey: who.public_key(),
+                scopes: buzz_auth::Scope::all_known(),
+                channel_ids: None,
+                auth_method: buzz_auth::AuthMethod::Nip42,
+                agent_owner_pubkey: None,
+            }),
+        );
+        Arc::get_mut(&mut conn).unwrap().tenant = tenant.clone();
+        let filters = serde_json::from_value(mixed.clone()).unwrap();
+        crate::handlers::req::handle_req(
+            "page".into(),
+            filters,
+            vec![],
+            conn.clone(),
+            state.clone(),
+        )
+        .await;
+        let frames = drain(&mut rx);
+        let rows: Vec<_> = frames.iter().filter(|frame| frame[0] == "EVENT").collect();
+        assert_eq!(rows.len(), 1, "{frames:?}");
+        let is_owner = who.public_key() == owner.public_key();
+        assert_eq!(
+            rows[0][2]["id"],
+            if is_owner {
+                reminder.id.to_hex()
+            } else {
+                public[0].id.to_hex()
+            }
+        );
+        crate::handlers::count::handle_count(
+            "count".into(),
+            serde_json::from_value(mixed.clone()).unwrap(),
+            conn,
+            state.clone(),
+        )
+        .await;
+        let frames = drain(&mut rx);
+        assert_eq!(frames[0][0], "COUNT", "{frames:?}");
+        assert_eq!(frames[0][2]["count"], if is_owner { 3 } else { 2 });
+    }
+    // More foreign reminders than COUNT's candidate budget must not turn an
+    // outsider's small visible count into a 'narrower constraints' error. Seed
+    // signed storage rows directly to avoid thousands of HTTP admission calls.
+    for _ in 0..crate::handlers::req::COUNT_FALLBACK_CANDIDATE_LIMIT {
+        let event = EventBuilder::new(reminder.kind, &ciphertext)
+            .tags([Tag::parse(["d", &uuid::Uuid::new_v4().to_string()]).unwrap()])
+            .custom_created_at(Timestamp::from(now))
+            .sign_with_keys(&owner)
+            .unwrap();
+        assert!(
+            state
+                .db
+                .insert_event(community, &event, None)
+                .await
+                .unwrap()
+                .1
+        );
+    }
+    let (status, result) = post(&state, &host, "/count", &outsider, mixed.clone(), true).await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(result["count"], 2);
+    // The budget must still reject genuinely over-budget visible candidate sets.
+    let (status, _) = post(&state, &host, "/count", &owner, mixed.clone(), true).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn private_read_auth_distinguishes_signed_proof_from_declared_identity() {
+    let keys = Keys::generate();
+    let url = "https://private-read.example/query";
+    let proof = EventBuilder::new(Kind::HttpAuth, "")
+        .tags([
+            Tag::parse(["u", url]).unwrap(),
+            Tag::parse(["method", "POST"]).unwrap(),
+        ])
+        .sign_with_keys(&keys)
+        .unwrap();
+    let mut signed = HeaderMap::new();
+    signed.insert(
+        "authorization",
+        format!(
+            "Nostr {}",
+            base64::engine::general_purpose::STANDARD.encode(serde_json::to_vec(&proof).unwrap())
+        )
+        .parse()
+        .unwrap(),
+    );
+    let mut declared = HeaderMap::new();
+    declared.insert("x-pubkey", keys.public_key().to_hex().parse().unwrap());
+    let mut cases = vec![
+        (json!({}), true),
+        (json!({"kinds":[]}), false),
+        (json!({"kinds":[1]}), false),
+        (json!({"ids":[proof.id.to_hex()]}), true),
+    ];
+    for kind in buzz_core::kind::AUTHOR_ONLY_KINDS {
+        cases.push((
+            json!({"kinds":[kind], "authors":[keys.public_key().to_hex()]}),
+            true,
+        ));
+        cases.push((json!({"kinds":[1,kind]}), true));
+    }
+    for (raw, needs_proof) in cases {
+        let filters = vec![serde_json::from_value(raw.clone()).unwrap()];
+        for headers in [&declared, &signed] {
+            let auth = verify_bridge_auth(headers, "POST", url, None, false).unwrap();
+            let allowed = authorize_author_only_read(&filters, auth.signed_created_at).is_ok();
+            assert_eq!(
+                allowed,
+                !needs_proof || auth.signed_created_at.is_some(),
+                "{raw}"
+            );
+        }
+    }
+    assert!(verify_bridge_auth(&declared, "POST", url, None, true).is_err());
+    assert!(verify_bridge_auth(&signed, "POST", url, None, true).is_ok());
+    assert!(
+        verify_bridge_auth(&signed, "POST", "https://other.example/query", None, false).is_err()
+    );
+    assert!(verify_bridge_auth(&signed, "GET", url, None, false).is_err());
+}

--- a/crates/buzz-relay/src/api/private_read_postgres_tests.rs
+++ b/crates/buzz-relay/src/api/private_read_postgres_tests.rs
@@ -66,7 +66,7 @@ fn drain(rx: &mut tokio::sync::mpsc::Receiver<axum::extract::ws::Message>) -> Ve
 
 #[tokio::test]
 #[ignore = "requires Postgres"]
-async fn existing_private_reads_require_proof_and_preserve_visible_pages() {
+async fn existing_private_reads_preserve_visible_pages_and_counts() {
     let mut state = bridge_handler_test_state()
         .await
         .expect("test infrastructure");
@@ -113,18 +113,18 @@ async fn existing_private_reads_require_proof_and_preserve_visible_pages() {
     let own = json!([{"kinds":[30300], "authors":[owner.public_key().to_hex()]}]);
     let known = json!([{"ids":[reminder.id.to_hex()]}]);
     let mixed = json!([{"kinds":[30300,1], "limit":1}]);
-    // Test both the deployed strict-auth branch and the explicit dev fallback.
+    // Exercise the existing production NIP-98 contract and development X-Pubkey
+    // contract. Both must page/count using the reader selected by that mode.
     for strict in [false, true] {
         Arc::make_mut(&mut Arc::get_mut(&mut state).unwrap().config).require_auth_token = strict;
         for route in ["/query", "/count"] {
-            for filters in [&own, &known, &mixed] {
-                let (status, result) =
-                    post(&state, &host, route, &owner, filters.clone(), false).await;
+            if strict {
+                let (status, result) = post(&state, &host, route, &owner, own.clone(), false).await;
                 assert_eq!(status, StatusCode::UNAUTHORIZED, "{route}: {result}");
             }
-            let (status, result) = post(&state, &host, route, &outsider, own.clone(), true).await;
+            let (status, result) = post(&state, &host, route, &outsider, own.clone(), strict).await;
             assert_eq!(status, StatusCode::FORBIDDEN, "{result}");
-            let (status, result) = post(&state, &host, route, &owner, own.clone(), true).await;
+            let (status, result) = post(&state, &host, route, &owner, own.clone(), strict).await;
             assert_eq!(status, StatusCode::OK, "{result}");
             if route == "/query" {
                 assert_eq!(result[0]["id"], reminder.id.to_hex());
@@ -151,23 +151,8 @@ async fn existing_private_reads_require_proof_and_preserve_visible_pages() {
             );
         }
         for who in [&owner, &outsider] {
-            let (status, rows) = post(
-                &state,
-                &host,
-                "/query",
-                who,
-                json!([{"kinds":[30300,1], "search":"private reminder"}]),
-                true,
-            )
-            .await;
-            assert_eq!(status, StatusCode::OK, "{rows}");
-            assert!(rows
-                .as_array()
-                .unwrap()
-                .iter()
-                .all(|row| row["kind"] != 30300));
             let is_owner = who.public_key() == owner.public_key();
-            let (status, rows) = post(&state, &host, "/query", who, mixed.clone(), true).await;
+            let (status, rows) = post(&state, &host, "/query", who, mixed.clone(), strict).await;
             assert_eq!(status, StatusCode::OK, "{rows}");
             assert_eq!(rows.as_array().unwrap().len(), 1);
             assert_eq!(
@@ -179,13 +164,13 @@ async fn existing_private_reads_require_proof_and_preserve_visible_pages() {
                 }
             );
             // COUNT ignores the page limit, but must count only visible rows.
-            let (status, result) = post(&state, &host, "/count", who, mixed.clone(), true).await;
+            let (status, result) = post(&state, &host, "/count", who, mixed.clone(), strict).await;
             assert_eq!(status, StatusCode::OK, "{result}");
             assert_eq!(result["count"], if is_owner { 3 } else { 2 });
-            let (status, rows) = post(&state, &host, "/query", who, known.clone(), true).await;
+            let (status, rows) = post(&state, &host, "/query", who, known.clone(), strict).await;
             assert_eq!(status, StatusCode::OK, "{rows}");
             assert_eq!(rows.as_array().unwrap().len(), usize::from(is_owner));
-            let (status, result) = post(&state, &host, "/count", who, known.clone(), true).await;
+            let (status, result) = post(&state, &host, "/count", who, known.clone(), strict).await;
             assert_eq!(status, StatusCode::OK, "{result}");
             assert_eq!(result["count"], u64::from(is_owner));
         }
@@ -268,60 +253,4 @@ async fn existing_private_reads_require_proof_and_preserve_visible_pages() {
     // The budget must still reject genuinely over-budget visible candidate sets.
     let (status, _) = post(&state, &host, "/count", &owner, mixed.clone(), true).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
-}
-
-#[test]
-fn private_read_auth_distinguishes_signed_proof_from_declared_identity() {
-    let keys = Keys::generate();
-    let url = "https://private-read.example/query";
-    let proof = EventBuilder::new(Kind::HttpAuth, "")
-        .tags([
-            Tag::parse(["u", url]).unwrap(),
-            Tag::parse(["method", "POST"]).unwrap(),
-        ])
-        .sign_with_keys(&keys)
-        .unwrap();
-    let mut signed = HeaderMap::new();
-    signed.insert(
-        "authorization",
-        format!(
-            "Nostr {}",
-            base64::engine::general_purpose::STANDARD.encode(serde_json::to_vec(&proof).unwrap())
-        )
-        .parse()
-        .unwrap(),
-    );
-    let mut declared = HeaderMap::new();
-    declared.insert("x-pubkey", keys.public_key().to_hex().parse().unwrap());
-    let mut cases = vec![
-        (json!({}), true),
-        (json!({"kinds":[]}), false),
-        (json!({"kinds":[1]}), false),
-        (json!({"ids":[proof.id.to_hex()]}), true),
-    ];
-    for kind in buzz_core::kind::AUTHOR_ONLY_KINDS {
-        cases.push((
-            json!({"kinds":[kind], "authors":[keys.public_key().to_hex()]}),
-            true,
-        ));
-        cases.push((json!({"kinds":[1,kind]}), true));
-    }
-    for (raw, needs_proof) in cases {
-        let filters = vec![serde_json::from_value(raw.clone()).unwrap()];
-        for headers in [&declared, &signed] {
-            let auth = verify_bridge_auth(headers, "POST", url, None, false).unwrap();
-            let allowed = authorize_author_only_read(&filters, auth.signed_created_at).is_ok();
-            assert_eq!(
-                allowed,
-                !needs_proof || auth.signed_created_at.is_some(),
-                "{raw}"
-            );
-        }
-    }
-    assert!(verify_bridge_auth(&declared, "POST", url, None, true).is_err());
-    assert!(verify_bridge_auth(&signed, "POST", url, None, true).is_ok());
-    assert!(
-        verify_bridge_auth(&signed, "POST", "https://other.example/query", None, false).is_err()
-    );
-    assert!(verify_bridge_auth(&signed, "GET", url, None, false).is_err());
 }

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -357,6 +357,9 @@ pub async fn handle_req(
             let mut params =
                 filter_to_query_params(filter, per_filter_channel, conn.tenant.community());
             params.before_id = before_ids.get(idx).cloned().flatten();
+            if filter_can_match_author_only_kinds(filter) {
+                params.author_only_reader = Some(pubkey_bytes.clone());
+            }
             apply_channel_scope_to_query(
                 &mut params,
                 filter,
@@ -826,12 +829,16 @@ async fn handle_search_req(
 /// Resolves accessible channels for the given pubkey and builds the query.
 pub async fn build_event_query_from_filter(
     filter: &Filter,
-    _pubkey_bytes: &[u8],
+    pubkey_bytes: &[u8],
     _state: &AppState,
     community: buzz_core::tenant::CommunityId,
 ) -> EventQuery {
     let channel_id = extract_channel_id_from_filter(filter);
-    filter_to_query_params(filter, channel_id, community)
+    let mut query = filter_to_query_params(filter, channel_id, community);
+    if filter_can_match_author_only_kinds(filter) {
+        query.author_only_reader = Some(pubkey_bytes.to_vec());
+    }
+    query
 }
 
 /// Maximum SQL candidate rows a non-pushable COUNT filter may inspect before


### PR DESCRIPTION
## Summary

Fix pagination and COUNT candidate-budget correctness for **existing author-only queries**, including the existing reminder event family. Rows that are not visible to the current reader should not consume a visible page or the bounded COUNT fallback's candidate budget.

- Carry the reader into existing HTTP/WS query construction.
- Apply the existing author-only visibility predicate in SQL **before ordering, offset and LIMIT**; retain existing result filtering and COUNT fallback/over-budget checks.
- Keep production NIP-98 authentication and the intentional development-mode X-Pubkey contract unchanged. The earlier extra development-mode proof requirement has been removed from this draft.
- Keep a PostgreSQL-backed HTTP/WS regression covering owner/outsider visibility, mixed pages, known IDs, tied timestamps, offset/cursor pagination and COUNT budget behavior. HTTP cases use each mode's existing identity contract.

This is pagination/count correctness only, not authentication hardening or a new private-content feature. No new kinds, schema, lifecycle or client changes. Closest related PR: #7322 (new owner-private intent), unchanged and outside this scope.

Candidate: `5e51c4fa5096f08f20b34d43d09c659ec75e871b` (one additive scope-reduction commit over the original draft). Net diff: **4 files, 290 additions / 5 deletions**. Original merge-base: `01bacb8df3d2f5718e0a468828e07ae874a38eae`; no merge commit or history rewrite.

## Validation on this candidate

Using installed pinned Rust tools and existing dependency caches, offline:

- Focused bridge tests: **64 passed, 7 ignored**; REQ tests: **55 passed**.
- Existing NIP-98 verifier tests: **14 passed**, including real signature and URL/method validation. Production bridge code is byte-identical to the base after excluding test-module wiring.
- Broader package libraries attempted once: `buzz-db` **122 passed, 252 ignored**; `buzz-relay` **1021 passed, 13 failed, 90 ignored**. The 13 failures occur at sandbox-denied network operations: six media cases attempting DB fixture setup, six localhost mock/listener cases, and a metrics child reporting Bind instead of RecorderConflict. This is **not** an all-package pass. Focused passes above overlap with the package run and are not additional unique tests.
- Relay/DB all test targets compiled (`--no-run`); relay/DB all-target clippy with warnings denied passed.
- Four-file Rust formatting, diff whitespace, PostgreSQL test discovery, and all three surface size ratchets passed; size policy suite **10 passed**.

## Initial remote CI

[New-head CI run 33888392074](https://github.com/block/buzz/actions/runs/33888392074) is in progress. Initial DCO and Desktop Release Candidate checks passed; relay/Rust/PostgreSQL results are not yet available. Skipped review jobs are not review acceptance.

## Pending / draft limits

- The updated PostgreSQL HTTP/WS regression is **compiled, not behaviorally executed locally**. No authorized isolated desired-schema PostgreSQL/Redis fixture is available. Baseline/final storage behavior and reader/SQL mutation controls remain pending; normal remote CI is the next evidence source.
- No full local `just ci` / `just test` pass. No installs, provisioning or runtime changes were made to obtain a green result.
- The fixture bypasses replay tracking and relay membership and injects WS authenticated state; it does not certify replay, closed membership or the NIP-42 handshake. Large-budget coverage is HTTP-only. No new FTS guarantee.
- No native/live acceptance, deployment, or merge-readiness claim. Ignored/skipped checks are not passes.
