### PR TITLE
fix(agents): keep unavailable saved effort visible

### DIFF
--- a/desktop/src/features/agents/ui/effortPicker.test.mjs
+++ b/desktop/src/features/agents/ui/effortPicker.test.mjs
@@ -78,14 +78,19 @@ test("current effort preselects the matching option", () => {
   assert.equal(state.selectValue, "high");
 });
 
-test("an unknown current effort falls back to the adapter-default sentinel", () => {
+test("an unavailable saved effort stays visible without becoming the default", () => {
   const state = effortPickerState({
     backend: localBackend,
     effortConfigId: "thought_level",
     effortOptions: options,
     currentEffort: "extreme",
   });
-  assert.equal(state.selectValue, EFFORT_DEFAULT_DROPDOWN_VALUE);
+  assert.equal(state.selectValue, "extreme");
+  assert.deepEqual(state.options.at(-1), {
+    label: "extreme (unavailable)",
+    value: "extreme",
+    disabled: true,
+  });
 });
 
 test("a null current effort selects the adapter-default sentinel", () => {

--- a/desktop/src/features/agents/ui/effortPicker.ts
+++ b/desktop/src/features/agents/ui/effortPicker.ts
@@ -49,14 +49,20 @@ export function effortPickerState({
     })),
   ];
 
-  // Preselect the currently-configured effort when it maps to a known option;
-  // otherwise fall back to the adapter-default sentinel (also the null case).
+  // Preserve an explicit value when the adapter catalog changes. Presenting
+  // it as the default would hide the configured override without clearing it.
   const trimmed = currentEffort?.trim() ?? "";
-  const selectValue =
-    trimmed.length > 0 &&
-    (effortOptions ?? []).some((option) => option.value === trimmed)
-      ? trimmed
-      : EFFORT_DEFAULT_DROPDOWN_VALUE;
+  if (
+    trimmed &&
+    !(effortOptions ?? []).some((option) => option.value === trimmed)
+  ) {
+    options.push({
+      label: `${trimmed} (unavailable)`,
+      value: trimmed,
+      disabled: true,
+    });
+  }
+  const selectValue = trimmed || EFFORT_DEFAULT_DROPDOWN_VALUE;
 
   return { visible, options, selectValue };
 }

--- a/desktop/src/features/agents/ui/effortPickerField.test.mjs
+++ b/desktop/src/features/agents/ui/effortPickerField.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EffortPickerField } from "./EffortPickerField.tsx";
+
+const options = [{ value: "low", displayName: "Low" }];
+function render(value, effortOptions = options) {
+  return renderToStaticMarkup(
+    React.createElement(EffortPickerField, {
+      agent: { backend: { type: "local" } },
+      config: { effortConfigId: "depth", effortOptions },
+      value,
+      disabled: false,
+      onChange: () =>
+        assert.fail("Rendering must not rewrite the saved effort"),
+    }),
+  );
+}
+
+test("the real effort trigger discloses an unavailable explicit value", () => {
+  const html = render("high");
+  assert.match(html, /high \(unavailable\)/);
+  assert.doesNotMatch(html, />Adapter default</);
+});
+
+test("catalog recovery restores the adapter label without changing the value", () => {
+  const html = render("high", [
+    ...options,
+    { value: "high", displayName: "High" },
+  ]);
+  assert.match(html, />High</);
+  assert.doesNotMatch(html, /unavailable/);
+});
+
+test("only an unset effort displays the adapter default", () => {
+  assert.match(render(null), />Adapter default</);
+});


### PR DESCRIPTION
When an adapter stops advertising an agent’s saved effort value, the edit dialog currently displays “Adapter default” even though the explicit override remains configured.

Keep that saved value selected as a disabled “(unavailable)” option. Users can still choose an advertised value or explicitly clear the override. If discovery advertises the saved value again, the picker returns to the adapter’s label. This changes presentation only; persistence and startup behavior stay unchanged.

Validation: 6,452 desktop tests passed, including 13 focused picker tests. The real component’s rendered trigger is checked for unavailable values, catalog recovery, and an unset override. Restoring the old production helper makes the regression tests fail. Type checking, targeted formatting, the file-size check, and the production build passed.

Full repository check: `just ci` passed, including Rust/Tauri tests, desktop and web builds, and all 2,072 mobile tests.
