### PR TITLE
fix(mobile): close retired relay handshakes

### DIFF
--- a/mobile/lib/shared/relay/relay_socket.dart
+++ b/mobile/lib/shared/relay/relay_socket.dart
@@ -98,7 +98,12 @@ class RelaySocket {
       if (identical(_connectingClient, client)) _connectingClient = null;
     }
 
-    if (!identical(_channel, channel)) return;
+    if (!identical(_channel, channel)) {
+      // Cancellation can race with a completed upgrade. That socket is no
+      // longer owned by the HTTP client, so close the retired channel too.
+      unawaited(channel.sink.close());
+      return;
+    }
 
     _state = SocketState.authenticating;
     _authCompleter = Completer<void>();

--- a/mobile/lib/shared/relay/relay_socket.dart
+++ b/mobile/lib/shared/relay/relay_socket.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show HttpClient;
 
 import 'package:flutter/foundation.dart';
 import 'package:nostr/nostr.dart' as nostr;
@@ -44,6 +45,7 @@ class RelaySocket {
   final void Function(Object? error) _onDisconnected;
 
   WebSocketChannel? _channel;
+  HttpClient? _connectingClient;
   StreamSubscription<dynamic>? _subscription;
   SocketState _state = SocketState.disconnected;
   Completer<void>? _authCompleter;
@@ -69,24 +71,34 @@ class RelaySocket {
     if (_state != SocketState.disconnected) return;
     _state = SocketState.connecting;
 
+    final client = HttpClient();
+    _connectingClient = client;
+    final WebSocketChannel channel;
     try {
-      _channel = IOWebSocketChannel.connect(
+      channel = IOWebSocketChannel.connect(
         Uri.parse(_wsUrl),
         pingInterval: debugPingInterval,
+        customClient: client,
       );
-      await _channel!.ready;
+      _channel = channel;
+      await channel.ready;
     } catch (e) {
-      _state = SocketState.disconnected;
-      _onDisconnected(e);
+      // Explicit disconnect/dispose already retired this attempt. It must not
+      // notify the session or overwrite a newer connection's state.
+      if (identical(_connectingClient, client)) {
+        _channel = null;
+        _state = SocketState.disconnected;
+        _onDisconnected(e);
+      }
       return;
+    } finally {
+      // Retire this attempt's HTTP transport. A successful upgrade has already
+      // detached its socket, so it remains open for authentication.
+      client.close(force: true);
+      if (identical(_connectingClient, client)) _connectingClient = null;
     }
 
-    // The channel may have been disposed while we were awaiting ready
-    // (e.g. provider rebuild triggered dispose() concurrently).
-    if (_channel == null) {
-      _state = SocketState.disconnected;
-      return;
-    }
+    if (!identical(_channel, channel)) return;
 
     _state = SocketState.authenticating;
     _authCompleter = Completer<void>();
@@ -133,21 +145,28 @@ class RelaySocket {
 
   /// Gracefully close the connection.
   Future<void> disconnect() async {
+    final wasConnecting = _state == SocketState.connecting;
     _resetConnection();
     final channel = _channel;
     _channel = null;
-    if (channel != null) {
+    // Before ready, the channel has no WebSocket to close. Its sink's close
+    // future may never settle; _resetConnection has closed the HTTP client.
+    if (channel != null && !wasConnecting) {
       await channel.sink.close();
     }
   }
 
   void dispose() {
+    final wasConnecting = _state == SocketState.connecting;
     _resetConnection();
-    _channel?.sink.close();
+    if (!wasConnecting) _channel?.sink.close();
     _channel = null;
   }
 
   void _resetConnection() {
+    final client = _connectingClient;
+    _connectingClient = null;
+    client?.close(force: true);
     _state = SocketState.disconnected;
     _subscription?.cancel();
     _subscription = null;

--- a/mobile/test/features/settings/connection_section_test.dart
+++ b/mobile/test/features/settings/connection_section_test.dart
@@ -33,6 +33,7 @@ void main() {
       WidgetHelpers.testable(
         overrides: [
           relayConfigProvider.overrideWith(_RelayConfigNotifier.new),
+          relaySessionProvider.overrideWith(_SettingsRelaySession.new),
           authProvider.overrideWith(_AuthNotifier.new),
           pairingProvider.overrideWith(
             () => _PairingNotifier(Future<bool>.value(true)),
@@ -79,6 +80,7 @@ void main() {
       WidgetHelpers.testable(
         overrides: [
           relayConfigProvider.overrideWith(_RelayConfigNotifier.new),
+          relaySessionProvider.overrideWith(_SettingsRelaySession.new),
           authProvider.overrideWith(_AuthNotifier.new),
           pairingProvider.overrideWith(() => pairing),
           savedPrefsProvider.overrideWithValue(prefs),
@@ -117,6 +119,7 @@ void main() {
       WidgetHelpers.testable(
         overrides: [
           relayConfigProvider.overrideWith(_RelayConfigNotifier.new),
+          relaySessionProvider.overrideWith(_SettingsRelaySession.new),
           authProvider.overrideWith(_AuthNotifier.new),
           pairingProvider.overrideWith(() => pairing),
           savedPrefsProvider.overrideWithValue(prefs),
@@ -157,6 +160,7 @@ void main() {
       WidgetHelpers.testable(
         overrides: [
           relayConfigProvider.overrideWith(_RelayConfigNotifier.new),
+          relaySessionProvider.overrideWith(_SettingsRelaySession.new),
           authProvider.overrideWith(_AuthNotifier.new),
           pairingProvider.overrideWith(() => pairing),
           savedPrefsProvider.overrideWithValue(prefs),
@@ -200,6 +204,7 @@ void main() {
       WidgetHelpers.testable(
         overrides: [
           relayConfigProvider.overrideWith(_RelayConfigNotifier.new),
+          relaySessionProvider.overrideWith(_SettingsRelaySession.new),
           authProvider.overrideWith(_AuthNotifier.new),
           pairingProvider.overrideWith(() => pairing),
           savedPrefsProvider.overrideWithValue(prefs),
@@ -244,6 +249,7 @@ void main() {
       WidgetHelpers.testable(
         overrides: [
           relayConfigProvider.overrideWith(_RelayConfigNotifier.new),
+          relaySessionProvider.overrideWith(_SettingsRelaySession.new),
           authProvider.overrideWith(_AuthNotifier.new),
           pairingProvider.overrideWith(() => pairing),
           savedPrefsProvider.overrideWithValue(prefs),
@@ -309,4 +315,11 @@ class _PairingNotifier extends PairingNotifier {
   void reset() {
     resetCalls++;
   }
+}
+
+// Settings tests exercise identity controls, without opening a real relay socket.
+class _SettingsRelaySession extends RelaySessionNotifier {
+  @override
+  SessionState build() =>
+      const SessionState(status: SessionStatus.disconnected);
 }

--- a/mobile/test/shared/relay/relay_socket_connect_test.dart
+++ b/mobile/test/shared/relay/relay_socket_connect_test.dart
@@ -3,8 +3,62 @@ import 'dart:io';
 
 import 'package:buzz/shared/relay/relay_socket.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _HttpClient extends Mock implements HttpClient {}
 
 void main() {
+  test('a retired attempt closes a socket that already upgraded', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final peerClosed = Completer<void>();
+    WebSocket? peer;
+    server.listen((request) async {
+      peer = await WebSocketTransformer.upgrade(request);
+      peer!.listen((_) {}, onDone: peerClosed.complete);
+    });
+    final realClient = HttpClient();
+    final client = _HttpClient();
+    registerFallbackValue(Uri());
+    when(() => client.openUrl(any(), any())).thenAnswer(
+      (invocation) => realClient.openUrl(
+        invocation.positionalArguments[0] as String,
+        invocation.positionalArguments[1] as Uri,
+      ),
+    );
+    final errors = <Object?>[];
+    final socket = RelaySocket(
+      wsUrl: 'ws://127.0.0.1:${server.port}',
+      nsec: null,
+      onMessage: (_) {},
+      onConnected: () => fail('The attempt was retired before authentication'),
+      onDisconnected: errors.add,
+    );
+    var retired = false;
+    when(() => client.close(force: true)).thenAnswer((_) {
+      realClient.close(force: true);
+      // Retire after the real upgrade, before connect resumes authentication.
+      // This makes the otherwise narrow cancellation race deterministic.
+      if (!retired) {
+        retired = true;
+        socket.dispose();
+      }
+    });
+    addTearDown(() async {
+      socket.dispose();
+      realClient.close(force: true);
+      await peer?.close();
+      await server.close(force: true);
+    });
+
+    await HttpOverrides.runZoned(
+      socket.connect,
+      createHttpClient: (_) => client,
+    ).timeout(const Duration(seconds: 2));
+    expect(socket.state, SocketState.disconnected);
+    expect(errors, isEmpty);
+    await peerClosed.future.timeout(const Duration(seconds: 2));
+  });
+
   for (final disposeWhileConnecting in [false, true]) {
     test(
       disposeWhileConnecting

--- a/mobile/test/shared/relay/relay_socket_connect_test.dart
+++ b/mobile/test/shared/relay/relay_socket_connect_test.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:buzz/shared/relay/relay_socket.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  for (final disposeWhileConnecting in [false, true]) {
+    test(
+      disposeWhileConnecting
+          ? 'disposing during the handshake closes the pending transport quietly'
+          : 'disconnecting during the handshake closes the pending transport quietly',
+      () async {
+        final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+        final peers = <Socket>[];
+        final requestReceived = Completer<void>();
+        final peerClosed = Completer<void>();
+        server.listen((peer) {
+          peers.add(peer);
+          // Accept the upgrade request but never return an HTTP response.
+          peer.listen(
+            (_) {
+              if (!requestReceived.isCompleted) requestReceived.complete();
+            },
+            onDone: () {
+              if (!peerClosed.isCompleted) peerClosed.complete();
+            },
+            onError: (Object _) {},
+          );
+        });
+        final errors = <Object?>[];
+        var connected = false;
+        final socket = RelaySocket(
+          wsUrl: 'ws://127.0.0.1:${server.port}',
+          nsec: null,
+          onMessage: (_) {},
+          onConnected: () => connected = true,
+          onDisconnected: errors.add,
+        );
+        addTearDown(() async {
+          socket.dispose();
+          for (final peer in peers) {
+            peer.destroy();
+          }
+          await server.close();
+        });
+
+        final attempt = socket.connect();
+        await requestReceived.future.timeout(const Duration(seconds: 2));
+        expect(socket.state, SocketState.connecting);
+        if (disposeWhileConnecting) {
+          socket.dispose();
+        } else {
+          await socket.disconnect().timeout(const Duration(seconds: 2));
+        }
+
+        await attempt.timeout(const Duration(seconds: 2));
+        expect(socket.state, SocketState.disconnected);
+        expect(connected, isFalse);
+        expect(errors, isEmpty);
+        await peerClosed.future.timeout(const Duration(seconds: 2));
+      },
+    );
+  }
+
+  test('a retired handshake cannot disconnect its replacement', () async {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final peers = <Socket>[];
+    final requests = [Completer<void>(), Completer<void>()];
+    server.listen((peer) {
+      final received = requests[peers.length];
+      peers.add(peer);
+      peer.listen((_) {
+        if (!received.isCompleted) received.complete();
+      }, onError: (Object _) {});
+    });
+    final errors = <Object?>[];
+    final socket = RelaySocket(
+      wsUrl: 'ws://127.0.0.1:${server.port}',
+      nsec: null,
+      onMessage: (_) {},
+      onConnected: () => fail('Neither peer completed the upgrade'),
+      onDisconnected: errors.add,
+    );
+    addTearDown(() async {
+      socket.dispose();
+      for (final peer in peers) {
+        peer.destroy();
+      }
+      await server.close();
+    });
+
+    final first = socket.connect();
+    await requests[0].future.timeout(const Duration(seconds: 2));
+    socket.dispose();
+    final second = socket.connect();
+    await requests[1].future.timeout(const Duration(seconds: 2));
+    await first.timeout(const Duration(seconds: 2));
+    expect(socket.state, SocketState.connecting);
+    expect(errors, isEmpty);
+
+    socket.dispose();
+    await second.timeout(const Duration(seconds: 2));
+    expect(socket.state, SocketState.disconnected);
+    expect(errors, isEmpty);
+  });
+}


### PR DESCRIPTION
When a network or provider change retires a relay connection before the WebSocket upgrade completes, the pending HTTP transport stays open. `disconnect()` can also wait forever on a channel sink that has no WebSocket yet. A late completion can overwrite a replacement attempt's state.

Give each handshake its own HTTP client, close it when the attempt ends, and check attempt identity before reporting a failure or starting authentication. Skip the WebSocket close wait while the transport is still connecting. If cancellation races with a completed upgrade, close that retired WebSocket too. Active connections keep the existing authentication and ping behavior.

This complements #4826, which adds a handshake deadline. It does not add another deadline or change reconnect backoff. The settings widget tests now stub the relay session instead of opening real sockets.

Validation:

- Six loopback socket tests cover `disconnect`, `dispose`, peer closure, replacement attempts, cancellation after upgrade, and healthy/silent upgraded peers. The stalled-disposal and completed-upgrade regressions failed before their respective fixes.
- `just mobile-check` passed after the final change.
- Full `just ci` passed on a local checkout combining this PR, #7397, and #7405. That run passed all 2,077 mobile tests and 3,165 desktop Tauri tests (19 ignored). The earlier unrelated Codex-adapter test failure did not recur.

I have not measured this change on a physical iPhone. It fixes connection cleanup; it does not claim a measured cold-start improvement.
