### PR TITLE
perf(mobile): parallelize independent channel startup reads

### DIFF
--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -232,41 +232,35 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     }
     final dedupedMetas = latestMetaPerId.values.toList();
 
-    // Resolve DM participant display names. Extracted into the part file so
-    // `channels_provider.dart` stays under the 1200-line ceiling enforced by
-    // `just file-size-check`.
-    final displayNames = await _resolveDmDisplayNames(
-      session,
-      fence,
-      dedupedMetas,
-      myPk,
-    );
-
-    final hiddenDmIds = await _fenced(fence, _fetchHiddenDmIds(session, myPk));
-    _hiddenDmIds = Set.unmodifiable(hiddenDmIds);
-    // Fetch the authoritative membership snapshots before filtering Huddle
-    // backing channels. The relay-signed kind:39000 metadata identifies the
-    // relay, not the channel creator; the owner role in kind:39002 is the
-    // canonical creator identity used to reject forged Huddle links.
+    // These four reads depend on the metadata and member ids above, not on
+    // each other. Join them before publishing any derived state; the fence
+    // rejects a retired refresh on both the success and error paths.
     final memberCountChannelIds = memberChannelIds.toList();
-    final memberEvents = memberCountChannelIds.isEmpty
-        ? const <NostrEvent>[]
-        : await _fenced(
-            fence,
-            session.fetchHistory(
-              NostrFilter(
-                kinds: const [39002],
-                tags: {'#d': memberCountChannelIds},
-                limit: memberCountChannelIds.length,
+    final (
+      displayNames,
+      hiddenDmIds,
+      memberEvents,
+      huddleStarts,
+    ) = await _fenced(
+      fence,
+      (
+        _resolveDmDisplayNames(session, fence, dedupedMetas, myPk),
+        _fetchHiddenDmIds(session, myPk),
+        memberCountChannelIds.isEmpty
+            ? Future.value(const <NostrEvent>[])
+            : session.fetchHistory(
+                NostrFilter(
+                  kinds: const [39002],
+                  tags: {'#d': memberCountChannelIds},
+                  limit: memberCountChannelIds.length,
+                ),
               ),
-            ),
-          );
-    final huddleStarts = memberCountChannelIds.isEmpty
-        ? const <NostrEvent>[]
-        : await _fenced(
-            fence,
-            _fetchHuddleStarts(session, memberCountChannelIds),
-          );
+        _fetchHuddleStarts(session, memberCountChannelIds),
+      ).wait,
+    );
+    _hiddenDmIds = Set.unmodifiable(hiddenDmIds);
+    // The authoritative member snapshots identify Huddle creators. Relay-
+    // signed channel metadata alone cannot establish ownership.
     final huddleBackingIds = huddleBackingChannelIds(
       huddleStarts,
       memberEvents,

--- a/mobile/test/features/channels/channels_provider_startup_cases.dart
+++ b/mobile/test/features/channels/channels_provider_startup_cases.dart
@@ -1,0 +1,39 @@
+part of 'channels_provider_test.dart';
+
+void _channelStartupCases() {
+  test(
+    'starts independent channel reads together and waits for all of them',
+    () async {
+      final session = _FakeRelaySession(
+        memberships: [_membership(_channelA, 'me')],
+        metadata: [_meta(id: _channelA, name: 'general')],
+      );
+      session.pauseNextHiddenDmQuery();
+      session.pauseNextMemberCountQuery();
+      session.pauseNextHuddleStartQuery();
+      final allStarted = Future.wait([
+        session.nextHiddenDmQueryStarted,
+        session.nextMemberCountQueryStarted,
+        session.nextHuddleStartQueryStarted,
+      ]);
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+      final loaded = container.read(channelsProvider.future);
+
+      try {
+        // None of the responses can complete until all requests have started.
+        // Serial reads cannot pass this assertion, regardless of machine speed.
+        await allStarted.timeout(const Duration(seconds: 2));
+        expect(container.read(channelsProvider).isLoading, isTrue);
+      } finally {
+        session.resumePausedMemberCountQuery();
+        session.resumePausedHuddleStartQuery();
+        session.resumePausedHiddenDmQuery();
+      }
+
+      final channels = await loaded;
+      expect(channels.map((channel) => channel.id), [_channelA]);
+      expect(channels.single.memberCount, 1);
+    },
+  );
+}

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -10,6 +10,7 @@ import 'package:buzz/shared/relay/relay.dart';
 
 part 'channels_provider_live_cases.dart';
 part 'channels_provider_terminal_cases.dart';
+part 'channels_provider_startup_cases.dart';
 
 /// Tests for [ChannelsNotifier] in the pure-Nostr world.
 ///
@@ -24,6 +25,7 @@ part 'channels_provider_terminal_cases.dart';
 /// records [subscribe] calls so we can assert filter shapes and emit live
 /// events on demand.
 void main() {
+  _channelStartupCases();
   const myPk = 'me';
 
   test(


### PR DESCRIPTION
The channel list fetches DM profile names, hidden-DM preferences, membership snapshots, and Huddle starts in sequence after it has the channel metadata. None of those four reads needs the result of another.

Start the four reads together and join them before writing channel state. Keep the refresh fence around the whole join, including its error path, and keep the authoritative member snapshots as the source for Huddle ownership checks. Query count, pagination, live subscriptions, and access filters stay the same. This removes up to three serial response waits from this part of startup; no physical-device timing is claimed.

This complements #7002 (subscription pacing/batching) and #5384 (timeline sync). It does not use a short page as an end-of-pagination signal: relays may cap responses below the requested limit.

Validation:

- A production-provider regression holds independent queries open and requires all of them to start before any response is released. It failed against the serial code and passes with this change.
- All 72 channel-provider tests passed, including stale refreshes, identity/community switches, membership and Huddle checks, and capped pagination.
- All 2,073 mobile tests passed; Flutter analysis passed.
- Full `just ci` also passed on a local checkout combining this PR, #7386, and #7405, including all 2,077 mobile tests and 3,165 desktop Tauri tests (19 ignored).
