### PR TITLE
fix(desktop): trust the per-worktree Vite dev port for WebKitGTK mic capture

### DIFF
--- a/desktop/src-tauri/src/linux_media.rs
+++ b/desktop/src-tauri/src/linux_media.rs
@@ -18,6 +18,14 @@
 //! so without the origin check any document that ended up in this webview would
 //! inherit silent mic/camera access for the process lifetime.
 //!
+//! In debug builds the app is served from the Vite dev server rather than
+//! `tauri://localhost`. The just-based entrypoints derive the dev port per
+//! worktree (`scripts/instance-env.sh`: `10000 + sha256(worktree) % 55000`) and
+//! export it as `VITE_PORT`, so the trusted dev origin is derived from that
+//! variable at webview startup; it falls back to Vite's default port (1420)
+//! when the variable is missing or invalid (e.g. a raw `pnpm tauri dev` without
+//! instance-env).
+//!
 //! Buzz's AppImage pins `GDK_BACKEND=x11` (see [`crate::webkit_rendering`]),
 //! which is the backend WebKitGTK media capture is reliable on.
 
@@ -27,18 +35,51 @@
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const PROD_ORIGIN: &str = "tauri://localhost";
 
-/// The Vite dev-server origin (`devUrl` in `tauri.conf.json`, `strictPort`
-/// 1420 in `vite.config.ts`). Only trusted in debug builds.
+/// Vite's default dev-server port (the `vite.config.ts` fallback), used as the
+/// trusted dev origin when `VITE_PORT` is missing or invalid.
 #[cfg(debug_assertions)]
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-const DEV_ORIGIN: &str = "http://localhost:1420";
+const DEV_DEFAULT_ORIGIN: &str = "http://localhost:1420";
+
+/// Build the trusted dev-server origin for debug builds from the configured
+/// Vite port. Pure over its input so it can be unit-tested without env
+/// interference; [`dev_media_origin`] supplies the real value.
+#[cfg(debug_assertions)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn dev_origin_for_port(vite_port: Option<&str>) -> String {
+    match vite_port {
+        // The port must be 1–5 ASCII digits that parse to a non-zero u16,
+        // which rejects empty input, `0`, values above 65535, and anything
+        // non-numeric.
+        Some(port)
+            if (1..=5).contains(&port.len())
+                && port.bytes().all(|b| b.is_ascii_digit())
+                && port.parse::<u16>().is_ok_and(|p| p != 0) =>
+        {
+            format!("http://localhost:{port}")
+        }
+        _ => DEV_DEFAULT_ORIGIN.to_string(),
+    }
+}
+
+/// The Vite dev-server origin to trust in this debug build. Derived from
+/// `VITE_PORT` (exported by `scripts/instance-env.sh` for the just-based
+/// entrypoints) so the per-worktree dev port is trusted, not only the
+/// hardcoded Vite default.
+#[cfg(debug_assertions)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn dev_media_origin() -> String {
+    dev_origin_for_port(std::env::var("VITE_PORT").ok().as_deref())
+}
 
 /// Whether `uri` (the webview's current document URI) is a trusted app origin
 /// allowed to use mic/camera. Matches the origin exactly or as a path prefix so
-/// `tauri://localhost.evil.com` and `http://localhost:14200` do not slip
-/// through. Pure and platform-independent so it can be unit-tested everywhere.
+/// `tauri://localhost.evil.com` and dev-port look-alikes do not slip through.
+/// `dev_origin` is `Some` only in debug builds, where the app is served from
+/// the dev server. Pure and platform-independent so it can be unit-tested
+/// everywhere.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn is_trusted_media_origin(uri: &str) -> bool {
+fn is_trusted_media_origin(uri: &str, dev_origin: Option<&str>) -> bool {
     fn matches(uri: &str, origin: &str) -> bool {
         uri == origin
             || uri
@@ -49,9 +90,10 @@ fn is_trusted_media_origin(uri: &str) -> bool {
     if matches(uri, PROD_ORIGIN) {
         return true;
     }
-    #[cfg(debug_assertions)]
-    if matches(uri, DEV_ORIGIN) {
-        return true;
+    if let Some(origin) = dev_origin {
+        if matches(uri, origin) {
+            return true;
+        }
     }
     false
 }
@@ -66,9 +108,17 @@ pub fn enable_media_capture<R: tauri::Runtime>(webview: &tauri::Webview<R>) {
         UserMediaPermissionRequestExt, WebViewExt,
     };
 
+    // Debug builds are served from the Vite dev server, whose port is derived
+    // per worktree by `scripts/instance-env.sh`; packaged builds are only
+    // reachable from `tauri://localhost`.
+    #[cfg(debug_assertions)]
+    let dev_origin = Some(dev_media_origin());
+    #[cfg(not(debug_assertions))]
+    let dev_origin: Option<String> = None;
+
     // `with_webview` runs the closure on the UI thread, which GTK calls
     // require. It errors only if the platform webview is unavailable.
-    let result = webview.with_webview(|platform_webview| {
+    let result = webview.with_webview(move |platform_webview| {
         // On Linux this is the underlying `webkit2gtk::WebView`.
         let webview = platform_webview.inner();
 
@@ -79,8 +129,10 @@ pub fn enable_media_capture<R: tauri::Runtime>(webview: &tauri::Webview<R>) {
         // Deny-by-default: allow only mic/camera requests from a trusted app
         // origin; deny everything else (still returning `true` so WebKit's
         // auto-deny default does not also run). Non-`UserMedia` requests return
-        // `false` and keep their default handling.
-        webview.connect_permission_request(|wv, request| {
+        // `false` and keep their default handling. The signal handler must be
+        // `'static`, so it moves its own clone of the trusted origin.
+        let trusted_dev = dev_origin.clone();
+        webview.connect_permission_request(move |wv, request| {
             let Some(request) = request.downcast_ref::<UserMediaPermissionRequest>() else {
                 return false;
             };
@@ -88,7 +140,7 @@ pub fn enable_media_capture<R: tauri::Runtime>(webview: &tauri::Webview<R>) {
             let uri = wv.uri().map(|u| u.to_string()).unwrap_or_default();
             let for_device = request.is_for_audio_device() || request.is_for_video_device();
 
-            if for_device && is_trusted_media_origin(&uri) {
+            if for_device && is_trusted_media_origin(&uri, trusted_dev.as_deref()) {
                 request.allow();
             } else {
                 request.deny();
@@ -113,34 +165,69 @@ mod tests {
 
     #[test]
     fn allows_production_app_origin() {
-        assert!(is_trusted_media_origin("tauri://localhost"));
+        assert!(is_trusted_media_origin("tauri://localhost", None));
         assert!(is_trusted_media_origin(
-            "tauri://localhost/channels/general"
+            "tauri://localhost/channels/general",
+            None
         ));
     }
 
     #[test]
     fn denies_untrusted_origins() {
-        assert!(!is_trusted_media_origin(""));
-        assert!(!is_trusted_media_origin("https://evil.example.com"));
+        assert!(!is_trusted_media_origin("", None));
+        assert!(!is_trusted_media_origin("https://evil.example.com", None));
         // Prefix look-alikes must not slip through.
-        assert!(!is_trusted_media_origin("tauri://localhost.evil.com"));
-        assert!(!is_trusted_media_origin("tauri://localhostfoo"));
+        assert!(!is_trusted_media_origin("tauri://localhost.evil.com", None));
+        assert!(!is_trusted_media_origin("tauri://localhostfoo", None));
     }
 
-    #[cfg(debug_assertions)]
     #[test]
-    fn allows_dev_origin_in_debug_only() {
-        assert!(is_trusted_media_origin("http://localhost:1420"));
-        assert!(is_trusted_media_origin("http://localhost:1420/"));
+    fn allows_trusted_dev_origin_and_denies_lookalikes() {
+        let dev = Some("http://localhost:43210");
+        assert!(is_trusted_media_origin("http://localhost:43210", dev));
+        assert!(is_trusted_media_origin("http://localhost:43210/", dev));
         // A different localhost port is still untrusted.
-        assert!(!is_trusted_media_origin("http://localhost:14200"));
-        assert!(!is_trusted_media_origin("http://localhost:3000"));
+        assert!(!is_trusted_media_origin("http://localhost:432100", dev));
+        assert!(!is_trusted_media_origin("http://localhost:1420", dev));
+        // The production origin is trusted regardless of the dev origin.
+        assert!(is_trusted_media_origin("tauri://localhost", dev));
+    }
+
+    #[test]
+    fn without_dev_origin_only_production_is_trusted() {
+        assert!(!is_trusted_media_origin("http://localhost:1420", None));
     }
 
     #[cfg(not(debug_assertions))]
     #[test]
     fn denies_dev_origin_in_release() {
-        assert!(!is_trusted_media_origin("http://localhost:1420"));
+        assert!(!is_trusted_media_origin("http://localhost:1420", None));
+    }
+
+    #[cfg(debug_assertions)]
+    mod dev_origin_tests {
+        use super::super::dev_origin_for_port;
+
+        #[test]
+        fn uses_configured_port() {
+            assert_eq!(dev_origin_for_port(Some("43210")), "http://localhost:43210");
+            assert_eq!(dev_origin_for_port(Some("1420")), "http://localhost:1420");
+        }
+
+        #[test]
+        fn falls_back_to_vite_default_port() {
+            // Missing, empty, non-numeric, zero, and out-of-range values must
+            // not produce a spoofable origin.
+            assert_eq!(dev_origin_for_port(None), "http://localhost:1420");
+            assert_eq!(dev_origin_for_port(Some("")), "http://localhost:1420");
+            assert_eq!(
+                dev_origin_for_port(Some("not-a-port")),
+                "http://localhost:1420"
+            );
+            assert_eq!(dev_origin_for_port(Some("0")), "http://localhost:1420");
+            assert_eq!(dev_origin_for_port(Some("99999")), "http://localhost:1420");
+            assert_eq!(dev_origin_for_port(Some("-1")), "http://localhost:1420");
+            assert_eq!(dev_origin_for_port(Some("142000")), "http://localhost:1420");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #7406 — huddles on Linux **dev** builds still fail with `NotAllowedError`
immediately after the mic is grabbed, because the WebKitGTK
`permission-request` handler added in #3607 (the fix for #3495) hardcodes the
trusted dev origin as `http://localhost:1420`, Vite's *default* port.

Every just-based entrypoint (`just dev`, `just desktop-standalone`,
`just staging`, `just production`) sources `scripts/instance-env.sh`, which
derives a stable per-worktree dev port in the range 10000–64999
(`10000 + sha256(worktree) % 55000`) and points `devUrl` at
`http://localhost:<port>`. The webview therefore loads from an origin the
handler never matches, so `getUserMedia` is denied with `NotAllowedError` and
the huddle tears down. The `1420` check is dead in practice; #3607 was
apparently validated against the raw default-port path (or a non-Linux
platform), so the regression slipped through the close of #3495.

## Change

`desktop/src-tauri/src/linux_media.rs` only:

- Replace the hardcoded `DEV_ORIGIN` constant with `dev_origin_for_port()`,
  which builds `http://localhost:<port>` from a validated 1–5 digit nonzero
  port, falling back to `http://localhost:1420` on missing/empty/non-numeric/
  zero/out-of-range input (so a raw `pnpm tauri dev` without instance-env
  behaves exactly as before).
- `dev_media_origin()` reads `VITE_PORT` from the process env — the exact
  variable `instance-env.sh` exports before launching `tauri dev`, inherited
  by the app.
- `is_trusted_media_origin(uri, dev_origin: Option<&str>)` stays pure and
  unit-testable; the production origin is always trusted, the dev origin only
  when `Some` (debug builds only).
- The WebKitGTK signal closure moves an owned clone of the trusted origin
  (`'static` requirement).

Security posture unchanged: scheme + host stay hardcoded to
`http://localhost` (only the port is env-derived, so no remote host can be
injected), exact-origin / path-prefix matching preserved (port look-alikes
like `:14200` still rejected), deny-by-default preserved, and the whole dev
path is `#[cfg(debug_assertions)]`-gated so packaged builds keep trusting only
`tauri://localhost`.

## Test plan

- [x] `cargo test --lib linux_media` — 6/6 pass (production origin, dev origin
      + look-alike rejection, port-validation fallback cases)
- [x] `cargo clippy --lib` — clean for `linux_media.rs`
- [x] `cargo fmt` applied (pre-commit desktop-tauri-fmt hook passed)
- [x] Manual: `just desktop-standalone` on Linux — huddle starts, mic is
      captured, and the companion window stays open (verified by reporter)

## Regression tests

`dev_origin_for_port` is new, pure, and fully unit-tested (configured port,
default fallback, and rejection of `""`, `"not-a-port"`, `"0"`, `"-1"`,
`"99999"`, `"142000"`). `is_trusted_media_origin` keeps its existing
look-alike tests, extended to the parameterized form.
