### PR TITLE
fix(relay): add a retry hint when shared admission is unavailable

### DIFF
--- a/crates/buzz-relay/src/rejection.rs
+++ b/crates/buzz-relay/src/rejection.rs
@@ -132,7 +132,9 @@ fn send_admission_result(
             metrics::counter!("buzz_admission_rejections_total", "transport" => "websocket", "reason" => "unavailable").increment(1);
             conn.send(request_rejection_message(
                 target,
-                "rate-limited: shared admission unavailable",
+                // This is a retry delay, not a quota reset: Redis may recover
+                // quickly. Without a hint, mobile gates all reads for 10s.
+                "rate-limited: shared admission unavailable; retry in 1s",
             ));
             false
         }
@@ -312,6 +314,10 @@ mod tests {
         );
         assert_eq!(frame[1], event_id);
         assert_eq!(frame[2], false);
+        assert_eq!(
+            frame[3],
+            "rate-limited: shared admission unavailable; retry in 1s"
+        );
     }
 
     #[tokio::test]
@@ -322,6 +328,10 @@ mod tests {
 
         assert_eq!(frame[0], "CLOSED");
         assert_eq!(frame[1], "count-abc");
+        assert_eq!(
+            frame[2],
+            "rate-limited: shared admission unavailable; retry in 1s"
+        );
     }
 
     #[tokio::test]
@@ -332,5 +342,9 @@ mod tests {
 
         assert_eq!(frame[0], "CLOSED");
         assert_eq!(frame[1], "history-abc");
+        assert_eq!(
+            frame[2],
+            "rate-limited: shared admission unavailable; retry in 1s"
+        );
     }
 }


### PR DESCRIPTION
When Redis admission fails, the relay sends `rate-limited: shared admission unavailable` without a retry hint. Mobile treats a rate-limited CLOSED with no hint as a ten-second session-wide gate, even if the Redis failure was brief.

Add `retry in 1s` to this WebSocket rejection. This is a retry delay, not a claim that Redis will recover within a second. Admission still fails closed, configured quota resets keep their existing hints, and EVENT/REQ/COUNT rejections keep their existing correlation fields. HTTP responses do not change.

The three regression assertions drive `enforce_ws_admission` with deliberately unreachable Redis and inspect the actual outbound EVENT, REQ, and COUNT responses. All three failed before the production change. All seven rejection tests pass after it.

Validation beyond the seven rejection tests:

- Full `just ci` passed on a local checkout combining this PR, #7386, and #7397.
- All 1,040 relay library tests passed with isolated PostgreSQL 17 and Redis 7 (89 ignored). A mesh echo test timed out on the first run, then passed alone and in the complete repeat. The six earlier media fixture failures passed once PostgreSQL was available.
- All nine relay boot-lifecycle integration tests passed.
- `just test` remains red at `buzz-db::observability_source::p0_pool_acquisitions_use_typed_operation_pairs_without_other`, which reports `event production path bypasses operation attribution with .fetch_all(pool)`. The same test fails with the same message from an untouched archive of base commit `f038cbbb0`. This PR changes none of its source inputs. That failure stops the combined integration run before later packages, so the relay tests above ran separately.
