### PR TITLE
test(relay): make mesh demo test use production's directory lease

### DIFF
--- a/crates/buzz-relay/src/api/mesh_demo.rs
+++ b/crates/buzz-relay/src/api/mesh_demo.rs
@@ -146,8 +146,6 @@ fn echo_error(status: StatusCode, what: &str, e: &ReliableStreamError) -> Respon
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use axum::body::to_bytes;
     use buzz_relay_mesh::endpoint::MeshEndpoint;
     use buzz_relay_mesh::{
@@ -173,10 +171,9 @@ mod tests {
             .query_async::<String>(&mut *conn)
             .await
             .ok()?;
-        Some(SessionDirectory::with_lease_ttl(
-            pool,
-            Duration::from_secs(5),
-        ))
+        // Match the production mesh handle's 30-second directory lease. The
+        // demo join intentionally does not renew, and its echo timeout is 10s.
+        Some(SessionDirectory::new(pool))
     }
 
     struct NoopTransport;


### PR DESCRIPTION
## Problem

`mesh_demo::demo_join_forwarded_arm_round_trips_echo` fails with a 504 under load and passes in isolation — a timing race, not a logic bug.

The test helper builds its `SessionDirectory` with a **test-only 5-second lease override**, while `run_demo_join`'s echo timeout is **10 seconds** and the demo join intentionally does not renew. The lease therefore expires mid-wait and the echo can never arrive in time. The detached owner task hides the fence expiry, so it surfaces as an opaque 504.

Adding tracing changed the scheduling enough for the same test to pass in 0.01s, which confirms the race.

## Fix

Drop the test-only override and construct the directory exactly as production does:

```
mesh_boot.rs:720   SessionDirectory::new(pool)   <- production
mesh_demo.rs:176   SessionDirectory::new(pool)   <- now the test
```

`SessionDirectory::new` delegates to `with_lease_ttl(pool, DEFAULT_LEASE_TTL)` where `DEFAULT_LEASE_TTL = 30s` (`tunnel/directory.rs:15,191`).

Note this deliberately makes the test *faithful* rather than merely *tolerant* — inflating the TTL to some larger number would have widened the race window instead of removing the premise. The test was exercising a lease configuration production never uses.

## Verification

Isolated test passes, exit 0. No production code changed — the diff is confined to `#[cfg(test)] mod tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
