### PR TITLE
fix(relay): preserve query strings during URL normalization

### DIFF
--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -3723,12 +3723,39 @@ async fn send_auth_response(
 ///
 /// `ws://host:port` → `http://host:port`
 /// `wss://host:port` → `https://host:port`
-/// Trailing slashes are stripped.
+/// A root path slash is removed; non-root paths and queries are preserved.
 pub(crate) fn relay_ws_to_http(url: &str) -> String {
-    url.replace("wss://", "https://")
-        .replace("ws://", "http://")
-        .trim_end_matches('/')
-        .to_string()
+    let mut parsed = match url::Url::parse(url.trim()) {
+        Ok(parsed) => parsed,
+        Err(_) => return url.trim().to_string(),
+    };
+    let scheme = match parsed.scheme() {
+        "wss" => "https".to_owned(),
+        "ws" => "http".to_owned(),
+        scheme => scheme.to_owned(),
+    };
+    let _ = parsed.set_scheme(&scheme);
+    let had_root_path = parsed.path() == "/";
+    if had_root_path {
+        parsed.set_path("");
+    } else if parsed.query().is_none() && parsed.fragment().is_none() {
+        let path = parsed.path().trim_end_matches('/').to_owned();
+        parsed.set_path(&path);
+    }
+    let mut serialized = parsed.to_string();
+    if had_root_path {
+        let delimiter = serialized.find(['?', '#']);
+        match delimiter {
+            Some(index) if serialized.as_bytes().get(index.wrapping_sub(1)) == Some(&b'/') => {
+                serialized.remove(index - 1);
+            }
+            None if serialized.ends_with('/') => {
+                serialized.pop();
+            }
+            _ => {}
+        }
+    }
+    serialized
 }
 
 /// Build the subscription ID for a channel: `ch-<uuid>`.
@@ -4430,6 +4457,26 @@ mod tests {
         assert_eq!(
             relay_ws_to_http("wss://relay.example.com:4000/ws"),
             "https://relay.example.com:4000/ws"
+        );
+    }
+
+    #[test]
+    fn relay_ws_to_http_preserves_queries() {
+        assert_eq!(
+            relay_ws_to_http("wss://relay.example.com/?next=/"),
+            "https://relay.example.com?next=/"
+        );
+        assert_eq!(
+            relay_ws_to_http("wss://relay.example.com/?url=wss://other.example/"),
+            "https://relay.example.com?url=wss://other.example/"
+        );
+        assert_eq!(
+            relay_ws_to_http("wss://relay.example.com/nostr/"),
+            "https://relay.example.com/nostr"
+        );
+        assert_eq!(
+            relay_ws_to_http("wss://relay.example.com/nostr/?next=/"),
+            "https://relay.example.com/nostr/?next=/"
         );
     }
 

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -1348,20 +1348,67 @@ impl BuzzClient {
     }
 }
 
-/// Normalize a relay URL: ws:// → http://, wss:// → https://, strip trailing slash.
+/// Normalize a relay URL: ws:// → http:// and wss:// → https://.
 /// BUZZ_RELAY_URL may be ws/wss (copied from MCP config).
 pub fn normalize_relay_url(url: &str) -> String {
-    url.replace("wss://", "https://")
-        .replace("ws://", "http://")
-        .trim_end_matches('/')
-        .to_string()
+    let mut parsed = match url::Url::parse(url.trim()) {
+        Ok(parsed) => parsed,
+        Err(_) => return url.trim().to_string(),
+    };
+    let scheme = match parsed.scheme() {
+        "wss" => "https".to_owned(),
+        "ws" => "http".to_owned(),
+        scheme => scheme.to_owned(),
+    };
+    let _ = parsed.set_scheme(&scheme);
+    let had_root_path = parsed.path() == "/";
+    if had_root_path {
+        parsed.set_path("");
+    } else if parsed.query().is_none() && parsed.fragment().is_none() {
+        let path = parsed.path().trim_end_matches('/').to_owned();
+        parsed.set_path(&path);
+    }
+    serialize_relay_url(parsed, had_root_path)
 }
 
 /// Convert an HTTP(S) relay base URL back to a WebSocket URL for NIP-01 connections.
 fn to_ws_url(http_url: &str) -> String {
-    http_url
-        .replace("https://", "wss://")
-        .replace("http://", "ws://")
+    let mut parsed = match url::Url::parse(http_url.trim()) {
+        Ok(parsed) => parsed,
+        Err(_) => return http_url.trim().to_string(),
+    };
+    let scheme = match parsed.scheme() {
+        "https" => "wss".to_owned(),
+        "http" => "ws".to_owned(),
+        scheme => scheme.to_owned(),
+    };
+    let _ = parsed.set_scheme(&scheme);
+    let had_root_path = parsed.path() == "/";
+    if had_root_path {
+        parsed.set_path("");
+    } else if parsed.query().is_none() && parsed.fragment().is_none() {
+        let path = parsed.path().trim_end_matches('/').to_owned();
+        parsed.set_path(&path);
+    }
+    serialize_relay_url(parsed, had_root_path)
+}
+
+fn serialize_relay_url(parsed: url::Url, had_root_path: bool) -> String {
+    let mut serialized = parsed.to_string();
+    if !had_root_path {
+        return serialized;
+    }
+    let delimiter = serialized.find(['?', '#']);
+    match delimiter {
+        Some(index) if serialized.as_bytes().get(index.wrapping_sub(1)) == Some(&b'/') => {
+            serialized.remove(index - 1);
+        }
+        None if serialized.ends_with('/') => {
+            serialized.pop();
+        }
+        _ => {}
+    }
+    serialized
 }
 
 /// Normalize raw event JSON array into the canonical Nostr event shape.
@@ -2370,9 +2417,33 @@ mod retry_policy_tests {
 mod tests {
     use super::{
         advance_query_cursor, create_response_with_id_if_accepted, extract_relay_response_field,
-        normalize_events, BuzzClient,
+        normalize_events, normalize_relay_url, to_ws_url, BuzzClient,
     };
     use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    #[test]
+    fn relay_url_scheme_conversion_preserves_query_bytes() {
+        assert_eq!(
+            normalize_relay_url("wss://relay.example/?next=/"),
+            "https://relay.example?next=/"
+        );
+        assert_eq!(
+            normalize_relay_url("wss://relay.example/?url=wss://other.example/"),
+            "https://relay.example?url=wss://other.example/"
+        );
+        assert_eq!(
+            to_ws_url("https://relay.example/?next=/foo/"),
+            "wss://relay.example?next=/foo/"
+        );
+        assert_eq!(
+            normalize_relay_url("wss://relay.example/nostr/"),
+            "https://relay.example/nostr"
+        );
+        assert_eq!(
+            normalize_relay_url("wss://relay.example/nostr/?next=/"),
+            "https://relay.example/nostr/?next=/"
+        );
+    }
 
     #[test]
     fn normalize_events_preserves_the_complete_signed_event_shape() {

--- a/crates/buzz-core/src/relay.rs
+++ b/crates/buzz-core/src/relay.rs
@@ -71,10 +71,28 @@ pub fn normalize_relay_url(raw: &str) -> Result<String, NormalizeRelayUrlError> 
         url.set_port(None)
             .map_err(|_| NormalizeRelayUrlError::InvalidScheme)?;
     }
-    if url.path() == "/" {
+    let had_root_path = url.path() == "/";
+    if had_root_path {
         url.set_path("");
     }
-    Ok(url.to_string().trim_end_matches('/').to_string())
+    let mut serialized = url.to_string();
+    if had_root_path {
+        remove_root_path_separator(&mut serialized);
+    }
+    Ok(serialized)
+}
+
+fn remove_root_path_separator(serialized: &mut String) {
+    let delimiter = serialized.find(['?', '#']);
+    match delimiter {
+        Some(index) if serialized.as_bytes().get(index.wrapping_sub(1)) == Some(&b'/') => {
+            serialized.remove(index - 1);
+        }
+        None if serialized.ends_with('/') => {
+            serialized.pop();
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -101,6 +119,23 @@ mod tests {
             normalize_relay_url("ws://relay.example:8080/community/?x=1").unwrap(),
             "ws://relay.example:8080/community/?x=1"
         );
+    }
+
+    #[test]
+    fn preserves_queries_when_removing_root_path() {
+        for (input, expected) in [
+            ("wss://relay.example/?next=/", "wss://relay.example?next=/"),
+            (
+                "wss://relay.example/?next=/foo/",
+                "wss://relay.example?next=/foo/",
+            ),
+            (
+                "wss://relay.example/?url=wss://other.example/",
+                "wss://relay.example?url=wss://other.example/",
+            ),
+        ] {
+            assert_eq!(normalize_relay_url(input).unwrap(), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION

## Summary

Fix relay URL normalization so query parameters are not modified accidentally.

The previous implementations used string-wide `trim_end_matches('/')` and `replace()` calls. These operations could alter query values or nested URLs, for example:

```text
wss://relay.example/?next=/
```

could become:

```text
wss://relay.example?next=
```

and:

```text
wss://relay.example/path?redirect=wss://other.example/
```

could have its nested query URL rewritten.

The updated code parses URLs with `url::Url`, changes only the URL scheme and intended path component, and preserves query strings.

### Related issue

Fixes #<issue-number>


### Testing

- `cargo test -p buzz-core relay::tests --lib`
- `cargo test -p buzz-cli client::tests --lib`
- `cargo test -p buzz-acp relay::tests --lib`
- `cargo clippy -p buzz-core -p buzz-cli -p buzz-acp --all-targets -- -D warnings`


Regression coverage includes:

```text
wss://relay.example/?next=/
wss://relay.example/?next=/foo/
wss://relay.example/?url=wss://other.example/
```
```