### PR TITLE
fix(relay): advertise NIP-45 COUNT in SUPPORTED_NIPS (#7432)

### DIFF
--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -12,7 +12,7 @@ use crate::config::DEFAULT_MAX_FRAME_BYTES;
 ///
 /// NIP-43 (relay membership) is advertised separately by [`RelayInfo::build`]
 /// only when membership enforcement is actually enabled — see that function.
-pub(crate) const SUPPORTED_NIPS: &[u32] = &[1, 2, 10, 11, 16, 17, 23, 25, 29, 33, 38, 42, 50, 56];
+pub(crate) const SUPPORTED_NIPS: &[u32] = &[1, 2, 10, 11, 16, 17, 23, 25, 29, 33, 38, 42, 45, 50, 56];
 
 /// NIP-43 (relay membership). Advertised only when the relay actually
 /// enforces membership (`BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`) AND has a
@@ -438,6 +438,14 @@ mod tests {
         assert!(
             SUPPORTED_NIPS.contains(&38),
             "NIP-38 (user statuses) must be advertised"
+        );
+    }
+
+    #[test]
+    fn supported_nips_includes_nip45() {
+        assert!(
+            SUPPORTED_NIPS.contains(&45),
+            "NIP-45 (COUNT) must be advertised"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add `45` to `SUPPORTED_NIPS` in `crates/buzz-relay/src/nip11.rs` so NIP-11 advertises COUNT.
- COUNT is already implemented (`handlers/count.rs`); clients checking NIP-11 were incorrectly skipping it.
- Add unit test `supported_nips_includes_nip45`.

Closes #7432

## Test plan
- [ ] `cargo test -p buzz-relay supported_nips_includes_nip45`
- [ ] Confirm NIP-11 document lists 45 alongside existing NIPs