### PR TITLE
fix(desktop): require a Codex adapter with Astra support

### DIFF
--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1167,7 +1167,7 @@ mod tests {
         // Simulate the minimum supported adapter version.
         std::fs::write(
             &bin,
-            "#!/bin/sh\necho '@agentclientprotocol/codex-acp 1.1.7'\nexit 0\n",
+            "#!/bin/sh\necho '@agentclientprotocol/codex-acp 1.10.0'\nexit 0\n",
         )
         .expect("write script");
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
@@ -1189,10 +1189,10 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let bin = dir.path().join("codex-acp");
-        // A 1.x adapter below MIN_CODEX_ACP_VERSION must still be reinstalled.
+        // The observed adapter bundles Codex 0.148.x and must be upgraded.
         std::fs::write(
             &bin,
-            "#!/bin/sh\necho '@agentclientprotocol/codex-acp 1.1.5'\nexit 0\n",
+            "#!/bin/sh\necho '@agentclientprotocol/codex-acp 1.6.2'\nexit 0\n",
         )
         .expect("write script");
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -783,12 +783,14 @@ pub(crate) fn classify_runtime(
 /// The oldest `codex-acp` version supported by Buzz managed agents.
 ///
 /// Older 1.x adapters are detected successfully, but can still bundle a Codex runtime
-/// that does not reliably give `buzz` CLI subprocesses outbound relay access.
+/// that cannot use newer models. Adapter 1.6.2 bundles Codex 0.148.x, which rejects
+/// GPT-6 Astra even when the separately installed Codex CLI has been updated.
+/// Published adapter 1.10.0 depends on `@openai/codex ^0.153.3`.
 ///
 /// Bump policy: raise this only when a newer adapter fixes a defect that breaks managed
 /// agents, and only to a version already published on npm — every user below the floor is
 /// offered a reinstall on their next discovery pass.
-pub(crate) const MIN_CODEX_ACP_VERSION: (u64, u64, u64) = (1, 1, 7);
+pub(crate) const MIN_CODEX_ACP_VERSION: (u64, u64, u64) = (1, 10, 0);
 
 /// Probe the full version of a `codex-acp` binary by running `--version`.
 ///

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -684,7 +684,7 @@ fn codex_adapter_availability_available_for_minimum_supported_binary() {
     let bin = dir.join("codex-acp");
     std::fs::write(
         &bin,
-        "#!/bin/sh\necho '@agentclientprotocol/codex-acp 1.1.7'\nexit 0\n",
+        "#!/bin/sh\necho '@agentclientprotocol/codex-acp 1.10.0'\nexit 0\n",
     )
     .expect("write script");
     std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod script");
@@ -718,27 +718,6 @@ fn codex_adapter_availability_outdated_for_0x_binary() {
         status,
         AcpAvailabilityStatus::AdapterOutdated,
         "0.x adapter (non-zero exit) must classify as AdapterOutdated"
-    );
-}
-
-#[cfg(unix)]
-#[test]
-fn codex_adapter_availability_outdated_for_older_1x_binary() {
-    use std::os::unix::fs::PermissionsExt;
-
-    let dir = tempfile::tempdir().expect("temp dir");
-    let bin = dir.path().join("codex-acp");
-    std::fs::write(
-        &bin,
-        "#!/bin/sh\necho '@agentclientprotocol/codex-acp 1.1.5'\nexit 0\n",
-    )
-    .expect("write script");
-    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod script");
-
-    assert_eq!(
-        codex_adapter_availability(&bin),
-        AcpAvailabilityStatus::AdapterOutdated,
-        "a 1.x adapter below the floor must be offered an upgrade"
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery/tests/codex_version.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests/codex_version.rs
@@ -46,3 +46,30 @@ fn probe_codex_acp_version_uses_augmented_path_for_env_shebang_interpreter() {
         "the injected augmented PATH should allow /usr/bin/env to find node"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn codex_adapter_availability_outdated_for_older_1x_binary() {
+    use super::super::{codex_adapter_availability, codex_adapter_is_outdated};
+    use crate::managed_agents::AcpAvailabilityStatus;
+    use std::os::unix::fs::PermissionsExt;
+
+    for version in ["1.1.5", "1.1.7", "1.6.2", "1.9.0"] {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let bin = dir.path().join("codex-acp");
+        std::fs::write(
+            &bin,
+            format!("#!/bin/sh\necho '@agentclientprotocol/codex-acp {version}'\nexit 0\n"),
+        )
+        .expect("write script");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod script");
+
+        assert_eq!(
+            codex_adapter_availability(&bin),
+            AcpAvailabilityStatus::AdapterOutdated,
+            "adapter {version} must be offered an upgrade"
+        );
+        assert!(codex_adapter_is_outdated(&bin));
+    }
+}


### PR DESCRIPTION
## Summary

Buzz considers codex-acp 1.6.2 current because the supported adapter floor is still 1.1.7. That adapter bundles Codex 0.148.0, so updating a separate Codex CLI to 0.153.4 leaves managed agents on the older runtime and unable to use GPT-6 Astra.

Raise the supported adapter floor to the published 1.10.0 release, which depends on `@openai/codex ^0.153.3`. Existing discovery and installation code then classifies older adapters as outdated and offers the managed reinstall path. Update the availability and install-plan regressions to cover the observed 1.6.2 installation and the new minimum.

This follows the existing version-floor policy. It does not automatically update a running installation: the user must complete Buzz’s offered adapter upgrade. Future upstream compatibility changes may require another floor update.

### Related issue

No exact duplicate found in searches for Astra, CODEX_PATH, bundled Codex, outdated runtime, and codex-acp 1.10. Related: #3097 raised the older floor to 1.1.7 (already present on main); #2422 covers lost error details for runtime mismatches. Neither resolves this version gap.

Originating conversation: buzz://message?channel=3286cd76-f83e-4c7d-8317-10a16580744d&id=8b79a73078217222b870fff144c27e7d27bcd5a67c966869c18fe726db716898

### Testing

- Isolated npm install of codex-acp 1.10.0 resolved bundled Codex 0.153.4, with no CODEX_PATH override.
- Live macOS ACP probe: initialize protocol v1 → session/new → select gpt-6-astra[medium] → prompt. Received `OK` and `stopReason: end_turn`; usage metadata confirms gpt-6-astra.
- Existing adapter 1.6.2 initialized but advertised no Astra model in the same probe.
- Desktop Rust formatting and `git diff --check` pass.
- `just desktop-tauri-test`: 3,266 passed, 20 ignored, zero failures across the Desktop workspace and integration tests.
- Workspace and Desktop Clippy, frontend static checks, and `just file-size-check` pass.
- Repository `just ci`: still running the remaining mobile/build/workspace-test stages.

The installed Buzz app and managed adapter were not replaced or restarted. The live check validates the new adapter/runtime path; a complete packaged Desktop upgrade workflow remains untested.
