### PR TITLE
feat(desktop): add focused-message and unread navigation shortcuts

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -20,6 +20,7 @@ import { useLiveHomeFeedActions } from "@/app/useLiveHomeFeedActions";
 import { useChannelBrowserDialog } from "@/app/useChannelBrowserDialog";
 import { useMarkAsReadShortcuts } from "@/app/useMarkAsReadShortcuts";
 import { useSettingsShortcuts } from "@/app/useSettingsShortcuts";
+import { useUnreadConversationShortcuts } from "@/app/useUnreadConversationShortcuts";
 import { useAppShellKeyboardShortcuts } from "@/app/useAppShellKeyboardShortcuts";
 import { useAppShellDesktopNotifications } from "@/app/useAppShellDesktopNotifications";
 import { useAppShellLifecycleEffects } from "@/app/useAppShellLifecycleEffects";
@@ -696,6 +697,18 @@ export function AppShell() {
     markAllChannelsRead,
     markChannelRead,
     selectedView,
+  });
+  useUnreadConversationShortcuts({
+    disabled: settingsOpen || isHuddleRoom,
+    mutedChannelIds,
+    onNavigateChannel: (channelId) => {
+      void goChannel(channelId);
+    },
+    onNavigateHome: () => goHome(),
+    selectedChannelId,
+    selectedView,
+    threadPreviewChannelIds: unreadThreadChannelIds,
+    unreadChannelIds,
   });
   return (
     <PreventSleepProvider>

--- a/desktop/src/app/unreadNavigationEvents.ts
+++ b/desktop/src/app/unreadNavigationEvents.ts
@@ -1,0 +1,37 @@
+import { JUMP_TO_UNREAD_EVENT } from "@/shared/lib/keyboard-shortcuts";
+
+// Latch Threads requests until navigation mounts HomeView.
+
+const OPEN_INBOX_THREADS_EVENT = "buzz:open-inbox-threads";
+
+let pendingOpenInboxThreads = false;
+
+export function requestOpenInboxThreads() {
+  pendingOpenInboxThreads = true;
+  window.dispatchEvent(new CustomEvent(OPEN_INBOX_THREADS_EVENT));
+}
+
+export function consumePendingOpenInboxThreads(): boolean {
+  const pending = pendingOpenInboxThreads;
+  pendingOpenInboxThreads = false;
+  return pending;
+}
+
+export function subscribeOpenInboxThreads(handler: () => void) {
+  function handleOpenInboxThreads() {
+    pendingOpenInboxThreads = false;
+    handler();
+  }
+
+  window.addEventListener(OPEN_INBOX_THREADS_EVENT, handleOpenInboxThreads);
+  return () => {
+    window.removeEventListener(
+      OPEN_INBOX_THREADS_EVENT,
+      handleOpenInboxThreads,
+    );
+  };
+}
+
+export function requestJumpToUnread() {
+  window.dispatchEvent(new CustomEvent(JUMP_TO_UNREAD_EVENT));
+}

--- a/desktop/src/app/useUnreadConversationShortcuts.test.mjs
+++ b/desktop/src/app/useUnreadConversationShortcuts.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  matchModShiftChord,
+  matchUnreadConversationChord,
+} from "./useUnreadConversationShortcuts.ts";
+
+function chord(overrides = {}) {
+  return {
+    altKey: false,
+    code: "",
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...overrides,
+  };
+}
+
+const macUp = () => chord({ altKey: true, shiftKey: true, code: "ArrowUp" });
+const macDown = () =>
+  chord({ altKey: true, shiftKey: true, code: "ArrowDown" });
+const winUp = () =>
+  chord({ altKey: true, shiftKey: true, ctrlKey: true, code: "ArrowUp" });
+const winDown = () =>
+  chord({ altKey: true, shiftKey: true, ctrlKey: true, code: "ArrowDown" });
+
+test("macOS Alt+Shift+Arrows step to the adjacent unread conversation", () => {
+  assert.equal(matchUnreadConversationChord(macUp(), true), "previous");
+  assert.equal(matchUnreadConversationChord(macDown(), true), "next");
+});
+
+test("Windows/Linux needs Ctrl on the unread step chord", () => {
+  assert.equal(matchUnreadConversationChord(winUp(), false), "previous");
+  assert.equal(matchUnreadConversationChord(winDown(), false), "next");
+  assert.equal(matchUnreadConversationChord(macUp(), false), null);
+  assert.equal(matchUnreadConversationChord(winUp(), true), null);
+});
+
+test("the unread step chord rejects ordinary navigation and modified chords", () => {
+  assert.equal(
+    matchUnreadConversationChord(
+      chord({ altKey: true, code: "ArrowUp" }),
+      true,
+    ),
+    null,
+  );
+  assert.equal(
+    matchUnreadConversationChord(
+      chord({ altKey: true, shiftKey: true, code: "ArrowUp" }),
+      false,
+    ),
+    null,
+  );
+  assert.equal(
+    matchUnreadConversationChord(
+      chord({ shiftKey: true, code: "ArrowUp" }),
+      true,
+    ),
+    null,
+  );
+  assert.equal(
+    matchUnreadConversationChord({ ...macUp(), metaKey: true }, true),
+    null,
+  );
+});
+
+test("Mod+Shift+T opens threads without claiming plain terminal chords", () => {
+  assert.equal(
+    matchModShiftChord(
+      chord({ metaKey: true, shiftKey: true, code: "KeyT" }),
+      "KeyT",
+      true,
+    ),
+    true,
+  );
+  assert.equal(
+    matchModShiftChord(
+      chord({ ctrlKey: true, shiftKey: true, code: "KeyT" }),
+      "KeyT",
+      false,
+    ),
+    true,
+  );
+  assert.equal(
+    matchModShiftChord(chord({ metaKey: true, code: "KeyT" }), "KeyT", true),
+    false,
+  );
+  assert.equal(
+    matchModShiftChord(chord({ ctrlKey: true, code: "KeyT" }), "KeyT", false),
+    false,
+  );
+});
+
+test("Mod+Shift+J jumps to unread while plain Mod+J stays terminal", () => {
+  assert.equal(
+    matchModShiftChord(
+      chord({ metaKey: true, shiftKey: true, code: "KeyJ" }),
+      "KeyJ",
+      true,
+    ),
+    true,
+  );
+  assert.equal(
+    matchModShiftChord(
+      chord({ ctrlKey: true, shiftKey: true, code: "KeyJ" }),
+      "KeyJ",
+      false,
+    ),
+    true,
+  );
+  assert.equal(
+    matchModShiftChord(chord({ metaKey: true, code: "KeyJ" }), "KeyJ", true),
+    false,
+  );
+  assert.equal(
+    matchModShiftChord(chord({ ctrlKey: true, code: "KeyJ" }), "KeyJ", false),
+    false,
+  );
+});
+
+test("Mod+Shift chords reject cross-platform and alt-modified variants", () => {
+  assert.equal(
+    matchModShiftChord(
+      chord({ ctrlKey: true, shiftKey: true, code: "KeyT" }),
+      "KeyT",
+      true,
+    ),
+    false,
+  );
+  assert.equal(
+    matchModShiftChord(
+      chord({ metaKey: true, shiftKey: true, code: "KeyT" }),
+      "KeyT",
+      false,
+    ),
+    false,
+  );
+  assert.equal(
+    matchModShiftChord(
+      chord({ metaKey: true, shiftKey: true, altKey: true, code: "KeyT" }),
+      "KeyT",
+      true,
+    ),
+    false,
+  );
+  assert.equal(
+    matchModShiftChord(
+      chord({ metaKey: true, shiftKey: true, code: "KeyK" }),
+      "KeyT",
+      true,
+    ),
+    false,
+  );
+});

--- a/desktop/src/app/useUnreadConversationShortcuts.ts
+++ b/desktop/src/app/useUnreadConversationShortcuts.ts
@@ -1,0 +1,157 @@
+import * as React from "react";
+
+import {
+  findUnreadNeighbor,
+  readDisplayedConversationOrder,
+  type UnreadStepDirection,
+} from "@/features/sidebar/lib/unreadConversationOrder";
+import { hasActiveEscapeSurface } from "@/shared/hooks/escapeSurfaces";
+import { isMacPlatform } from "@/shared/lib/platform";
+
+import {
+  requestJumpToUnread,
+  requestOpenInboxThreads,
+} from "@/app/unreadNavigationEvents";
+
+type KeyChord = Pick<
+  KeyboardEvent,
+  "altKey" | "code" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
+/**
+ * Previous/next unread conversation. Alt+Shift+Arrows on macOS,
+ * Ctrl+Alt+Shift+Arrows on Windows/Linux — plain Alt+Arrows stay reserved for
+ * ordinary channel navigation, so the extra Shift (plus Ctrl off-mac, where
+ * Alt+Shift+Arrow carries no native text semantics worth preserving) keeps the
+ * two namespaces apart.
+ */
+export function matchUnreadConversationChord(
+  event: KeyChord,
+  isMac: boolean,
+): UnreadStepDirection | null {
+  if (event.code !== "ArrowUp" && event.code !== "ArrowDown") return null;
+  if (!event.altKey || !event.shiftKey || event.metaKey) return null;
+  if (isMac ? event.ctrlKey : !event.ctrlKey) return null;
+  return event.code === "ArrowDown" ? "next" : "previous";
+}
+
+/**
+ * Platform primary modifier plus Shift on the given code. Shift is required:
+ * plain Mod+J must keep toggling the terminal.
+ */
+export function matchModShiftChord(
+  event: KeyChord,
+  code: string,
+  isMac: boolean,
+): boolean {
+  if (event.code !== code || !event.shiftKey || event.altKey) return false;
+  return isMac
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+}
+
+export function useUnreadConversationShortcuts({
+  disabled,
+  selectedChannelId,
+  selectedView,
+  unreadChannelIds,
+  threadPreviewChannelIds,
+  mutedChannelIds,
+  onNavigateChannel,
+  onNavigateHome,
+}: {
+  disabled: boolean;
+  selectedChannelId: string | null;
+  selectedView: string;
+  unreadChannelIds: ReadonlySet<string>;
+  threadPreviewChannelIds: ReadonlySet<string>;
+  mutedChannelIds: ReadonlySet<string>;
+  onNavigateChannel: (channelId: string) => void;
+  onNavigateHome: () => Promise<unknown>;
+}) {
+  const stateRef = React.useRef({
+    selectedChannelId,
+    selectedView,
+    unreadChannelIds,
+    threadPreviewChannelIds,
+    mutedChannelIds,
+    onNavigateChannel,
+    onNavigateHome,
+  });
+  stateRef.current = {
+    selectedChannelId,
+    selectedView,
+    unreadChannelIds,
+    threadPreviewChannelIds,
+    mutedChannelIds,
+    onNavigateChannel,
+    onNavigateHome,
+  };
+
+  React.useEffect(() => {
+    if (disabled) return;
+
+    // Capture phase so navigation wins even when a composer or control has
+    // focus and stops keydown propagation. Modal dialogs, closable overlay
+    // surfaces, and IME composition yield instead of navigating.
+    function handleKeyDown(event: KeyboardEvent) {
+      const isMac = isMacPlatform();
+      const direction = matchUnreadConversationChord(event, isMac);
+      const wantsThreads = matchModShiftChord(event, "KeyT", isMac);
+      const wantsJump = matchModShiftChord(event, "KeyJ", isMac);
+      if (!direction && !wantsThreads && !wantsJump) return;
+      if (event.repeat || event.defaultPrevented || event.isComposing) return;
+      if (hasActiveEscapeSurface()) return;
+      if (document.querySelector('[role="dialog"], [role="alertdialog"]')) {
+        return;
+      }
+
+      const state = stateRef.current;
+      if (direction) {
+        const unread = new Set<string>([
+          ...state.unreadChannelIds,
+          ...state.threadPreviewChannelIds,
+        ]);
+        const target = findUnreadNeighbor(
+          readDisplayedConversationOrder(),
+          unread,
+          state.mutedChannelIds,
+          state.selectedChannelId,
+          direction,
+        );
+        if (!target) return;
+        event.preventDefault();
+        state.onNavigateChannel(target);
+        return;
+      }
+
+      if (wantsThreads) {
+        event.preventDefault();
+        if (state.selectedView === "home") {
+          requestOpenInboxThreads();
+        } else {
+          // HomeView mounts after the navigation commits; the request latches
+          // until it consumes the pending open.
+          void Promise.resolve()
+            .then(() => state.onNavigateHome())
+            .then(() => requestOpenInboxThreads());
+        }
+        return;
+      }
+
+      if (
+        wantsJump &&
+        state.selectedView === "channel" &&
+        state.selectedChannelId
+      ) {
+        event.preventDefault();
+        requestJumpToUnread();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
+    };
+  }, [disabled]);
+}

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -2,6 +2,10 @@ import * as React from "react";
 import { RefreshCcw } from "lucide-react";
 
 import { useAppShell } from "@/app/AppShellContext";
+import {
+  consumePendingOpenInboxThreads,
+  subscribeOpenInboxThreads,
+} from "@/app/unreadNavigationEvents";
 import { useKnownAgentPubkeys } from "@/features/agents/useKnownAgentPubkeys";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { RightAuxiliaryPane } from "@/features/channels/ui/RightAuxiliaryPane";
@@ -579,6 +583,13 @@ export function HomeView({
       unreadOnly,
     ],
   );
+  // The global threads shortcut opens the existing Threads tab through the
+  // same selection-reset path as the filter menu. A pending request survives
+  // the navigation that mounts this view after the keypress.
+  React.useEffect(() => {
+    if (consumePendingOpenInboxThreads()) handleFilterChange("thread");
+    return subscribeOpenInboxThreads(() => handleFilterChange("thread"));
+  }, [handleFilterChange]);
 
   if (isLoading && !feed) {
     return <HomeLoadingState />;

--- a/desktop/src/features/messages/lib/focusedMessageNavigation.test.mjs
+++ b/desktop/src/features/messages/lib/focusedMessageNavigation.test.mjs
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  resolveFocusedMessageAction,
+  shouldClaimComposerTimelineFocus,
+} from "./focusedMessageNavigation.ts";
+
+const ALL_AVAILABLE = {
+  canReply: true,
+  canGoBack: true,
+  canReact: true,
+  canEdit: true,
+  canMarkUnread: true,
+  canCopyLink: true,
+};
+
+const NONE_AVAILABLE = {
+  canReply: false,
+  canGoBack: false,
+  canReact: false,
+  canEdit: false,
+  canMarkUnread: false,
+  canCopyLink: false,
+};
+
+function keyState(overrides = {}) {
+  return {
+    key: "t",
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    isComposing: false,
+    rowOwnsFocus: true,
+    overlayOpen: false,
+    ...overrides,
+  };
+}
+
+test("plain arrows move focus, modified arrows are left alone", () => {
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "ArrowUp" }), ALL_AVAILABLE),
+    "focus-prev",
+  );
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "ArrowDown" }), ALL_AVAILABLE),
+    "focus-next",
+  );
+  for (const modifiers of [
+    { shiftKey: true },
+    { altKey: true },
+    { ctrlKey: true },
+    { metaKey: true },
+  ]) {
+    assert.equal(
+      resolveFocusedMessageAction(
+        keyState({ key: "ArrowUp", ...modifiers }),
+        ALL_AVAILABLE,
+      ),
+      null,
+    );
+    assert.equal(
+      resolveFocusedMessageAction(
+        keyState({ key: "ArrowDown", ...modifiers }),
+        ALL_AVAILABLE,
+      ),
+      null,
+    );
+  }
+});
+
+test("single letters map to actions and respect availability", () => {
+  const expected = {
+    t: "reply",
+    r: "react",
+    e: "edit",
+    u: "mark-unread",
+    l: "copy-link",
+  };
+  for (const [letter, action] of Object.entries(expected)) {
+    assert.equal(
+      resolveFocusedMessageAction(keyState({ key: letter }), ALL_AVAILABLE),
+      action,
+    );
+    // Shift folds case: `T` still replies.
+    assert.equal(
+      resolveFocusedMessageAction(
+        keyState({ key: letter.toUpperCase(), shiftKey: true }),
+        ALL_AVAILABLE,
+      ),
+      action,
+    );
+    assert.equal(
+      resolveFocusedMessageAction(keyState({ key: letter }), NONE_AVAILABLE),
+      null,
+    );
+  }
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "q" }), ALL_AVAILABLE),
+    null,
+  );
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "Enter" }), ALL_AVAILABLE),
+    null,
+  );
+});
+
+test("letters require no Ctrl/Meta/Alt and an unmodified Escape returns to composer", () => {
+  for (const modifiers of [
+    { ctrlKey: true },
+    { metaKey: true },
+    { altKey: true },
+  ]) {
+    assert.equal(
+      resolveFocusedMessageAction(
+        keyState({ key: "t", ...modifiers }),
+        ALL_AVAILABLE,
+      ),
+      null,
+    );
+  }
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "Escape" }), NONE_AVAILABLE),
+    "to-composer",
+  );
+  assert.equal(
+    resolveFocusedMessageAction(
+      keyState({ key: "Escape", ctrlKey: true }),
+      ALL_AVAILABLE,
+    ),
+    null,
+  );
+  assert.equal(
+    resolveFocusedMessageAction(
+      keyState({ key: "Escape", shiftKey: true }),
+      ALL_AVAILABLE,
+    ),
+    null,
+  );
+});
+
+test("IME, nested focus, and open overlays swallow every shortcut", () => {
+  for (const guard of [
+    { isComposing: true },
+    { rowOwnsFocus: false },
+    { overlayOpen: true },
+  ]) {
+    for (const key of ["ArrowUp", "ArrowDown", "ArrowRight", "Escape", "t"]) {
+      assert.equal(
+        resolveFocusedMessageAction(keyState({ key, ...guard }), ALL_AVAILABLE),
+        null,
+        `${key} with ${Object.keys(guard)[0]}`,
+      );
+    }
+  }
+});
+
+test("ArrowRight replies and ArrowLeft goes back only when available", () => {
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "ArrowRight" }), ALL_AVAILABLE),
+    "reply",
+  );
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "ArrowRight" }), {
+      ...ALL_AVAILABLE,
+      canReply: false,
+    }),
+    null,
+  );
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "ArrowLeft" }), ALL_AVAILABLE),
+    "go-back",
+  );
+  assert.equal(
+    resolveFocusedMessageAction(keyState({ key: "ArrowLeft" }), {
+      ...ALL_AVAILABLE,
+      canGoBack: false,
+    }),
+    null,
+  );
+  // Modified arrows never navigate (Alt+arrows stay reserved for channels).
+  assert.equal(
+    resolveFocusedMessageAction(
+      keyState({ key: "ArrowRight", altKey: true }),
+      ALL_AVAILABLE,
+    ),
+    null,
+  );
+  assert.equal(
+    resolveFocusedMessageAction(
+      keyState({ key: "ArrowLeft", altKey: true }),
+      ALL_AVAILABLE,
+    ),
+    null,
+  );
+});
+
+function composerKey(overrides = {}) {
+  return {
+    key: "F6",
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    isComposing: false,
+    autocompleteOpen: false,
+    overlayOpen: false,
+    ...overrides,
+  };
+}
+
+test("F6 claims timeline focus; modifiers, IME, autocomplete, and overlays decline", () => {
+  assert.equal(shouldClaimComposerTimelineFocus(composerKey()), true);
+  for (const decline of [
+    { key: "F5" },
+    { ctrlKey: true },
+    { metaKey: true },
+    { altKey: true },
+    { shiftKey: true },
+    { repeat: true },
+    { isComposing: true },
+    { autocompleteOpen: true },
+    { overlayOpen: true },
+  ]) {
+    assert.equal(
+      shouldClaimComposerTimelineFocus(composerKey(decline)),
+      false,
+      JSON.stringify(decline),
+    );
+  }
+});

--- a/desktop/src/features/messages/lib/focusedMessageNavigation.ts
+++ b/desktop/src/features/messages/lib/focusedMessageNavigation.ts
@@ -1,0 +1,334 @@
+import type * as React from "react";
+
+import type { TimelineMessage } from "@/features/messages/types";
+import { buildMessageLink } from "@/features/messages/lib/messageLink";
+import { getThreadReference } from "@/features/messages/lib/threading";
+import { KIND_HUDDLE_STARTED } from "@/shared/constants/kinds";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
+
+// Row-scoped shortcuts leave text input and nested controls untouched.
+
+/** Marks a focusable message row (`<article data-message-focus="true">`). */
+export const FOCUSED_MESSAGE_ROW_SELECTOR = '[data-message-focus="true"]';
+
+/** Scopes ArrowUp/Down movement to one conversation surface (`main`/`thread`). */
+export const FOCUSED_MESSAGE_LIST_ATTRIBUTE = "data-focused-message-list";
+
+const THREAD_PANEL_TESTID = "message-thread-panel";
+const CHANNEL_DROP_ZONE_TESTID = "channel-drop-zone";
+const COMPOSER_INPUT_TESTID = "message-input";
+
+/** Copying a message link is offered from the hover action bar, the More menu,
+ *  and the `L` keyboard shortcut; all paths share this exact link-building +
+ *  toast behavior. */
+export function copyMessageLink(channelId: string, message: TimelineMessage) {
+  const { rootId } = getThreadReference(message.tags ?? []);
+  const link = buildMessageLink({
+    channelId,
+    messageId: message.id,
+    threadRootId: rootId,
+  });
+  copyTextToClipboard(link, "Link copied to clipboard");
+}
+
+/** Gate shared by every copy-link surface: pending sends have no delivered
+ *  event to link to, huddle system rows aren't linkable, and callers without
+ *  a channelId (e.g. inbox preview rows) can't build the link. */
+export function canCopyMessageLink(
+  message: TimelineMessage,
+  channelId: string | null | undefined,
+): channelId is string {
+  return (
+    !message.pending &&
+    message.kind !== KIND_HUDDLE_STARTED &&
+    Boolean(channelId)
+  );
+}
+
+export type FocusedMessageAction =
+  | "focus-prev"
+  | "focus-next"
+  | "reply"
+  | "go-back"
+  | "to-composer"
+  | "react"
+  | "edit"
+  | "mark-unread"
+  | "copy-link";
+
+export type FocusedMessageActionAvailability = {
+  canReply: boolean;
+  canGoBack: boolean;
+  canReact: boolean;
+  canEdit: boolean;
+  canMarkUnread: boolean;
+  canCopyLink: boolean;
+};
+
+export type FocusedMessageKeyState = {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  isComposing: boolean;
+  /** True only when the row itself owns focus (not a nested link/control). */
+  rowOwnsFocus: boolean;
+  /** True while a dialog, menu, or listbox (e.g. the reaction picker) is open. */
+  overlayOpen: boolean;
+};
+
+/**
+ * Pure key→action decision for a focused message row. Kept side-effect free
+ * so the guard matrix (modifiers, IME, focus ownership, overlays,
+ * per-action availability) is covered by unit tests; the DOM effects live in
+ * `handleFocusedMessageKeyDown` below.
+ */
+export function resolveFocusedMessageAction(
+  event: FocusedMessageKeyState,
+  availability: FocusedMessageActionAvailability,
+): FocusedMessageAction | null {
+  if (event.isComposing || !event.rowOwnsFocus || event.overlayOpen) {
+    return null;
+  }
+  const hasModifier = event.ctrlKey || event.metaKey || event.altKey;
+  switch (event.key) {
+    case "ArrowUp":
+      return event.ctrlKey || event.metaKey || event.altKey || event.shiftKey
+        ? null
+        : "focus-prev";
+    case "ArrowDown":
+      return event.ctrlKey || event.metaKey || event.altKey || event.shiftKey
+        ? null
+        : "focus-next";
+    // ArrowLeft/Right with modifiers are left to the browser / app bindings
+    // (Alt+arrows are reserved for channel navigation).
+    case "ArrowRight":
+      return !hasModifier && !event.shiftKey && availability.canReply
+        ? "reply"
+        : null;
+    case "ArrowLeft":
+      return !hasModifier && !event.shiftKey && availability.canGoBack
+        ? "go-back"
+        : null;
+    case "Escape":
+      return hasModifier || event.shiftKey ? null : "to-composer";
+    default:
+      break;
+  }
+  // Single letters fire without Ctrl/Meta/Alt (Shift is folded by
+  // lower-casing, so `T` and `t` both reply). Anything else — Enter, Space,
+  // Tab, multi-char keys — is left alone.
+  if (hasModifier || event.key.length !== 1) {
+    return null;
+  }
+  switch (event.key.toLowerCase()) {
+    case "t":
+      return availability.canReply ? "reply" : null;
+    case "r":
+      return availability.canReact ? "react" : null;
+    case "e":
+      return availability.canEdit ? "edit" : null;
+    case "u":
+      return availability.canMarkUnread ? "mark-unread" : null;
+    case "l":
+      return availability.canCopyLink ? "copy-link" : null;
+    default:
+      return null;
+  }
+}
+
+/** F6 from the composer claims timeline focus (even with a non-empty draft,
+ *  which is left untouched). Alt/Ctrl/Meta, IME, autocomplete, and open
+ *  overlays all decline so app and channel-navigation bindings keep the key. */
+export function shouldClaimComposerTimelineFocus(event: {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  repeat: boolean;
+  isComposing: boolean;
+  autocompleteOpen: boolean;
+  overlayOpen: boolean;
+}): boolean {
+  return (
+    event.key === "F6" &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey &&
+    !event.repeat &&
+    !event.isComposing &&
+    !event.autocompleteOpen &&
+    !event.overlayOpen
+  );
+}
+
+function queryScopeRows(scope: ParentNode): HTMLElement[] {
+  return [...scope.querySelectorAll<HTMLElement>(FOCUSED_MESSAGE_ROW_SELECTOR)];
+}
+
+function focusRow(row: HTMLElement) {
+  row.focus({ preventScroll: true });
+  // `nearest` keeps the focused row visible without yanking the reader's
+  // scroll position; in the virtualized timeline this stays inside mounted
+  // rows because movement is always to an adjacent row.
+  row.scrollIntoView({ block: "nearest" });
+}
+
+/** True while a dialog, menu, or listbox overlay (reaction picker, dropdown,
+ *  confirm dialog, autocomplete) is open somewhere in the document. */
+export function isFocusOverlayOpen(): boolean {
+  if (typeof document === "undefined") return false;
+  return (
+    document.querySelector(
+      '[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"]',
+    ) !== null
+  );
+}
+
+/** Focus the adjacent focusable row within the same conversation surface. */
+export function focusNeighborRow(
+  current: HTMLElement,
+  direction: 1 | -1,
+): boolean {
+  const scope =
+    current.closest(`[${FOCUSED_MESSAGE_LIST_ATTRIBUTE}]`) ?? document;
+  const rows = queryScopeRows(scope);
+  const next = rows[rows.indexOf(current) + direction];
+  if (!next) return false;
+  focusRow(next);
+  return true;
+}
+
+/**
+ * Explicit keyboard entry from the composer: focus the newest focusable row
+ * in the composer's own surface (thread panel rows for the thread composer,
+ * main timeline rows otherwise). Never modifies the draft.
+ */
+export function focusLastRowForElement(anchor: Element): boolean {
+  const scope =
+    anchor.closest(`[data-testid="${THREAD_PANEL_TESTID}"]`) ??
+    anchor.closest(`[data-testid="${CHANNEL_DROP_ZONE_TESTID}"]`) ??
+    document;
+  const rows = queryScopeRows(scope);
+  const last = rows[rows.length - 1];
+  if (!last) return false;
+  focusRow(last);
+  return true;
+}
+
+/** Escape from a focused row: return focus to that surface's composer. */
+export function focusComposerForRow(row: HTMLElement): boolean {
+  const scope =
+    row.closest(`[data-testid="${THREAD_PANEL_TESTID}"]`) ??
+    row.closest(`[data-testid="${CHANNEL_DROP_ZONE_TESTID}"]`) ??
+    document;
+  const input = scope.querySelector<HTMLElement>(
+    `[data-testid="${COMPOSER_INPUT_TESTID}"]`,
+  );
+  if (!input) return false;
+  input.focus();
+  return true;
+}
+
+/** `R` opens the row's existing reaction picker via its own trigger, reusing
+ *  the action bar's picker, toggle, and error handling unchanged. */
+export function openReactionPickerForRow(
+  row: HTMLElement,
+  messageId: string,
+): boolean {
+  const escapeId =
+    typeof CSS !== "undefined" && typeof CSS.escape === "function"
+      ? CSS.escape
+      : (value: string) => value;
+  const trigger = row.querySelector<HTMLElement>(
+    `[data-testid="react-message-${escapeId(messageId)}"]`,
+  );
+  if (!trigger) return false;
+  trigger.click();
+  return true;
+}
+
+export type FocusedMessageKeyHandlers = {
+  channelId?: string | null;
+  message: TimelineMessage;
+  onReply?: (message: TimelineMessage) => void;
+  onEdit?: (message: TimelineMessage) => void;
+  onMarkUnread?: (message: TimelineMessage) => void;
+  onNavigateBack?: () => void;
+  canOpenReactions: boolean;
+};
+
+/**
+ * Row-level `onKeyDown` for a focused message. Returns true when the key was
+ * claimed (the event is already `preventDefault`ed). All action callbacks are
+ * the row's existing ones, including edit authorization (call sites only pass
+ * `onEdit` for manageable messages) and reaction availability.
+ */
+export function handleFocusedMessageKeyDown(
+  event: React.KeyboardEvent<HTMLElement>,
+  handlers: FocusedMessageKeyHandlers,
+): boolean {
+  if (event.defaultPrevented) return false;
+  const { message } = handlers;
+  const action = resolveFocusedMessageAction(
+    {
+      key: event.key,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      altKey: event.altKey,
+      shiftKey: event.shiftKey,
+      isComposing: event.nativeEvent?.isComposing ?? false,
+      rowOwnsFocus: event.target === event.currentTarget,
+      overlayOpen: isFocusOverlayOpen(),
+    },
+    {
+      canReply: handlers.onReply !== undefined,
+      canGoBack: handlers.onNavigateBack !== undefined,
+      canReact: handlers.canOpenReactions,
+      canEdit: handlers.onEdit !== undefined,
+      canMarkUnread: handlers.onMarkUnread !== undefined,
+      canCopyLink: canCopyMessageLink(message, handlers.channelId),
+    },
+  );
+  if (action === null) return false;
+  const row = event.currentTarget;
+  switch (action) {
+    case "focus-prev":
+      if (!focusNeighborRow(row, -1)) return false;
+      break;
+    case "focus-next":
+      if (!focusNeighborRow(row, 1)) return false;
+      break;
+    case "reply":
+      handlers.onReply?.(message);
+      break;
+    case "go-back":
+      handlers.onNavigateBack?.();
+      break;
+    case "to-composer":
+      if (!focusComposerForRow(row)) return false;
+      break;
+    case "react":
+      if (!openReactionPickerForRow(row, message.id)) return false;
+      break;
+    case "edit":
+      handlers.onEdit?.(message);
+      break;
+    case "mark-unread":
+      // Marking unread can remount timeline rows; keep focus in the composer.
+      focusComposerForRow(row);
+      handlers.onMarkUnread?.(message);
+      break;
+    case "copy-link":
+      if (handlers.channelId === undefined || handlers.channelId === null) {
+        return false;
+      }
+      copyMessageLink(handlers.channelId, message);
+      break;
+  }
+  event.preventDefault();
+  return true;
+}

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -50,6 +50,11 @@ import { SpoilerMark } from "./spoilerMark";
 import { createComposerLinkPasteHandler } from "./composerMessageLinkNode";
 import type { ComposerMessageLinkChannel } from "./useComposerMessageLinks";
 import { useComposerMessageLinks } from "./useComposerMessageLinks";
+import {
+  focusLastRowForElement,
+  isFocusOverlayOpen,
+  shouldClaimComposerTimelineFocus,
+} from "./focusedMessageNavigation";
 
 /**
  * Plain-text edit descriptor returned by autocomplete hooks
@@ -501,6 +506,31 @@ export function useRichTextEditor({
             !event.isComposing
           ) {
             return onLinkShortcutRef.current?.() ?? false;
+          }
+
+          // F6 moves focus into the timeline (explicit keyboard entry). Unlike
+          // ArrowUp edit-last it works with a non-empty draft — the draft is
+          // never modified — and it declines while autocomplete is open, IME
+          // is composing, modifiers are held, or a dialog/menu is open, so
+          // app and channel-navigation bindings keep the key.
+          if (event.key === "F6") {
+            if (
+              shouldClaimComposerTimelineFocus({
+                key: event.key,
+                ctrlKey: event.ctrlKey,
+                metaKey: event.metaKey,
+                altKey: event.altKey,
+                shiftKey: event.shiftKey,
+                repeat: event.repeat,
+                isComposing: event.isComposing,
+                autocompleteOpen: isAutocompleteOpen?.current ?? false,
+                overlayOpen: isFocusOverlayOpen(),
+              })
+            ) {
+              event.preventDefault();
+              return focusLastRowForElement(view.dom);
+            }
+            return false;
           }
 
           if (event.key !== "ArrowUp") return false;

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -16,11 +16,13 @@ import {
 import * as React from "react";
 import { toast } from "sonner";
 
-import { buildMessageLink } from "@/features/messages/lib/messageLink";
 import { EmojiPicker } from "@/features/custom-emoji/ui/EmojiPicker";
 import { useCustomEmoji } from "@/features/custom-emoji/hooks";
 import { buildMentionClipboardHtml } from "@/features/messages/lib/mentionClipboard";
-import { getThreadReference } from "@/features/messages/lib/threading";
+import {
+  canCopyMessageLink,
+  copyMessageLink,
+} from "@/features/messages/lib/focusedMessageNavigation";
 import { useMessageMentionIdentities } from "@/features/messages/lib/useMessageMentionIdentities";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { ReportMessageDialog } from "@/features/moderation/ui/ReportMessageDialog";
@@ -56,32 +58,6 @@ import { ProtectedMessageAction } from "@protected-feature-components";
 
 const ACTION_BUTTON_CLASS = "h-8 w-8 rounded-full p-0";
 const ACTION_ICON_CLASS = "!h-4 !w-4";
-
-/** Copying a message link is offered from both the hover action bar and the
- *  More menu; both paths share this exact link-building + toast behavior. */
-function copyMessageLink(channelId: string, message: TimelineMessage) {
-  const { rootId } = getThreadReference(message.tags ?? []);
-  const link = buildMessageLink({
-    channelId,
-    messageId: message.id,
-    threadRootId: rootId,
-  });
-  copyTextToClipboard(link, "Link copied to clipboard");
-}
-
-/** Gate shared by every copy-link surface: pending sends have no delivered
- *  event to link to, huddle system rows aren't linkable, and callers without
- *  a channelId (e.g. inbox preview rows) can't build the link. */
-function canCopyMessageLink(
-  message: TimelineMessage,
-  channelId: string | null | undefined,
-): channelId is string {
-  return (
-    !message.pending &&
-    message.kind !== KIND_HUDDLE_STARTED &&
-    Boolean(channelId)
-  );
-}
 
 function MoreActionsMenu({
   channelId,

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -58,6 +58,7 @@ import { MessageTimestamp } from "./MessageTimestamp";
 import { SentFromThreadLine } from "./SentFromThreadLine";
 import { WaveMessageAttachment } from "./WaveMessageAttachment";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { handleFocusedMessageKeyDown } from "@/features/messages/lib/focusedMessageNavigation";
 import { useMessageAgentAddressPrefix } from "./MessageAgentAddressPrefix";
 const DiffMessage = React.lazy(() => import("./DiffMessage"));
 const DiffMessageExpanded = React.lazy(() => import("./DiffMessageExpanded"));
@@ -99,6 +100,7 @@ export const MessageRow = React.memo(
     onMarkUnread,
     onMarkRead,
     onToggleReaction,
+    onNavigateBack,
     onReply,
     onSendToChannel,
     onEntranceComplete,
@@ -151,6 +153,8 @@ export const MessageRow = React.memo(
       remove: boolean,
     ) => Promise<void>;
     onReply?: (message: TimelineMessage) => void;
+    /** Thread surfaces only: ArrowLeft returns to the source conversation. */
+    onNavigateBack?: () => void;
     onSendToChannel?: (message: TimelineMessage) => Promise<void>;
     onUnfollowThread?: (message: TimelineMessage) => void;
     onEntranceComplete?: (messageId: string) => void;
@@ -888,10 +892,28 @@ export const MessageRow = React.memo(
             highlighted
               ? "-mx-4 rounded-none px-6 before:absolute before:-inset-y-1.5 before:inset-x-0 before:animate-[route-target-highlight-fade_2s_ease-out_forwards] before:bg-primary/10 before:content-[''] motion-reduce:before:animate-none sm:-mx-6 sm:px-8"
               : "",
+            // Keyboard focus ring for focused-message navigation (F6 entry,
+            // ArrowUp/Down movement). Rows stay out of tab order
+            // (`tabIndex={-1}`); F6 is the explicit entry point.
+            "focus:outline-none focus-visible:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60",
+            "focus:scroll-mt-[var(--channel-top-chrome-height,4.5rem)] focus:scroll-mb-[var(--composer-overlay-height,6rem)]",
           )}
+          data-message-focus="true"
           data-message-id={message.id}
           data-testid="message-row"
           onAnimationEnd={handleEntranceAnimationEnd}
+          onKeyDown={(event) =>
+            handleFocusedMessageKeyDown(event, {
+              channelId,
+              message,
+              onEdit,
+              onMarkUnread,
+              onNavigateBack,
+              onReply,
+              canOpenReactions: canToggleReactions,
+            })
+          }
+          tabIndex={-1}
         >
           {isThreadReplyLayout ? (
             <>

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -281,6 +281,33 @@ export function MessageThreadPanel({
     },
     [collapseThreadHeadReplies, onExpandReplies, threadHeadId],
   );
+  // ArrowLeft on a focused thread row returns to the source conversation:
+  // close the panel, then restore focus to the source message row in the
+  // main timeline (falling back to the main composer when the row is gone).
+  const handleThreadBack = React.useCallback(() => {
+    const sourceId = threadHeadId;
+    onClose();
+    if (!sourceId) return;
+    requestAnimationFrame(() => {
+      const escapeId =
+        typeof CSS !== "undefined" && typeof CSS.escape === "function"
+          ? CSS.escape(sourceId)
+          : sourceId;
+      const sourceRow = document.querySelector<HTMLElement>(
+        `article[data-message-id="${escapeId}"]`,
+      );
+      if (sourceRow) {
+        sourceRow.focus({ preventScroll: true });
+        sourceRow.scrollIntoView({ block: "nearest" });
+        return;
+      }
+      document
+        .querySelector<HTMLElement>(
+          '[data-testid="channel-drop-zone"] [data-testid="message-input"]',
+        )
+        ?.focus();
+    });
+  }, [onClose, threadHeadId]);
 
   const composerReplyTarget =
     replyTargetMessage && threadHead && replyTargetMessage.id !== threadHead.id
@@ -520,6 +547,7 @@ export function MessageThreadPanel({
       <div
         className={cn(hasConstrainedColumn && THREAD_PANEL_COLUMN_CLASS)}
         data-image-gallery-scope="thread"
+        data-focused-message-list="thread"
         ref={threadContentRef}
         style={
           hasConstrainedColumn ? { maxWidth: columnMaxWidthPx } : undefined
@@ -569,6 +597,7 @@ export function MessageThreadPanel({
                 }
                 onMarkUnread={onMarkUnread}
                 onMarkRead={onMarkRead}
+                onNavigateBack={handleThreadBack}
                 onToggleReaction={onToggleReaction}
                 onUnfollowThread={
                   onUnfollowThread ? (_msg) => onUnfollowThread() : undefined
@@ -736,6 +765,7 @@ export function MessageThreadPanel({
                           }
                           onMarkUnread={onMarkUnread}
                           onMarkRead={onMarkRead}
+                          onNavigateBack={handleThreadBack}
                           onReply={onSelectReplyTarget}
                           onSendToChannel={stableSendToChannel}
                           onToggleReaction={onToggleReaction}

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -1,3 +1,4 @@
+import { JUMP_TO_UNREAD_EVENT } from "@/shared/lib/keyboard-shortcuts";
 import * as React from "react";
 
 import {
@@ -524,6 +525,16 @@ const MessageTimelineBase = React.forwardRef<
       jumpToMessage(firstUnreadMessageId);
     }
   }, [firstUnreadMessageId, jumpToMessage]);
+  // Keyboard navigation uses the unread pill's existing jump path.
+  React.useEffect(() => {
+    const handleJumpToUnreadEvent = () => {
+      handleJumpToOldestUnread();
+    };
+    window.addEventListener(JUMP_TO_UNREAD_EVENT, handleJumpToUnreadEvent);
+    return () => {
+      window.removeEventListener(JUMP_TO_UNREAD_EVENT, handleJumpToUnreadEvent);
+    };
+  }, [handleJumpToOldestUnread]);
 
   // Scroll to the active search match when it changes. `jumpToMessage` updates
   // the scroll anchor (so the post-commit restore won't yank the view back off
@@ -705,6 +716,7 @@ const MessageTimelineBase = React.forwardRef<
     <TooltipProvider>
       <div
         className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+        data-focused-message-list="main"
         onCopy={handleTimelineMentionCopy}
       >
         {showUnreadPill ? (

--- a/desktop/src/features/sidebar/lib/unreadConversationOrder.test.mjs
+++ b/desktop/src/features/sidebar/lib/unreadConversationOrder.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findUnreadNeighbor } from "./unreadConversationOrder.ts";
+
+const displayed = ["starred", "alpha", "beta", "gamma", "dm-1", "dm-2"];
+const unread = new Set(["alpha", "gamma", "dm-2"]);
+const muted = new Set(["gamma"]);
+const none = new Set();
+
+test("next steps over read and muted entries without wrapping", () => {
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, "starred", "next"),
+    "alpha",
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, "alpha", "next"),
+    "dm-2",
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, "dm-2", "next"),
+    null,
+  );
+});
+
+test("previous steps back without wrapping", () => {
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, "dm-2", "previous"),
+    "alpha",
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, "alpha", "previous"),
+    null,
+  );
+});
+
+test("an unread current conversation steps past itself", () => {
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, none, "alpha", "next"),
+    "gamma",
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, none, "gamma", "previous"),
+    "alpha",
+  );
+});
+
+test("a null or unknown current id anchors at the list edge", () => {
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, null, "next"),
+    "alpha",
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, null, "previous"),
+    "dm-2",
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, "elsewhere", "next"),
+    "alpha",
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, muted, "elsewhere", "previous"),
+    "dm-2",
+  );
+});
+
+test("empty and fully muted projections have no neighbor", () => {
+  assert.equal(findUnreadNeighbor([], unread, muted, null, "next"), null);
+  assert.equal(
+    findUnreadNeighbor(displayed, new Set(), muted, "alpha", "next"),
+    null,
+  );
+  assert.equal(
+    findUnreadNeighbor(displayed, unread, new Set(displayed), null, "next"),
+    null,
+  );
+});

--- a/desktop/src/features/sidebar/lib/unreadConversationOrder.ts
+++ b/desktop/src/features/sidebar/lib/unreadConversationOrder.ts
@@ -1,0 +1,81 @@
+/**
+ * Display-order helpers for previous/next unread conversation navigation.
+ *
+ * The sidebar owns grouping, per-group sort preferences, and collapsed state,
+ * so the only ordering that is definitionally "the displayed order" is the
+ * rendered row order. Callers read it from the DOM (`data-channel-id` rows
+ * are rendered exclusively by the sidebar) and project the app-level unread
+ * sets over it here: muted and read entries are skipped, DMs are included
+ * wherever the sidebar conversation semantics place them, and stepping never
+ * wraps (matching the ordinary channel-navigation precedent).
+ */
+
+export type UnreadStepDirection = "next" | "previous";
+
+type ChannelChordSets = {
+  unreadChannelIds: ReadonlySet<string>;
+  mutedChannelIds: ReadonlySet<string>;
+};
+
+function isNavigableConversation(
+  channelId: string,
+  { unreadChannelIds, mutedChannelIds }: ChannelChordSets,
+): boolean {
+  return unreadChannelIds.has(channelId) && !mutedChannelIds.has(channelId);
+}
+
+/**
+ * Reads rendered sidebar conversation order. Sidebar rows are the sole
+ * producers of `data-channel-id`, so document order is display order across
+ * starred, sectioned, channel, forum, and DM groupings.
+ */
+export function readDisplayedConversationOrder(
+  root: ParentNode = document,
+): string[] {
+  const ids: string[] = [];
+  for (const element of root.querySelectorAll("[data-channel-id]")) {
+    const channelId = element.getAttribute("data-channel-id");
+    if (channelId !== null) ids.push(channelId);
+  }
+  return ids;
+}
+
+/**
+ * Steps from the current conversation to the nearest navigable unread entry
+ * in `direction`, or null when there is none. A null/unknown current id
+ * anchors at the list edge (first for next, last for previous); the current
+ * conversation itself is never returned, even when unread; both ends stop
+ * without wrapping.
+ */
+export function findUnreadNeighbor(
+  displayedChannelIds: readonly string[],
+  unreadChannelIds: ReadonlySet<string>,
+  mutedChannelIds: ReadonlySet<string>,
+  currentChannelId: string | null,
+  direction: UnreadStepDirection,
+): string | null {
+  const sets = { unreadChannelIds, mutedChannelIds };
+  const currentIndex =
+    currentChannelId === null
+      ? -1
+      : displayedChannelIds.indexOf(currentChannelId);
+  if (direction === "next") {
+    const startIndex = currentIndex === -1 ? 0 : currentIndex + 1;
+    for (
+      let index = startIndex;
+      index < displayedChannelIds.length;
+      index += 1
+    ) {
+      const channelId = displayedChannelIds[index];
+      if (isNavigableConversation(channelId, sets)) return channelId;
+    }
+    return null;
+  }
+  const startIndex =
+    currentIndex === -1 ? displayedChannelIds.length - 1 : currentIndex - 1;
+  for (let index = startIndex; index >= 0; index -= 1) {
+    const channelId = displayedChannelIds[index];
+    if (isNavigableConversation(channelId, sets)) return channelId;
+  }
+  return null;
+}

--- a/desktop/src/shared/lib/keyboard-shortcuts.ts
+++ b/desktop/src/shared/lib/keyboard-shortcuts.ts
@@ -1,6 +1,7 @@
 import { isMacPlatform } from "@/shared/lib/platform";
 
 export const HUDDLE_SHORTCUT_EVENT = "buzz:huddle-shortcut";
+export const JUMP_TO_UNREAD_EVENT = "buzz:jump-to-unread";
 
 export type HuddleShortcutDetail = {
   channelId: string;
@@ -23,6 +24,38 @@ export type KeyboardShortcut = {
 
 export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   // Navigation
+  {
+    id: "previous-unread-conversation",
+    label: "Previous unread conversation",
+    description: "Open the previous unread conversation in sidebar order",
+    keys: "⌥⇧↑",
+    keysWindows: "Ctrl+Alt+Shift+↑",
+    category: "Navigation",
+  },
+  {
+    id: "next-unread-conversation",
+    label: "Next unread conversation",
+    description: "Open the next unread conversation in sidebar order",
+    keys: "⌥⇧↓",
+    keysWindows: "Ctrl+Alt+Shift+↓",
+    category: "Navigation",
+  },
+  {
+    id: "open-threads",
+    label: "Threads",
+    description: "Open the Threads filter in Inbox",
+    keys: "⇧⌘T",
+    keysWindows: "Ctrl+Shift+T",
+    category: "Navigation",
+  },
+  {
+    id: "jump-to-unread",
+    label: "Jump to unread messages",
+    description: "Jump to the unread position in the current conversation",
+    keys: "⇧⌘J",
+    keysWindows: "Ctrl+Shift+J",
+    category: "Navigation",
+  },
   {
     id: "quick-search",
     label: "Quick search",
@@ -148,6 +181,94 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
 
   // Messages
   {
+    id: "focus-messages",
+    label: "Focus messages",
+    description: "Move from the composer to the message timeline",
+    keys: "F6",
+    keysWindows: "F6",
+    category: "Messages",
+  },
+  {
+    id: "previous-message",
+    label: "Previous message",
+    description: "Focus the previous message in the timeline",
+    keys: "↑",
+    keysWindows: "↑",
+    category: "Messages",
+  },
+  {
+    id: "next-message",
+    label: "Next message",
+    description: "Focus the next message in the timeline",
+    keys: "↓",
+    keysWindows: "↓",
+    category: "Messages",
+  },
+  {
+    id: "reply-to-message",
+    label: "Reply in thread",
+    description: "Open a thread for the focused message",
+    keys: "T / →",
+    keysWindows: "T / →",
+    category: "Messages",
+  },
+  {
+    id: "return-to-channel",
+    label: "Return to conversation",
+    description: "Return from a focused thread message to its conversation",
+    keys: "←",
+    keysWindows: "←",
+    category: "Messages",
+  },
+  {
+    id: "focus-composer",
+    label: "Focus composer",
+    description: "Return from the focused message to its composer",
+    keys: "Escape",
+    keysWindows: "Escape",
+    category: "Messages",
+  },
+  {
+    id: "react-to-message",
+    label: "React to message",
+    description: "Open the reaction picker for the focused message",
+    keys: "R",
+    keysWindows: "R",
+    category: "Messages",
+  },
+  {
+    id: "edit-message",
+    label: "Edit message",
+    description: "Edit the focused message when you have permission",
+    keys: "E",
+    keysWindows: "E",
+    category: "Messages",
+  },
+  {
+    id: "mark-message-unread",
+    label: "Mark message unread",
+    description: "Mark the focused message unread",
+    keys: "U",
+    keysWindows: "U",
+    category: "Messages",
+  },
+  {
+    id: "copy-message-link",
+    label: "Copy message link",
+    description: "Copy a link to the focused message",
+    keys: "L",
+    keysWindows: "L",
+    category: "Messages",
+  },
+  {
+    id: "edit-last-message",
+    label: "Edit last message",
+    description: "Edit your last message from an empty composer",
+    keys: "↑",
+    keysWindows: "↑",
+    category: "Messages",
+  },
+  {
     id: "send-message",
     label: "Send message",
     description: "Send the current message",
@@ -226,8 +347,8 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     id: "format-strikethrough",
     label: "Strikethrough",
     description: "Toggle strikethrough formatting",
-    keys: "⌘⇧X",
-    keysWindows: "Ctrl+Shift+X",
+    keys: "⌘⇧S",
+    keysWindows: "Ctrl+Shift+S",
     category: "Formatting",
   },
   {

--- a/desktop/tests/e2e/virtualization.spec.ts
+++ b/desktop/tests/e2e/virtualization.spec.ts
@@ -894,3 +894,96 @@ test("live tail arrivals stay buffered while reading and release on jump", async
   await page.getByTestId("message-scroll-to-latest").click();
   await expect(page.getByText("buffered live tail sentinel")).toBeVisible();
 });
+
+test("keyboard message focus stays clear of timeline chrome and preserves drafts", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-deep-history").click();
+  await expect(
+    page.locator('[data-message-id="mock-deep-history-599"]'),
+  ).toBeVisible();
+  const composer = page.getByTestId("message-input");
+  await composer.fill("Keep this draft");
+  await composer.press("F6");
+  await expect(
+    page.locator('[data-message-id="mock-deep-history-599"]'),
+  ).toBeFocused();
+  for (let index = 598; index >= 574; index -= 1) {
+    await page.keyboard.press("ArrowUp");
+    await expect(
+      page.locator(`[data-message-id="mock-deep-history-${index}"]`),
+    ).toBeFocused();
+  }
+  const focused = page.locator('[data-message-id="mock-deep-history-574"]');
+  await expect
+    .poll(async () => {
+      const row = await focused.boundingBox();
+      const header = await page.getByTestId("chat-title").boundingBox();
+      const input = await composer.boundingBox();
+      return Boolean(
+        row &&
+          header &&
+          input &&
+          row.y >= header.y + header.height &&
+          row.y + row.height <= input.y,
+      );
+    })
+    .toBe(true);
+  await page.keyboard.press("Escape");
+  await expect(composer).toBeFocused();
+  await expect(composer).toHaveText("Keep this draft");
+});
+test("focused actions preserve editing and mark-unread focus", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  const composer = page.getByTestId("message-input");
+  const own = page.locator('[data-message-id="mock-general-welcome"]');
+  await expect(own).toBeVisible();
+  await composer.press("F6");
+  await page.keyboard.press("ArrowUp");
+  await page.keyboard.press("ArrowUp");
+  await expect(own).toBeFocused();
+  await page.keyboard.press("e");
+  await expect(composer).toBeFocused();
+  await expect(composer).toContainText("Welcome to");
+  await composer.fill("Edited using focused shortcut");
+  await composer.press("Enter");
+  await expect(own).toContainText("Edited using focused shortcut");
+  await expect(composer).toHaveText("");
+  await composer.press("ArrowUp");
+  await expect(composer).toContainText("Edited using focused shortcut");
+  await composer.press("Escape");
+  await composer.press("F6");
+  await page.keyboard.press("ArrowUp");
+  await page.keyboard.press("l");
+  await expect
+    .poll(() => page.evaluate(() => window.__BUZZ_E2E_LAST_CLIPBOARD__?.text))
+    .toContain("mock-general-alice");
+  await page.keyboard.press("t");
+  const panel = page.getByTestId("message-thread-panel");
+  await expect(panel).toBeVisible();
+  await panel.getByTestId("message-input").press("F6");
+  await page.keyboard.press("ArrowLeft");
+  await expect(panel).toHaveCount(0);
+  await expect(
+    page.locator('[data-message-id="mock-general-alice"]'),
+  ).toBeFocused();
+  await page.keyboard.press("r");
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await composer.press("F6");
+  await page.keyboard.press("u");
+  await expect(page.getByTestId("channel-general")).toHaveClass(/font-bold/);
+  await page.keyboard.press("Escape");
+  await expect(composer).toBeFocused();
+  await composer.fill("treul");
+  await expect(panel).toHaveCount(0);
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(composer).toHaveText("treul");
+});


### PR DESCRIPTION
## Summary
Add keyboard-driven conversation handling to the standard desktop UI while preserving existing composer and terminal bindings.

- `F6` moves from the composer into the message timeline without modifying the draft; unmodified up/down move between focused messages.
- On a focused message: `T` / right arrow replies in a thread, `R` opens the existing reaction picker, `E` edits when permitted, `U` marks unread, and `L` copies the message link. Left arrow returns from a thread to the source conversation; Escape returns to the composer.
- Add previous/next unread conversation navigation: Option+Shift+up/down on macOS, Ctrl+Alt+Shift+up/down on Windows/Linux. Uses rendered sidebar order, includes rendered DMs, skips read/muted entries, and does not wrap.
- Add Cmd/Ctrl+Shift+T for Inbox's Threads filter and Cmd/Ctrl+Shift+J for the current conversation's unread position.
- Register the bindings in shortcut help and correct strikethrough help to the existing Cmd/Ctrl+Shift+S binding.

Single-letter actions require direct message-row focus, not a nested control or editable field. IME, dialogs, modifier conflicts, existing up-arrow-to-edit, Shift+Escape, and terminal bindings retain precedence. Focus styling and scroll margins keep selected messages clear of the fixed header/composer; marking unread returns focus to the stable composer before the timeline rebuilds.

### Duplicate check
Closest work: #3377 / #3078 already covers ordinary previous/next channel shortcuts and explicitly defers unread navigation. This PR does not implement or override those ordinary shortcuts. #3459 is an alternate developer-mode UI, rather than these standard-UI bindings. #6549 concerns customizable bindings, which remain outside this change. Searched issues and PRs for shortcuts, keyboard navigation, focused-message actions, and unread/thread shortcuts; no equivalent standard-UI contribution found.

### Testing
- TypeScript typecheck, Biome checks on all 16 changed files, and file-size checks pass.
- 17 focused unit cases pass, covering modifier/platform precedence, focused-action availability, IME/overlay guards, and unread ordering/boundaries.
- Two retained browser regressions pass: focused messages remain visible beneath timeline chrome without altering drafts; edit/thread/mark-unread focus transitions preserve keyboard operation.
- Local Chromium smoke exercised reaction picking, copy link, unread conversation navigation, unread-position jump, Threads navigation, and shortcut help. Visually checked focus styling and help layout.

Browser verification uses the existing mock Tauri/relay bridge. Windows/Linux chord matching is unit-tested; native Windows/Linux runtime interaction was not exercised.
