### PR TITLE
fix(cli): lowercase event ids in social get queries

### DIFF
--- a/crates/buzz-cli/src/commands/social.rs
+++ b/crates/buzz-cli/src/commands/social.rs
@@ -71,6 +71,7 @@ pub async fn cmd_set_contact_list(
 /// Get a single event by ID via POST /query.
 pub async fn cmd_get_event(client: &BuzzClient, event_id: &str) -> Result<(), CliError> {
     validate_hex64(event_id)?;
+    let event_id = event_id.to_ascii_lowercase();
     let filter = serde_json::json!({
         "ids": [event_id]
     });


### PR DESCRIPTION
## Summary
- `validate_hex64` accepts A-F, but `ids` filters are lowercase-only.
- Lowercase before querying so uppercase lookups do not look like missing events.

## Test plan
- [ ] `buzz social get --id <UPPERCASE_EVENT_ID>` finds the event
- [ ] Lowercase ids still work

Made with [Cursor](https://cursor.com)