### PR TITLE
fix(desktop): treat relay-closed mobile pairing as expired

### DIFF
--- a/desktop/src/features/settings/ui/MobilePairingCard.tsx
+++ b/desktop/src/features/settings/ui/MobilePairingCard.tsx
@@ -50,7 +50,13 @@ function pairingErrorMessage(error: unknown) {
 }
 
 function isPairingSessionTimeout(message: string) {
-  return message.toLowerCase().includes("session timed out");
+  const normalized = message.toLowerCase();
+  // Sidecar closes the socket at 120s before the desktop "session timed out"
+  // path; treat that the same as expiry (matches IdentityRecoveryPairing).
+  return (
+    normalized.includes("session timed out") ||
+    normalized.includes("relay connection closed")
+  );
 }
 
 function PairingStepIndicator({


### PR DESCRIPTION
## Summary
- The pair-relay closes the socket at 120s before settings recognized `session timed out`.
- Treat `relay connection closed` as expired, matching identity recovery pairing.

## Test plan
- [ ] Let a mobile pairing QR sit past the relay timeout and confirm the expired step
- [ ] A real error still shows the error step

Made with [Cursor](https://cursor.com)