### PR TITLE
fix(mobile): revalidate exact agent intent before publication

### DIFF
--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -41,6 +41,15 @@ class ComposeBar extends HookConsumerWidget {
     final draftKey = composeDraftKey(channelId, threadHeadId: threadHeadId);
     final draftRevision = useRef(0);
     final draftIdentity = _composerDraftIdentity(ref);
+    final authorizationVisit = useRef<Object?>(null);
+    final authorizationAttempt = useRef<Object?>(null);
+    useEffect(() {
+      final visit = Object();
+      authorizationVisit.value = visit;
+      return () {
+        if (authorizationVisit.value == visit) authorizationVisit.value = null;
+      };
+    }, [draftKey, draftIdentity]);
     final isComposerExpanded = useState(false);
     final androidImeTransitionStarted = useState(
       defaultTargetPlatform != TargetPlatform.android,
@@ -464,51 +473,93 @@ class ComposeBar extends HookConsumerWidget {
           uploadingCount.value > 0) {
         return;
       }
-      final submittedDraftRevision = draftRevision.value;
-      // Resolved before any await: see
-      // `_reportSendCancelledByCommunitySwitch`.
-      final messenger = ScaffoldMessenger.maybeOf(context);
-
-      // Extract pubkeys for mentions present in the final text.
-      final selectedMentions = <MentionCandidate>[
-        for (final entry in mentionMap.value.entries)
-          if (hasMention(text, entry.key)) entry.value,
-      ];
-      final outgoing = _OutgoingMentions(selectedMentions);
-      final scan = await _scanNonMemberMentions(
-        ref,
-        channelId: channelId,
-        selectedMentions: selectedMentions,
-        currentPubkey: currentPubkey,
-      );
-
-      // Mentioning humans outside the channel prompts "Invite" / "Do
-      // nothing" (send without inviting) — mirrors desktop's
-      // NonMemberMentionDialog. Agents keep the existing silent auto-add.
-      if (scan.humans.isNotEmpty) {
-        if (!context.mounted) return;
-        final choice = await _promptNonMemberMention(
-          context,
-          names: [for (final candidate in scan.humans) candidate.label],
-          canInvite: scan.canAddMembers,
-        );
-        if (choice == null) return; // Dismissed — keep the draft, send nothing.
-        outgoing.resolveHumanChoice(choice, scan.humans);
-      }
-
-      final queuedAttachments = List<_PendingAttachment>.of(attachments.value);
-      final channelActions = ref.read(channelActionsProvider);
-
-      // An add that was refused doesn't block the message: it is reported and
-      // the un-added mentions are demoted to reference tags so the send lands.
-      Future<void> addMentionedNonMembers() => outgoing.addNonMembers(
-        channelActions,
-        scan: scan,
-        messenger: messenger,
-      );
-
+      final attempt = Object();
+      authorizationAttempt.value = attempt;
       isSending.value = true;
       try {
+        final submittedDraftRevision = draftRevision.value;
+        var authorizationRevision = submittedDraftRevision;
+        final visit = authorizationVisit.value;
+        final config = ref.read(relayConfigProvider);
+        final readAuthorization = ref.read(agentAuthorizationReaderProvider);
+        bool isAuthorizationCurrent() =>
+            context.mounted &&
+            visit == authorizationVisit.value &&
+            authorizationRevision == draftRevision.value &&
+            identical(config, ref.read(relayConfigProvider));
+        // Resolved before any await: see
+        // `_reportSendCancelledByCommunitySwitch`.
+        final messenger = ScaffoldMessenger.maybeOf(context);
+
+        // Extract pubkeys for mentions present in the final text.
+        final selectedMentions = <MentionCandidate>[
+          for (final entry in mentionMap.value.entries)
+            if (hasMention(text, entry.key)) entry.value,
+        ];
+        final outgoing = _OutgoingMentions(selectedMentions);
+        final intendedAgentKeys = {
+          for (final mention in selectedMentions)
+            if (mention.isAgent) mention.pubkey.toLowerCase(),
+        };
+        final scan = await _scanNonMemberMentions(
+          ref,
+          channelId: channelId,
+          selectedMentions: selectedMentions,
+          currentPubkey: currentPubkey,
+        );
+
+        if (intendedAgentKeys.isNotEmpty && !isAuthorizationCurrent()) return;
+        // Mentioning humans outside the channel prompts "Invite" / "Do
+        // nothing" (send without inviting) — mirrors desktop's
+        // NonMemberMentionDialog. Agents keep the existing silent auto-add.
+        if (scan.humans.isNotEmpty) {
+          if (!context.mounted) return;
+          final choice = await _promptNonMemberMention(
+            context,
+            names: [for (final candidate in scan.humans) candidate.label],
+            canInvite: scan.canAddMembers,
+          );
+          if (choice == null) {
+            return; // Dismissed — keep the draft, send nothing.
+          }
+          outgoing.resolveHumanChoice(choice, scan.humans);
+        }
+
+        final queuedAttachments = List<_PendingAttachment>.of(
+          attachments.value,
+        );
+        final channelActions = ref.read(channelActionsProvider);
+
+        // Agent failures stop publication; the original draft keeps its keys.
+        Future<void> addMentionedNonMembers() async {
+          final keys = intendedAgentKeys.intersection(outgoing.pubkeys.toSet());
+          await authorizeAgentMentions(
+            readAuthorization,
+            keys,
+            currentPubkey,
+            channelId,
+            isAuthorizationCurrent,
+            prepare: true,
+          );
+          await outgoing.addNonMembers(
+            channelActions,
+            scan: scan,
+            messenger: messenger,
+          );
+          if (!outgoing.pubkeys.toSet().containsAll(keys)) {
+            throw Exception(
+              'Mention invitation failed. Draft kept; retry or remove the mention.',
+            );
+          }
+          await authorizeAgentMentions(
+            readAuthorization,
+            keys,
+            currentPubkey,
+            channelId,
+            isAuthorizationCurrent,
+          );
+        }
+
         if (queuedAttachments.isEmpty) {
           if (!context.mounted) return;
           await _sendTextOnlyDraft(
@@ -532,13 +583,17 @@ class ComposeBar extends HookConsumerWidget {
           return;
         }
 
+        if (intendedAgentKeys.isNotEmpty && !isAuthorizationCurrent()) return;
         final draftText = controller.value;
         final draftAttachments = List<_PendingAttachment>.of(attachments.value);
         final draftMentions = Map<String, MentionCandidate>.of(
           mentionMap.value,
         );
-        clearComposer();
+        // Agent authorization is preparation, not a detached background send.
+        final preparingAgents = intendedAgentKeys.isNotEmpty;
+        if (!preparingAgents) clearComposer();
         final clearedDraftRevision = draftRevision.value;
+        authorizationRevision = clearedDraftRevision;
         uploadingCount.value += 1;
         uploadProgress.value = 0;
         isSending.value = false;
@@ -578,6 +633,11 @@ class ComposeBar extends HookConsumerWidget {
             if (queueGeneration != uploadGeneration.value) return;
             await addMentionedNonMembers();
             if (queueGeneration != uploadGeneration.value) return;
+            if (preparingAgents) {
+              if (!isAuthorizationCurrent()) return;
+              clearComposer();
+              authorizationRevision = draftRevision.value;
+            }
             await delivery(
               payload.content,
               outgoing.pubkeys,
@@ -585,10 +645,12 @@ class ComposeBar extends HookConsumerWidget {
             );
           } catch (error) {
             if (cancellation.isCancelled) return;
-            if (context.mounted) uploadError.value = _formatUploadError(error);
+            if (context.mounted) {
+              uploadError.value = _formatUploadError(error);
+            }
             if (context.mounted &&
                 queueGeneration == uploadGeneration.value &&
-                draftRevision.value == clearedDraftRevision) {
+                draftRevision.value == authorizationRevision) {
               controller.value = draftText;
               attachments.value = draftAttachments;
               retainedForRetry = true;
@@ -598,7 +660,13 @@ class ComposeBar extends HookConsumerWidget {
               focusNode.requestFocus();
             }
           } finally {
-            if (!retainedForRetry) {
+            final sourceRetainsFiles =
+                preparingAgents &&
+                context.mounted &&
+                attachments.value.any(
+                  (item) => queuedAttachments.contains(item),
+                );
+            if (!retainedForRetry && !sourceRetainsFiles) {
               await _deleteOwnedAttachments(queuedAttachments);
             }
             if (activeUploadCancellation.value == cancellation) {
@@ -609,8 +677,17 @@ class ComposeBar extends HookConsumerWidget {
             }
           }
         }());
+      } catch (error) {
+        if (context.mounted) {
+          ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+            SnackBar(content: Text(_composeSendErrorMessage(error))),
+          );
+        }
       } finally {
-        if (context.mounted && isSending.value) isSending.value = false;
+        if (context.mounted && authorizationAttempt.value == attempt) {
+          authorizationAttempt.value = null;
+          isSending.value = false;
+        }
       }
     }
 

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -489,11 +489,11 @@ class ComposeBar extends HookConsumerWidget {
             identical(config, ref.read(relayConfigProvider));
         void ensureAuthorizationCurrent() {
           if (!context.mounted) throw const _ComposeAuthorizationCancelled();
-          if (visit != authorizationVisit.value ||
-              !identical(config, ref.read(relayConfigProvider))) {
+          if (!identical(config, ref.read(relayConfigProvider))) {
             throw StateError('Community changed during authorization');
           }
-          if (authorizationRevision != draftRevision.value) {
+          if (visit != authorizationVisit.value ||
+              authorizationRevision != draftRevision.value) {
             throw const _ComposeAuthorizationCancelled();
           }
         }

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -487,6 +487,37 @@ class ComposeBar extends HookConsumerWidget {
             visit == authorizationVisit.value &&
             authorizationRevision == draftRevision.value &&
             identical(config, ref.read(relayConfigProvider));
+        void ensureAuthorizationCurrent() {
+          if (!context.mounted) throw const _ComposeAuthorizationCancelled();
+          if (visit != authorizationVisit.value ||
+              !identical(config, ref.read(relayConfigProvider))) {
+            throw StateError('Community changed during authorization');
+          }
+          if (authorizationRevision != draftRevision.value) {
+            throw const _ComposeAuthorizationCancelled();
+          }
+        }
+
+        Future<void> authorize(Set<String> keys, {bool prepare = false}) async {
+          if (keys.isEmpty) return;
+          ensureAuthorizationCurrent();
+          try {
+            await authorizeAgentMentions(
+              readAuthorization,
+              keys,
+              currentPubkey,
+              channelId,
+              isAuthorizationCurrent,
+              prepare: prepare,
+            );
+          } catch (_) {
+            // A stale request is cancellation, not an access decision.
+            ensureAuthorizationCurrent();
+            rethrow;
+          }
+          ensureAuthorizationCurrent();
+        }
+
         // Resolved before any await: see
         // `_reportSendCancelledByCommunitySwitch`.
         final messenger = ScaffoldMessenger.maybeOf(context);
@@ -533,14 +564,7 @@ class ComposeBar extends HookConsumerWidget {
         // Agent failures stop publication; the original draft keeps its keys.
         Future<void> addMentionedNonMembers() async {
           final keys = intendedAgentKeys.intersection(outgoing.pubkeys.toSet());
-          await authorizeAgentMentions(
-            readAuthorization,
-            keys,
-            currentPubkey,
-            channelId,
-            isAuthorizationCurrent,
-            prepare: true,
-          );
+          await authorize(keys, prepare: true);
           await outgoing.addNonMembers(
             channelActions,
             scan: scan,
@@ -551,13 +575,7 @@ class ComposeBar extends HookConsumerWidget {
               'Mention invitation failed. Draft kept; retry or remove the mention.',
             );
           }
-          await authorizeAgentMentions(
-            readAuthorization,
-            keys,
-            currentPubkey,
-            channelId,
-            isAuthorizationCurrent,
-          );
+          await authorize(keys);
         }
 
         if (queuedAttachments.isEmpty) {
@@ -643,9 +661,13 @@ class ComposeBar extends HookConsumerWidget {
               outgoing.pubkeys,
               mediaTags: [...payload.mediaTags, ...outgoing.referenceTags],
             );
+          } on _ComposeAuthorizationCancelled {
+            // Keep the newer draft without displaying a false access error.
           } catch (error) {
             if (cancellation.isCancelled) return;
-            if (context.mounted) {
+            if (error is StateError) {
+              _reportSendCancelledByCommunitySwitch(messenger);
+            } else if (context.mounted) {
               uploadError.value = _formatUploadError(error);
             }
             if (context.mounted &&

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -476,6 +476,7 @@ class ComposeBar extends HookConsumerWidget {
       final attempt = Object();
       authorizationAttempt.value = attempt;
       isSending.value = true;
+      void Function()? checkPreparationCurrent;
       try {
         final submittedDraftRevision = draftRevision.value;
         var authorizationRevision = submittedDraftRevision;
@@ -497,6 +498,8 @@ class ComposeBar extends HookConsumerWidget {
             throw const _ComposeAuthorizationCancelled();
           }
         }
+
+        checkPreparationCurrent = ensureAuthorizationCurrent;
 
         Future<void> authorize(Set<String> keys, {bool prepare = false}) async {
           if (keys.isEmpty) return;
@@ -539,7 +542,7 @@ class ComposeBar extends HookConsumerWidget {
           currentPubkey: currentPubkey,
         );
 
-        if (intendedAgentKeys.isNotEmpty && !isAuthorizationCurrent()) return;
+        if (intendedAgentKeys.isNotEmpty) ensureAuthorizationCurrent();
         // Mentioning humans outside the channel prompts "Invite" / "Do
         // nothing" (send without inviting) — mirrors desktop's
         // NonMemberMentionDialog. Agents keep the existing silent auto-add.
@@ -550,6 +553,7 @@ class ComposeBar extends HookConsumerWidget {
             names: [for (final candidate in scan.humans) candidate.label],
             canInvite: scan.canAddMembers,
           );
+          if (intendedAgentKeys.isNotEmpty) ensureAuthorizationCurrent();
           if (choice == null) {
             return; // Dismissed — keep the draft, send nothing.
           }
@@ -601,7 +605,7 @@ class ComposeBar extends HookConsumerWidget {
           return;
         }
 
-        if (intendedAgentKeys.isNotEmpty && !isAuthorizationCurrent()) return;
+        if (intendedAgentKeys.isNotEmpty) ensureAuthorizationCurrent();
         final draftText = controller.value;
         final draftAttachments = List<_PendingAttachment>.of(attachments.value);
         final draftMentions = Map<String, MentionCandidate>.of(
@@ -652,7 +656,7 @@ class ComposeBar extends HookConsumerWidget {
             await addMentionedNonMembers();
             if (queueGeneration != uploadGeneration.value) return;
             if (preparingAgents) {
-              if (!isAuthorizationCurrent()) return;
+              ensureAuthorizationCurrent();
               clearComposer();
               authorizationRevision = draftRevision.value;
             }
@@ -700,10 +704,25 @@ class ComposeBar extends HookConsumerWidget {
           }
         }());
       } catch (error) {
+        var communityChanged = false;
+        // Failed awaits need the same scope/edit classification as success.
+        try {
+          checkPreparationCurrent?.call();
+          if (error is _ComposeAuthorizationCancelled) return;
+        } on _ComposeAuthorizationCancelled {
+          return;
+        } on StateError {
+          communityChanged = true;
+        }
         if (context.mounted) {
-          ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-            SnackBar(content: Text(_composeSendErrorMessage(error))),
-          );
+          final messenger = ScaffoldMessenger.maybeOf(context);
+          if (communityChanged) {
+            _reportSendCancelledByCommunitySwitch(messenger);
+          } else {
+            messenger?.showSnackBar(
+              SnackBar(content: Text(_composeSendErrorMessage(error))),
+            );
+          }
         }
       } finally {
         if (context.mounted && authorizationAttempt.value == attempt) {

--- a/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
+++ b/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
@@ -1,5 +1,9 @@
 part of '../compose_bar.dart';
 
+class _ComposeAuthorizationCancelled implements Exception {
+  const _ComposeAuthorizationCancelled();
+}
+
 Future<void> _sendTextOnlyDraft({
   required BuildContext context,
   required _MarkdownEditingController controller,
@@ -49,6 +53,8 @@ Future<void> _sendTextOnlyDraft({
       outgoing.pubkeys,
       mediaTags: [...payload.mediaTags, ...outgoing.referenceTags],
     );
+  } on _ComposeAuthorizationCancelled {
+    restoreClearedDraft();
   } on StateError {
     restoreClearedDraft();
     _reportSendCancelledByCommunitySwitch(messenger);

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -10,6 +10,7 @@ import '../../shared/relay/relay.dart';
 
 part 'agent_policy.dart';
 part 'agent_authorization.dart';
+part 'agent_publication.dart';
 
 /// A relay agent parsed from its kind:10100 agent-profile event.
 ///

--- a/mobile/lib/shared/mentions/agent_publication.dart
+++ b/mobile/lib/shared/mentions/agent_publication.dart
@@ -1,0 +1,64 @@
+part of 'agent_identity_provider.dart';
+
+/// Fresh reader used by the composer; suggestions never authorize publication.
+typedef AgentAuthorizationReader =
+    Future<List<AgentDirectoryEntry>> Function(
+      Set<String> keys,
+      String? viewer,
+      String channelId,
+      bool Function() isCurrent,
+    );
+
+final agentAuthorizationReaderProvider = Provider<AgentAuthorizationReader>((
+  ref,
+) {
+  final session = ref.watch(relaySessionProvider.notifier);
+  return (keys, viewer, channelId, isCurrent) => readAgentAuthorization(
+    session,
+    keys,
+    viewer: viewer,
+    channelId: channelId,
+    isCurrent: isCurrent,
+  );
+});
+
+/// Verify every intended recipient; never silently shrink the notification set.
+Future<void> authorizeAgentMentions(
+  AgentAuthorizationReader read,
+  Set<String> keys,
+  String? viewer,
+  String channelId,
+  bool Function() isCurrent, {
+  bool prepare = false,
+}) async {
+  if (keys.isEmpty) return;
+  const message =
+      'Could not authorize a mentioned agent. Check its access and channel membership, then retry or remove the mention.';
+  try {
+    if (!isCurrent()) throw Exception(message);
+    final agents = await read(keys, viewer, channelId, isCurrent);
+    if (!isCurrent()) throw Exception(message);
+    for (final key in keys) {
+      final agent = agents.where((a) => a.pubkey == key).firstOrNull;
+      final owned = agent?.ownerPubkey != null && agent?.ownerPubkey == viewer;
+      final allowed =
+          agent != null &&
+          ((owned &&
+                  const [
+                    'owner-only',
+                    'allowlist',
+                    'anyone',
+                  ].contains(agent.respondTo)) ||
+              (agent.respondTo == 'allowlist' &&
+                  agent.respondToAllowlist.contains(viewer)) ||
+              (agent.respondTo == 'anyone' &&
+                  agent.channelIds.contains(channelId)));
+      if (!allowed ||
+          (!(prepare && owned) && !agent.channelIds.contains(channelId))) {
+        throw Exception(message);
+      }
+    }
+  } catch (_) {
+    throw Exception(message);
+  }
+}

--- a/mobile/lib/shared/mentions/agent_publication.dart
+++ b/mobile/lib/shared/mentions/agent_publication.dart
@@ -9,6 +9,11 @@ typedef AgentAuthorizationReader =
       bool Function() isCurrent,
     );
 
+/// Session-bound fresh authorization reader for exact recipient keys and one
+/// destination. Re-reads verified ownership, policy and relay-signed membership;
+/// cached directory suggestions are never publication authority. Query and
+/// scope-change failures propagate to the caller, which must check currentness
+/// before applying membership or publishing. This is not an atomic relay write.
 final agentAuthorizationReaderProvider = Provider<AgentAuthorizationReader>((
   ref,
 ) {

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -30,6 +30,8 @@ import 'package:buzz/shared/widgets/anchored_popover_menu.dart';
 import 'package:buzz/shared/widgets/mobile_tab_footer_backdrop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+part 'compose_bar_test/publication_tests.dart';
+
 final _pngBytes = Uint8List.fromList([
   0x89,
   0x50,
@@ -174,6 +176,7 @@ Widget _buildComposeBar({
   required ComposeBarOnSend onSend,
   List<ChannelMember> members = const <ChannelMember>[],
   Future<List<ChannelMember>>? membersFuture,
+  AgentAuthorizationReader? authorizationReader,
   List<AgentDirectoryEntry> relayAgents = const <AgentDirectoryEntry>[],
   List<Channel> channels = const <Channel>[],
   List<ChannelMember> cachedMembers = const <ChannelMember>[],
@@ -210,6 +213,18 @@ Widget _buildComposeBar({
       channelMembersProvider(
         'channel-1',
       ).overrideWith((ref) => membersFuture ?? Future.value(members)),
+      agentAuthorizationReaderProvider.overrideWithValue(
+        authorizationReader ??
+            (keys, viewer, channel, current) async => [
+              for (final key in keys)
+                AgentDirectoryEntry(
+                  pubkey: key,
+                  respondTo: 'anyone',
+                  ownerPubkey: viewer,
+                  channelIds: [channel],
+                ),
+            ],
+      ),
       agentDirectoryProvider.overrideWith((ref) async => relayAgents),
       agentOwnersProvider.overrideWith((ref) async => const <String, String>{}),
       relayClientProvider.overrideWithValue(
@@ -641,6 +656,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
 }
 
 void main() {
+  _publicationTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() async {
@@ -4235,7 +4251,7 @@ void main() {
       addMemberAcknowledgement.complete();
       await tester.pumpAndSettle();
 
-      expect(sentContent, 'hello @Helper Bot');
+      expect(sentContent, isNull);
       expect(
         tester.widget<TextField>(find.byType(TextField)).controller!.text,
         'newer draft',

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -176,6 +176,7 @@ Widget _buildComposeBar({
   required ComposeBarOnSend onSend,
   List<ChannelMember> members = const <ChannelMember>[],
   Future<List<ChannelMember>>? membersFuture,
+  Future<List<ChannelMember>> Function()? membersLoader,
   AgentAuthorizationReader? authorizationReader,
   List<AgentDirectoryEntry> relayAgents = const <AgentDirectoryEntry>[],
   List<Channel> channels = const <Channel>[],
@@ -210,9 +211,10 @@ Widget _buildComposeBar({
         ),
       photoLibraryProvider.overrideWithValue(photoLibrary),
       currentPubkeyProvider.overrideWith((ref) => currentPubkey),
-      channelMembersProvider(
-        'channel-1',
-      ).overrideWith((ref) => membersFuture ?? Future.value(members)),
+      channelMembersProvider('channel-1').overrideWith(
+        (ref) =>
+            membersLoader?.call() ?? membersFuture ?? Future.value(members),
+      ),
       agentAuthorizationReaderProvider.overrideWithValue(
         authorizationReader ??
             (keys, viewer, channel, current) async => [

--- a/mobile/test/features/channels/compose_bar_test/publication_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/publication_tests.dart
@@ -1,0 +1,217 @@
+part of '../compose_bar_test.dart';
+
+void _publicationTests() {
+  for (final mode in [
+    'deny',
+    'missing',
+    'error',
+    'revoke',
+    'removed',
+    'allow',
+  ]) {
+    testWidgets('publication authorization $mode retains exact intent', (
+      tester,
+    ) async {
+      final key = 'd' * 64;
+      final signer = nostr.Keys.generate();
+      var reads = 0;
+      var sent = 0;
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(signer.nsec),
+          currentPubkey: signer.public,
+          relayAgents: [_testAgent(key)],
+          channels: [
+            _makeCurrentChannel(channelType: 'dm'),
+            _makeSharedMemberChannel(),
+          ],
+          authorizationReader: (keys, viewer, destination, current) async {
+            expect(keys, {key});
+            expect(destination, 'channel-1');
+            expect(current(), isTrue);
+            reads++;
+            if (mode == 'error') throw StateError('unavailable');
+            if (mode == 'missing') return [];
+            return [
+              AgentDirectoryEntry(
+                pubkey: key,
+                ownerPubkey: viewer,
+                respondTo: mode == 'deny' || (mode == 'revoke' && reads == 2)
+                    ? 'nobody'
+                    : 'anyone',
+                channelIds: mode == 'removed' && reads == 2
+                    ? []
+                    : ['channel-1'],
+              ),
+            ];
+          },
+          onSend: (_, keys, {mediaTags = const []}) async {
+            expect(keys, [key]);
+            sent++;
+          },
+        ),
+      );
+      await _selectAndSendAgentMention(tester);
+      expect(sent, mode == 'allow' ? 1 : 0);
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        mode == 'allow' ? '' : 'hello @Helper Bot',
+      );
+      if (mode != 'allow') {
+        expect(
+          find.textContaining('Could not authorize a mentioned agent'),
+          findsOneWidget,
+        );
+      }
+      expect(
+        reads,
+        const ['allow', 'revoke', 'removed'].contains(mode) ? 2 : 1,
+      );
+    });
+  }
+
+  testWidgets(
+    'editing while authorization waits cancels publication without overwriting new draft',
+    (tester) async {
+      final key = 'd' * 64;
+      final signer = nostr.Keys.generate();
+      final pending = Completer<List<AgentDirectoryEntry>>();
+      var reads = 0;
+      var sent = 0;
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(signer.nsec),
+          currentPubkey: signer.public,
+          relayAgents: [_testAgent(key)],
+          channels: [
+            _makeCurrentChannel(channelType: 'dm'),
+            _makeSharedMemberChannel(),
+          ],
+          authorizationReader: (_, _, _, _) {
+            reads++;
+            return pending.future;
+          },
+          onSend: (_, _, {mediaTags = const []}) async {
+            sent++;
+          },
+        ),
+      );
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), '@hel');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Helper Bot'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pump();
+      expect(reads, 1);
+      await tester.enterText(find.byType(TextField), 'new intent');
+      pending.complete([
+        AgentDirectoryEntry(
+          pubkey: key,
+          respondTo: 'anyone',
+          channelIds: ['channel-1'],
+        ),
+      ]);
+      await tester.pumpAndSettle();
+      expect(sent, 0);
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'new intent',
+      );
+    },
+  );
+  testWidgets('revocation after upload retains agent draft and attachment', (
+    tester,
+  ) async {
+    final signer = nostr.Keys.generate();
+    final key = 'd' * 64;
+    final response = Completer<http.Response>();
+    var uploaded = false;
+    var reads = 0;
+    var sent = 0;
+    final service = MediaUploadService(
+      baseUrl: 'https://relay.example',
+      nsec: signer.nsec,
+      httpClient: http_testing.MockClient((_) {
+        uploaded = true;
+        return response.future;
+      }),
+      pickGalleryVideo: () async => null,
+      pickGalleryImage: () async => null,
+      pickGalleryImages: () async => [
+        XFile.fromData(_pngBytes, name: 'tiny.png'),
+      ],
+    );
+    await tester.pumpWidget(
+      _buildComposeBar(
+        uploadService: service,
+        currentPubkey: signer.public,
+        relayAgents: [_testAgent(key)],
+        channels: [
+          _makeCurrentChannel(channelType: 'dm'),
+          _makeSharedMemberChannel(),
+        ],
+        authorizationReader: (_, viewer, _, _) async {
+          reads++;
+          return [
+            AgentDirectoryEntry(
+              pubkey: key,
+              ownerPubkey: viewer,
+              respondTo: reads == 1 ? 'anyone' : 'nobody',
+              channelIds: ['channel-1'],
+            ),
+          ];
+        },
+        onSend: (_, _, {mediaTags = const []}) async {
+          sent++;
+        },
+      ),
+    );
+    await _openSystemPhotoPicker(tester);
+    await tester.pumpAndSettle();
+    await _expandComposer(tester);
+    await tester.enterText(find.byType(TextField), '@hel');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Helper Bot'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
+    await tester.tap(find.byIcon(LucideIcons.arrowUp));
+    await tester.runAsync(() async {
+      for (var i = 0; i < 100 && !uploaded; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    expect(uploaded, isTrue);
+    response.complete(
+      http.Response(
+        jsonEncode({
+          'url': 'https://relay.example/media/test.png',
+          'sha256': '0' * 64,
+          'size': 16,
+          'type': 'image/png',
+          'uploaded': 1,
+        }),
+        200,
+      ),
+    );
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pumpAndSettle();
+    expect(reads, 2);
+    expect(sent, 0);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      'hello @Helper Bot',
+    );
+    expect(
+      find.byKey(const ValueKey('composer-agent-mention-chip')),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Could not authorize a mentioned agent'),
+      findsOneWidget,
+    );
+  });
+}

--- a/mobile/test/features/channels/compose_bar_test/publication_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/publication_tests.dart
@@ -70,13 +70,18 @@ void _publicationTests() {
     });
   }
 
-  for (final switchCommunity in [false, true]) {
+  for (final (boundary, switchCommunity) in [
+    for (final boundary in ['reader', 'scan', 'scan error', 'prompt'])
+      for (final change in [false, true]) (boundary, change),
+  ]) {
     testWidgets(
-      'authorization cancellation reports scope change only: $switchCommunity',
+      'authorization cancellation $boundary reports scope change only: $switchCommunity',
       (tester) async {
         final key = 'd' * 64;
         final signer = nostr.Keys.generate();
         final pending = Completer<List<AgentDirectoryEntry>>();
+        final members = Completer<List<ChannelMember>>();
+        var scanPending = false;
         var reads = 0;
         var sent = 0;
         await tester.pumpWidget(
@@ -86,9 +91,27 @@ void _publicationTests() {
             relayConfig: () => _SwitchableRelayConfigNotifier(
               RelayConfig(baseUrl: 'https://relay.example', nsec: signer.nsec),
             ),
+            membersLoader: () => boundary == 'prompt'
+                ? Future.value(
+                    scanPending
+                        ? []
+                        : [
+                            ChannelMember(
+                              pubkey: 'a' * 64,
+                              displayName: 'Alice',
+                              role: 'member',
+                              joinedAt: DateTime(2025),
+                            ),
+                          ],
+                  )
+                : scanPending
+                ? members.future
+                : Future.value([]),
             relayAgents: [_testAgent(key)],
             channels: [
-              _makeCurrentChannel(channelType: 'dm'),
+              _makeCurrentChannel(
+                channelType: boundary == 'reader' ? 'dm' : 'stream',
+              ),
               _makeSharedMemberChannel(),
             ],
             authorizationReader: (_, _, _, _) {
@@ -105,17 +128,45 @@ void _publicationTests() {
         await tester.pumpAndSettle();
         await tester.tap(find.text('Helper Bot'));
         await tester.pumpAndSettle();
-        await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
+        if (boundary == 'prompt') {
+          await tester.enterText(find.byType(TextField), '@Helper Bot @ali');
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Alice'));
+          await tester.pumpAndSettle();
+        } else {
+          await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
+        }
+        final controller = tester
+            .widget<TextField>(find.byType(TextField))
+            .controller!;
+        if (boundary != 'reader') {
+          scanPending = true;
+          ProviderScope.containerOf(
+            tester.element(find.byType(ComposeBar)),
+          ).invalidate(channelMembersProvider('channel-1'));
+          await tester.pump();
+        }
         await tester.tap(find.byIcon(LucideIcons.arrowUp));
         await tester.pump();
-        expect(reads, 1);
+        expect(reads, boundary == 'reader' ? 1 : 0);
+        if (boundary == 'prompt') {
+          await tester.pump(const Duration(milliseconds: 300));
+        }
         if (switchCommunity) {
           ProviderScope.containerOf(tester.element(find.byType(ComposeBar)))
               .read(relayConfigProvider.notifier)
               .update(baseUrl: 'https://other.example', nsec: signer.nsec);
           await tester.pump();
         } else {
-          await tester.enterText(find.byType(TextField), 'new intent');
+          controller.text = 'new intent';
+        }
+        if (boundary == 'prompt') {
+          await tester.tap(find.text('Invite'));
+        }
+        if (boundary == 'scan error') {
+          members.completeError(StateError('scan unavailable'));
+        } else if (boundary == 'scan') {
+          members.complete([]);
         }
         pending.complete([
           AgentDirectoryEntry(
@@ -131,10 +182,7 @@ void _publicationTests() {
           switchCommunity ? findsOneWidget : findsNothing,
         );
         expect(find.textContaining('Could not authorize'), findsNothing);
-        expect(
-          tester.widget<TextField>(find.byType(TextField)).controller!.text,
-          switchCommunity ? '' : 'new intent',
-        );
+        expect(controller.text, switchCommunity ? '' : 'new intent');
       },
     );
   }

--- a/mobile/test/features/channels/compose_bar_test/publication_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/publication_tests.dart
@@ -70,57 +70,74 @@ void _publicationTests() {
     });
   }
 
-  testWidgets(
-    'editing while authorization waits cancels publication without overwriting new draft',
-    (tester) async {
-      final key = 'd' * 64;
-      final signer = nostr.Keys.generate();
-      final pending = Completer<List<AgentDirectoryEntry>>();
-      var reads = 0;
-      var sent = 0;
-      await tester.pumpWidget(
-        _buildComposeBar(
-          uploadService: _testUploadService(signer.nsec),
-          currentPubkey: signer.public,
-          relayAgents: [_testAgent(key)],
-          channels: [
-            _makeCurrentChannel(channelType: 'dm'),
-            _makeSharedMemberChannel(),
-          ],
-          authorizationReader: (_, _, _, _) {
-            reads++;
-            return pending.future;
-          },
-          onSend: (_, _, {mediaTags = const []}) async {
-            sent++;
-          },
-        ),
-      );
-      await _expandComposer(tester);
-      await tester.enterText(find.byType(TextField), '@hel');
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Helper Bot'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
-      await tester.tap(find.byIcon(LucideIcons.arrowUp));
-      await tester.pump();
-      expect(reads, 1);
-      await tester.enterText(find.byType(TextField), 'new intent');
-      pending.complete([
-        AgentDirectoryEntry(
-          pubkey: key,
-          respondTo: 'anyone',
-          channelIds: ['channel-1'],
-        ),
-      ]);
-      await tester.pumpAndSettle();
-      expect(sent, 0);
-      expect(
-        tester.widget<TextField>(find.byType(TextField)).controller!.text,
-        'new intent',
-      );
-    },
-  );
+  for (final switchCommunity in [false, true]) {
+    testWidgets(
+      'authorization cancellation reports scope change only: $switchCommunity',
+      (tester) async {
+        final key = 'd' * 64;
+        final signer = nostr.Keys.generate();
+        final pending = Completer<List<AgentDirectoryEntry>>();
+        var reads = 0;
+        var sent = 0;
+        await tester.pumpWidget(
+          _buildComposeBar(
+            uploadService: _testUploadService(signer.nsec),
+            currentPubkey: signer.public,
+            relayConfig: () => _SwitchableRelayConfigNotifier(
+              RelayConfig(baseUrl: 'https://relay.example', nsec: signer.nsec),
+            ),
+            relayAgents: [_testAgent(key)],
+            channels: [
+              _makeCurrentChannel(channelType: 'dm'),
+              _makeSharedMemberChannel(),
+            ],
+            authorizationReader: (_, _, _, _) {
+              reads++;
+              return pending.future;
+            },
+            onSend: (_, _, {mediaTags = const []}) async {
+              sent++;
+            },
+          ),
+        );
+        await _expandComposer(tester);
+        await tester.enterText(find.byType(TextField), '@hel');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Helper Bot'));
+        await tester.pumpAndSettle();
+        await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
+        await tester.tap(find.byIcon(LucideIcons.arrowUp));
+        await tester.pump();
+        expect(reads, 1);
+        if (switchCommunity) {
+          ProviderScope.containerOf(tester.element(find.byType(ComposeBar)))
+              .read(relayConfigProvider.notifier)
+              .update(baseUrl: 'https://other.example', nsec: signer.nsec);
+          await tester.pump();
+        } else {
+          await tester.enterText(find.byType(TextField), 'new intent');
+        }
+        pending.complete([
+          AgentDirectoryEntry(
+            pubkey: key,
+            respondTo: 'anyone',
+            channelIds: ['channel-1'],
+          ),
+        ]);
+        await tester.pumpAndSettle();
+        expect(sent, 0);
+        expect(
+          find.text('Message not sent: the community changed'),
+          switchCommunity ? findsOneWidget : findsNothing,
+        );
+        expect(find.textContaining('Could not authorize'), findsNothing);
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller!.text,
+          switchCommunity ? '' : 'new intent',
+        );
+      },
+    );
+  }
   testWidgets('revocation after upload retains agent draft and attachment', (
     tester,
   ) async {


### PR DESCRIPTION
<!-- Draft PR body for #7394 · fix(mobile): revalidate exact agent intent before publication · https://github.com/block/buzz/pull/7394 -->

🤖

## Summary

Mentions of agents were authorized once, at suggestion time — so a permission revoked between selection and send, a member removed mid-compose, or a policy change during a long media upload still published the message, silently shrinking or misdirecting its audience. This PR revalidates every selected agent recipient against fresh owner policy and relay membership right before the message is prepared and again immediately before it is delivered, including on the media path. Any denial, missing evidence, failed read or revocation sends nothing and keeps your draft — recipients still selected — instead of publishing a partial audience.

- Suggestions are never publication authority; only the fresh authorization read is.
- Sends are fenced by account/community, channel/thread visit, edits and overlapping attempts: a send that loses its original intent (you edited, navigated, or a newer attempt started) doesn't publish.
- Drafts containing agents or pending media stay recoverable while authorization is pending; existing background upload behavior for member-only sends is unchanged.
- Client-side revalidation is not an atomic authorization protocol — the relay remains authoritative.

Desktop reference: `agentMentionRevalidation.ts`, `ui/useMentionSendFlow.ts`.

### Related issue

- Fixes: N/A. No separate issue; the related work is the stack below.
- Depends on #7393 (declared base). Closest related: #7390 (independent explicit-invitation branch; neither PR subsumes the other).
- Rollout: widened agent discovery (#7395) must not be enabled until this PR and #7390 are integrated — a rollout condition, not a code dependency.
- Landing note: branches in this series overlap in the composer — when rebasing, keep exact/durable mention bindings, the explicit invite/reference-only choice, the account/visit/revision fences, and authorization before membership preparation and publication; don't resolve conflicts by taking either side wholesale.
- Draft — not requesting merge yet; the security advisory doesn't run on this stacked base (it reviews main-based ranges).

### Testing

- Production-composer regressions cover denial, missing evidence, errors, revocation, membership removal, and draft/media retention. Pending authorization, earlier member scans (success/error), and mixed human-agent invitation prompts explicitly test silent edit cancellation versus the community-switch explanation; genuine authorization failures remain visible.
- Final head `2fd0d0bcc45d987b62668985f0eae0134ccde2e2` (rebased onto #7393 `df61d54cb2e4f534a19ce8782a7fd6ccd165b467`): full `flutter test` **2,110 passed**, `flutter analyze` clean. Includes the authority lane's provider documentation and distinguishes stale visits from actual community changes. Earlier full `just ci` receipt is historical, not a run on this updated head.
- No native-device/simulator journey or new captures. Existing screenshots below retain their original exact-head provenance; they are not new-head acceptance evidence.
- #7387 persisted classification/restart integration remains separate and is not claimed fixed by these cancellation changes. #7527 addresses irreversible invitation feedback on the independent #7390 branch.

### Screenshots

Flutter production-widget test renders — not native-device screenshots or acceptance captures.

| Scenario | Before | After |
|---|---|---|
| Sending a DM after the mentioned agent's policy was revoked mid-compose | ![Before: the send goes through with the silently reduced audience and the composer clears](https://github.com/user-attachments/assets/250f6e41-5747-4cc2-a943-d45ad4e34899) | ![After: a visible authorization error blocks the send and the draft text is retained](https://github.com/user-attachments/assets/28b3ebbf-9195-402f-8ffb-069bc54c8fcf) |

<details>
<summary>Capture provenance</summary>

Rendered by the Flutter widget engine in a `flutter test` run (production widgets, production theme; no device or simulator). Before: this PR's declared base `882f69cbaf0f851717f071fba366b3b3a4a877d8`. After: its head `95b2465b6eeb26547c90296d012fafef56af1508`.

</details>
