### PR TITLE
test(buzz-acp): pin the explicit-publish delivery contract in base_prompt.md

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -5119,6 +5119,24 @@ mod agent_draft_prompt_tests {
             .contains("add them explicitly with `buzz channels add-member` only when authorized"));
         assert!(prompt.contains("never changes membership automatically"));
     }
+
+    /// Regression for a delivery-contract defect: a local edit once replaced
+    /// this section with "The Buzz bridge publishes your completed response
+    /// automatically" and told agents not to run `buzz messages send`
+    /// themselves. No code path turns a completed ACP turn's text into a
+    /// published relay event — `handle_session_update`'s `agent_message_chunk`
+    /// arm only logs it (see `acp.rs`) — so that claim silently dropped every
+    /// reply that didn't explicitly invoke the CLI. Pin the correct contract:
+    /// publishing is something the agent must actively do.
+    #[test]
+    fn shared_base_prompt_requires_explicit_publish_not_implicit_bridge_delivery() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("If your turn produced anything worth knowing, you MUST publish it."));
+        assert!(prompt.contains("Use `buzz messages send`."));
+        assert!(prompt.contains("If a human asked you something, you MUST reply to them"));
+        assert!(!prompt.contains("The Buzz bridge publishes your completed response automatically"));
+        assert!(!prompt.contains("Do not run `buzz messages send` yourself"));
+    }
 }
 
 fn default_heartbeat_prompt() -> String {


### PR DESCRIPTION
## Summary

A local, uncommitted edit to `crates/buzz-acp/src/base_prompt.md` (never part of any commit, found sitting in a shared checkout) had replaced the correct delivery instruction with a false one: "The Buzz bridge publishes your completed response automatically... Do not run `buzz messages send` yourself."

No code path in `buzz-acp` turns a completed ACP turn's text into a published relay event — `handle_session_update`'s `agent_message_chunk` arm only logs it (`acp.rs`). Since `base_prompt.md` is read fresh from disk at process startup (`BUZZ_ACP_BASE_PROMPT_FILE`, not compiled into the binary), any agent process that started while the false text was in place silently dropped every reply that didn't explicitly invoke the CLI.

Confirmed live in production: raised log verbosity on one affected agent's service, sent a plain-text health probe, and watched the agent correctly emit the response as an `agent_message_chunk` that the bridge received and discarded exactly as the code predicts.

## Changes

- `base_prompt.md` needed no edit — its committed `HEAD` content was already correct. This PR does not touch it.
- Adds `shared_base_prompt_requires_explicit_publish_not_implicit_bridge_delivery` in `crates/buzz-acp/src/lib.rs`, asserting the correct contract text is present and the false claim can't return.

## Test plan

- [x] Full `buzz-acp` crate suite: 900 passed, 0 failed
- [x] `pool_lifecycle_state` integration suite: 9/9 passed
- [x] New test confirmed to fail against the broken content (reproduced in a scratch copy) and pass against `HEAD`

No merge requested — opened for review/preservation per team direction. No BirdieFit source, credentials, or the deployed binary were touched.