### PR TITLE
fix(mobile): honor authenticated owner policy in agent candidates

### DIFF
--- a/mobile/lib/features/channels/channel_management_provider.dart
+++ b/mobile/lib/features/channels/channel_management_provider.dart
@@ -296,17 +296,7 @@ List<String> relayMemberPubkeysFromEvents(List<NostrEvent> events) {
 /// Converts kind:0 events into a deduplicated, alphabetized people directory.
 @visibleForTesting
 List<DirectoryUser> directoryUsersFromProfileEvents(List<NostrEvent> events) {
-  final latestByPubkey = <String, NostrEvent>{};
-  for (final event in events) {
-    if (event.kind != 0) {
-      continue;
-    }
-    final pubkey = event.pubkey.toLowerCase();
-    final current = latestByPubkey[pubkey];
-    if (current == null || event.createdAt > current.createdAt) {
-      latestByPubkey[pubkey] = event;
-    }
-  }
+  final latestByPubkey = latestProfileEvents(events);
 
   return [
     for (final event in latestByPubkey.values)
@@ -316,7 +306,7 @@ List<DirectoryUser> directoryUsersFromProfileEvents(List<NostrEvent> events) {
           displayName: profile.displayName,
           avatarUrl: profile.avatarUrl,
           nip05Handle: profile.nip05,
-          isAgent: verifiedOaOwnerPubkey(event.tags, event.pubkey) != null,
+          isAgent: verifiedOaOwnerPubkey(event) != null,
         ),
   ]..sort((a, b) {
     final labelComparison = a.label.toLowerCase().compareTo(
@@ -373,29 +363,14 @@ final relayDirectoryUsersProvider =
         NostrFilters.profilesBatch(memberPubkeys),
       ]);
       final profilesByPubkey = {
-        for (final event in profileEvents)
-          event.pubkey.toLowerCase(): ProfileData.fromEvent(event),
+        for (final user in directoryUsersFromProfileEvents(profileEvents))
+          user.pubkey: user,
       };
       users =
           [
             for (final pubkey in memberPubkeys)
               if (profilesByPubkey[pubkey] case final profile?)
-                DirectoryUser(
-                  pubkey: pubkey,
-                  displayName: profile.displayName,
-                  avatarUrl: profile.avatarUrl,
-                  nip05Handle: profile.nip05,
-                  isAgent:
-                      verifiedOaOwnerPubkey(
-                        profileEvents
-                            .firstWhere(
-                              (event) => event.pubkey.toLowerCase() == pubkey,
-                            )
-                            .tags,
-                        pubkey,
-                      ) !=
-                      null,
-                )
+                profile
               else
                 DirectoryUser(pubkey: pubkey),
           ]..sort((a, b) {

--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -12,6 +12,11 @@ bool agentIsSharedWithUser(
   Set<String> sharedChannelIds,
   String? currentPubkey,
 ) {
+  if (currentPubkey != null &&
+      agent.ownerPubkey == currentPubkey.toLowerCase() &&
+      const ['owner-only', 'allowlist', 'anyone'].contains(agent.respondTo)) {
+    return true;
+  }
   if (agent.respondTo == 'allowlist' && currentPubkey != null) {
     return agent.respondToAllowlist.contains(currentPubkey.toLowerCase());
   }
@@ -62,6 +67,11 @@ List<MentionCandidate> buildMentionCandidates({
     final profile = userCache[pk];
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile?.ownerPubkey;
     final isAgent = member.isBot || ownerPubkey != null;
+    final policy = relayAgents.where((agent) => agent.pubkey == pk).firstOrNull;
+    if (policy?.ownerPubkey != null &&
+        !agentIsSharedWithUser(policy!, sharedChannelIds, currentPubkey)) {
+      continue;
+    }
     candidates.add(
       MentionCandidate(
         pubkey: pk,
@@ -121,6 +131,12 @@ List<MentionCandidate> buildMentionCandidates({
       // verified NIP-OA owner) or shared via the relay agent directory.
       final ownedByCurrentUser =
           currentLower != null && ownerPubkey?.toLowerCase() == currentLower;
+      final policy = relayAgents
+          .where((agent) => agent.pubkey == pk)
+          .firstOrNull;
+      if (policy?.ownerPubkey != null && !sharedAgentPubkeys.contains(pk)) {
+        continue;
+      }
       if (!ownedByCurrentUser && !sharedAgentPubkeys.contains(pk)) {
         continue;
       }

--- a/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
@@ -38,16 +38,7 @@ final mentionUserSearchProvider = FutureProvider.autoDispose
       // Keep only the latest kind:0 event per pubkey (the bridge does not
       // honor the `kinds` filter under search, and may return several
       // profile revisions — mirrors desktop's `list_user_search_results`).
-      final latestByPubkey = <String, NostrEvent>{};
-      for (final event in events) {
-        if (event.kind != 0) continue;
-        final pk = event.pubkey.toLowerCase();
-        final current = latestByPubkey[pk];
-        if (current == null || event.createdAt > current.createdAt) {
-          latestByPubkey[pk] = event;
-        }
-      }
-
+      final latestByPubkey = latestProfileEvents(events);
       return [
         for (final event in latestByPubkey.values) _profileFromEvent(event),
       ];
@@ -61,7 +52,7 @@ UserProfile _profileFromEvent(NostrEvent event) {
     avatarUrl: data.avatarUrl,
     about: data.about,
     nip05Handle: data.nip05,
-    ownerPubkey: verifiedOaOwnerPubkey(event.tags, event.pubkey),
+    ownerPubkey: verifiedOaOwnerPubkey(event),
   );
 }
 

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -116,7 +116,7 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
       avatarUrl: data.avatarUrl,
       about: data.about,
       nip05Handle: data.nip05,
-      ownerPubkey: verifiedOaOwnerPubkey(latest.tags, data.pubkey),
+      ownerPubkey: verifiedOaOwnerPubkey(latest),
     );
     _requireCurrentWriteContext(context);
     _metadata = metadata;
@@ -233,7 +233,7 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
       avatarUrl: _metadata['picture'] as String?,
       about: _metadata['about'] as String?,
       nip05Handle: _metadata['nip05'] as String?,
-      ownerPubkey: verifiedOaOwnerPubkey(submittedEvent.tags, pubkey),
+      ownerPubkey: verifiedOaOwnerPubkey(submittedEvent),
     );
     state = AsyncData(profile);
     ref.read(userCacheProvider.notifier).put(profile);

--- a/mobile/lib/shared/crypto/nip_oa.dart
+++ b/mobile/lib/shared/crypto/nip_oa.dart
@@ -4,6 +4,9 @@ import 'dart:typed_data';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:pointycastle/digests/sha256.dart';
 
+import '../relay/nostr_models.dart';
+import 'signed_event.dart';
+
 /// NIP-OA (Owner Attestation) — verify the `auth` tag on a kind:0 profile
 /// that proves an owner key authorized an agent key.
 ///
@@ -15,48 +18,60 @@ import 'package:pointycastle/digests/sha256.dart';
 /// verified against the profile event author, so a forged or stale marker
 /// cannot turn a person into an agent.
 ///
-/// Returns the owner pubkey (lowercase hex) for the first valid auth tag,
-/// or null if none verifies.
-String? verifiedOaOwnerPubkey(List<List<String>> tags, String agentPubkey) {
-  final agent = agentPubkey.toLowerCase();
+/// Returns the owner only when the signed profile has exactly one valid auth
+/// tag whose conditions apply to that event (not to the verifier's clock).
+String? verifiedOaOwnerPubkey(NostrEvent event) {
+  if (event.kind != 0) return null;
+  final tags = event.tags.where((tag) => tag.isNotEmpty && tag[0] == 'auth');
+  if (tags.length != 1) return null;
+  final tag = tags.single;
+  if (tag.length != 4) return null;
+  final owner = tag[1];
+  final conditions = tag[2];
+  final sig = tag[3];
+  if (owner == event.pubkey ||
+      !RegExp(r'^[0-9a-f]{64}$').hasMatch(owner) ||
+      !RegExp(r'^[0-9a-f]{128}$').hasMatch(sig) ||
+      !_validConditions(conditions, event) ||
+      !verifySignedEvent(event)) {
+    return null;
+  }
+  final preimage = utf8.encode('nostr:agent-auth:${event.pubkey}:$conditions');
+  final digest = SHA256Digest().process(Uint8List.fromList(preimage));
+  final message = digest.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  try {
+    return nostr.Schnorr.verify(
+          publicKey: owner,
+          message: message,
+          signature: sig,
+        )
+        ? owner
+        : null;
+  } catch (_) {
+    return null;
+  }
+}
 
-  for (final tag in tags) {
-    if (tag.length != 4 || tag[0] != 'auth') continue;
-
-    final owner = tag[1].toLowerCase();
-    final conditions = tag[2];
-    final sig = tag[3];
-
-    // Self-attestation is meaningless and rejected.
-    if (owner == agent) continue;
-    if (owner.length != 64 || sig.length != 128) continue;
-    if (!_validConditions(conditions)) continue;
-
-    final preimage = utf8.encode('nostr:agent-auth:$agent:$conditions');
-    final digest = SHA256Digest().process(Uint8List.fromList(preimage));
-    final message = digest
-        .map((b) => b.toRadixString(16).padLeft(2, '0'))
-        .join();
-
-    try {
-      if (nostr.Schnorr.verify(
-        publicKey: owner,
-        message: message,
-        signature: sig,
-      )) {
-        return owner;
-      }
-    } catch (_) {
-      // Malformed hex — treat as an invalid tag.
+/// Select the latest profile before checking ownership, including revocations.
+/// NIP-01 ties choose the lowest event id, independent of response order.
+Map<String, NostrEvent> latestProfileEvents(Iterable<NostrEvent> events) {
+  final latest = <String, NostrEvent>{};
+  for (final event in events.where((event) => event.kind == 0)) {
+    final key = event.pubkey.toLowerCase();
+    final previous = latest[key];
+    if (previous == null ||
+        event.createdAt > previous.createdAt ||
+        (event.createdAt == previous.createdAt &&
+            event.id.compareTo(previous.id) < 0)) {
+      latest[key] = event;
     }
   }
-
-  return null;
+  return latest;
 }
 
 /// Validate the NIP-OA `conditions` string: empty, or `&`-joined clauses of
 /// `kind=<n>`, `created_at<<n>`, or `created_at><n>` with canonical decimals.
-bool _validConditions(String conditions) {
+bool _validConditions(String conditions, NostrEvent event) {
   if (conditions.isEmpty) return true;
   if (conditions.contains(RegExp(r'\s'))) return false;
 
@@ -67,7 +82,15 @@ bool _validConditions(String conditions) {
     if (match == null) return false;
     final value = int.tryParse(match.group(1)!);
     if (value == null || value > 4294967295) return false;
-    if (clause.startsWith('kind=') && value > 65535) return false;
+    if (clause.startsWith('kind=') && (value > 65535 || value != event.kind)) {
+      return false;
+    }
+    if (clause.startsWith('created_at<') && event.createdAt >= value) {
+      return false;
+    }
+    if (clause.startsWith('created_at>') && event.createdAt <= value) {
+      return false;
+    }
   }
 
   return true;

--- a/mobile/lib/shared/crypto/signed_event.dart
+++ b/mobile/lib/shared/crypto/signed_event.dart
@@ -1,0 +1,27 @@
+import 'package:nostr/nostr.dart' as nostr;
+
+import '../relay/nostr_models.dart';
+
+/// Verify the canonical event id and author's signature without a wall-clock
+/// freshness restriction. Authority readers apply their own kind/signer scope.
+bool verifySignedEvent(NostrEvent event) {
+  if (!RegExp(r'^[0-9a-f]{64}$').hasMatch(event.pubkey) ||
+      !RegExp(r'^[0-9a-f]{64}$').hasMatch(event.id) ||
+      !RegExp(r'^[0-9a-f]{128}$').hasMatch(event.sig) ||
+      event.createdAt < 0 ||
+      event.kind < 0 ||
+      event.kind > 65535) {
+    return false;
+  }
+  try {
+    final signed = nostr.Event.fromMap(event.toJson(), verify: false);
+    return signed.getEventId() == event.id &&
+        nostr.Schnorr.verify(
+          publicKey: event.pubkey,
+          message: event.id,
+          signature: event.sig,
+        );
+  } catch (_) {
+    return false;
+  }
+}

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -80,8 +80,8 @@ final agentOwnersProvider = FutureProvider<Map<String, String>>((ref) async {
     NostrFilters.profilesBatch([for (final agent in agents) agent.pubkey]),
   );
   final owners = <String, String>{};
-  for (final event in events) {
-    final owner = verifiedOaOwnerPubkey(event.tags, event.pubkey);
+  for (final event in latestProfileEvents(events).values) {
+    final owner = verifiedOaOwnerPubkey(event);
     if (owner != null) owners[event.pubkey.toLowerCase()] = owner;
   }
   return owners;

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -5,7 +5,10 @@ import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../shared/crypto/nip_oa.dart';
+import '../../shared/crypto/signed_event.dart';
 import '../../shared/relay/relay.dart';
+
+part 'agent_policy.dart';
 
 /// A relay agent parsed from its kind:10100 agent-profile event.
 ///
@@ -15,6 +18,7 @@ import '../../shared/relay/relay.dart';
 class AgentDirectoryEntry {
   final String pubkey;
   final String? displayName;
+  final String? ownerPubkey;
   final String? respondTo;
   final List<String> respondToAllowlist;
   final List<String> channelIds;
@@ -22,6 +26,7 @@ class AgentDirectoryEntry {
   const AgentDirectoryEntry({
     required this.pubkey,
     this.displayName,
+    this.ownerPubkey,
     this.respondTo,
     this.respondToAllowlist = const [],
     this.channelIds = const [],
@@ -66,7 +71,7 @@ final agentDirectoryProvider = FutureProvider<List<AgentDirectoryEntry>>((
   if (sessionState.status != SessionStatus.connected) return const [];
   final session = ref.read(relaySessionProvider.notifier);
   final events = await session.fetchHistory(NostrFilters.agentProfiles());
-  return [for (final event in events) AgentDirectoryEntry.fromEvent(event)];
+  return resolveAgentPolicies(session, events);
 });
 
 /// Verified NIP-OA owner pubkey per agent pubkey, from the agents' kind:0

--- a/mobile/lib/shared/mentions/agent_policy.dart
+++ b/mobile/lib/shared/mentions/agent_policy.dart
@@ -1,0 +1,140 @@
+part of 'agent_identity_provider.dart';
+
+bool _newer(NostrEvent event, NostrEvent previous) =>
+    event.createdAt > previous.createdAt ||
+    (event.createdAt == previous.createdAt &&
+        event.id.compareTo(previous.id) < 0);
+
+/// Exact-coordinate queries, bounded to ten filters in flight. An empty result
+/// is distinct from a failed read; failures must never revive runtime access.
+Future<List<NostrEvent>> _queryAgentFilters(
+  RelaySessionNotifier session,
+  List<NostrFilter> filters,
+) async {
+  final events = <NostrEvent>[];
+  for (var start = 0; start < filters.length; start += 10) {
+    events.addAll(
+      await session.queryRelay(filters.skip(start).take(10).toList()),
+    );
+  }
+  return events;
+}
+
+/// Overlay current owner-authenticated policy onto the existing runtime
+/// directory. This does not expand discovery to owner-only coordinates yet.
+Future<List<AgentDirectoryEntry>> resolveAgentPolicies(
+  RelaySessionNotifier session,
+  List<NostrEvent> runtimeEvents,
+) async {
+  final latest = <String, NostrEvent>{};
+  for (final event in runtimeEvents.where((event) => event.kind == 10100)) {
+    final previous = latest[event.pubkey];
+    if (previous == null || _newer(event, previous)) {
+      latest[event.pubkey] = event;
+    }
+  }
+  final profiles = latestProfileEvents(
+    await _queryAgentFilters(session, [
+      for (final key in latest.keys)
+        NostrFilter(kinds: const [0], authors: [key], limit: 1),
+    ]),
+  );
+  final owners = <String, String>{};
+  for (final profile in profiles.values) {
+    final owner = verifiedOaOwnerPubkey(profile);
+    if (owner != null && latest.containsKey(profile.pubkey)) {
+      owners[profile.pubkey] = owner;
+    }
+  }
+  final policies = await _queryAgentFilters(session, [
+    for (final owner in owners.entries)
+      NostrFilter(
+        kinds: const [30177],
+        authors: [owner.value],
+        tags: {
+          '#d': [owner.key],
+        },
+        limit: 1,
+      ),
+  ]);
+  return mergeAgentPolicies(latest.values, policies, owners);
+}
+
+/// Latest signed owner policy is the access authority, not runtime claims.
+/// Malformed/revoked policy reserves the identity with deny-all permissions;
+/// it must not fall back to an older permissive policy or kind:10100 record.
+List<AgentDirectoryEntry> mergeAgentPolicies(
+  Iterable<NostrEvent> runtimeEvents,
+  Iterable<NostrEvent> policies,
+  Map<String, String> verifiedOwners,
+) {
+  final latestPolicies = <String, NostrEvent>{};
+  for (final event in policies) {
+    final key = event.getTagValue('d');
+    if (key == null || verifiedOwners[key] != event.pubkey) continue;
+    final previous = latestPolicies[key];
+    if (previous == null || _newer(event, previous)) {
+      latestPolicies[key] = event;
+    }
+  }
+  final agents = <String, AgentDirectoryEntry>{};
+  for (final event in runtimeEvents) {
+    if (event.kind != 10100 || !verifySignedEvent(event)) continue;
+    final data = _tryDecodeJsonMap(event.content);
+    if (data == null) continue;
+    agents[event.pubkey] = AgentDirectoryEntry(
+      pubkey: event.pubkey,
+      displayName: data['display_name'] is String
+          ? data['display_name'] as String
+          : data['name'] is String
+          ? data['name'] as String
+          : null,
+      respondTo: data['respond_to'] is String
+          ? data['respond_to'] as String
+          : null,
+      respondToAllowlist: _stringList(data['respond_to_allowlist']) ?? const [],
+      channelIds: _stringList(data['channel_ids']) ?? const [],
+    );
+  }
+  for (final entry in latestPolicies.entries) {
+    final event = entry.value;
+    final data = _tryDecodeJsonMap(event.content);
+    final mode = data?['respond_to'];
+    final parallelism = data?['parallelism'];
+    final allowlist = _stringList(data?['respond_to_allowlist'] ?? []);
+    final valid =
+        event.kind == 30177 &&
+        verifySignedEvent(event) &&
+        event.tags.where((tag) => tag.isNotEmpty && tag[0] == 'd').length ==
+            1 &&
+        data?['name'] is String &&
+        parallelism is int &&
+        parallelism >= 0 &&
+        parallelism <= 4294967295 &&
+        const ['owner-only', 'allowlist', 'anyone', 'nobody'].contains(mode) &&
+        allowlist != null &&
+        const [
+          'persona_id',
+          'system_prompt',
+          'model',
+          'provider',
+          'persona_source_version',
+        ].every((key) => data?[key] == null || data?[key] is String);
+    agents[entry.key] = AgentDirectoryEntry(
+      pubkey: entry.key,
+      ownerPubkey: event.pubkey,
+      displayName: valid
+          ? data!['name'] as String
+          : agents[entry.key]?.displayName,
+      respondTo: valid ? mode as String : 'nobody',
+      respondToAllowlist: valid ? allowlist : const [],
+      channelIds: agents[entry.key]?.channelIds ?? const [],
+    );
+  }
+  return agents.values.toList();
+}
+
+List<String>? _stringList(Object? value) =>
+    value is List && value.every((v) => v is String)
+    ? value.cast<String>().map((v) => v.toLowerCase()).toList()
+    : null;

--- a/mobile/lib/shared/profile/user_cache_provider.dart
+++ b/mobile/lib/shared/profile/user_cache_provider.dart
@@ -181,7 +181,7 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
       avatarUrl: data.avatarUrl,
       about: data.about,
       nip05Handle: data.nip05,
-      ownerPubkey: verifiedOaOwnerPubkey(event.tags, event.pubkey),
+      ownerPubkey: verifiedOaOwnerPubkey(event),
     );
   }
 }

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -887,6 +887,7 @@ void main() {
         _profileEvent(
           id: 'newer-agent',
           pubkey: agent.public,
+          secretKey: agent.secret,
           createdAt: 2,
           name: 'Agent',
           tags: [_authTag(owner, agent.public)],
@@ -14420,15 +14421,26 @@ NostrEvent _profileEvent({
   required int createdAt,
   required String name,
   List<List<String>> tags = const [],
-}) => NostrEvent(
-  id: id,
-  pubkey: pubkey,
-  createdAt: createdAt,
-  kind: 0,
-  tags: tags,
-  content: jsonEncode({'name': name}),
-  sig: 'sig',
-);
+  String? secretKey,
+}) => secretKey != null
+    ? NostrEvent.fromJson(
+        nostr.Event.from(
+          kind: 0,
+          content: jsonEncode({'name': name}),
+          secretKey: secretKey,
+          createdAt: createdAt,
+          tags: tags,
+        ).toMap(),
+      )
+    : NostrEvent(
+        id: id,
+        pubkey: pubkey,
+        createdAt: createdAt,
+        kind: 0,
+        tags: tags,
+        content: jsonEncode({'name': name}),
+        sig: 'sig',
+      );
 
 List<String> _authTag(nostr.Keys owner, String agentPubkey) {
   final digest = SHA256Digest().process(

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -23,21 +23,21 @@ void main() {
       const ['custom', 'preserve-tag'],
     ];
     final relaySession = _ProfileRelaySession(
-      NostrEvent(
-        id: 'profile-1',
-        pubkey: keys.public,
-        createdAt: 1,
-        kind: EventKind.profile,
-        tags: profileTags,
-        content: jsonEncode({
-          'name': 'alice',
-          'display_name': 'Alice',
-          'about': 'Building Buzz',
-          'picture': 'https://relay.example/alice.png',
-          'nip05': 'alice@example.com',
-          'custom': 'preserve-me',
-        }),
-        sig: 'sig',
+      NostrEvent.fromJson(
+        nostr.Event.from(
+          secretKey: keys.secret,
+          createdAt: 1,
+          kind: EventKind.profile,
+          tags: profileTags,
+          content: jsonEncode({
+            'name': 'alice',
+            'display_name': 'Alice',
+            'about': 'Building Buzz',
+            'picture': 'https://relay.example/alice.png',
+            'nip05': 'alice@example.com',
+            'custom': 'preserve-me',
+          }),
+        ).toMap(),
       ),
     );
     final container = ProviderContainer(

--- a/mobile/test/shared/crypto/nip_oa_test.dart
+++ b/mobile/test/shared/crypto/nip_oa_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:pointycastle/digests/sha256.dart';
 import 'package:buzz/shared/crypto/nip_oa.dart';
+import 'package:buzz/shared/relay/relay.dart';
 
 String _sha256Hex(String input) {
   final digest = SHA256Digest().process(Uint8List.fromList(utf8.encode(input)));
@@ -21,6 +22,21 @@ List<String> authTag(
   return ['auth', owner.public, conditions, sig];
 }
 
+NostrEvent profile(
+  nostr.Keys agent,
+  List<List<String>> tags, {
+  int createdAt = 100,
+  int kind = 0,
+}) => NostrEvent.fromJson(
+  nostr.Event.from(
+    kind: kind,
+    content: '{}',
+    secretKey: agent.secret,
+    createdAt: createdAt,
+    tags: tags,
+  ).toMap(),
+);
+
 void main() {
   final owner = nostr.Keys.generate();
   final agent = nostr.Keys.generate();
@@ -28,7 +44,7 @@ void main() {
   test('returns the owner pubkey for a valid auth tag', () {
     final tag = authTag(owner, agent.public);
     expect(
-      verifiedOaOwnerPubkey([tag], agent.public),
+      verifiedOaOwnerPubkey(profile(agent, [tag])),
       owner.public.toLowerCase(),
     );
   });
@@ -36,7 +52,7 @@ void main() {
   test('accepts valid conditions strings', () {
     final tag = authTag(owner, agent.public, conditions: 'kind=0');
     expect(
-      verifiedOaOwnerPubkey([tag], agent.public),
+      verifiedOaOwnerPubkey(profile(agent, [tag])),
       owner.public.toLowerCase(),
     );
   });
@@ -44,7 +60,7 @@ void main() {
   test('rejects a signature over a different agent pubkey', () {
     final otherAgent = nostr.Keys.generate();
     final tag = authTag(owner, otherAgent.public);
-    expect(verifiedOaOwnerPubkey([tag], agent.public), isNull);
+    expect(verifiedOaOwnerPubkey(profile(agent, [tag])), isNull);
   });
 
   test('rejects a tampered signature', () {
@@ -55,25 +71,106 @@ void main() {
       1,
       tampered[3][0] == '0' ? '1' : '0',
     );
-    expect(verifiedOaOwnerPubkey([tampered], agent.public), isNull);
+    expect(verifiedOaOwnerPubkey(profile(agent, [tampered])), isNull);
   });
 
   test('rejects self-attestation', () {
     final tag = authTag(agent, agent.public);
-    expect(verifiedOaOwnerPubkey([tag], agent.public), isNull);
+    expect(verifiedOaOwnerPubkey(profile(agent, [tag])), isNull);
   });
 
   test('rejects malformed conditions', () {
     final tag = authTag(owner, agent.public, conditions: 'kind=abc');
-    expect(verifiedOaOwnerPubkey([tag], agent.public), isNull);
+    expect(verifiedOaOwnerPubkey(profile(agent, [tag])), isNull);
   });
 
   test('ignores unrelated tags', () {
     expect(
-      verifiedOaOwnerPubkey([
-        ['p', owner.public],
-      ], agent.public),
+      verifiedOaOwnerPubkey(
+        profile(agent, [
+          ['p', owner.public],
+        ]),
+      ),
       isNull,
     );
   });
+  test('rejects duplicate auth tags, including malformed companions', () {
+    final tag = authTag(owner, agent.public);
+    for (final duplicate in [
+      tag,
+      ['auth'],
+      ['auth', 'invalid'],
+    ]) {
+      expect(verifiedOaOwnerPubkey(profile(agent, [tag, duplicate])), isNull);
+      expect(verifiedOaOwnerPubkey(profile(agent, [duplicate, tag])), isNull);
+    }
+  });
+
+  test('conditions evaluate the signed profile time, with strict bounds', () {
+    for (final conditions in [
+      '',
+      'kind=0',
+      'created_at>99&created_at<101',
+      'created_at<4294967295',
+    ]) {
+      expect(
+        verifiedOaOwnerPubkey(
+          profile(agent, [
+            authTag(owner, agent.public, conditions: conditions),
+          ]),
+        ),
+        owner.public,
+      );
+    }
+    for (final conditions in [
+      'kind=1',
+      'created_at>100',
+      'created_at<100',
+      'kind=65536',
+      'kind=00',
+      'kind=+0',
+      'created_at<4294967296',
+      'kind=0&',
+      ' kind=0',
+      'kind=0&kind=1',
+    ]) {
+      expect(
+        verifiedOaOwnerPubkey(
+          profile(agent, [
+            authTag(owner, agent.public, conditions: conditions),
+          ]),
+        ),
+        isNull,
+        reason: conditions,
+      );
+    }
+  });
+
+  test(
+    'rejects noncanonical owner/signature and invalid profile envelopes',
+    () {
+      final tag = authTag(owner, agent.public);
+      for (final index in [1, 3]) {
+        final uppercase = [...tag];
+        uppercase[index] = uppercase[index].toUpperCase();
+        expect(verifiedOaOwnerPubkey(profile(agent, [uppercase])), isNull);
+      }
+      final valid = profile(agent, [tag]);
+      for (final patch in [
+        {'content': 'forged'},
+        {'created_at': 101},
+        {'id': '0' * 64},
+        {'sig': '0' * 128},
+        {'pubkey': owner.public},
+      ]) {
+        expect(
+          verifiedOaOwnerPubkey(
+            NostrEvent.fromJson({...valid.toJson(), ...patch}),
+          ),
+          isNull,
+        );
+      }
+      expect(verifiedOaOwnerPubkey(profile(agent, [tag], kind: 1)), isNull);
+    },
+  );
 }

--- a/mobile/test/shared/mentions/agent_owners_test.dart
+++ b/mobile/test/shared/mentions/agent_owners_test.dart
@@ -1,0 +1,86 @@
+import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/shared/mentions/agent_identity_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+import '../crypto/nip_oa_test.dart' show authTag, profile;
+
+void main() {
+  final owner = nostr.Keys.generate();
+  final agent = nostr.Keys.generate();
+  final owned = profile(agent, [authTag(owner, agent.public)]);
+  final revoked = profile(agent, [], createdAt: 101);
+  final tampered = NostrEvent.fromJson({
+    ...profile(agent, [authTag(owner, agent.public)], createdAt: 102).toJson(),
+    'content': 'forged',
+  });
+
+  Future<Map<String, String>> owners(List<NostrEvent> events) async {
+    final container = ProviderContainer(
+      overrides: [
+        agentDirectoryProvider.overrideWith(
+          (ref) async => [
+            AgentDirectoryEntry(pubkey: agent.public, displayName: 'Agent'),
+          ],
+        ),
+        relaySessionProvider.overrideWith(() => _Profiles(events)),
+      ],
+    );
+    try {
+      return await container.read(agentOwnersProvider.future);
+    } finally {
+      container.dispose();
+    }
+  }
+
+  test(
+    'directory resolves only the latest ownership, never older fallback',
+    () async {
+      expect(await owners([owned]), {agent.public: owner.public});
+      for (final latest in [revoked, tampered]) {
+        for (final events in [
+          [owned, latest],
+          [latest, owned],
+        ]) {
+          expect(await owners(events), isEmpty);
+          expect(
+            directoryUsersFromProfileEvents(events).single.isAgent,
+            isFalse,
+          );
+        }
+      }
+    },
+  );
+
+  test(
+    'same-second owner revocation is deterministic across directory paths',
+    () async {
+      final other = profile(agent, []);
+      final expected = owned.id.compareTo(other.id) < 0;
+      for (final events in [
+        [owned, other],
+        [other, owned],
+      ]) {
+        expect((await owners(events)).containsKey(agent.public), expected);
+        expect(
+          directoryUsersFromProfileEvents(events).single.isAgent,
+          expected,
+        );
+      }
+    },
+  );
+}
+
+class _Profiles extends RelaySessionNotifier {
+  _Profiles(this.events);
+  final List<NostrEvent> events;
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => events;
+}

--- a/mobile/test/shared/mentions/agent_policy_test.dart
+++ b/mobile/test/shared/mentions/agent_policy_test.dart
@@ -1,0 +1,280 @@
+import 'dart:convert';
+
+import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/features/channels/mentions/mention_candidates.dart';
+import 'package:buzz/shared/mentions/agent_identity_provider.dart';
+import 'package:buzz/shared/profile/user_profile.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+import '../crypto/nip_oa_test.dart' show authTag, profile;
+
+NostrEvent signed(
+  nostr.Keys key,
+  int kind,
+  Object content, {
+  int time = 100,
+  List<List<String>> tags = const [],
+}) => NostrEvent.fromJson(
+  nostr.Event.from(
+    kind: kind,
+    content: content is String ? content : jsonEncode(content),
+    secretKey: key.secret,
+    createdAt: time,
+    tags: tags,
+  ).toMap(),
+);
+
+class PolicySession extends RelaySessionNotifier {
+  PolicySession(this.events, {this.failPolicy = false});
+  final List<NostrEvent> events;
+  final bool failPolicy;
+  final queries = <NostrFilter>[];
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => events.where((e) => e.kind == 10100).toList();
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    expect(filters.length, lessThanOrEqualTo(10));
+    queries.addAll(filters);
+    if (failPolicy && filters.any((f) => f.kinds.contains(30177))) {
+      throw StateError('policy read failed');
+    }
+    return events
+        .where(
+          (event) => filters.any(
+            (f) =>
+                f.kinds.contains(event.kind) &&
+                f.authors!.contains(event.pubkey) &&
+                (f.tags['#d'] == null ||
+                    f.tags['#d']!.contains(event.getTagValue('d'))),
+          ),
+        )
+        .toList();
+  }
+}
+
+void main() {
+  final owner = nostr.Keys.generate();
+  final agent = nostr.Keys.generate();
+  final stranger = nostr.Keys.generate();
+  final owned = profile(agent, [authTag(owner, agent.public)]);
+  final runtime = signed(agent, 10100, {
+    'name': 'runtime',
+    'respond_to': 'anyone',
+    'channel_ids': ['channel'],
+  });
+  NostrEvent policy(Object content, {int time = 100, nostr.Keys? author}) =>
+      signed(
+        author ?? owner,
+        30177,
+        content,
+        time: time,
+        tags: [
+          ['d', agent.public],
+        ],
+      );
+  final allow = policy({
+    'name': 'Agent',
+    'parallelism': 1,
+    'respond_to': 'owner-only',
+  });
+
+  Future<List<AgentDirectoryEntry>> directory(
+    List<NostrEvent> events, {
+    bool failPolicy = false,
+    void Function(PolicySession)? inspect,
+  }) async {
+    final session = PolicySession(events, failPolicy: failPolicy);
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => session)],
+    );
+    try {
+      final result = await container.read(agentDirectoryProvider.future);
+      inspect?.call(session);
+      return result;
+    } finally {
+      container.dispose();
+    }
+  }
+
+  test(
+    'production directory reads exact authenticated owner coordinates',
+    () async {
+      final agents = await directory(
+        [runtime, owned, allow],
+        inspect: (session) {
+          final query = session.queries.singleWhere(
+            (q) => q.kinds.contains(30177),
+          );
+          expect(query.authors, [owner.public]);
+          expect(query.tags, {
+            '#d': [agent.public],
+          });
+          expect(query.limit, 1);
+        },
+      );
+      expect(agents.single.ownerPubkey, owner.public);
+      expect(agents.single.respondTo, 'owner-only');
+      expect(agents.single.displayName, 'Agent');
+      expect(agentIsSharedWithUser(agents.single, {}, owner.public), isTrue);
+      expect(
+        agentIsSharedWithUser(agents.single, {'channel'}, stranger.public),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'latest malformed policy reserves deny-all, never runtime/older fallback',
+    () async {
+      for (final body in [
+        '',
+        '{}',
+        {'name': 'Agent', 'parallelism': 1, 'respond_to': 'unknown'},
+        {
+          'name': 'Agent',
+          'parallelism': 1,
+          'respond_to': 'anyone',
+          'respond_to_allowlist': [3],
+        },
+        {'name': 'Agent', 'parallelism': -1, 'respond_to': 'anyone'},
+      ]) {
+        final bad = policy(body, time: 101);
+        for (final policies in [
+          [allow, bad],
+          [bad, allow],
+        ]) {
+          final result = await directory([runtime, owned, ...policies]);
+          expect(result.single.respondTo, 'nobody');
+          expect(
+            agentIsSharedWithUser(result.single, {'channel'}, owner.public),
+            isFalse,
+          );
+        }
+      }
+    },
+  );
+
+  test(
+    'same-second policy ties are independent of response ordering',
+    () async {
+      final deny = policy({
+        'name': 'Agent',
+        'parallelism': 1,
+        'respond_to': 'nobody',
+      });
+      for (final policies in [
+        [allow, deny],
+        [deny, allow],
+      ]) {
+        expect(
+          (await directory([runtime, owned, ...policies])).single.respondTo,
+          allow.id.compareTo(deny.id) < 0 ? 'owner-only' : 'nobody',
+        );
+      }
+    },
+  );
+
+  test(
+    'tampered authenticated policy cannot revive runtime permission',
+    () async {
+      final tampered = NostrEvent.fromJson({
+        ...allow.toJson(),
+        'content': '{}',
+      });
+      expect(
+        (await directory([runtime, owned, tampered])).single.respondTo,
+        'nobody',
+      );
+    },
+  );
+
+  test(
+    'foreign policy cannot override a headless runtime; revoked owner is not revived',
+    () async {
+      final foreign = policy({}, author: stranger);
+      expect(
+        (await directory([runtime, owned, foreign])).single.respondTo,
+        'anyone',
+      );
+      final revoked = profile(agent, [], createdAt: 101);
+      final result = await directory([runtime, owned, revoked, allow]);
+      expect(result.single.ownerPubkey, isNull);
+      expect(result.single.respondTo, 'anyone'); // OSS headless compatibility.
+    },
+  );
+
+  test(
+    'policy read failure propagates instead of falling back to runtime',
+    () async {
+      await expectLater(
+        directory([runtime, owned, allow], failPolicy: true),
+        throwsStateError,
+      );
+    },
+  );
+
+  test('latest tampered runtime never revives older valid runtime', () async {
+    final bad = NostrEvent.fromJson({...runtime.toJson(), 'created_at': 102});
+    expect(await directory([runtime, bad]), isEmpty);
+  });
+
+  test(
+    'policy denial applies to member, non-member and owned search candidates',
+    () async {
+      final deny = policy({
+        'name': 'Agent',
+        'parallelism': 1,
+        'respond_to': 'nobody',
+      });
+      final agents = await directory([runtime, owned, deny]);
+      for (final members in [
+        <ChannelMember>[],
+        [
+          ChannelMember(
+            pubkey: agent.public,
+            role: 'bot',
+            joinedAt: DateTime(2026),
+          ),
+        ],
+      ]) {
+        final candidates = buildMentionCandidates(
+          members: members,
+          relayAgents: agents,
+          sharedChannelIds: {'channel'},
+          userCache: {},
+          ownerByAgentPubkey: {agent.public: owner.public},
+          currentPubkey: owner.public,
+          searchResults: [
+            UserProfile(pubkey: agent.public, ownerPubkey: owner.public),
+          ],
+        );
+        expect(candidates, isEmpty);
+      }
+    },
+  );
+
+  test('owner is allowed by each supported mode except nobody', () async {
+    for (final mode in ['owner-only', 'allowlist', 'anyone', 'nobody']) {
+      final agents = await directory([
+        runtime,
+        owned,
+        policy({'name': 'Agent', 'parallelism': 1, 'respond_to': mode}),
+      ]);
+      expect(
+        agentIsSharedWithUser(agents.single, {}, owner.public),
+        mode != 'nobody',
+      );
+    }
+  });
+}

--- a/mobile/test/shared/profile/user_cache_provider_test.dart
+++ b/mobile/test/shared/profile/user_cache_provider_test.dart
@@ -60,6 +60,7 @@ void main() {
       _profileEvent(
         id: 'newer-agent',
         pubkey: agent.public,
+        secretKey: agent.secret,
         createdAt: 2,
         name: 'Agent',
         tags: [_authTag(owner, agent.public)],
@@ -101,6 +102,7 @@ void main() {
       _profileEvent(
         id: 'older-agent',
         pubkey: agent.public,
+        secretKey: agent.secret,
         createdAt: 1,
         name: 'Agent',
         tags: [_authTag(owner, agent.public)],
@@ -165,16 +167,27 @@ NostrEvent _profileEvent({
   required String name,
   String pubkey = 'agent',
   List<List<String>> tags = const [],
+  String? secretKey,
   int kind = 0,
-}) => NostrEvent(
-  id: id,
-  pubkey: pubkey,
-  createdAt: createdAt,
-  kind: kind,
-  tags: tags,
-  content: jsonEncode({'name': name}),
-  sig: 'sig',
-);
+}) => secretKey != null
+    ? NostrEvent.fromJson(
+        nostr.Event.from(
+          kind: 0,
+          content: jsonEncode({'name': name}),
+          secretKey: secretKey,
+          createdAt: createdAt,
+          tags: tags,
+        ).toMap(),
+      )
+    : NostrEvent(
+        id: id,
+        pubkey: pubkey,
+        createdAt: createdAt,
+        kind: kind,
+        tags: tags,
+        content: jsonEncode({'name': name}),
+        sig: 'sig',
+      );
 
 List<String> _authTag(nostr.Keys owner, String agentPubkey) {
   final digest = SHA256Digest().process(


### PR DESCRIPTION
<!-- Draft PR body for #7392 · fix(mobile): honor authenticated owner policy in agent candidates · https://github.com/block/buzz/pull/7392 -->

🤖

## Summary

Which agents mobile suggested could ignore their owner's latest decision: the picker trusted the permissions an agent's running instance advertised, so an owner's newer policy — revoking an agent's mention access, or publishing a broken latest policy — didn't reliably remove that agent from suggestions. This PR makes the owner's latest signed policy the authority for candidate eligibility: it overlays exact, authenticated policy reads on the existing runtime directory, so an agent the owner has denied no longer appears as a mention candidate.

- Applies to member rows, non-member rows and owned search results. Owners remain permitted under every supported policy mode except "nobody", matching Desktop.
- A malformed or revoked latest policy means no access (deny-all) — it never falls back to an older permissive policy.
- Policy queries are exact and bounded; an empty result is distinct from a failed read, and failed reads never revive advertised runtime access.
- Does not expand discovery to owner-only coordinates yet — that is #7395.

Desktop reference: `desktop/src-tauri/src/nostr_convert/agent_directory.rs`, `commands/agent_discovery/relay_directory.rs`, `agentAutocompleteEligibility.ts`.

### Related issue

- Fixes: N/A. No separate issue; the related work is the stack below.
- Depends on #7389 (declared base) for the verified latest profiles this policy check reads. #7393 (child) adds relay-signed membership reads on top.
- Draft — not requesting merge yet; the security advisory doesn't run on this stacked base (it reviews main-based ranges).

### Testing

- Production-provider regressions cover signed envelopes, revocation, same-second ties, foreign authors, malformed policies, and failed exact reads.
- At the branch head: `just mobile-check`, the full mobile test suite, and full local `just ci` all pass — receipts in the [exact-head evidence comment](https://github.com/block/buzz/pull/7392#issuecomment-5574636551).
- Verification is widget-test level; no native device or simulator run is claimed.

### Screenshots

Flutter production-widget test renders — not native-device screenshots or acceptance captures.

| Scenario | Before | After |
|---|---|---|
| Mention suggestions after the owner publishes a newer signed deny policy | ![Before: the agent stays listed because its running instance advertised access](https://github.com/user-attachments/assets/c9283ded-8b45-4743-940a-e1fd6b5d0b5e) | ![After: the denied agent is filtered out; the ordinary human member remains](https://github.com/user-attachments/assets/ba618301-564b-48a4-b030-c2de01ece830) |

<details>
<summary>Capture provenance</summary>

Rendered by the Flutter widget engine in a `flutter test` run (production widgets, production theme; no device or simulator). Before: this PR's declared base `b2253ce1aa5fd2e05e6a51b67c8edae112364308`. After: its head `804c07f016b7f73504b614d1bf81ef6f0120d83d`.

</details>
