### PR TITLE
feat(acp): wake PR authors after merge

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -266,10 +266,11 @@ Forum event kinds:
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
-3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
-4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
-5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
-6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
+3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag) and global project lifecycle events addressed to the agent.
+4. **Project lifecycle routing** — For a merged NIP-34 status (`kind:1631`), resolves the signed root PR, requires that this agent authored it and that the repository owner signed the merge, then routes the wakeup to the PR's signed source-channel `h` tag. Pending/completed IDs are persisted as self-encrypted NIP-78 application data for reconnect/restart idempotency.
+5. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
+6. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
+7. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
 
 Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when agents > 1.
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -8,6 +8,7 @@ mod observer;
 mod pi_launcher;
 mod pool;
 mod pool_lifecycle;
+mod project_lifecycle;
 mod prompt_framing;
 mod prompt_project;
 mod queue;
@@ -648,7 +649,12 @@ impl QueuedNormalListenerEvent {
         let Some(signal) = mode_gate_signal(handling, &self.effective_author, owner) else {
             return;
         };
-        let native_attempted = matches!(signal, ControlSignal::Steer)
+        // A lifecycle completion must remain attached to a tracked prompt task
+        // until that task returns successfully. Native steer acknowledgements
+        // are transport-level and can arrive after the owning task returns, so
+        // lifecycle wakeups use the universal cancel+merge path instead.
+        let native_attempted = self.prompt_tag_for_steer != project_lifecycle::PROMPT_TAG
+            && matches!(signal, ControlSignal::Steer)
             && try_native_steer(
                 pool,
                 queue,
@@ -2668,7 +2674,22 @@ async fn tokio_main() -> Result<()> {
     }
     let owner_cache = OwnerCache::new(startup_owner.clone());
 
-    let mut relay_observer_control_rx = None;
+    // One global addressed subscription carries both observer controls and
+    // kind:1631 merge lifecycle events. The lifecycle manager validates and
+    // durably records merge events before returning them for normal admission.
+    relay
+        .subscribe_observer_controls()
+        .await
+        .map_err(|e| anyhow::anyhow!("addressed event subscribe error: {e}"))?;
+    let addressed_rx = relay
+        .take_observer_control_rx()
+        .ok_or_else(|| anyhow::anyhow!("addressed event receiver already taken"))?;
+    let (lifecycle_handle, mut addressed_event_rx, mut lifecycle_task) =
+        project_lifecycle::start(config.keys.clone(), relay_rest_client.clone(), addressed_rx)
+            .await
+            .map_err(|e| anyhow::anyhow!("project lifecycle startup error: {e}"))?;
+    tracing::info!("subscribed to addressed observer and project lifecycle events");
+
     let mut relay_observer_publisher_task = None;
     let mut relay_observer_publisher = None;
     if config.relay_observer {
@@ -2685,11 +2706,6 @@ async fn tokio_main() -> Result<()> {
                         owner_pubkey_hex,
                         owner_pubkey,
                     ));
-                    relay
-                        .subscribe_observer_controls()
-                        .await
-                        .map_err(|e| anyhow::anyhow!("observer control subscribe error: {e}"))?;
-                    relay_observer_control_rx = relay.take_observer_control_rx();
                     tracing::info!("relay observer enabled");
                 }
                 Err(error) => {
@@ -3208,16 +3224,13 @@ async fn tokio_main() -> Result<()> {
                     }
                     None
                 }
-                control_event = async {
-                    match relay_observer_control_rx.as_mut() {
-                        Some(rx) => rx.recv().await,
-                        None => std::future::pending().await,
-                    }
-                } => {
+                addressed_event = addressed_event_rx.recv() => {
                     let _ = result_rx;
-                    match control_event {
-                        Some(event) => {
-                            if let Some(ref owner_hex) = owner_cache.pubkey {
+                    match addressed_event {
+                        Some(project_lifecycle::AddressedEvent::ObserverControl(event)) => {
+                            if !config.relay_observer {
+                                tracing::debug!("observer control received while relay observer is disabled — dropping");
+                            } else if let Some(ref owner_hex) = owner_cache.pubkey {
                                 handle_relay_observer_control_event(
                                     &config.keys,
                                     event,
@@ -3230,12 +3243,84 @@ async fn tokio_main() -> Result<()> {
                                 tracing::warn!("observer control frame received but no owner resolved — dropping");
                             }
                         }
+                        Some(project_lifecycle::AddressedEvent::Merge(wakeup)) => {
+                            let event_id = wakeup.buzz_event.event.id.to_hex();
+                            let channel_id = wakeup.buzz_event.channel_id;
+                            if !subscribed_channel_ids.contains(&channel_id) {
+                                tracing::info!(
+                                    %channel_id,
+                                    %event_id,
+                                    "ignoring merged PR wakeup outside current channel subscriptions"
+                                );
+                                if let Err(error) = lifecycle_handle.ignore(event_id) {
+                                    tracing::error!(%error, "failed to record ignored lifecycle wakeup");
+                                }
+                            } else if let Some(authorized_event) = authorize_normal_listener_event(
+                                &mut author_gate_ctx,
+                                wakeup.buzz_event,
+                                &config.respond_to,
+                                &config.respond_to_allowlist,
+                                &owner_cache,
+                                &ctx.channel_info,
+                                &ctx.rest_client,
+                            )
+                            .await
+                            {
+                                let (buzz_event, effective_author) = authorized_event.into_parts();
+                                let session_scope = scope::SessionScope::derive(
+                                    config.session_policy,
+                                    buzz_event.channel_id,
+                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await,
+                                    &buzz_event.event,
+                                );
+                                let ingress = NormalListenerIngress {
+                                    buzz_event,
+                                    effective_author,
+                                    prompt_tag: project_lifecycle::PROMPT_TAG.into(),
+                                };
+                                let queued = ingress.push(&mut queue, session_scope);
+                                if queued.accepted {
+                                    // Lifecycle events are not chat messages, so do not add a
+                                    // synthetic-looking seen reaction to the global status event.
+                                    queued.steer_or_interrupt(
+                                        config.multiple_event_handling,
+                                        owner_cache.get(),
+                                        &mut pool,
+                                        &mut queue,
+                                        &steer_ack_tx,
+                                    );
+                                    if pool_ready {
+                                        for (scope, thread_tags) in dispatch_pending(
+                                            &mut pool,
+                                            &mut queue,
+                                            &ctx,
+                                            &mut last_activity,
+                                            observer.as_ref(),
+                                        ) {
+                                            typing_channels.insert(scope, thread_tags);
+                                        }
+                                    }
+                                } else if let Err(error) = lifecycle_handle.ignore(event_id) {
+                                    tracing::error!(%error, "failed to record policy-dropped lifecycle wakeup");
+                                }
+                            } else if let Err(error) = lifecycle_handle.ignore(event_id) {
+                                tracing::error!(%error, "failed to record unauthorized lifecycle wakeup");
+                            }
+                        }
                         None => {
-                            relay_observer_control_rx = None;
-                            tracing::warn!("relay observer control channel closed");
+                            tracing::error!("addressed lifecycle event processor stopped — exiting");
+                            break;
                         }
                     }
                     None
+                }
+                lifecycle_result = &mut lifecycle_task => {
+                    let _ = result_rx;
+                    match lifecycle_result {
+                        Ok(()) => tracing::error!("project lifecycle manager exited unexpectedly"),
+                        Err(error) => tracing::error!(%error, "project lifecycle manager failed"),
+                    }
+                    break;
                 }
                 // Remaining branches don't touch pool — evaluated when pool is idle.
                 buzz_event = relay.next_event() => {
@@ -3342,6 +3427,14 @@ async fn tokio_main() -> Result<()> {
                                     // case is a known limitation — fix belongs in
                                     // the relay (clean up bot reactions on removal).
                                     if !drained_ids.is_empty() {
+                                        if let Err(error) =
+                                            lifecycle_handle.ignore_many(drained_ids.clone())
+                                        {
+                                            tracing::error!(
+                                                %error,
+                                                "failed to record lifecycle events drained on channel removal"
+                                            );
+                                        }
                                         let rc = ctx.rest_client.clone();
                                         let ids = drained_ids.clone();
                                         tokio::spawn(async move {
@@ -3742,6 +3835,30 @@ async fn tokio_main() -> Result<()> {
 
         match pool_event {
             Some(PoolEvent::Result(result)) => {
+                let lifecycle_event_ids = pool
+                    .task_map()
+                    .values()
+                    .find(|meta| meta.agent_index == result.agent.index)
+                    .map(|meta| meta.lifecycle_event_ids.clone())
+                    .unwrap_or_default();
+                if matches!(&result.outcome, PromptOutcome::Ok(_)) {
+                    if let Err(error) = lifecycle_handle.complete(lifecycle_event_ids) {
+                        // The encrypted pending ledger remains authoritative; a
+                        // restart will retry rather than silently losing the wakeup.
+                        tracing::error!(%error, "failed to record successful lifecycle turn");
+                    }
+                } else if result
+                    .source
+                    .channel_id()
+                    .is_some_and(|channel_id| removed_channels.contains(&channel_id))
+                {
+                    if let Err(error) = lifecycle_handle.ignore_many(lifecycle_event_ids) {
+                        tracing::error!(
+                            %error,
+                            "failed to record lifecycle turn dropped after channel removal"
+                        );
+                    }
+                }
                 // Stop the typing indicator for the completed turn's exact scope,
                 // not the whole channel — a sibling thread still running in the
                 // same channel must keep its indicator.
@@ -4140,6 +4257,7 @@ async fn tokio_main() -> Result<()> {
     if let Some(handle) = relay_observer_publisher_task.take() {
         handle.abort();
     }
+    lifecycle_task.abort();
 
     // Graceful relay shutdown — sends WebSocket close frame and waits up to 5s
     // for the background task to finish, rather than aborting immediately (#40).
@@ -4508,6 +4626,7 @@ fn dispatch_pending(
             DedupMode::Queue => Some(batch.clone()),
             DedupMode::Drop => None,
         };
+        let lifecycle_event_ids = project_lifecycle::batch_event_ids(&batch);
 
         let result_tx = pool.result_tx();
         let ctx_clone = Arc::clone(ctx);
@@ -4553,6 +4672,7 @@ fn dispatch_pending(
                 scope: Some(scope.clone()),
                 turn_id,
                 recoverable_batch,
+                lifecycle_event_ids,
                 control_tx: Some(control_tx),
                 steer_tx,
                 successful_steer_deliveries: HashSet::new(),
@@ -5227,6 +5347,7 @@ fn dispatch_heartbeat(
             scope: None,
             turn_id,
             recoverable_batch: None,
+            lifecycle_event_ids: Vec::new(),
             control_tx: None,
             steer_tx: None,
             successful_steer_deliveries: HashSet::new(),
@@ -6043,6 +6164,7 @@ mod owner_control_command_tests {
                 scope: Some(scope::SessionScope::Conversation { channel_id }),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: Some(control_tx),
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -6089,6 +6211,7 @@ mod owner_control_command_tests {
                 scope: Some(scope),
                 turn_id: "t".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: Some(control_tx),
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -9394,6 +9517,7 @@ mod error_outcome_emission_tests {
                 scope: Some(scope::SessionScope::Conversation { channel_id }),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::from([
@@ -9469,6 +9593,7 @@ mod error_outcome_emission_tests {
                 scope: Some(scope::SessionScope::Conversation { channel_id }),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::from([
@@ -9591,6 +9716,7 @@ mod error_outcome_emission_tests {
                 scope: Some(scope::SessionScope::Conversation { channel_id }),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::from([
@@ -9660,6 +9786,7 @@ mod error_outcome_emission_tests {
                 scope: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -9740,6 +9867,7 @@ mod error_outcome_emission_tests {
                 scope: Some(scope::SessionScope::Conversation { channel_id }),
                 turn_id: "panic-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -9832,6 +9960,7 @@ mod error_outcome_emission_tests {
                 scope: Some(scope.clone()),
                 turn_id: "panic-turn-id".to_string(),
                 recoverable_batch: Some(batch),
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -9931,6 +10060,7 @@ mod error_outcome_emission_tests {
                     scope: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
+                    lifecycle_event_ids: Vec::new(),
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
@@ -10028,6 +10158,7 @@ mod error_outcome_emission_tests {
                     scope: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
+                    lifecycle_event_ids: Vec::new(),
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
@@ -10136,6 +10267,7 @@ mod error_outcome_emission_tests {
                     scope: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
+                    lifecycle_event_ids: Vec::new(),
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
@@ -10214,6 +10346,7 @@ mod error_outcome_emission_tests {
                 scope: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -10311,6 +10444,7 @@ mod error_outcome_emission_tests {
                 scope: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -10431,6 +10565,7 @@ mod error_outcome_emission_tests {
                 scope: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -10573,6 +10708,7 @@ mod error_outcome_emission_tests {
                 scope: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -10706,6 +10842,7 @@ mod error_outcome_emission_tests {
                 scope: Some(session_scope.clone()),
                 turn_id: "indeterminate-project".into(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -10861,6 +10998,7 @@ mod error_outcome_emission_tests {
                 scope: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -10949,6 +11087,7 @@ mod error_outcome_emission_tests {
                 scope: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -69,6 +69,10 @@ pub struct TaskMeta {
     pub turn_id: String,
     /// Clone of batch for Queue mode panic recovery.
     pub recoverable_batch: Option<FlushBatch>,
+    /// Lifecycle event IDs delivered by this prompt. Kept independently from
+    /// `recoverable_batch` because drop-mode prompts are not panic-requeued but
+    /// still need durable completion acknowledgement after success.
+    pub lifecycle_event_ids: Vec<String>,
     /// Control signal for the in-flight prompt task.
     /// `None` for heartbeat tasks (not controllable) and after signal is consumed.
     pub control_tx: Option<tokio::sync::oneshot::Sender<ControlSignal>>,
@@ -7506,6 +7510,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
                 scope: Some(busy_scope),
                 turn_id: "t".into(),
                 recoverable_batch: None,
+                lifecycle_event_ids: Vec::new(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),

--- a/crates/buzz-acp/src/project_lifecycle.rs
+++ b/crates/buzz-acp/src/project_lifecycle.rs
@@ -944,7 +944,7 @@ pub fn prompt_guidance(event: &Event, prompt_tag: &str) -> Option<String> {
          Pull request: {pull_request_id}\n\
          Repository: {repository}\n\
          Merge commit: {merge_commit}\n\
-         Instruction: This is a verified lifecycle wakeup for a pull request you authored, not a new human request. Resume ownership of the work now that it has merged: inspect the pull request context and perform any useful post-merge follow-up. Do not post a generic acknowledgement; send a channel/thread update only when there is concrete follow-up or information worth sharing."
+         Instruction: This is a verified lifecycle wakeup for a pull request you authored, not a new human request. Resume ownership of the work now that it has merged: inspect the pull request context and perform any useful post-merge follow-up. Do not post a generic acknowledgement. The merged-status event is global and cannot be a channel-message reply parent; post at channel level, or reply to an original channel message only if you can identify one. Send an update only when there is concrete follow-up or information worth sharing."
     ))
 }
 

--- a/crates/buzz-acp/src/project_lifecycle.rs
+++ b/crates/buzz-acp/src/project_lifecycle.rs
@@ -1,0 +1,952 @@
+//! Event-driven project lifecycle wakeups for ACP agents.
+//!
+//! A merged NIP-34 status event is global, while ACP sessions are channel
+//! scoped. This module resolves the status event's root pull request, validates
+//! that the current agent authored it, and recovers the originating channel
+//! from the pull request's signed `h` tag. Only then does it emit a routed
+//! [`BuzzEvent`](crate::relay::BuzzEvent) for normal ACP admission and queueing.
+//!
+//! Delivery state is stored as encrypted NIP-78 application data. A merge is
+//! added to `pending` before it is handed to the queue and moved to `completed`
+//! only after the ACP turn succeeds (or normal admission deliberately ignores
+//! it). This makes reconnect/restart recovery at-least-once without polling.
+
+use std::collections::{HashSet, VecDeque};
+use std::time::Duration;
+
+use buzz_core::kind::{KIND_GIT_PULL_REQUEST, KIND_GIT_STATUS_MERGED, KIND_READ_STATE};
+use nostr::nips::nip44::{self, Version};
+use nostr::{Event, EventBuilder, EventId, JsonUtil, Keys, Kind, PublicKey, Tag, Timestamp};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use crate::relay::{BuzzEvent, RelayError, RestClient};
+
+/// Prompt type attached only after a merge event passes lifecycle validation.
+pub const PROMPT_TAG: &str = "pull-request-merged";
+
+const LEDGER_D_TAG: &str = "buzz-acp:project-lifecycle:v1";
+const LEDGER_VERSION: u8 = 1;
+const MAX_PENDING: usize = 32;
+const MAX_COMPLETED: usize = 128;
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(300);
+const OUTPUT_CAPACITY: usize = 64;
+const COMPLETION_CAPACITY: usize = 64;
+
+/// A successfully validated merge routed to the pull request's source channel.
+#[derive(Debug)]
+pub struct MergeWakeup {
+    /// Routed status event. Its `channel_id` comes from the signed root PR.
+    pub buzz_event: BuzzEvent,
+}
+
+/// Events emitted by the addressed-event processor.
+#[derive(Debug)]
+pub enum AddressedEvent {
+    /// An observer frame, unchanged; the existing observer authorization path
+    /// still decides whether it is actionable.
+    ObserverControl(Event),
+    /// A validated and durably-pending pull-request merge.
+    Merge(MergeWakeup),
+}
+
+/// Final disposition reported by normal ACP admission/processing.
+#[derive(Debug, Clone, Copy)]
+pub enum Disposition {
+    /// The ACP turn completed successfully.
+    Completed,
+    /// Normal policy deliberately ignored the wakeup (for example, the agent
+    /// is no longer subscribed to the originating channel).
+    Ignored,
+}
+
+#[derive(Debug)]
+struct Completion {
+    event_ids: Vec<String>,
+    disposition: Disposition,
+}
+
+/// Cloneable completion handle retained by the ACP main loop.
+#[derive(Clone)]
+pub struct LifecycleHandle {
+    completion_tx: mpsc::Sender<Completion>,
+}
+
+impl LifecycleHandle {
+    /// Mark lifecycle event IDs complete after their ACP turn succeeds.
+    ///
+    /// A full/closed channel is returned as an error instead of silently losing
+    /// the completion. The encrypted `pending` record remains durable, so a
+    /// process restart will retry the wakeup.
+    pub fn complete(&self, event_ids: Vec<String>) -> Result<(), LifecycleError> {
+        self.send_disposition(event_ids, Disposition::Completed)
+    }
+
+    /// Mark a wakeup deliberately ignored by normal admission policy.
+    pub fn ignore(&self, event_id: String) -> Result<(), LifecycleError> {
+        self.ignore_many(vec![event_id])
+    }
+
+    /// Mark event IDs deliberately removed by normal queue/channel policy.
+    /// Ordinary event IDs are harmless: the manager only completes IDs present
+    /// in its lifecycle `pending` set.
+    pub fn ignore_many(&self, event_ids: Vec<String>) -> Result<(), LifecycleError> {
+        self.send_disposition(event_ids, Disposition::Ignored)
+    }
+
+    fn send_disposition(
+        &self,
+        event_ids: Vec<String>,
+        disposition: Disposition,
+    ) -> Result<(), LifecycleError> {
+        if event_ids.is_empty() {
+            return Ok(());
+        }
+        self.completion_tx
+            .try_send(Completion {
+                event_ids,
+                disposition,
+            })
+            .map_err(|error| LifecycleError::CompletionChannel(error.to_string()))
+    }
+}
+
+/// Lifecycle validation or persistence failure.
+#[derive(Debug, Error)]
+pub enum LifecycleError {
+    /// Relay HTTP bridge failure.
+    #[error(transparent)]
+    Relay(#[from] RelayError),
+    /// Encrypted lifecycle state could not be decoded.
+    #[error("invalid project lifecycle ledger: {0}")]
+    Ledger(String),
+    /// A completion could not be handed to the lifecycle manager.
+    #[error("project lifecycle completion channel unavailable: {0}")]
+    CompletionChannel(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct PendingEntry {
+    event_id: String,
+    semantic_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct CompletedEntry {
+    event_id: String,
+    semantic_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Ledger {
+    version: u8,
+    pending: Vec<PendingEntry>,
+    completed: Vec<CompletedEntry>,
+}
+
+impl Default for Ledger {
+    fn default() -> Self {
+        Self {
+            version: LEDGER_VERSION,
+            pending: Vec::new(),
+            completed: Vec::new(),
+        }
+    }
+}
+
+impl Ledger {
+    fn validate(&self) -> Result<(), LifecycleError> {
+        if self.version != LEDGER_VERSION {
+            return Err(LifecycleError::Ledger(format!(
+                "unsupported version {}",
+                self.version
+            )));
+        }
+        if self.pending.len() > MAX_PENDING || self.completed.len() > MAX_COMPLETED {
+            return Err(LifecycleError::Ledger("entry bound exceeded".into()));
+        }
+        let mut event_ids = HashSet::new();
+        let mut semantic_keys = HashSet::new();
+        for entry in self
+            .pending
+            .iter()
+            .map(|entry| (&entry.event_id, &entry.semantic_key))
+            .chain(
+                self.completed
+                    .iter()
+                    .map(|entry| (&entry.event_id, &entry.semantic_key)),
+            )
+        {
+            validate_hex(entry.0, 64, "ledger event id")?;
+            validate_hex(entry.1, 64, "ledger semantic key")?;
+            if !event_ids.insert(entry.0) {
+                return Err(LifecycleError::Ledger("duplicate event id".into()));
+            }
+            if !semantic_keys.insert(entry.1) {
+                return Err(LifecycleError::Ledger("duplicate semantic key".into()));
+            }
+        }
+        Ok(())
+    }
+
+    fn contains_event(&self, event_id: &str) -> bool {
+        self.pending.iter().any(|entry| entry.event_id == event_id)
+            || self
+                .completed
+                .iter()
+                .any(|entry| entry.event_id == event_id)
+    }
+
+    fn contains_semantic(&self, semantic_key: &str) -> bool {
+        self.pending
+            .iter()
+            .any(|entry| entry.semantic_key == semantic_key)
+            || self
+                .completed
+                .iter()
+                .any(|entry| entry.semantic_key == semantic_key)
+    }
+
+    fn add_pending(&mut self, event_id: String, semantic_key: String) -> bool {
+        if self.contains_event(&event_id) || self.contains_semantic(&semantic_key) {
+            return false;
+        }
+        if self.pending.len() >= MAX_PENDING {
+            return false;
+        }
+        self.pending.push(PendingEntry {
+            event_id,
+            semantic_key,
+        });
+        true
+    }
+
+    fn complete(&mut self, event_id: &str) -> bool {
+        let Some(index) = self
+            .pending
+            .iter()
+            .position(|entry| entry.event_id == event_id)
+        else {
+            return false;
+        };
+        let entry = self.pending.remove(index);
+        self.completed.push(CompletedEntry {
+            event_id: entry.event_id,
+            semantic_key: entry.semantic_key,
+        });
+        if self.completed.len() > MAX_COMPLETED {
+            let overflow = self.completed.len() - MAX_COMPLETED;
+            self.completed.drain(..overflow);
+        }
+        true
+    }
+}
+
+#[derive(Debug)]
+struct RetryWork {
+    event_id: String,
+    event: Option<Event>,
+    expected_semantic_key: Option<String>,
+    attempts: u32,
+    retry_at: tokio::time::Instant,
+}
+
+impl RetryWork {
+    fn live(event: Event) -> Self {
+        Self {
+            event_id: event.id.to_hex(),
+            event: Some(event),
+            expected_semantic_key: None,
+            attempts: 0,
+            retry_at: tokio::time::Instant::now(),
+        }
+    }
+
+    fn recovered(entry: &PendingEntry) -> Self {
+        Self {
+            event_id: entry.event_id.clone(),
+            event: None,
+            expected_semantic_key: Some(entry.semantic_key.clone()),
+            attempts: 0,
+            retry_at: tokio::time::Instant::now(),
+        }
+    }
+
+    fn defer(&mut self) {
+        self.attempts = self.attempts.saturating_add(1);
+        self.retry_at = tokio::time::Instant::now() + retry_delay(self.attempts);
+    }
+}
+
+struct Manager {
+    keys: Keys,
+    rest: RestClient,
+    ledger: Ledger,
+    ledger_created_at: u64,
+    dispatched: HashSet<String>,
+    work: VecDeque<RetryWork>,
+    pending_completions: VecDeque<Completion>,
+    completion_retry_at: tokio::time::Instant,
+    completion_retry_attempts: u32,
+    addressed_rx: mpsc::Receiver<Event>,
+    output_tx: mpsc::Sender<AddressedEvent>,
+    completion_rx: mpsc::Receiver<Completion>,
+}
+
+/// Start the lifecycle manager over the relay's global addressed-event stream.
+///
+/// Loading the encrypted ledger is a startup boundary: corrupt or unavailable
+/// state fails closed rather than risking duplicate model turns. Once started,
+/// transient resolution/persistence failures remain in a bounded retry queue
+/// with capped exponential backoff.
+pub async fn start(
+    keys: Keys,
+    rest: RestClient,
+    addressed_rx: mpsc::Receiver<Event>,
+) -> Result<
+    (
+        LifecycleHandle,
+        mpsc::Receiver<AddressedEvent>,
+        tokio::task::JoinHandle<()>,
+    ),
+    LifecycleError,
+> {
+    let (ledger, ledger_created_at) = load_ledger(&rest, &keys).await?;
+    let mut work = VecDeque::with_capacity(ledger.pending.len());
+    for pending in &ledger.pending {
+        work.push_back(RetryWork::recovered(pending));
+    }
+
+    let (output_tx, output_rx) = mpsc::channel(OUTPUT_CAPACITY);
+    let (completion_tx, completion_rx) = mpsc::channel(COMPLETION_CAPACITY);
+    let handle = LifecycleHandle { completion_tx };
+    let mut manager = Manager {
+        keys,
+        rest,
+        ledger,
+        ledger_created_at,
+        dispatched: HashSet::new(),
+        work,
+        pending_completions: VecDeque::new(),
+        completion_retry_at: tokio::time::Instant::now(),
+        completion_retry_attempts: 0,
+        addressed_rx,
+        output_tx,
+        completion_rx,
+    };
+    let task = tokio::spawn(async move { manager.run().await });
+    Ok((handle, output_rx, task))
+}
+
+impl Manager {
+    async fn run(&mut self) {
+        loop {
+            let retry_at = self.next_retry_at();
+            tokio::select! {
+                biased;
+                completion = self.completion_rx.recv() => {
+                    match completion {
+                        Some(completion) => self.pending_completions.push_back(completion),
+                        None => {
+                            warn!("project lifecycle completion channel closed");
+                            return;
+                        }
+                    }
+                }
+                _ = async move {
+                    match retry_at {
+                        Some(retry_at) => tokio::time::sleep_until(retry_at).await,
+                        None => std::future::pending().await,
+                    }
+                } => {}
+                event = self.addressed_rx.recv(), if self.ledger.pending.len() + self.work.len() < MAX_PENDING => {
+                    match event {
+                        Some(event) if is_merge_status(&event) => self.accept_raw_merge(event),
+                        Some(event) => {
+                            if self.output_tx.send(AddressedEvent::ObserverControl(event)).await.is_err() {
+                                warn!("project lifecycle output channel closed");
+                                return;
+                            }
+                        }
+                        None => {
+                            warn!("addressed relay event channel closed");
+                            return;
+                        }
+                    }
+                }
+            }
+
+            self.flush_one_completion().await;
+            if !self.process_one_work_item().await {
+                return;
+            }
+        }
+    }
+
+    fn next_retry_at(&self) -> Option<tokio::time::Instant> {
+        let work_retry = self.work.iter().map(|work| work.retry_at).min();
+        let completion_retry =
+            (!self.pending_completions.is_empty()).then_some(self.completion_retry_at);
+        match (work_retry, completion_retry) {
+            (Some(work), Some(completion)) => Some(work.min(completion)),
+            (Some(work), None) => Some(work),
+            (None, Some(completion)) => Some(completion),
+            (None, None) => None,
+        }
+    }
+
+    fn accept_raw_merge(&mut self, event: Event) {
+        let event_id = event.id.to_hex();
+        if self.ledger.contains_event(&event_id)
+            || self.dispatched.contains(&event_id)
+            || self.work.iter().any(|work| work.event_id == event_id)
+        {
+            debug!(event_id, "duplicate project lifecycle event suppressed");
+            return;
+        }
+        self.work.push_back(RetryWork::live(event));
+    }
+
+    async fn flush_one_completion(&mut self) {
+        if self.completion_retry_at > tokio::time::Instant::now() {
+            return;
+        }
+        let Some(completion) = self.pending_completions.pop_front() else {
+            return;
+        };
+        let mut next = self.ledger.clone();
+        let mut changed = false;
+        for event_id in &completion.event_ids {
+            changed |= next.complete(event_id);
+        }
+        if !changed {
+            return;
+        }
+        match persist_ledger(&self.rest, &self.keys, &next, self.ledger_created_at).await {
+            Ok(created_at) => {
+                for event_id in &completion.event_ids {
+                    self.dispatched.remove(event_id);
+                }
+                self.ledger = next;
+                self.ledger_created_at = created_at;
+                self.completion_retry_attempts = 0;
+                self.completion_retry_at = tokio::time::Instant::now();
+                info!(
+                    disposition = ?completion.disposition,
+                    events = completion.event_ids.len(),
+                    "persisted project lifecycle completion"
+                );
+            }
+            Err(error) => {
+                self.completion_retry_attempts = self.completion_retry_attempts.saturating_add(1);
+                self.completion_retry_at =
+                    tokio::time::Instant::now() + retry_delay(self.completion_retry_attempts);
+                warn!(
+                    %error,
+                    attempts = self.completion_retry_attempts,
+                    "failed to persist project lifecycle completion — will retry"
+                );
+                self.pending_completions.push_front(completion);
+            }
+        }
+    }
+
+    async fn process_one_work_item(&mut self) -> bool {
+        let Some(index) = self
+            .work
+            .iter()
+            .position(|work| work.retry_at <= tokio::time::Instant::now())
+        else {
+            return true;
+        };
+        let Some(mut work) = self.work.remove(index) else {
+            return true;
+        };
+
+        let event = match work.event.take() {
+            Some(event) => event,
+            None => {
+                match fetch_event_by_id(&self.rest, &work.event_id, KIND_GIT_STATUS_MERGED).await {
+                    Ok(event) => event,
+                    Err(error) => {
+                        warn!(event_id = %work.event_id, %error, "failed to recover pending merge status — will retry");
+                        work.defer();
+                        self.work.push_back(work);
+                        return true;
+                    }
+                }
+            }
+        };
+
+        let resolved = match resolve_merge(&event, &self.rest, &self.keys.public_key()).await {
+            Ok(resolved) => resolved,
+            Err(ResolveFailure::Invalid(reason)) if work.expected_semantic_key.is_none() => {
+                warn!(event_id = %work.event_id, %reason, "rejected project lifecycle event");
+                return true;
+            }
+            Err(error) => {
+                warn!(event_id = %work.event_id, %error, "project lifecycle resolution failed — will retry");
+                work.event = Some(event);
+                work.defer();
+                self.work.push_back(work);
+                return true;
+            }
+        };
+
+        if let Some(expected) = &work.expected_semantic_key {
+            if expected != &resolved.semantic_key {
+                error!(
+                    event_id = %work.event_id,
+                    "recovered project lifecycle event changed semantic identity — retaining pending record"
+                );
+                work.event = Some(event);
+                work.defer();
+                self.work.push_back(work);
+                return true;
+            }
+        } else {
+            if self.ledger.contains_semantic(&resolved.semantic_key) {
+                debug!(event_id = %work.event_id, "semantic duplicate merge suppressed");
+                return true;
+            }
+            let mut next = self.ledger.clone();
+            if !next.add_pending(work.event_id.clone(), resolved.semantic_key.clone()) {
+                warn!(event_id = %work.event_id, "project lifecycle pending ledger full — will retry");
+                work.event = Some(event);
+                work.defer();
+                self.work.push_back(work);
+                return true;
+            }
+            match persist_ledger(&self.rest, &self.keys, &next, self.ledger_created_at).await {
+                Ok(created_at) => {
+                    self.ledger = next;
+                    self.ledger_created_at = created_at;
+                }
+                Err(error) => {
+                    warn!(event_id = %work.event_id, %error, "failed to persist pending merge — will retry");
+                    work.event = Some(event);
+                    work.defer();
+                    self.work.push_back(work);
+                    return true;
+                }
+            }
+        }
+
+        let event_id = work.event_id;
+        self.dispatched.insert(event_id.clone());
+        if self
+            .output_tx
+            .send(AddressedEvent::Merge(MergeWakeup {
+                buzz_event: BuzzEvent {
+                    connection_generation: 0,
+                    channel_id: resolved.channel_id,
+                    event,
+                },
+            }))
+            .await
+            .is_err()
+        {
+            warn!(
+                event_id,
+                "project lifecycle output channel closed; pending record retained"
+            );
+            return false;
+        }
+        true
+    }
+}
+
+#[derive(Debug)]
+struct ResolvedMerge {
+    channel_id: Uuid,
+    semantic_key: String,
+}
+
+#[derive(Debug, Error)]
+enum ResolveFailure {
+    #[error("{0}")]
+    Invalid(String),
+    #[error(transparent)]
+    Relay(#[from] RelayError),
+}
+
+async fn resolve_merge(
+    status: &Event,
+    rest: &RestClient,
+    agent_pubkey: &PublicKey,
+) -> Result<ResolvedMerge, ResolveFailure> {
+    let status_meta = validate_status(status, agent_pubkey).map_err(ResolveFailure::Invalid)?;
+    let pull_request = fetch_event_by_id(rest, &status_meta.pull_request_id, KIND_GIT_PULL_REQUEST)
+        .await
+        .map_err(ResolveFailure::Relay)?;
+    validate_pull_request(&pull_request, status, &status_meta, agent_pubkey)
+        .map_err(ResolveFailure::Invalid)
+}
+
+#[derive(Debug)]
+struct StatusMeta {
+    pull_request_id: String,
+    repository: String,
+    repository_owner: String,
+    merge_commit: String,
+}
+
+fn validate_status(status: &Event, agent_pubkey: &PublicKey) -> Result<StatusMeta, String> {
+    if !is_merge_status(status) {
+        return Err("wrong event kind".into());
+    }
+    if !status.content.is_empty() {
+        return Err("merged status content must be empty".into());
+    }
+    let pull_request_id = single_root_event_id(status)?;
+    let repository = single_tag_value(status, "a")?;
+    let repository_owner = parse_repo_owner(&repository)?;
+    if status.pubkey.to_hex() != repository_owner {
+        return Err("merged status is not signed by the repository owner".into());
+    }
+    let merge_commit = single_tag_value(status, "merge-commit")?;
+    validate_commit(&merge_commit)?;
+    if !tag_values(status, "r").any(|value| value == merge_commit) {
+        return Err("merged status lacks matching r tag".into());
+    }
+    let agent_hex = agent_pubkey.to_hex();
+    let recipients: HashSet<&str> = tag_values(status, "p").collect();
+    if !recipients.contains(agent_hex.as_str()) {
+        return Err("merged status is not addressed to this agent".into());
+    }
+    Ok(StatusMeta {
+        pull_request_id,
+        repository,
+        repository_owner,
+        merge_commit,
+    })
+}
+
+fn validate_pull_request(
+    pull_request: &Event,
+    status: &Event,
+    status_meta: &StatusMeta,
+    agent_pubkey: &PublicKey,
+) -> Result<ResolvedMerge, String> {
+    if pull_request.id.to_hex() != status_meta.pull_request_id {
+        return Err("root pull request ID mismatch".into());
+    }
+    if pull_request.kind.as_u16() as u32 != KIND_GIT_PULL_REQUEST {
+        return Err("root event is not a pull request".into());
+    }
+    if &pull_request.pubkey != agent_pubkey {
+        return Err("root pull request was not authored by this agent".into());
+    }
+    if pull_request.created_at > status.created_at {
+        return Err("merged status predates its pull request".into());
+    }
+    if single_tag_value(pull_request, "a")? != status_meta.repository {
+        return Err("pull request repository does not match merged status".into());
+    }
+    if pull_request.pubkey.to_hex() != status_meta.repository_owner
+        && !tag_values(pull_request, "p").any(|value| value == status_meta.repository_owner)
+    {
+        return Err("pull request does not address the repository owner".into());
+    }
+    let channel = single_tag_value(pull_request, "h")?;
+    let channel_id = Uuid::parse_str(&channel)
+        .map_err(|_| "pull request h tag is not a canonical channel UUID".to_string())?;
+    if channel_id.to_string() != channel {
+        return Err("pull request h tag is not canonical".into());
+    }
+    let commit = single_tag_value(pull_request, "c")?;
+    validate_commit(&commit)?;
+
+    Ok(ResolvedMerge {
+        channel_id,
+        semantic_key: semantic_key(
+            &status_meta.repository,
+            &status_meta.pull_request_id,
+            &status_meta.merge_commit,
+        ),
+    })
+}
+
+fn is_merge_status(event: &Event) -> bool {
+    event.kind.as_u16() as u32 == KIND_GIT_STATUS_MERGED
+}
+
+fn single_root_event_id(event: &Event) -> Result<String, String> {
+    let roots: Vec<&str> = event
+        .tags
+        .iter()
+        .filter_map(|tag| {
+            let fields = tag.as_slice();
+            (fields.first().map(String::as_str) == Some("e")
+                && fields.get(3).map(String::as_str) == Some("root"))
+            .then(|| fields.get(1).map(String::as_str))
+            .flatten()
+        })
+        .collect();
+    if roots.len() != 1 {
+        return Err("merged status must have exactly one root e tag".into());
+    }
+    validate_lower_hex(roots[0], 64, "pull request event id")?;
+    Ok(roots[0].to_string())
+}
+
+fn single_tag_value(event: &Event, name: &str) -> Result<String, String> {
+    let values: Vec<&str> = tag_values(event, name).collect();
+    if values.len() != 1 {
+        return Err(format!("expected exactly one {name} tag"));
+    }
+    Ok(values[0].to_string())
+}
+
+fn tag_values<'a>(event: &'a Event, name: &'a str) -> impl Iterator<Item = &'a str> {
+    event.tags.iter().filter_map(move |tag| {
+        let fields = tag.as_slice();
+        (fields.first().map(String::as_str) == Some(name))
+            .then(|| fields.get(1).map(String::as_str))
+            .flatten()
+    })
+}
+
+fn parse_repo_owner(repository: &str) -> Result<String, String> {
+    let mut parts = repository.splitn(3, ':');
+    if parts.next() != Some("30617") {
+        return Err("repository coordinate must start with 30617".into());
+    }
+    let owner = parts
+        .next()
+        .ok_or_else(|| "repository coordinate lacks owner".to_string())?;
+    validate_lower_hex(owner, 64, "repository owner")?;
+    PublicKey::from_hex(owner).map_err(|_| "repository owner is not a valid pubkey".to_string())?;
+    let identifier = parts
+        .next()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "repository coordinate lacks identifier".to_string())?;
+    if identifier.chars().any(char::is_control) {
+        return Err("repository identifier contains control characters".into());
+    }
+    Ok(owner.to_string())
+}
+
+fn validate_commit(value: &str) -> Result<(), String> {
+    if value.len() != 40 && value.len() != 64 {
+        return Err("merge commit must be a full SHA-1 or SHA-256 object ID".into());
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("merge commit must be lowercase hexadecimal".into());
+    }
+    Ok(())
+}
+
+fn validate_lower_hex(value: &str, length: usize, label: &str) -> Result<(), String> {
+    if value.len() != length
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(format!(
+            "{label} must be {length} lowercase hexadecimal characters"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_hex(value: &str, length: usize, label: &str) -> Result<(), LifecycleError> {
+    validate_lower_hex(value, length, label).map_err(LifecycleError::Ledger)
+}
+
+fn retry_delay(attempts: u32) -> Duration {
+    let exponent = attempts.saturating_sub(1).min(6);
+    let seconds = 5_u64.saturating_mul(1_u64 << exponent);
+    Duration::from_secs(seconds).min(MAX_RETRY_DELAY)
+}
+
+fn semantic_key(repository: &str, pull_request_id: &str, merge_commit: &str) -> String {
+    let mut hash = Sha256::new();
+    hash.update(repository.as_bytes());
+    hash.update([0]);
+    hash.update(pull_request_id.as_bytes());
+    hash.update([0]);
+    hash.update(merge_commit.as_bytes());
+    hex::encode(hash.finalize())
+}
+
+async fn fetch_event_by_id(
+    rest: &RestClient,
+    event_id: &str,
+    kind: u32,
+) -> Result<Event, RelayError> {
+    let event_id = EventId::from_hex(event_id)
+        .map_err(|error| RelayError::Http(format!("invalid event ID: {error}")))?;
+    let filter = nostr::Filter::new()
+        .kind(Kind::Custom(kind as u16))
+        .id(event_id)
+        .limit(2);
+    let response = rest.query(&[filter]).await?;
+    let events = response
+        .as_array()
+        .ok_or_else(|| RelayError::Http("event lookup response is not an array".into()))?;
+    if events.len() != 1 {
+        return Err(RelayError::Http(format!(
+            "event lookup returned {} events, expected exactly one",
+            events.len()
+        )));
+    }
+    let event = Event::from_json(events[0].to_string()).map_err(|error| {
+        RelayError::Http(format!("event lookup returned invalid event: {error}"))
+    })?;
+    buzz_core::verify_event(&event)
+        .map_err(|error| RelayError::Http(format!("event lookup signature invalid: {error}")))?;
+    Ok(event)
+}
+
+async fn load_ledger(rest: &RestClient, keys: &Keys) -> Result<(Ledger, u64), LifecycleError> {
+    use nostr::{Alphabet, SingleLetterTag};
+
+    let filter = nostr::Filter::new()
+        .kind(Kind::Custom(KIND_READ_STATE as u16))
+        .author(keys.public_key())
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [LEDGER_D_TAG])
+        .limit(2);
+    let response = rest.query(&[filter]).await?;
+    let values = response
+        .as_array()
+        .ok_or_else(|| LifecycleError::Ledger("query response is not an array".into()))?;
+    if values.is_empty() {
+        return Ok((Ledger::default(), 0));
+    }
+
+    let mut events = Vec::with_capacity(values.len());
+    for value in values {
+        let event = Event::from_json(value.to_string())
+            .map_err(|error| LifecycleError::Ledger(format!("invalid event JSON: {error}")))?;
+        buzz_core::verify_event(&event)
+            .map_err(|error| LifecycleError::Ledger(format!("invalid event signature: {error}")))?;
+        if event.kind.as_u16() as u32 != KIND_READ_STATE
+            || event.pubkey != keys.public_key()
+            || single_tag_value(&event, "d").map_err(LifecycleError::Ledger)? != LEDGER_D_TAG
+        {
+            return Err(LifecycleError::Ledger(
+                "query returned an event outside the lifecycle ledger address".into(),
+            ));
+        }
+        events.push(event);
+    }
+    events.sort_by_key(|event| (event.created_at.as_secs(), event.id.to_hex()));
+    let event = events
+        .pop()
+        .ok_or_else(|| LifecycleError::Ledger("ledger event disappeared".into()))?;
+    let ledger = decode_ledger_event(&event, keys)?;
+    Ok((ledger, event.created_at.as_secs()))
+}
+
+fn decode_ledger_event(event: &Event, keys: &Keys) -> Result<Ledger, LifecycleError> {
+    buzz_core::verify_event(event)
+        .map_err(|error| LifecycleError::Ledger(format!("invalid event signature: {error}")))?;
+    if event.kind.as_u16() as u32 != KIND_READ_STATE
+        || event.pubkey != keys.public_key()
+        || single_tag_value(event, "d").map_err(LifecycleError::Ledger)? != LEDGER_D_TAG
+    {
+        return Err(LifecycleError::Ledger(
+            "event is outside the lifecycle ledger address".into(),
+        ));
+    }
+    let plaintext = nip44::decrypt(keys.secret_key(), &keys.public_key(), &event.content)
+        .map_err(|error| LifecycleError::Ledger(format!("decrypt failed: {error}")))?;
+    let ledger: Ledger = serde_json::from_str(&plaintext)
+        .map_err(|error| LifecycleError::Ledger(format!("JSON decode failed: {error}")))?;
+    ledger.validate()?;
+    Ok(ledger)
+}
+
+fn build_ledger_event(
+    keys: &Keys,
+    ledger: &Ledger,
+    previous_created_at: u64,
+) -> Result<(Event, u64), LifecycleError> {
+    ledger.validate()?;
+    let plaintext = serde_json::to_string(ledger)
+        .map_err(|error| LifecycleError::Ledger(format!("JSON encode failed: {error}")))?;
+    let ciphertext = nip44::encrypt(
+        keys.secret_key(),
+        &keys.public_key(),
+        plaintext,
+        Version::V2,
+    )
+    .map_err(|error| LifecycleError::Ledger(format!("encrypt failed: {error}")))?;
+    let created_at = Timestamp::now()
+        .as_secs()
+        .max(previous_created_at.saturating_add(1));
+    let d_tag = Tag::parse(["d", LEDGER_D_TAG])
+        .map_err(|error| LifecycleError::Ledger(format!("d tag failed: {error}")))?;
+    let event = EventBuilder::new(Kind::Custom(KIND_READ_STATE as u16), ciphertext)
+        .tag(d_tag)
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(keys)
+        .map_err(|error| LifecycleError::Ledger(format!("sign failed: {error}")))?;
+    Ok((event, created_at))
+}
+
+async fn persist_ledger(
+    rest: &RestClient,
+    keys: &Keys,
+    ledger: &Ledger,
+    previous_created_at: u64,
+) -> Result<u64, LifecycleError> {
+    let (event, created_at) = build_ledger_event(keys, ledger, previous_created_at)?;
+    let response = rest.submit_event(&event).await?;
+    if response
+        .get("accepted")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        return Err(LifecycleError::Ledger(format!(
+            "relay rejected ledger event: {}",
+            response
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown rejection")
+        )));
+    }
+    Ok(created_at)
+}
+
+/// Extract lifecycle event IDs from a dispatched batch.
+pub fn batch_event_ids(batch: &crate::queue::FlushBatch) -> Vec<String> {
+    batch
+        .cancelled_events
+        .iter()
+        .chain(batch.events.iter())
+        .filter(|event| event.prompt_tag == PROMPT_TAG)
+        .map(|event| event.event.id.to_hex())
+        .collect()
+}
+
+/// Render trusted lifecycle guidance for a validated merged-status event.
+pub fn prompt_guidance(event: &Event, prompt_tag: &str) -> Option<String> {
+    if prompt_tag != PROMPT_TAG || !is_merge_status(event) {
+        return None;
+    }
+    let pull_request_id = single_root_event_id(event).ok()?;
+    let repository = single_tag_value(event, "a").ok()?;
+    let merge_commit = single_tag_value(event, "merge-commit").ok()?;
+    Some(format!(
+        "Lifecycle: pull request merged successfully\n\
+         Pull request: {pull_request_id}\n\
+         Repository: {repository}\n\
+         Merge commit: {merge_commit}\n\
+         Instruction: This is a verified lifecycle wakeup for a pull request you authored, not a new human request. Resume ownership of the work now that it has merged: inspect the pull request context and perform any useful post-merge follow-up. Do not post a generic acknowledgement; send a channel/thread update only when there is concrete follow-up or information worth sharing."
+    ))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/buzz-acp/src/project_lifecycle/tests.rs
+++ b/crates/buzz-acp/src/project_lifecycle/tests.rs
@@ -1,0 +1,289 @@
+use super::*;
+
+fn signed_pr(agent: &Keys, owner: &Keys, channel: Uuid, created_at: u64) -> Event {
+    let repository = format!("30617:{}:buzz", owner.public_key().to_hex());
+    EventBuilder::new(Kind::Custom(KIND_GIT_PULL_REQUEST as u16), "ship it")
+        .tags([
+            Tag::parse(["a", repository.as_str()]).unwrap(),
+            Tag::parse(["p", owner.public_key().to_hex().as_str()]).unwrap(),
+            Tag::parse(["subject", "Lifecycle wakeup"]).unwrap(),
+            Tag::parse(["c", "a".repeat(40).as_str()]).unwrap(),
+            Tag::parse(["h", channel.to_string().as_str()]).unwrap(),
+            Tag::parse(["clone", "https://example.test/buzz.git"]).unwrap(),
+        ])
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(agent)
+        .unwrap()
+}
+
+fn signed_status(owner: &Keys, agent: &Keys, pr: &Event, created_at: u64) -> Event {
+    let repository = format!("30617:{}:buzz", owner.public_key().to_hex());
+    let pr_id = pr.id.to_hex();
+    let merge = "b".repeat(40);
+    EventBuilder::new(Kind::Custom(KIND_GIT_STATUS_MERGED as u16), "")
+        .tags([
+            Tag::parse(["e", pr_id.as_str(), "", "root"]).unwrap(),
+            Tag::parse(["a", repository.as_str()]).unwrap(),
+            Tag::parse(["p", owner.public_key().to_hex().as_str()]).unwrap(),
+            Tag::parse(["p", agent.public_key().to_hex().as_str()]).unwrap(),
+            Tag::parse(["merge-commit", merge.as_str()]).unwrap(),
+            Tag::parse(["r", merge.as_str()]).unwrap(),
+        ])
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(owner)
+        .unwrap()
+}
+
+async fn lifecycle_test_server(
+    pull_request: Event,
+) -> (
+    RestClient,
+    mpsc::Receiver<(String, serde_json::Value)>,
+    tokio::task::JoinHandle<()>,
+) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let keys = Keys::generate();
+    let client = RestClient {
+        http: reqwest::Client::builder().build().unwrap(),
+        base_url,
+        keys,
+        auth_tag_json: None,
+    };
+    let (request_tx, request_rx) = mpsc::channel(8);
+    let server = tokio::spawn(async move {
+        for _ in 0..4 {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            let header_end;
+            let content_length;
+            loop {
+                let read = socket.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "request closed before headers");
+                request.extend_from_slice(&chunk[..read]);
+                assert!(request.len() <= 64 * 1024, "test request exceeded bound");
+                if let Some(end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                    header_end = end + 4;
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.strip_prefix("content-length: ")
+                                .or_else(|| line.strip_prefix("Content-Length: "))
+                        })
+                        .and_then(|value| value.trim().parse::<usize>().ok())
+                        .unwrap_or(0);
+                    break;
+                }
+            }
+            while request.len() < header_end + content_length {
+                let read = socket.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "request closed before body");
+                request.extend_from_slice(&chunk[..read]);
+                assert!(request.len() <= 64 * 1024, "test request exceeded bound");
+            }
+            let first_line = String::from_utf8_lossy(&request[..header_end])
+                .lines()
+                .next()
+                .unwrap()
+                .to_string();
+            let path = first_line.split_whitespace().nth(1).unwrap().to_string();
+            let body: serde_json::Value =
+                serde_json::from_slice(&request[header_end..header_end + content_length]).unwrap();
+            request_tx.send((path.clone(), body.clone())).await.unwrap();
+
+            let response_body = if path == "/query"
+                && body[0]["kinds"] == serde_json::json!([KIND_GIT_PULL_REQUEST])
+            {
+                serde_json::to_string(&vec![&pull_request]).unwrap()
+            } else if path == "/query" {
+                "[]".to_string()
+            } else {
+                serde_json::json!({
+                    "event_id": "a".repeat(64),
+                    "accepted": true,
+                    "message": "stored"
+                })
+                .to_string()
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    (client, request_rx, server)
+}
+
+#[tokio::test]
+async fn manager_binds_resolution_persistence_routing_and_completion_seams() {
+    let agent = Keys::generate();
+    let owner = Keys::generate();
+    let channel = Uuid::new_v4();
+    let pull_request = signed_pr(&agent, &owner, channel, 10);
+    let status = signed_status(&owner, &agent, &pull_request, 20);
+    let status_id = status.id.to_hex();
+    let (mut rest, mut requests, server) = lifecycle_test_server(pull_request).await;
+    rest.keys = agent.clone();
+    let (addressed_tx, addressed_rx) = mpsc::channel(4);
+    let (handle, mut output_rx, manager) = start(agent, rest, addressed_rx).await.unwrap();
+
+    addressed_tx.send(status).await.unwrap();
+    let output = tokio::time::timeout(Duration::from_secs(2), output_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let AddressedEvent::Merge(wakeup) = output else {
+        panic!("expected merge wakeup");
+    };
+    assert_eq!(wakeup.buzz_event.channel_id, channel);
+    assert_eq!(wakeup.buzz_event.event.id.to_hex(), status_id);
+    handle.ignore(status_id).unwrap();
+
+    let mut recorded = Vec::new();
+    for _ in 0..4 {
+        recorded.push(
+            tokio::time::timeout(Duration::from_secs(2), requests.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+        );
+    }
+    assert_eq!(recorded[0].0, "/query");
+    assert_eq!(
+        recorded[0].1[0]["kinds"],
+        serde_json::json!([KIND_READ_STATE])
+    );
+    assert_eq!(
+        recorded[1].1[0]["kinds"],
+        serde_json::json!([KIND_GIT_PULL_REQUEST])
+    );
+    assert_eq!(recorded[2].0, "/events");
+    assert_eq!(recorded[2].1["kind"], KIND_READ_STATE);
+    assert_eq!(recorded[3].0, "/events");
+    assert_eq!(recorded[3].1["kind"], KIND_READ_STATE);
+
+    manager.abort();
+    server.await.unwrap();
+}
+
+#[test]
+fn production_validators_route_only_agent_authored_pr() {
+    let agent = Keys::generate();
+    let owner = Keys::generate();
+    let channel = Uuid::new_v4();
+    let pr = signed_pr(&agent, &owner, channel, 10);
+    let status = signed_status(&owner, &agent, &pr, 20);
+    let meta = validate_status(&status, &agent.public_key()).unwrap();
+    let resolved = validate_pull_request(&pr, &status, &meta, &agent.public_key()).unwrap();
+    assert_eq!(resolved.channel_id, channel);
+
+    let other_agent = Keys::generate();
+    assert!(validate_pull_request(&pr, &status, &meta, &other_agent.public_key()).is_err());
+}
+
+#[test]
+fn status_signer_must_be_repository_owner() {
+    let agent = Keys::generate();
+    let owner = Keys::generate();
+    let impostor = Keys::generate();
+    let pr = signed_pr(&agent, &owner, Uuid::new_v4(), 10);
+    let repository = format!("30617:{}:buzz", owner.public_key().to_hex());
+    let pr_id = pr.id.to_hex();
+    let merge = "b".repeat(40);
+    let status = EventBuilder::new(Kind::Custom(KIND_GIT_STATUS_MERGED as u16), "")
+        .tags([
+            Tag::parse(["e", pr_id.as_str(), "", "root"]).unwrap(),
+            Tag::parse(["a", repository.as_str()]).unwrap(),
+            Tag::parse(["p", owner.public_key().to_hex().as_str()]).unwrap(),
+            Tag::parse(["p", agent.public_key().to_hex().as_str()]).unwrap(),
+            Tag::parse(["merge-commit", merge.as_str()]).unwrap(),
+            Tag::parse(["r", merge.as_str()]).unwrap(),
+        ])
+        .custom_created_at(Timestamp::from(20))
+        .sign_with_keys(&impostor)
+        .unwrap();
+    assert!(validate_status(&status, &agent.public_key()).is_err());
+}
+
+#[test]
+fn semantic_dedup_survives_distinct_status_event_ids() {
+    let key = semantic_key(
+        &format!("30617:{}:buzz", "a".repeat(64)),
+        &"b".repeat(64),
+        &"c".repeat(40),
+    );
+    let mut ledger = Ledger::default();
+    assert!(ledger.add_pending("d".repeat(64), key.clone()));
+    assert!(!ledger.add_pending("e".repeat(64), key));
+    assert!(ledger.complete(&"d".repeat(64)));
+    ledger.validate().unwrap();
+}
+
+#[test]
+fn lifecycle_ledger_round_trips_through_signed_self_encrypted_event() {
+    let keys = Keys::generate();
+    let mut ledger = Ledger::default();
+    assert!(ledger.add_pending("d".repeat(64), "e".repeat(64)));
+    let (event, created_at) = build_ledger_event(&keys, &ledger, 42).unwrap();
+    assert!(created_at >= 43);
+    assert_ne!(event.content, serde_json::to_string(&ledger).unwrap());
+    assert_eq!(decode_ledger_event(&event, &keys).unwrap(), ledger);
+}
+
+#[test]
+fn dispatched_batch_tracks_lifecycle_ids_across_cancel_merge_framing() {
+    let agent = Keys::generate();
+    let owner = Keys::generate();
+    let channel = Uuid::new_v4();
+    let pr = signed_pr(&agent, &owner, channel, 10);
+    let status = signed_status(&owner, &agent, &pr, 20);
+    let lifecycle_id = status.id.to_hex();
+    let lifecycle = crate::queue::BatchEvent {
+        event: status,
+        prompt_tag: PROMPT_TAG.into(),
+        received_at: std::time::Instant::now(),
+    };
+    let ordinary = crate::queue::BatchEvent {
+        event: signed_pr(&agent, &owner, channel, 30),
+        prompt_tag: "all".into(),
+        received_at: std::time::Instant::now(),
+    };
+    let batch = crate::queue::FlushBatch {
+        channel_id: channel,
+        scope: crate::scope::SessionScope::Conversation {
+            channel_id: channel,
+        },
+        events: vec![ordinary],
+        cancelled_events: vec![lifecycle],
+        cancel_reason: Some(crate::queue::CancelReason::Steer),
+    };
+    assert_eq!(batch_event_ids(&batch), vec![lifecycle_id]);
+}
+
+#[test]
+fn production_prompt_formatter_is_bound_to_validated_prompt_tag() {
+    let agent = Keys::generate();
+    let owner = Keys::generate();
+    let channel = Uuid::new_v4();
+    let pr = signed_pr(&agent, &owner, channel, 10);
+    let status = signed_status(&owner, &agent, &pr, 20);
+    let mut batch_event = crate::queue::BatchEvent {
+        event: status,
+        prompt_tag: "all".into(),
+        received_at: std::time::Instant::now(),
+    };
+    let ordinary = crate::queue::format_event_block(channel, None, &batch_event, None);
+    assert!(!ordinary.contains("verified lifecycle wakeup"));
+
+    batch_event.prompt_tag = PROMPT_TAG.into();
+    let lifecycle = crate::queue::format_event_block(channel, None, &batch_event, None);
+    assert!(lifecycle.contains("pull request merged successfully"));
+    assert!(lifecycle.contains(&pr.id.to_hex()));
+    assert!(lifecycle.contains("Do not post a generic acknowledgement"));
+}

--- a/crates/buzz-acp/src/project_lifecycle/tests.rs
+++ b/crates/buzz-acp/src/project_lifecycle/tests.rs
@@ -286,4 +286,5 @@ fn production_prompt_formatter_is_bound_to_validated_prompt_tag() {
     assert!(lifecycle.contains("pull request merged successfully"));
     assert!(lifecycle.contains(&pr.id.to_hex()));
     assert!(lifecycle.contains("Do not post a generic acknowledgement"));
+    assert!(lifecycle.contains("cannot be a channel-message reply parent"));
 }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1356,6 +1356,11 @@ pub(crate) fn format_event_block(
         block.push_str(&format!("\nParsed: {}", parsed_parts.join(", ")));
     }
 
+    if let Some(guidance) = crate::project_lifecycle::prompt_guidance(&be.event, &be.prompt_tag) {
+        block.push('\n');
+        block.push_str(&guidance);
+    }
+
     block
 }
 

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -117,8 +117,8 @@ const GATED_OBSERVER_QUEUE_CAP: usize = 256;
 use std::time::Instant;
 
 use buzz_core::kind::{
-    KIND_AGENT_OBSERVER_FRAME, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
-    KIND_TYPING_INDICATOR,
+    KIND_AGENT_OBSERVER_FRAME, KIND_GIT_STATUS_MERGED, KIND_MEMBER_ADDED_NOTIFICATION,
+    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_TYPING_INDICATOR,
 };
 use futures_util::{SinkExt, StreamExt};
 use nostr::{Event, EventBuilder, Keys, Kind, RelayUrl, Tag};
@@ -657,8 +657,11 @@ enum RelayMessage {
 
 /// Subscription ID for the global membership notification subscription.
 const MEMBERSHIP_NOTIF_SUB_ID: &str = "membership-notif";
-/// Subscription ID for encrypted owner-to-agent observer control frames.
-const OBSERVER_CONTROL_SUB_ID: &str = "agent-observer-control";
+/// Subscription ID for events addressed globally to this agent.
+///
+/// The REQ carries separate filters for encrypted observer controls and durable
+/// project-lifecycle events so each can use the correct replay window.
+const OBSERVER_CONTROL_SUB_ID: &str = "agent-addressed-events";
 
 /// Commands sent from `HarnessRelay` to the background WebSocket task.
 enum RelayCommand {
@@ -1140,6 +1143,11 @@ struct BgState {
     active_subscriptions: HashMap<Uuid, String>,
     /// Most recent `created_at` timestamp seen per channel (for `since` filter).
     last_seen: HashMap<Uuid, u64>,
+    /// Newest successfully forwarded merge lifecycle timestamp.
+    lifecycle_last_seen: Option<u64>,
+    /// Oldest merge lifecycle timestamp dropped under addressed-channel
+    /// backpressure. Included in the next combined addressed REQ.
+    lifecycle_dropped_since: Option<u64>,
     /// Two-generation dedup set of event IDs seen.
     seen_ids: TwoGenDedup,
     /// Per-channel filter used on subscribe (for resubscribe after reconnect).
@@ -1230,6 +1238,8 @@ impl BgState {
         Self {
             active_subscriptions: HashMap::new(),
             last_seen: HashMap::new(),
+            lifecycle_last_seen: None,
+            lifecycle_dropped_since: None,
             seen_ids: TwoGenDedup::new(SEEN_ID_LIMIT),
             active_filters: HashMap::new(),
             membership_dropped_since: None,
@@ -1291,6 +1301,16 @@ impl BgState {
                 .get(channel_id)
                 .copied()
                 .or(self.startup_watermark),
+        }
+    }
+
+    /// Replay cursor for durable project lifecycle events.
+    fn lifecycle_since(&self) -> Option<u64> {
+        match (self.lifecycle_last_seen, self.lifecycle_dropped_since) {
+            (Some(last), Some(dropped)) => Some(last.min(dropped)),
+            (Some(last), None) => Some(last),
+            (None, Some(dropped)) => Some(dropped),
+            (None, None) => self.startup_watermark,
         }
     }
 
@@ -1656,9 +1676,12 @@ async fn execute_connected_command(
                 state.observer_resub_needed = true;
                 return true;
             }
-            let sent = send_observer_control_subscribe(ws, agent_pubkey_hex).await;
+            let sent =
+                send_observer_control_subscribe(ws, agent_pubkey_hex, state.lifecycle_since())
+                    .await;
             if sent {
                 state.observer_resub_needed = false;
+                state.lifecycle_dropped_since = None;
                 true
             } else {
                 warn!("observer control subscribe REQ failed — recording intent for reconnect");
@@ -1932,8 +1955,15 @@ async fn run_background_task(
                     }
                 }
                 if state.observer_resub_needed && budget > 0 {
-                    if send_observer_control_subscribe(&mut ws, &agent_pubkey_hex).await {
+                    if send_observer_control_subscribe(
+                        &mut ws,
+                        &agent_pubkey_hex,
+                        state.lifecycle_since(),
+                    )
+                    .await
+                    {
                         state.observer_resub_needed = false;
+                        state.lifecycle_dropped_since = None;
                         budget = budget.saturating_sub(1);
                         any_sent = true;
                     } else {
@@ -2298,10 +2328,36 @@ async fn handle_ws_message(
                     };
 
                     if subscription_id == OBSERVER_CONTROL_SUB_ID {
+                        let is_lifecycle = event.kind.as_u16() as u32 == KIND_GIT_STATUS_MERGED;
+                        let event_id_hex = event.id.to_hex();
+                        let ts = event.created_at.as_secs();
+                        if is_lifecycle && !state.seen_ids.insert(event_id_hex.clone()) {
+                            debug!(event_id = %event_id_hex, "duplicate project lifecycle event — skipping");
+                            return true;
+                        }
                         match observer_control_tx.try_send(*event) {
-                            Ok(()) => {}
+                            Ok(()) => {
+                                if is_lifecycle {
+                                    state.lifecycle_last_seen =
+                                        Some(state.lifecycle_last_seen.unwrap_or(0).max(ts));
+                                }
+                            }
                             Err(mpsc::error::TrySendError::Full(_)) => {
-                                warn!("observer control event dropped because control channel is full");
+                                if is_lifecycle {
+                                    state.seen_ids.remove(&event_id_hex);
+                                    state.lifecycle_dropped_since = Some(
+                                        state.lifecycle_dropped_since.map_or(ts, |d| d.min(ts)),
+                                    );
+                                    state.observer_resub_needed = true;
+                                    state.proactive_resubscribe_needed = true;
+                                    warn!(
+                                        event_id = %event_id_hex,
+                                        ts,
+                                        "project lifecycle event dropped under backpressure — proactive replay queued"
+                                    );
+                                } else {
+                                    warn!("observer control event dropped because control channel is full");
+                                }
                             }
                             Err(mpsc::error::TrySendError::Closed(_)) => return false,
                         }
@@ -2505,9 +2561,15 @@ async fn handle_ws_message(
                     // resubscribe_after_reconnect() needs the subscription to
                     // still be in state so it can restore it.
                     if subscription_id == OBSERVER_CONTROL_SUB_ID {
-                        let sent = send_observer_control_subscribe(ws, agent_pubkey_hex).await;
+                        let sent = send_observer_control_subscribe(
+                            ws,
+                            agent_pubkey_hex,
+                            state.lifecycle_since(),
+                        )
+                        .await;
                         if sent {
                             state.observer_control_sub_active = true;
+                            state.lifecycle_dropped_since = None;
                         } else {
                             warn!("observer control resubscribe failed after CLOSED — triggering reconnect");
                             return false;
@@ -2843,12 +2905,14 @@ async fn resubscribe_after_reconnect(
             if !pacing_sleep(cmd_rx, &mut deferred_commands, REQ_PACING_INTERVAL).await {
                 return ResubscribeResult::Shutdown;
             }
-            if !send_observer_control_subscribe(ws, agent_pubkey_hex).await {
-                warn!("failed to resubscribe observer controls after reconnect");
+            if !send_observer_control_subscribe(ws, agent_pubkey_hex, state.lifecycle_since()).await
+            {
+                warn!("failed to resubscribe addressed events after reconnect");
                 retain_deferred_command_intent(state, &mut deferred_commands);
                 return ResubscribeResult::RetryConnection;
             }
             state.observer_resub_needed = false;
+            state.lifecycle_dropped_since = None;
         }
     }
 
@@ -3526,36 +3590,62 @@ async fn send_membership_subscribe(
     }
 }
 
-/// Send a NIP-01 REQ for owner-to-agent observer control frames.
-async fn send_observer_control_subscribe(ws: &mut WsStream, agent_pubkey_hex: &str) -> bool {
-    let req = json!([
+/// Build the combined global addressed-event REQ.
+fn addressed_subscription_request(
+    agent_pubkey_hex: &str,
+    lifecycle_since: Option<u64>,
+    now: u64,
+) -> Value {
+    let lifecycle_since = lifecycle_since
+        .unwrap_or(now)
+        .saturating_sub(SINCE_SKEW_SECS);
+    json!([
         "REQ",
         OBSERVER_CONTROL_SUB_ID,
         {
             "kinds": [KIND_AGENT_OBSERVER_FRAME],
             "#p": [agent_pubkey_hex],
-            "since": std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            "since": now,
+        },
+        {
+            "kinds": [KIND_GIT_STATUS_MERGED],
+            "#p": [agent_pubkey_hex],
+            "since": lifecycle_since,
         }
-    ]);
+    ])
+}
+
+/// Send a NIP-01 REQ for global events addressed to this agent.
+///
+/// Observer controls intentionally start at `now`; replaying old pause/resume
+/// commands is unsafe. Merged statuses are durable and replay from their own
+/// watermark so a reconnect cannot lose a successful merge.
+async fn send_observer_control_subscribe(
+    ws: &mut WsStream,
+    agent_pubkey_hex: &str,
+    lifecycle_since: Option<u64>,
+) -> bool {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let req = addressed_subscription_request(agent_pubkey_hex, lifecycle_since, now);
 
     match serde_json::to_string(&req) {
         Ok(text) => {
             match ws_send_timeout(ws, Message::Text(text.into()), WS_SEND_TIMEOUT_SECS).await {
                 Ok(()) => {
-                    debug!("subscribed to observer control frames");
+                    debug!("subscribed to addressed observer and project lifecycle events");
                     true
                 }
                 Err(e) => {
-                    warn!("failed to send observer control REQ: {e}");
+                    warn!("failed to send addressed event REQ: {e}");
                     false
                 }
             }
         }
         Err(e) => {
-            warn!("failed to serialize observer control REQ: {e}");
+            warn!("failed to serialize addressed event REQ: {e}");
             false
         }
     }
@@ -4251,6 +4341,30 @@ async fn wait_for_any_ok(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn addressed_subscription_separates_control_and_lifecycle_replay_windows() {
+        let pubkey = "a".repeat(64);
+        let request = addressed_subscription_request(&pubkey, Some(1_000), 2_000);
+        assert_eq!(request[0], "REQ");
+        assert_eq!(request[1], OBSERVER_CONTROL_SUB_ID);
+        assert_eq!(request[2]["kinds"], json!([KIND_AGENT_OBSERVER_FRAME]));
+        assert_eq!(request[2]["#p"], json!([pubkey]));
+        assert_eq!(request[2]["since"], 2_000);
+        assert_eq!(request[3]["kinds"], json!([KIND_GIT_STATUS_MERGED]));
+        assert_eq!(request[3]["#p"], request[2]["#p"]);
+        assert_eq!(request[3]["since"], 995);
+    }
+
+    #[test]
+    fn lifecycle_reconnect_cursor_covers_oldest_dropped_event() {
+        let mut state = BgState::new();
+        state.startup_watermark = Some(900);
+        assert_eq!(state.lifecycle_since(), Some(900));
+        state.lifecycle_last_seen = Some(1_100);
+        state.lifecycle_dropped_since = Some(1_050);
+        assert_eq!(state.lifecycle_since(), Some(1_050));
+    }
 
     async fn nip11_test_client(
         responses: HashMap<String, (u16, String)>,
@@ -5033,6 +5147,41 @@ mod tests {
             observer_control_rx.try_recv(),
             Err(mpsc::error::TryRecvError::Empty)
         ));
+    }
+
+    #[tokio::test]
+    async fn lifecycle_backpressure_preserves_replay_cursor_and_dedup_recovery() {
+        let (mut client, _server) = test_ws_pair().await;
+        let (event_tx, _event_rx) = mpsc::channel(1);
+        let (observer_control_tx, mut observer_control_rx) = mpsc::channel(1);
+        let mut state = BgState::new();
+        let keys = Keys::generate();
+        let blocker = make_signed_channel_event(&keys, "blocker", 1_999);
+        observer_control_tx.send(blocker).await.unwrap();
+        let lifecycle = EventBuilder::new(Kind::Custom(KIND_GIT_STATUS_MERGED as u16), "")
+            .tags([])
+            .custom_created_at(nostr::Timestamp::from(2_000))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let event_id = lifecycle.id.to_hex();
+
+        assert!(
+            handle_test_relay_event(
+                &mut client,
+                &event_tx,
+                &observer_control_tx,
+                &mut state,
+                OBSERVER_CONTROL_SUB_ID,
+                &lifecycle,
+            )
+            .await
+        );
+
+        assert!(!state.seen_ids.contains(&event_id));
+        assert_eq!(state.lifecycle_dropped_since, Some(2_000));
+        assert!(state.observer_resub_needed);
+        assert!(state.proactive_resubscribe_needed);
+        assert!(observer_control_rx.try_recv().is_ok());
     }
 
     fn test_channel_filter() -> ChannelFilter {


### PR DESCRIPTION
## Summary

- add a global, agent-addressed NIP-34 merge-status subscription without changing channel subscriptions
- resolve each `kind:1631` root PR and fail closed unless the current agent authored it, the signed repository coordinate matches, the repository owner signed the merge, the merge commit is canonical, and the PR has a canonical source-channel `h` tag
- route validated wakeups through the existing ACP author gate, session scope, queue, parallelism, retry, and prompt pipeline
- persist pending/completed lifecycle IDs and semantic merge keys in self-encrypted NIP-78 application data before dispatch
- replay merge events across reconnects and retain pending work across harness restarts
- avoid synthetic chat events/reactions; provide a structured lifecycle prompt that discourages generic acknowledgements

## Why

A pull-request merge is published as a global NIP-34 status event. Existing ACP subscriptions always add `#h`, so the agent that authored a PR cannot observe its merge and continue post-merge ownership without polling or a synthetic message. The signed root PR already records the source channel; resolving it provides the missing routing boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp` (924 unit/integration tests)
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `just file-size-check`
- `cargo build --release -p buzz-acp`
- launched the release binary under Buzz Desktop against a live relay and confirmed NIP-42 auth, encrypted ledger load, global addressed subscription, channel discovery, and presence publication
- completed a live agent-authored PR merge: the harness persisted the pending NIP-78 record, initialized a normal ACP turn three seconds after `kind:1631`, the agent verified the merged tip and performed concrete cleanup/build/browser follow-up, then the harness persisted the `Completed` disposition
- the live pass caught one UX issue: the agent first tried to use the global status as a channel reply parent; the follow-up commit makes the production prompt explicitly require a channel-level post (or a separately identified original channel message)

## Scope notes

- This wakes an already-running harness. If the harness was fully stopped before the merge and had no pending record, startup does not scan historical merges.
- Routing is reliably restored to the PR's signed source channel. Under the default channel session policy this resumes that channel session; exact pre-PR chat-thread provenance is not available in the current PR event.
