### PR TITLE
fix(mobile): make non-member invitations explicit; stopping halts publication but cannot retract accepted invitations

### DIFF
--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -543,21 +543,26 @@ class ComposeBar extends HookConsumerWidget {
         );
 
         ensureAuthorizationCurrent();
-        // Mentioning humans outside the channel prompts "Invite" / "Do
-        // nothing" (send without inviting) — mirrors desktop's
-        // NonMemberMentionDialog. Agents keep the existing silent auto-add.
-        if (scan.humans.isNotEmpty) {
+        // Agents and humans both require deliberate invitation intent.
+        final nonMembers = [
+          ...scan.humans,
+          ...selectedMentions.where(
+            (candidate) =>
+                scan.agentPubkeys.contains(candidate.pubkey.toLowerCase()),
+          ),
+        ];
+        if (nonMembers.isNotEmpty) {
           if (!context.mounted) return;
           final choice = await _promptNonMemberMention(
             context,
-            names: [for (final candidate in scan.humans) candidate.label],
+            names: [for (final candidate in nonMembers) candidate.label],
             canInvite: scan.canAddMembers,
           );
           ensureAuthorizationCurrent();
           if (choice == null) {
             return; // Dismissed — keep the draft, send nothing.
           }
-          outgoing.resolveHumanChoice(choice, scan.humans);
+          outgoing.resolveChoice(choice, nonMembers);
         }
 
         final queuedAttachments = List<_PendingAttachment>.of(

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -542,7 +542,7 @@ class ComposeBar extends HookConsumerWidget {
           currentPubkey: currentPubkey,
         );
 
-        if (intendedAgentKeys.isNotEmpty) ensureAuthorizationCurrent();
+        ensureAuthorizationCurrent();
         // Mentioning humans outside the channel prompts "Invite" / "Do
         // nothing" (send without inviting) — mirrors desktop's
         // NonMemberMentionDialog. Agents keep the existing silent auto-add.
@@ -553,7 +553,7 @@ class ComposeBar extends HookConsumerWidget {
             names: [for (final candidate in scan.humans) candidate.label],
             canInvite: scan.canAddMembers,
           );
-          if (intendedAgentKeys.isNotEmpty) ensureAuthorizationCurrent();
+          ensureAuthorizationCurrent();
           if (choice == null) {
             return; // Dismissed — keep the draft, send nothing.
           }
@@ -573,6 +573,7 @@ class ComposeBar extends HookConsumerWidget {
             channelActions,
             scan: scan,
             messenger: messenger,
+            ensureCurrent: ensureAuthorizationCurrent,
           );
           if (!outgoing.pubkeys.toSet().containsAll(keys)) {
             throw Exception(
@@ -605,14 +606,15 @@ class ComposeBar extends HookConsumerWidget {
           return;
         }
 
-        if (intendedAgentKeys.isNotEmpty) ensureAuthorizationCurrent();
+        ensureAuthorizationCurrent();
         final draftText = controller.value;
         final draftAttachments = List<_PendingAttachment>.of(attachments.value);
         final draftMentions = Map<String, MentionCandidate>.of(
           mentionMap.value,
         );
         // Agent authorization is preparation, not a detached background send.
-        final preparingAgents = intendedAgentKeys.isNotEmpty;
+        final preparingAgents =
+            intendedAgentKeys.isNotEmpty || scan.humans.isNotEmpty;
         if (!preparingAgents) clearComposer();
         final clearedDraftRevision = draftRevision.value;
         authorizationRevision = clearedDraftRevision;

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -479,13 +479,18 @@ class ComposeBar extends HookConsumerWidget {
       void Function()? checkPreparationCurrent;
       try {
         final submittedDraftRevision = draftRevision.value;
+        final submittedUploadGeneration = uploadGeneration.value;
         var authorizationRevision = submittedDraftRevision;
         final visit = authorizationVisit.value;
         final config = ref.read(relayConfigProvider);
         final readAuthorization = ref.read(agentAuthorizationReaderProvider);
-        bool isAuthorizationCurrent() =>
+        bool ownsSource() =>
             context.mounted &&
             visit == authorizationVisit.value &&
+            identical(config, ref.read(relayConfigProvider));
+        bool isAuthorizationCurrent() =>
+            ownsSource() &&
+            submittedUploadGeneration == uploadGeneration.value &&
             authorizationRevision == draftRevision.value &&
             identical(config, ref.read(relayConfigProvider));
         void ensureAuthorizationCurrent() {
@@ -493,7 +498,8 @@ class ComposeBar extends HookConsumerWidget {
           if (!identical(config, ref.read(relayConfigProvider))) {
             throw StateError('Community changed during authorization');
           }
-          if (visit != authorizationVisit.value ||
+          if (submittedUploadGeneration != uploadGeneration.value ||
+              visit != authorizationVisit.value ||
               authorizationRevision != draftRevision.value) {
             throw const _ComposeAuthorizationCancelled();
           }
@@ -586,6 +592,12 @@ class ComposeBar extends HookConsumerWidget {
             );
           }
           await authorize(keys);
+          if (queuedAttachments.isEmpty ||
+              (intendedAgentKeys.isNotEmpty ||
+                  scan.humans.isNotEmpty ||
+                  scan.agentPubkeys.isNotEmpty)) {
+            ensureAuthorizationCurrent();
+          }
         }
 
         if (queuedAttachments.isEmpty) {
@@ -596,6 +608,7 @@ class ComposeBar extends HookConsumerWidget {
             mentionMap: mentionMap,
             draftRevision: draftRevision,
             submittedDraftRevision: submittedDraftRevision,
+            ownsSource: ownsSource,
             focusNode: focusNode,
             clearComposer: clearComposer,
             addMentionedNonMembers: addMentionedNonMembers,

--- a/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
+++ b/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
@@ -10,6 +10,7 @@ Future<void> _sendTextOnlyDraft({
   required ObjectRef<Map<String, MentionCandidate>> mentionMap,
   required ObjectRef<int> draftRevision,
   required int submittedDraftRevision,
+  required bool Function() ownsSource,
   required FocusNode focusNode,
   required VoidCallback clearComposer,
   required Future<void> Function() addMentionedNonMembers,
@@ -23,7 +24,7 @@ Future<void> _sendTextOnlyDraft({
   int? clearedDraftRevision;
 
   void restoreClearedDraft() {
-    if (!context.mounted ||
+    if (!ownsSource() ||
         clearedDraftText == null ||
         clearedDraftMentions == null ||
         clearedDraftRevision == null ||
@@ -39,6 +40,7 @@ Future<void> _sendTextOnlyDraft({
 
   try {
     await addMentionedNonMembers();
+    if (!ownsSource()) return;
     // Clear before optimistic insertion so the outgoing row and draft never
     // appear simultaneously during the send transition. If the user edited
     // while membership changes were pending, preserve that newer draft.
@@ -86,12 +88,18 @@ void _useComposeDraftLifecycle({
   required _IOSAttachmentPopoverController iosAttachmentPopover,
   required VoidCallback onDraftIdentityChanged,
 }) {
+  // Fence old listeners before effects restore an incoming draft.
+  final owner = useMemoized(Object.new, [draftKey, draftIdentity]);
+  final currentOwner = useRef(owner)..value = owner;
   final lastDraftIdentity = useRef<String?>(null);
+  final lastDraftKey = useRef<String?>(null);
   useEffect(() {
     final identityChanged =
         lastDraftIdentity.value != null &&
-        lastDraftIdentity.value != draftIdentity;
+        (lastDraftIdentity.value != draftIdentity ||
+            lastDraftKey.value != draftKey);
     lastDraftIdentity.value = draftIdentity;
+    lastDraftKey.value = draftKey;
     final saved = ref.read(composeDraftsProvider.notifier).textFor(draftKey);
     if (identityChanged) {
       draftRevision.value += 1;
@@ -114,6 +122,7 @@ void _useComposeDraftLifecycle({
 
     var lastPersistedText = controller.text;
     void persistDraft() {
+      if (!identical(currentOwner.value, owner)) return;
       final text = controller.text;
       if (text == lastPersistedText) return;
       lastPersistedText = text;

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -324,7 +324,7 @@ String _composeSendErrorMessage(Object error) {
   return error.toString().replaceFirst('Exception: ', '');
 }
 
-/// Ask whether to invite mentioned humans who aren't channel members, or
+/// Ask whether to invite mentioned identities who aren't channel members, or
 /// send without inviting them. Mirrors desktop's `NonMemberMentionDialog`.
 /// [canInvite] false (a private channel the sender doesn't own/administer)
 /// drops the Invite action — the relay rejects that add, so offering it would
@@ -338,7 +338,7 @@ Future<_NonMemberMentionChoice?> _promptNonMemberMention(
   return showBuzzDialog<_NonMemberMentionChoice>(
     context: context,
     builder: (dialogContext) => AlertDialog(
-      title: const Text('Mention people outside this channel?'),
+      title: const Text('Invite mentioned people or agents?'),
       content: Text(
         canInvite
             ? '${names.join(', ')} $verb not in this channel. Invite them to '
@@ -352,7 +352,7 @@ Future<_NonMemberMentionChoice?> _promptNonMemberMention(
           onPressed: () => Navigator.of(
             dialogContext,
           ).pop(_NonMemberMentionChoice.sendWithoutInviting),
-          child: Text(canInvite ? 'Do nothing' : 'Send anyway'),
+          child: const Text('Send without inviting'),
         ),
         if (canInvite)
           TextButton(
@@ -435,8 +435,8 @@ class _NonMemberAddOutcome {
 
 /// Adds mentioned non-members to the channel before a send.
 ///
-/// Agents are added silently with the `bot` role; humans are only passed here
-/// after they have been explicitly invited from the mention prompt.
+/// Agents use the `bot` role, humans the `member` role. Both require an explicit
+/// invitation choice before reaching this helper.
 ///
 /// A rejection is reported, never thrown: the send is fire-and-forget, so an
 /// escaping error would drop the message with nothing shown. [StateError] still
@@ -567,13 +567,13 @@ Future<_NonMemberMentionScan> _scanNonMemberMentions(
 
 /// The p-tags and `mention` reference tags an outgoing message should carry.
 ///
-/// Anyone who ends up *not* added is demoted from a p-tag to a reference tag so
-/// their name still renders without notifying a non-member — mirrors desktop's
-/// `mergeOutgoingTagsWithReferenceMentions`.
+/// Only an explicit reference-only choice demotes p-tags. Failed invitation
+/// preparation must preserve intent and prevent publication.
 class _OutgoingMentions {
   List<String> pubkeys;
   final List<List<String>> referenceTags = [];
   List<String> _invitedHumanPubkeys = const [];
+  bool _inviteAgents = false;
 
   _OutgoingMentions(List<MentionCandidate> selectedMentions)
     : pubkeys = LinkedHashSet<String>.from(
@@ -593,22 +593,23 @@ class _OutgoingMentions {
   }
 
   /// Applies the mention prompt's outcome: invite them, or send without.
-  void resolveHumanChoice(
+  void resolveChoice(
     _NonMemberMentionChoice choice,
-    List<MentionCandidate> humans,
+    List<MentionCandidate> nonMembers,
   ) {
-    final humanPubkeys = [
-      for (final candidate in humans) candidate.pubkey.toLowerCase(),
-    ];
     switch (choice) {
       case _NonMemberMentionChoice.invite:
-        _invitedHumanPubkeys = humanPubkeys;
+        _inviteAgents = true;
+        _invitedHumanPubkeys = [
+          for (final candidate in nonMembers)
+            if (!candidate.isAgent) candidate.pubkey.toLowerCase(),
+        ];
       case _NonMemberMentionChoice.sendWithoutInviting:
-        demote(humanPubkeys);
+        demote(nonMembers.map((candidate) => candidate.pubkey));
     }
   }
 
-  /// Adds the scanned non-members, demoting and reporting whatever didn't land.
+  /// Adds explicitly invited non-members, failing the send on any refusal.
   Future<void> addNonMembers(
     ChannelActions channelActions, {
     required _NonMemberMentionScan scan,
@@ -618,16 +619,13 @@ class _OutgoingMentions {
     final outcome = await _addMentionedNonMembers(
       channelActions,
       channelId: scan.channelId,
-      agentPubkeys: scan.agentPubkeys,
+      agentPubkeys: _inviteAgents ? scan.agentPubkeys : const [],
       humanPubkeys: _invitedHumanPubkeys,
       canAddMembers: scan.canAddMembers,
       ensureCurrent: ensureCurrent,
     );
-    demote(outcome.notAdded);
-    if (outcome.errors.isNotEmpty) {
-      messenger?.showSnackBar(
-        SnackBar(content: Text(outcome.errors.join(' '))),
-      );
+    if (outcome.notAdded.isNotEmpty) {
+      throw Exception('Message not sent. ${outcome.errors.join(' ')}');
     }
   }
 }

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -447,10 +447,11 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
   required List<String> agentPubkeys,
   required List<String> humanPubkeys,
   required bool canAddMembers,
+  required VoidCallback ensureCurrent,
 }) async {
   final pending = [
-    if (agentPubkeys.isNotEmpty) (agentPubkeys, 'bot'),
-    if (humanPubkeys.isNotEmpty) (humanPubkeys, 'member'),
+    for (final pubkey in agentPubkeys) ([pubkey], 'bot'),
+    for (final pubkey in humanPubkeys) ([pubkey], 'member'),
   ];
   if (pending.isEmpty) return _NonMemberAddOutcome.empty;
 
@@ -467,11 +468,15 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
   final errors = <String>[];
   for (final (pubkeys, role) in pending) {
     try {
+      ensureCurrent();
       await channelActions.addMembers(
         channelId: channelId,
         pubkeys: pubkeys,
         role: role,
       );
+      ensureCurrent();
+    } on _ComposeSendCancelled {
+      rethrow;
     } on StateError {
       rethrow;
     } catch (error) {
@@ -518,12 +523,13 @@ Future<_NonMemberMentionScan> _scanNonMemberMentions(
   );
   if (selectedMentions.isEmpty) return none;
 
-  final channel = (await ref.read(
-    channelsProvider.future,
-  )).firstWhere((candidate) => candidate.id == channelId);
+  // Capture both reads before yielding: WidgetRef may be disposed while waiting.
+  final (channels, members) = await (
+    ref.read(channelsProvider.future),
+    ref.read(channelMembersProvider(channelId).future),
+  ).wait;
+  final channel = channels.firstWhere((candidate) => candidate.id == channelId);
   if (channel.isDm) return none;
-
-  final members = await ref.read(channelMembersProvider(channelId).future);
   final memberPubkeys = {
     for (final member in members) member.pubkey.toLowerCase(),
   };
@@ -607,6 +613,7 @@ class _OutgoingMentions {
     ChannelActions channelActions, {
     required _NonMemberMentionScan scan,
     required ScaffoldMessengerState? messenger,
+    required VoidCallback ensureCurrent,
   }) async {
     final outcome = await _addMentionedNonMembers(
       channelActions,
@@ -614,6 +621,7 @@ class _OutgoingMentions {
       agentPubkeys: scan.agentPubkeys,
       humanPubkeys: _invitedHumanPubkeys,
       canAddMembers: scan.canAddMembers,
+      ensureCurrent: ensureCurrent,
     );
     demote(outcome.notAdded);
     if (outcome.errors.isNotEmpty) {

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -475,7 +475,7 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
         role: role,
       );
       ensureCurrent();
-    } on _ComposeSendCancelled {
+    } on _ComposeAuthorizationCancelled {
       rethrow;
     } on StateError {
       rethrow;

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -3231,12 +3231,15 @@ void main() {
         final signer = nostr.Keys.generate();
         final publishedEvents = <Map<String, dynamic>>[];
         final uploadResponse = Completer<http.Response>();
+        var uploadStarted = false;
+        var sends = 0;
         final uploadService = MediaUploadService(
           baseUrl: 'https://relay.example',
           nsec: signer.nsec,
-          httpClient: http_testing.MockClient(
-            (request) => uploadResponse.future,
-          ),
+          httpClient: http_testing.MockClient((request) {
+            uploadStarted = true;
+            return uploadResponse.future;
+          }),
           pickGalleryVideo: () async => null,
           pickGalleryImage: () async => null,
           pickGalleryImages: () async => [
@@ -3250,7 +3253,9 @@ void main() {
             currentPubkey: signer.public,
             relayAgents: [_testAgent(agentPubkey)],
             channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
-            onSend: (_, _, {mediaTags = const <List<String>>[]}) async {},
+            onSend: (_, _, {mediaTags = const <List<String>>[]}) async {
+              sends += 1;
+            },
           ),
         );
 
@@ -3271,7 +3276,12 @@ void main() {
         await tester.pumpAndSettle();
         await tester.tap(find.text('Helper Bot'));
         await tester.pumpAndSettle();
-        await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
+        await tester.enterText(find.byType(TextField), 'hello @Helper Bot ');
+        await tester.pumpAndSettle();
+        final submittedText = tester
+            .widget<TextField>(find.byType(TextField))
+            .controller!
+            .text;
         await tester.tap(find.byIcon(LucideIcons.arrowUp));
         await tester.pump();
 
@@ -3281,6 +3291,7 @@ void main() {
         );
 
         await tester.pump(const Duration(milliseconds: 220));
+        expect(uploadStarted, isTrue);
         await tester.tap(find.byKey(const ValueKey('compose-upload-cancel')));
         uploadResponse.complete(
           http.Response(
@@ -3303,8 +3314,13 @@ void main() {
         );
         expect(
           tester.widget<TextField>(find.byType(TextField)).controller!.text,
-          'hello @Helper Bot',
+          submittedText,
         );
+        expect(sends, 0);
+        // Restoring the draft can start a new autocomplete debounce. Dispose
+        // its owner before draining fake time; do not leak a timer to teardown.
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(milliseconds: 300));
       },
     );
 

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -32,6 +32,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 part 'compose_bar_test/publication_tests.dart';
 part 'compose_bar_test/send_lifecycle_tests.dart';
+part 'compose_bar_test/invitation_tests.dart';
 
 final _pngBytes = Uint8List.fromList([
   0x89,
@@ -585,6 +586,7 @@ class _RecordingRelaySocket extends RelaySocket {
   /// Invoked after an event is handed to the socket but before its relay
   /// acknowledgement is delivered. Tests may defer that acknowledgement.
   final Future<void> Function(Map<String, dynamic> event)? beforeAcknowledged;
+  final bool rejectAdds;
 
   /// Invoked after an event has been recorded and acknowledged, before the
   /// caller's `await` resumes. Lets a test interleave state changes (such as
@@ -595,6 +597,7 @@ class _RecordingRelaySocket extends RelaySocket {
     this.events,
     this.handleMessage, {
     this.beforeAcknowledged,
+    this.rejectAdds = false,
     this.onEventAcknowledged,
   }) : super(
          wsUrl: 'ws://localhost',
@@ -614,12 +617,22 @@ class _RecordingRelaySocket extends RelaySocket {
       final id = event['id'] as String;
       final pending = beforeAcknowledged?.call(event);
       if (pending == null) {
-        super.debugHandleOkForTest(['OK', id, true, '']);
+        super.debugHandleOkForTest([
+          'OK',
+          id,
+          !(rejectAdds && event['kind'] == 9000),
+          'test relay refusal',
+        ]);
         onEventAcknowledged?.call(event);
       } else {
         unawaited(
           pending.then((_) {
-            super.debugHandleOkForTest(['OK', id, true, '']);
+            super.debugHandleOkForTest([
+              'OK',
+              id,
+              !(rejectAdds && event['kind'] == 9000),
+              'test relay refusal',
+            ]);
             onEventAcknowledged?.call(event);
           }),
         );
@@ -663,6 +676,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
 void main() {
   _publicationTests();
   sendLifecycleTests();
+  invitationTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() async {
@@ -3141,6 +3155,9 @@ void main() {
       await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
       await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Invite'));
       await tester.pumpAndSettle();
 
       // The cancelled send must not reach the relay.
@@ -3284,6 +3301,9 @@ void main() {
             .text;
         await tester.tap(find.byIcon(LucideIcons.arrowUp));
         await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Invite'));
+        await tester.pump();
 
         expect(
           publishedEvents.where((event) => event['kind'] == 9000),
@@ -3312,6 +3332,8 @@ void main() {
           publishedEvents.where((event) => event['kind'] == 9000),
           isEmpty,
         );
+        await tester.tap(find.text('hello @Helper Bot'));
+        await tester.pumpAndSettle();
         expect(
           tester.widget<TextField>(find.byType(TextField)).controller!.text,
           submittedText,
@@ -4198,6 +4220,9 @@ void main() {
       );
       await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
       await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Invite'));
       await tester.pumpAndSettle();
 
       expect(sentContent, 'hello @Helper Bot');
@@ -4267,12 +4292,18 @@ void main() {
       await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
       await tester.tap(find.byIcon(LucideIcons.arrowUp));
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Invite'));
+      await tester.pump();
 
       expect(
         publishedEvents.where((event) => event['kind'] == 9000),
         hasLength(1),
       );
 
+      await tester.tap(find.text('hello @Helper Bot'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
       await tester.enterText(find.byType(TextField), 'newer draft');
       addMemberAcknowledgement.complete();
       await tester.pumpAndSettle();
@@ -4512,6 +4543,9 @@ void main() {
         await tester.pumpAndSettle();
         await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
         await tester.tap(find.byIcon(LucideIcons.arrowUp));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Invite'));
         await tester.pumpAndSettle();
 
         expect(didSend, isTrue);

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -31,6 +31,7 @@ import 'package:buzz/shared/widgets/mobile_tab_footer_backdrop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 part 'compose_bar_test/publication_tests.dart';
+part 'compose_bar_test/send_lifecycle_tests.dart';
 
 final _pngBytes = Uint8List.fromList([
   0x89,
@@ -194,6 +195,7 @@ Widget _buildComposeBar({
   ValueChanged<VoidCallback>? onFocusRestorerChanged,
   AppLifecycleNotifier Function()? appLifecycle,
   String composeBarKey = 'compose-bar',
+  String? threadHeadId,
   VoiceNoteRecorder Function()? voiceNoteRecorderFactory,
   VoiceNotePlayerController Function()? voiceNotePlayerFactory,
 }) {
@@ -270,6 +272,7 @@ Widget _buildComposeBar({
                 final composeBar = ComposeBar(
                   key: ValueKey(composeBarKey),
                   channelId: 'channel-1',
+                  threadHeadId: threadHeadId,
                   focusNode: focusNode,
                   onFocusRestorerChanged: onFocusRestorerChanged,
                   onFocusRequested: onFocusRequested,
@@ -659,6 +662,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
 
 void main() {
   _publicationTests();
+  sendLifecycleTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() async {
@@ -3296,6 +3300,10 @@ void main() {
         expect(
           publishedEvents.where((event) => event['kind'] == 9000),
           isEmpty,
+        );
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller!.text,
+          'hello @Helper Bot',
         );
       },
     );

--- a/mobile/test/features/channels/compose_bar_test/invitation_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/invitation_tests.dart
@@ -1,0 +1,88 @@
+part of '../compose_bar_test.dart';
+
+void invitationTests() {
+  for (final choice in ['reference', 'cancel', 'failure', 'revisit']) {
+    testWidgets('agent invitation $choice preserves deliberate audience', (
+      tester,
+    ) async {
+      final signer = nostr.Keys.generate();
+      final agent = 'a' * 64;
+      final events = <Map<String, dynamic>>[];
+      List<String>? recipients;
+      List<List<String>> tags = [];
+      final service = _testUploadService(signer.nsec);
+      Widget build({String? thread}) => _buildComposeBar(
+        uploadService: service,
+        currentPubkey: signer.public,
+        relayAgents: [_testAgent(agent)],
+        channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
+        threadHeadId: thread,
+        onSend: (_, keys, {mediaTags = const []}) async {
+          recipients = keys;
+          tags = mediaTags;
+        },
+      );
+      await tester.pumpWidget(build());
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ComposeBar)),
+      );
+      final session = container.read(relaySessionProvider.notifier);
+      session.debugAttachSocketForTest(
+        _RecordingRelaySocket(
+          events,
+          session.debugHandleSocketMessageForTest,
+          rejectAdds: choice == 'failure',
+        ),
+      );
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), '@hel');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Helper Bot'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Invite mentioned people or agents?'), findsOneWidget);
+      expect(events.where((e) => e['kind'] == 9000), isEmpty);
+      expect(recipients, isNull);
+      if (choice == 'revisit') {
+        await tester.pumpWidget(build(thread: 'other'));
+        await tester.pumpWidget(build());
+      }
+      if (choice == 'cancel') {
+        Navigator.of(tester.element(find.byType(AlertDialog))).pop();
+      } else {
+        await tester.tap(
+          find.text(choice == 'reference' ? 'Send without inviting' : 'Invite'),
+        );
+      }
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 300));
+      if (choice == 'reference') {
+        expect(recipients, isEmpty);
+        expect(tags, [
+          ['mention', agent],
+        ]);
+      } else {
+        expect(recipients, isNull);
+        if (choice == 'failure') {
+          expect(find.textContaining('Message not sent.'), findsOneWidget);
+          ScaffoldMessenger.of(
+            tester.element(find.byType(ComposeBar)),
+          ).removeCurrentSnackBar();
+          await tester.pumpAndSettle();
+        }
+        await tester.tap(find.text('@Helper Bot'));
+        await tester.pumpAndSettle();
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller!.text,
+          '@Helper Bot ',
+        );
+      }
+      expect(
+        events.where((e) => e['kind'] == 9000),
+        hasLength(choice == 'failure' ? 1 : 0),
+      );
+    });
+  }
+}

--- a/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
@@ -1,0 +1,152 @@
+part of '../compose_bar_test.dart';
+
+void sendLifecycleTests() {
+  for (final action in [
+    'double send',
+    'edit',
+    'revisit',
+    'unmount',
+    'failure',
+  ]) {
+    testWidgets('send preparation fences $action', (tester) async {
+      final gate = Completer<List<ChannelMember>>();
+      final members = [
+        ChannelMember(
+          pubkey: 'a' * 64,
+          displayName: 'Alice',
+          role: 'member',
+          joinedAt: DateTime(2025),
+        ),
+      ];
+      var pending = false;
+      var sent = 0;
+      final service = _testUploadService(nostr.Keys.generate().nsec);
+      Widget build({String? thread}) => _buildComposeBar(
+        uploadService: service,
+        channels: [_makeCurrentChannel()],
+        membersLoader: () => pending ? gate.future : Future.value(members),
+        threadHeadId: thread,
+        onSend: (_, _, {mediaTags = const []}) async {
+          sent++;
+        },
+      );
+      await tester.pumpWidget(build());
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), '@ali');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Alice'));
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ComposeBar)),
+      );
+      pending = true;
+      container.invalidate(channelMembersProvider('channel-1'));
+      await tester.pump();
+      // Invoke twice without a frame: an asynchronous latch is too late.
+      final button = tester.widget<GestureDetector>(
+        find
+            .ancestor(
+              of: find.byIcon(LucideIcons.arrowUp),
+              matching: find.byType(GestureDetector),
+            )
+            .first,
+      );
+      button.onTap!();
+      if (action == 'double send') button.onTap!();
+      await tester.pump();
+      if (action == 'edit') {
+        await tester.enterText(find.byType(TextField), 'new intent');
+      }
+      if (action == 'revisit') {
+        await tester.pumpWidget(build(thread: 'other-thread'));
+        await tester.pumpWidget(build());
+      }
+      if (action == 'unmount') await tester.pumpWidget(const SizedBox());
+      if (action == 'failure') {
+        gate.completeError(Exception('membership unavailable'));
+      } else {
+        gate.complete(members);
+      }
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(sent, action == 'double send' ? 1 : 0);
+      if (action == 'edit') {
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller!.text,
+          'new intent',
+        );
+      }
+      if (action == 'failure') {
+        expect(find.textContaining('membership unavailable'), findsOneWidget);
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller!.text,
+          '@Alice ',
+        );
+      }
+    });
+  }
+  testWidgets('a revisited source cannot finish an old membership batch', (
+    tester,
+  ) async {
+    final signer = nostr.Keys.generate();
+    final gate = Completer<void>();
+    final events = <Map<String, dynamic>>[];
+    var sends = 0;
+    final service = _testUploadService(signer.nsec);
+    Widget build({String? thread}) => _buildComposeBar(
+      uploadService: service,
+      currentPubkey: signer.public,
+      relayAgents: [
+        _testAgent('b' * 64),
+        AgentDirectoryEntry(
+          pubkey: 'c' * 64,
+          displayName: 'Other Bot',
+          respondTo: 'anyone',
+          channelIds: const ['shared-channel'],
+        ),
+      ],
+      channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
+      threadHeadId: thread,
+      onSend: (_, _, {mediaTags = const []}) async {
+        sends++;
+      },
+    );
+    await tester.pumpWidget(build());
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ComposeBar)),
+    );
+    final session = container.read(relaySessionProvider.notifier);
+    session.debugAttachSocketForTest(
+      _RecordingRelaySocket(
+        events,
+        session.debugHandleSocketMessageForTest,
+        beforeAcknowledged: (event) async {
+          if (event['kind'] == 9000) await gate.future;
+        },
+      ),
+    );
+    await _expandComposer(tester);
+    await tester.enterText(find.byType(TextField), '@hel');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Helper Bot'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), '@Helper Bot @oth');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Other Bot'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(LucideIcons.arrowUp));
+    await tester.pump();
+    expect(events.where((e) => e['kind'] == 9000), hasLength(1));
+    await tester.pumpWidget(build(thread: 'other'));
+    await tester.pumpWidget(build());
+    gate.complete();
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(sends, 0);
+    expect(events.where((e) => e['kind'] == 9000), hasLength(1));
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      '@Helper Bot @Other Bot ',
+    );
+  });
+}

--- a/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
@@ -136,6 +136,9 @@ void sendLifecycleTests() {
     await tester.pumpAndSettle();
     await tester.tap(find.byIcon(LucideIcons.arrowUp));
     await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text('Invite'));
+    await tester.pump();
     expect(events.where((e) => e['kind'] == 9000), hasLength(1));
     await tester.pumpWidget(build(thread: 'other'));
     await tester.pumpWidget(build());
@@ -143,6 +146,8 @@ void sendLifecycleTests() {
     await tester.pumpAndSettle();
     await tester.pump(const Duration(milliseconds: 300));
     expect(sends, 0);
+    await tester.tap(find.text('@Helper Bot @Other Bot'));
+    await tester.pumpAndSettle();
     expect(events.where((e) => e['kind'] == 9000), hasLength(1));
     expect(
       tester.widget<TextField>(find.byType(TextField)).controller!.text,

--- a/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
@@ -42,7 +42,6 @@ void sendLifecycleTests() {
       pending = true;
       container.invalidate(channelMembersProvider('channel-1'));
       await tester.pump();
-      // Invoke twice without a frame: an asynchronous latch is too late.
       final button = tester.widget<GestureDetector>(
         find
             .ancestor(
@@ -85,73 +84,102 @@ void sendLifecycleTests() {
       }
     });
   }
-  testWidgets('a revisited source cannot finish an old membership batch', (
-    tester,
-  ) async {
-    final signer = nostr.Keys.generate();
-    final gate = Completer<void>();
-    final events = <Map<String, dynamic>>[];
-    var sends = 0;
-    final service = _testUploadService(signer.nsec);
-    Widget build({String? thread}) => _buildComposeBar(
-      uploadService: service,
-      currentPubkey: signer.public,
-      relayAgents: [
-        _testAgent('b' * 64),
-        AgentDirectoryEntry(
-          pubkey: 'c' * 64,
-          displayName: 'Other Bot',
-          respondTo: 'anyone',
-          channelIds: const ['shared-channel'],
-        ),
-      ],
-      channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
-      threadHeadId: thread,
-      onSend: (_, _, {mediaTags = const []}) async {
-        sends++;
-      },
-    );
-    await tester.pumpWidget(build());
-    final container = ProviderScope.containerOf(
-      tester.element(find.byType(ComposeBar)),
-    );
-    final session = container.read(relaySessionProvider.notifier);
-    session.debugAttachSocketForTest(
-      _RecordingRelaySocket(
-        events,
-        session.debugHandleSocketMessageForTest,
-        beforeAcknowledged: (event) async {
-          if (event['kind'] == 9000) await gate.future;
+  for (final action in ['revisit', 'cancel', 'partial refusal']) {
+    testWidgets('$action cannot finish an old membership batch', (
+      tester,
+    ) async {
+      final signer = nostr.Keys.generate();
+      final gate = Completer<void>();
+      final events = <Map<String, dynamic>>[];
+      var sends = 0;
+      final service = _FakeVideoUploadService(
+        XFile.fromData(_pngBytes, name: 'clip.mp4', mimeType: 'video/mp4'),
+      );
+      Widget build({String? thread}) => _buildComposeBar(
+        uploadService: service,
+        currentPubkey: signer.public,
+        relayAgents: [
+          _testAgent('b' * 64),
+          AgentDirectoryEntry(
+            pubkey: 'c' * 64,
+            displayName: 'Other Bot',
+            respondTo: 'anyone',
+            channelIds: const ['shared-channel'],
+          ),
+        ],
+        channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
+        threadHeadId: thread,
+        onSend: (_, _, {mediaTags = const []}) async {
+          sends++;
         },
-      ),
-    );
-    await _expandComposer(tester);
-    await tester.enterText(find.byType(TextField), '@hel');
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Helper Bot'));
-    await tester.pumpAndSettle();
-    await tester.enterText(find.byType(TextField), '@Helper Bot @oth');
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Other Bot'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(LucideIcons.arrowUp));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-    await tester.tap(find.text('Invite'));
-    await tester.pump();
-    expect(events.where((e) => e['kind'] == 9000), hasLength(1));
-    await tester.pumpWidget(build(thread: 'other'));
-    await tester.pumpWidget(build());
-    gate.complete();
-    await tester.pumpAndSettle();
-    await tester.pump(const Duration(milliseconds: 300));
-    expect(sends, 0);
-    await tester.tap(find.text('@Helper Bot @Other Bot'));
-    await tester.pumpAndSettle();
-    expect(events.where((e) => e['kind'] == 9000), hasLength(1));
-    expect(
-      tester.widget<TextField>(find.byType(TextField)).controller!.text,
-      '@Helper Bot @Other Bot ',
-    );
-  });
+      );
+      await tester.pumpWidget(build());
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ComposeBar)),
+      );
+      final session = container.read(relaySessionProvider.notifier);
+      session.debugAttachSocketForTest(
+        _RecordingRelaySocket(
+          events,
+          session.debugHandleSocketMessageForTest,
+          beforeAcknowledged: (event) async {
+            if (event['kind'] == 9000) await gate.future;
+          },
+          onEventAcknowledged: (event) {
+            if (action == 'partial refusal' && event['kind'] == 9000) {
+              session.debugAttachSocketForTest(
+                _RecordingRelaySocket(
+                  events,
+                  session.debugHandleSocketMessageForTest,
+                  rejectAdds: true,
+                ),
+              );
+            }
+          },
+        ),
+      );
+      if (action == 'cancel') {
+        await _openAttachmentMenu(tester);
+        await tester.tap(find.text('Video'));
+        await tester.pumpAndSettle();
+      }
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), '@hel');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Helper Bot'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '@Helper Bot @oth');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Other Bot'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Invite'));
+      await tester.pump();
+      expect(events.where((e) => e['kind'] == 9000), hasLength(1));
+      if (action == 'cancel') {
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.byKey(const ValueKey('compose-upload-cancel')));
+      } else if (action == 'revisit') {
+        await tester.pumpWidget(build(thread: 'other'));
+        await tester.pumpWidget(build());
+      }
+      gate.complete();
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+      expect(sends, 0);
+      await tester.tap(find.text('@Helper Bot @Other Bot'));
+      await tester.pumpAndSettle();
+      expect(
+        events.where((e) => e['kind'] == 9000),
+        hasLength(action == 'partial refusal' ? 2 : 1),
+      );
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        '@Helper Bot @Other Bot ',
+      );
+    });
+  }
 }


### PR DESCRIPTION
🤖

## Summary

Mentioning a person who wasn't in the channel already prompted you to invite them or send anyway — but mentioning an agent outside the channel **silently added it as a channel bot and sent**, changing your audience without asking. A refused invitation demoted the mentions to plain references and sent anyway, and an interrupted media upload could still leave membership changes behind. This PR makes both people and agents an explicit choice; stopping halts pending invitations and publication but cannot retract an invitation the relay has already accepted:

- Sending with a non-member mention asks: **Invite mentioned people or agents?** — Invite (offered when you can add members), or **Send without inviting** (references only). Only the explicit reference-only choice demotes the mentions; agents are never added silently.
- Dismissing the dialog or cancelling before invitations begin sends nothing and adds nobody. Failed or interrupted invitation sequences stop publication; already accepted invitations remain in effect (recovery disclosure in #7527).
- Send preparation is fenced by account/community, channel/thread visit and draft revision — a stale prompt can't finish its invitation batch after you switch away and back (A→B→A).
- Member additions wait until a media upload succeeds. Existing background delivery for current members is unchanged.

### Related issue

- Fixes: N/A. No separate issue; the related work is the series below.
- Originally independent on `main`; now deliberately based on #7531, including #7394 publication guards. See the serial sequence below.
- Rollout: widened agent discovery (#7395) must not be enabled until this PR and #7394 are integrated — a rollout condition, not a code dependency.
- Landing note: branches in this series overlap in the composer — when rebasing, keep exact/durable mention bindings, the explicit invite/reference-only choice, the account/visit/revision fences, and authorization before membership preparation and publication; don't resolve conflicts by taking either side wholesale.
- Ready for review; no merge requested. The historical security advisory timed out without results (no verdict); no new dispatch or security verdict is claimed.

### Testing

- Dialog regressions cover Invite / send-without-inviting / dismiss / refusal; the upload-phase cancellation regression proves an interrupted upload initiates no membership events, no sends, and leaves the draft text unchanged, and the mid-batch stop regression proves that stopping while invitation writes are in flight yields no sends and no further membership events while one already accepted invitation stays in effect.
- At current `1f571bd3d`: `just mobile-check` and full `flutter test` pass (2,131 tests). The [earlier exact-head evidence comment](https://github.com/block/buzz/pull/7390#issuecomment-5574636244) applies only to its historical head, not this rebased candidate; no new whole-repository `just ci` pass claimed.
- Verification is widget-test level; no native device or simulator run is claimed.

To see it: mention a person or agent outside the channel and send — choose Invite, Send without inviting, or dismiss; each outcome matches the bullets above.

### Screenshots

Flutter production-widget test renders — not native-device screenshots or acceptance captures.

| Scenario | Before | After |
|---|---|---|
| Sending a message that mentions an agent outside the channel | ![Before: the message sends immediately and the agent is silently added as a member — no prompt](https://github.com/user-attachments/assets/4c4b8220-07f5-469e-8614-5a226c4dfc10) | ![After: the composer asks Invite or Send without inviting, and keeps the draft until you choose](https://github.com/user-attachments/assets/1f56e15c-27a6-461f-af2c-f1d29c868561) |

<details>
<summary>Capture provenance</summary>

Rendered by the Flutter widget engine in a `flutter test` run (production widgets, production theme; no device or simulator). Before: the historical base `3c7f288c60d67df78577b237e27c3dfc8831aaa1`. After: the historical head `9b000415f0644010f0f5606a971ac8eb92d63bae`.

</details>


### Authorized serial integration carry (2026-09-09)

Current HEAD `1f571bd3d74eedee2a0c2dbbdf0a402698c31398`; own PR range **466 changed lines**, including tests. Existing PR retained; no duplicate feature patch or merge. Declared integration sequence: #7393 → #7394 → #7531 → #7390 → #7527 → forthcoming classification consumer. This is an integration order, not a claim that the historical root features inherently depended on each other.

Final carried HEAD: `just mobile-check` passes; full `flutter test`: **2131 passed**. These supersede prior standalone counts for this head. Existing widget-render screenshot attachments remain historical UI evidence, not a new composed runtime run. Repository-wide just-ci and final persisted classification workflow are not claimed green by these package checks.

Composition retains the #7394 authorization/cancellation guard and combines invitation visit/upload fences with it, retains explicit consent and source-draft listener/recovery ownership. #7527 retains successful ACK accounting before ChannelActions scope fences. Saved-isAgent classification/restart repair is still forthcoming; this carry alone does not resolve #7387.


## Mechanical docs-carry note — 2026-09-10

Head mechanically carried to `d080eccb12c50a79c6d345e295b5beaae22c7ed9` (corrected parent #7531 `1fe1193a2974…` + this PR's original own commits, zero conflicts, original messages/authors/DCO preserved). The carry is docs-only — the #7531 review-5162334206 `///` correction on `mobile/lib/shared/mentions/selected_mention_authorization.dart` (comment-stripped file equality; `mobile/test` bytes identical to `069c8b71a4b43edc3dae946e14d2523fc8a16d29`); earlier "Head `069c8b71a4b43edc3dae946e14d2523fc8a16d29`"/current-HEAD mappings above are dated receipts for their pre-carry heads, including their CI links. Own churn is unchanged at **466 including tests** (inherited docs are not counted as own); no executable delta. Normal CI on the carried head: https://github.com/block/buzz/actions/runs/34436597921.

## Workflows helper test carry — 2026-09-10

Head rebased to `5f8744a3fb571b6dd9a6d3853ae254694ab9eeea` (same four commits, authors and messages preserved, on corrected parent #7531 `612a131b24a3a57e2b365de87dc98007e165a17d`); no conflicts, no merge commits. Own range vs the corrected parent is unchanged at **416 additions + 50 deletions = 466 lines including tests**; the only old-head→new-head content delta is the carried #7531 Desktop E2E test repair in `desktop/tests/e2e/workflows.spec.ts` (+15/−3) and `desktop/tests/e2e/workflow-local-controls.spec.ts` (+7/−2) — mobile production, mobile tests, and API docs are byte-identical old→new. Current-head review 5162786862 predates this head movement and requires re-validation on the new head per its own terms. Normal CI on the new head is running; no green claim is made here.


## Workflow regression test carry — 2026-09-10

Head rebased to `c93d15ebc48f48aa96e3a6eed157bb1b18967d0d` (same four commits, authors, messages, and DCO preserved, on parent #7531 `893c668e1475997142c27dc661def869f56a848a`); no conflicts, no merge commits. Own range vs the new parent is unchanged at **416 additions + 50 deletions = 466 lines including tests**; the only old-head→new-head content delta is the carried #7531 test-only +24/−0 regression coverage in `desktop/tests/e2e/workflows.spec.ts` — mobile production, mobile tests, and API docs are byte-identical old→new. Current-head review 5163162911 predates this head movement and is not resolved or invalidated-as-addressed by this test-only carry. Normal CI on the new head: https://github.com/block/buzz/actions/runs/34444700430 (no green claim is made here).
