### PR TITLE
feat(desktop): support authenticated external git remotes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,13 @@ BUZZ_PUSH_ENABLED=false
 # BUZZ_GIT_PACK_CACHE_MAX_BYTES=5368709120
 # BUZZ_GIT_PACK_CACHE_MAX_CONCURRENT_POPULATIONS=2
 
+# Buzz Desktop permits github.com external repositories by default. Add exact
+# HTTPS origins here to permit other CLI-managed forges (for example, a
+# self-hosted GitLab authenticated with `glab auth login`). This value contains
+# hostnames only, never credentials. Packaged GUI launches must receive it in
+# their process environment.
+# BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS=https://gitlab.example.com
+
 # -----------------------------------------------------------------------------
 # S3-Compatible Object Storage (media + Git/CAS)
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -150,11 +150,10 @@ BUZZ_PUSH_ENABLED=false
 # BUZZ_GIT_PACK_CACHE_MAX_BYTES=5368709120
 # BUZZ_GIT_PACK_CACHE_MAX_CONCURRENT_POPULATIONS=2
 
-# Buzz Desktop permits github.com external repositories by default. Add exact
-# HTTPS origins here to permit other CLI-managed forges (for example, a
-# self-hosted GitLab authenticated with `glab auth login`). This value contains
-# hostnames only, never credentials. Packaged GUI launches must receive it in
-# their process environment.
+# Buzz Desktop permits the exact https://github.com origin by default. Add
+# exact HTTPS origins here for self-hosted GitLab instances authenticated with
+# `glab auth login`. This allowlist contains origins only, never credentials.
+# Packaged GUI launches must receive it in their process environment.
 # BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS=https://gitlab.example.com
 
 # -----------------------------------------------------------------------------

--- a/desktop/src-tauri/src/commands/project_git.rs
+++ b/desktop/src-tauri/src/commands/project_git.rs
@@ -1,6 +1,6 @@
 use super::project_git_exec::{
     build_git_auth_config, build_git_auth_config_for_url, clean_branch, clean_target_ref, run_git,
-    validate_local_clone_url_for_workspace, GitAuthConfig,
+    validate_local_clone_url_for_workspace, validate_workspace_clone_url, GitAuthConfig,
 };
 use super::project_git_file_content::{checkout_project_repo, read_preview_content};
 use super::project_git_push::push_project_local_repository_blocking;
@@ -806,8 +806,8 @@ pub async fn push_project_local_repository(
     base_branch: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoPushResult, String> {
-    validate_local_clone_url_for_workspace(&clone_url, &state)?;
-    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
+    validate_workspace_clone_url(&clone_url, &state)?;
+    let auth = build_git_auth_config(&state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         let Some(repo_dir) =

--- a/desktop/src-tauri/src/commands/project_git.rs
+++ b/desktop/src-tauri/src/commands/project_git.rs
@@ -1,6 +1,6 @@
 use super::project_git_exec::{
-    build_git_auth_config, clean_branch, clean_target_ref, run_git, validate_workspace_clone_url,
-    GitAuthConfig,
+    build_git_auth_config, build_git_auth_config_for_url, clean_branch, clean_target_ref, run_git,
+    validate_local_clone_url_for_workspace, GitAuthConfig,
 };
 use super::project_git_file_content::{checkout_project_repo, read_preview_content};
 use super::project_git_push::push_project_local_repository_blocking;
@@ -626,8 +626,8 @@ pub async fn get_project_repo_snapshot(
     target_commit: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoSnapshotInfo, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
-    let auth = build_git_auth_config(&state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
     let branch = clean_branch(default_branch);
     let base_branch = clean_branch(base_branch);
     let target_ref = clean_target_ref(target_ref);
@@ -734,7 +734,7 @@ pub async fn open_project_repository_folder(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
     let repo_dir = tauri::async_runtime::spawn_blocking(move || {
         find_local_repo_dir(repos_dir.as_deref(), &project_dtag, Some(&clone_url))?
             .ok_or_else(|| "No local checkout found.".to_string())
@@ -755,8 +755,8 @@ pub async fn get_project_repo_sync_status(
     base_branch: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoSyncStatusInfo, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
-    let auth = build_git_auth_config(&state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         let Some(repo_dir) =
@@ -806,8 +806,8 @@ pub async fn push_project_local_repository(
     base_branch: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoPushResult, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
-    let auth = build_git_auth_config(&state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         let Some(repo_dir) =
@@ -837,8 +837,8 @@ pub async fn pull_project_local_repository(
     branch_name: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoPullResult, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
-    let auth = build_git_auth_config(&state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         let Some(repo_dir) =

--- a/desktop/src-tauri/src/commands/project_git_branches.rs
+++ b/desktop/src-tauri/src/commands/project_git_branches.rs
@@ -3,8 +3,7 @@
 use super::project_git::first_output_line;
 use super::project_git_diff::clean_commit;
 use super::project_git_exec::{
-    build_git_auth_config_for_url, clean_branch, run_git, validate_local_clone_url_for_workspace,
-    GitAuthConfig,
+    build_git_auth_config, clean_branch, run_git, validate_workspace_clone_url, GitAuthConfig,
 };
 use crate::app_state::AppState;
 use serde::Serialize;
@@ -174,14 +173,14 @@ pub async fn create_project_remote_branch(
     new_branch: String,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoBranchResult, String> {
-    validate_local_clone_url_for_workspace(&clone_url, &state)?;
+    validate_workspace_clone_url(&clone_url, &state)?;
     let source_branch = normalize_branch(&source_branch, "source")?;
     let expected_commit = normalize_commit(&expected_commit, "source")?;
     let new_branch = normalize_branch(&new_branch, "new")?;
     if new_branch == source_branch {
         return Err("The new branch must have a different name.".to_string());
     }
-    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
+    let auth = build_git_auth_config(&state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         create_remote_branch_blocking(
@@ -203,10 +202,10 @@ pub async fn delete_project_remote_branch(
     expected_commit: String,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoBranchResult, String> {
-    validate_local_clone_url_for_workspace(&clone_url, &state)?;
+    validate_workspace_clone_url(&clone_url, &state)?;
     let branch = normalize_branch(&branch, "branch")?;
     let expected_commit = normalize_commit(&expected_commit, "branch")?;
-    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
+    let auth = build_git_auth_config(&state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         delete_remote_branch_blocking(&clone_url, &branch, &expected_commit, &auth)

--- a/desktop/src-tauri/src/commands/project_git_branches.rs
+++ b/desktop/src-tauri/src/commands/project_git_branches.rs
@@ -3,7 +3,8 @@
 use super::project_git::first_output_line;
 use super::project_git_diff::clean_commit;
 use super::project_git_exec::{
-    build_git_auth_config, clean_branch, run_git, validate_workspace_clone_url, GitAuthConfig,
+    build_git_auth_config_for_url, clean_branch, run_git, validate_local_clone_url_for_workspace,
+    GitAuthConfig,
 };
 use crate::app_state::AppState;
 use serde::Serialize;
@@ -173,14 +174,14 @@ pub async fn create_project_remote_branch(
     new_branch: String,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoBranchResult, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
     let source_branch = normalize_branch(&source_branch, "source")?;
     let expected_commit = normalize_commit(&expected_commit, "source")?;
     let new_branch = normalize_branch(&new_branch, "new")?;
     if new_branch == source_branch {
         return Err("The new branch must have a different name.".to_string());
     }
-    let auth = build_git_auth_config(&state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         create_remote_branch_blocking(
@@ -202,10 +203,10 @@ pub async fn delete_project_remote_branch(
     expected_commit: String,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoBranchResult, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
     let branch = normalize_branch(&branch, "branch")?;
     let expected_commit = normalize_commit(&expected_commit, "branch")?;
-    let auth = build_git_auth_config(&state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         delete_remote_branch_blocking(&clone_url, &branch, &expected_commit, &auth)

--- a/desktop/src-tauri/src/commands/project_git_diff.rs
+++ b/desktop/src-tauri/src/commands/project_git_diff.rs
@@ -474,7 +474,13 @@ pub async fn get_project_local_repo_diff(
     target_commit: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<Option<ProjectRepoDiffInfo>, String> {
-    let auth = build_git_auth_config(&state)?;
+    let auth = match clone_url.as_deref() {
+        Some(clone_url) => {
+            validate_local_clone_url_for_workspace(clone_url, &state)?;
+            build_git_auth_config_for_url(clone_url, &state)?
+        }
+        None => build_git_auth_config(&state)?,
+    };
     let branch = clean_branch(default_branch);
     let base_branch = clean_branch(base_branch);
     let base_commit = clean_commit(base_commit);

--- a/desktop/src-tauri/src/commands/project_git_diff.rs
+++ b/desktop/src-tauri/src/commands/project_git_diff.rs
@@ -1,5 +1,6 @@
 use super::project_git_exec::{
-    build_git_auth_config, clean_branch, run_git, validate_workspace_clone_url, GitAuthConfig,
+    build_git_auth_config, build_git_auth_config_for_url, clean_branch, run_git,
+    validate_local_clone_url_for_workspace, GitAuthConfig,
 };
 use super::project_repo_paths::find_local_repo_dir;
 use crate::app_state::AppState;
@@ -408,8 +409,8 @@ pub async fn get_project_repo_diff(
     target_commit: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoDiffInfo, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
-    let auth = build_git_auth_config(&state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
     let branch = clean_branch(default_branch);
     let base_branch = clean_branch(base_branch);
     let target_ref = clean_target_ref(target_ref);

--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -3,6 +3,12 @@
 //! Runs the system `git` with an ephemeral, env-only auth configuration:
 //! the identity nsec is handed to `git-credential-nostr` via environment
 //! variables so nothing key-related ever touches disk or global git config.
+//!
+//! External (non-Buzz) remotes are restricted to the github.com built-in
+//! plus any exact HTTPS origins the operator lists in
+//! `BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS` (see [`parse_trusted_external_origins`]).
+//! Those remotes authenticate through the OS-keyring-backed `gh`/`glab` CLI
+//! rather than the Buzz identity — never a value read from that env var.
 
 use crate::{app_state::AppState, managed_agents::resolve_command};
 use nostr::{Keys, ToBech32};
@@ -46,9 +52,14 @@ fn git_needs_credentials(args: &[&str]) -> bool {
 
 pub(crate) struct GitAuthConfig {
     git_path: std::path::PathBuf,
-    credential_helper: Option<std::path::PathBuf>,
-    nsec: String,
+    credential_entries: Vec<(String, String)>,
+    nsec: Option<String>,
     allow_file_transport: bool,
+    /// Set when an external remote is trusted but its credential helper
+    /// (`gh`/`glab`) is not on PATH. The clone/fetch still runs anonymously
+    /// (so public repositories keep working); this records which helper to
+    /// point the user at if the operation then fails on a private repo.
+    missing_credential_helper: Option<&'static str>,
 }
 
 fn read_pipe_lossy(pipe: Option<impl Read>) -> String {
@@ -119,11 +130,23 @@ pub(crate) fn run_git(
     let stderr = stderr_thread.join().unwrap_or_default();
     if !status.success() {
         let stderr = stderr.trim().to_string();
-        return Err(if stderr.is_empty() {
+        let mut message = if stderr.is_empty() {
             format!("git exited with status {status}")
         } else {
             stderr
-        });
+        };
+        // An external remote with no `gh`/`glab` on PATH runs anonymously
+        // (see `missing_credential_helper`), so a private repo fails here
+        // rather than at auth-config time. Point the user at the fix instead
+        // of surfacing a bare git 401/403.
+        if needs_credentials {
+            if let Some(helper_name) = auth.missing_credential_helper {
+                message.push_str(&format!(
+                    "\n\nIf this repository is private, install the {helper_name} CLI and run `{helper_name} auth login`, then try again."
+                ));
+            }
+        }
+        return Err(message);
     }
     Ok(stdout)
 }
@@ -169,15 +192,14 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
         ),
     ];
     if needs_credentials {
-        let Some(cred_helper) = &auth.credential_helper else {
-            return apply_git_config(command, &entries);
-        };
-        command.env("NOSTR_PRIVATE_KEY", &auth.nsec);
-        entries.push((
-            "credential.helper",
-            credential_helper_config_value(cred_helper),
-        ));
-        entries.push(("credential.useHttpPath", "true".to_string()));
+        if let Some(nsec) = &auth.nsec {
+            command.env("NOSTR_PRIVATE_KEY", nsec);
+        }
+        entries.extend(
+            auth.credential_entries
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.clone())),
+        );
     }
     apply_git_config(command, &entries);
 }
@@ -185,9 +207,17 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
 /// Format a path for git `credential.helper`.
 ///
 /// Git for Windows invokes helpers via MinGW bash, which treats `\` as
-/// escapes. Forward slashes work on every platform git supports.
+/// escapes, so paths need forward slashes there. On POSIX platforms a
+/// backslash is an ordinary (if unusual) filename character, so it must be
+/// left alone here — blanket-replacing it would corrupt any POSIX path that
+/// legitimately contains one.
 fn credential_helper_config_value(path: &std::path::Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    let value = path.to_string_lossy().into_owned();
+    if cfg!(windows) {
+        value.replace('\\', "/")
+    } else {
+        value
+    }
 }
 
 fn apply_git_config(command: &mut Command, entries: &[(&str, String)]) {
@@ -203,20 +233,42 @@ pub(crate) fn build_git_auth_config(state: &AppState) -> Result<GitAuthConfig, S
     build_git_auth_config_for_keys(&keys)
 }
 
-pub(crate) fn build_git_clone_auth_config(
+/// Builds the auth config to use for network git operations against
+/// `clone_url`, which may be a Buzz repository or a trusted external HTTPS
+/// remote (see [`external_https_remote`]). Falls back to the viewer's Buzz
+/// identity for anything that isn't an external remote.
+pub(crate) fn build_git_auth_config_for_url(
     clone_url: &str,
     state: &AppState,
 ) -> Result<GitAuthConfig, String> {
-    if validate_github_clone_url(clone_url).is_ok() {
-        return Ok(GitAuthConfig {
-            git_path: resolve_command("git")
-                .ok_or_else(|| "git was not found on PATH".to_string())?,
-            credential_helper: None,
-            nsec: String::new(),
-            allow_file_transport: false,
-        });
+    if let Some(remote) = external_https_remote(clone_url)? {
+        return build_external_auth_for_remote(&remote);
     }
     build_git_auth_config(state)
+}
+
+/// As [`build_git_auth_config_for_url`], but for Buzz repositories the auth
+/// is scoped to a specific identity (e.g. a managed agent acting as a
+/// repository owner) instead of the viewer's own signing keys.
+pub(crate) fn build_git_auth_config_for_url_with_keys(
+    clone_url: &str,
+    keys: &Keys,
+) -> Result<GitAuthConfig, String> {
+    if let Some(remote) = external_https_remote(clone_url)? {
+        return build_external_auth_for_remote(&remote);
+    }
+    build_git_auth_config_for_keys(keys)
+}
+
+/// Missing `gh`/`glab` does not fail here — it degrades to an anonymous
+/// clone/fetch (see [`GitAuthConfig::missing_credential_helper`]), so public
+/// repositories on a trusted external origin still work without either CLI
+/// installed. A private repository then fails naturally at the git call,
+/// where `run_git` attaches setup guidance.
+fn build_external_auth_for_remote(remote: &ExternalHttpsRemote) -> Result<GitAuthConfig, String> {
+    let helper_name = external_helper_name(remote);
+    let helper = resolve_command(helper_name);
+    build_external_git_auth_config(remote, helper)
 }
 
 pub(crate) fn build_git_auth_config_for_keys(keys: &Keys) -> Result<GitAuthConfig, String> {
@@ -226,11 +278,29 @@ pub(crate) fn build_git_auth_config_for_keys(keys: &Keys) -> Result<GitAuthConfi
         .secret_key()
         .to_bech32()
         .map_err(|error| format!("encode identity key: {error}"))?;
+    let credential_entries = credential_helper
+        .as_ref()
+        .map(|helper| {
+            vec![
+                (
+                    // Wrapped in `!'...'` (shell-quoted) rather than assigned
+                    // as a bare path: git always runs a slash-containing
+                    // `credential.helper` value through the shell, so an
+                    // unquoted path containing a space would be split into
+                    // multiple argv words.
+                    "credential.helper".to_string(),
+                    credential_helper_command(helper, &[]),
+                ),
+                ("credential.useHttpPath".to_string(), "true".to_string()),
+            ]
+        })
+        .unwrap_or_default();
     Ok(GitAuthConfig {
         git_path,
-        credential_helper,
-        nsec,
+        credential_entries,
+        nsec: credential_helper.is_some().then_some(nsec),
         allow_file_transport: false,
+        missing_credential_helper: None,
     })
 }
 
@@ -304,51 +374,215 @@ pub(crate) fn validate_clone_url(clone_url: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_github_clone_url(clone_url: &str) -> Result<(), String> {
+struct ExternalHttpsRemote {
+    host: String,
+    credential_url: String,
+}
+
+fn external_helper_name(remote: &ExternalHttpsRemote) -> &'static str {
+    if remote.host == "github.com" {
+        "gh"
+    } else {
+        "glab"
+    }
+}
+
+/// Operator-configured allowlist of additional external git origins, beyond
+/// the github.com built-in. A value, not a secret: it names hosts, never
+/// credentials — `gh`/`glab` own the actual auth. See
+/// [`parse_trusted_external_origins`] for the exact grammar.
+const TRUSTED_EXTERNAL_GIT_ORIGINS_ENV: &str = "BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS";
+
+fn trusted_external_origins_env() -> Vec<String> {
+    std::env::var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV)
+        .ok()
+        .map(|value| parse_trusted_external_origins(&value))
+        .unwrap_or_default()
+}
+
+/// Parses a comma-separated list of exact HTTPS origins the operator has
+/// chosen to trust for external git remotes (e.g.
+/// `https://gitlab.onlyarag.com`), in addition to the github.com built-in.
+/// Each entry must be a bare origin: https scheme, no userinfo, no path
+/// beyond `/`, no query, no fragment. Matching against a clone URL later is
+/// by exact origin string (see [`Url::origin`]'s `ascii_serialization`),
+/// which normalizes away a default `:443` on both sides — so an origin's
+/// explicit non-default port is significant, and an omitted port matches
+/// only the HTTPS default. A malformed entry is dropped with a warning
+/// rather than failing the whole list, since this is operator configuration
+/// rather than attacker input.
+fn parse_trusted_external_origins(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .filter_map(|entry| {
+            let parsed = Url::parse(entry).ok().filter(|parsed| {
+                parsed.scheme() == "https"
+                    && parsed.host_str().is_some()
+                    && parsed.username().is_empty()
+                    && parsed.password().is_none()
+                    && parsed.query().is_none()
+                    && parsed.fragment().is_none()
+                    && matches!(parsed.path(), "" | "/")
+            });
+            let Some(parsed) = parsed else {
+                // Do not echo malformed configuration: an operator may have
+                // accidentally included URL credentials, and diagnostics must
+                // never turn that mistake into a log leak.
+                eprintln!(
+                    "buzz-desktop: ignoring an invalid {TRUSTED_EXTERNAL_GIT_ORIGINS_ENV} entry"
+                );
+                return None;
+            };
+            Some(parsed.origin().ascii_serialization())
+        })
+        .collect()
+}
+
+fn external_https_remote(clone_url: &str) -> Result<Option<ExternalHttpsRemote>, String> {
+    external_https_remote_with_trusted(clone_url, &trusted_external_origins_env())
+}
+
+fn external_https_remote_with_trusted(
+    clone_url: &str,
+    trusted_origins: &[String],
+) -> Result<Option<ExternalHttpsRemote>, String> {
+    if validate_clone_url(clone_url).is_ok() {
+        return Ok(None);
+    }
     let parsed = Url::parse(clone_url).map_err(|error| format!("invalid clone URL: {error}"))?;
     if parsed.scheme() != "https"
-        || parsed.host_str() != Some("github.com")
-        || parsed.port().is_some()
+        || parsed.host_str().is_none()
         || !parsed.username().is_empty()
         || parsed.password().is_some()
         || parsed.query().is_some()
         || parsed.fragment().is_some()
     {
-        return Err("GitHub clone URL must use public https://github.com/owner/repository".into());
+        return Err(
+            "external clone URL must use https without credentials, a query, or fragment".into(),
+        );
     }
-    let segments = parsed
-        .path_segments()
-        .map(|segments| {
-            segments
-                .filter(|segment| !segment.is_empty())
-                .collect::<Vec<_>>()
-        })
+    let raw_path = clone_url
+        .split_once("://")
+        .and_then(|(_, rest)| rest.split_once('/').map(|(_, path)| path))
         .unwrap_or_default();
+    if raw_path
+        .split('/')
+        .any(|segment| segment == "." || segment == "..")
+    {
+        return Err("external clone URL must not contain path traversal".into());
+    }
+    let mut segments = parsed
+        .path_segments()
+        .map(|segments| segments.collect::<Vec<_>>())
+        .unwrap_or_default();
+    if segments.last() == Some(&"") {
+        // A trailing slash produces one trailing empty segment (e.g.
+        // `owner/repo/`); drop it instead of counting it as a path
+        // component.
+        segments.pop();
+    }
     let valid_segment = |segment: &&str| {
-        !segment.starts_with('-')
+        !segment.is_empty()
+            && !segment.starts_with('-')
             && !segment.contains("..")
             && segment.chars().all(|character| {
                 character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
             })
     };
-    if segments.len() != 2 || !segments.iter().all(valid_segment) {
+    if segments.len() < 2 || !segments.iter().all(valid_segment) {
+        return Err("external clone URL must name a repository with safe path segments".into());
+    }
+    let host = parsed
+        .host_str()
+        .expect("checked above")
+        .to_ascii_lowercase();
+    if host == "github.com" && segments.len() != 2 {
         return Err("GitHub clone URL must name one owner and repository".into());
     }
-    Ok(())
+    let origin = parsed.origin().ascii_serialization();
+    let is_trusted = host == "github.com" || trusted_origins.contains(&origin);
+    if !is_trusted {
+        return Err(
+            "external clone URL host must be github.com or a host listed in \
+             BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS"
+                .into(),
+        );
+    }
+    Ok(Some(ExternalHttpsRemote {
+        host,
+        credential_url: origin,
+    }))
+}
+
+fn external_credential_entries(
+    remote: &ExternalHttpsRemote,
+    helper: &std::path::Path,
+) -> Vec<(String, String)> {
+    let scope = format!("credential.{}", remote.credential_url);
+    vec![
+        (
+            format!("{scope}.helper"),
+            credential_helper_command(helper, &["auth", "git-credential"]),
+        ),
+        (format!("{scope}.useHttpPath"), "true".to_string()),
+    ]
+}
+
+fn build_external_git_auth_config(
+    remote: &ExternalHttpsRemote,
+    helper: Option<std::path::PathBuf>,
+) -> Result<GitAuthConfig, String> {
+    let git_path = resolve_command("git").ok_or_else(|| "git was not found on PATH".to_string())?;
+    match helper {
+        Some(helper) => Ok(GitAuthConfig {
+            git_path,
+            credential_entries: external_credential_entries(remote, &helper),
+            nsec: None,
+            allow_file_transport: false,
+            missing_credential_helper: None,
+        }),
+        // No `gh`/`glab` on PATH: proceed anonymously so a public repository
+        // still clones/fetches. `run_git` attaches setup guidance if a
+        // credentialed operation then fails.
+        None => Ok(GitAuthConfig {
+            git_path,
+            credential_entries: Vec::new(),
+            nsec: None,
+            allow_file_transport: false,
+            missing_credential_helper: Some(external_helper_name(remote)),
+        }),
+    }
+}
+
+/// Builds a `!'<path>' [args...]` credential.helper value. Git runs any
+/// slash-containing `credential.helper` value through the shell (appending
+/// the get/store/erase operation as the final word), so the path is always
+/// single-quoted here — an unquoted path containing a space would otherwise
+/// be split into multiple argv words. `args` are trusted literals (fixed
+/// gh/glab subcommands), never caller-supplied values.
+fn credential_helper_command(path: &std::path::Path, args: &[&str]) -> String {
+    let escaped_path = credential_helper_config_value(path).replace('\'', "'\"'\"'");
+    let mut command = format!("!'{escaped_path}'");
+    for arg in args {
+        command.push(' ');
+        command.push_str(arg);
+    }
+    command
 }
 
 pub(crate) fn validate_local_clone_url(clone_url: &str) -> Result<(), String> {
-    if validate_clone_url(clone_url).is_ok() || validate_github_clone_url(clone_url).is_ok() {
+    if validate_clone_url(clone_url).is_ok() || external_https_remote(clone_url)?.is_some() {
         return Ok(());
     }
-    Err("clone URL must point at a Buzz repository or public GitHub repository".into())
+    Err("clone URL must point at a Buzz repository or a safe external HTTPS repository".into())
 }
 
 pub(crate) fn validate_local_clone_url_for_workspace(
     clone_url: &str,
     state: &AppState,
 ) -> Result<(), String> {
-    if validate_github_clone_url(clone_url).is_ok() {
+    if external_https_remote(clone_url)?.is_some() {
         return Ok(());
     }
     validate_workspace_clone_url(clone_url, state)
@@ -393,19 +627,275 @@ fn validate_clone_url_against_relay(clone_url: &str, relay_base: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        clean_branch, clean_target_ref, credential_helper_config_value, git_needs_credentials,
-        git_subcommand, validate_clone_url, validate_clone_url_against_relay,
-        validate_local_clone_url,
+        build_external_git_auth_config, clean_branch, clean_target_ref, credential_helper_command,
+        credential_helper_config_value, external_credential_entries, external_helper_name,
+        external_https_remote, external_https_remote_with_trusted, git_needs_credentials,
+        git_subcommand, parse_trusted_external_origins, run_git, trusted_external_origins_env,
+        validate_clone_url, validate_clone_url_against_relay, validate_local_clone_url,
+        TRUSTED_EXTERNAL_GIT_ORIGINS_ENV,
     };
 
+    // Guards tests that mutate `BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS`: env vars
+    // are process-global, so parallel `cargo test` threads must serialize
+    // around it (same pattern as `app_state_tests::ENV_LOCK`).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[cfg(windows)]
     #[test]
-    fn credential_helper_config_value_uses_forward_slashes() {
+    fn credential_helper_config_value_uses_forward_slashes_on_windows() {
         let path =
             std::path::PathBuf::from(r"C:\Users\x\AppData\Local\Buzz\git-credential-nostr.exe");
         assert_eq!(
             credential_helper_config_value(&path),
             "C:/Users/x/AppData/Local/Buzz/git-credential-nostr.exe",
         );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn credential_helper_config_value_preserves_posix_backslashes() {
+        // A backslash is an ordinary filename character on POSIX; blanket
+        // replacement would corrupt a path that legitimately contains one.
+        let path = std::path::PathBuf::from("/opt/weird\\name/git-credential-nostr");
+        assert_eq!(
+            credential_helper_config_value(&path),
+            "/opt/weird\\name/git-credential-nostr",
+        );
+    }
+
+    #[test]
+    fn credential_helper_command_has_no_trailing_space_with_no_args() {
+        assert_eq!(
+            credential_helper_command(
+                std::path::Path::new("/usr/local/bin/git-credential-nostr"),
+                &[]
+            ),
+            "!'/usr/local/bin/git-credential-nostr'"
+        );
+    }
+
+    #[test]
+    fn credential_helper_command_escapes_embedded_single_quotes() {
+        assert_eq!(
+            credential_helper_command(std::path::Path::new("/opt/it's/glab"), &["auth"]),
+            "!'/opt/it'\"'\"'s/glab' auth"
+        );
+    }
+
+    #[test]
+    fn external_helpers_are_origin_scoped_and_never_receive_credentials_in_argv() {
+        let trusted = ["https://gitlab.onlyarag.com".to_string()];
+        let remote = external_https_remote_with_trusted(
+            "https://gitlab.onlyarag.com/group/private-repo.git",
+            &trusted,
+        )
+        .unwrap()
+        .expect("external remote");
+        let entries = external_credential_entries(
+            &remote,
+            std::path::Path::new("/Applications/GitLab CLI/glab"),
+        );
+        assert_eq!(
+            entries[0].0,
+            "credential.https://gitlab.onlyarag.com.helper"
+        );
+        assert_eq!(
+            entries[0].1,
+            "!'/Applications/GitLab CLI/glab' auth git-credential"
+        );
+        assert_eq!(
+            entries[1],
+            (
+                "credential.https://gitlab.onlyarag.com.useHttpPath".into(),
+                "true".into()
+            )
+        );
+        assert_eq!(
+            credential_helper_command(std::path::Path::new("/bin/gh"), &["auth", "git-credential"]),
+            "!'/bin/gh' auth git-credential"
+        );
+        let github = external_https_remote("https://github.com/block/buzz.git")
+            .unwrap()
+            .expect("GitHub remote");
+        assert_eq!(external_helper_name(&github), "gh");
+        assert_eq!(external_helper_name(&remote), "glab");
+    }
+
+    #[test]
+    fn missing_helper_yields_anonymous_auth_with_setup_hint() {
+        let remote = external_https_remote_with_trusted(
+            "https://gitlab.onlyarag.com/group/private-repo.git",
+            &["https://gitlab.onlyarag.com".to_string()],
+        )
+        .unwrap()
+        .expect("external remote");
+        let auth = build_external_git_auth_config(&remote, None).expect("build anonymous auth");
+        assert!(auth.credential_entries.is_empty());
+        assert!(auth.nsec.is_none());
+        assert_eq!(auth.missing_credential_helper, Some("glab"));
+    }
+
+    #[test]
+    fn run_git_appends_setup_guidance_when_credential_helper_is_missing() {
+        let remote = external_https_remote_with_trusted(
+            "https://gitlab.onlyarag.com/group/private-repo.git",
+            &["https://gitlab.onlyarag.com".to_string()],
+        )
+        .unwrap()
+        .expect("external remote");
+        let mut auth = build_external_git_auth_config(&remote, None).expect("build anonymous auth");
+        auth.allow_file_transport = true;
+        let repo = tempfile::tempdir().expect("create test directory");
+        let repo_path = repo.path().to_str().expect("repo path");
+        run_git(&["init", "--bare", "--", repo_path], None, &auth).expect("init bare repo");
+
+        let error = run_git(
+            &["fetch", "--end-of-options", "origin", "main"],
+            Some(repo.path()),
+            &auth,
+        )
+        .expect_err("fetch against a repo with no configured remote fails");
+        assert!(
+            error.contains("install the glab CLI") && error.contains("glab auth login"),
+            "expected setup guidance in error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_trusted_external_origins_accepts_bare_https_origins_only() {
+        assert_eq!(
+            parse_trusted_external_origins("https://gitlab.onlyarag.com"),
+            vec!["https://gitlab.onlyarag.com".to_string()],
+        );
+        // Trailing slash, mixed case host, and a redundant default port all
+        // normalize to the same bare origin.
+        assert_eq!(
+            parse_trusted_external_origins("https://GitLab.OnlyArag.com/"),
+            vec!["https://gitlab.onlyarag.com".to_string()],
+        );
+        assert_eq!(
+            parse_trusted_external_origins("https://gitlab.onlyarag.com:443"),
+            vec!["https://gitlab.onlyarag.com".to_string()],
+        );
+        // An explicit non-default port stays significant.
+        assert_eq!(
+            parse_trusted_external_origins("https://gitlab.onlyarag.com:8443"),
+            vec!["https://gitlab.onlyarag.com:8443".to_string()],
+        );
+        // Multiple entries, whitespace-tolerant.
+        assert_eq!(
+            parse_trusted_external_origins(" https://a.example , https://b.example "),
+            vec![
+                "https://a.example".to_string(),
+                "https://b.example".to_string()
+            ],
+        );
+    }
+
+    #[test]
+    fn parse_trusted_external_origins_drops_invalid_entries() {
+        // http (not https), a path beyond `/`, userinfo, query, and
+        // fragment are all invalid — dropped, not fatal for the rest of the
+        // list.
+        assert_eq!(
+            parse_trusted_external_origins(
+                "http://gitlab.onlyarag.com,\
+                 https://gitlab.onlyarag.com/group,\
+                 https://user@gitlab.onlyarag.com,\
+                 https://gitlab.onlyarag.com?x=1,\
+                 https://gitlab.onlyarag.com#frag,\
+                 not a url,\
+                 ,\
+                 https://good.example"
+            ),
+            vec!["https://good.example".to_string()],
+        );
+    }
+
+    #[test]
+    fn external_https_remote_rejects_hosts_outside_the_trusted_list() {
+        let trusted = ["https://gitlab.onlyarag.com".to_string()];
+        // gitlab.com is not on the trusted list, so it is rejected outright
+        // rather than silently treated as a Buzz repo.
+        assert!(
+            external_https_remote_with_trusted("https://gitlab.com/block/buzz", &trusted).is_err()
+        );
+        // A lookalike host is not the trusted origin.
+        assert!(external_https_remote_with_trusted(
+            "https://gitlab.onlyarag.com.evil.test/block/buzz",
+            &trusted
+        )
+        .is_err());
+        // Trusted host, but the wrong port — no implicit match.
+        assert!(external_https_remote_with_trusted(
+            "https://gitlab.onlyarag.com:8443/block/buzz",
+            &trusted
+        )
+        .is_err());
+        // Configuring the exact port allows it.
+        let trusted_with_port = ["https://gitlab.onlyarag.com:8443".to_string()];
+        assert!(external_https_remote_with_trusted(
+            "https://gitlab.onlyarag.com:8443/block/buzz",
+            &trusted_with_port
+        )
+        .unwrap()
+        .is_some());
+        // github.com is always trusted, independent of the configured list.
+        assert!(
+            external_https_remote_with_trusted("https://github.com/block/buzz", &[])
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn external_https_remote_filters_trailing_slash_empty_segment() {
+        let trusted = ["https://gitlab.onlyarag.com".to_string()];
+        // A trailing slash must not count as an extra path segment.
+        let remote = external_https_remote_with_trusted("https://github.com/block/buzz/", &trusted)
+            .unwrap()
+            .expect("trailing slash still names owner/repo");
+        assert_eq!(remote.host, "github.com");
+        // An empty segment from a doubled slash elsewhere in the path is
+        // still rejected.
+        assert!(external_https_remote_with_trusted(
+            "https://gitlab.onlyarag.com/group//repo",
+            &trusted
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn trusted_external_origins_env_reads_the_configured_variable() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = std::env::var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV).ok();
+
+        std::env::set_var(
+            TRUSTED_EXTERNAL_GIT_ORIGINS_ENV,
+            "https://gitlab.onlyarag.com, not a url, https://gitlab.com",
+        );
+        assert_eq!(
+            trusted_external_origins_env(),
+            vec![
+                "https://gitlab.onlyarag.com".to_string(),
+                "https://gitlab.com".to_string(),
+            ],
+        );
+        assert!(
+            external_https_remote("https://gitlab.onlyarag.com/group/repo")
+                .unwrap()
+                .is_some()
+        );
+        assert!(external_https_remote("https://not-configured.example/group/repo").is_err());
+
+        std::env::remove_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV);
+        assert_eq!(trusted_external_origins_env(), Vec::<String>::new());
+        assert!(external_https_remote("https://gitlab.onlyarag.com/group/repo").is_err());
+
+        match previous {
+            Some(value) => std::env::set_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV, value),
+            None => std::env::remove_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV),
+        }
     }
 
     #[test]
@@ -510,13 +1000,61 @@ mod tests {
     }
 
     #[test]
-    fn local_clone_url_allows_only_public_github_https_urls() {
+    fn local_clone_url_allows_safe_external_https_urls() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = std::env::var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV).ok();
+        std::env::remove_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV);
+
         assert!(validate_local_clone_url("https://github.com/block/buzz").is_ok());
         assert!(validate_local_clone_url("https://github.com/block/buzz.git").is_ok());
         assert!(validate_local_clone_url("http://github.com/block/buzz").is_err());
         assert!(validate_local_clone_url("https://github.com/block/buzz/issues").is_err());
         assert!(validate_local_clone_url("https://user@github.com/block/buzz").is_err());
-        assert!(validate_local_clone_url("https://github.com.evil.test/block/buzz").is_err());
+        assert!(validate_local_clone_url("https://github.com/block/../buzz").is_err());
+        assert!(validate_local_clone_url("https://github.com/-upload-pack/buzz").is_err());
+        assert!(validate_local_clone_url("ssh://git@github.com/block/buzz").is_err());
+        // With no operator-configured trust entry, any external host other
+        // than the github.com built-in is rejected outright — this is the
+        // fix for the regression that had accepted every https host.
+        assert!(
+            validate_local_clone_url("https://gitlab.onlyarag.com/group/private-repo.git").is_err()
+        );
         assert!(validate_local_clone_url("https://gitlab.com/block/buzz").is_err());
+        assert!(validate_local_clone_url("https://github.com.evil.test/block/buzz").is_err());
+
+        match previous {
+            Some(value) => std::env::set_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV, value),
+            None => std::env::remove_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV),
+        }
+    }
+
+    #[test]
+    fn local_clone_url_allows_operator_trusted_external_origin() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = std::env::var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV).ok();
+        std::env::set_var(
+            TRUSTED_EXTERNAL_GIT_ORIGINS_ENV,
+            "https://gitlab.onlyarag.com",
+        );
+
+        assert!(
+            validate_local_clone_url("https://gitlab.onlyarag.com/group/private-repo.git").is_ok()
+        );
+        assert!(validate_local_clone_url(
+            "https://gitlab.onlyarag.com/group/subgroup/private-repo.git"
+        )
+        .is_ok());
+        assert!(
+            validate_local_clone_url("https://gitlab.onlyarag.com/group/buzz?token=secret")
+                .is_err()
+        );
+        assert!(validate_local_clone_url("https://gitlab.onlyarag.com/group/buzz#branch").is_err());
+        // Still not github.com or the trusted origin.
+        assert!(validate_local_clone_url("https://gitlab.com/block/buzz").is_err());
+
+        match previous {
+            Some(value) => std::env::set_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV, value),
+            None => std::env::remove_var(TRUSTED_EXTERNAL_GIT_ORIGINS_ENV),
+        }
     }
 }

--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -46,7 +46,17 @@ fn git_subcommand<'a>(args: &'a [&str]) -> Option<&'a str> {
 fn git_needs_credentials(args: &[&str]) -> bool {
     matches!(
         git_subcommand(args),
-        Some("clone" | "fetch" | "push" | "pull" | "ls-remote" | "merge")
+        Some(
+            "clone"
+                | "fetch"
+                | "push"
+                | "pull"
+                | "ls-remote"
+                | "merge"
+                | "checkout"
+                | "show"
+                | "diff"
+        )
     )
 }
 
@@ -162,8 +172,21 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
         "GIT_ALTERNATE_OBJECT_DIRECTORIES",
         "GIT_SSH_COMMAND",
         "GIT_EXTERNAL_DIFF",
+        "GIT_ASKPASS",
+        "SSH_ASKPASS",
+        "GIT_EXEC_PATH",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_COUNT",
+        "NOSTR_PRIVATE_KEY",
+        TRUSTED_EXTERNAL_GIT_ORIGINS_ENV,
     ] {
         command.env_remove(key);
+    }
+    for (key, _) in std::env::vars_os() {
+        let key = key.to_string_lossy();
+        if key.starts_with("GIT_CONFIG_KEY_") || key.starts_with("GIT_CONFIG_VALUE_") {
+            command.env_remove(key.as_ref());
+        }
     }
     // Git for Windows maps `/dev/null` to `NUL` internally, so this value
     // disables the global config file on every platform.
@@ -351,6 +374,13 @@ pub(crate) fn validate_clone_url(clone_url: &str) -> Result<(), String> {
     if !matches!(parsed.scheme(), "http" | "https") {
         return Err("clone URL must be http or https".into());
     }
+    if !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err("clone URL must not contain credentials, a query, or fragment".into());
+    }
     // Buzz git remotes are served at `…/git/<owner-pubkey>/<repo-id>` — a
     // literal `git` segment followed by the 64-hex owner pubkey and a
     // non-empty repository id (the relay may live under a path prefix).
@@ -501,7 +531,7 @@ fn external_https_remote_with_trusted(
         return Err("GitHub clone URL must name one owner and repository".into());
     }
     let origin = parsed.origin().ascii_serialization();
-    let is_trusted = host == "github.com" || trusted_origins.contains(&origin);
+    let is_trusted = origin == "https://github.com" || trusted_origins.contains(&origin);
     if !is_trusted {
         return Err(
             "external clone URL host must be github.com or a host listed in \
@@ -1007,6 +1037,7 @@ mod tests {
 
         assert!(validate_local_clone_url("https://github.com/block/buzz").is_ok());
         assert!(validate_local_clone_url("https://github.com/block/buzz.git").is_ok());
+        assert!(validate_local_clone_url("https://github.com:8443/block/buzz").is_err());
         assert!(validate_local_clone_url("http://github.com/block/buzz").is_err());
         assert!(validate_local_clone_url("https://github.com/block/buzz/issues").is_err());
         assert!(validate_local_clone_url("https://user@github.com/block/buzz").is_err());

--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -177,6 +177,8 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
         "GIT_EXEC_PATH",
         "GIT_CONFIG_PARAMETERS",
         "GIT_CONFIG_COUNT",
+        "GIT_ALLOW_PROTOCOL",
+        "GIT_PROTOCOL_FROM_USER",
         "NOSTR_PRIVATE_KEY",
         TRUSTED_EXTERNAL_GIT_ORIGINS_ENV,
     ] {

--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -7,7 +7,7 @@
 //! External (non-Buzz) remotes are restricted to the github.com built-in
 //! plus any exact HTTPS origins the operator lists in
 //! `BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS` (see [`parse_trusted_external_origins`]).
-//! Those remotes authenticate through the OS-keyring-backed `gh`/`glab` CLI
+//! Those remotes authenticate through CLI-managed `gh`/`glab` credentials
 //! rather than the Buzz identity — never a value read from that env var.
 
 use crate::{app_state::AppState, managed_agents::resolve_command};
@@ -142,7 +142,7 @@ pub(crate) fn run_git(
         if needs_credentials {
             if let Some(helper_name) = auth.missing_credential_helper {
                 message.push_str(&format!(
-                    "\n\nIf this repository is private, install the {helper_name} CLI and run `{helper_name} auth login`, then try again."
+                    "\n\nIf this repository is private, install the {helper_name} CLI, run `{helper_name} auth login`, and restart Buzz before trying again."
                 ));
             }
         }

--- a/desktop/src-tauri/src/commands/project_git_file_content.rs
+++ b/desktop/src-tauri/src/commands/project_git_file_content.rs
@@ -1,7 +1,7 @@
 use super::project_git::first_output_line;
 use super::project_git_exec::{
-    build_git_auth_config, clean_branch, clean_target_ref, run_git, validate_workspace_clone_url,
-    GitAuthConfig,
+    build_git_auth_config_for_url, clean_branch, clean_target_ref, run_git,
+    validate_local_clone_url_for_workspace, GitAuthConfig,
 };
 use super::project_repo_paths::find_local_repo_dir;
 use crate::app_state::AppState;
@@ -130,9 +130,9 @@ pub async fn get_project_repo_file_content(
     path: String,
     state: State<'_, AppState>,
 ) -> Result<Option<String>, String> {
-    validate_workspace_clone_url(&clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&clone_url, &state)?;
     validate_repo_file_path(&path)?;
-    let auth = build_git_auth_config(&state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
     let branch = clean_branch(default_branch);
     let target_ref = clean_target_ref(target_ref);
     let target_commit = target_commit

--- a/desktop/src-tauri/src/commands/project_git_workflow.rs
+++ b/desktop/src-tauri/src/commands/project_git_workflow.rs
@@ -4,7 +4,8 @@ use super::project_git::{first_output_line, normalize_branch_option};
 use super::project_git_diff::clean_commit;
 use super::project_git_exec::{
     build_git_auth_config_for_url, build_git_auth_config_for_url_with_keys, clone_url_owner,
-    run_git, validate_local_clone_url, validate_local_clone_url_for_workspace, GitAuthConfig,
+    run_git, validate_local_clone_url, validate_local_clone_url_for_workspace,
+    validate_workspace_clone_url, GitAuthConfig,
 };
 use super::project_repo_paths::{
     canonical_repos_roots, canonicalize_repos_root, default_repos_root_candidates,
@@ -506,7 +507,10 @@ pub async fn merge_project_pull_request(
         source_branch,
         expected_commit,
     } = input;
-    validate_local_clone_url_for_workspace(&target_clone_url, &state)?;
+    // Merge targets remain Buzz-hosted because target ownership is enforced
+    // from the relay-shaped URL. External repositories are supported as
+    // readable/source remotes, not as Buzz-managed merge targets.
+    validate_workspace_clone_url(&target_clone_url, &state)?;
     validate_local_clone_url_for_workspace(&source_clone_url, &state)?;
     let target_owner = target_owner.trim().to_ascii_lowercase();
     if target_owner.len() != 64 || !target_owner.chars().all(|c| c.is_ascii_hexdigit()) {

--- a/desktop/src-tauri/src/commands/project_git_workflow.rs
+++ b/desktop/src-tauri/src/commands/project_git_workflow.rs
@@ -3,9 +3,8 @@
 use super::project_git::{first_output_line, normalize_branch_option};
 use super::project_git_diff::clean_commit;
 use super::project_git_exec::{
-    build_git_auth_config_for_keys, build_git_clone_auth_config, clone_url_owner, run_git,
-    validate_local_clone_url, validate_local_clone_url_for_workspace, validate_workspace_clone_url,
-    GitAuthConfig,
+    build_git_auth_config_for_url, build_git_auth_config_for_url_with_keys, clone_url_owner,
+    run_git, validate_local_clone_url, validate_local_clone_url_for_workspace, GitAuthConfig,
 };
 use super::project_repo_paths::{
     canonical_repos_roots, canonicalize_repos_root, default_repos_root_candidates,
@@ -426,7 +425,7 @@ pub async fn clone_project_repository(
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoCloneResult, String> {
     validate_local_clone_url_for_workspace(&clone_url, &state)?;
-    let auth = build_git_clone_auth_config(&clone_url, &state)?;
+    let auth = build_git_auth_config_for_url(&clone_url, &state)?;
     tauri::async_runtime::spawn_blocking(move || {
         clone_project_repository_blocking(
             repos_dir.as_deref(),
@@ -507,8 +506,8 @@ pub async fn merge_project_pull_request(
         source_branch,
         expected_commit,
     } = input;
-    validate_workspace_clone_url(&target_clone_url, &state)?;
-    validate_workspace_clone_url(&source_clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&target_clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&source_clone_url, &state)?;
     let target_owner = target_owner.trim().to_ascii_lowercase();
     if target_owner.len() != 64 || !target_owner.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err("Invalid target repository owner.".to_string().into());
@@ -537,7 +536,13 @@ pub async fn merge_project_pull_request(
         &pull_request_id,
         &pull_request_author,
     )?;
-    let auth = build_git_auth_config_for_keys(&owner_identity.keys)?;
+    // Target and source may be different hosts (e.g. merging in a pull
+    // request from an externally-mirrored fork into a Buzz-hosted target),
+    // so each clone URL gets auth scoped to itself.
+    let target_auth =
+        build_git_auth_config_for_url_with_keys(&target_clone_url, &owner_identity.keys)?;
+    let source_auth =
+        build_git_auth_config_for_url_with_keys(&source_clone_url, &owner_identity.keys)?;
 
     let git_result = tauri::async_runtime::spawn_blocking(
         move || -> Result<ProjectRepoMergeGitResult, ProjectPullRequestMergeError> {
@@ -560,7 +565,7 @@ pub async fn merge_project_pull_request(
                     repo_path,
                 ],
                 None,
-                &auth,
+                &target_auth,
             )?;
             run_git(
                 &[
@@ -571,9 +576,9 @@ pub async fn merge_project_pull_request(
                     source_branch.as_str(),
                 ],
                 Some(&repo_dir),
-                &auth,
+                &source_auth,
             )?;
-            let source_head = run_git(&["rev-parse", "FETCH_HEAD"], Some(&repo_dir), &auth)
+            let source_head = run_git(&["rev-parse", "FETCH_HEAD"], Some(&repo_dir), &source_auth)
                 .ok()
                 .and_then(|output| first_output_line(&output))
                 .ok_or_else(|| "Could not resolve the pull request branch.".to_string())?;
@@ -598,13 +603,13 @@ pub async fn merge_project_pull_request(
                     expected_commit.as_str(),
                 ],
                 Some(&repo_dir),
-                &auth,
+                &target_auth,
             );
             if let Err(error) = merge_result {
                 let has_conflicts = run_git(
                     &["diff", "--name-only", "--diff-filter=U"],
                     Some(&repo_dir),
-                    &auth,
+                    &target_auth,
                 )
                 .is_ok_and(|output| !output.trim().is_empty());
                 return Err(classify_merge_error(
@@ -614,7 +619,7 @@ pub async fn merge_project_pull_request(
                     &source_branch,
                 ));
             }
-            let merge_commit = run_git(&["rev-parse", "HEAD"], Some(&repo_dir), &auth)
+            let merge_commit = run_git(&["rev-parse", "HEAD"], Some(&repo_dir), &target_auth)
                 .ok()
                 .and_then(|output| first_output_line(&output))
                 .ok_or_else(|| "Could not resolve the merge commit.".to_string())?;
@@ -626,7 +631,7 @@ pub async fn merge_project_pull_request(
                     format!("HEAD:{target_branch}").as_str(),
                 ],
                 Some(&repo_dir),
-                &auth,
+                &target_auth,
             )?;
 
             Ok(ProjectRepoMergeGitResult {

--- a/desktop/src-tauri/src/commands/project_terminal.rs
+++ b/desktop/src-tauri/src/commands/project_terminal.rs
@@ -11,7 +11,7 @@ use super::project_git::{first_output_line, normalize_branch_option};
 use super::project_git_diff::clean_commit;
 use super::project_git_exec::{
     build_git_auth_config, build_git_auth_config_for_url, run_git,
-    validate_local_clone_url_for_workspace,
+    validate_local_clone_url_for_workspace, validate_workspace_clone_url,
 };
 use super::project_git_workflow::clone_project_repository_blocking;
 use super::project_repo_paths::find_local_repo_dir;
@@ -170,7 +170,7 @@ pub async fn open_project_merge_recovery_terminal(
     input: ProjectMergeRecoveryTerminalInput,
     state: State<'_, AppState>,
 ) -> Result<ProjectMergeRecoveryTerminalResult, String> {
-    validate_local_clone_url_for_workspace(&input.target_clone_url, &state)?;
+    validate_workspace_clone_url(&input.target_clone_url, &state)?;
     validate_local_clone_url_for_workspace(&input.source_clone_url, &state)?;
     let target_branch = normalize_branch_option(Some(&input.target_branch))
         .ok_or_else(|| "Invalid target branch.".to_string())?;

--- a/desktop/src-tauri/src/commands/project_terminal.rs
+++ b/desktop/src-tauri/src/commands/project_terminal.rs
@@ -10,8 +10,8 @@ use crate::app_state::AppState;
 use super::project_git::{first_output_line, normalize_branch_option};
 use super::project_git_diff::clean_commit;
 use super::project_git_exec::{
-    build_git_auth_config, build_git_clone_auth_config, run_git,
-    validate_local_clone_url_for_workspace, validate_workspace_clone_url,
+    build_git_auth_config, build_git_auth_config_for_url, run_git,
+    validate_local_clone_url_for_workspace,
 };
 use super::project_git_workflow::clone_project_repository_blocking;
 use super::project_repo_paths::find_local_repo_dir;
@@ -115,11 +115,11 @@ pub async fn open_project_terminal(
     if let Some(clone_url) = clone_url.as_deref() {
         validate_local_clone_url_for_workspace(clone_url, &state)?;
     }
-    // Public GitHub clones stay anonymous; Buzz remotes use the workspace
-    // identity. Keep the result outside the blocking task so it borrows no
-    // Tauri state.
+    // External HTTPS clones use the OS-keyring-backed `gh` or `glab` helper;
+    // Buzz remotes use the workspace identity. Keep the result outside the
+    // blocking task so it borrows no Tauri state.
     let auth = if let Some(clone_url) = clone_url.as_deref() {
-        build_git_clone_auth_config(clone_url, &state)
+        build_git_auth_config_for_url(clone_url, &state)
     } else {
         build_git_auth_config(&state)
     };
@@ -170,15 +170,19 @@ pub async fn open_project_merge_recovery_terminal(
     input: ProjectMergeRecoveryTerminalInput,
     state: State<'_, AppState>,
 ) -> Result<ProjectMergeRecoveryTerminalResult, String> {
-    validate_workspace_clone_url(&input.target_clone_url, &state)?;
-    validate_workspace_clone_url(&input.source_clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&input.target_clone_url, &state)?;
+    validate_local_clone_url_for_workspace(&input.source_clone_url, &state)?;
     let target_branch = normalize_branch_option(Some(&input.target_branch))
         .ok_or_else(|| "Invalid target branch.".to_string())?;
     let source_branch = normalize_branch_option(Some(&input.source_branch))
         .ok_or_else(|| "Invalid source branch.".to_string())?;
     let expected_commit = clean_commit(Some(input.expected_commit.trim().to_ascii_lowercase()))
         .ok_or_else(|| "Invalid pull request commit.".to_string())?;
-    let auth = build_git_auth_config(&state)?;
+    // Target and source may be different hosts (e.g. a Buzz-hosted target
+    // with an externally-mirrored source), so each gets its own auth scoped
+    // to its own clone URL.
+    let target_auth = build_git_auth_config_for_url(&input.target_clone_url, &state)?;
+    let source_auth = build_git_auth_config_for_url(&input.source_clone_url, &state)?;
 
     tauri::async_runtime::spawn_blocking(move || {
         let existing_dir = find_local_repo_dir(
@@ -196,7 +200,7 @@ pub async fn open_project_merge_recovery_terminal(
                 &input.project_dtag,
                 &input.target_clone_url,
                 Some(&target_branch),
-                &auth,
+                &target_auth,
             )?;
             (std::path::PathBuf::from(clone_result.path), true)
         };
@@ -211,9 +215,9 @@ pub async fn open_project_merge_recovery_terminal(
                 target_branch.as_str(),
             ],
             Some(&repo_dir),
-            &auth,
+            &target_auth,
         )?;
-        let target_head = run_git(&["rev-parse", "FETCH_HEAD"], Some(&repo_dir), &auth)
+        let target_head = run_git(&["rev-parse", "FETCH_HEAD"], Some(&repo_dir), &target_auth)
             .ok()
             .and_then(|output| first_output_line(&output))
             .ok_or_else(|| "Could not resolve the target branch.".to_string())?;
@@ -221,7 +225,7 @@ pub async fn open_project_merge_recovery_terminal(
         run_git(
             &["update-ref", target_ref.as_str(), target_head.as_str()],
             Some(&repo_dir),
-            &auth,
+            &target_auth,
         )?;
 
         run_git(
@@ -234,9 +238,9 @@ pub async fn open_project_merge_recovery_terminal(
                 source_branch.as_str(),
             ],
             Some(&repo_dir),
-            &auth,
+            &source_auth,
         )?;
-        let source_head = run_git(&["rev-parse", "FETCH_HEAD"], Some(&repo_dir), &auth)
+        let source_head = run_git(&["rev-parse", "FETCH_HEAD"], Some(&repo_dir), &source_auth)
             .ok()
             .and_then(|output| first_output_line(&output))
             .ok_or_else(|| "Could not resolve the pull request branch.".to_string())?;
@@ -251,7 +255,7 @@ pub async fn open_project_merge_recovery_terminal(
         run_git(
             &["update-ref", recovery_ref.as_str(), expected_commit.as_str()],
             Some(&repo_dir),
-            &auth,
+            &target_auth,
         )?;
         launch_terminal_at(&repo_dir)?;
         Ok(ProjectMergeRecoveryTerminalResult {

--- a/desktop/src/features/projects/lib/projectGitError.test.mjs
+++ b/desktop/src/features/projects/lib/projectGitError.test.mjs
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { projectCloneErrorPresentation } from "./projectGitError.ts";
 
-test("explains unsupported authenticated GitHub clones without exposing git output", () => {
+test("explains authenticated GitHub clone failures without exposing git output", () => {
   assert.deepEqual(
     projectCloneErrorPresentation(
       new Error(
@@ -14,7 +14,23 @@ test("explains unsupported authenticated GitHub clones without exposing git outp
     {
       title: "Repository access required",
       description:
-        "This repository requires GitHub authentication. Buzz currently clones public GitHub repositories without credentials.",
+        "This repository requires GitHub authentication. Sign in with the GitHub CLI and try again.",
+    },
+  );
+});
+
+test("explains authenticated GitLab clone failures with glab login guidance", () => {
+  assert.deepEqual(
+    projectCloneErrorPresentation(
+      new Error(
+        "Cloning into '/Users/person/repos/app'... remote: HTTP Basic: Access denied fatal: Authentication failed for 'https://gitlab.onlyarag.com/group/private-repo.git/'",
+      ),
+      "https://gitlab.onlyarag.com/group/private-repo.git",
+    ),
+    {
+      title: "Repository access required",
+      description:
+        "This repository requires GitLab authentication. Sign in with the GitLab CLI (`glab auth login`) and try again.",
     },
   );
 });

--- a/desktop/src/features/projects/lib/projectGitError.test.mjs
+++ b/desktop/src/features/projects/lib/projectGitError.test.mjs
@@ -35,6 +35,22 @@ test("explains authenticated GitLab clone failures with glab login guidance", ()
   );
 });
 
+test("preserves missing credential helper remediation", () => {
+  assert.deepEqual(
+    projectCloneErrorPresentation(
+      new Error(
+        "fatal: could not read Username. If this repository is private, install the glab CLI, run `glab auth login`, and restart Buzz before trying again.",
+      ),
+      "https://gitlab.onlyarag.com/example/app.git",
+    ),
+    {
+      title: "GitLab CLI required",
+      description:
+        "Install the GitLab CLI, run `glab auth login`, restart Buzz, and try again.",
+    },
+  );
+});
+
 test("presents missing and network failures clearly", () => {
   assert.equal(
     projectCloneErrorPresentation(new Error("Repository not found")).title,

--- a/desktop/src/features/projects/lib/projectGitError.ts
+++ b/desktop/src/features/projects/lib/projectGitError.ts
@@ -47,6 +47,20 @@ export function projectCloneErrorPresentation(
         "You need access to the repository’s channel before you can clone it.",
     };
   }
+  if (message.includes("install the gh cli")) {
+    return {
+      title: "GitHub CLI required",
+      description:
+        "Install the GitHub CLI, run `gh auth login`, restart Buzz, and try again.",
+    };
+  }
+  if (message.includes("install the glab cli")) {
+    return {
+      title: "GitLab CLI required",
+      description:
+        "Install the GitLab CLI, run `glab auth login`, restart Buzz, and try again.",
+    };
+  }
   if (
     /\b(?:401|403)\b|authenticat|authoriz|permission denied|access denied|ssh certificate/.test(
       message,

--- a/desktop/src/features/projects/lib/projectGitError.ts
+++ b/desktop/src/features/projects/lib/projectGitError.ts
@@ -47,6 +47,13 @@ export function projectCloneErrorPresentation(
         "You need access to the repository’s channel before you can clone it.",
     };
   }
+  if (message.includes("must be github.com or a host listed in")) {
+    return {
+      title: "Repository host not trusted",
+      description:
+        "Ask your Buzz operator to add this GitLab origin to `BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS` and restart Buzz.",
+    };
+  }
   if (message.includes("install the gh cli")) {
     return {
       title: "GitHub CLI required",

--- a/desktop/src/features/projects/lib/projectGitError.ts
+++ b/desktop/src/features/projects/lib/projectGitError.ts
@@ -18,6 +18,19 @@ function isGitHubUrl(cloneUrl: string | null | undefined) {
   }
 }
 
+// Operator-trusted external origins beyond github.com (see
+// `BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS` in project_git_exec.rs) are typically
+// self-hosted GitLab instances, authenticated via `glab`. The frontend has
+// no visibility into the exact trust list, so this is a hostname heuristic
+// rather than an exact match.
+function isGitLabUrl(cloneUrl: string | null | undefined) {
+  try {
+    return new URL(cloneUrl ?? "").hostname.toLowerCase().includes("gitlab");
+  } catch {
+    return false;
+  }
+}
+
 export function projectCloneErrorPresentation(
   error: unknown,
   cloneUrl?: string | null,
@@ -25,6 +38,7 @@ export function projectCloneErrorPresentation(
 ): ProjectGitErrorPresentation {
   const message = errorText(error);
   const github = isGitHubUrl(cloneUrl);
+  const gitlab = isGitLabUrl(cloneUrl);
 
   if (unavailableReason === "access") {
     return {
@@ -41,8 +55,10 @@ export function projectCloneErrorPresentation(
     return {
       title: "Repository access required",
       description: github
-        ? "This repository requires GitHub authentication. Buzz currently clones public GitHub repositories without credentials."
-        : "Buzz could not authenticate with this repository. Check your access and try again.",
+        ? "This repository requires GitHub authentication. Sign in with the GitHub CLI and try again."
+        : gitlab
+          ? "This repository requires GitLab authentication. Sign in with the GitLab CLI (`glab auth login`) and try again."
+          : "Buzz could not authenticate with this repository. Check your access and try again.",
     };
   }
   if (/\b404\b|repository not found|repository does not exist/.test(message)) {

--- a/desktop/src/features/projects/useProjectRepoHost.ts
+++ b/desktop/src/features/projects/useProjectRepoHost.ts
@@ -24,9 +24,10 @@ export function useProjectRepoPresentation(
   return {
     host,
     webUrl,
-    canCloneLocally:
-      host.kind === "buzz" ||
-      (host.kind === "external" && host.host === "github.com"),
+    // The backend enforces the exact trusted-origin allowlist before cloning.
+    // Keep the affordance available for configured GitLab/self-hosted remotes
+    // instead of hiding every external host except github.com.
+    canCloneLocally: host.kind !== "unresolved",
     controls: {
       externalUrl: host.kind === "external" ? webUrl : null,
       remoteKind: host.kind === "unresolved" ? undefined : host.kind,


### PR DESCRIPTION
## Summary
- authenticate private GitHub repositories through the existing `gh` CLI credential helper
- allow operator-trusted self-hosted GitLab origins through `glab` without storing credentials in Buzz
- keep external repositories read-only while preserving Buzz-hosted write and merge ownership checks
- harden Git subprocess environment and clone URL validation

## Configuration
Set `BUZZ_TRUSTED_EXTERNAL_GIT_ORIGINS=https://gitlab.example.com` in the packaged desktop process environment. `github.com` is trusted by default.

## Validation
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib commands::project_git` (49 passed)
- Biome check on changed project UI files
- project Git error Node tests (5 passed)
- independent security/correctness reviews, with findings fixed
