### PR TITLE
feat(multiverse): mounted Start Restart and Move controls

### DIFF
--- a/desktop/src-tauri/src/commands/desktop_stop.rs
+++ b/desktop/src-tauri/src/commands/desktop_stop.rs
@@ -86,13 +86,14 @@ pub async fn receive_desktop_stop(
         if managed_agents::placement::desired(&conn, &target.agent)?
             .is_some_and(|(host, _)| host == desktop)
         {
-            return StopResult {
+            let result = StopResult {
                 target,
                 request: event.id.to_hex(),
                 outcome: StopOutcome::Unknown,
             }
-            .sign(&scope.owner_keys)
-            .map(Some);
+            .sign(&scope.owner_keys)?;
+            remote_stop::save_result(&mut conn, &event.id.to_hex(), &result.as_json())?;
+            return Ok(Some(result));
         }
         let owned = owned_local(&app, &state, &owner, &target.agent)?;
         remote_stop::receive(

--- a/desktop/src/features/agents/desktopList.test.mjs
+++ b/desktop/src/features/agents/desktopList.test.mjs
@@ -160,6 +160,8 @@ test("rendered list distinguishes current, partial, unavailable and empty withou
 });
 
 test("mounted cache clears both scopes, fences late reads and retains rows on failure", async (t) => {
+  const originalRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = (fn) => setTimeout(fn, 0);
   const { JSDOM } = await import("jsdom");
   const dom = new JSDOM("<div id='root'></div>", {
     url: "https://desktop.test",
@@ -375,6 +377,7 @@ test("mounted cache clears both scopes, fences late reads and retains rows on fa
       "reconnect producer unsubscribed on unmount",
     );
     t.mock.timers.reset();
+    globalThis.requestAnimationFrame = originalRaf;
     dom.window.close();
   }
 });

--- a/desktop/src/features/agents/ui/DesktopLifecycleControl.test.mjs
+++ b/desktop/src/features/agents/ui/DesktopLifecycleControl.test.mjs
@@ -3,7 +3,11 @@ import test from "node:test";
 import React from "react";
 import { JSDOM } from "jsdom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { DesktopLifecycleControl } from "./DesktopLifecycleControl.tsx";
+import {
+  DesktopLifecycleControl,
+  DesktopLifecycleReceiver,
+} from "./DesktopLifecycleControl.tsx";
+import { toast } from "sonner";
 import { relayClient } from "../../../shared/api/relayClient.ts";
 
 test("mounted Start exposes unavailable provisioning and exact retry; Restart resolves source", async () => {
@@ -128,6 +132,108 @@ test("mounted Start exposes unavailable provisioning and exact retry; Restart re
     client.clear();
     relayClient.fetchEvents = originals.fetch;
     relayClient.publishEvent = originals.publish;
+    dom.window.close();
+  }
+});
+
+test("receiver failure is a scope-owned notification, not pre-shell layout", async () => {
+  const originalRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = (fn) => setTimeout(fn, 0);
+  const dom = new JSDOM("<div id='root'></div>", {
+    url: "https://desktop.test",
+  });
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    localStorage: dom.window.localStorage,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const { createRoot } = await import("react-dom/client");
+  const originals = {
+    fetch: relayClient.fetchEvents,
+    subscribe: relayClient.subscribeLive,
+  };
+  let readiness;
+  let closed = 0;
+  let rejectLate;
+  let delayed = false;
+  relayClient.fetchEvents = async () => {
+    if (delayed)
+      return new Promise((_, reject) => {
+        rejectLate = reject;
+      });
+    return [];
+  };
+  relayClient.subscribeLive = async (_filter, _event, onReadiness) => {
+    readiness = onReadiness;
+    return () => {
+      closed++;
+    };
+  };
+  window.__TAURI_INTERNALS__ = {
+    invoke: async () => {
+      throw new Error("fixture: storage unavailable");
+    },
+  };
+  const root = createRoot(document.getElementById("root"));
+  const scope = { owner: "owner", community: "wss://one.example" };
+  const warnings = () =>
+    toast
+      .getToasts()
+      .filter((t) => String(t.title).startsWith("Desktop lifecycle"));
+  try {
+    await React.act(async () =>
+      root.render(React.createElement(DesktopLifecycleReceiver, { scope })),
+    );
+    assert.equal(
+      document.getElementById("root").childElementCount,
+      0,
+      "startup must not render in-flow failure UI",
+    );
+    assert.equal(warnings().length, 1);
+    assert.equal(
+      warnings()[0].title,
+      "Desktop lifecycle receiver is unavailable.",
+    );
+    assert.equal(warnings()[0].duration, Infinity);
+    assert.equal(warnings()[0].closeButton, true);
+    readiness("closed");
+    assert.equal(
+      warnings().length,
+      1,
+      "repeated failures update one notification",
+    );
+    await React.act(async () =>
+      root.render(
+        React.createElement(DesktopLifecycleReceiver, { scope: null }),
+      ),
+    );
+    assert.equal(warnings().length, 0, "leaving the scope removes its warning");
+    readiness("closed");
+    assert.equal(
+      warnings().length,
+      0,
+      "retired receiver cannot notify another scope",
+    );
+    delayed = true;
+    await React.act(async () =>
+      root.render(React.createElement(DesktopLifecycleReceiver, { scope })),
+    );
+    assert.equal(typeof rejectLate, "function");
+    await React.act(async () => root.unmount());
+    await React.act(async () => rejectLate(new Error("late failure")));
+    assert.equal(
+      warnings().length,
+      0,
+      "late startup rejection must not recreate the warning",
+    );
+    assert.equal(closed, 2, "both failed subscriptions are released");
+  } finally {
+    await React.act(async () => root.unmount());
+    relayClient.fetchEvents = originals.fetch;
+    relayClient.subscribeLive = originals.subscribe;
+    for (const warning of warnings()) toast.dismiss(warning.id);
+    globalThis.requestAnimationFrame = originalRaf;
     dom.window.close();
   }
 });

--- a/desktop/src/features/agents/ui/DesktopLifecycleControl.test.mjs
+++ b/desktop/src/features/agents/ui/DesktopLifecycleControl.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { JSDOM } from "jsdom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DesktopLifecycleControl } from "./DesktopLifecycleControl.tsx";
+import { relayClient } from "../../../shared/api/relayClient.ts";
+
+test("mounted Start exposes unavailable provisioning and exact retry; Restart resolves source", async () => {
+  const dom = new JSDOM("<div id='root'></div>", {
+    url: "https://desktop.test",
+  });
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    localStorage: dom.window.localStorage,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const { createRoot } = await import("react-dom/client");
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(
+    ["relay-agents"],
+    [
+      { pubkey: "agent", name: "Owned agent", ownerPubkey: "owner" },
+      { pubkey: "foreign", name: "Foreign agent", ownerPubkey: "other" },
+    ],
+  );
+  const scope = { owner: "owner", community: "wss://one.example" };
+  const originals = {
+    fetch: relayClient.fetchEvents,
+    publish: relayClient.publishEvent,
+  };
+  const prepared = [],
+    sent = [];
+  let stop = "failed";
+  window.__TAURI_INTERNALS__ = {
+    invoke: async (command, args) => {
+      assert.equal(args.owner, scope.owner);
+      assert.equal(args.community, scope.community);
+      if (command === "observe_desktop_placement") return;
+      if (command === "read_desktop_placement") return ["source", "selection"];
+      if (
+        command === "prepare_desktop_lifecycle" ||
+        command === "prepare_desktop_stop"
+      ) {
+        const request = {
+          id: `request-${prepared.length}`,
+          kind: command.endsWith("_stop") ? 50180 : 50182,
+          ...args,
+        };
+        prepared.push(request);
+        return request;
+      }
+      if (command === "read_desktop_lifecycle_results")
+        return args.request.action === "status"
+          ? "running"
+          : "provisioning_unavailable";
+      if (command === "read_desktop_stop_results") return stop;
+      throw Error(command);
+    },
+  };
+  relayClient.fetchEvents = async () => [];
+  relayClient.publishEvent = async (event, _timeout, _failure, check) => {
+    check();
+    sent.push(event);
+  };
+  const root = createRoot(document.getElementById("root"));
+  const click = (text) =>
+    React.act(async () =>
+      [...document.querySelectorAll("button")]
+        .find((b) => b.textContent === text)
+        .click(),
+    );
+  const select = (label, value) =>
+    React.act(async () => {
+      const element = document.querySelector(`select[aria-label="${label}"]`);
+      element.value = value;
+      element.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+    });
+  try {
+    await React.act(async () =>
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client },
+          React.createElement(DesktopLifecycleControl, {
+            scope,
+            desktops: [
+              { id: "source", name: "Source" },
+              { id: "destination", name: "Destination" },
+            ],
+          }),
+        ),
+      ),
+    );
+    assert.doesNotMatch(document.body.textContent, /Foreign agent/);
+    await select("Agent to place", "agent");
+    await select("Destination Desktop", "destination");
+    await click("Start on destination");
+    assert.match(
+      document.body.textContent,
+      /keyless launch provisioning is unavailable/,
+    );
+    assert.equal(prepared[0].desktop, "destination");
+    await click("Retry same request");
+    assert.equal(prepared.length, 1);
+    assert.equal(sent[0], sent[1]);
+    await click("Restart on current Desktop");
+    const restart = prepared.at(-1);
+    assert.equal(
+      restart.desktop,
+      "source",
+      "destination picker must not redirect Restart",
+    );
+    assert.equal(restart.action, "restart");
+    assert.equal(restart.observed, prepared.at(-2).id);
+    await click("Move to destination");
+    assert.match(document.body.textContent, /destination was not started/);
+    const count = prepared.length;
+    stop = "stopped";
+    await React.act(async () => {});
+    assert.equal(prepared.length, count, "late Stop cannot resume failed Move");
+    assert.doesNotMatch(document.body.textContent, /Retry same request/);
+  } finally {
+    await React.act(async () => root.unmount());
+    client.clear();
+    relayClient.fetchEvents = originals.fetch;
+    relayClient.publishEvent = originals.publish;
+    dom.window.close();
+  }
+});

--- a/desktop/src/features/agents/ui/DesktopLifecycleControl.tsx
+++ b/desktop/src/features/agents/ui/DesktopLifecycleControl.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/shared/ui/button";
+import type { RelayEvent } from "@/shared/api/types";
+import type { DesktopRow, DesktopScope } from "../desktopList";
+import {
+  lifecycleClient,
+  receiveLifecycle,
+  type LifecycleOutcome,
+} from "../desktopLifecycle";
+import { useRelayAgentsQuery } from "../hooks";
+
+export function DesktopLifecycleReceiver({
+  scope,
+}: {
+  scope: DesktopScope | null;
+}) {
+  const [error, setError] = useState("");
+  const { owner, community } = scope ?? {};
+  useEffect(() => {
+    if (!owner || !community) return;
+    let active = true;
+    let close: (() => void) | undefined;
+    setError("");
+    void receiveLifecycle({ owner, community }, () => active, setError)
+      .then((fn) => {
+        if (active) close = fn;
+        else fn();
+      })
+      .catch(() => {
+        if (active) setError("Desktop lifecycle receiver is unavailable.");
+      });
+    return () => {
+      active = false;
+      close?.();
+    };
+  }, [owner, community]);
+  return error ? (
+    <p role="status" className="text-xs text-muted-foreground">
+      {error}
+    </p>
+  ) : null;
+}
+function message(outcome: LifecycleOutcome) {
+  switch (outcome) {
+    case "running":
+      return "Desktop confirmed a running local process. This does not prove model readiness.";
+    case "provisioning_unavailable":
+      return "Destination keyless launch provisioning is unavailable. No new process was started.";
+    case "stopped":
+      return "Desktop reports the agent stopped.";
+    case "failed":
+      return "Desktop rejected or failed the operation. No successful launch was confirmed.";
+    default:
+      return "Operation unconfirmed. A dispatched effect may still finish; no automatic retry will run.";
+  }
+}
+/** Start/Move choose destination; Restart has no host picker and resolves actual current state. */
+export function DesktopLifecycleControl({
+  scope,
+  desktops,
+}: {
+  scope: DesktopScope;
+  desktops: DesktopRow[];
+}) {
+  const agents = useRelayAgentsQuery();
+  const [agent, setAgent] = useState("");
+  const [destination, setDestination] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState("");
+  const [request, setRequest] = useState<RelayEvent | null>(null);
+  const active = useRef(true);
+  const generation = useRef(0);
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      generation.current++;
+    };
+  }, []);
+  const run = async (action: "start" | "restart" | "move" | "retry") => {
+    const token = ++generation.current;
+    const valid = () => active.current && generation.current === token;
+    const client = lifecycleClient(scope, valid);
+    setBusy(true);
+    setStatus("Checking authenticated Desktop state…");
+    if (action !== "retry") setRequest(null);
+    try {
+      if (action === "move") {
+        const outcome = await client.move(
+          agent,
+          destination,
+          desktops.map((d) => d.id),
+          (stage) => {
+            if (valid()) setStatus(stage);
+          },
+        );
+        client.check();
+        setStatus(message(outcome));
+      } else {
+        const next =
+          action === "retry"
+            ? request
+            : action === "start"
+              ? await client.start(destination, agent)
+              : await client.restart(
+                  agent,
+                  desktops.map((d) => d.id),
+                );
+        if (!next) throw new Error("No request to retry");
+        client.check();
+        setRequest(next);
+        setStatus("Request sent. Waiting for the Desktop’s actual result…");
+        const outcome = await client.send(next);
+        client.check();
+        setStatus(message(outcome));
+      }
+    } catch (error) {
+      if (valid())
+        setStatus(
+          error instanceof Error ? error.message : "Operation unconfirmed",
+        );
+    } finally {
+      if (valid()) setBusy(false);
+    }
+  };
+  const reset = () => {
+    setRequest(null);
+    setStatus("");
+  };
+  return (
+    <section
+      aria-label="Agent placement controls"
+      className="space-y-2 rounded border p-3"
+    >
+      <h3 className="text-sm font-medium">Start, restart, or move an agent</h3>
+      <label className="block text-xs">
+        Agent
+        <select
+          aria-label="Agent to place"
+          value={agent}
+          disabled={busy}
+          onChange={(e) => {
+            setAgent(e.target.value);
+            reset();
+          }}
+          className="ml-2 rounded border bg-background p-1"
+        >
+          <option value="">Choose your agent</option>
+          {(agents.data ?? [])
+            .filter((a) => a.ownerPubkey === scope.owner)
+            .map((a) => (
+              <option key={a.pubkey} value={a.pubkey}>
+                {a.name}
+              </option>
+            ))}
+        </select>
+      </label>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={!agent || busy}
+        onClick={() => void run("restart")}
+      >
+        Restart on current Desktop
+      </Button>
+      <label className="block text-xs">
+        Destination for Start or Move
+        <select
+          aria-label="Destination Desktop"
+          value={destination}
+          disabled={busy}
+          onChange={(e) => {
+            setDestination(e.target.value);
+            reset();
+          }}
+          className="ml-2 rounded border bg-background p-1"
+        >
+          <option value="">Choose a Desktop</option>
+          {desktops.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="text-xs text-muted-foreground">
+        Start may overlap with an agent still running elsewhere until that
+        Desktop reconnects. Move starts the destination only after source Stop
+        is confirmed. Nothing transfers files, configuration, or keys.
+      </p>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={!agent || !destination || busy}
+          onClick={() => void run("start")}
+        >
+          Start on destination
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={!agent || !destination || busy}
+          onClick={() => void run("move")}
+        >
+          Move to destination
+        </Button>
+        {request && (
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={busy}
+            onClick={() => void run("retry")}
+          >
+            Retry same request
+          </Button>
+        )}
+      </div>
+      {status && (
+        <p role="status" className="text-xs">
+          {status}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/desktop/src/features/agents/ui/DesktopLifecycleControl.tsx
+++ b/desktop/src/features/agents/ui/DesktopLifecycleControl.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/shared/ui/button";
 import type { RelayEvent } from "@/shared/api/types";
 import type { DesktopRow, DesktopScope } from "../desktopList";
@@ -14,31 +15,38 @@ export function DesktopLifecycleReceiver({
 }: {
   scope: DesktopScope | null;
 }) {
-  const [error, setError] = useState("");
   const { owner, community } = scope ?? {};
   useEffect(() => {
     if (!owner || !community) return;
     let active = true;
     let close: (() => void) | undefined;
-    setError("");
-    void receiveLifecycle({ owner, community }, () => active, setError)
+    let notification: string | number | undefined;
+    const reportError = (message: string) => {
+      if (!active) return;
+      // Startup mounts before the app shell: failure UI must not participate
+      // in layout or displace the fixed macOS window controls. Keep one visible
+      // notification for this receiver, and retire it with its owner/scope.
+      notification = toast.error(message, {
+        id: notification,
+        duration: Infinity,
+        closeButton: true,
+      });
+    };
+    void receiveLifecycle({ owner, community }, () => active, reportError)
       .then((fn) => {
         if (active) close = fn;
         else fn();
       })
       .catch(() => {
-        if (active) setError("Desktop lifecycle receiver is unavailable.");
+        reportError("Desktop lifecycle receiver is unavailable.");
       });
     return () => {
       active = false;
       close?.();
+      if (notification !== undefined) toast.dismiss(notification);
     };
   }, [owner, community]);
-  return error ? (
-    <p role="status" className="text-xs text-muted-foreground">
-      {error}
-    </p>
-  ) : null;
+  return null;
 }
 function message(outcome: LifecycleOutcome) {
   switch (outcome) {

--- a/desktop/src/features/agents/ui/KnownDesktops.tsx
+++ b/desktop/src/features/agents/ui/KnownDesktops.tsx
@@ -1,4 +1,8 @@
-import { DesktopStopControl, DesktopStopReceiver } from "./DesktopStopControl";
+import {
+  DesktopLifecycleControl,
+  DesktopLifecycleReceiver,
+} from "./DesktopLifecycleControl";
+import { DesktopStopControl } from "./DesktopStopControl";
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -62,6 +66,7 @@ function useDesktopList() {
 
 /** Startup and Agents share the existing owner/community query cache. */
 export function DesktopListStartup() {
+  const [epoch, setEpoch] = useState(0);
   const { refetch } = useDesktopList();
   const { refetch: pulse } = useDesktopObservations(useDesktopScope());
   const { refetch: report } = useDesktopCapabilities(useDesktopScope());
@@ -71,6 +76,7 @@ export function DesktopListStartup() {
       void report();
     }, DESKTOP_PULSE_MS);
     const unsubscribe = relayClient.subscribeToReconnects(() => {
+      setEpoch((n) => n + 1);
       void refetch();
       void pulse();
       void report();
@@ -80,7 +86,8 @@ export function DesktopListStartup() {
       unsubscribe();
     };
   }, [refetch, pulse, report]);
-  return <DesktopStopReceiver scope={useDesktopScope()} />;
+  const scope = useDesktopScope();
+  return <DesktopLifecycleReceiver key={`lifecycle:${epoch}`} scope={scope} />;
 }
 
 export function KnownDesktops() {
@@ -170,6 +177,13 @@ export function DesktopListView({
         <p role="status">Partial list: showing up to 100 profiles.</p>
       )}
       {list && !list.rows.length && !error && <p>No Desktop profiles found.</p>}
+      {scope && list && (
+        <DesktopLifecycleControl
+          key={`${scope.owner}:${scope.community}`}
+          scope={scope}
+          desktops={list.rows}
+        />
+      )}
       <ul className="space-y-2">
         {list?.rows.map((row) => (
           <li key={row.id} className="text-sm">

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -306,6 +306,7 @@ type E2eConfig = {
       mcp?: MockCommandAvailability;
     };
     managedAgents?: MockManagedAgentSeed[];
+    desktopLifecycleObservationError?: string;
     /** Result returned by the mocked `add_agent_to_huddle` command. */
     addAgentToHuddleResult?: {
       ephemeral_added: boolean;
@@ -13906,6 +13907,11 @@ export function maybeInstallE2eTauriMocks() {
             },
           ],
         };
+      }
+      case "observe_desktop_placement": {
+        const error = activeConfig?.mock?.desktopLifecycleObservationError;
+        if (error) throw new Error(error);
+        return null;
       }
       case "list_managed_agents":
         return handleListManagedAgents(activeConfig);

--- a/desktop/tests/e2e/desktop-stop.spec.ts
+++ b/desktop/tests/e2e/desktop-stop.spec.ts
@@ -31,12 +31,20 @@ test("remote Stop distinguishes delivery, uncertainty, and confirmed result", as
         confirmed: boolean;
         prepared: number;
         sends: string[];
+        lifecyclePrepared: number;
+        lifecycleSends: string[];
       };
       __TAURI_INTERNALS__: {
         invoke: (command: string, payload?: any, options?: any) => Promise<any>;
       };
     };
-    w.__STOP_FIXTURE__ = { confirmed: false, prepared: 0, sends: [] };
+    w.__STOP_FIXTURE__ = {
+      confirmed: false,
+      prepared: 0,
+      sends: [],
+      lifecyclePrepared: 0,
+      lifecycleSends: [],
+    };
     const original = w.__TAURI_INTERNALS__.invoke.bind(w.__TAURI_INTERNALS__);
     const now = Math.floor(Date.now() / 1000);
     const local = "11111111-1111-4111-8111-111111111111";
@@ -74,6 +82,19 @@ test("remote Stop distinguishes delivery, uncertainty, and confirmed result", as
             reported: now,
             runtimes: [],
           }));
+        case "observe_desktop_placement":
+          return;
+        case "read_desktop_placement":
+        case "receive_desktop_lifecycle":
+          return null;
+        case "prepare_desktop_lifecycle":
+          w.__STOP_FIXTURE__.lifecyclePrepared++;
+          return sign(50182, [
+            ["p", payload.owner],
+            ["d", payload.desktop],
+          ]);
+        case "read_desktop_lifecycle_results":
+          return "provisioning_unavailable";
         case "prepare_desktop_stop":
           w.__STOP_FIXTURE__.prepared++;
           return sign(50180, [
@@ -88,6 +109,8 @@ test("remote Stop distinguishes delivery, uncertainty, and confirmed result", as
           const wire = JSON.parse(payload.message.data);
           if (wire[0] === "EVENT" && wire[1]?.kind === 50180)
             w.__STOP_FIXTURE__.sends.push(JSON.stringify(wire[1]));
+          if (wire[0] === "EVENT" && wire[1]?.kind === 50182)
+            w.__STOP_FIXTURE__.lifecycleSends.push(JSON.stringify(wire[1]));
           break;
         }
       }
@@ -98,7 +121,7 @@ test("remote Stop distinguishes delivery, uncertainty, and confirmed result", as
   const desktops = page.getByRole("region", { name: "Known Desktops" });
   await desktops.getByRole("button", { name: "Refresh", exact: true }).click();
   await expect(
-    desktops.getByText("Lab Desktop", { exact: true }),
+    desktops.getByRole("listitem").getByText("Lab Desktop", { exact: true }),
   ).toBeVisible();
   await desktops
     .getByRole("combobox", { name: "Agent to stop on Lab Desktop" })
@@ -160,4 +183,46 @@ test("remote Stop distinguishes delivery, uncertainty, and confirmed result", as
   await desktops.screenshot({
     path: "test-results/desktop-stop/04-confirmed.png",
   });
+
+  // The mounted lifecycle selector shares host labels with the Stop rows.
+  // IPC explicitly refuses launch; no native process is created by this fixture.
+  const controls = desktops.getByRole("region", {
+    name: "Agent placement controls",
+  });
+  await controls
+    .getByRole("combobox", { name: "Agent to place" })
+    .selectOption(agent);
+  await controls
+    .getByRole("combobox", { name: "Destination Desktop" })
+    .selectOption("22222222-2222-4222-8222-222222222222");
+  await controls
+    .getByRole("button", { name: "Start on destination", exact: true })
+    .click();
+  await expect(controls.getByRole("status")).toHaveText(
+    "Destination keyless launch provisioning is unavailable. No new process was started.",
+  );
+  await waitForAnimations(page);
+  await desktops.screenshot({
+    path: "test-results/desktop-stop/05-launch-unavailable.png",
+  });
+  await controls
+    .getByRole("button", { name: "Retry same request", exact: true })
+    .click();
+  await expect(controls.getByRole("status")).toHaveText(
+    "Destination keyless launch provisioning is unavailable. No new process was started.",
+  );
+  const lifecycle = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          __STOP_FIXTURE__: {
+            lifecyclePrepared: number;
+            lifecycleSends: string[];
+          };
+        }
+      ).__STOP_FIXTURE__,
+  );
+  expect(lifecycle.lifecyclePrepared).toBe(1);
+  expect(lifecycle.lifecycleSends).toHaveLength(2);
+  expect(lifecycle.lifecycleSends[1]).toBe(lifecycle.lifecycleSends[0]);
 });

--- a/desktop/tests/e2e/top-chrome-zoom-clearance.spec.ts
+++ b/desktop/tests/e2e/top-chrome-zoom-clearance.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import { readFileSync } from "node:fs";
 
 import { installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
 
 type TauriConfig = {
   app: {
@@ -109,8 +110,18 @@ test.describe("top chrome macOS traffic-light clearance under text zoom", () => 
     page,
   }) => {
     await spoofMacPlatform(page);
-    await installMockBridge(page);
+    await installMockBridge(page, {
+      desktopLifecycleObservationError:
+        "fixture: lifecycle storage unavailable",
+    });
     await page.goto("/");
+    // A failed global receiver must remain visible without entering the shell's
+    // layout flow. This also forces the error to settle before measuring chrome.
+    await expect(
+      page.getByText("Desktop lifecycle receiver is unavailable.", {
+        exact: true,
+      }),
+    ).toBeVisible();
 
     // Lock the native and webview placements together: removing this explicit
     // Tauri inset or shifting the nav row regresses the macOS chrome alignment.
@@ -133,6 +144,10 @@ test.describe("top chrome macOS traffic-light clearance under text zoom", () => 
     );
     await expectNavButtonsFixedSize(page);
     await expectTopChromeFixedHeight(page);
+    await waitForAnimations(page);
+    await page.screenshot({
+      path: "test-results/desktop-lifecycle/receiver-error-chrome.png",
+    });
   });
 
   test("nav buttons still clear the traffic lights when zoomed out", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -221,6 +221,8 @@ type MockBridgeOptions = {
     mcp?: MockCommandAvailability;
   };
   managedAgents?: MockManagedAgentSeed[];
+  /** Fail lifecycle history admission to exercise the global receiver warning. */
+  desktopLifecycleObservationError?: string;
   /** Result returned by the mocked `add_agent_to_huddle` command. */
   addAgentToHuddleResult?: {
     ephemeral_added: boolean;


### PR DESCRIPTION
## Draft scope
Mount one live lifecycle/Stop receiver and Known Desktops controls. Start/Move choose destination; Restart resolves current host. Exact retry keeps signed bytes; unavailable provisioning is visible. Mounted interaction regression test.

Depends on `feat/lifecycle-client-16211fef`; part of six dependent drafts atop #7347 (`dfce9ba3`). Frozen inventory/Stop heads are unchanged. Head: `9800686a59d81e17528ce79fa891b357cca8f886`.

## Evidence
The composed candidate `5ec1955862d11bd9c01b7e3318f09b7076101423` passed full `just ci`, 6,266 frontend tests, production artifact build, 3,178 native unit + 10 integration tests, and native/workspace Clippy. This is composed-candidate evidence, not a claim that each earlier unmounted slice independently exercises the whole feature. Splitting changed no product bytes.

Earlier direct package attempts exposed environment limitations: relay media tests lacked a configured PostgreSQL pool; a direct buzz-db source-attribution guard failed in the unchanged production source; the first separate PostgreSQL lane failed local setup before tests. Full `just ci` subsequently passed its configured lanes. Separate populated PostgreSQL/private relay evidence is being collected, not assumed green.

## Explicitly unperformed / not delivered
- No two-Desktop/two-Mac lifecycle walkthrough, successful real relocation, or real process-tree cleanup acceptance. These are documented limits, not a drafting gate.
- No deployed host-owned broker credential provisioner. Production Start/Restart cannot spawn a new keyless runtime until that integration is supplied; the current provider returns `provisioning_unavailable`. Injected success tests are not deployed provisioning evidence.
- No keys, files, configuration, or workspaces transferred. No auth weakening, arbitrary signer, or keyful launch fallback.
- Draft only: no merge, deployment, release artifact, or technical approval claimed.

## Product authority
Approved Multiverse semantics: newer sender seconds/lower event-ID ties; scoped Stop; current-host-only Restart; failed/interrupted Move has no automatic continuation. This follows the settled Multiverse design rather than the older provider/key-transfer vision in VISION_REMOTE_AGENTS.md.

Origin channel: `f45d3304-dcf0-44e8-a46d-bcd63b235fbc`
Origin thread: `16211fefcee85904f49802ce5e1709bf24b4895401a944f0585e70233c4e4d39`
Owner drafting direction: `4ed62424758aea3898b084f9e24d7fd9791d7dc53738d01ed1c0dbbae1adb8e7`.

## CI slice correction — 2026-09-04
Current head: `4e7b31e0dc6ab265c6f10f173dbe503e3eeeb814`. CI attempt 1 fixed a split-only Clippy failure: #7352 introduced `provision` before its receiver caller existed. The stub and its two imports now arrive with #7353 instead. No lint suppression was added. #7352's corrected source passed native fmt, full native workspace tests, and `desktop-tauri-clippy` locally. #7353–#7355 were rebased; each resulting source tree is identical to its respective previously validated head (verified with `git diff --exit-code`). The composed tip is `4e7b31e0dc6ab265c6f10f173dbe503e3eeeb814`, source-identical to `2f26d5f3`. Remote checks are being followed on the new heads; not yet claimed green.

Review disposition: self-review complete, no submitted GitHub technical review at this readback. No independent approval claimed. The launch-provisioning integration and native walkthrough limitations above remain unchanged.

## Mounted integration correction
Current head: `9800686a59d81e17528ce79fa891b357cca8f886`. Test-only follow-up scopes the existing Stop host-label assertion to the host list (the new destination option uses the same label). The mounted smoke path now also exercises Start provisioning refusal and exact-byte retry. `pnpm test:e2e:smoke desktop-stop.spec.ts` passed; full frontend suite passed all 6,266 tests. Product sources are unchanged from `4e7b31e0`; prior native/relay/DB evidence is reused. Fresh CI is running. The screenshot is mock-IPC evidence, not real launch acceptance.
