### PR TITLE
docs: separate Buzz Kanban operations from Linza

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,17 @@ access information.
 
 ---
 
+## Kanban AI
+
+The operator-managed Buzz roadmap is tracked in a dedicated private `Buzz`
+project on its self-hosted Kanban AI instance; this is not a contributor-wide
+project requirement. Operators with access must read
+[docs/kanban-ai.md](docs/kanban-ai.md) before reading or changing that board; it
+defines project ownership, safe access, backup requirements, and the realtime
+voice roadmap boundary.
+
+---
+
 ## Repo Structure
 
 ```

--- a/docs/kanban-ai.md
+++ b/docs/kanban-ai.md
@@ -1,0 +1,139 @@
+# Kanban AI Operations
+
+## Canonical Instance
+
+- SSH alias: `sd-105293`
+- Container: `kanban-ai-self-hosted`
+- Host-loopback endpoint: `http://127.0.0.1:3331`
+- Live data: `/data/kanban.sqlite` inside the container
+- Backups: `/data/backups` inside the container
+- MCP key file: `/run/secrets/kanban_mcp_key` inside the container; never print it,
+  copy it into the repository, or include it in logs
+
+The loopback endpoint belongs to the host network namespace. Run authenticated
+MCP verification on the host, not from inside the container. A host-side helper
+may capture `docker exec ... cat /run/secrets/kanban_mcp_key` directly through a
+subprocess pipe into process memory; never use shell substitution, print the
+value, or place it in arguments, files, or logs.
+
+## Project Ownership
+
+- `Buzz` (`28fe656f-de10-4df9-9f49-cef6cbfa22c0`) owns changes delivered to
+  Buzz clients, relay, agents, operations, or releases.
+- `linza` owns Linza changes even when Buzz supplied the architectural idea.
+- `[DISCOVERY][BUZZ→LINZA]` stays in `linza`.
+- Cross-project work has one owning card and links to related task IDs; do not
+  duplicate cards.
+
+Stop and resolve ownership before creating or moving a card when the delivery
+target is ambiguous.
+
+## Supported Operations
+
+Prefer authenticated MCP tools: `list_projects`, `get_board`, `create_project`,
+`update_project`, `create_task`, `update_task`, and comments. Use read-only
+`list_projects` and `get_board` for application-facing discovery and
+verification. Treat `delete_project`, `delete_task`, and comment deletion as
+destructive operations requiring an exact-ID preflight and a verified online
+backup, regardless of whether they run through MCP or direct SQL.
+
+The current `update_task` interface cannot change `project_id`, and
+`create_task` cannot accept a caller-selected task ID. A board move or
+ID-preserving restore is therefore an exceptional database migration: back up
+first, validate exact IDs and ownership, use one transaction, and verify through
+both SQLite and MCP afterward. Do not use direct SQL for ordinary board edits.
+
+## Safety and Verification
+
+Use read-only SQLite handles for discovery. Before any direct write, or before
+a destructive MCP operation:
+
+1. Confirm the exact target IDs and expected ownership.
+2. For creation or moves, confirm the target project name/ID is absent and every
+   source task ID exists exactly once on its expected board.
+3. Create an online SQLite backup in `/data/backups` and record its SHA-256.
+4. Run `PRAGMA integrity_check` against the backup before writing.
+5. Apply related direct writes in one transaction with fail-closed
+   postconditions.
+6. Compare preserved task fields and comments against the backup.
+7. Run `PRAGMA integrity_check` on live and backup databases.
+8. Verify project and board state through authenticated MCP reads.
+
+Stop on ambiguous ownership, duplicate project names, missing tasks, unexpected
+counts, changed preserved fields, or a failed integrity check. Never expose the
+MCP key or application credentials in commands, output, commits, task
+descriptions, or receipts.
+
+The container root filesystem is read-only. If a reviewed one-time migration
+script is required, place it temporarily under writable `/data`, execute it once,
+and delete it after final verification. Do not retain migration scripts that
+embed task content or operational assumptions.
+
+## Buzz Realtime Voice Roadmap
+
+This is the boundary snapshot recorded at migration time; the cards listed in
+the receipt are the status and execution source of truth. VOICE 0 is the epic,
+VOICE 1 is active discovery, and VOICE 2–8 follow in dependency order. Use the
+existing Huddle relay and connect an agent as an authorized audio peer. Buzz
+retains identity, authorization, room membership, and effects; OpenAI or
+ElevenLabs sits behind the smallest proven media/dialogue provider boundary.
+Tool calls use existing managed-agent boundaries.
+
+Do not add a new SFU, gateway, or plugin framework without measured necessity.
+Do not duplicate [PR #7217](https://github.com/block/buzz/pull/7217), which
+covers provider-hosted A/V sessions. Treat
+[PR #7232](https://github.com/block/buzz/pull/7232) as an STT backend, not
+realtime speech-to-speech.
+
+## Migration Receipt
+
+- UTC migration time: `2026-09-06T07:12:21.062Z`
+- Backup basename: `kanban-before-buzz-20260906T071221.062Z.sqlite`
+- Backup size: `2293760` bytes
+- Backup SHA-256: `ecdd2ac054914aa48331803fcfb130ae78a7b57b9525c70e2a66cf598557912f`
+- Buzz project ID: `28fe656f-de10-4df9-9f49-cef6cbfa22c0`
+- Project visibility: private (`private = 1` verified in live SQLite)
+- Owner collaborator: `a8fe8636-e369-41b3-aa94-a4cb0722b0c2`, role `owner`
+- Moved task IDs:
+  - `228ca147-4522-43b1-8222-7864db1fe9fa`
+  - `8a0959da-6031-435a-92af-dedf3e9771b1`
+  - `ab90c07d-3b8b-4b91-8b5c-6ebf8c233674`
+  - `c855f629-5eef-4efe-85e7-f028428536f2`
+  - `7b6bdbaa-c207-4684-80c0-851ea4911e74`
+- VOICE task IDs:
+  - VOICE 0: `bdd8e725-dce7-4024-abcd-f1f383cd8b72`
+  - VOICE 1: `3851de3f-f828-44e9-bfa6-dc271562a848`
+  - VOICE 2: `f4c8e194-f108-4942-acc2-b424002f91a8`
+  - VOICE 3: `08b2282c-cb67-4b54-9b08-badf82290172`
+  - VOICE 4: `1afafb59-e50b-46c8-83bf-d2fe807ef581`
+  - VOICE 5: `ac29a94f-a5c1-4ab6-a688-d64e0bc1bff0`
+  - VOICE 6: `49489cfb-f605-4bda-8770-d0ae84afa035`
+  - VOICE 7: `912ebd57-9df3-4ba8-94e5-05f3efb24502`
+  - VOICE 8: `ba307d6a-580f-4e21-bca8-c125f207448c`
+- Preserved Linza discovery task IDs:
+  - `04aa4a08-a8ae-4294-a1bc-5fd28f55cf9d`
+  - `1eabba45-78f2-469e-a848-b47554af6f70`
+  - `3df3b24c-730b-44fd-8afd-2f814cae55b9`
+  - `44da8efa-0562-4d91-b2bd-3270092f2c85`
+  - `4c2982ea-c06e-44d4-91fc-9499bc079917`
+  - `5b04e032-9fb5-4485-adc5-ec977a87651b`
+  - `a06da5a4-b3ef-40bb-835f-6058401b6100`
+  - `aaac7b5b-f591-4b2e-9000-3fe6c0e7cb95`
+  - `cb11cec2-8a92-4906-bffb-60df989bcfcb`
+  - `e37e507c-0f67-406f-bc52-7afbfad71f35`
+  - `fa301550-2b43-4ee3-b39f-ccac9397ea68`
+- Before: 433 Linza tasks; 11 listed discovery tasks in Linza
+- After: 14 Buzz tasks (5 moved, 9 VOICE); 428 Linza tasks; the same 11
+  discovery task IDs still in Linza
+- SQLite verification: live `ok`; backup `ok`; moved fields and comments match
+- MCP verification: projects `linza` and `Buzz`; Buzz board has 14 tasks with 2
+  `in-progress`, 10 `todo`, and 2 previously completed moved tasks
+
+## Rollback
+
+The verified backup is the rollback source for this one-time migration. A restore
+always discards every board write made after `2026-09-06T07:12:21.062Z`; stopping
+the application prevents concurrent-write corruption but does not preserve
+those later writes. Before restoring, stop the application, inventory and
+explicitly accept or export post-migration changes, verify the backup SHA-256,
+then replace the database and rerun SQLite and MCP verification.

--- a/docs/kanban-ai.md
+++ b/docs/kanban-ai.md
@@ -49,8 +49,10 @@ Use read-only SQLite handles for discovery. Before any direct write, or before
 a destructive MCP operation:
 
 1. Confirm the exact target IDs and expected ownership.
-2. For creation or moves, confirm the target project name/ID is absent and every
-   source task ID exists exactly once on its expected board.
+2. For project creation, confirm the target project name/ID is absent. For a
+   move or ID-preserving restore, confirm exactly one destination project exists
+   at the expected name/ID and every source task ID exists exactly once on its
+   expected board.
 3. Create an online SQLite backup in `/data/backups` and record its SHA-256.
 4. Run `PRAGMA integrity_check` against the backup before writing.
 5. Apply related direct writes in one transaction with fail-closed

--- a/docs/kanban-ai.md
+++ b/docs/kanban-ai.md
@@ -136,6 +136,24 @@ realtime speech-to-speech.
 The verified backup is the rollback source for this one-time migration. A restore
 always discards every board write made after `2026-09-06T07:12:21.062Z`; stopping
 the application prevents concurrent-write corruption but does not preserve
-those later writes. Before restoring, stop the application, inventory and
-explicitly accept or export post-migration changes, verify the backup SHA-256,
-then replace the database and rerun SQLite and MCP verification.
+those later writes.
+
+Restore only from an operator shell with the application fully stopped and the
+data volume mounted without another writer. Inventory and explicitly accept or
+export post-migration changes first. Then:
+
+1. Copy the backup to a uniquely named staging file on the same `/data`
+   filesystem; verify its recorded SHA-256 and run `PRAGMA integrity_check`
+   against that staging file.
+2. Record the ownership and mode of `/data/kanban.sqlite`. Move the current
+   database and any `/data/kanban.sqlite-wal` and `/data/kanban.sqlite-shm`
+   sidecars together into a uniquely named quarantine directory. Never copy a
+   backup over the existing database in place.
+3. Apply the recorded ownership and mode to the staged database and atomically
+   rename it to `/data/kanban.sqlite`. Confirm that no WAL or SHM sidecar remains
+   at the canonical database path.
+4. While the application is still stopped, open the restored canonical database
+   read-only and require `PRAGMA integrity_check` to return `ok`. On failure,
+   keep the application stopped and restore the quarantined database triplet.
+5. Start the application, then verify projects, task counts, statuses, and
+   selected comments through authenticated MCP reads.

--- a/docs/superpowers/plans/2026-09-05-buzz-kanban-separation.md
+++ b/docs/superpowers/plans/2026-09-05-buzz-kanban-separation.md
@@ -146,9 +146,15 @@ Docs: required identifiers, receipt basename, secret-pattern scan, git diff --ch
 
 Rollback is the verified backup in `/data/backups`. Restoring it discards every
 board write after the receipt timestamp. Restore only if later verification
-reveals a migration defect: stop the application to prevent concurrent-write
-corruption, inventory and explicitly accept or export later changes, verify the
-recorded SHA-256, replace the database, and rerun SQLite and MCP checks.
+reveals a migration defect. Inventory and explicitly accept or export later
+changes, stop the application completely, and use an operator shell with the
+data volume mounted without another writer. Stage and SHA/integrity-check the
+backup on the `/data` filesystem; quarantine the current database together with
+its `-wal` and `-shm` sidecars; preserve database ownership/mode; then atomically
+rename the staged database into place. Require a read-only integrity check while
+the application is still stopped and confirm no stale canonical sidecars remain
+before restart. If that check fails, keep the application stopped and restore
+the quarantined triplet. After restart, rerun authenticated MCP verification.
 
-The exact receipt and permanent operating rules live in
+The exact step-by-step procedure, receipt, and permanent operating rules live in
 [`docs/kanban-ai.md`](../../kanban-ai.md).

--- a/docs/superpowers/plans/2026-09-05-buzz-kanban-separation.md
+++ b/docs/superpowers/plans/2026-09-05-buzz-kanban-separation.md
@@ -1,0 +1,154 @@
+# Buzz Kanban Separation Implementation Plan
+
+**Goal:** Give Buzz a dedicated self-hosted Kanban AI project, preserve five
+existing Buzz-native cards, recreate VOICE 0–8, and document safe operation.
+
+**Delivery mode:** STANDARD migration. The data change is narrow but requires a
+backup, atomicity, and exact post-migration evidence.
+
+## Scope Lock
+
+### MUST NOW
+
+- Create `Buzz` with ID `28fe656f-de10-4df9-9f49-cef6cbfa22c0`.
+- Move the five approved Buzz-native cards by changing only `project_id`.
+- Create VOICE 0–8 with the approved IDs, status split, dependencies, and
+  architecture constraints.
+- Preserve every `[DISCOVERY][BUZZ→LINZA]` card in `linza`.
+- Verify a pre-write online backup, transactional postconditions, live database,
+  application-facing MCP reads, and a secret-free receipt.
+- Add an operator runbook and link it from `AGENTS.md`.
+
+### NOT NOW
+
+- Realtime voice implementation.
+- A new SFU, gateway, plugin framework, state store, dependency, or deployment.
+- Changes to existing card content, status, comments, or timestamps.
+- General-purpose Kanban migration tooling.
+
+### Done When
+
+- Buzz has 14 cards: 5 moved and 9 VOICE.
+- VOICE 0–1 are `in-progress`; VOICE 2–8 are `todo`.
+- Linza has lost only the five approved IDs and retains the exact preflight set
+  of 11 Buzz-inspired discovery task IDs.
+- Live and backup `PRAGMA integrity_check` return `ok`.
+- Preserved task fields and comments match the backup exactly.
+- MCP `list_projects` and `get_board` agree with SQLite.
+- The committed runbook contains the exact non-secret receipt.
+
+## Chosen Design
+
+Use one reviewed, temporary Node ESM script inside the existing container. Load
+the already installed `better-sqlite3` from `/app/package.json`; do not add a
+dependency. The container root filesystem is read-only, so copy the script to
+writable `/data`, execute it once, and remove it after verification.
+
+The script uses one named validation contract rather than scattered validation
+fences. It compares actual and expected values for:
+
+- target project and epic absence;
+- exact source IDs and Linza ownership;
+- local owner/collaborator identities;
+- the complete task-field inventory excluding only `project_id`;
+- source task fields, comments, and unrelated Linza task IDs;
+- VOICE IDs, titles, statuses, and total board counts;
+- backup/pre-write snapshot equality and both integrity checks.
+
+Create the online backup before the transaction and verify it before any live
+write. Revalidate the same snapshot inside the transaction, apply project
+creation, collaborator creation, five moves, and nine inserts, then assert all
+postconditions before commit. Any failed assertion rolls the transaction back.
+
+The authenticated MCP endpoint is on the SSH host loopback, not in the container
+network namespace. Run final MCP reads on the host and read the mounted bearer
+key into process memory without printing or persisting it.
+
+## Alternatives
+
+| Option | Benefit | Cost/risk | Decision |
+|---|---|---|---|
+| MCP-only recreation | Supported public write path | Cannot preserve task or epic IDs; comments/history would need recreation | Rejected |
+| One-time validated SQLite transaction | Preserves IDs and content; atomic and reversible from backup | Exceptional privileged operation | Chosen |
+| Permanent migration framework | Reusable | No second use case; adds maintenance and attack surface | Not now |
+| Do nothing | No migration risk | Buzz work remains mixed with Linza and roadmap remains absent | Rejected |
+
+## DRY / KISS / YAGNI Audit
+
+- **DRY — OK:** one canonical validation contract owns identity, field
+  completeness, and state comparisons.
+- **KISS — SIMPLE ENOUGH:** one temporary script uses the existing database
+  library; no production code or service changes.
+- **YAGNI — NO SPECULATION:** no reusable migration framework or voice runtime
+  foundation is introduced.
+- **Deletion test:** backup, transaction, field/comment comparison, and MCP read
+  each close a named integrity or application-visibility risk. Everything else
+  is excluded.
+
+## Execution
+
+### Task 1 — Fail-closed dry run
+
+- [x] Inspect live schema, owner identities, source cards, comments, counts,
+  foreign-key mode, and integrity with a read-only handle.
+- [x] Confirm one `linza`, no `Buzz`, absent epic ID, exactly five approved
+  source IDs in Linza, and 11 discovery cards.
+- [x] Validate the temporary script syntax in and outside the container.
+- [x] Run dry-run and confirm planned project ID, five sources, and nine VOICE
+  IDs without changing the database.
+
+**Evidence:** 433 Linza tasks before migration; source count 5; discovery count
+11; initial live integrity `ok`.
+
+### Task 2 — Atomic live migration
+
+- [x] Create and verify the online backup before opening the write transaction;
+  record its size and SHA-256 in the permanent receipt.
+- [x] Revalidate exact pre-write state inside the transaction.
+- [x] Insert the Buzz project and owner collaborator, move five cards, and insert
+  VOICE 0–8 in one transaction.
+- [x] Verify all postconditions before transaction commit.
+
+**Evidence:** migration applied at `2026-09-06T07:12:21.062Z`; backup basename
+`kanban-before-buzz-20260906T071221.062Z.sqlite`.
+
+### Task 3 — Independent data and application verification
+
+- [x] Open live and backup databases read-only and rerun integrity checks.
+- [x] Compare every moved field except `project_id`, plus all source comments.
+- [x] Confirm unrelated Linza task IDs and the exact 11 discovery task IDs
+  remain.
+- [x] Call MCP `list_projects` and `get_board` through host loopback.
+- [x] Remove the temporary migration script after verification.
+
+**Evidence:** live/backup integrity `ok`; moved fields/comments equal; Buzz has
+14 tasks; Linza has 428; MCP reports 10 `todo`, 2 `in-progress`, and 2 previously
+completed moved tasks.
+
+### Task 4 — Repository runbook
+
+- [x] Add `docs/kanban-ai.md` with routing, access, backup, failure, and roadmap
+  boundaries.
+- [x] Record the exact non-secret migration receipt.
+- [x] Link the runbook from `AGENTS.md`.
+- [x] Run identifier, secret-pattern, Markdown whitespace, and diff checks.
+- [x] Prepare the DCO-signed commit after independent review.
+
+## Validation and Rollback
+
+Focused checks:
+
+```text
+SQLite: exact IDs/counts/statuses, preserved fields/comments, live+backup integrity
+MCP: list_projects and get_board(include_comments=false)
+Docs: required identifiers, receipt basename, secret-pattern scan, git diff --check
+```
+
+Rollback is the verified backup in `/data/backups`. Restoring it discards every
+board write after the receipt timestamp. Restore only if later verification
+reveals a migration defect: stop the application to prevent concurrent-write
+corruption, inventory and explicitly accept or export later changes, verify the
+recorded SHA-256, replace the database, and rerun SQLite and MCP checks.
+
+The exact receipt and permanent operating rules live in
+[`docs/kanban-ai.md`](../../kanban-ai.md).

--- a/docs/superpowers/specs/2026-09-05-buzz-kanban-separation-design.md
+++ b/docs/superpowers/specs/2026-09-05-buzz-kanban-separation-design.md
@@ -81,10 +81,10 @@ Every roadmap description must preserve these decisions:
 ## Migration Safety
 
 Before any write, create a consistent backup of the live SQLite database using
-SQLite's online backup mechanism. Apply project creation, task moves, and task
-creation in one transaction. Abort the transaction if the source task set is
-not exactly the five approved Buzz-native tasks or if the requested epic ID has
-appeared since discovery.
+SQLite's online backup mechanism and verify its integrity. Apply project and
+owner-collaborator creation, task moves, and task creation in one transaction.
+Abort the transaction if the source task set is not exactly the five approved
+Buzz-native tasks or if the requested epic ID has appeared since discovery.
 
 After the transaction, verify:
 
@@ -92,7 +92,8 @@ After the transaction, verify:
 - The five existing Buzz-native IDs now belong to `Buzz` and retain all other
   fields.
 - All nine realtime voice tasks exist in `Buzz` with the intended statuses.
-- No `[DISCOVERY][BUZZ→LINZA]` task moved out of `linza`.
+- The exact preflight set of 11 `[DISCOVERY][BUZZ→LINZA]` task IDs remains in
+  `linza`.
 - The `linza` project and its unrelated task count are otherwise unchanged.
 
 The backup path and verification counts form the rollback receipt. No secrets

--- a/docs/superpowers/specs/2026-09-05-buzz-kanban-separation-design.md
+++ b/docs/superpowers/specs/2026-09-05-buzz-kanban-separation-design.md
@@ -1,0 +1,120 @@
+# Buzz Kanban Separation Design
+
+Date: 2026-09-05
+
+## Goal
+
+Give Buzz its own Kanban AI project on the self-hosted Scaleway instance instead
+of mixing Buzz delivery work into the `linza` project. Preserve Linza-owned
+discovery work in `linza`, recreate the missing realtime voice roadmap in the
+new Buzz project, and document the operating boundary in the Buzz repository.
+
+## Current State
+
+The self-hosted Kanban AI instance runs on SSH host `sd-105293` in container
+`kanban-ai-self-hosted`. Its active SQLite database contains one project named
+`linza`.
+
+The database does not contain task `bdd8e725-dce7-4024-abcd-f1f383cd8b72` or
+any task whose title or description contains `BUZZ REALTIME`. Five existing
+Buzz-native tasks are currently assigned to `linza`:
+
+- `228ca147-4522-43b1-8222-7864db1fe9fa` — BUZZ AGENTS
+- `8a0959da-6031-435a-92af-dedf3e9771b1` — BUZZ CLOUD 0
+- `ab90c07d-3b8b-4b91-8b5c-6ebf8c233674` — BUZZ CLOUD 1
+- `c855f629-5eef-4efe-85e7-f028428536f2` — BUZZ CLOUD 2
+- `7b6bdbaa-c207-4684-80c0-851ea4911e74` — BUZZ CLOUD 3
+
+Eleven `[DISCOVERY][BUZZ→LINZA]` tasks also mention Buzz, but their delivery
+target and acceptance authority are Linza.
+
+## Board Boundary
+
+Create one project named `Buzz` for work whose delivery target is the Buzz
+repository, clients, relay, or Buzz deployment. Move the five existing
+Buzz-native tasks to it without changing their IDs, descriptions, statuses,
+priorities, sprint values, or timestamps.
+
+Keep every `[DISCOVERY][BUZZ→LINZA]` task in `linza`. The source of an idea does
+not determine board ownership; the system receiving the change does.
+
+This routing rule applies to future tasks:
+
+- Buzz implementation, operations, release, and Buzz-only discovery → `Buzz`
+- Linza implementation or discovery inspired by Buzz → `linza`
+- Cross-project work → one owning board, with links to related task IDs rather
+  than duplicate cards
+
+## Realtime Voice Roadmap
+
+Create these nine tasks in `Buzz`:
+
+1. `VOICE 0 — общий epic realtime-общения в Huddle`
+2. `VOICE 1 — аудит текущего audio flow и выбор provider boundary`
+3. `VOICE 2 — OpenAI Realtime через существующий Huddle Opus room`
+4. `VOICE 3 — ElevenLabs adapter после подтверждения общего seam`
+5. `VOICE 4 — полный разрешённый tool/effect path агента`
+6. `VOICE 5 — barge-in, floor control и echo protection`
+7. `VOICE 6 — lifecycle, reconnect и cleanup`
+8. `VOICE 7 — privacy, credentials, spend limits и observability`
+9. `VOICE 8 — физический Desktop + неизменённый Mobile E2E и release gate`
+
+Preserve the requested epic ID
+`bdd8e725-dce7-4024-abcd-f1f383cd8b72`; generate stable UUIDs for VOICE 1–8.
+Set VOICE 0 and VOICE 1 to `in-progress`; set VOICE 2–8 to `todo`. Encode the
+dependency order and the epic relationship in task descriptions because the
+current Kanban schema has no separate dependency table.
+
+Every roadmap description must preserve these decisions:
+
+- Use the existing Huddle relay and attach the agent as an authorized audio
+  peer.
+- Keep OpenAI and ElevenLabs behind a media/dialogue provider boundary; they do
+  not own Buzz identity, authorization, or effects.
+- Route tool calls through existing managed-agent boundaries.
+- Do not build a new SFU, gateway, or plugin framework without evidence that it
+  is necessary.
+- Do not duplicate PR #7217, which concerns provider-hosted A/V sessions rather
+  than the Huddle runtime.
+- Treat PR #7232 as an STT backend, not as realtime speech-to-speech.
+
+## Migration Safety
+
+Before any write, create a consistent backup of the live SQLite database using
+SQLite's online backup mechanism. Apply project creation, task moves, and task
+creation in one transaction. Abort the transaction if the source task set is
+not exactly the five approved Buzz-native tasks or if the requested epic ID has
+appeared since discovery.
+
+After the transaction, verify:
+
+- `Buzz` exists exactly once.
+- The five existing Buzz-native IDs now belong to `Buzz` and retain all other
+  fields.
+- All nine realtime voice tasks exist in `Buzz` with the intended statuses.
+- No `[DISCOVERY][BUZZ→LINZA]` task moved out of `linza`.
+- The `linza` project and its unrelated task count are otherwise unchanged.
+
+The backup path and verification counts form the rollback receipt. No secrets
+or raw credentials are printed or committed.
+
+## Repository Documentation
+
+Add `docs/kanban-ai.md` to Buzz and link it from `AGENTS.md`. The runbook will
+record:
+
+- the canonical SSH alias, container name, loopback port, and non-secret data
+  locations;
+- the `Buzz` versus `linza` routing rule;
+- read-only discovery and verification commands;
+- the authenticated write path and backup requirement, without embedding the
+  MCP key or other credentials;
+- failure handling: stop on ambiguous ownership, duplicate project names,
+  unexpected task counts, or missing backup receipts.
+
+## Acceptance Criteria
+
+The change is complete when the live board separation passes the verification
+queries, the runbook is present and linked from agent guidance, repository
+documentation checks pass, and the exact migration receipt is recorded without
+secrets.


### PR DESCRIPTION
## Summary

- document the operator-managed private Buzz Kanban AI project and routing boundary from Linza
- record the verified one-time migration receipt for five preserved cards and VOICE 0–8
- add backup, destructive-operation, rollback, and secret-handling guidance

## Verification

- live and backup SQLite integrity checks: `ok`
- moved task fields and comments match the backup
- MCP `list_projects` and `get_board`: Buzz project visible with 14 tasks
- full local gate completed in two bounded phases after the initial 30-minute command timeout:
  - `just ci` completed check, unit, desktop JS, and desktop build lanes
  - `just desktop-tauri-check desktop-tauri-test web-build mobile-test` completed the remaining lanes
- independent review completed; all release-blocking findings resolved

## Scope

Documentation and administrative board separation only. No Buzz runtime, SFU, gateway, provider adapter, or voice implementation is included.
