### PR TITLE
fix(web): filter repo refs by relay pubkey (#7433)

### DIFF
--- a/web/src/features/repos/ui/RepoDetailPage.tsx
+++ b/web/src/features/repos/ui/RepoDetailPage.tsx
@@ -194,6 +194,7 @@ export function RepoDetailPage() {
     preview: showMockRepo,
   });
   const { data: refs, isLoading: refsLoading } = useRepoRefs(repoId, {
+    ownerPubkey: repo?.owner,
     preview: showMockRepo,
   });
 

--- a/web/src/features/repos/use-repo-context.ts
+++ b/web/src/features/repos/use-repo-context.ts
@@ -27,6 +27,7 @@ export function useRepoContext(
     error: repoError,
   } = useRepo(repoId, { preview });
   const { data: refs, isLoading: refsLoading } = useRepoRefs(repoId, {
+    ownerPubkey: repo?.owner,
     preview,
   });
 

--- a/web/src/features/repos/use-repo-refs.ts
+++ b/web/src/features/repos/use-repo-refs.ts
@@ -1,5 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryEvents, type NostrEvent } from "@/shared/lib/nostr-client";
+import {
+  fetchRelaySelfPubkey,
+  trustedRepoRefAuthors,
+} from "@/shared/lib/relay-self";
 import { relayWsUrl } from "@/shared/lib/relay-url";
 import { dedup } from "./use-repos";
 
@@ -48,18 +52,35 @@ function parseRefs(events: NostrEvent[]): RepoRefs {
   return { branches, tags, head };
 }
 
-async function fetchRepoRefs(repoId: string): Promise<RepoRefs> {
-  // TODO: Filter by `authors: [relayPubkey]` once the relay's own pubkey is
-  // exposed to the client. Without this, a user with ReposWrite permission
-  // could publish fake kind:30618 events with spoofed refs.
+async function fetchRepoRefs(
+  repoId: string,
+  ownerPubkey?: string | null,
+): Promise<RepoRefs> {
+  // Buzz signs authoritative kind:30618 events with the relay keypair
+  // (see crates/buzz-relay/.../manifest_event.rs). Scope the query to that
+  // pubkey — matching desktop fetchRepoState — so ReposWrite holders cannot
+  // spoof refs. Include the repo owner when known for NIP-34 interop.
+  const relayPubkey = await fetchRelaySelfPubkey();
+  if (!relayPubkey) {
+    throw new Error(
+      "Relay NIP-11 `self` pubkey unavailable; refusing unscoped kind:30618 query",
+    );
+  }
   const events = await queryEvents(relayWsUrl(), {
     kinds: [30618],
+    authors: trustedRepoRefAuthors(relayPubkey, ownerPubkey),
     "#d": [repoId],
   });
   return parseRefs(events);
 }
 
-export function useRepoRefs(repoId: string, { preview = false } = {}) {
+export function useRepoRefs(
+  repoId: string,
+  {
+    preview = false,
+    ownerPubkey,
+  }: { preview?: boolean; ownerPubkey?: string | null } = {},
+) {
   const mockRefs: RepoRefs = {
     branches: ["main"],
     tags: ["v0.1.0"],
@@ -67,8 +88,12 @@ export function useRepoRefs(repoId: string, { preview = false } = {}) {
   };
 
   return useQuery({
-    queryKey: preview ? ["repo-refs", "mock", repoId] : ["repo-refs", repoId],
-    queryFn: preview ? async () => mockRefs : () => fetchRepoRefs(repoId),
+    queryKey: preview
+      ? ["repo-refs", "mock", repoId]
+      : ["repo-refs", repoId, ownerPubkey ?? null],
+    queryFn: preview
+      ? async () => mockRefs
+      : () => fetchRepoRefs(repoId, ownerPubkey),
     initialData: preview ? mockRefs : undefined,
     staleTime: 60_000,
   });

--- a/web/src/shared/lib/relay-self.test.mjs
+++ b/web/src/shared/lib/relay-self.test.mjs
@@ -1,0 +1,57 @@
+/**
+ * Mirrors the pure helpers in relay-self.ts. Run with:
+ *   node --test web/src/shared/lib/relay-self.test.mjs
+ *
+ * Kept self-contained because buzz-web has no vitest/ts-node runner.
+ * If these assertions drift from relay-self.ts, update both.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const HEX_PUBKEY = /^[0-9a-f]{64}$/;
+
+function parseRelaySelfPubkey(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return HEX_PUBKEY.test(normalized) ? normalized : null;
+}
+
+function trustedRepoRefAuthors(relaySelf, ownerPubkey) {
+  return [
+    ...new Set(
+      [ownerPubkey, relaySelf]
+        .map((value) => (typeof value === "string" ? value.toLowerCase() : ""))
+        .filter((value) => HEX_PUBKEY.test(value)),
+    ),
+  ];
+}
+
+test("parseRelaySelfPubkey accepts lowercase hex", () => {
+  const pk = "a".repeat(64);
+  assert.equal(parseRelaySelfPubkey(pk), pk);
+});
+
+test("parseRelaySelfPubkey normalizes uppercase", () => {
+  const pk = "AB".repeat(32);
+  assert.equal(parseRelaySelfPubkey(pk), pk.toLowerCase());
+});
+
+test("parseRelaySelfPubkey rejects invalid values", () => {
+  assert.equal(parseRelaySelfPubkey(null), null);
+  assert.equal(parseRelaySelfPubkey(undefined), null);
+  assert.equal(parseRelaySelfPubkey("short"), null);
+  assert.equal(parseRelaySelfPubkey("g".repeat(64)), null);
+  assert.equal(parseRelaySelfPubkey(123), null);
+});
+
+test("trustedRepoRefAuthors requires relay self and dedupes owner", () => {
+  const relay = "b".repeat(64);
+  const owner = "c".repeat(64);
+  assert.deepEqual(trustedRepoRefAuthors(relay), [relay]);
+  assert.deepEqual(
+    trustedRepoRefAuthors(relay, owner).sort(),
+    [owner, relay].sort(),
+  );
+  assert.deepEqual(trustedRepoRefAuthors(relay, relay), [relay]);
+  assert.deepEqual(trustedRepoRefAuthors(relay, "not-a-key"), [relay]);
+});

--- a/web/src/shared/lib/relay-self.ts
+++ b/web/src/shared/lib/relay-self.ts
@@ -1,0 +1,61 @@
+/**
+ * Fetch the active relay's NIP-11 `self` pubkey (its own signing key, hex).
+ *
+ * Buzz signs authoritative kind:30618 repo-state events with this key
+ * (`build_ref_state_event` / `relay_keypair`). Clients must scope ref queries
+ * to `authors: [self]` so spoofed 30618 events from other pubkeys are ignored.
+ *
+ * Returns `null` when the relay advertises no `self` or an invalid key.
+ * Network / malformed-document failures reject.
+ */
+import { relayHttpBaseUrl } from "@/shared/lib/relay-url";
+
+const HEX_PUBKEY = /^[0-9a-f]{64}$/;
+
+type Nip11Document = {
+  self?: unknown;
+};
+
+/** Validate and normalize a NIP-11 `self` value to lowercase hex, or null. */
+export function parseRelaySelfPubkey(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return HEX_PUBKEY.test(normalized) ? normalized : null;
+}
+
+/**
+ * Trusted authors for a kind:30618 repo-state query.
+ *
+ * Matches desktop `fetchRepoState`: relay `self` is required (Buzz signs
+ * 30618 with the relay keypair). The repo owner is included when known for
+ * NIP-34 interop with owner-published state announcements.
+ */
+export function trustedRepoRefAuthors(
+  relaySelf: string,
+  ownerPubkey?: string | null,
+): string[] {
+  return [
+    ...new Set(
+      [ownerPubkey, relaySelf]
+        .map((value) => (typeof value === "string" ? value.toLowerCase() : ""))
+        .filter((value) => HEX_PUBKEY.test(value)),
+    ),
+  ];
+}
+
+/** GET the relay NIP-11 document and return its `self` pubkey, or null. */
+export async function fetchRelaySelfPubkey(
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const httpUrl = relayHttpBaseUrl();
+  // Prefer `/info` (always JSON) — same document as Accept-negotiated `/`.
+  const response = await fetch(`${httpUrl.replace(/\/+$/, "")}/info`, {
+    headers: { Accept: "application/nostr+json" },
+    signal,
+  });
+  if (!response.ok) {
+    return null;
+  }
+  const doc = (await response.json()) as Nip11Document;
+  return parseRelaySelfPubkey(doc.self);
+}


### PR DESCRIPTION
## Summary
- Scope kind:30618 repo ref queries to NIP-11 relay `self` (+ owner when known)
- Fail closed if relay self unavailable
- Matches desktop `fetchRepoState` / relay_keypair signing for 30618
- Add pure helper tests for `relay-self` parsing / author list

Fixes #7433

## Test plan
- [x] `node --test web/src/shared/lib/relay-self.test.mjs`
- [ ] Spot-check repo browser refs with spoofed foreign-pubkey 30618 events