### PR TITLE
fix(cortex-mcp): take the private MCP endpoint out of the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ __pycache__/
 .env.local
 .env.*.local
 
+# Compose deployment: every .env variant except the example, plus the secrets
+# mount dir. Real values live in coffer, never in git.
+deploy/compose/.env*
+!deploy/compose/.env.example
+deploy/compose/secrets/
+
 # Editor / IDE
 .idea/
 .vscode/*

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -268,6 +268,13 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_CORTEX_MCP_TOKEN", default_value = "", hide_env_values = true)]
     pub cortex_mcp_token: String,
 
+    /// Base URL of the Cortex remote MCP endpoint, passed to mcp-remote.
+    /// Deployment configuration with no default: the endpoint is private
+    /// infrastructure and never ships in this repository. Empty means no
+    /// Cortex MCP server is added, even when a token is present.
+    #[arg(long, env = "BUZZ_ACP_CORTEX_MCP_URL", default_value = "")]
+    pub cortex_mcp_url: String,
+
     /// Idle timeout: max seconds of silence before killing a turn.
     /// Resets on any agent stdout activity.
     #[arg(long, env = "BUZZ_ACP_IDLE_TIMEOUT")]
@@ -515,6 +522,7 @@ pub struct Config {
     pub agent_args: Vec<String>,
     pub mcp_command: String,
     pub cortex_mcp_token: String,
+    pub cortex_mcp_url: String,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
     pub agents: u32,
@@ -1086,6 +1094,7 @@ impl Config {
             agent_args,
             mcp_command: args.mcp_command,
             cortex_mcp_token: args.cortex_mcp_token,
+            cortex_mcp_url: args.cortex_mcp_url,
             idle_timeout_secs,
             max_turn_duration_secs,
             agents: args.agents,
@@ -1467,6 +1476,7 @@ mod tests {
             agent_args: vec!["acp".into()],
             mcp_command: "".into(),
             cortex_mcp_token: "".into(),
+            cortex_mcp_url: "".into(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -261,6 +261,13 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_MCP_COMMAND", default_value = "")]
     pub mcp_command: String,
 
+    /// Bearer token for the Cortex MCP bridge (mcp-remote -> Cortex's remote
+    /// MCP endpoint). Sourced by Desktop from wicket at spawn time, never
+    /// from a shell-inherited env var. Empty means no Cortex MCP server is
+    /// added to this session's `session/new` mcp_servers list.
+    #[arg(long, env = "BUZZ_ACP_CORTEX_MCP_TOKEN", default_value = "", hide_env_values = true)]
+    pub cortex_mcp_token: String,
+
     /// Idle timeout: max seconds of silence before killing a turn.
     /// Resets on any agent stdout activity.
     #[arg(long, env = "BUZZ_ACP_IDLE_TIMEOUT")]
@@ -507,6 +514,7 @@ pub struct Config {
     pub agent_command: String,
     pub agent_args: Vec<String>,
     pub mcp_command: String,
+    pub cortex_mcp_token: String,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
     pub agents: u32,
@@ -1077,6 +1085,7 @@ impl Config {
             agent_command,
             agent_args,
             mcp_command: args.mcp_command,
+            cortex_mcp_token: args.cortex_mcp_token,
             idle_timeout_secs,
             max_turn_duration_secs,
             agents: args.agents,
@@ -1457,6 +1466,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "".into(),
+            cortex_mcp_token: "".into(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -5058,18 +5058,20 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
     // Cortex MCP bridge, added alongside (not instead of) the dev-mcp server
     // above -- buzz-agent's McpRegistry supports up to MAX_MCP_SERVERS (16),
     // so there's no need to sacrifice dev-mcp's tools to get Cortex tools.
-    // Gated on cortex_mcp_token being set; Desktop sources that token from
-    // wicket at spawn time (see managed_agents/runtime.rs) and sets it as
-    // BUZZ_ACP_CORTEX_MCP_TOKEN, so an empty value here just means Cortex
-    // wasn't wired up for this persona / wicket lookup failed -- not an error.
-    if !config.cortex_mcp_token.is_empty() {
+    // Gated on BOTH the token and the endpoint URL being set. Desktop sources
+    // the token from wicket at spawn time (see managed_agents/runtime.rs); the
+    // URL is deployment configuration supplied through the environment, since
+    // a private MCP endpoint is not something this repository should name.
+    // Either one empty just means Cortex wasn't wired up for this persona --
+    // not an error.
+    if !config.cortex_mcp_token.is_empty() && !config.cortex_mcp_url.is_empty() {
         servers.push(McpServer {
             name: "cortex".to_string(),
             command: "npx".to_string(),
             args: vec![
                 "-y".into(),
                 "mcp-remote@0.1.16".into(),
-                "https://mcp.1507.cloud/cortex/mcp".into(),
+                config.cortex_mcp_url.clone(),
                 "--header".into(),
                 // No space after the colon: documented mcp-remote arg-escaping
                 // workaround for passing a header value containing a space.
@@ -6756,6 +6758,7 @@ mod build_mcp_servers_tests {
             agent_args: vec!["acp".into()],
             mcp_command: "test-mcp-server".into(),
             cortex_mcp_token: "".into(),
+            cortex_mcp_url: "".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -6958,6 +6961,7 @@ mod build_mcp_servers_tests {
     fn cortex_mcp_token_adds_a_cortex_server_alongside_dev_mcp() {
         let mut config = test_config();
         config.cortex_mcp_token = "test-cortex-token".into();
+        config.cortex_mcp_url = "https://mcp.example.invalid/cortex/mcp".into();
         let servers = build_mcp_servers(&config);
 
         // Both the existing dev-mcp server and the new Cortex server should be
@@ -6975,7 +6979,7 @@ mod build_mcp_servers_tests {
             vec![
                 "-y",
                 "mcp-remote@0.1.16",
-                "https://mcp.1507.cloud/cortex/mcp",
+                "https://mcp.example.invalid/cortex/mcp",
                 "--header",
                 "Authorization:Bearer test-cortex-token",
             ]
@@ -6991,9 +6995,25 @@ mod build_mcp_servers_tests {
         let mut config = test_config();
         config.mcp_command = "".into();
         config.cortex_mcp_token = "test-cortex-token".into();
+        config.cortex_mcp_url = "https://mcp.example.invalid/cortex/mcp".into();
         let servers = build_mcp_servers(&config);
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].name, "cortex");
+    }
+
+    // The endpoint URL is deployment configuration, not a source constant. A
+    // token with no URL must add nothing rather than fall back to a baked-in
+    // endpoint -- this is the guard on that.
+    #[test]
+    fn cortex_mcp_token_without_a_url_adds_no_cortex_server() {
+        let mut config = test_config();
+        config.cortex_mcp_token = "test-cortex-token".into();
+        config.cortex_mcp_url = "".into();
+        let servers = build_mcp_servers(&config);
+        assert!(
+            !servers.iter().any(|s| s.name == "cortex"),
+            "a token with no endpoint URL should not add a cortex MCP server"
+        );
     }
 }
 
@@ -7033,6 +7053,7 @@ mod error_outcome_emission_tests {
             agent_args: vec![],
             mcp_command: "test-mcp-server".into(),
             cortex_mcp_token: "".into(),
+            cortex_mcp_url: "".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4999,60 +4999,87 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
 }
 
 fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
-    if config.mcp_command.is_empty() {
-        return vec![];
+    let mut servers = Vec::new();
+
+    if !config.mcp_command.is_empty() {
+        servers.push(McpServer {
+            name: std::path::Path::new(&config.mcp_command)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("mcp")
+                .to_string(),
+            command: config.mcp_command.clone(),
+            args: vec![],
+            env: {
+                let mut env = vec![
+                    EnvVar {
+                        name: "BUZZ_RELAY_URL".into(),
+                        value: config.relay_url.clone(),
+                    },
+                    EnvVar {
+                        name: "BUZZ_PRIVATE_KEY".into(),
+                        // bech32 encoding of a valid secret key is infallible.
+                        // Panic here is correct: injecting a bogus secret would cause
+                        // delayed, hard-to-diagnose agent failures downstream.
+                        value: config
+                            .keys
+                            .secret_key()
+                            .to_bech32()
+                            .expect("secret key bech32 encoding should never fail"),
+                    },
+                ];
+                // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
+                // so the MCP server can attach it to every signed event.
+                if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
+                    if !auth_tag.is_empty() {
+                        env.push(EnvVar {
+                            name: "BUZZ_AUTH_TAG".into(),
+                            value: auth_tag,
+                        });
+                    }
+                }
+                // Forward the agent's display name so dev-mcp can use it as the git
+                // author name instead of the raw npub. Read from the process env
+                // rather than Config: this is a pass-through of a contract owned
+                // upstream, and absent simply means dev-mcp falls back to the npub.
+                if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
+                    if !display_name.is_empty() {
+                        env.push(EnvVar {
+                            name: "BUZZ_ACP_DISPLAY_NAME".into(),
+                            value: display_name,
+                        });
+                    }
+                }
+                env
+            },
+        });
     }
-    vec![McpServer {
-        name: std::path::Path::new(&config.mcp_command)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("mcp")
-            .to_string(),
-        command: config.mcp_command.clone(),
-        args: vec![],
-        env: {
-            let mut env = vec![
-                EnvVar {
-                    name: "BUZZ_RELAY_URL".into(),
-                    value: config.relay_url.clone(),
-                },
-                EnvVar {
-                    name: "BUZZ_PRIVATE_KEY".into(),
-                    // bech32 encoding of a valid secret key is infallible.
-                    // Panic here is correct: injecting a bogus secret would cause
-                    // delayed, hard-to-diagnose agent failures downstream.
-                    value: config
-                        .keys
-                        .secret_key()
-                        .to_bech32()
-                        .expect("secret key bech32 encoding should never fail"),
-                },
-            ];
-            // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
-            // so the MCP server can attach it to every signed event.
-            if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
-                if !auth_tag.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_AUTH_TAG".into(),
-                        value: auth_tag,
-                    });
-                }
-            }
-            // Forward the agent's display name so dev-mcp can use it as the git
-            // author name instead of the raw npub. Read from the process env
-            // rather than Config: this is a pass-through of a contract owned
-            // upstream, and absent simply means dev-mcp falls back to the npub.
-            if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
-                if !display_name.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_ACP_DISPLAY_NAME".into(),
-                        value: display_name,
-                    });
-                }
-            }
-            env
-        },
-    }]
+
+    // Cortex MCP bridge, added alongside (not instead of) the dev-mcp server
+    // above -- buzz-agent's McpRegistry supports up to MAX_MCP_SERVERS (16),
+    // so there's no need to sacrifice dev-mcp's tools to get Cortex tools.
+    // Gated on cortex_mcp_token being set; Desktop sources that token from
+    // wicket at spawn time (see managed_agents/runtime.rs) and sets it as
+    // BUZZ_ACP_CORTEX_MCP_TOKEN, so an empty value here just means Cortex
+    // wasn't wired up for this persona / wicket lookup failed -- not an error.
+    if !config.cortex_mcp_token.is_empty() {
+        servers.push(McpServer {
+            name: "cortex".to_string(),
+            command: "npx".to_string(),
+            args: vec![
+                "-y".into(),
+                "mcp-remote@0.1.16".into(),
+                "https://mcp.1507.cloud/cortex/mcp".into(),
+                "--header".into(),
+                // No space after the colon: documented mcp-remote arg-escaping
+                // workaround for passing a header value containing a space.
+                format!("Authorization:Bearer {}", config.cortex_mcp_token),
+            ],
+            env: vec![],
+        });
+    }
+
+    servers
 }
 
 #[cfg(test)]
@@ -6728,6 +6755,7 @@ mod build_mcp_servers_tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "test-mcp-server".into(),
+            cortex_mcp_token: "".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -6914,6 +6942,59 @@ mod build_mcp_servers_tests {
             "Path::new(\".\").file_stem() is None — should fall back to \"mcp\""
         );
     }
+
+    #[test]
+    fn empty_cortex_mcp_token_adds_no_cortex_server() {
+        let mut config = test_config();
+        config.cortex_mcp_token = "".into();
+        let servers = build_mcp_servers(&config);
+        assert!(
+            !servers.iter().any(|s| s.name == "cortex"),
+            "empty cortex_mcp_token should not add a cortex MCP server"
+        );
+    }
+
+    #[test]
+    fn cortex_mcp_token_adds_a_cortex_server_alongside_dev_mcp() {
+        let mut config = test_config();
+        config.cortex_mcp_token = "test-cortex-token".into();
+        let servers = build_mcp_servers(&config);
+
+        // Both the existing dev-mcp server and the new Cortex server should be
+        // present — Cortex is additive, never a replacement.
+        assert_eq!(servers.len(), 2);
+        assert!(servers.iter().any(|s| s.name == "test-mcp-server"));
+
+        let cortex = servers
+            .iter()
+            .find(|s| s.name == "cortex")
+            .expect("cortex server should be present when cortex_mcp_token is set");
+        assert_eq!(cortex.command, "npx");
+        assert_eq!(
+            cortex.args,
+            vec![
+                "-y",
+                "mcp-remote@0.1.16",
+                "https://mcp.1507.cloud/cortex/mcp",
+                "--header",
+                "Authorization:Bearer test-cortex-token",
+            ]
+        );
+        assert!(
+            cortex.env.is_empty(),
+            "cortex server should carry no extra env -- the token travels in the header arg"
+        );
+    }
+
+    #[test]
+    fn cortex_mcp_token_alone_adds_only_the_cortex_server() {
+        let mut config = test_config();
+        config.mcp_command = "".into();
+        config.cortex_mcp_token = "test-cortex-token".into();
+        let servers = build_mcp_servers(&config);
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "cortex");
+    }
 }
 
 #[cfg(test)]
@@ -6951,6 +7032,7 @@ mod error_outcome_emission_tests {
             agent_command: "true".into(),
             agent_args: vec![],
             mcp_command: "test-mcp-server".into(),
+            cortex_mcp_token: "".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,5 +1,13 @@
 {$BUZZ_DOMAIN} {
   encode zstd gzip
 
+  tls {
+    dns cloudflare {env.BUZZ_CF_DNS_TOKEN}
+  }
+
+  handle /pair* {
+    reverse_proxy host.docker.internal:3011
+  }
+
   reverse_proxy relay:3000
 }

--- a/deploy/compose/Dockerfile.caddy-cloudflare
+++ b/deploy/compose/Dockerfile.caddy-cloudflare
@@ -1,0 +1,11 @@
+# Custom Caddy build with the Cloudflare DNS provider plugin, for DNS-01
+# ACME challenges against zones (like wiles.1507.cloud) that only resolve to
+# a Tailscale IP and can never satisfy an HTTP-01 challenge.
+FROM caddy:2-builder-alpine AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/cloudflare
+
+FROM caddy:2-alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/deploy/compose/Dockerfile.caddy-cloudflare
+++ b/deploy/compose/Dockerfile.caddy-cloudflare
@@ -1,6 +1,6 @@
 # Custom Caddy build with the Cloudflare DNS provider plugin, for DNS-01
-# ACME challenges against zones (like wiles.1507.cloud) that only resolve to
-# a Tailscale IP and can never satisfy an HTTP-01 challenge.
+# ACME challenges against a $BUZZ_DOMAIN that resolves only to a private
+# address and can therefore never satisfy an HTTP-01 challenge.
 FROM caddy:2-builder-alpine AS builder
 
 RUN xcaddy build \

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -30,6 +30,9 @@ keypair.
 - Default `BUZZ_IMAGE` tracks `ghcr.io/block/buzz:main` for early testing. Pin it to `ghcr.io/block/buzz:sha-<7>` or a semver release tag for production once available.
 - Keep `BUZZ_RELAY_PRIVATE_KEY`, `BUZZ_GIT_HOOK_HMAC_SECRET`, database/Redis,
   and S3 secrets stable across restarts.
+- Secrets live in coffer, not in git: `secrets/` and every `.env*` variant
+  except `.env.example` are gitignored, and `BUZZ_CF_DNS_TOKEN` reaches Caddy
+  only through the environment.
 - `RELAY_OWNER_PUBKEY` is intentionally not prefixed with `BUZZ_`; it must be a
   64-character hex Nostr pubkey when closed relay mode is enabled.
 - `BUZZ_AUTO_MIGRATE` is opt-in. Set `BUZZ_AUTO_MIGRATE=true` or run

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -1,14 +1,14 @@
 services:
-  relay:
-    ports: !reset []
-
   caddy:
-    image: caddy:2-alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.caddy-cloudflare
     depends_on:
       relay:
         condition: service_healthy
     environment:
       BUZZ_DOMAIN: ${BUZZ_DOMAIN:?set BUZZ_DOMAIN}
+      BUZZ_CF_DNS_TOKEN: ${BUZZ_CF_DNS_TOKEN:?set BUZZ_CF_DNS_TOKEN}
     ports:
       - "${CADDY_HTTP_PORT:-80}:80"
       - "${CADDY_HTTPS_PORT:-443}:443"

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -567,6 +567,14 @@ pub fn spawn_agent_child(
         }
     }
     command.env("BUZZ_ACP_CORTEX_MCP_TOKEN", &cortex_mcp_token);
+    // The Cortex MCP endpoint URL is deployment configuration, forwarded from
+    // this process's environment rather than compiled in. Absent means the
+    // Cortex bridge stays off for this spawn, which buzz-acp treats as "not
+    // wired up" rather than an error.
+    command.env(
+        "BUZZ_ACP_CORTEX_MCP_URL",
+        std::env::var("BUZZ_ACP_CORTEX_MCP_URL").unwrap_or_default(),
+    );
     // Enable MCP hook tools (_Stop, _PostCompact) for agents that need them.
     // Uses "*" because build_mcp_servers() hard-codes the server name to "buzz-mcp".
     let runtime_meta = known_acp_runtime(effective_command);

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -491,6 +491,30 @@ pub fn spawn_agent_child(
             }
         }
     };
+    // Cortex MCP bridge token, sourced from the local wicket credential broker
+    // (never from a shell-inherited env var -- a DMG/GUI-launched Buzz.app
+    // does not source ~/.zshrc, so a bare `export CORTEX_TOKEN=...` there is
+    // invisible to this process no matter which layer reads it). Best-effort:
+    // a wicket failure here degrades to no Cortex MCP server for this spawn
+    // rather than failing the spawn outright, mirroring the missing-
+    // mcp_command handling immediately above.
+    let cortex_mcp_token = resolve_command("wicket")
+        .and_then(|wicket_path| {
+            std::process::Command::new(wicket_path)
+                .args(["get", "cortex-buzz-agent/token"])
+                .output()
+                .ok()
+        })
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            eprintln!(
+                "buzz-desktop: wicket get cortex-buzz-agent/token failed, skipping Cortex MCP bridge"
+            );
+            String::new()
+        });
     // Resolve agent command to a full path (DMG launches have minimal PATH).
     let resolved_agent_command = resolve_command(effective_command)
         .map(|p| p.display().to_string())
@@ -542,6 +566,7 @@ pub fn spawn_agent_child(
             command.env("BUZZ_ACP_MCP_COMMAND", "");
         }
     }
+    command.env("BUZZ_ACP_CORTEX_MCP_TOKEN", &cortex_mcp_token);
     // Enable MCP hook tools (_Stop, _PostCompact) for agents that need them.
     // Uses "*" because build_mcp_servers() hard-codes the server name to "buzz-mcp".
     let runtime_meta = known_acp_runtime(effective_command);


### PR DESCRIPTION
This fork is public. The Cortex remote MCP endpoint URL was a literal in `crates/buzz-acp/src/lib.rs` (production path and test assertion), and the Caddy Dockerfile comment named the live ingress hostname. Both are private infrastructure.

- Endpoint now comes from `BUZZ_ACP_CORTEX_MCP_URL` with no default.
- The cortex MCP server is added only when BOTH the URL and the token are set, so an unconfigured build adds nothing rather than falling back to a baked-in host.
- Desktop forwards the variable to the buzz-acp child alongside the wicket-sourced token.
- New test pins that a token without a URL adds no server.

**Not compile-verified:** this machine has no Rust toolchain. The change is a new `String` field threaded through all four `Config` literals plus one call site.

**Operator action:** set `BUZZ_ACP_CORTEX_MCP_URL` in the environment Buzz.app launches with, or the Cortex bridge stays off. The endpoint remains readable in this repo's published history (bdd0397f, plus the ingress hostname in faa69f2d and merge 44f03aff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)