### PR TITLE
fix(desktop): report a failed DM close instead of silently restoring the row

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       name: "smoke",
       testMatch: [
         "**/smoke.spec.ts",
+        "**/dm-hide-failure.spec.ts",
         "**/owned-agent-discovery.spec.ts",
         "**/thread-head-stale-edit.spec.ts",
         "**/sidebar-offcanvas-rail.spec.ts",

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ProtectedGlobalOverlay } from "@protected-feature-components";
 import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useLocation } from "@tanstack/react-router";
+import { toast } from "sonner";
 import { deriveShellRoute, markAllReadSources } from "@/app/AppShell.helpers";
 import { useTerminalContext } from "@/app/useTerminalContext";
 import { AppShellProvider } from "@/app/AppShellContext";
@@ -625,7 +626,12 @@ export function AppShell() {
     async (channelId: string) => {
       try {
         await hideDmMutation.mutateAsync(channelId);
-      } catch {
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to close direct message",
+        );
         return;
       }
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1364,6 +1364,8 @@ declare global {
     __BUZZ_E2E_UNSUPPORTED_PROJECT_ANNOUNCEMENTS__?: boolean;
     /** Project event kinds accepted once but reported as failed to test lost acknowledgements. */
     __BUZZ_E2E_FAIL_PROJECT_EVENT_ACK_KINDS__?: number[];
+    /** Makes hiding a DM fail, to exercise the error path of the sidebar close action. */
+    __BUZZ_E2E_FAIL_HIDE_DM__?: string;
     /**
      * Extra project events appended to the mock store on first access.
      * Use to seed standalone repositories (kind 30617) or other project-scoped
@@ -7401,6 +7403,11 @@ async function handleHideDm(
   args: { channelId: string },
   config: E2eConfig | undefined,
 ) {
+  const forcedFailure = window.__BUZZ_E2E_FAIL_HIDE_DM__;
+  if (forcedFailure) {
+    throw new Error(forcedFailure);
+  }
+
   const identity = getIdentity(config);
   if (!identity) {
     const index = mockChannels.findIndex(

--- a/desktop/tests/e2e/dm-hide-failure.spec.ts
+++ b/desktop/tests/e2e/dm-hide-failure.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const DM_NAME = "alice-tyler";
+const RELAY_ERROR = "relay error 400: forbidden: not a member of this DM";
+
+test("a rejected DM close reports the relay error and keeps the row", async ({
+  page,
+}) => {
+  await page.addInitScript((message) => {
+    window.__BUZZ_E2E_FAIL_HIDE_DM__ = message;
+  }, RELAY_ERROR);
+  await installMockBridge(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const dmRow = page.getByTestId(`channel-${DM_NAME}`);
+  await expect(dmRow).toBeVisible();
+
+  await dmRow.hover();
+  await page.getByTestId(`hide-dm-${DM_NAME}`).click();
+
+  await expect(
+    page.locator("[data-sonner-toast]").filter({ hasText: RELAY_ERROR }),
+  ).toBeVisible();
+
+  // The optimistic removal must roll back: the conversation is still there,
+  // so the sidebar must not claim it went away.
+  await expect(dmRow).toBeVisible();
+});


### PR DESCRIPTION
Refs #7310.

## What the report asked for, and what the code does

#7310 reports that deleting a group DM from Desktop drops the row locally
while the channel survives on the relay. I could not reproduce a delete:
Desktop never offers one for a DM.

| Surface | Why a DM never reaches delete |
|---|---|
| Sidebar DM section | `AppSidebar.tsx:749` passes `onHideDm` and never `onDeleteChannel` (Channels and Forums both pass it) |
| Sidebar context menu | `ChannelContextMenu.tsx:198` — `canLoadOwnerActions` requires `channelType !== "dm"` |
| Channel settings sheet | `ChannelManagementSheet.tsx:148` — `canEditChannel` requires `channelType !== "dm"` |

The one affordance on a DM row is the `X`, labelled `Close direct message`,
and it publishes kind:41012 (hide) — not kind:9008 (delete).

The reporter's CLI measurements are accurate: `buzz channels delete` against
a DM is rejected, deterministically, because `create_dm` enrols every
participant with `role='member'` (`crates/buzz-db/src/dm.rs:181`) while
kind:9008 requires `owner` (`crates/buzz-relay/src/handlers/side_effects.rs:721`).
That is #4739. Desktop simply does not take that path.

The remaining symptom — "no way back to it from the UI even though it still
exists and still receives messages" — was a real bug, and #6885 fixed it on
2026-08-27. The report is against 0.5.19 (tagged 2026-08-25); the fix shipped
in 0.5.22.

## The silent failure that is real

What survives from the report is its subtitle. Closing a DM removes the row
optimistically and rolls it back when the relay rejects the hide, but the
handler discarded the error:

```ts
} catch {
  return;
}
```

`hideDmMutation.error` is not rendered anywhere. A reader whose relay is
unreachable, or whose membership the relay no longer recognises
(`forbidden: not a member of this DM`), sees the conversation flicker out and
return with no explanation, and cannot tell a transient failure from a refusal.

This reports the failure the way the sidebar's project delete already does
(`SidebarProjectsSection.tsx:239`), preferring the relay's own message. The
optimistic removal and its rollback are unchanged.

## Verification

`desktop/tests/e2e/dm-hide-failure.spec.ts` drives the sidebar `X` with the
hide forced to fail, and asserts both halves: the error is shown, and the row
is still there afterwards.

Red/green, each on a clean `dist` with port 4173 killed first:

```
without the fix   expect(locator).toBeVisible() failed
                  locator('[data-sonner-toast]').filter({ hasText: ... })
                  element(s) not found
with the fix      1 passed
```

- `pnpm typecheck` — clean
- `pnpm exec biome check` on the four touched files — no fixes applied
- Full `--project=smoke` suite: 1396 passed, 8 failed, 1 skipped

**On the 8:** none are mine. Running the same eight specs on `origin/main`
without this branch gives 4 failed / 127 passed, and all four reproduce here.
The rest vary between runs — re-running the two extras against unchanged code
passed them. The one that fails every time,
`workflow-local-controls … restores the caret`, fails on `origin/main` too.

## Scope

This does not make group DMs deletable; that needs #4739. It stops Desktop
from failing quietly when the relay says no.
