### PR TITLE
fix(acp): keep Grok managed agents on headless stdio with Buzz auth

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -98,6 +98,41 @@ buzz-acp
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
 
+## Running with Grok Build
+
+Grok Build speaks ACP natively over stdio. Empty `BUZZ_ACP_AGENT_ARGS` must not
+launch the interactive TUI (that fails with `ENXIO` under Desktop). The harness
+defaults to headless ACP and keeps grokShell from dropping `BUZZ_PRIVATE_KEY`
+(`*KEY*` matches Grok's default env denylist).
+
+```bash
+# Install: https://build.x.ai/docs (binary often lands in ~/.grok/bin)
+grok login   # or export XAI_API_KEY=...
+
+export BUZZ_ACP_AGENT_COMMAND="grok"
+# Optional — empty args resolve to the same argv:
+# export BUZZ_ACP_AGENT_ARGS="agent,--always-approve,--no-leader,stdio"
+
+buzz-acp
+```
+
+`--no-leader` keeps a managed agent off the interactive TUI leader socket when
+`[cli] use_leader` is on. An explicit `--leader` in `BUZZ_ACP_AGENT_ARGS` is
+left alone.
+
+`GROK_CONFIG` is injected with `shell_environment_policy.ignore_default_excludes=true`
+so `buzz messages send` can sign. Some Grok security gates read
+`~/.grok/config.toml` instead of that overlay; if grokShell still reports
+`BUZZ_PRIVATE_KEY is required`, pin the same table on disk:
+
+```toml
+[shell_environment_policy]
+inherit = "all"
+ignore_default_excludes = true
+```
+
+That disk table is operator-local. It is not a Buzz config file.
+
 ## Configuration
 
 All configuration is via environment variables (or CLI flags — every env var has a matching flag).

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -787,13 +787,46 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
         .collect()
 }
 
+/// Managed Grok Build ACP argv. `--no-leader` keeps the subprocess off the
+/// interactive TUI leader socket when `[cli] use_leader` is on.
+const GROK_ACP_ARGS: &[&str] = &["agent", "--always-approve", "--no-leader", "stdio"];
+
+fn grok_acp_args() -> Vec<String> {
+    GROK_ACP_ARGS.iter().map(|arg| (*arg).to_string()).collect()
+}
+
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
+        "grok" => Some(grok_acp_args()),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
     }
+}
+
+/// Insert `--no-leader` for Grok ACP argv that omitted it. Leaves an explicit
+/// `--leader` or existing `--no-leader` alone so operators can still share a
+/// leader on purpose. Does not rewrite stored persona JSON.
+fn with_grok_managed_stdio(command: &str, mut args: Vec<String>) -> Vec<String> {
+    if normalize_agent_command_identity(command) != "grok" {
+        return args;
+    }
+    if args
+        .iter()
+        .any(|arg| arg == "--no-leader" || arg == "--leader")
+    {
+        return args;
+    }
+    if let Some(index) = args.iter().position(|arg| arg == "--always-approve") {
+        args.insert(index + 1, "--no-leader".to_string());
+        return args;
+    }
+    if let Some(index) = args.iter().position(|arg| arg == "agent") {
+        args.insert(index + 1, "--no-leader".to_string());
+        return args;
+    }
+    args
 }
 
 /// Per-runtime environment defaults applied when Buzz owns the agent process.
@@ -808,9 +841,20 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
 /// startup budget (see block/buzz#3355). Skip that unrelated global startup
 /// by default; an operator or persona can still opt back in by setting the
 /// variable explicitly.
+/// Grok's bash tool drops `*KEY*` / `*SECRET*` / `*TOKEN*` unless this overlay
+/// turns default excludes off. `BUZZ_PRIVATE_KEY` matches `*KEY*`, so grokShell
+/// cannot run `buzz messages send` and the model scrapes `/proc` for the parent
+/// env. Overlay-allowlisted filter fields only — it cannot inject secret values
+/// (those already sit on the grok process). Some grok security gates read
+/// `~/.grok/config.toml` instead of this overlay; operators can pin the same
+/// table on disk if bash still strips the key.
+const GROK_SHELL_KEEP_BUZZ_AUTH: &str =
+    r#"{"shell_environment_policy":{"inherit":"all","ignore_default_excludes":true}}"#;
+
 pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'static str)] {
     match normalize_agent_command_identity(command).as_str() {
         "hermes" | "hermes-agent" | "hermes-acp" => &[("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")],
+        "grok" => &[("GROK_CONFIG", GROK_SHELL_KEEP_BUZZ_AUTH)],
         _ => &[],
     }
 }
@@ -876,11 +920,11 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         .collect::<Vec<_>>();
 
     let Some(default_args) = default_agent_args(command) else {
-        return normalized;
+        return with_grok_managed_stdio(command, normalized);
     };
 
     if normalized.is_empty() {
-        return default_args;
+        return with_grok_managed_stdio(command, default_args);
     }
 
     // Older callers relied on the Goose-specific default even for runtimes like
@@ -888,10 +932,10 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
     // providers so desktop- and env-based launches behave the same way.
     if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
     {
-        return default_args;
+        return with_grok_managed_stdio(command, default_args);
     }
 
-    normalized
+    with_grok_managed_stdio(command, normalized)
 }
 
 /// Propagate legacy env-var aliases to their canonical names.
@@ -1761,6 +1805,53 @@ mod tests {
                 "non-Hermes command must have no env defaults: {command}"
             );
         }
+    }
+
+    #[test]
+    fn default_agent_env_keeps_buzz_auth_in_grok_shell() {
+        for command in ["grok", "/usr/local/bin/grok", r"C:\Users\test\grok.exe"] {
+            let env = default_agent_env(command);
+            assert_eq!(env[0].0, "GROK_CONFIG", "unexpected env key for {command}");
+            assert!(
+                env[0].1.contains("ignore_default_excludes"),
+                "GROK_CONFIG must disable *KEY* stripping for {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalizes_grok_args_to_headless_stdio_without_leader() {
+        let expected = vec![
+            "agent".to_string(),
+            "--always-approve".to_string(),
+            "--no-leader".to_string(),
+            "stdio".to_string(),
+        ];
+        assert_eq!(normalize_agent_args("grok", Vec::new()), expected);
+        assert_eq!(
+            normalize_agent_args("/usr/local/bin/grok", vec!["".into()]),
+            expected
+        );
+        assert_eq!(
+            normalize_agent_args(
+                r"C:\Users\test\grok.exe",
+                vec!["agent".into(), "--always-approve".into(), "stdio".into()]
+            ),
+            expected
+        );
+        assert_eq!(
+            normalize_agent_args("grok", expected.clone()),
+            expected,
+            "already-headless argv must stay idempotent"
+        );
+        assert_eq!(
+            normalize_agent_args(
+                "grok",
+                vec!["agent".into(), "--leader".into(), "stdio".into()]
+            ),
+            vec!["agent", "--leader", "stdio"],
+            "explicit --leader must not be rewritten"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -927,11 +927,11 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         return with_grok_managed_stdio(command, default_args);
     }
 
-    // Older callers relied on the Goose-specific default even for runtimes like
-    // Codex and Claude. Treat that legacy fallback as "no args" for zero-arg
-    // providers so desktop- and env-based launches behave the same way.
-    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
-    {
+    // Clap's `BUZZ_ACP_AGENT_ARGS` default is the Goose sentinel `acp`. Treat
+    // that as "no args" whenever this command has a table default so Grok gets
+    // headless stdio instead of `grok acp`. Goose's own default is `["acp"]`,
+    // so this is a no-op there; Codex/Claude still collapse it to empty.
+    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") {
         return with_grok_managed_stdio(command, default_args);
     }
 
@@ -1829,6 +1829,11 @@ mod tests {
         ];
         assert_eq!(normalize_agent_args("grok", Vec::new()), expected);
         assert_eq!(
+            normalize_agent_args("grok", vec!["acp".into()]),
+            expected,
+            "Clap's default BUZZ_ACP_AGENT_ARGS=acp must not launch grok acp"
+        );
+        assert_eq!(
             normalize_agent_args("/usr/local/bin/grok", vec!["".into()]),
             expected
         );
@@ -1851,6 +1856,27 @@ mod tests {
             ),
             vec!["agent", "--leader", "stdio"],
             "explicit --leader must not be rewritten"
+        );
+    }
+
+    #[test]
+    fn grok_cli_without_agent_args_uses_headless_stdio() {
+        let args = CliArgs::parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--agent-command",
+            "grok",
+        ]);
+        assert_eq!(
+            args.agent_args,
+            vec!["acp"],
+            "clap still defaults BUZZ_ACP_AGENT_ARGS to acp"
+        );
+        let cfg = Config::from_args(args).expect("from_args");
+        assert_eq!(
+            cfg.agent_args,
+            vec!["agent", "--always-approve", "--no-leader", "stdio"]
         );
     }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -319,13 +319,45 @@ pub fn try_record_agent_command(
     Ok(default_agent_command())
 }
 
+/// Managed Grok Build ACP argv. `--no-leader` keeps the subprocess off the
+/// interactive TUI leader socket when `[cli] use_leader` is on.
+const GROK_ACP_ARGS: &[&str] = &["agent", "--always-approve", "--no-leader", "stdio"];
+
+fn grok_acp_args() -> Vec<String> {
+    GROK_ACP_ARGS.iter().map(|arg| (*arg).to_string()).collect()
+}
+
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
+        "grok" => Some(grok_acp_args()),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
     }
+}
+
+/// Insert `--no-leader` for Grok ACP argv that omitted it. Leaves an explicit
+/// `--leader` or existing `--no-leader` alone. Does not rewrite stored JSON.
+fn with_grok_managed_stdio(command: &str, mut args: Vec<String>) -> Vec<String> {
+    if normalize_command_identity(command) != "grok" {
+        return args;
+    }
+    if args
+        .iter()
+        .any(|arg| arg == "--no-leader" || arg == "--leader")
+    {
+        return args;
+    }
+    if let Some(index) = args.iter().position(|arg| arg == "--always-approve") {
+        args.insert(index + 1, "--no-leader".to_string());
+        return args;
+    }
+    if let Some(index) = args.iter().position(|arg| arg == "agent") {
+        args.insert(index + 1, "--no-leader".to_string());
+        return args;
+    }
+    args
 }
 
 pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
@@ -336,19 +368,19 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         .collect::<Vec<_>>();
 
     let Some(default_args) = default_agent_args(command) else {
-        return normalized;
+        return with_grok_managed_stdio(command, normalized);
     };
 
     if normalized.is_empty() {
-        return default_args;
+        return with_grok_managed_stdio(command, default_args);
     }
 
     if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
     {
-        return default_args;
+        return with_grok_managed_stdio(command, default_args);
     }
 
-    normalized
+    with_grok_managed_stdio(command, normalized)
 }
 
 fn profile_target_dirs(root: &Path) -> [PathBuf; 2] {

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -375,8 +375,7 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         return with_grok_managed_stdio(command, default_args);
     }
 
-    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
-    {
+    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") {
         return with_grok_managed_stdio(command, default_args);
     }
 

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -156,7 +156,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         id: "grok",
         label: "Grok Build",
         command: "grok",
-        args: &["agent", "--always-approve", "stdio"],
+        args: &["agent", "--always-approve", "--no-leader", "stdio"],
         install_instructions_url: "https://build.x.ai/docs",
         install_hint: "Buzz talks to Grok Build through its CLI's agent stdio mode.",
         underlying_cli: None,
@@ -343,6 +343,28 @@ mod tests {
         underlying_cli_install_hint: Some("Install the Amp Test CLI."),
         underlying_cli_install_instructions_url: Some("https://example.com/amp"),
     };
+
+    #[test]
+    fn grok_preset_uses_headless_stdio_without_leader() {
+        let preset = PRESET_HARNESSES
+            .iter()
+            .find(|preset| preset.id == "grok")
+            .expect("Grok Build preset should be present");
+
+        assert_eq!(preset.command, "grok");
+        assert_eq!(
+            preset.args,
+            &["agent", "--always-approve", "--no-leader", "stdio"]
+        );
+
+        let entry = preset_catalog_entry(preset, |command| {
+            (command == "grok").then(|| PathBuf::from("/usr/local/bin/grok"))
+        });
+        assert_eq!(
+            entry.default_args,
+            vec!["agent", "--always-approve", "--no-leader", "stdio"]
+        );
+    }
 
     #[test]
     fn devin_preset_uses_official_native_acp_invocation() {

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -103,6 +103,7 @@ fn normalizes_grok_args_to_headless_stdio_without_leader() {
         "stdio".to_string(),
     ];
     assert_eq!(normalize_agent_args("grok", Vec::new()), expected);
+    assert_eq!(normalize_agent_args("grok", vec!["acp".into()]), expected);
     assert_eq!(
         normalize_agent_args("/usr/local/bin/grok", Vec::new()),
         expected

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -94,6 +94,35 @@ fn normalizes_buzz_agent_args_to_empty() {
     );
 }
 
+#[test]
+fn normalizes_grok_args_to_headless_stdio_without_leader() {
+    let expected = vec![
+        "agent".to_string(),
+        "--always-approve".to_string(),
+        "--no-leader".to_string(),
+        "stdio".to_string(),
+    ];
+    assert_eq!(normalize_agent_args("grok", Vec::new()), expected);
+    assert_eq!(
+        normalize_agent_args("/usr/local/bin/grok", Vec::new()),
+        expected
+    );
+    assert_eq!(
+        normalize_agent_args(
+            "grok",
+            vec!["agent".into(), "--always-approve".into(), "stdio".into()]
+        ),
+        expected
+    );
+    assert_eq!(
+        normalize_agent_args(
+            "grok",
+            vec!["agent".into(), "--leader".into(), "stdio".into()]
+        ),
+        vec!["agent", "--leader", "stdio"]
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn explicit_path_resolution_ignores_non_executable_files() {


### PR DESCRIPTION
## Summary

Managed Grok Build agents were slow and often mute in the room for two harness reasons, not model reasons:

1. Empty `agent_args` launched interactive `grok` (ENXIO under Desktop). Catalog argv `agent --always-approve stdio` still omitted `--no-leader`, so a managed agent shared the interactive TUI leader socket when `[cli] use_leader` is on.
2. grokShell drops `*KEY*` / `*SECRET*` / `*TOKEN*` unless `shell_environment_policy.ignore_default_excludes` is true. `BUZZ_PRIVATE_KEY` matches `*KEY*`, so `buzz messages send` failed with `auth_error` and the model spent a dozen tool calls scraping `/proc`.

This PR makes **any** Grok-harnessed managed agent use headless ACP and keep harness auth env in grokShell. It does not rewrite stored persona JSON.

## Changes

- Catalog + `default_agent_args`: `agent --always-approve --no-leader stdio` for command identity `grok`.
- Spawn-time insert of `--no-leader` on existing ACP argv. Explicit `--leader` is left alone.
- Inject `GROK_CONFIG` with overlay-allowlisted `shell_environment_policy` filter fields so grokShell keeps `BUZZ_*` already on the grok process. It does not inject secret values.
- README: Running with Grok Build, plus the operator disk fallback. Some Grok security gates read `~/.grok/config.toml` instead of the overlay.

## Related

- Fixes the empty-argv half of #3457 (open PRs #3458 / #3521 / #3804 cover defaults without `--no-leader` or grokShell auth).
- Same product symptom as #4224 (runtime terminal missing auth env), Grok-specific cause.
- Intentional tension with #2883 / #5288 (keep keys *out* of agent shells). This PR keeps the current CLI-sign contract working for Grok. If that isolation lands, grokShell strip becomes correct and this overlay should come out.

## Test plan

- [x] `cargo test -p buzz-acp --lib grok`
- [x] Desktop grok normalize/preset tests (extras tree; origin worktree sidecar-less `tauri` build cannot compile the desktop lib here)
- [ ] Manual: Grok Build managed agent with empty args initializes ACP, `buzz messages send` succeeds without `/proc` hunting, and does not attach to an interactive `grok` TUI leader