### PR TITLE
test(pair-relay): drop self-declared duplicate test_cancellation_immediate

### DIFF
--- a/crates/buzz-pair-relay/tests/integration.rs
+++ b/crates/buzz-pair-relay/tests/integration.rs
@@ -1176,20 +1176,6 @@ async fn test_reader_backpressure_closes() {
     }
 }
 
-/// 42. Connection closes promptly after 120 s (virtual time).
-///     Explicit duplicate of test 9 with a slightly different assertion style.
-#[tokio::test(start_paused = true)]
-async fn test_cancellation_immediate() {
-    let url = start_relay().await;
-    let mut ws = connect(&url).await;
-
-    tokio::time::advance(Duration::from_secs(121)).await;
-    tokio::task::yield_now().await;
-
-    // The connection must be closed — not just slow.
-    assert_closed(&mut ws).await;
-}
-
 /// 43. Client-initiated graceful close receives a Close reply.
 ///     Explicit duplicate of test 34 with a different connection state.
 #[tokio::test]


### PR DESCRIPTION
## Problem

`test_cancellation_immediate` in `crates/buzz-pair-relay/tests/integration.rs` flakes under parallel load and passes in isolation.

It is a duplicate — and the source says so itself:

```rust
/// 42. Connection closes promptly after 120 s (virtual time).
///     Explicit duplicate of test 9 with a slightly different assertion style.
```

In practice even the "different assertion style" is not different. Both tests are identical: `start_relay`, `connect`, `advance(121s)`, `yield_now`, `assert_closed`. The name is also misleading — it tests a 120-second timeout, not immediate cancellation.

## Fix

Delete the duplicate. `test_120s_timeout` (test 9) remains the canonical virtual-time coverage, so **no coverage is lost**.

## Verification

`test_120s_timeout` passes after the deletion, exit 0. Nothing else in the file is touched.

## Note, not addressed here

The same file declares another self-described duplicate a few lines below:

```rust
/// 43. ... Explicit duplicate of test 34 with a different connection state.
```

Left alone deliberately to keep this patch minimal — flagging it in case it is also worth pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
