### PR TITLE
fix(mobile): bind same-name mentions to exact selected identities

### DIFF
--- a/mobile/lib/features/activity/compose_drafts_provider.dart
+++ b/mobile/lib/features/activity/compose_drafts_provider.dart
@@ -22,6 +22,10 @@ class ComposeDraft {
   final String channelId;
   final String? threadHeadId;
   final String text;
+
+  /// Literal picker labels bound to exact keys, never authorization metadata.
+  /// An empty key/value is a malformed-record tombstone; send must refuse it.
+  final Map<String, String> mentionKeys;
   final int updatedAt; // unix seconds
 
   const ComposeDraft({
@@ -30,6 +34,7 @@ class ComposeDraft {
     required this.threadHeadId,
     required this.text,
     required this.updatedAt,
+    this.mentionKeys = const {},
   });
 
   Map<String, dynamic> toJson() => {
@@ -37,6 +42,7 @@ class ComposeDraft {
     'channel_id': channelId,
     if (threadHeadId != null) 'thread_head_id': threadHeadId,
     'text': text,
+    'mention_keys': mentionKeys,
     'updated_at': updatedAt,
   };
 
@@ -48,10 +54,32 @@ class ComposeDraft {
     final updatedAt = raw['updated_at'];
     if (key is! String || channelId is! String || text is! String) return null;
     if (text.trim().isEmpty) return null;
+    final bindings = raw['mention_keys'];
+    final mentionKeys = <String, String>{};
+    if (raw.containsKey('mention_keys')) {
+      if (bindings is! Map<String, dynamic>) {
+        mentionKeys[''] = '';
+      } else {
+        final labels = <String>{};
+        for (final entry in bindings.entries) {
+          if (!labels.add(entry.key.toLowerCase())) mentionKeys[''] = '';
+          final value = entry.value;
+          mentionKeys[entry.key] =
+              entry.key.isNotEmpty &&
+                  value is String &&
+                  RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(value)
+              ? value.toLowerCase()
+              : '';
+        }
+      }
+    }
     return ComposeDraft(
       key: key,
       channelId: channelId,
-      threadHeadId: raw['thread_head_id'] as String?,
+      threadHeadId: raw['thread_head_id'] is String
+          ? raw['thread_head_id'] as String
+          : null,
+      mentionKeys: Map.unmodifiable(mentionKeys),
       text: text,
       updatedAt: updatedAt is int ? updatedAt : 0,
     );
@@ -108,18 +136,23 @@ class ComposeDraftsNotifier extends Notifier<List<ComposeDraft>> {
     required String channelId,
     String? threadHeadId,
     required String text,
+    Map<String, String> mentionKeys = const {},
   }) {
     if (text.trim().isEmpty) {
       remove(key);
       return;
     }
     final existing = state.where((d) => d.key == key).firstOrNull;
-    if (existing?.text == text) return;
+    if (existing?.text == text &&
+        mapEquals(existing?.mentionKeys, mentionKeys)) {
+      return;
+    }
     final draft = ComposeDraft(
       key: key,
       channelId: channelId,
       threadHeadId: threadHeadId,
       text: text,
+      mentionKeys: Map.unmodifiable(mentionKeys),
       updatedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
     );
     final next = [draft, ...state.where((d) => d.key != key)];
@@ -131,8 +164,11 @@ class ComposeDraftsNotifier extends Notifier<List<ComposeDraft>> {
     _persist([...state.where((d) => d.key != key)]);
   }
 
-  String? textFor(String key) =>
-      state.where((d) => d.key == key).firstOrNull?.text;
+  /// Read text and selected identities from the same persisted snapshot.
+  ComposeDraft? draftFor(String key) =>
+      state.where((d) => d.key == key).firstOrNull;
+
+  String? textFor(String key) => draftFor(key)?.text;
 
   void _persist(List<ComposeDraft> drafts) {
     state = List.unmodifiable(drafts);

--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -18,6 +18,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:nostr/nostr.dart' as nostr;
 
 import '../../shared/mentions/agent_identity_provider.dart';
+import '../../shared/mentions/mention_bindings.dart';
 import '../../shared/huddle/huddle_session.dart';
 import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme.dart';

--- a/mobile/lib/features/channels/compose_bar/agent_mention_labels.dart
+++ b/mobile/lib/features/channels/compose_bar/agent_mention_labels.dart
@@ -1,10 +1,54 @@
 part of '../compose_bar.dart';
 
 Set<String> _agentMentionLabels({
-  required Iterable<MentionCandidate> candidates,
-}) {
-  return <String>{
-    for (final candidate in candidates)
-      if (candidate.isAgent) candidate.label,
+  required Map<String, MentionCandidate> bindings,
+}) => {
+  for (final entry in bindings.entries)
+    if (entry.value.isAgent) entry.key,
+};
+
+List<MentionCandidate> _resolveComposerMentions(
+  String text,
+  Map<String, MentionCandidate> selected,
+  List<MentionCandidate> members,
+  List<MentionCandidate> restoredCandidates,
+) {
+  // A broken record cannot fall back to a same-name roster entry.
+  if (selected.values.any((c) => c.pubkey.isEmpty)) {
+    throw const FormatException(
+      'Saved mention identity is invalid. Clear the draft and select again.',
+    );
+  }
+  final candidates = <String, List<MentionCandidate>>{
+    for (final e in selected.entries) e.key.toLowerCase(): [e.value],
   };
+  final selectedNames = candidates.keys.toSet();
+  for (final member in members) {
+    final label = member.label.toLowerCase();
+    if (!selectedNames.contains(label)) (candidates[label] ??= []).add(member);
+  }
+  final winners = <String, MentionCandidate>{};
+  for (final range in mentionOccurrences(text, candidates.keys)) {
+    final identities = {
+      for (final c in candidates[range.label]!) c.pubkey.toLowerCase(): c,
+    };
+    if (identities.length > 1) {
+      throw FormatException(
+        'The mention @${range.label} is ambiguous. Choose a recipient from the mention picker.',
+      );
+    }
+    for (final entry in identities.entries) {
+      final selected = entry.value;
+      final current = restoredCandidates
+          .where((c) => c.pubkey == entry.key)
+          .firstOrNull;
+      if (selected.requiresRevalidation && current == null) {
+        throw const FormatException(
+          'Saved mention is no longer available. Select it again from the picker.',
+        );
+      }
+      winners[entry.key] = selected.requiresRevalidation ? current! : selected;
+    }
+  }
+  return winners.values.toList();
 }

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -86,7 +86,9 @@ class ComposeBar extends HookConsumerWidget {
       attachments: attachments,
     );
     final voiceNoteRef = useRef(voiceNote)..value = voiceNote;
+    final mentionMap = useRef(<String, MentionCandidate>{});
     _useComposeDraftLifecycle(
+      mentionMap: mentionMap,
       ref: ref,
       controller: controller,
       draftKey: draftKey,
@@ -219,7 +221,6 @@ class ComposeBar extends HookConsumerWidget {
     // Map of displayName → selected mention candidate built as the user selects
     // mentions. Used to pass resolved pubkeys directly to onSend and to attach
     // selected non-member agents before the message is published.
-    final mentionMap = useRef(<String, MentionCandidate>{});
 
     // Channel autocomplete state ----------------------------------------------
     final channelQuery = useState<String?>(null);
@@ -244,9 +245,7 @@ class ComposeBar extends HookConsumerWidget {
     // owners so @mention suggestions show names ("managed by …" included).
     final relayAgents = ref.watch(agentDirectoryProvider).asData?.value;
     final agentOwners = ref.watch(agentOwnersProvider).asData?.value;
-    final agentMentionLabels = _agentMentionLabels(
-      candidates: mentionMap.value.values,
-    );
+    final agentMentionLabels = _agentMentionLabels(bindings: mentionMap.value);
     final agentMentionLabelsKey = (agentMentionLabels.toList()..sort()).join(
       '\u0000',
     );
@@ -263,6 +262,9 @@ class ComposeBar extends HookConsumerWidget {
         );
         final pubkeys = [
           ...memberList.map((m) => m.pubkey),
+          ...mentionMap.value.values
+              .where((c) => c.requiresRevalidation && c.pubkey.isNotEmpty)
+              .map((c) => c.pubkey),
           ...?relayAgents?.map((a) => a.pubkey),
           ...?agentOwners?.values,
         ];
@@ -272,6 +274,8 @@ class ComposeBar extends HookConsumerWidget {
         return null;
       },
       [
+        draftIdentity,
+        draftKey,
         membersAsync.asData?.value.length,
         cachedMembers.length,
         relayAgents?.length,
@@ -382,7 +386,10 @@ class ComposeBar extends HookConsumerWidget {
 
     // Insert a selected mention into the text field.
     void insertMention(MentionCandidate candidate) {
-      final name = candidate.label;
+      final name = selectedMentionLabel(candidate.label, candidate.pubkey, {
+        for (final entry in mentionMap.value.entries)
+          entry.key: entry.value.pubkey,
+      });
       // Track the resolved candidate so we can pass its pubkey and prepare
       // selected non-member agents at send time.
       mentionMap.value[name] = candidate;
@@ -470,10 +477,45 @@ class ComposeBar extends HookConsumerWidget {
       final messenger = ScaffoldMessenger.maybeOf(context);
 
       // Extract pubkeys for mentions present in the final text.
-      final selectedMentions = <MentionCandidate>[
-        for (final entry in mentionMap.value.entries)
-          if (hasMention(text, entry.key)) entry.value,
-      ];
+      List<MentionCandidate> selectedMentions;
+      try {
+        selectedMentions = _resolveComposerMentions(
+          text,
+          mentionMap.value,
+          buildMentionCandidates(
+            members: channelMembersForAutocomplete(
+              membersAsync: membersAsync,
+              sessionStatus: sessionStatus,
+              cachedMembers: cachedMembers,
+            ),
+            relayAgents: const [],
+            sharedChannelIds: const {},
+            userCache: userCache,
+            ownerByAgentPubkey: agentOwners ?? const {},
+          ),
+          buildMentionCandidates(
+            members: membersAsync.asData?.value ?? const [],
+            relayAgents: relayAgents ?? const [],
+            sharedChannelIds: {
+              for (final c in channels)
+                if (c.isMember && !c.isArchived) c.id,
+            },
+            userCache: userCache,
+            ownerByAgentPubkey: agentOwners ?? const {},
+            currentPubkey: currentPubkey,
+            // Reuse ordinary search-result classification, not membership as
+            // permission. Persisted keys/flags themselves prove no role.
+            searchResults: [
+              for (final c in mentionMap.value.values)
+                if (c.requiresRevalidation && userCache[c.pubkey] != null)
+                  userCache[c.pubkey]!,
+            ],
+          ),
+        );
+      } on FormatException catch (error) {
+        messenger?.showSnackBar(SnackBar(content: Text(error.message)));
+        return;
+      }
       final outgoing = _OutgoingMentions(selectedMentions);
       final scan = await _scanNonMemberMentions(
         ref,
@@ -589,12 +631,12 @@ class ComposeBar extends HookConsumerWidget {
             if (context.mounted &&
                 queueGeneration == uploadGeneration.value &&
                 draftRevision.value == clearedDraftRevision) {
-              controller.value = draftText;
               attachments.value = draftAttachments;
               retainedForRetry = true;
               mentionMap.value
                 ..clear()
                 ..addAll(draftMentions);
+              controller.value = draftText;
               focusNode.requestFocus();
             }
           } finally {

--- a/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
+++ b/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
@@ -26,10 +26,10 @@ Future<void> _sendTextOnlyDraft({
         draftRevision.value != clearedDraftRevision) {
       return;
     }
-    controller.value = clearedDraftText;
     mentionMap.value
       ..clear()
       ..addAll(clearedDraftMentions);
+    controller.value = clearedDraftText;
     focusNode.requestFocus();
   }
 
@@ -63,6 +63,7 @@ Future<void> _sendTextOnlyDraft({
 }
 
 void _useComposeDraftLifecycle({
+  required ObjectRef<Map<String, MentionCandidate>> mentionMap,
   required WidgetRef ref,
   required _MarkdownEditingController controller,
   required String draftKey,
@@ -82,11 +83,25 @@ void _useComposeDraftLifecycle({
 }) {
   final lastDraftIdentity = useRef<String?>(null);
   useEffect(() {
+    final identity = '$draftIdentity\u0000$draftKey';
+    final shouldHydrate = lastDraftIdentity.value != identity;
     final identityChanged =
-        lastDraftIdentity.value != null &&
-        lastDraftIdentity.value != draftIdentity;
-    lastDraftIdentity.value = draftIdentity;
-    final saved = ref.read(composeDraftsProvider.notifier).textFor(draftKey);
+        lastDraftIdentity.value != null && lastDraftIdentity.value != identity;
+    lastDraftIdentity.value = identity;
+    final saved = ref.read(composeDraftsProvider.notifier).draftFor(draftKey);
+    if (shouldHydrate) {
+      mentionMap.value
+        ..clear()
+        ..addAll({
+          for (final entry
+              in (saved?.mentionKeys ?? <String, String>{}).entries)
+            entry.key: MentionCandidate(
+              pubkey: entry.value,
+              displayName: entry.key,
+              requiresRevalidation: true,
+            ),
+        });
+    }
     if (identityChanged) {
       draftRevision.value += 1;
       onDraftIdentityChanged();
@@ -101,15 +116,38 @@ void _useComposeDraftLifecycle({
       final staleAttachments = attachments.value;
       attachments.value = const [];
       unawaited(_deleteOwnedAttachments(staleAttachments));
-      controller.text = saved ?? '';
+      controller.text = saved?.text ?? '';
     } else if (saved != null && controller.text.isEmpty) {
-      controller.text = saved;
+      controller.text = saved.text;
     }
 
     var lastPersistedText = controller.text;
+    var lastBindings = <String, String>{
+      for (final e in mentionMap.value.entries) e.key: e.value.pubkey,
+    };
     void persistDraft() {
       final text = controller.text;
-      if (text == lastPersistedText) return;
+      if (text != lastPersistedText) {
+        // Prune before the atomic snapshot, not in a later editor listener.
+        // Code formatting hides a binding without deleting its literal.
+        final retained = mentionOccurrences(
+          text.replaceAll('`', ' '),
+          mentionMap.value.keys,
+        ).map((range) => range.label).toSet();
+        // Whole-record taint has no literal to prune. Removing every @ is a
+        // safe reset; unrelated edits must not turn lost keys into name lookup.
+        mentionMap.value.removeWhere(
+          (label, _) =>
+              label.isEmpty ? !text.contains('@') : !retained.contains(label),
+        );
+      }
+      final bindings = <String, String>{
+        for (final e in mentionMap.value.entries) e.key: e.value.pubkey,
+      };
+      if (text == lastPersistedText && mapEquals(bindings, lastBindings)) {
+        return;
+      }
+      lastBindings = bindings;
       lastPersistedText = text;
       draftRevision.value += 1;
       ref
@@ -119,6 +157,7 @@ void _useComposeDraftLifecycle({
             channelId: channelId,
             threadHeadId: threadHeadId,
             text: text,
+            mentionKeys: bindings,
           );
     }
 

--- a/mobile/lib/features/channels/compose_bar/markdown_editing_controller.dart
+++ b/mobile/lib/features/channels/compose_bar/markdown_editing_controller.dart
@@ -282,6 +282,16 @@ class _MarkdownEditingController extends TextEditingController {
       if (prefix.isNotEmpty) spans.add(TextSpan(text: prefix, style: style));
 
       final label = match.group(2)!;
+      if (RegExp(r'\([0-9a-f]{64}\)').hasMatch(label)) {
+        spans.add(
+          TextSpan(
+            text: '@$label',
+            style: style.copyWith(color: context.colors.primary),
+          ),
+        );
+        offset = match.end;
+        continue;
+      }
       spans.add(
         WidgetSpan(
           alignment: PlaceholderAlignment.baseline,

--- a/mobile/lib/features/channels/mentions/mention_ranking.dart
+++ b/mobile/lib/features/channels/mentions/mention_ranking.dart
@@ -7,6 +7,9 @@ import '../../../shared/utils/string_utils.dart';
 @immutable
 class MentionCandidate {
   final String pubkey;
+
+  /// Restored identity only: eligibility must come from current community state.
+  final bool requiresRevalidation;
   final String? displayName;
   final String? secondaryLabel;
   final String? avatarUrl;
@@ -17,6 +20,7 @@ class MentionCandidate {
 
   const MentionCandidate({
     required this.pubkey,
+    this.requiresRevalidation = false,
     this.displayName,
     this.secondaryLabel,
     this.avatarUrl,

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -14,6 +14,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:video_player/video_player.dart';
 
 import '../../shared/clipboard_utils.dart';
+import '../../shared/mentions/mention_bindings.dart';
+import '../../shared/mentions/mention_tags.dart';
 import '../../shared/deeplink/deep_link.dart';
 import '../../shared/deeplink/pending_deep_link_provider.dart';
 import '../../shared/relay/relay.dart';
@@ -158,6 +160,12 @@ class MessageContent extends HookConsumerWidget {
         baseStyle ??
         context.textTheme.bodyMedium?.copyWith(color: context.colors.onSurface);
     final resolvedMentionNames = mentionNames;
+    final signedMentionPubkeys = mentionedPubkeysFromTags(tags);
+    final mentionBindings = renderedMentionBindings(
+      content,
+      mentionNames,
+      signedMentionPubkeys,
+    );
     final resolvedAgentMentionPubkeys = {
       ...agentMentionPubkeys.map((pubkey) => pubkey.toLowerCase()),
     };
@@ -196,6 +204,7 @@ class MessageContent extends HookConsumerWidget {
             ..sort((a, b) => a.key.compareTo(b.key))))
         '${entry.key}\u0000${entry.value}',
       ...(resolvedAgentMentionPubkeys.toList()..sort()),
+      ...(signedMentionPubkeys.toList()..sort()),
     ].join('\u0001');
 
     // Decided here rather than by the caller: this is where the event's own
@@ -235,14 +244,15 @@ class MessageContent extends HookConsumerWidget {
           mentionBuf.write('`${mentionParts[i]}`');
         } else {
           var segment = mentionParts[i];
-          for (final name in resolvedMentionNames.values) {
-            if (name.contains(' ')) {
-              final normalizedName = _markdownMentionName(name);
-              segment = segment.replaceAllMapped(
-                RegExp('@${RegExp.escape(name)}', caseSensitive: false),
-                (m) => '@$normalizedName',
-              );
-            }
+          for (final range in mentionOccurrences(
+            segment,
+            mentionBindings.keys,
+          ).reversed) {
+            segment = segment.replaceRange(
+              range.start,
+              range.end,
+              '@${_markdownMentionName(range.label)}',
+            );
           }
           mentionBuf.write(segment);
         }
@@ -288,6 +298,14 @@ class MessageContent extends HookConsumerWidget {
         inlineComponents: [
           _MentionMd(
             mentionNames: resolvedMentionNames,
+            bindings: mentionBindings,
+            displayLabels: {
+              for (final range in mentionOccurrences(
+                content,
+                mentionBindings.keys,
+              ))
+                range.label: content.substring(range.start + 1, range.end),
+            },
             agentMentionPubkeys: resolvedAgentMentionPubkeys,
             onMentionTap: onMentionTap,
           ),
@@ -807,16 +825,20 @@ class _MessageCodeBlock extends HookWidget {
 }
 
 class _MentionMd extends InlineMd {
+  final Map<String, Set<String>> bindings;
+  final Map<String, String> displayLabels;
   final Map<String, String> mentionNames;
   final Set<String> agentMentionPubkeys;
   final void Function(String pubkey)? onMentionTap;
   late final RegExp _exp = _buildPrefixPattern(
     prefix: '@',
-    knownNames: _mentionAliases(mentionNames.values),
+    knownNames: bindings.keys.map(_markdownMentionName),
     genericTokenPattern: r'[A-Za-z0-9_][A-Za-z0-9_\u00A0-]*',
   );
 
   _MentionMd({
+    required this.bindings,
+    required this.displayLabels,
     required this.mentionNames,
     required this.agentMentionPubkeys,
     this.onMentionTap,
@@ -837,22 +859,25 @@ class _MentionMd extends InlineMd {
     }
 
     final name = raw.substring(1).replaceAll('\u00A0', ' ').toLowerCase();
-    String? displayName;
-    String? pubkey;
-    for (final entry in mentionNames.entries) {
-      final entryName = entry.value.toLowerCase();
-      final firstName = entryName.split(RegExp(r'\s+')).first;
-      if (entryName == name || firstName == name) {
-        displayName = entry.value;
-        pubkey = entry.key;
-        break;
-      }
+    final matches = bindings[name] ?? const <String>{};
+    final pubkey = matches.length == 1 ? matches.single : null;
+    if (bindings.containsKey(name) && matches.length != 1) {
+      return TextSpan(text: text, style: config.style);
     }
+    final displayName = name.contains(RegExp(r'\([0-9a-f]{64}\)'))
+        ? displayLabels[name]
+        : mentionNames[pubkey];
 
     final isAgent =
         pubkey != null && agentMentionPubkeys.contains(pubkey.toLowerCase());
+    final fullLabel = displayName ?? raw.substring(1);
+    final visibleLabel = fullLabel.replaceAllMapped(
+      RegExp(r'\(([0-9a-f]{64})\)'),
+      (m) => '(${m[1]!.substring(0, 8)}…${m[1]!.substring(60)})',
+    );
     final pill = _MentionPill(
-      label: displayName ?? raw.substring(1),
+      label: visibleLabel,
+      semanticsLabel: fullLabel,
       isAgent: isAgent,
       textStyle: config.style,
     );
@@ -861,7 +886,7 @@ class _MentionMd extends InlineMd {
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
       child: pubkey != null && onMentionTap != null
-          ? GestureDetector(onTap: () => onMentionTap!(pubkey!), child: pill)
+          ? GestureDetector(onTap: () => onMentionTap!(pubkey), child: pill)
           : pill,
     );
   }
@@ -869,11 +894,13 @@ class _MentionMd extends InlineMd {
 
 class _MentionPill extends StatelessWidget {
   final String label;
+  final String? semanticsLabel;
   final bool isAgent;
   final TextStyle? textStyle;
 
   const _MentionPill({
     required this.label,
+    this.semanticsLabel,
     required this.isAgent,
     this.textStyle,
   });
@@ -920,7 +947,9 @@ class _MentionPill extends StatelessWidget {
               offset: const Offset(0, -Grid.quarter),
               child: Text('@', style: style),
             ),
-          Text(label, style: style),
+          Flexible(
+            child: Text(label, style: style, semanticsLabel: semanticsLabel),
+          ),
         ],
       ),
     );
@@ -928,15 +957,3 @@ class _MentionPill extends StatelessWidget {
 }
 
 String _markdownMentionName(String name) => name.replaceAll(' ', '\u00A0');
-
-Iterable<String> _mentionAliases(Iterable<String> mentionNames) sync* {
-  for (final name in mentionNames) {
-    final trimmed = name.trim();
-    if (trimmed.isEmpty) continue;
-    yield _markdownMentionName(trimmed);
-    final firstName = trimmed.split(RegExp(r'\s+')).first;
-    if (firstName.isNotEmpty) {
-      yield firstName;
-    }
-  }
-}

--- a/mobile/lib/shared/mentions/mention_bindings.dart
+++ b/mobile/lib/shared/mentions/mention_bindings.dart
@@ -1,0 +1,88 @@
+/// Reserve an exact label without retargeting an earlier selection.
+String selectedMentionLabel(
+  String name,
+  String pubkey,
+  Map<String, String> bindings,
+) {
+  final normalized = {
+    for (final e in bindings.entries)
+      e.key.toLowerCase(): e.value.toLowerCase(),
+  };
+  bool conflicts(String label) =>
+      normalized.containsKey(label.toLowerCase()) &&
+      normalized[label.toLowerCase()] != pubkey.toLowerCase();
+  if (!conflicts(name)) return name;
+  final qualified = '$name (${pubkey.toLowerCase()})';
+  var label = qualified;
+  for (var suffix = 2; conflicts(label); suffix++) {
+    label = '$qualified $suffix';
+  }
+  return label;
+}
+
+/// Longest literal ranges win, including labels containing another @ sign.
+/// Recognition precedes eligibility: ambiguous labels still block shorter ones.
+List<({int start, int end, String label})> mentionOccurrences(
+  String text,
+  Iterable<String> labels,
+) {
+  final matches = <int, ({int start, int end, String label})>{};
+  for (final label in labels) {
+    if (label.isEmpty) continue;
+    // A qualifier and reservation suffix belong to the literal even when no
+    // candidate binds it. Never fall back to a shorter, different recipient.
+    final suffix =
+        RegExp(r' \([0-9a-f]{64}\)$', caseSensitive: false).hasMatch(label)
+        ? r'(?! (?:[2-9]|[1-9][0-9]+)(?=[\s,;.!?:)\]}*_]|$))'
+        : '';
+    final pattern = RegExp(
+      '(?:^|\\s|[*_]{1,3}|\\|\\|)(@${RegExp.escape(label)})(?! \\([0-9a-f]{64}\\))$suffix(?=\\|\\||[\\s,;.!?:)\\]}*_]|\$)',
+      caseSensitive: false,
+    );
+    for (final match in pattern.allMatches(text)) {
+      final start = match.end - match.group(1)!.length;
+      if (matches[start] == null || matches[start]!.end < match.end) {
+        matches[start] = (start: start, end: match.end, label: label);
+      }
+    }
+  }
+  final result = <({int start, int end, String label})>[];
+  for (final match
+      in matches.values.toList()..sort((a, b) => a.start.compareTo(b.start))) {
+    if (result.isEmpty || match.start >= result.last.end) result.add(match);
+  }
+  return result;
+}
+
+/// Bind tagged qualifiers and ordinary aliases, never historical namesakes.
+Map<String, Set<String>> renderedMentionBindings(
+  String content,
+  Map<String, String> names, [
+  Iterable<String> signedPubkeys = const [],
+]) {
+  final bindings = <String, Set<String>>{};
+  void add(String label, String key) =>
+      (bindings[label.toLowerCase()] ??= {}).add(key.toLowerCase());
+  for (final entry in names.entries) {
+    add(entry.value, entry.key);
+    add(entry.value.split(RegExp(r'\s+')).first, entry.key);
+  }
+  final keys = signedPubkeys.map((key) => key.toLowerCase()).toSet();
+  for (final match in RegExp(
+    r'@([^@\r\n]+) \(([0-9a-f]{64})\)(?: ((?:[1-9][0-9]+|[2-9])))?',
+    caseSensitive: false,
+  ).allMatches(content)) {
+    final key = match.group(2)!.toLowerCase();
+    final label = match.group(0)!.substring(1).toLowerCase();
+    if (!mentionOccurrences(content, [
+      label,
+    ]).any((range) => range.start == match.start)) {
+      continue;
+    }
+    // Text can deny historical aliases without a profile, never authorize keys.
+    bindings[label] = keys.contains(key) ? {key} : <String>{};
+    // Recipient tags/current names cannot establish the historical plain owner.
+    bindings[match.group(1)!.toLowerCase()] = <String>{};
+  }
+  return bindings;
+}

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -476,6 +476,76 @@ void main() {
     _testPrefs = await SharedPreferences.getInstance();
   });
 
+  for (final thread in [false, true]) {
+    for (final reverse in [false, true]) {
+      testWidgets('signed qualified caller thread=$thread reverse=$reverse', (
+        tester,
+      ) async {
+        final first = 'a' * 64, second = 'b' * 64, sibling = 'c' * 64;
+        Future<void> tapProfile(String label, String key) async {
+          await tester.tap(find.text(label));
+          await tester.pumpAndSettle();
+          expect(
+            tester
+                .widget<UserProfileSheet>(find.byType(UserProfileSheet))
+                .pubkey,
+            key,
+          );
+          await tester.tap(find.byTooltip('Close sheet'));
+          await tester.pumpAndSettle();
+        }
+
+        for (final firstName in ['Scout', 'Renamed Scout', first, null]) {
+          for (final secondName in [null, 'Scout', 'Renamed Scout', second]) {
+            for (final bystander in [null, 'Bob', 'Scout']) {
+              final names = {
+                first: ?firstName,
+                second: ?secondName,
+                sibling: 'Alice',
+                'd' * 64: ?bystander,
+              };
+              final keys = [
+                first,
+                second.toUpperCase(),
+                sibling,
+                if (bystander != null) 'd' * 64,
+              ];
+              final event = _textMsg(
+                id: 'qualified',
+                pubkey: 'author',
+                content: '@Scout @Scout ($second) @Alice @Other (${'e' * 64})',
+                extraTags: [
+                  for (final key in reverse ? keys.reversed : keys) ['p', key],
+                ],
+              );
+              await tester.pumpWidget(
+                _buildTestable(
+                  messages: [event],
+                  users: {
+                    for (final e in names.entries)
+                      e.key: UserProfile(pubkey: e.key, displayName: e.value),
+                  },
+                  threadReplies: const {'qualified': []},
+                  initialThreadRootId: thread ? 'qualified' : null,
+                ),
+              );
+              await tester.pumpAndSettle();
+              await tapProfile('Scout (bbbbbbbb…bbbb)', second);
+              expect(find.text('Scout'), findsNothing);
+              expect(find.text('Bob'), findsNothing);
+              if (firstName != null) expect(find.text(firstName), findsNothing);
+              expect(find.text('Other (eeeeeeee…eeee)'), findsNothing);
+              await tapProfile('Alice', sibling);
+              expect(tester.takeException(), isNull);
+              await tester.pumpWidget(const SizedBox.shrink());
+              await tester.pumpAndSettle();
+            }
+          }
+        }
+      });
+    }
+  }
+
   group('ChannelDetailPage', () {
     testWidgets(
       'bot-role author avatars stay squircles in channel and thread',

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -16,6 +16,7 @@ import 'package:nostr/nostr.dart' as nostr;
 import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/compose_bar.dart';
+import 'package:buzz/features/channels/send_message_provider.dart';
 import 'package:buzz/features/channels/channels_provider.dart';
 import 'package:buzz/features/channels/photo_library.dart';
 import 'package:buzz/features/channels/voice_note_play_pause_icon.dart';
@@ -25,12 +26,16 @@ import 'package:buzz/shared/custom_emoji/custom_emoji.dart';
 import 'package:buzz/shared/custom_emoji/custom_emoji_provider.dart';
 import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
+import 'package:buzz/shared/profile/user_cache_provider.dart';
+import 'package:buzz/shared/profile/user_profile.dart';
 import 'package:buzz/shared/theme/theme.dart';
 import 'package:buzz/shared/utils/string_utils.dart';
 import 'package:buzz/shared/widgets/anchored_popover_menu.dart';
 import 'package:buzz/shared/widgets/avatar_image.dart';
 import 'package:buzz/shared/widgets/mobile_tab_footer_backdrop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+part 'compose_bar_test/exact_mention_tests.dart';
 
 final _pngBytes = Uint8List.fromList([
   0x89,
@@ -643,6 +648,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
 }
 
 void main() {
+  exactMentionTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() async {

--- a/mobile/test/features/channels/compose_bar_test/exact_mention_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/exact_mention_tests.dart
@@ -1,0 +1,312 @@
+part of '../compose_bar_test.dart';
+
+void exactMentionTests() {
+  final first = 'a' * 64;
+  final second = 'b' * 64;
+  List<ChannelMember> members() => [
+    for (final key in [first, second])
+      ChannelMember(
+        pubkey: key,
+        displayName: 'Scout',
+        role: 'member',
+        joinedAt: DateTime(2025),
+      ),
+  ];
+  Future<void> mountComposer(
+    WidgetTester tester,
+    List<ChannelMember> roster,
+    ComposeBarOnSend onSend, {
+    nostr.Keys? signer,
+  }) async {
+    await tester.pumpWidget(
+      _buildComposeBar(
+        uploadService: _testUploadService(
+          (signer ?? nostr.Keys.generate()).nsec,
+        ),
+        members: roster,
+        channels: [_makeCurrentChannel()],
+        currentPubkey: signer?.public,
+        relayConfig: signer == null
+            ? null
+            : () => _SwitchableRelayConfigNotifier(
+                RelayConfig(
+                  baseUrl: 'https://relay.example',
+                  nsec: signer.nsec,
+                ),
+              ),
+        onSend: onSend,
+      ),
+    );
+    if (find.byType(TextField).evaluate().isEmpty &&
+        find.textContaining('@Scout').evaluate().isNotEmpty) {
+      // A restored draft displays its text, not the empty composer hint.
+      await tester.tap(find.textContaining('@Scout'));
+      await tester.pumpAndSettle();
+    } else {
+      await _expandComposer(tester);
+    }
+  }
+
+  Future<void> pick(
+    WidgetTester tester,
+    String text, {
+    bool last = false,
+  }) async {
+    await tester.enterText(find.byType(TextField), text);
+    await tester.pumpAndSettle();
+    await tester.tap(last ? find.text('Scout').last : find.text('Scout').first);
+    await tester.pumpAndSettle();
+  }
+
+  for (final scenario in [
+    'rename',
+    'map edited',
+    'map reset',
+    'map plain',
+    'map reselected',
+    'removed',
+    'legacy',
+    'malformed',
+    'tainted',
+    'non-member human',
+    'non-member denied agent',
+  ]) {
+    testWidgets('persisted selection restore to signed send: $scenario', (
+      tester,
+    ) async {
+      final signer = nostr.Keys.generate();
+      final events = <Map<String, dynamic>>[];
+      late SendMessage sendMessage;
+      Future<void> mount(List<ChannelMember> roster) async {
+        await mountComposer(
+          tester,
+          roster,
+          (text, keys, {mediaTags = const []}) => sendMessage(
+            channelId: 'channel-1',
+            content: text,
+            mentionPubkeys: keys,
+            mediaTags: mediaTags,
+          ),
+          signer: signer,
+        );
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(ComposeBar)),
+        );
+        final session = container.read(relaySessionProvider.notifier);
+        session.debugAttachSocketForTest(
+          _RecordingRelaySocket(
+            events,
+            session.debugHandleSocketMessageForTest,
+          ),
+        );
+        sendMessage = SendMessage(
+          signedEventRelay: SignedEventRelay(
+            session: session,
+            nsec: signer.nsec,
+          ),
+          fetchMembers: (_) async => roster,
+          readUserCache: () => const {},
+          addLocalMessage: (_, _) {},
+          completeLocalMessage: (_, _) {},
+          removeLocalMessage: (_, _) {},
+        );
+      }
+
+      await mount(members());
+      await pick(tester, '@');
+      final prefsKey =
+          'compose_drafts_v1:https://relay.example:${signer.public}';
+      final saved = jsonDecode(_testPrefs.getString(prefsKey)!) as List;
+      expect(saved.single['text'], '@Scout ');
+      expect(saved.single['mention_keys'], {'Scout': first});
+      // Dispose the actual provider state, not just the text controller.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+      if (scenario.startsWith('map ')) saved.single['mention_keys'] = null;
+      if (scenario == 'legacy') saved.single.remove('mention_keys');
+      if (scenario == 'malformed') {
+        saved.single['mention_keys'] = {'Scout': 'not-a-key'};
+      }
+      if (scenario == 'tainted') {
+        saved.single['mention_keys'] = {
+          'Scout': {'pubkey': second, 'is_agent': true},
+        };
+      }
+      await _testPrefs.setString(prefsKey, jsonEncode(saved));
+      await mount([
+        if (![
+          'removed',
+          'non-member human',
+          'non-member denied agent',
+        ].contains(scenario))
+          ChannelMember(
+            pubkey: first,
+            displayName: 'Renamed',
+            role: 'member',
+            joinedAt: DateTime(2025),
+          ),
+        members().last,
+      ]);
+      if (scenario.startsWith('non-member')) {
+        ProviderScope.containerOf(tester.element(find.byType(ComposeBar)))
+            .read(userCacheProvider.notifier)
+            .put(
+              UserProfile(
+                pubkey: first,
+                displayName: 'Renamed',
+                ownerPubkey: scenario == 'non-member denied agent'
+                    ? second
+                    : null,
+              ),
+            );
+        await tester.pumpAndSettle();
+      }
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        '@Scout ',
+      );
+      var expectedText = '@Scout ';
+      if (scenario.startsWith('map ')) {
+        expectedText = '@Scout hello';
+        await tester.enterText(find.byType(TextField), expectedText);
+        await tester.pumpAndSettle();
+        expect(
+          jsonDecode(_testPrefs.getString(prefsKey)!).single['mention_keys'],
+          {'': ''},
+        );
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+        await mount(members());
+        if (scenario != 'map edited') {
+          expectedText = scenario == 'map plain' ? 'hello' : '';
+          await tester.enterText(find.byType(TextField), expectedText);
+          await tester.pumpAndSettle();
+          if (scenario != 'map plain') {
+            await pick(tester, '@', last: scenario == 'map reselected');
+            expectedText = '@Scout ';
+          }
+        }
+      }
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pumpAndSettle();
+      if (scenario == 'non-member human') {
+        expect(
+          find.textContaining('Renamed is not in this channel'),
+          findsOneWidget,
+        );
+        await tester.tap(find.text('Do nothing'));
+        await tester.pumpAndSettle();
+      }
+      final messages = events.where(
+        (e) => e['kind'] == EventKind.streamMessage,
+      );
+      if ([
+        'rename',
+        'legacy',
+        'non-member human',
+        'map reset',
+        'map plain',
+        'map reselected',
+      ].contains(scenario)) {
+        final event = messages.single;
+        expect(event['content'], expectedText.trim());
+        expect((event['tags'] as List).where((t) => t[0] == 'p').toList(), [
+          if (scenario != 'non-member human' && scenario != 'map plain')
+            [
+              'p',
+              ['legacy', 'map reselected'].contains(scenario) ? second : first,
+            ],
+        ]);
+        if (scenario == 'non-member human') {
+          expect(
+            (event['tags'] as List).where((t) => t[0] == 'mention').toList(),
+            [
+              ['mention', first],
+            ],
+          );
+          expect(events.where((e) => e['kind'] == 9000), isEmpty);
+        }
+        expect(event['pubkey'], signer.public);
+        expect(event['sig'], matches(RegExp(r'^[0-9a-f]{128}$')));
+        expect(nostr.Event.fromMap(event).id, event['id']);
+      } else {
+        expect(messages, isEmpty);
+        expect(events.where((e) => e['kind'] == 9000), isEmpty);
+        expect(find.textContaining('Saved mention'), findsOneWidget);
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller!.text,
+          expectedText,
+        );
+      }
+      // Refusal leaves autocomplete open. Dispose before draining its existing
+      // 250ms search debounce; no send assertion depends on this cleanup pump.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 250));
+    });
+  }
+  testWidgets(
+    'same-name picker selections retain exact recipients through removal',
+    (tester) async {
+      List<String>? sent;
+      await mountComposer(
+        tester,
+        members(),
+        (_, keys, {mediaTags = const []}) async => sent = keys,
+      );
+      await pick(tester, '@');
+      final controller = tester
+          .widget<TextField>(find.byType(TextField))
+          .controller!;
+      expect(controller.text, '@Scout ');
+      await pick(tester, '@Scout @', last: true);
+      expect(controller.text, '@Scout @Scout ($second) ');
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pumpAndSettle();
+      expect(sent, [first, second]);
+      await pick(tester, '@');
+      await pick(tester, '@Scout @', last: true);
+      await tester.enterText(find.byType(TextField), '@Scout ($second) ');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pumpAndSettle();
+      expect(sent, [second]);
+    },
+  );
+
+  testWidgets('unbound qualified text cannot notify a shorter member alias', (
+    tester,
+  ) async {
+    List<String>? sent;
+    await mountComposer(tester, [
+      members().first,
+    ], (_, keys, {mediaTags = const []}) async => sent = keys);
+    await tester.enterText(find.byType(TextField), '@Scout ($second)');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(LucideIcons.arrowUp));
+    await tester.pumpAndSettle();
+    expect(sent, isEmpty);
+  });
+
+  testWidgets('ambiguous typed names fail visibly without clearing the draft', (
+    tester,
+  ) async {
+    var sent = false;
+    await mountComposer(tester, members(), (
+      _,
+      _, {
+      mediaTags = const [],
+    }) async {
+      sent = true;
+    });
+    await tester.enterText(find.byType(TextField), '@Scout hello');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(LucideIcons.arrowUp));
+    await tester.pumpAndSettle();
+    expect(sent, isFalse);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      '@Scout hello',
+    );
+    expect(find.textContaining('is ambiguous'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/channels/message_content_exact_mentions_test.dart
+++ b/mobile/test/features/channels/message_content_exact_mentions_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/features/channels/message_content.dart';
+import '../../helpers/widget_helpers.dart';
+
+void main() {
+  for (final tagged in [false, true]) {
+    testWidgets(
+      'qualified chips preserve authority and narrow layout: $tagged',
+      (tester) async {
+        tester.view.physicalSize = const Size(320, 640);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final semantics = tester.ensureSemantics();
+        final first = 'a' * 64, second = 'b' * 64;
+        String? tapped;
+        await tester.pumpWidget(
+          WidgetHelpers.testable(
+            child: MediaQuery(
+              data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+              child: MessageContent(
+                content: '@Scout @Scout ($second)',
+                mentionNames: {second: 'Scout', first: 'Scout'},
+                tags: [
+                  for (final key in [first, if (tagged) second]) ['p', key],
+                ],
+                onMentionTap: (key) => tapped = key,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Scout'), findsNothing);
+        final qualified = find.text('Scout (bbbbbbbb…bbbb)');
+        if (tagged) {
+          await tester.tap(qualified);
+          expect(tapped, second);
+          expect(
+            find.bySemanticsLabel(RegExp('Scout.*$second')),
+            findsOneWidget,
+          );
+        } else {
+          expect(qualified, findsNothing);
+          expect(tapped, isNull);
+        }
+        expect(tester.takeException(), isNull);
+        semantics.dispose();
+      },
+    );
+  }
+}

--- a/mobile/test/shared/mentions/mention_bindings_test.dart
+++ b/mobile/test/shared/mentions/mention_bindings_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/shared/mentions/mention_bindings.dart';
+
+void main() {
+  final first = 'a' * 64;
+  final second = 'b' * 64;
+  test('qualification is case-insensitive and collision-safe', () {
+    final bindings = {'Scout': first, 'Scout ($second)': first};
+    expect(selectedMentionLabel('scout', first, bindings), 'scout');
+    expect(
+      selectedMentionLabel('Scout', second, bindings),
+      'Scout ($second) 2',
+    );
+  });
+  test('longest occurrences block shorter and interior recipients', () {
+    expect(
+      mentionOccurrences('@Scout ($second) 2', [
+        'Scout',
+        'Scout ($second)',
+        'Scout ($second) 2',
+      ]).single.label,
+      'Scout ($second) 2',
+    );
+    expect(mentionOccurrences('@A @B', ['A @B', 'B']).single.label, 'A @B');
+    expect(mentionOccurrences('mail@Scout', ['Scout']), isEmpty);
+    expect(mentionOccurrences('@Scout ($second)', ['Scout']), isEmpty);
+    expect(
+      mentionOccurrences('@Scout ($second) 2', ['Scout ($second)']),
+      isEmpty,
+    );
+  });
+  // Historical plain denial and both tag orders run through channel/thread UI.
+  test('ordinary ambiguity and qualification require signed authority', () {
+    expect(
+      renderedMentionBindings('@Scout', {
+        first: 'Scout',
+        second: 'Scout',
+      })['scout'],
+      {first, second},
+    );
+    expect(
+      renderedMentionBindings('@Scout ($second)', {
+        first: 'Scout',
+      })['scout ($second)'],
+      isEmpty,
+    );
+    expect(
+      renderedMentionBindings(
+        '@Old ($second)',
+        {second: 'New'},
+        [second],
+      )['old ($second)'],
+      {second},
+    );
+  });
+}


### PR DESCRIPTION
<!-- Draft PR body for #7385 · fix(mobile): bind same-name mentions to exact selected identities · https://github.com/block/buzz/pull/7385 -->

🤖

## Summary

If two people in a channel share a display name, mobile couldn't tell them apart in mentions: picking the second could overwrite the first's selection, a rendered mention linked whichever same-name person matched first, and a later rename or a shorter name could re-bind the text to the wrong recipient. This PR binds every mention to the exact selected identity:

- Each same-name selection keeps its own recipient instead of overwriting by name; conflicting picks get a qualified label like `Name (key…)`.
- The longest matching label wins, so a shorter or interior name can never claim part of a longer one and steal its identity.
- Rendering resolves recipients by the signed identity key from the event's tags — never from message text alone — so qualified labels stay correct regardless of tag order and survive later renames; an untagged ambiguous label blocks shorter mentions instead of silently re-binding.

Ports the landed Desktop exact-recipient behavior (see `docs/mention-editor.md`).

### Related issue

- Fixes: N/A. No mobile issue; Desktop's landed exact-recipient fixes are the reference this ports.
- Independent base (`main`). #7387 (child) persists these exact selections in saved drafts.
- Landing note: branches in this series overlap in the composer — when rebasing, keep exact/durable mention bindings, the explicit invite/reference-only choice, the account/visit/revision fences, and authorization before membership preparation and publication; don't resolve conflicts by taking either side wholesale.
- Draft — not requesting merge yet; the security advisory run for this range timed out without results (no verdict).

### Testing

- Regressions cover same-name collisions, prefix/overlap, removal, tag order, and renames.
- At `acd841354a692243f1cb4c04059baad42f1d2abb`: `just mobile-check` and full `just mobile-test` pass (2,082 tests). The earlier full `just ci` receipt linked below is reused only for unchanged non-mobile code/tooling, not claimed as a rerun at this head.
- Previous-head evidence: `just mobile-check`, the full mobile test suite, and full local `just ci` all pass — receipts in the [exact-head evidence comment](https://github.com/block/buzz/pull/7385#issuecomment-5574635836).
- Verification is widget-test level; no native device or simulator run is claimed.

To see it: mention two teammates with the same display name — both stay distinct, the second shows a qualified label, and the rendered message keeps both correct even after either renames.

### Screenshots

Flutter production-widget test renders — not native-device screenshots or acceptance captures.

| Scenario | Before | After |
|---|---|---|
| Qualified mention chip for same-name recipients, at 200% text scale (deliberate stress fixture) | ![Before: the short chip is followed by the distinguishing key spilling out as raw text](https://github.com/user-attachments/assets/f1e40acc-24f1-47f7-b2f7-e3ba2348c169) | ![After: the full qualified label wraps inside the bounded chip, keeping the @ and robot glyph visible](https://github.com/user-attachments/assets/b949e44f-e3f6-4c72-98ff-68139b2e1ab3) |

<details>
<summary>Capture provenance</summary>

Rendered by the Flutter widget engine in a `flutter test` run (production widgets, production theme; no device or simulator). Before: this PR's declared base `3c7f288c60d67df78577b237e27c3dfc8831aaa1`. After: its head `39afd73b0adfde14164f4b10dbd089cb498312b6`.

</details>
