### PR TITLE
fix(mobile): surface terminal relay failures in the channel list

### DIFF
--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -266,23 +266,46 @@ class ChannelsPage extends HookConsumerWidget {
 
     // Only surface fetch errors while the relay is stably connected. During a
     // reconnect the session owns recovery, so a cancelled in-flight query must
-    // not turn into a manual Retry page.
+    // not turn into a manual Retry page. The exception is a terminal session
+    // failure (rejected AUTH), which never recovers on its own.
     final showError = useState(false);
     final hasError = channelsAsync.hasError && channels == null;
     final canSurfaceError =
         hasError &&
-        sessionState.status != SessionStatus.connecting &&
-        sessionState.status != SessionStatus.reconnecting;
+        (sessionState.isTerminal ||
+            (sessionState.status != SessionStatus.connecting &&
+                sessionState.status != SessionStatus.reconnecting));
     useEffect(() {
       if (!canSurfaceError) {
         showError.value = false;
+        return null;
+      }
+      if (sessionState.isTerminal) {
+        showError.value = true;
         return null;
       }
       final timer = Timer(const Duration(seconds: 2), () {
         showError.value = true;
       });
       return timer.cancel;
-    }, [canSurfaceError]);
+    }, [canSurfaceError, sessionState.isTerminal]);
+
+    // A cold start that never lands a first payload would otherwise shimmer
+    // forever: the provider stays AsyncLoading (no error to surface) while the
+    // session loops connecting/reconnecting. Bound that wait so the user gets
+    // a retry instead of an endless skeleton.
+    final stalledWithoutContent = useState(false);
+    final isStalled = channels == null && !channelsAsync.hasError;
+    useEffect(() {
+      if (!isStalled) {
+        stalledWithoutContent.value = false;
+        return null;
+      }
+      final timer = Timer(const Duration(seconds: 20), () {
+        stalledWithoutContent.value = true;
+      });
+      return timer.cancel;
+    }, [isStalled]);
 
     // Keep cached content steady through brief socket flaps. A sustained
     // reconnect swaps to element-shaped skeletons that match desktop.
@@ -368,13 +391,23 @@ class ChannelsPage extends HookConsumerWidget {
         channels: channels,
         channelsAsync: channelsAsync,
         showError: showError.value,
+        showStalled: stalledWithoutContent.value,
         sessionStatus: sessionState.status,
         showConnectionSkeleton: showConnectionSkeleton.value,
         currentPubkey: currentPubkey,
         topSectionHeight: topSectionHeight,
         usesPinnedGradient: usesPinnedGradient,
         scrollController: channelsScrollController,
-        onRefresh: () => ref.read(channelsProvider.notifier).refresh(),
+        onRefresh: () async {
+          // `refresh()` deliberately no-ops while the socket is down, which is
+          // precisely when Retry is on screen. Re-establish the session first
+          // so the button actually does something.
+          if (ref.read(relaySessionProvider).status !=
+              SessionStatus.connected) {
+            await ref.read(relaySessionProvider.notifier).reconnect();
+          }
+          await ref.read(channelsProvider.notifier).refresh();
+        },
         onSelectChannel: openChannel,
       ),
     );

--- a/mobile/lib/features/channels/channels_page/badges.dart
+++ b/mobile/lib/features/channels/channels_page/badges.dart
@@ -25,10 +25,23 @@ class _EphemeralBadge extends StatelessWidget {
 class _ErrorView extends StatelessWidget {
   final Object error;
   final VoidCallback onRetry;
+  final String title;
 
-  const _ErrorView({required this.error, required this.onRetry});
+  const _ErrorView({
+    required this.error,
+    required this.onRetry,
+    this.title = 'Could not load channels',
+  });
 
   static String _userMessage(Object error) {
+    if (error is RelayAuthRejectedException) {
+      return 'The relay rejected this device\'s sign-in. '
+          'Sign in again to reconnect.';
+    }
+    if (error is TimeoutException) {
+      return 'Still trying to reach the relay. '
+          'Check your connection, then retry.';
+    }
     if (error is RelayException) {
       if (error.statusCode == 401) {
         return 'Not authorized. Check your API token.';
@@ -58,10 +71,7 @@ class _ErrorView extends StatelessWidget {
               color: context.colors.error,
             ),
             const SizedBox(height: Grid.xs),
-            Text(
-              'Could not load channels',
-              style: context.textTheme.titleMedium,
-            ),
+            Text(title, style: context.textTheme.titleMedium),
             const SizedBox(height: Grid.xxs),
             Text(
               _userMessage(error),

--- a/mobile/lib/features/channels/channels_page/body.dart
+++ b/mobile/lib/features/channels/channels_page/body.dart
@@ -4,6 +4,7 @@ class _ChannelsBody extends StatelessWidget {
   final List<Channel>? channels;
   final AsyncValue<List<Channel>> channelsAsync;
   final bool showError;
+  final bool showStalled;
   final SessionStatus sessionStatus;
   final bool showConnectionSkeleton;
   final String? currentPubkey;
@@ -17,6 +18,7 @@ class _ChannelsBody extends StatelessWidget {
     required this.channels,
     required this.channelsAsync,
     required this.showError,
+    required this.showStalled,
     required this.sessionStatus,
     required this.showConnectionSkeleton,
     required this.currentPubkey,
@@ -31,12 +33,26 @@ class _ChannelsBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final barHeight = topSectionHeight;
     final loadedChannels = channels;
+    // `showStalled` covers the cold start that never lands a payload: the
+    // provider is still AsyncLoading, so there is no error to surface, but
+    // shimmering indefinitely is worse than offering a retry.
+    final stalled = showStalled && loadedChannels == null && !showError;
     final loading =
-        showConnectionSkeleton || (loadedChannels == null && !showError);
+        showConnectionSkeleton ||
+        (loadedChannels == null && !showError && !stalled);
     final content = showError && channelsAsync.hasError
         ? Padding(
             padding: EdgeInsets.only(top: barHeight),
             child: _ErrorView(error: channelsAsync.error!, onRetry: onRefresh),
+          )
+        : stalled
+        ? Padding(
+            padding: EdgeInsets.only(top: barHeight),
+            child: _ErrorView(
+              error: TimeoutException('Channel list did not load'),
+              title: 'Still connecting',
+              onRetry: onRefresh,
+            ),
           )
         : loadedChannels == null
         ? const SizedBox.shrink()

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -113,7 +113,15 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     final waitingForInitialConnection =
         sessionState.status != SessionStatus.connected;
     ref.listen(relaySessionProvider, (previous, next) {
-      if (next.status != SessionStatus.connected) return;
+      if (next.status != SessionStatus.connected) {
+        // A terminal session failure (rejected AUTH) never reconnects, so the
+        // initial-connection wait below would hang forever on a permanent
+        // skeleton. Surface it as a provider error instead.
+        if (next.isTerminal && !connected.isCompleted) {
+          connected.completeError(next.terminalError!, StackTrace.current);
+        }
+        return;
+      }
       if (waitingForInitialConnection &&
           !_hasLoaded &&
           !connected.isCompleted) {
@@ -145,6 +153,9 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     if (sessionState.status != SessionStatus.connected) {
       // Keep the prior community's cache visible until the new relay connects.
       if (_hasLoaded) return state.value ?? const [];
+      // Already terminal before we started listening — fail now rather than
+      // awaiting a completer nothing will ever complete.
+      if (sessionState.isTerminal) throw sessionState.terminalError!;
       await connected.future;
     }
 

--- a/mobile/lib/features/profile/profile_avatar.dart
+++ b/mobile/lib/features/profile/profile_avatar.dart
@@ -53,9 +53,17 @@ class ProfileAvatar extends ConsumerWidget {
   }
 
   Widget _buildPlaceholder(BuildContext context) {
-    return CircleAvatar(
-      radius: size / 2,
-      backgroundColor: context.colors.primaryContainer,
+    // Must stay tappable: while the profile is loading this is the only route
+    // to Settings, and a stalled relay keeps it in exactly this state — the
+    // case where reaching Settings (relay config, identity, leave community)
+    // matters most.
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: CircleAvatar(
+        radius: size / 2,
+        backgroundColor: context.colors.primaryContainer,
+      ),
     );
   }
 

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -518,7 +518,10 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _flushTimer = null;
     if (error is RelayAuthRejectedException) {
       _reconnectTimer?.cancel();
-      state = const SessionState(status: SessionStatus.disconnected);
+      state = SessionState(
+        status: SessionStatus.disconnected,
+        terminalError: error,
+      );
       return;
     }
     _scheduleReconnect();

--- a/mobile/lib/shared/relay/relay_session_types.dart
+++ b/mobile/lib/shared/relay/relay_session_types.dart
@@ -18,7 +18,19 @@ class SessionState {
   final SessionStatus status;
   final int reconnectAttempt;
 
-  const SessionState({required this.status, this.reconnectAttempt = 0});
+  /// Non-null when the session stopped for a reason no amount of waiting will
+  /// fix — currently a rejected NIP-42 AUTH. The session schedules no
+  /// reconnect in this case, so consumers blocked on "wait for connected"
+  /// must fail instead of hanging forever.
+  final Object? terminalError;
+
+  const SessionState({
+    required this.status,
+    this.reconnectAttempt = 0,
+    this.terminalError,
+  });
+
+  bool get isTerminal => terminalError != null;
 }
 
 /// Recovery lifecycle for a live relay subscription.

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -2083,6 +2083,45 @@ void main() {
     },
   );
 
+  test('fails instead of hanging when the session rejects AUTH', () async {
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+      initialStatus: SessionStatus.disconnected,
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    final pending = container.read(channelsProvider.future);
+    // The provider is parked waiting for a connection that will never come.
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(channelsProvider).isLoading, isTrue);
+
+    session.failTerminally();
+
+    await expectLater(pending, throwsA(isA<RelayAuthRejectedException>()));
+    expect(container.read(channelsProvider).hasError, isTrue);
+  });
+
+  test('fails immediately when the session is already terminal', () async {
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+      initialStatus: SessionStatus.disconnected,
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+    // Initialize the session notifier before mutating its state, then fail it
+    // *before* channelsProvider ever builds.
+    container.read(relaySessionProvider);
+    session.failTerminally();
+
+    await expectLater(
+      container.read(channelsProvider.future),
+      throwsA(isA<RelayAuthRejectedException>()),
+    );
+  });
+
   test('initial fetch issues membership + metadata queries', () async {
     final session = _FakeRelaySession(
       memberships: [_membership(_channelA, myPk)],
@@ -2238,7 +2277,10 @@ class _FakeRelaySession extends RelaySessionNotifier {
     this.huddleStarts = const [],
     this.recentMessages = const [],
     this.membershipFailures = 0,
+    this.initialStatus = SessionStatus.connected,
   });
+
+  final SessionStatus initialStatus;
 
   List<NostrEvent> memberships;
   final List<List<NostrEvent>>? membershipPages;
@@ -2463,7 +2505,7 @@ class _FakeRelaySession extends RelaySessionNotifier {
   }
 
   @override
-  SessionState build() => const SessionState(status: SessionStatus.connected);
+  SessionState build() => SessionState(status: initialStatus);
 
   @override
   Future<List<NostrEvent>> fetchHistory(
@@ -2700,6 +2742,15 @@ class _FakeRelaySession extends RelaySessionNotifier {
 
   void setStatus(SessionStatus status) {
     state = SessionState(status: status);
+  }
+
+  /// Mimic a rejected NIP-42 AUTH: the real session stops here and schedules
+  /// no reconnect.
+  void failTerminally() {
+    state = const SessionState(
+      status: SessionStatus.disconnected,
+      terminalError: RelayAuthRejectedException('auth-rejected'),
+    );
   }
 
   /// Emit a live event to all subscribers.

--- a/mobile/test/features/profile/profile_avatar_test.dart
+++ b/mobile/test/features/profile/profile_avatar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -13,17 +15,21 @@ void main() {
     bool showPresence = true,
     String presence = 'online',
     String? avatarUrl,
+    VoidCallback? onTap,
+    ProfileNotifier Function()? profileNotifier,
   }) {
     return ProviderScope(
       overrides: [
         profileProvider.overrideWith(
-          () => _FakeProfileNotifier(avatarUrl: avatarUrl),
+          profileNotifier ?? () => _FakeProfileNotifier(avatarUrl: avatarUrl),
         ),
         presenceProvider.overrideWith(() => _FakePresenceNotifier(presence)),
       ],
       child: MaterialApp(
         theme: AppTheme.light(),
-        home: Center(child: ProfileAvatar(showPresence: showPresence)),
+        home: Center(
+          child: ProfileAvatar(showPresence: showPresence, onTap: onTap),
+        ),
       ),
     );
   }
@@ -83,6 +89,24 @@ void main() {
     expect(dotColor(tester), theme.colorScheme.outline);
   });
 
+  testWidgets('stays tappable while the profile is still loading', (
+    tester,
+  ) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      harness(
+        onTap: () => taps++,
+        profileNotifier: _PendingProfileNotifier.new,
+      ),
+    );
+    await tester.pump();
+
+    // The profile never resolves, so the placeholder is on screen. It must
+    // still route to Settings — that is the only way out of a stalled relay.
+    await tester.tap(find.byType(ProfileAvatar));
+    expect(taps, 1);
+  });
+
   testWidgets('leaves the avatar unmasked when presence is hidden', (
     tester,
   ) async {
@@ -128,6 +152,12 @@ void main() {
       posterUrl,
     );
   });
+}
+
+/// Never resolves — mirrors a stalled relay, where the profile query hangs.
+class _PendingProfileNotifier extends ProfileNotifier {
+  @override
+  Future<UserProfile?> build() => Completer<UserProfile?>().future;
 }
 
 class _FakeProfileNotifier extends ProfileNotifier {


### PR DESCRIPTION
## Summary

The channel list can shimmer indefinitely with no error and no way out.

`ChannelsNotifier.build()` awaits a completer that is only ever completed on a
successful connection — nothing completes it with an error. When the relay never
connects the provider stays in `AsyncLoading`, and since the UI gates its error
view on `channelsAsync.hasError`, there is nothing to show but the skeleton.

Two paths reach that state:

1. **A rejected NIP-42 AUTH.** `_handleDisconnected` already recognises
   `RelayAuthRejectedException`, cancels the reconnect timer, and then sets a
   bare `SessionState(status: disconnected)` — detecting the terminal case and
   discarding the reason, so consumers cannot tell it apart from a recoverable
   drop.
2. **An unreachable host** (a tailnet-only or otherwise unroutable relay), which
   loops connecting/reconnecting forever while the error view stays suppressed.

Changes:

- `SessionState` carries `terminalError`; `_handleDisconnected` passes the
  `RelayAuthRejectedException` it already has instead of dropping it.
- `ChannelsNotifier` fails the initial-connection wait on a terminal state, and
  throws immediately if the session is already terminal before the listener
  attaches.
- Terminal errors bypass the 2s debounce (which exists for reconnect flaps that
  do not apply here); a contentless load degrades to a retry after 20s, covering
  the case where the provider never errors at all.
- Retry reconnects the session before refreshing — `refresh()` no-ops while
  disconnected, which is exactly when Retry is on screen.

Also makes the profile avatar's loading placeholder tappable. It had no
`GestureDetector`, and the avatar is the only entry point to Settings. With the
identity in the iOS Keychain (which survives app deletion) and the pairing page
reachable only when unauthenticated, a stalled relay left no in-app route to
Settings, and reinstalling restored the same key.

### Related issue

None found for mobile. The closest existing report is #5141, which describes the
same class of failure on desktop (fresh install adopts an unreachable relay and
hangs on "connecting to relay" with no error). This PR does not address that one
— different client, different code path.

### Testing

Verified against the Hermit-pinned toolchain (Flutter 3.41.7 / Dart 3.11.5), not
a system install:

- `flutter analyze` — no issues.
- `flutter test` — 2075 passed, 0 failed. Baseline on `main` immediately before
  the change was green on the same SDK, so this is green-to-green.
- New coverage in `channels_provider_test.dart` (terminal-state failure paths)
  and `profile_avatar_test.dart` (placeholder tappability).

No before/after recording: the failure needs a relay that accepts TCP and then
rejects AUTH, or a host that never routes, and I do not have a rig that produces
that deterministically on a simulator. The behaviour is covered by the widget and
provider tests instead. Happy to add a recording if a maintainer wants one.
