### PR TITLE
fix(desktop): route forum message links to the post, not the post list

### DIFF
--- a/desktop/src/app/navigation/messageLinkRequests.ts
+++ b/desktop/src/app/navigation/messageLinkRequests.ts
@@ -1,0 +1,13 @@
+let currentRequest: object | undefined;
+
+/** Supersede pending message-link lookups across all mounted hook instances. */
+export function beginMessageLinkRequest(): () => boolean {
+  const request = {};
+  currentRequest = request;
+  return () => currentRequest === request;
+}
+
+/** Invalidate pending message-link routing before switching communities. */
+export function resetMessageLinkRequests(): void {
+  currentRequest = undefined;
+}

--- a/desktop/src/app/navigation/resolveMessageLinkDestination.test.mjs
+++ b/desktop/src/app/navigation/resolveMessageLinkDestination.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Regression for #7315: `buzz://message` links into a forum channel routed
+ * through `goChannel`, and `/channels/$channelId` cannot select a forum post
+ * (it hardcodes `selectedPostId={null}`), so the link landed on the post list
+ * with nothing selected. Search already resolved this correctly via
+ * `resolveSearchHitDestination`; this mirrors that branching for message links.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveMessageLinkDestination } from "./resolveMessageLinkDestination.ts";
+
+const CHANNEL = "a27e1ee9-76a6-5bdf-a5d5-1d85610dad11";
+const KIND_STREAM_MESSAGE = 9;
+const KIND_FORUM_POST = 45001;
+const KIND_FORUM_COMMENT = 45003;
+
+function fetcher(event) {
+  return async () => event;
+}
+
+test("a forum post link opens the post, not the post list", async () => {
+  const destination = await resolveMessageLinkDestination(
+    CHANNEL,
+    "post-1",
+    null,
+    fetcher({ id: "post-1", kind: KIND_FORUM_POST, tags: [] }),
+  );
+
+  assert.deepEqual(destination, {
+    kind: "forum-post",
+    channelId: CHANNEL,
+    postId: "post-1",
+  });
+});
+
+test("a forum comment link opens its post and carries the reply id", async () => {
+  const destination = await resolveMessageLinkDestination(
+    CHANNEL,
+    "comment-1",
+    null,
+    fetcher({
+      id: "comment-1",
+      kind: KIND_FORUM_COMMENT,
+      // A top-level forum comment carries both markers, the way
+      // `getThreadReference` expects: a `root` pointing at the post and a
+      // `reply` pointing at whatever it answers.
+      tags: [
+        ["e", "post-1", "", "root"],
+        ["e", "post-1", "", "reply"],
+      ],
+    }),
+  );
+
+  assert.deepEqual(destination, {
+    kind: "forum-post",
+    channelId: CHANNEL,
+    postId: "post-1",
+    replyId: "comment-1",
+  });
+});
+
+test("a stream message link keeps the channel destination", async () => {
+  const destination = await resolveMessageLinkDestination(
+    CHANNEL,
+    "message-1",
+    "root-1",
+    fetcher({ id: "message-1", kind: KIND_STREAM_MESSAGE, tags: [] }),
+  );
+
+  assert.deepEqual(destination, {
+    kind: "channel",
+    channelId: CHANNEL,
+    messageId: "message-1",
+    threadRootId: "root-1",
+  });
+});
+
+test("a comment with no resolvable root falls back to the channel", async () => {
+  const destination = await resolveMessageLinkDestination(
+    CHANNEL,
+    "comment-2",
+    null,
+    fetcher({ id: "comment-2", kind: KIND_FORUM_COMMENT, tags: [] }),
+  );
+
+  assert.equal(destination.kind, "channel");
+  assert.equal(destination.channelId, CHANNEL);
+});
+
+test("a failed lookup never makes the link unclickable", async () => {
+  const destination = await resolveMessageLinkDestination(
+    CHANNEL,
+    "message-3",
+    null,
+    async () => {
+      throw new Error("relay unavailable");
+    },
+  );
+
+  assert.deepEqual(destination, {
+    kind: "channel",
+    channelId: CHANNEL,
+    messageId: "message-3",
+    threadRootId: null,
+  });
+});

--- a/desktop/src/app/navigation/resolveMessageLinkDestination.test.mjs
+++ b/desktop/src/app/navigation/resolveMessageLinkDestination.test.mjs
@@ -77,7 +77,7 @@ test("a stream message link keeps the channel destination", async () => {
   });
 });
 
-test("a comment with no resolvable root falls back to the channel", async () => {
+test("a comment with no resolvable root has no destination", async () => {
   const destination = await resolveMessageLinkDestination(
     CHANNEL,
     "comment-2",
@@ -85,11 +85,10 @@ test("a comment with no resolvable root falls back to the channel", async () => 
     fetcher({ id: "comment-2", kind: KIND_FORUM_COMMENT, tags: [] }),
   );
 
-  assert.equal(destination.kind, "channel");
-  assert.equal(destination.channelId, CHANNEL);
+  assert.equal(destination, null);
 });
 
-test("a failed lookup never makes the link unclickable", async () => {
+test("a failed lookup does not claim a channel destination", async () => {
   const destination = await resolveMessageLinkDestination(
     CHANNEL,
     "message-3",
@@ -99,10 +98,5 @@ test("a failed lookup never makes the link unclickable", async () => {
     },
   );
 
-  assert.deepEqual(destination, {
-    kind: "channel",
-    channelId: CHANNEL,
-    messageId: "message-3",
-    threadRootId: null,
-  });
+  assert.equal(destination, null);
 });

--- a/desktop/src/app/navigation/resolveMessageLinkDestination.ts
+++ b/desktop/src/app/navigation/resolveMessageLinkDestination.ts
@@ -1,0 +1,84 @@
+import { getThreadReference } from "@/features/messages/lib/threading";
+import { getEventById } from "@/shared/api/tauri";
+import { KIND_FORUM_COMMENT, KIND_FORUM_POST } from "@/shared/constants/kinds";
+
+/**
+ * Where a `buzz://message` link should land.
+ *
+ * Mirrors `SearchHitDestination`. Search already resolves this correctly —
+ * `openSearchHitWithNavigation` branches to `goForumPost` for forum targets —
+ * but message links (deep links and the in-app markdown handler) routed
+ * everything through `goChannel`. `/channels/$channelId` hardcodes
+ * `selectedPostId={null}`, and `useChannelRouteTarget` returns early for
+ * `channelType === "forum"`, so a forum target landed on the post list with
+ * nothing selected.
+ */
+export type MessageLinkDestination =
+  | {
+      kind: "channel";
+      channelId: string;
+      messageId?: string;
+      threadRootId?: string | null;
+    }
+  | {
+      kind: "forum-post";
+      channelId: string;
+      postId: string;
+      replyId?: string;
+    };
+
+/**
+ * Resolves a message link by fetching the target event and branching on its
+ * kind, the way `resolveSearchHitDestination` does for search hits.
+ *
+ * A message link carries no kind of its own, so the event has to be fetched.
+ * Every failure path falls back to the channel destination the caller would
+ * have used anyway, so a link never becomes unclickable because the lookup
+ * failed.
+ */
+export async function resolveMessageLinkDestination(
+  channelId: string,
+  messageId: string,
+  threadRootId?: string | null,
+  fetchEvent: typeof getEventById = getEventById,
+): Promise<MessageLinkDestination> {
+  const channelDestination: MessageLinkDestination = {
+    kind: "channel",
+    channelId,
+    messageId,
+    threadRootId: threadRootId ?? null,
+  };
+
+  try {
+    const event = await fetchEvent(messageId);
+
+    if (event.kind === KIND_FORUM_POST) {
+      return { kind: "forum-post", channelId, postId: messageId };
+    }
+
+    if (event.kind === KIND_FORUM_COMMENT) {
+      const thread = getThreadReference(event.tags);
+      const postId = thread.rootId ?? thread.parentId ?? null;
+
+      if (!postId) {
+        return channelDestination;
+      }
+
+      return {
+        kind: "forum-post",
+        channelId,
+        postId,
+        replyId: messageId,
+      };
+    }
+
+    return channelDestination;
+  } catch (error) {
+    console.error(
+      "Failed to resolve message link destination",
+      messageId,
+      error,
+    );
+    return channelDestination;
+  }
+}

--- a/desktop/src/app/navigation/resolveMessageLinkDestination.ts
+++ b/desktop/src/app/navigation/resolveMessageLinkDestination.ts
@@ -32,16 +32,15 @@ export type MessageLinkDestination =
  * kind, the way `resolveSearchHitDestination` does for search hits.
  *
  * A message link carries no kind of its own, so the event has to be fetched.
- * Every failure path falls back to the channel destination the caller would
- * have used anyway, so a link never becomes unclickable because the lookup
- * failed.
+ * Returns null on lookup failure so durable callers can keep the link queued.
+ * Interactive callers may choose a best-effort channel fallback.
  */
 export async function resolveMessageLinkDestination(
   channelId: string,
   messageId: string,
   threadRootId?: string | null,
   fetchEvent: typeof getEventById = getEventById,
-): Promise<MessageLinkDestination> {
+): Promise<MessageLinkDestination | null> {
   const channelDestination: MessageLinkDestination = {
     kind: "channel",
     channelId,
@@ -61,7 +60,7 @@ export async function resolveMessageLinkDestination(
       const postId = thread.rootId ?? thread.parentId ?? null;
 
       if (!postId) {
-        return channelDestination;
+        return null;
       }
 
       return {
@@ -79,6 +78,6 @@ export async function resolveMessageLinkDestination(
       messageId,
       error,
     );
-    return channelDestination;
+    return null;
   }
 }

--- a/desktop/src/app/navigation/useOpenMessageLink.test.mjs
+++ b/desktop/src/app/navigation/useOpenMessageLink.test.mjs
@@ -190,3 +190,128 @@ test("in-app hook lookup cannot navigate after community unmount", async () => {
   assert.equal(await result, false);
   assert.deepEqual(calls, []);
 });
+
+for (const message of ["relay unavailable", "event not found"]) {
+  test(`failed lookup (${message}) stays queued and retries the forum destination`, async () => {
+    fetchEvent = async () => {
+      throw new Error(message);
+    };
+    queue.push({ id: "pending", kind: "message", ...link });
+    const app = await mount(true);
+    try {
+      await settle();
+      assert.deepEqual(calls, []);
+      assert.deepEqual(accepted, []);
+      assert.equal(queue.length, 1);
+    } finally {
+      await app.unmount();
+    }
+    fetchEvent = async () => ({ kind: 45001, tags: [] });
+    const retry = await mount(true);
+    try {
+      await settle();
+      assert.deepEqual(calls, [
+        ["forum", "channel", "message", { replyId: undefined }],
+      ]);
+      assert.deepEqual(accepted, ["pending"]);
+    } finally {
+      await retry.unmount();
+    }
+  });
+}
+
+test("in-app failed lookup keeps its best-effort channel fallback", async () => {
+  fetchEvent = async () => {
+    throw new Error("relay unavailable");
+  };
+  const app = await mount();
+  try {
+    assert.equal(await app.open(link), true);
+    assert.deepEqual(calls, [
+      ["channel", "channel", { messageId: "message", threadRootId: null }],
+    ]);
+  } finally {
+    await app.unmount();
+  }
+});
+
+for (const olderFails of [false, true]) {
+  test(`latest activation wins when an older lookup ${olderFails ? "fails" : "succeeds"} late`, async () => {
+    const older = deferred();
+    fetchEvent = async ({ eventId }) => {
+      if (eventId === "message") {
+        await older.promise;
+        if (olderFails) throw new Error("old lookup failed");
+      }
+      return { kind: 45001, tags: [] };
+    };
+    const app = await mount();
+    try {
+      const first = app.open(link);
+      assert.equal(await app.open({ ...link, messageId: "newer" }), true);
+      older.resolve();
+      assert.equal(await first, false);
+      assert.deepEqual(calls, [
+        ["forum", "channel", "newer", { replyId: undefined }],
+      ]);
+    } finally {
+      await app.unmount();
+    }
+  });
+}
+
+test("a newer activation in another mounted renderer supersedes the old lookup", async () => {
+  const older = deferred();
+  fetchEvent = async ({ eventId }) => {
+    if (eventId === "message") await older.promise;
+    return { kind: 45001, tags: [] };
+  };
+  const firstRenderer = await mount();
+  const secondRenderer = await mount();
+  try {
+    const first = firstRenderer.open(link);
+    assert.equal(
+      await secondRenderer.open({ ...link, messageId: "newer" }),
+      true,
+    );
+    older.resolve();
+    assert.equal(await first, false);
+    assert.deepEqual(calls, [
+      ["forum", "channel", "newer", { replyId: undefined }],
+    ]);
+  } finally {
+    await firstRenderer.unmount();
+    await secondRenderer.unmount();
+  }
+});
+
+test("community reset invalidates a lookup even before hook cleanup", async () => {
+  const { resetMessageLinkRequests } = await import("./messageLinkRequests.ts");
+  const lookup = deferred();
+  fetchEvent = () => lookup.promise;
+  const app = await mount();
+  try {
+    const pending = app.open(link);
+    resetMessageLinkRequests();
+    lookup.resolve({ kind: 45001, tags: [] });
+    assert.equal(await pending, false);
+    assert.deepEqual(calls, []);
+    assert.equal(await app.open({ ...link, messageId: "new-community" }), true);
+  } finally {
+    await app.unmount();
+  }
+});
+
+test("a queued forum comment without a root is not acknowledged as a channel visit", async () => {
+  fetchEvent = async () => ({ kind: 45003, tags: [] });
+  queue.push({ id: "pending", kind: "message", ...link });
+  const app = await mount(true);
+  try {
+    await settle();
+    assert.deepEqual(calls, []);
+    assert.deepEqual(accepted, []);
+    assert.equal(queue.length, 1);
+  } finally {
+    await app.unmount();
+  }
+});

--- a/desktop/src/app/navigation/useOpenMessageLink.test.mjs
+++ b/desktop/src/app/navigation/useOpenMessageLink.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import { after, beforeEach, test } from "node:test";
+import { JSDOM } from "jsdom";
+
+// Keep both production hooks, destination resolution and the durable drain real;
+// substitute only navigation and Tauri IPC to observe their boundary contracts.
+registerHooks({
+  resolve(specifier, context, next) {
+    if (specifier === "@/app/navigation/useAppNavigation") {
+      return { shortCircuit: true, url: "buzz-test:navigation" };
+    }
+    return next(specifier, context);
+  },
+  load(url, context, next) {
+    if (url === "buzz-test:navigation") {
+      return {
+        shortCircuit: true,
+        format: "module",
+        source:
+          "export function useAppNavigation() { return globalThis.testNavigation; }",
+      };
+    }
+    return next(url, context);
+  },
+});
+const dom = new JSDOM("<!doctype html><body></body>", {
+  url: "http://localhost",
+});
+Object.assign(globalThis, {
+  window: dom.window,
+  document: dom.window.document,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+const { createElement, act } = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { useOpenMessageLink } = await import("./useOpenMessageLink.ts");
+const { useMessageDeepLinks } = await import("@/shared/useMessageDeepLinks");
+const { resetNavigationDeepLinkDrain } = await import("@/shared/deep-link");
+let queue, calls, accepted, fetchEvent, navigate;
+const ipc = {
+  transformCallback: () => 1,
+  invoke: async (command, args) => {
+    if (command === "clear_pending_navigation_deep_links") return;
+    if (command === "get_event") return JSON.stringify(await fetchEvent(args));
+    if (command === "take_pending_navigation_deep_link")
+      return queue[0] ?? null;
+    if (command === "acknowledge_pending_navigation_deep_link") {
+      accepted.push(args.id);
+      queue.shift();
+      return true;
+    }
+    if (command.startsWith("plugin:event|")) return 1;
+    throw new Error(`Unexpected IPC: ${command}`);
+  },
+};
+globalThis.__TAURI_INTERNALS__ = dom.window.__TAURI_INTERNALS__ = ipc;
+dom.window.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener() {} };
+const link = { channelId: "channel", messageId: "message", threadRootId: null };
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+async function settle() {
+  await act(async () => {
+    await new Promise((done) => setTimeout(done, 10));
+  });
+}
+async function mount(listener = false) {
+  let open;
+  function Harness({ enabled }) {
+    open = useOpenMessageLink();
+    useMessageDeepLinks(listener && enabled);
+    return null;
+  }
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  await act(async () => root.render(createElement(Harness, { enabled: true })));
+  return {
+    open: (...args) => open(...args),
+    disable: async () =>
+      act(async () => root.render(createElement(Harness, { enabled: false }))),
+    unmount: async () => act(async () => root.unmount()),
+  };
+}
+beforeEach(async () => {
+  await resetNavigationDeepLinkDrain();
+  queue = [];
+  calls = [];
+  accepted = [];
+  fetchEvent = async () => ({ kind: 45001, tags: [] });
+  navigate = async () => true;
+  globalThis.testNavigation = {
+    goChannel: (...args) => {
+      calls.push(["channel", ...args]);
+      return navigate();
+    },
+    goForumPost: (...args) => {
+      calls.push(["forum", ...args]);
+      return navigate();
+    },
+  };
+});
+after(() => dom.window.close());
+for (const [kind, expected] of [
+  [45001, ["forum", "channel", "message", { replyId: undefined }]],
+  [45003, ["forum", "channel", "a".repeat(64), { replyId: "message" }]],
+  [9, ["channel", "channel", { messageId: "message", threadRootId: null }]],
+]) {
+  test(`production hook routes event kind ${kind}`, async () => {
+    fetchEvent = async () => ({
+      kind,
+      tags: [
+        ["e", "a".repeat(64), "", "root"],
+        ["e", "a".repeat(64), "", "reply"],
+      ],
+    });
+    const app = await mount();
+    try {
+      assert.equal(await app.open(link), true);
+      assert.deepEqual(calls, [expected]);
+    } finally {
+      await app.unmount();
+    }
+  });
+}
+for (const kind of [45001, 9]) {
+  test(`refused kind ${kind} stays queued until an accepted retry`, async () => {
+    fetchEvent = async () => ({ kind, tags: [] });
+    queue.push({ id: "pending", kind: "message", ...link });
+    navigate = async () => false;
+    const app = await mount(true);
+    await settle();
+    assert.equal(calls.length, 1);
+    assert.deepEqual(accepted, []);
+    assert.equal(queue.length, 1);
+    await app.unmount();
+    navigate = async () => true;
+    const retry = await mount(true);
+    try {
+      await settle();
+      assert.deepEqual(accepted, ["pending"]);
+      assert.equal(queue.length, 0);
+    } finally {
+      await retry.unmount();
+    }
+  });
+}
+test("acknowledgement waits for navigation completion", async () => {
+  const pending = deferred();
+  navigate = () => pending.promise;
+  queue.push({ id: "pending", kind: "message", ...link });
+  const app = await mount(true);
+  try {
+    await settle();
+    assert.equal(calls.length, 1);
+    assert.deepEqual(accepted, []);
+    pending.resolve(true);
+    await settle();
+    assert.deepEqual(accepted, ["pending"]);
+  } finally {
+    await app.unmount();
+  }
+});
+for (const lifecycle of ["unmount", "disable"]) {
+  test(`${lifecycle} during lookup prevents stale navigation and acknowledgement`, async () => {
+    const lookup = deferred();
+    fetchEvent = () => lookup.promise;
+    queue.push({ id: "pending", kind: "message", ...link });
+    const app = await mount(true);
+    await settle();
+    await app[lifecycle]();
+    lookup.resolve({ kind: 45001, tags: [] });
+    await settle();
+    assert.deepEqual(calls, []);
+    assert.deepEqual(accepted, []);
+    if (lifecycle === "disable") await app.unmount();
+  });
+}
+test("in-app hook lookup cannot navigate after community unmount", async () => {
+  const lookup = deferred();
+  fetchEvent = () => lookup.promise;
+  const app = await mount();
+  const result = app.open(link);
+  await app.unmount();
+  lookup.resolve({ kind: 9, tags: [] });
+  assert.equal(await result, false);
+  assert.deepEqual(calls, []);
+});

--- a/desktop/src/app/navigation/useOpenMessageLink.ts
+++ b/desktop/src/app/navigation/useOpenMessageLink.ts
@@ -15,28 +15,34 @@ import type { ParsedMessageLink } from "@/features/messages/lib/messageLink";
  *
  * Shared by the in-app markdown handler and the deep-link listener so both
  * route identically.
+ *
+ * Returns the navigation promise. The deep-link listener acks a pending link by
+ * resolving `true`, and that ack drops the link from the durable queue, so it
+ * has to await the navigation it claims to have performed — the channel-only
+ * listener beside it already awaits `goChannel`. Click handlers that have
+ * nothing to wait for can discard it.
  */
 export function useOpenMessageLink() {
   const { goChannel, goForumPost } = useAppNavigation();
 
   return React.useCallback(
-    (link: ParsedMessageLink) => {
-      void resolveMessageLinkDestination(
+    (link: ParsedMessageLink): Promise<void> =>
+      resolveMessageLinkDestination(
         link.channelId,
         link.messageId,
         link.threadRootId,
-      ).then((destination) => {
+      ).then(async (destination) => {
         if (destination.kind === "forum-post") {
-          return goForumPost(destination.channelId, destination.postId, {
+          await goForumPost(destination.channelId, destination.postId, {
             replyId: destination.replyId,
           });
+          return;
         }
-        return goChannel(destination.channelId, {
+        await goChannel(destination.channelId, {
           messageId: destination.messageId,
           threadRootId: destination.threadRootId,
         });
-      });
-    },
+      }),
     [goChannel, goForumPost],
   );
 }

--- a/desktop/src/app/navigation/useOpenMessageLink.ts
+++ b/desktop/src/app/navigation/useOpenMessageLink.ts
@@ -1,0 +1,42 @@
+import * as React from "react";
+
+import { resolveMessageLinkDestination } from "@/app/navigation/resolveMessageLinkDestination";
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import type { ParsedMessageLink } from "@/features/messages/lib/messageLink";
+
+/**
+ * Opens a `buzz://message` link at its real destination.
+ *
+ * Resolves the target event's kind before routing: `/channels/$channelId`
+ * hardcodes `selectedPostId={null}`, so a forum post or comment sent through
+ * `goChannel` lands on the post list with nothing selected. Stream targets keep
+ * the previous behaviour — `goChannel` with `messageId`, resolved by
+ * `useAnchoredScroll` + `getEventById` backfill.
+ *
+ * Shared by the in-app markdown handler and the deep-link listener so both
+ * route identically.
+ */
+export function useOpenMessageLink() {
+  const { goChannel, goForumPost } = useAppNavigation();
+
+  return React.useCallback(
+    (link: ParsedMessageLink) => {
+      void resolveMessageLinkDestination(
+        link.channelId,
+        link.messageId,
+        link.threadRootId,
+      ).then((destination) => {
+        if (destination.kind === "forum-post") {
+          return goForumPost(destination.channelId, destination.postId, {
+            replyId: destination.replyId,
+          });
+        }
+        return goChannel(destination.channelId, {
+          messageId: destination.messageId,
+          threadRootId: destination.threadRootId,
+        });
+      });
+    },
+    [goChannel, goForumPost],
+  );
+}

--- a/desktop/src/app/navigation/useOpenMessageLink.ts
+++ b/desktop/src/app/navigation/useOpenMessageLink.ts
@@ -16,33 +16,41 @@ import type { ParsedMessageLink } from "@/features/messages/lib/messageLink";
  * Shared by the in-app markdown handler and the deep-link listener so both
  * route identically.
  *
- * Returns the navigation promise. The deep-link listener acks a pending link by
- * resolving `true`, and that ack drops the link from the durable queue, so it
- * has to await the navigation it claims to have performed — the channel-only
- * listener beside it already awaits `goChannel`. Click handlers that have
- * nothing to wait for can discard it.
+ * Returns whether navigation was accepted, so refused links remain queued.
+ * Pending lookups cannot navigate after this hook unmounts or the caller's
+ * lifecycle signal aborts.
  */
 export function useOpenMessageLink() {
   const { goChannel, goForumPost } = useAppNavigation();
 
+  const lifecycle = React.useRef<AbortController | null>(null);
+  React.useEffect(() => {
+    const controller = new AbortController();
+    lifecycle.current = controller;
+    return () => controller.abort();
+  }, []);
+
   return React.useCallback(
-    (link: ParsedMessageLink): Promise<void> =>
-      resolveMessageLinkDestination(
+    async (link: ParsedMessageLink, signal?: AbortSignal): Promise<boolean> => {
+      const ownerSignal = lifecycle.current?.signal;
+      const cancelled = () => ownerSignal?.aborted || signal?.aborted;
+      if (cancelled()) return false;
+      const destination = await resolveMessageLinkDestination(
         link.channelId,
         link.messageId,
         link.threadRootId,
-      ).then(async (destination) => {
-        if (destination.kind === "forum-post") {
-          await goForumPost(destination.channelId, destination.postId, {
-            replyId: destination.replyId,
-          });
-          return;
-        }
-        await goChannel(destination.channelId, {
-          messageId: destination.messageId,
-          threadRootId: destination.threadRootId,
+      );
+      if (cancelled()) return false;
+      if (destination.kind === "forum-post") {
+        return goForumPost(destination.channelId, destination.postId, {
+          replyId: destination.replyId,
         });
-      }),
+      }
+      return goChannel(destination.channelId, {
+        messageId: destination.messageId,
+        threadRootId: destination.threadRootId,
+      });
+    },
     [goChannel, goForumPost],
   );
 }

--- a/desktop/src/app/navigation/useOpenMessageLink.ts
+++ b/desktop/src/app/navigation/useOpenMessageLink.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { beginMessageLinkRequest } from "@/app/navigation/messageLinkRequests";
 import { resolveMessageLinkDestination } from "@/app/navigation/resolveMessageLinkDestination";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import type { ParsedMessageLink } from "@/features/messages/lib/messageLink";
@@ -18,7 +19,8 @@ import type { ParsedMessageLink } from "@/features/messages/lib/messageLink";
  *
  * Returns whether navigation was accepted, so refused links remain queued.
  * Pending lookups cannot navigate after this hook unmounts or the caller's
- * lifecycle signal aborts.
+ * lifecycle signal aborts. Newer activations supersede older pending lookups,
+ * including those started by another mounted message renderer.
  */
 export function useOpenMessageLink() {
   const { goChannel, goForumPost } = useAppNavigation();
@@ -31,16 +33,32 @@ export function useOpenMessageLink() {
   }, []);
 
   return React.useCallback(
-    async (link: ParsedMessageLink, signal?: AbortSignal): Promise<boolean> => {
+    async (
+      link: ParsedMessageLink,
+      options?: {
+        signal?: AbortSignal;
+        /** Disable best-effort fallback when success acknowledges a durable link. */
+        allowChannelFallback?: boolean;
+      },
+    ): Promise<boolean> => {
+      const signal = options?.signal;
       const ownerSignal = lifecycle.current?.signal;
       const cancelled = () => ownerSignal?.aborted || signal?.aborted;
       if (cancelled()) return false;
+      const isCurrent = beginMessageLinkRequest();
       const destination = await resolveMessageLinkDestination(
         link.channelId,
         link.messageId,
         link.threadRootId,
       );
-      if (cancelled()) return false;
+      if (cancelled() || !isCurrent()) return false;
+      if (!destination) {
+        if (options?.allowChannelFallback === false) return false;
+        return goChannel(link.channelId, {
+          messageId: link.messageId,
+          threadRootId: link.threadRootId,
+        });
+      }
       if (destination.kind === "forum-post") {
         return goForumPost(destination.channelId, destination.postId, {
           replyId: destination.replyId,

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { isTauri } from "@tauri-apps/api/core";
+import { resetMessageLinkRequests } from "@/app/navigation/messageLinkRequests";
 import { isMacPlatform } from "@/shared/lib/platform";
 
 import { relayClient } from "@/shared/api/relayClient";
@@ -61,6 +62,7 @@ async function resetCommunityState({
 }: {
   resetAvatarState: boolean;
 }): Promise<void> {
+  resetMessageLinkRequests();
   relayClient.disconnect();
   await resetNavigationDeepLinkDrain();
   resetRateLimitGate();

--- a/desktop/src/features/messages/lib/messageLink.ts
+++ b/desktop/src/features/messages/lib/messageLink.ts
@@ -14,10 +14,10 @@ export type MessageLinkInput = {
    * Optional thread root event id. Present when the linked message is a
    * reply (so the caller can route into a thread / forum post view).
    *
-   * Currently emitted into the URL but not consumed by the click handler
-   * or deep-link listener — both route via `goChannel(channelId,
-   * { messageId })` and let `useAnchoredScroll` resolve the target.
-   * Reserved for future "open in thread view" routing.
+   * Consumed by both the click handler and the deep-link listener: each
+   * runs `resolveMessageLinkDestination`, which routes forum targets to
+   * `goForumPost` and passes this through to `goChannel` for stream
+   * targets, where `useAnchoredScroll` resolves it.
    */
   threadRootId?: string | null;
 };

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -5,13 +5,13 @@ import { ChevronLeft, ChevronRight, Download } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useOpenMessageLink } from "@/app/navigation/useOpenMessageLink";
 import { requestOpenSnapshotImport } from "@/features/agents/openSnapshotImportFromUrlEvent";
 import { parseChannelLink } from "@/features/messages/lib/channelLink";
 import { isAudioAttachment } from "@/features/messages/lib/audioAttachment";
 import {
   parseMessageLink,
   resolveMessageLinkRenderTarget,
-  type ParsedMessageLink,
 } from "@/features/messages/lib/messageLink";
 import { renderAudioMessageAttachment } from "@/features/messages/ui/AudioMessageAttachment";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
@@ -1706,18 +1706,7 @@ function MarkdownInner({
     [goChannel],
   );
   const onOpenEntityLink = useOpenEntityLink();
-  const onOpenMessageLink = React.useCallback(
-    (link: ParsedMessageLink) => {
-      // Always route through `goChannel` with `messageId` set: the navigation
-      // boundary guards every message-targeting caller before URL mutation.
-      // `useAnchoredScroll` + `getEventById` backfill, and works for
-      void goChannel(link.channelId, {
-        messageId: link.messageId,
-        threadRootId: link.threadRootId,
-      });
-    },
-    [goChannel],
-  );
+  const onOpenMessageLink = useOpenMessageLink();
   const relayOrigin = useRelayOrigin();
   const resolvedLinkPreviews = useMessageLinkPreviews({
     content,

--- a/desktop/src/shared/useMessageDeepLinks.ts
+++ b/desktop/src/shared/useMessageDeepLinks.ts
@@ -35,7 +35,10 @@ export function useMessageDeepLinks(enabled = true) {
       },
       async (payload) => {
         if (cancelled) return false;
-        openMessageLink({
+        // Resolving `true` acks the link and drops it from the durable pending
+        // queue, so the navigation has to have landed first — same contract the
+        // channel listener above keeps by awaiting `goChannel`.
+        await openMessageLink({
           channelId: payload.channelId,
           messageId: payload.messageId,
           threadRootId: payload.threadRootId,

--- a/desktop/src/shared/useMessageDeepLinks.ts
+++ b/desktop/src/shared/useMessageDeepLinks.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { useOpenMessageLink } from "@/app/navigation/useOpenMessageLink";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { listenForNavigationDeepLinks } from "@/shared/deep-link";
 
@@ -13,12 +14,14 @@ import { listenForNavigationDeepLinks } from "@/shared/deep-link";
  * Mirrors the cold-start race handling of the `connect` listener in
  * `App.tsx`: late-arriving payloads from a fresh launch are picked up the
  * first time the listener mounts. Routing matches the in-app buzz://
- * handler in `markdown.tsx`: always `goChannel` with `messageId` and let
- * the channel route's existing scroll-into-view + getEventById backfill
- * resolve the target (works for both stream replies and forum threads).
+ * handler in `markdown.tsx`: resolve the target event's kind first, then
+ * route forum posts and comments to `goForumPost` and everything else to
+ * `goChannel`. `/channels/$channelId` cannot select a forum post, so
+ * routing a forum target through it lands on the post list instead.
  */
 export function useMessageDeepLinks(enabled = true) {
   const { goChannel } = useAppNavigation();
+  const openMessageLink = useOpenMessageLink();
 
   React.useEffect(() => {
     if (!enabled) return;
@@ -32,15 +35,17 @@ export function useMessageDeepLinks(enabled = true) {
       },
       async (payload) => {
         if (cancelled) return false;
-        return goChannel(payload.channelId, {
+        openMessageLink({
+          channelId: payload.channelId,
           messageId: payload.messageId,
           threadRootId: payload.threadRootId,
         });
+        return true;
       },
     );
     return () => {
       cancelled = true;
       void unlistenPromise.then((unlisten) => unlisten());
     };
-  }, [enabled, goChannel]);
+  }, [enabled, goChannel, openMessageLink]);
 }

--- a/desktop/src/shared/useMessageDeepLinks.ts
+++ b/desktop/src/shared/useMessageDeepLinks.ts
@@ -41,7 +41,7 @@ export function useMessageDeepLinks(enabled = true) {
             messageId: payload.messageId,
             threadRootId: payload.threadRootId,
           },
-          signal,
+          { signal, allowChannelFallback: false },
         );
       },
     );

--- a/desktop/src/shared/useMessageDeepLinks.ts
+++ b/desktop/src/shared/useMessageDeepLinks.ts
@@ -26,28 +26,27 @@ export function useMessageDeepLinks(enabled = true) {
   React.useEffect(() => {
     if (!enabled) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
+    const { signal } = controller;
     const unlistenPromise = listenForNavigationDeepLinks(
       async (payload) => {
-        if (cancelled) return false;
-        await goChannel(payload.channelId);
-        return true;
+        if (signal.aborted) return false;
+        return goChannel(payload.channelId);
       },
       async (payload) => {
-        if (cancelled) return false;
-        // Resolving `true` acks the link and drops it from the durable pending
-        // queue, so the navigation has to have landed first — same contract the
-        // channel listener above keeps by awaiting `goChannel`.
-        await openMessageLink({
-          channelId: payload.channelId,
-          messageId: payload.messageId,
-          threadRootId: payload.threadRootId,
-        });
-        return true;
+        if (signal.aborted) return false;
+        return openMessageLink(
+          {
+            channelId: payload.channelId,
+            messageId: payload.messageId,
+            threadRootId: payload.threadRootId,
+          },
+          signal,
+        );
       },
     );
     return () => {
-      cancelled = true;
+      controller.abort();
       void unlistenPromise.then((unlisten) => unlisten());
     };
   }, [enabled, goChannel, openMessageLink]);


### PR DESCRIPTION
## Why

Fixes #7315. A `buzz://message` link into a **forum** channel opens the post
list and never selects the post, so a forum message is unreachable from its own
"Copy link".

## Root cause

Both message-link entry points routed everything through `goChannel`:

- `desktop/src/shared/useMessageDeepLinks.ts` — the deep-link listener
- `desktop/src/shared/ui/markdown.tsx` — the in-app `buzz://` handler

`/channels/$channelId` cannot select a forum post: `channels.$channelId.tsx`
hardcodes `selectedPostId={null}`, and `useChannelRouteTarget` returns early
when `activeChannel.channelType === "forum"`. The route that works —
`/channels/$channelId/posts/$postId` — was never used by message links.

## What

Add `resolveMessageLinkDestination(channelId, messageId, threadRootId)`,
mirroring `resolveSearchHitDestination`. Search already solves exactly this:
`openSearchHitWithNavigation` resolves a destination first and branches to
`goForumPost` for forum targets. A message link carries no kind of its own, so
the event is fetched and branched on `KIND_FORUM_POST` / `KIND_FORUM_COMMENT`;
a comment resolves its post via `getThreadReference` and passes itself as
`replyId`.

Both entry points share `useOpenMessageLink`. Queued OS links are acknowledged
only after their destination is resolved and navigation is accepted. Lookup
failures, missing forum roots, and refused navigation leave the durable entry
available for retry. In-app clicks retain their best-effort channel fallback.

Pending lookups cannot navigate after community teardown or listener cancellation.
A shared request token makes the latest message-link activation win, including
clicks from separate mounted message renderers; community reset invalidates the token.

Extracting the hook also takes `markdown.tsx` from 1862 to 1850 lines — the
file-size ratchet blocks growth on files already over the limit, and inlining
the branch there would have added 14.

Two comments asserting the old behaviour is fine are corrected in the same
change (`messageLink.ts`, `useMessageDeepLinks.ts`); the issue calls both out.

## Before / after

The two destinations, in the mock `watercooler` forum. A forum message link
used to land on the left and now lands on the right.

**Before** — `/channels/<forum>?messageId=<post>`: the post list, nothing selected:

![before](https://raw.githubusercontent.com/PresentJay/buzz/31af1fdcadd0c623133433c9aa596ffe23f281e2/pr-7315--01-before.png)

**After** — `/channels/<forum>/posts/<post>`: the post, with its 25 replies:

![after](https://raw.githubusercontent.com/PresentJay/buzz/31af1fdcadd0c623133433c9aa596ffe23f281e2/pr-7315--02-after.png)

## Tests

`resolveMessageLinkDestination.test.mjs` covers forum post, forum comment
(asserting both `postId` and `replyId`), stream message, a comment with no
resolvable root, and a failed lookup. `useOpenMessageLink.test.mjs` mounts the
production hooks with the real resolver and durable deep-link drain. It covers
routing, acknowledgement ordering, failure/refusal and retry, teardown, and
out-of-order lookup completion across hook instances. Mutation checks verify
that restoring fallback acknowledgement or removing the request fence fails
the relevant regressions.

Fork PRs need maintainer approval before CI runs, so local results for the
pushed head, via the repo's pre-push lanes:

```
desktop-check      ✔  biome + check:px-text + check:pubkey-truncation
desktop-typecheck  ✔  tsc --noEmit
desktop-test       ✔
file-size-check    ✔  markdown.tsx 1862 -> 1850
```
