### PR TITLE
fix(desktop): preserve full thread context when opening reply notifications

### DIFF
--- a/desktop/src/app/routes/ChannelRouteScreen.tsx
+++ b/desktop/src/app/routes/ChannelRouteScreen.tsx
@@ -161,10 +161,7 @@ export function ChannelRouteScreen({
     enumeratedProjectHome ?? projectHomeLookupQuery.data ?? null;
   const [targetMessageEvents, setTargetMessageEvents] = React.useState<
     RelayEvent[]
-  >(() => {
-    const cachedTarget = getCachedSearchHitEvent(targetMessageId);
-    return cachedTarget ? [cachedTarget] : [];
-  });
+  >([]);
   const [activeSearchHighlight, setActiveSearchHighlight] =
     React.useState<SearchHighlightNavigation | null>(searchHighlight ?? null);
   const appliedSearchActivationIdRef = React.useRef<string | null>(
@@ -211,13 +208,8 @@ export function ChannelRouteScreen({
     targetReplyId,
     targetThreadRootId,
   ]);
-
-  // Reset spliced target events when the channel changes. Tied to channel
-  // identity rather than the route target so clearing the `messageId` param
-  // mid-channel keeps the deep-linked row in view. Seeded with the mount key so
-  // the initial cache-seeded events survive first commit; only a genuine
-  // channel change clears them. Declared before the fetch effect so a channel
-  // switch clears stale events before the new target is fetched.
+  // Keep spliced events after the route target clears so a deep-linked row
+  // remains visible, but discard them when switching channels.
   const previousResetKeyRef = React.useRef<string>(channelId);
   React.useEffect(() => {
     if (previousResetKeyRef.current === channelId) return;
@@ -243,13 +235,9 @@ export function ChannelRouteScreen({
     }
 
     const cachedTarget = getCachedSearchHitEvent(targetMessageId);
-    if (cachedTarget) {
-      setTargetMessageEvents((currentEvents) =>
-        currentEvents.some((event) => event.id === cachedTarget.id)
-          ? currentEvents
-          : [...currentEvents, cachedTarget],
-      );
-    }
+    // Search/notification projections have no reply tags. Inserting one before
+    // hydration can select the reply as a root and consume the route target.
+    // Retain it only as a fallback after the authoritative lookup completes.
 
     const eventIds = [
       targetMessageId,
@@ -268,6 +256,9 @@ export function ChannelRouteScreen({
           const eventsById = new Map<string, RelayEvent>();
           for (const event of [...currentEvents, ...events]) {
             eventsById.set(event.id, event);
+          }
+          if (cachedTarget && !eventsById.has(cachedTarget.id)) {
+            eventsById.set(cachedTarget.id, cachedTarget);
           }
           return Array.from(eventsById.values());
         });

--- a/desktop/tests/e2e/navigation.spec.ts
+++ b/desktop/tests/e2e/navigation.spec.ts
@@ -1058,3 +1058,68 @@ test("cold-start message deep link preserves its thread target", async ({
   await expect(page).toHaveURL(/messageId=mock-forum-release-reply/);
   await expect(page).toHaveURL(/threadRootId=mock-forum-release-thread/);
 });
+
+test("reply notification hydration opens the full thread instead of the cached reply", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("message-input")).toBeVisible();
+  const targetId = await page.evaluate(() => {
+    const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+    if (!emit) throw new Error("Mock message fixture unavailable");
+    const input = {
+      channelName: "engineering",
+      pubkey:
+        "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f",
+    };
+    const root = emit({ ...input, content: "Notification context root" });
+    emit({
+      ...input,
+      parentEventId: root.id,
+      content: "Sibling reply retains context",
+    });
+    const parent = emit({
+      ...input,
+      parentEventId: root.id,
+      content: "Parent reply retains context",
+    });
+    const target = emit({
+      ...input,
+      parentEventId: parent.id,
+      content: "Nested notification reply",
+    });
+    window.__BUZZ_E2E_DEFER_GET_EVENT__ = target.id;
+    window.__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?.({
+      category: "mention",
+      channel_id: "1c7e1c02-87bb-5e88-b2da-5a7a9432d0c9",
+      channel_name: "engineering",
+      content: target.content,
+      created_at: Math.floor(Date.now() / 1000) + 5,
+      id: target.id,
+      kind: target.kind,
+      pubkey: target.pubkey,
+      tags: target.tags.concat([["p", "deadbeef".repeat(8)]]),
+    });
+    return target.id;
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(() => window.__BUZZ_E2E_NOTIFICATIONS__?.length ?? 0),
+    )
+    .toBe(1);
+  await page.evaluate(() => window.__BUZZ_E2E_CLICK_NOTIFICATION__?.(0));
+  await expect(page.getByTestId("chat-title")).toHaveText("engineering");
+  // Hold the authoritative lookup until navigation has committed. The cached
+  // notification has no reply tags and must not become the selected thread.
+  await page.evaluate(() => window.__BUZZ_E2E_RELEASE_GET_EVENT__?.());
+  const thread = page.getByTestId("message-thread-panel");
+  await expect(thread.getByTestId("message-thread-head")).toContainText(
+    "Notification context root",
+  );
+  await expect(thread).toContainText("Sibling reply retains context");
+  await expect(thread).toContainText("Parent reply retains context");
+  await expect(thread.locator(`[data-message-id="${targetId}"]`)).toContainText(
+    "Nested notification reply",
+  );
+});


### PR DESCRIPTION
## Summary
Fix reply notifications opening a thread containing only the clicked reply instead of its root and surrounding conversation.

Notification/search navigation caches a display-only RelayEvent with no reply tags. ChannelRouteScreen inserted that projection before fetching the actual event. useChannelRouteTarget consequently classified it as a root, selected the reply as the thread head, and consumed the route target. Hydrating the real reply afterward did not repair the already-accepted selection.

Defer inserting the cached projection until the existing authoritative event/root/ancestor fetch completes. Merge fetched events first, and retain the projection only as a fallback when the event cannot be fetched. Existing timeline rows remain mounted after the route target clears.

### Duplicate check
Searched issues/PRs for notification thread navigation. Closest prior fix is merged #790, which carries the thread root through notification routing. This fixes a later projection/hydration race in that route path, not another notification transport implementation. #6695 concerns displaying replies in the channel timeline.

### Testing
- Added a deterministic browser regression that holds the clicked reply's get_event lookup, clicks a real mock desktop notification, then releases hydration. It requires the root, sibling reply, intermediate parent, and nested target in the thread panel.
- Before the fix: regression fails because the thread head is `Nested notification reply`.
- After the fix: regression passes; full navigation spec has 20 passing cases and one pre-existing skipped case.
- Existing `notification settings drive Inbox badge and desktop alerts` integration case passes, including the cache-only notification fallback.
- Typecheck, Biome checks on the changed files, and file-size checks pass.
- Visually verified notification activation in local Chromium using the existing mock Tauri/relay bridge: root, parent, sibling, and nested reply all visible.

No relay protocol, notification payload, or installed-app configuration changes.
