### PR TITLE
fix(desktop): sign invite claims against the canonical origin from /info

### DIFF
--- a/desktop/src/shared/api/invites.test.mjs
+++ b/desktop/src/shared/api/invites.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getJoinPolicy, mintInvite } from "./invites.ts";
+import { claimInvite, getJoinPolicy, mintInvite } from "./invites.ts";
 
 function withFetch(response, run) {
   const originalFetch = globalThis.fetch;
@@ -121,7 +121,10 @@ test("mintInvite serializes bounded max_uses in the request body", async () => {
   try {
     const originalFetch = globalThis.fetch;
     let capturedBody;
-    globalThis.fetch = async (_url, init) => {
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith("/info")) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
       capturedBody = JSON.parse(init.body);
       return new Response(
         JSON.stringify({
@@ -155,7 +158,10 @@ test("mintInvite omits max_uses when null (unlimited)", async () => {
   try {
     const originalFetch = globalThis.fetch;
     let capturedBody;
-    globalThis.fetch = async (_url, init) => {
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith("/info")) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
       capturedBody = JSON.parse(init.body);
       return new Response(
         JSON.stringify({
@@ -186,7 +192,10 @@ test("mintInvite omits max_uses when not provided (unlimited default)", async ()
   try {
     const originalFetch = globalThis.fetch;
     let capturedBody;
-    globalThis.fetch = async (_url, init) => {
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith("/info")) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
       capturedBody = JSON.parse(init.body);
       return new Response(
         JSON.stringify({
@@ -207,5 +216,235 @@ test("mintInvite omits max_uses when not provided (unlimited default)", async ()
     }
   } finally {
     teardownTauriStubs();
+  }
+});
+
+// --- canonical-origin signing (alias-host auth fix) ---
+
+function setupClaimFetch(infoBody, claimResult = { status: "joined" }) {
+  const calls = { urls: [], claimInit: null };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.urls.push(String(url));
+    if (String(url).endsWith("/info")) {
+      // `{ __rawInfo }` serves an exact raw document (truncated JSON, null…)
+      const body =
+        infoBody && typeof infoBody === "object" && "__rawInfo" in infoBody
+          ? infoBody.__rawInfo
+          : JSON.stringify(infoBody);
+      return new Response(body, { status: 200 });
+    }
+    calls.claimInit = init;
+    return new Response(
+      JSON.stringify({
+        status: claimResult.status,
+        community_id: "cid",
+        host: "beehivenature.buzz",
+        role: "member",
+      }),
+    );
+  };
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+function signedUTag(calls) {
+  const signCall = calls.invokeArgs.find((c) => c.command === "sign_event");
+  assert.ok(signCall, "sign_event was invoked");
+  return signCall.args.tags.find((t) => t[0] === "u")?.[1];
+}
+
+test("claimInvite signs the canonical origin from /info while requesting the transport host", async () => {
+  // relay2.skaists.dev advertises beehivenature.buzz — the alias-host case
+  const tauri = setupTauriStubs("https://unused-active-relay.example");
+  const fetchMock = setupClaimFetch({
+    push: { origin: "wss://beehivenature.buzz" },
+  });
+  try {
+    const result = await claimInvite("wss://relay2.skaists.dev", "v2.code");
+    assert.equal(result.status, "joined");
+    assert.equal(result.host, "beehivenature.buzz");
+    // the road: /info and the claim POST both rode the transport host
+    assert.deepEqual(fetchMock.calls.urls, [
+      "https://relay2.skaists.dev/info",
+      "https://relay2.skaists.dev/api/invites/claim",
+    ]);
+    // the identity: the u tag is signed against the CANONICAL origin
+    assert.equal(
+      signedUTag(tauri),
+      "https://beehivenature.buzz/api/invites/claim",
+    );
+  } finally {
+    fetchMock.restore();
+    teardownTauriStubs();
+  }
+});
+
+test("claimInvite keeps signing the transport host when /info advertises no canonical origin", async () => {
+  // plain relay: no push.origin — the road IS the identity
+  const tauri = setupTauriStubs("https://unused-active-relay.example");
+  const fetchMock = setupClaimFetch({ name: "Buzz Relay" });
+  try {
+    await claimInvite("wss://relay.example", "v2.code");
+    assert.equal(
+      signedUTag(tauri),
+      "https://relay.example/api/invites/claim",
+    );
+  } finally {
+    fetchMock.restore();
+    teardownTauriStubs();
+  }
+});
+
+test("claimInvite fails closed on a malformed canonical advertisement", async () => {
+  for (const bad of [
+    { push: { origin: "not a url" } },
+    { push: { origin: "ftp://beehivenature.buzz" } },
+    { push: { origin: 42 } },
+  ]) {
+    const tauri = setupTauriStubs("https://unused-active-relay.example");
+    const fetchMock = setupClaimFetch(bad);
+    try {
+      await assert.rejects(
+        claimInvite("wss://relay2.skaists.dev", "v2.code"),
+        /canonical origin|URL verification|malformed/,
+      );
+      // nothing was claimed — no POST left the client
+      assert.equal(
+        fetchMock.calls.urls.filter((u) => u.endsWith("/claim")).length,
+        0,
+      );
+    } finally {
+      fetchMock.restore();
+      teardownTauriStubs();
+    }
+  }
+});
+
+// Review round 1: an UNREADABLE /info document proves nothing about what
+// the relay advertises — it must stop the request before signing or POST,
+// never silently restore transport signing.
+
+test("claimInvite fails closed when /info is invalid JSON", async () => {
+  const tauri = setupTauriStubs("https://unused-active-relay.example");
+  const fetchMock = setupClaimFetch({
+    __rawInfo: '{"push":{"origin":"wss://beehivenature.buzz"',
+  });
+  try {
+    await assert.rejects(
+      claimInvite("wss://relay2.skaists.dev", "v2.code"),
+      /malformed document/,
+    );
+    assert.equal(
+      fetchMock.calls.urls.filter((u) => u.endsWith("/claim")).length,
+      0,
+    );
+  } finally {
+    fetchMock.restore();
+    teardownTauriStubs();
+  }
+});
+
+test("claimInvite fails closed when /info decodes to a non-object root", async () => {
+  for (const raw of ["null", "[]", '"a string"']) {
+    const tauri = setupTauriStubs("https://unused-active-relay.example");
+    const fetchMock = setupClaimFetch({ __rawInfo: raw });
+    try {
+      await assert.rejects(
+        claimInvite("wss://relay2.skaists.dev", "v2.code"),
+        /malformed document/,
+      );
+      assert.equal(
+        fetchMock.calls.urls.filter((u) => u.endsWith("/claim")).length,
+        0,
+      );
+    } finally {
+      fetchMock.restore();
+      teardownTauriStubs();
+    }
+  }
+});
+
+test("claimInvite fails closed when the push descriptor is the wrong shape", async () => {
+  for (const bad of [{ push: "not-an-object" }, { push: [1, 2] }, { push: null }]) {
+    const tauri = setupTauriStubs("https://unused-active-relay.example");
+    const fetchMock = setupClaimFetch(bad);
+    try {
+      await assert.rejects(
+        claimInvite("wss://relay2.skaists.dev", "v2.code"),
+        /malformed push descriptor/,
+      );
+    } finally {
+      fetchMock.restore();
+      teardownTauriStubs();
+    }
+  }
+});
+
+// Review round 1: the advertisement must be a STRUCTURAL ws/wss origin —
+// components beyond the origin would land inside the signed target.
+
+test("claimInvite rejects origins carrying non-origin components", async () => {
+  for (const origin of [
+    "wss://beehivenature.buzz#section",
+    "wss://beehivenature.buzz?x=1",
+    "wss://beehivenature.buzz/nested",
+    "wss://synthetic:synthetic@beehivenature.buzz",
+  ]) {
+    const tauri = setupTauriStubs("https://unused-active-relay.example");
+    const fetchMock = setupClaimFetch({ push: { origin } });
+    try {
+      await assert.rejects(
+        claimInvite("wss://relay2.skaists.dev", "v2.code"),
+        /URL verification/,
+      );
+      assert.equal(
+        fetchMock.calls.urls.filter((u) => u.endsWith("/claim")).length,
+        0,
+      );
+    } finally {
+      fetchMock.restore();
+      teardownTauriStubs();
+    }
+  }
+});
+
+test("claimInvite signs a valid IPv6 origin and preserves ports", async () => {
+  // positive IPv6 control — a direct relay road with no dot in its host
+  {
+    const tauri = setupTauriStubs("https://unused-active-relay.example");
+    const fetchMock = setupClaimFetch({ push: { origin: "ws://[::1]:3000" } });
+    try {
+      await claimInvite("wss://relay2.skaists.dev", "v2.code");
+      assert.equal(signedUTag(tauri), "http://[::1]:3000/api/invites/claim");
+      assert.deepEqual(fetchMock.calls.urls, [
+        "https://relay2.skaists.dev/info",
+        "https://relay2.skaists.dev/api/invites/claim",
+      ]);
+    } finally {
+      fetchMock.restore();
+      teardownTauriStubs();
+    }
+  }
+  // port preservation on a dotted canonical host
+  {
+    const tauri = setupTauriStubs("https://unused-active-relay.example");
+    const fetchMock = setupClaimFetch({
+      push: { origin: "wss://beehivenature.buzz:8443/" },
+    });
+    try {
+      await claimInvite("wss://relay2.skaists.dev", "v2.code");
+      assert.equal(
+        signedUTag(tauri),
+        "https://beehivenature.buzz:8443/api/invites/claim",
+      );
+    } finally {
+      fetchMock.restore();
+      teardownTauriStubs();
+    }
   }
 });

--- a/desktop/src/shared/api/invites.test.mjs
+++ b/desktop/src/shared/api/invites.test.mjs
@@ -290,10 +290,7 @@ test("claimInvite keeps signing the transport host when /info advertises no cano
   const fetchMock = setupClaimFetch({ name: "Buzz Relay" });
   try {
     await claimInvite("wss://relay.example", "v2.code");
-    assert.equal(
-      signedUTag(tauri),
-      "https://relay.example/api/invites/claim",
-    );
+    assert.equal(signedUTag(tauri), "https://relay.example/api/invites/claim");
   } finally {
     fetchMock.restore();
     teardownTauriStubs();
@@ -370,7 +367,11 @@ test("claimInvite fails closed when /info decodes to a non-object root", async (
 });
 
 test("claimInvite fails closed when the push descriptor is the wrong shape", async () => {
-  for (const bad of [{ push: "not-an-object" }, { push: [1, 2] }, { push: null }]) {
+  for (const bad of [
+    { push: "not-an-object" },
+    { push: [1, 2] },
+    { push: null },
+  ]) {
     const tauri = setupTauriStubs("https://unused-active-relay.example");
     const fetchMock = setupClaimFetch(bad);
     try {

--- a/desktop/src/shared/api/invites.ts
+++ b/desktop/src/shared/api/invites.ts
@@ -13,6 +13,12 @@ import {
 // - POST /api/invites/claim  — claim a code, signed by the *joining* key.
 //   This one targets an arbitrary relay (the invite's relay, not necessarily
 //   the active community), so the claim helper takes an explicit ws URL.
+//
+// Canonical-origin signing law: the NIP-98 `u` tag is signed against the
+// origin the relay ADVERTISES in GET /info, while the HTTP request rides
+// the transport host the caller supplied — sign the identity, ride the
+// road (an alias host like relay2.skaists.dev serving the canonical
+// beehivenature.buzz identity otherwise fails invite auth).
 
 const NIP98_KIND = 27235;
 
@@ -75,14 +81,102 @@ async function nip98PostHeader(url: string, body: string): Promise<string> {
   return `Nostr ${btoa(JSON.stringify(authEvent))}`;
 }
 
+/**
+ * The canonical HTTP origin this relay advertises for itself, from GET
+ * `/info` on the TRANSPORT road.
+ *
+ * A deployment's identity can differ from the host a client rides
+ * (`relay2.skaists.dev` advertises `wss://beehivenature.buzz`): the relay
+ * verifies NIP-98 `u` tags against the canonical origin, so clients must
+ * SIGN the identity while RIDING the road.
+ *
+ * Fail-closed rules (review round 1):
+ * - An UNREADABLE /info document (invalid JSON, or a decoded non-object
+ *   root such as `null`/array) stops the request before signing or POST —
+ *   it proves nothing about what the relay advertises, and silently
+ *   signing the transport host instead is the alias-host auth bug itself.
+ *   Only a well-formed info OBJECT with no advertised origin means "the
+ *   road IS the identity" (plain relays keep working).
+ * - The advertisement must be a STRUCTURAL ws/wss ORIGIN — no userinfo,
+ *   query, fragment, or non-root path; port and IPv6 literals are valid.
+ *   Components beyond the origin would land inside the signed target.
+ * - The HTTP signing origin is CONSTRUCTED from the parsed/validated URL
+ *   (never by concatenating the raw advertisement string).
+ * - No DNS/network resolution is performed as validation.
+ */
+async function canonicalSigningBase(transportHttpBase: string): Promise<string> {
+  const infoUrl = `${transportHttpBase.replace(/\/+$/, "")}/info`;
+  const response = await fetch(infoUrl, {
+    signal: AbortSignal.timeout(INVITE_REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`relay /info HTTP ${response.status}`);
+  }
+  const text = await response.text();
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(text);
+  } catch {
+    throw new Error("relay /info returned a malformed document");
+  }
+  if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+    throw new Error("relay /info returned a malformed document");
+  }
+  const info = decoded as { push?: unknown };
+  let advertised: unknown;
+  if (info.push !== undefined) {
+    if (typeof info.push !== "object" || info.push === null || Array.isArray(info.push)) {
+      throw new Error("relay /info returned a malformed push descriptor");
+    }
+    advertised = (info.push as { origin?: unknown }).origin;
+  }
+  if (advertised === undefined) {
+    return transportHttpBase;
+  }
+  if (typeof advertised !== "string") {
+    throw new Error("relay /info advertises a malformed canonical origin");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(advertised);
+  } catch {
+    throw new Error("relay /info canonical origin failed URL verification");
+  }
+  if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+    throw new Error("relay /info canonical origin failed URL verification");
+  }
+  if (
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new Error("relay /info canonical origin failed URL verification");
+  }
+  if (parsed.pathname !== "" && parsed.pathname !== "/") {
+    throw new Error("relay /info canonical origin failed URL verification");
+  }
+  if (parsed.hostname === "") {
+    throw new Error("relay /info canonical origin failed URL verification");
+  }
+  // Constructed from the PARSED url: scheme upgraded ws→http / wss→https,
+  // url.host keeps any port and IPv6 bracket literals.
+  const scheme = parsed.protocol === "wss:" ? "https" : "http";
+  return `${scheme}://${parsed.host}`;
+}
+
 async function invitePost<T>(
   httpBase: string,
   path: string,
   body: string,
 ): Promise<T> {
-  const url = `${httpBase.replace(/\/+$/, "")}${path}`;
-  const authorization = await nip98PostHeader(url, body);
-  const response = await fetch(url, {
+  const transportUrl = `${httpBase.replace(/\/+$/, "")}${path}`;
+  // Sign the canonical identity; request the transport road. With no
+  // advertised origin these are the same URL and behavior is unchanged.
+  const signingBase = await canonicalSigningBase(httpBase);
+  const signedUrl = `${signingBase.replace(/\/+$/, "")}${path}`;
+  const authorization = await nip98PostHeader(signedUrl, body);
+  const response = await fetch(transportUrl, {
     method: "POST",
     headers: {
       Authorization: authorization,

--- a/desktop/src/shared/api/invites.ts
+++ b/desktop/src/shared/api/invites.ts
@@ -104,7 +104,9 @@ async function nip98PostHeader(url: string, body: string): Promise<string> {
  *   (never by concatenating the raw advertisement string).
  * - No DNS/network resolution is performed as validation.
  */
-async function canonicalSigningBase(transportHttpBase: string): Promise<string> {
+async function canonicalSigningBase(
+  transportHttpBase: string,
+): Promise<string> {
   const infoUrl = `${transportHttpBase.replace(/\/+$/, "")}/info`;
   const response = await fetch(infoUrl, {
     signal: AbortSignal.timeout(INVITE_REQUEST_TIMEOUT_MS),
@@ -119,13 +121,21 @@ async function canonicalSigningBase(transportHttpBase: string): Promise<string> 
   } catch {
     throw new Error("relay /info returned a malformed document");
   }
-  if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+  if (
+    typeof decoded !== "object" ||
+    decoded === null ||
+    Array.isArray(decoded)
+  ) {
     throw new Error("relay /info returned a malformed document");
   }
   const info = decoded as { push?: unknown };
   let advertised: unknown;
   if (info.push !== undefined) {
-    if (typeof info.push !== "object" || info.push === null || Array.isArray(info.push)) {
+    if (
+      typeof info.push !== "object" ||
+      info.push === null ||
+      Array.isArray(info.push)
+    ) {
       throw new Error("relay /info returned a malformed push descriptor");
     }
     advertised = (info.push as { origin?: unknown }).origin;


### PR DESCRIPTION
## fix(desktop): sign invite claims against the canonical origin from `/info` — final

**Replaces [#7458](https://github.com/block/buzz/pull/7458) and [#7460](https://github.com/block/buzz/pull/7460):** same patch, review corrections included, DCO sign-off added, and now branched **directly from the upstream commit** so the PR range carries exactly one properly signed commit (the previous attempt accidentally included the fork's unsigned merge commit). No force-push anywhere; the superseded branches keep their history and review trail.

**Alias-host auth bug.** `relay2.skaists.dev` advertises `wss://beehivenature.buzz` in `GET /info`; the relay verifies NIP-98 `u` tags against the canonical origin, so the desktop signing the transport hostname failed invite auth regardless of retries. `invitePost` now signs `{canonical}{path}` while the request rides `{transport}{path}`; a well-formed `/info` advertising no origin keeps byte-identical legacy signing (plain relays unaffected).

**Review-round corrections (both findings):**

1. **Unreadable metadata fails closed.** Invalid JSON, a non-object root (`null`/array/string), or a malformed push descriptor stops the request *before signing or POST* — it proves nothing about what the relay advertises, and silently restoring transport signing is the bug itself. Container shapes are validated, not cast.
2. **Structural origin validation.** The advertisement must be a pure ws/wss origin: no userinfo, query, fragment, or non-root path; **ports and IPv6 literals are valid** (`ws://[::1]:3000` signs `http://[::1]:3000/...`). The HTTP signing origin is **constructed from the parsed URL**, never concatenated from the raw string. No dot heuristic; no DNS resolution as validation.

**Tests** (`invites.test.mjs`, 15/0): alias-host regression (signs `beehivenature.buzz` while both `/info` and the POST provably ride `relay2.skaists.dev`), compat control, nine fail-closed controls (all reject pre-POST), and positive IPv6 + port-preservation controls.

**Verification:** desktop suite **4961 passed / 1 flake** (an unrelated `useDocumentVisible` timing test that also flakes on clean main and passes in isolation and on re-run); `tsc --noEmit` clean.
