### PR TITLE
fix(acp): forward ATLASSIAN_SA_TOKEN into buzz-dev-mcp env

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -5779,6 +5779,21 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
                     });
                 }
             }
+            // Forward ATLASSIAN_SA_TOKEN so shell tools under buzz-dev-mcp
+            // (bin/atlassian-sa.sh) see the managed agent's service-account
+            // identity. Desktop writes the var into the buzz-acp child via
+            // descriptor.env; buzz-agent then env_clear()s and restores only
+            // spec.env, so omitting it here drops the token at the MCP hop.
+            // Same contract as BUZZ_AUTH_TAG: present-and-nonempty is
+            // forwarded; unset/empty is omitted. Do not copy the parent env.
+            if let Ok(token) = std::env::var("ATLASSIAN_SA_TOKEN") {
+                if !token.is_empty() {
+                    env.push(EnvVar {
+                        name: "ATLASSIAN_SA_TOKEN".into(),
+                        value: token,
+                    });
+                }
+            }
             env
         },
     }]
@@ -8890,6 +8905,37 @@ mod build_mcp_servers_tests {
     /// Env-var-touching tests must run serially — env vars are process-global.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Restore a process env var even if the test panics. Required here
+    /// because the agent process running these tests may already hold a
+    /// real `ATLASSIAN_SA_TOKEN`; a bare `remove_var` would drop it.
+    struct EnvRestore {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvRestore {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, prev }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     fn test_config() -> Config {
         Config {
             keys: nostr::Keys::generate(),
@@ -9040,6 +9086,71 @@ mod build_mcp_servers_tests {
                 .iter()
                 .any(|e| e.name == "BUZZ_ACP_DISPLAY_NAME"),
             "empty display name should not be forwarded"
+        );
+    }
+
+    #[test]
+    fn session_new_mcp_server_forwards_atlassian_sa_token() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _token = EnvRestore::set("ATLASSIAN_SA_TOKEN", "test-atlassian-sa-token");
+        let servers = build_mcp_servers(&test_config());
+
+        let entry = servers[0]
+            .env
+            .iter()
+            .find(|e| e.name == "ATLASSIAN_SA_TOKEN");
+        assert_eq!(
+            entry.map(|e| e.value.as_str()),
+            Some("test-atlassian-sa-token"),
+            "configured ATLASSIAN_SA_TOKEN must reach the MCP server EnvVar list"
+        );
+    }
+
+    #[test]
+    fn session_new_mcp_server_omits_unset_atlassian_sa_token() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _token = EnvRestore::unset("ATLASSIAN_SA_TOKEN");
+        let servers = build_mcp_servers(&test_config());
+
+        assert!(
+            !servers[0]
+                .env
+                .iter()
+                .any(|e| e.name == "ATLASSIAN_SA_TOKEN"),
+            "unset ATLASSIAN_SA_TOKEN must be absent, not empty-valued"
+        );
+    }
+
+    #[test]
+    fn session_new_mcp_server_skips_empty_atlassian_sa_token() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _token = EnvRestore::set("ATLASSIAN_SA_TOKEN", "");
+        let servers = build_mcp_servers(&test_config());
+
+        assert!(
+            !servers[0]
+                .env
+                .iter()
+                .any(|e| e.name == "ATLASSIAN_SA_TOKEN"),
+            "empty ATLASSIAN_SA_TOKEN should not be forwarded"
+        );
+    }
+
+    #[test]
+    fn session_new_mcp_server_does_not_forward_unlisted_parent_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _token = EnvRestore::set("ATLASSIAN_SA_TOKEN", "test-atlassian-sa-token");
+        let _unlisted = EnvRestore::set("UNRELATED_PARENT_SECRET", "must-not-leak");
+        let servers = build_mcp_servers(&test_config());
+        let names: Vec<&str> = servers[0].env.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"ATLASSIAN_SA_TOKEN"),
+            "allowlisted token must still be forwarded; got {names:?}"
+        );
+        assert!(
+            !names.contains(&"UNRELATED_PARENT_SECRET"),
+            "build_mcp_servers must not copy the parent environment; got {names:?}"
         );
     }
 


### PR DESCRIPTION
## Problem

Managed agents get `ATLASSIAN_SA_TOKEN` in the Desktop definition. Desktop writes `descriptor.env` into the `buzz-acp` child, but `build_mcp_servers` only forwarded `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, optional `BUZZ_AUTH_TAG`, and `BUZZ_ACP_DISPLAY_NAME`. `buzz-agent` then `env_clear()`s and restores `spec.env`, so `buzz-dev-mcp` shell tools never see the token. A Desktop restart cannot fix this hop.

Diagnosed on IT-139 comment 59775. Closest open PR: #4798 (general `BUZZ_ACP_FORWARD_ENV` forwarding). That PR still refuses API tokens by design, so it would not close this gap. This change is the narrow `BUZZ_AUTH_TAG`-shaped allowlist hop, not a parent-env copy.

## Fix

If `ATLASSIAN_SA_TOKEN` is present and nonempty in the `buzz-acp` process, add it to the trusted MCP server `EnvVar` list. Unset/empty omits the key. Unlisted parent secrets are not forwarded.

## Tests

Four `build_mcp_servers` cases bind the production function: set, unset, empty, and an unlisted parent secret that must not leak. Tests restore the previous process value so a real token in the runner is not dropped.

`cargo test -p buzz-acp` at `1f0da474` (parent `ee883d73`): 909 lib + 9 `pool_lifecycle_state` passed. Two clap default tests fail in this managed-agent process unless `BUZZ_ACP_LAZY_POOL` and `BUZZ_ACP_IDLE_POOL_SLEEP` are unset; those vars are Desktop launch policy, not this diff. Re-ran the package with those two unset.

No deployment or live harness change in this PR. Independent review requested before rebuild/restart.