### PR TITLE
feat(nix): add sidecars-only flake for headless/server deployment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788531059,
+        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Buzz sidecar binaries (buzz-acp, buzz-agent, buzz CLI) — headless/server Nix packaging, no desktop app";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.default = pkgs.callPackage ./nix/buzz.nix { };
+        packages.buzz-sidecars = pkgs.callPackage ./nix/buzz.nix { };
+      });
+}

--- a/nix/buzz.nix
+++ b/nix/buzz.nix
@@ -1,0 +1,45 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl }:
+
+let
+  versions = import ./versions.nix;
+
+  src = fetchFromGitHub {
+    owner = "block";
+    repo = "buzz";
+    rev = versions.buzzRev;
+    hash = versions.buzzSrcHash;
+  };
+
+  # Only the CLI-side binaries a headless/server deployment needs. The
+  # desktop app (Tauri + pnpm frontend + sherpa-onnx) and its two
+  # desktop-only sidecars (buzz-dev-mcp, git-credential-nostr) are out of
+  # scope here — see flake.nix's description and the PR this shipped in.
+  sidecarPackages = [ "buzz-acp" "buzz-agent" "buzz-cli" ];
+in
+rustPlatform.buildRustPackage {
+  pname = "buzz-sidecars";
+  version = builtins.substring 0 8 versions.buzzRev;
+  inherit src;
+
+  cargoLock = {
+    lockFileContents = builtins.readFile (src + "/Cargo.lock");
+    outputHashes = versions.sidecarCargoOutputHashes;
+  };
+
+  cargoBuildFlags = lib.concatMap (p: [ "-p" p ]) sidecarPackages;
+  # The workspace test suite covers crates this build doesn't compile (the
+  # relay, desktop app, etc.) and wasn't evaluated for network/workspace-wide
+  # assumptions a sandboxed sidecars-only build can't satisfy.
+  doCheck = false;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
+    description = "Buzz sidecar binaries (buzz-acp, buzz-agent, buzz CLI) for headless/server deployment";
+    homepage = "https://github.com/block/buzz";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    mainProgram = "buzz-acp";
+  };
+}

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -1,0 +1,17 @@
+{
+  # buzz-acp/buzz-agent/buzz-cli don't carry an independent release version —
+  # the whole workspace shares `workspace.package.version = "0.1.0"` — so a
+  # commit SHA is the only meaningful pin for this sidecars-only build.
+  # Bump by hand; `nix build` reports the correct new hash on mismatch.
+  buzzRev = "dad5a33865fc81a2e55b3b60746632f615ec1e3a";
+  buzzSrcHash = "sha256-5Y6KhzrpGUb7tw71t3bN5asJg45rNz413gNt0m4lPks=";
+
+  # Cargo.lock entries sourced from git rather than crates.io.
+  # buildRustPackage needs an explicit FOD hash for each distinct git
+  # source. Regenerate by deleting an entry and letting `nix build` report
+  # the correct hash on mismatch.
+  sidecarCargoOutputHashes = {
+    "aws-creds-0.39.1" = "sha256-QAAm1phmeLFtDRgfDCoHijN1ce/rYzh18KziOUbL+hw=";
+    "mesh-llm-api-client-0.75.1" = "sha256-RXjmM66u40cxnacbvTtCFJShMK4BM+MHOyJ2vQ7Gw60=";
+  };
+}


### PR DESCRIPTION
## Summary

Adds a `nix build` path for just the three CLI-side binaries —
`buzz-acp`, `buzz-agent`, and the `buzz` CLI — with none of the desktop
app's dependency footprint (no Tauri, no pnpm frontend, no
gtk/webkit/alsa/gstreamer, no sherpa-onnx). Intended for headless Linux
server deployment, e.g. running `buzz-acp` as a systemd unit on a
server that will never run the desktop app.

### What's included

- **`flake.nix`** — standard flake output via `flake-utils.eachDefaultSystem`.
- **`nix/buzz.nix`** — a single `rustPlatform.buildRustPackage` derivation
  building `-p buzz-acp -p buzz-agent -p buzz-cli` from the workspace.
- **`nix/versions.nix`** — single source of truth for the pinned commit,
  source hash, and Cargo.lock `outputHashes` for the two git-sourced
  dependencies (`aws-creds`, `mesh-llm-api-client`).

### Related to #3434

#3434 adds first-class Nix support for the full desktop+sidecars flake
(five crates: `buzz-acp`, `buzz-agent`, `buzz-dev-mcp`,
`git-credential-nostr`, `buzz-cli`, plus the Tauri desktop app). This PR
is a narrower, standalone alternative scoped to just the three crates a
headless server actually runs — no desktop app, no `buzz-dev-mcp`/
`git-credential-nostr` (both desktop-dev-only). Its own `nix build`
succeeds today, independent of #3434 landing.

One correction along the way: #3434 marks its combined derivation
`licenses.unfree`, driven by the desktop app's bundled sherpa-onnx
binaries. A sidecars-only build has none of that dependency and is
clean Apache-2.0, matching this repo's own `LICENSE`.

One deliberate structural difference from #3434, noted in
`nix/versions.nix`: this pins `src` via `fetchFromGitHub` with an
explicit rev+hash rather than a self-referencing flake input, so a
fresh checkout builds reproducibly without a separate `nix flake
update` step first.

If #3434 lands first, this PR becomes redundant and can be closed in
favor of consuming its `buzz-sidecars` output directly — flagging that
tradeoff here rather than duplicating effort silently.

### Testing

```
nix flake check   # evaluation passes on x86_64-linux
nix build         # builds cleanly
./result/bin/buzz-acp --help
./result/bin/buzz --help
```

Verified with a real `nix build` against this PR's pinned commit
(`dad5a33865fc81a2e55b3b60746632f615ec1e3a`) on x86_64-linux — all
three binaries (`buzz-acp`, `buzz-agent`, `buzz`) build and run.
`buzz-acp` from this exact packaging approach (same crate set, same
sidecar-only scope) has also been running as a durable systemd unit in
production for about a month, handling live `@claude` mentions on a
real relay.

### Related issue

None found — no existing issue proposes sidecars-only Nix packaging
specifically; #3434 (linked above) is the closest existing PR.
