### PR TITLE
fix(acp): wake quiet hosts for respawns and queued retries

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -11,6 +11,7 @@ mod pool_lifecycle;
 mod prompt_framing;
 mod prompt_project;
 mod queue;
+mod recovery_wake;
 mod relay;
 mod scope;
 mod setup_mode;
@@ -3005,6 +3006,7 @@ async fn tokio_main() -> Result<()> {
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
         Wake(u32, Result<AgentPool, String>),
+        Recovery(recovery_wake::RecoveryWake),
     }
 
     loop {
@@ -3090,37 +3092,8 @@ async fn tokio_main() -> Result<()> {
             }
         }
 
-        let mut respawn_collected = false;
-        while let Ok(rr) = respawn_rx.try_recv() {
-            crash_history[rr.index].respawn_in_flight = false;
-            match rr.result {
-                Ok((acp, protocol_version, agent_name)) => {
-                    let agent = OwnedAgent {
-                        index: rr.index,
-                        acp,
-                        state: SessionState::default(),
-                        model_capabilities: None,
-                        desired_model: config.model.clone(),
-                        model_overridden: false,
-                        desired_model_request_id: None,
-                        desired_model_pending_ack: false,
-                        startup_effort: config.effort_level.clone(),
-                        agent_name,
-                        goose_system_prompt_supported: None,
-                        protocol_version,
-                    };
-                    pool.return_agent(agent);
-                    tracing::info!(agent = rr.index, "respawn complete");
-                    respawn_collected = true;
-                }
-                Err(e) => {
-                    crash_history[rr.index].mark_spawn_failed();
-                    tracing::warn!(agent = rr.index, "respawn failed: {e} — circuit re-opened");
-                }
-            }
-        }
         // Reap completed respawn handles from the JoinSet. Payloads are
-        // delivered out-of-band through `respawn_rx` (drained above), so the
+        // delivered out-of-band through `respawn_rx` (selected below), so the
         // JoinSet is never joined by the normal flow — Tokio retains finished
         // tasks until `join_next`, so without this the set grows on every
         // refill/crash recovery and `!respawn_tasks.is_empty()` would stay true
@@ -3130,26 +3103,27 @@ async fn tokio_main() -> Result<()> {
         // slot's `respawn_in_flight` is cleared when its payload is received),
         // not JoinSet occupancy.
         while respawn_tasks.join_next().now_or_never().flatten().is_some() {}
-        // Flush requeued events that were waiting for a live agent. Without
-        // this, batches requeued during crash recovery sit idle until the
-        // next relay event arrives — which can be minutes on quiet channels.
-        if respawn_collected {
-            for (scope, thread_tags) in dispatch_pending(
-                &mut pool,
-                &mut queue,
-                &ctx,
-                &mut last_activity,
-                observer.as_ref(),
-            ) {
-                typing_channels.insert(scope, thread_tags);
-            }
-        }
+        // Retry deadlines are actionable only with idle capacity. A busy pool
+        // wakes on its result/respawn instead of spinning on an expired retry.
+        let retry_at = if pool_ready && pool.any_idle() {
+            queue.next_retry_deadline()
+        } else {
+            None
+        };
+        let maintenance_at = pool_ready.then_some(last_maintenance + maintenance_interval);
 
         // Borrow result_rx and join_set simultaneously via split-borrow helper.
         let pool_event: Option<PoolEvent> = {
             let (result_rx, join_set) = pool.rx_and_join_set();
             tokio::select! {
                 biased;
+                _ = shutdown_rx.changed() => {
+                    tracing::info!("shutting down");
+                    break;
+                }
+                wake = recovery_wake::wait(&mut respawn_rx, retry_at, maintenance_at) => {
+                    Some(PoolEvent::Recovery(wake))
+                }
                 // recv() returning None means all senders dropped (pool was torn down).
                 // Break cleanly instead of panicking.
                 r = result_rx.recv(), if pool_ready => match r {
@@ -3733,14 +3707,56 @@ async fn tokio_main() -> Result<()> {
                     }
                     None
                 }
-                _ = shutdown_rx.changed() => {
-                    tracing::info!("shutting down");
-                    break;
-                }
             }
         };
 
         match pool_event {
+            Some(PoolEvent::Recovery(wake)) => {
+                match wake {
+                    recovery_wake::RecoveryWake::Respawn(rr) => {
+                        crash_history[rr.index].respawn_in_flight = false;
+                        match rr.result {
+                            Ok((acp, protocol_version, agent_name)) => {
+                                let agent = OwnedAgent {
+                                    index: rr.index,
+                                    acp,
+                                    state: SessionState::default(),
+                                    model_capabilities: None,
+                                    desired_model: config.model.clone(),
+                                    model_overridden: false,
+                                    desired_model_request_id: None,
+                                    desired_model_pending_ack: false,
+                                    startup_effort: config.effort_level.clone(),
+                                    agent_name,
+                                    goose_system_prompt_supported: None,
+                                    protocol_version,
+                                };
+                                pool.return_agent(agent);
+                                tracing::info!(agent = rr.index, "respawn complete");
+                            }
+                            Err(e) => {
+                                crash_history[rr.index].mark_spawn_failed();
+                                tracing::warn!(
+                                    agent = rr.index,
+                                    "respawn failed: {e} — circuit re-opened"
+                                );
+                            }
+                        }
+                    }
+                    // Maintenance runs at the top of the next iteration.
+                    recovery_wake::RecoveryWake::Maintenance => continue,
+                    recovery_wake::RecoveryWake::Retry => {}
+                }
+                for (scope, thread_tags) in dispatch_pending(
+                    &mut pool,
+                    &mut queue,
+                    &ctx,
+                    &mut last_activity,
+                    observer.as_ref(),
+                ) {
+                    typing_channels.insert(scope, thread_tags);
+                }
+            }
             Some(PoolEvent::Result(result)) => {
                 // Stop the typing indicator for the completed turn's exact scope,
                 // not the whole channel — a sibling thread still running in the

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -494,6 +494,24 @@ impl EventQueue {
         })
     }
 
+    /// Earliest retry throttle for queued work not already in flight.
+    ///
+    /// Includes expired deadlines: an event-loop iteration can cross eligibility
+    /// before it arms its timer. The caller must gate on idle pool capacity and
+    /// dispatch when woken. Dispatch either makes the scope in-flight or releases
+    /// it with `mark_complete`, which clears the expired throttle even when a
+    /// busy session owner holds the batch. Empty/removed scopes never arm a timer.
+    pub fn next_retry_deadline(&self) -> Option<Instant> {
+        self.retry_after
+            .iter()
+            .filter(|(scope, _)| {
+                !self.in_flight_scopes.contains(*scope)
+                    && self.queues.get(*scope).is_some_and(|q| !q.is_empty())
+            })
+            .map(|(_, &deadline)| deadline)
+            .min()
+    }
+
     /// Mark the prompt for `channel_id` as complete.
     ///
     /// Removes the channel from `in_flight_channels` and `in_flight_deadlines`.
@@ -2199,6 +2217,95 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Timestamp};
     use std::time::Duration;
+
+    #[tokio::test]
+    async fn retry_wake_redelivers_before_and_after_replacement_eligibility() {
+        use crate::recovery_wake::{wait, RecoveryWake};
+        for replacement_first in [true, false] {
+            let mut queue = EventQueue::new(DedupMode::Queue);
+            let channel = Uuid::new_v4();
+            let event = make_queued(channel, "original batch");
+            let id = event.event.id;
+            let received_at = event.received_at;
+            queue.push(event);
+            let batch = queue.flush_next().unwrap();
+            assert!(queue.requeue(batch).is_none());
+            queue.mark_complete(channel);
+            // Production requeue installs a future throttle, not an immediate
+            // dispatch. Accelerate only the test's clock boundary.
+            assert!(queue.next_retry_deadline().unwrap() > Instant::now());
+            let deadline = if replacement_first {
+                Instant::now() + Duration::from_millis(30)
+            } else {
+                Instant::now() - Duration::from_millis(30)
+            };
+            queue.retry_after.insert(conv(channel), deadline);
+            let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+            tx.send(crate::RespawnResult {
+                index: 0,
+                result: Err(anyhow::anyhow!("wake token")),
+            })
+            .await
+            .unwrap();
+            // With no idle agent the event loop disables the retry timer,
+            // even if its deadline is already past. Respawn is the wake owner.
+            assert!(matches!(
+                wait(&mut rx, None, None).await,
+                RecoveryWake::Respawn(_)
+            ));
+            if replacement_first {
+                assert!(
+                    queue.flush_next().is_none(),
+                    "respawn must not bypass backoff"
+                );
+            }
+            assert!(matches!(
+                wait(&mut rx, queue.next_retry_deadline(), None).await,
+                RecoveryWake::Retry
+            ));
+            let retried = queue.flush_next().unwrap();
+            assert_eq!(retried.events.len(), 1);
+            assert_eq!(retried.events[0].event.id, id);
+            assert_eq!(retried.events[0].received_at, received_at);
+            assert_eq!(
+                queue.next_retry_deadline(),
+                None,
+                "in-flight work cannot hot-loop"
+            );
+            queue.mark_complete(channel);
+            assert!(
+                queue.flush_next().is_none(),
+                "completed work must not duplicate"
+            );
+            assert_eq!(queue.next_retry_deadline(), None);
+            assert!(tokio::time::timeout(
+                Duration::from_millis(20),
+                wait(&mut rx, queue.next_retry_deadline(), None)
+            )
+            .await
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn retry_deadline_excludes_empty_removed_and_held_scopes() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel = Uuid::new_v4();
+        let past = Instant::now() - Duration::from_secs(1);
+        queue.retry_after.insert(conv(channel), past);
+        assert_eq!(queue.next_retry_deadline(), None);
+        queue.push(make_queued(channel, "held"));
+        assert_eq!(queue.next_retry_deadline(), Some(past));
+        let held = queue.flush_next().unwrap();
+        assert_eq!(queue.next_retry_deadline(), None);
+        // This is dispatch_pending's busy-owner / no-slot release path.
+        queue.requeue_preserve_timestamps(held);
+        queue.mark_complete(channel);
+        assert_eq!(queue.next_retry_deadline(), None);
+        queue.retry_after.insert(conv(channel), past);
+        queue.drain_channel(channel);
+        assert_eq!(queue.next_retry_deadline(), None);
+    }
 
     /// Build a test event with the given content and kind.
     fn make_event(content: &str) -> Event {

--- a/crates/buzz-acp/src/recovery_wake.rs
+++ b/crates/buzz-acp/src/recovery_wake.rs
@@ -1,0 +1,105 @@
+//! Quiet-host recovery wake sources, independent of presence/typing/heartbeat.
+
+use std::time::Instant;
+use tokio::sync::mpsc;
+
+use crate::RespawnResult;
+
+pub(super) enum RecoveryWake {
+    Respawn(Box<RespawnResult>),
+    Retry,
+    Maintenance,
+}
+
+async fn sleep_until(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Cancellation-safe: selecting another host event never consumes a respawn.
+/// A closed receiver disables only that source, not retry/refill timers.
+pub(super) async fn wait(
+    respawns: &mut mpsc::Receiver<RespawnResult>,
+    retry_at: Option<Instant>,
+    maintenance_at: Option<Instant>,
+) -> RecoveryWake {
+    tokio::select! {
+        Some(result) = respawns.recv() => RecoveryWake::Respawn(Box::new(result)),
+        _ = sleep_until(retry_at) => RecoveryWake::Retry,
+        _ = sleep_until(maintenance_at) => RecoveryWake::Maintenance,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn respawn_wakes_without_optional_timers() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send(RespawnResult {
+            index: 0,
+            result: Err(anyhow::anyhow!("fixture spawn failure")),
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            timeout(Duration::from_secs(1), wait(&mut rx, None, None))
+                .await
+                .unwrap(),
+            RecoveryWake::Respawn(result) if result.index == 0
+        ));
+        // Consumed exactly once: neither an empty queue nor a completed spawn
+        // produces an immediately ready arm on the next loop iteration.
+        assert!(
+            timeout(Duration::from_millis(20), wait(&mut rx, None, None))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_respawn_channel_does_not_spin_or_disable_refill() {
+        let (tx, mut rx) = mpsc::channel(1);
+        drop(tx);
+        assert!(
+            timeout(Duration::from_millis(20), wait(&mut rx, None, None))
+                .await
+                .is_err()
+        );
+        assert!(matches!(
+            wait(
+                &mut rx,
+                None,
+                Some(Instant::now() + Duration::from_millis(20))
+            )
+            .await,
+            RecoveryWake::Maintenance
+        ));
+    }
+
+    #[tokio::test]
+    async fn host_shutdown_can_cancel_wait_without_losing_later_respawn() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let (shutdown, mut shutdown_rx) = tokio::sync::watch::channel(());
+        shutdown.send(()).unwrap();
+        tokio::select! {
+            _ = shutdown_rx.changed() => {}
+            _ = wait(&mut rx, None, None) => panic!("unexpected wake"),
+        }
+        tx.send(RespawnResult {
+            index: 0,
+            result: Err(anyhow::anyhow!("fixture")),
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            wait(&mut rx, None, None).await,
+            RecoveryWake::Respawn(_)
+        ));
+    }
+}


### PR DESCRIPTION
## Problem

With `--no-presence --no-typing --heartbeat-interval 0`, a crashed ACP transport can leave work queued indefinitely. Background respawn results were only drained before `select!`; neither their arrival nor queue retry eligibility woke the host. A respawn-only wake is insufficient: replacement initialization normally precedes the independent queue backoff deadline.

## Change

- Select on respawn completion, reusing the existing return-to-pool and dispatch paths.
- Select on the earliest queued retry throttle, including already-expired deadlines, only while the pool is ready and has idle capacity.
- Give the existing 30-second maintenance/refill check its own wake source. Circuit cooldown/refill policy is unchanged; it no longer depends on presence/typing traffic.
- Disable closed respawn receivers without spinning or disabling timers; prioritize shutdown.
- Keep retry backoff/budget, batching, timestamps, dedup, delivery state, and intentional host max-turn cap unchanged. Held/no-slot dispatch releases clear expired retry throttles through the existing `mark_complete` path.

No reconnect/gateway changes or adapter retry engine. Based directly on main, independent of other ACP plumbing work. Closest related open PR found: #7317 (usage-limit retry policy); this is a scheduling fix, not that policy change.

## Validation

- `cargo test -p buzz-acp`: 920 library tests + 9 integration tests pass.
- Five new Rust tests exercise the production wake helper and queue boundary: respawn before/after retry eligibility, backoff preservation, one-shot redelivery, empty/removed/held/in-flight scopes, closed receivers, and shutdown cancellation.
- `cargo clippy -p buzz-acp --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, `just file-size-check`, and `git diff --check`: pass.
- Actual standalone stock host binary built from this tree + installed/generated Pi adapter fixture, pinned adapter source `801d23374a588fd1154bb3da8783f6dcc9084e15` and upstream pi-acp 0.0.33. Loopback-only synthetic relay/provider; no live agent/config changes.
  - All optional presence/typing/heartbeat wakes disabled; 2.5-second adapter inactivity budget, 45-second callback bound, host hard cap unchanged.
  - Fast replacement: initialization 1.347s after requeue, retry eligible at 4.447s. Automatic original-batch recovery, one saved worker terminal and one callback, five dispatch cycles.
  - Delayed replacement: initialization 9.118s after requeue, retry eligible at 4.157s. Same recovery invariants, four dispatch cycles.
  - Both use exactly one relay input; both settle within 2.84s of the later of replacement/eligibility (including a 1.5s duplicate-observation window). This also rejects waiting for the 30s maintenance tick.
  - Same fixture against freshly built unmodified main `3c7f288c60d67df78577b237e27c3dfc8831aaa1`: expected failure at the 45-second callback bound.

Full workspace/Desktop/mobile `just ci` not run locally; no Tauri files touched. Relevant ACP package checks above are complete.

## Review / integration gate

Draft for independent review. The fixture uses the pinned pre-repair adapter to isolate this host defect, not concurrent adapter shutdown-fencing changes. Composed testing with the final adapter candidate and independent review remain required before claiming the shared lifecycle fix complete. No activation, merge, direct main push, or incident replay performed. Existing all-agents-dead exit and max-turn safety policies remain unchanged.
