### PR TITLE
fix(db): attribute huddle_started_links pool acquisition (#7112 regression)

### DIFF
--- a/crates/buzz-db/src/store/event.rs
+++ b/crates/buzz-db/src/store/event.rs
@@ -237,6 +237,11 @@ pub async fn huddle_started_links(
     if parent_channel_ids.is_empty() || ephemeral_channel_ids.is_empty() {
         return Ok(Vec::new());
     }
+    let mut connection = crate::observability::acquire_writer(
+        pool,
+        crate::observability::WriterOperation::SubscriptionHistory,
+    )
+    .await?;
     let rows = sqlx::query(
         r#"
         SELECT DISTINCT ON (backing.id)
@@ -267,7 +272,7 @@ pub async fn huddle_started_links(
     .bind(KIND_HUDDLE_STARTED as i32)
     .bind(ephemeral_channel_ids)
     .bind(HUDDLE_LINK_CONTENT_MAX_BYTES)
-    .fetch_all(pool)
+    .fetch_all(&mut *connection)
     .await?;
 
     rows.into_iter()


### PR DESCRIPTION
## Problem

`huddle_started_links` (`crates/buzz-db/src/store/event.rs`) calls `.fetch_all(pool)` directly, bypassing the typed pool-acquisition attribution that the rest of the event store uses. This trips the repo's own guard:

```
observability_source::p0_pool_acquisitions_use_typed_operation_pairs_without_other
```

Introduced in c6ca9d94d ("Show status and huddle indicators beside names", #7112).

## Why CI did not catch it

The guard commit `91ab9d31b` **predates #7112 by one day**, so that PR's CI either did not run the guard or did not enforce its failure. Worth a look independently of this patch — the guard is currently not protecting `main`.

## Fix

Acquire the connection through the existing `WriterOperation::SubscriptionHistory` label, matching the convention already used by the neighbouring `query_events` / `count` / `get_last_message_at` subscription-history reads in the same file, where replica routing does not select a reader.

SQL, binds, returned rows, ordering, and propagated errors are unchanged — this is attribution only.

## Verification

- Guard observed **failing** on the unmodified line, then **passing** after the change (both directions observed, so the check discriminates).
- `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
