### PR TITLE
feat(auth): add read-only relay observer role

### DIFF
--- a/NOSTR.md
+++ b/NOSTR.md
@@ -213,9 +213,21 @@ nak req -k 1059 --tag "p=<your-hex-pubkey>" \
 
 ## Relay Membership (NIP-43)
 
-When `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`, every authenticated connection is checked against the
-`relay_members` table. In today's single-community deployment this is the relay-wide member list; in multi-community mode the same rule is scoped to the host-derived community. Only pubkeys with a row for that community may use that community. The relay owner
-is bootstrapped automatically from `RELAY_OWNER_PUBKEY` on startup.
+Every authenticated connection is checked for a direct role in the
+`relay_members` table. When `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`, pubkeys without
+a qualifying row are denied; on an open relay they retain the normal open-relay
+authority. In today's single-community deployment this is the relay-wide member
+list; in multi-community mode the same rule is scoped to the host-derived
+community. The relay owner is bootstrapped automatically from
+`RELAY_OWNER_PUBKEY` on startup.
+
+The `observer` role is directly provisioned and grants exactly
+`messages:read`. Existing channel membership still determines which private
+channel events it may read. It cannot delegate through NIP-OA or use event
+submission, media, Git, huddle, GIF, workflow, membership, join, or leave
+mutation paths. Observer pubkeys and their role are included in the relay's
+kind:13534 membership snapshot, so observer identities are operational service
+identities and must not be treated as secret.
 
 ### CLI: Managing Members
 
@@ -227,6 +239,7 @@ In a Docker Compose deployment, use `run.sh`:
 ./run.sh add-member npub1abc...
 ./run.sh add-member <64-char-hex-pubkey>
 ./run.sh add-member npub1abc... --role admin
+./run.sh add-member npub1observer... --role observer
 
 # Remove a member
 ./run.sh remove-member npub1abc...
@@ -241,6 +254,7 @@ Or invoke `buzz-admin` directly inside the container:
 ```bash
 docker compose exec relay buzz-admin add-member --pubkey npub1abc...
 docker compose exec relay buzz-admin add-member --pubkey npub1abc... --role admin
+docker compose exec relay buzz-admin add-member --pubkey npub1observer... --role observer
 docker compose exec relay buzz-admin remove-member --pubkey npub1abc...
 docker compose exec relay buzz-admin list-members
 ```
@@ -271,9 +285,9 @@ the sender to be authenticated (NIP-42) as the relay owner or an admin.
 
 | Kind | Action | Required tags |
 |------|--------|---------------|
-| 9030 | Add member | `["p", "<hex-pubkey>"]`, optional `["role", "member\|admin"]` |
-| 9031 | Remove member | `["p", "<hex-pubkey>"]`, optional `["role", "member\|admin"]` |
-| 9032 | Change role | `["p", "<hex-pubkey>"]`, `["role", "member\|admin"]` |
+| 9030 | Add member | `["p", "<hex-pubkey>"]`, optional `["role", "member\|admin\|observer"]`; only the owner may grant `admin` or `observer` |
+| 9031 | Remove member | `["p", "<hex-pubkey>"]`, optional `["role", "member\|admin\|observer"]` |
+| 9032 | Change role | `["p", "<hex-pubkey>"]`, `["role", "member\|admin\|observer"]`; owner only |
 | 9033 | Set workspace profile (icon) | `["icon", "<https-url or data:image/* URL>"]` (empty clears) |
 
 Example using `nak`:

--- a/crates/buzz-admin/src/main.rs
+++ b/crates/buzz-admin/src/main.rs
@@ -52,8 +52,9 @@ enum Command {
         #[arg(long)]
         pubkey: String,
 
-        /// Role: "admin" or "member" (default: member). Cannot be "owner" —
-        /// use RELAY_OWNER_PUBKEY config to set the relay owner.
+        /// Role: "admin", "member", or "observer" (default: member). An
+        /// observer can read channel events but cannot mutate relay state.
+        /// Cannot be "owner" — use RELAY_OWNER_PUBKEY config to set the owner.
         #[arg(long, default_value = "member")]
         role: String,
     },
@@ -299,15 +300,15 @@ async fn cmd_list_members() -> Result<i32> {
     Ok(0)
 }
 
-/// Validate that `role` is `"member"` or `"admin"`. Rejects `"owner"`.
+/// Validate a role that can be directly provisioned by the operator CLI.
 fn validate_role(role: &str) -> std::result::Result<(), String> {
     match role {
-        "member" | "admin" => Ok(()),
+        "member" | "admin" | "observer" => Ok(()),
         "owner" => {
             Err("role 'owner' cannot be set via CLI — use RELAY_OWNER_PUBKEY config".to_string())
         }
         other => Err(format!(
-            "invalid role '{other}': must be 'member' or 'admin'"
+            "invalid role '{other}': must be 'member', 'admin', or 'observer'"
         )),
     }
 }
@@ -630,4 +631,19 @@ async fn reconcile_channels(
         channels.len()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_role;
+
+    #[test]
+    fn operator_can_provision_only_supported_non_owner_roles() {
+        for role in ["member", "admin", "observer"] {
+            assert_eq!(validate_role(role), Ok(()), "role {role}");
+        }
+        assert!(validate_role("owner").is_err());
+        assert!(validate_role("future-role").is_err());
+        assert!(validate_role("").is_err());
+    }
 }

--- a/crates/buzz-auth/src/scope.rs
+++ b/crates/buzz-auth/src/scope.rs
@@ -61,6 +61,14 @@ pub enum Scope {
 }
 
 impl Scope {
+    /// Return the complete authority granted to a directly provisioned observer.
+    ///
+    /// Observers may read channel events only. Channel and community visibility
+    /// remain independently constrained by the relay's existing membership gates.
+    pub fn observer_read_only() -> Vec<Scope> {
+        vec![Self::MessagesRead]
+    }
+
     /// Return a `Vec` containing every known scope variant.
     ///
     /// Used in dev mode (`require_auth_token=false`) where `X-Pubkey` header
@@ -245,5 +253,13 @@ mod tests {
                 "all_known() must not contain Unknown variants"
             );
         }
+    }
+
+    #[test]
+    fn observer_authority_is_explicit_nonempty_and_read_only() {
+        let scopes = Scope::observer_read_only();
+        assert_eq!(scopes, vec![Scope::MessagesRead]);
+        assert!(!scopes.is_empty());
+        assert!(scopes.iter().all(|scope| scope.as_str().ends_with(":read")));
     }
 }

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -702,7 +702,7 @@ mod postgres_tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 44);
+        assert_eq!(migrations.len(), 45);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -1287,6 +1287,12 @@ mod postgres_tests {
             desired_schema.contains("'rate_limit_violations'\n    ]::TEXT[])"),
             "schema.sql exclusion list must match the pre-0041 body after ledger removal"
         );
+
+        assert_eq!(migrations[44].version, 45);
+        let observer_role = migrations[44].sql.as_str();
+        assert!(observer_role.contains("relay_members_role_check"));
+        assert!(observer_role.contains("'observer'"));
+        assert!(desired_schema.contains("'observer'"));
     }
 
     #[test]

--- a/crates/buzz-db/src/store/relay_members.rs
+++ b/crates/buzz-db/src/store/relay_members.rs
@@ -20,7 +20,7 @@ use crate::{observability, replaceable, CommunityId, Db, RouteDecision, RoutePre
 pub struct RelayMember {
     /// 64-char lowercase hex pubkey.
     pub pubkey: String,
-    /// Role: `"owner"`, `"admin"`, or `"member"`.
+    /// Role: `"owner"`, `"admin"`, `"member"`, or `"observer"`.
     pub role: String,
     /// Hex pubkey of who added this member, or `None` for bootstrap entries.
     pub added_by: Option<String>,
@@ -1270,6 +1270,56 @@ mod postgres_tests {
             list_b.iter().all(|m| m.pubkey != pubkey),
             "community B list must not contain A's member"
         );
+    }
+
+    /// The authoritative NIP-43 snapshot must advertise the same observer role
+    /// that drives admission. Omitting observers would create protocol/DB drift;
+    /// dropping the role would hide the relay policy clients are allowed to
+    /// display even though the server remains authoritative for permissions.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn observer_role_round_trips_through_nip43_snapshot_and_reconciliation() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let observer = test_pubkey();
+        add_relay_member(&pool, community, &observer, "observer", None)
+            .await
+            .expect("add observer");
+
+        let db = Db::from_pool(pool.clone());
+        let relay_keys = nostr::Keys::generate();
+        let (snapshot, inserted, member_count) = db
+            .publish_nip43_membership_locked(community, &relay_keys)
+            .await
+            .expect("publish membership snapshot");
+        assert!(inserted);
+        assert_eq!(member_count, 1);
+        assert!(snapshot.event.tags.iter().any(|tag| {
+            tag.as_slice()
+                == [
+                    "member".to_string(),
+                    observer.clone(),
+                    "observer".to_string(),
+                ]
+        }));
+        assert!(!db
+            .nip43_membership_snapshot_needs_reconciliation_for_maintenance(
+                community,
+                &relay_keys.public_key(),
+            )
+            .await
+            .expect("snapshot matches canonical observer row"));
+
+        update_relay_member_role(&pool, community, &observer, "member")
+            .await
+            .expect("change observer role");
+        assert!(db
+            .nip43_membership_snapshot_needs_reconciliation_for_maintenance(
+                community,
+                &relay_keys.public_key(),
+            )
+            .await
+            .expect("role drift is detected"));
     }
 
     /// Owner bootstrap is community-scoped: bootstrapping the owner in A does not

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -921,7 +921,7 @@ async fn submit_event_authed(
 
     // Enforce relay membership (with NIP-OA fallback via x-auth-tag header).
     let auth_tag = super::relay_members::extract_auth_tag_header(headers);
-    let nip_oa_owner = match super::relay_members::enforce_relay_membership(
+    let authorization = match super::relay_members::resolve_principal_authorization(
         state,
         tenant.community(),
         &pubkey_bytes,
@@ -930,17 +930,7 @@ async fn submit_event_authed(
     )
     .await
     {
-        Ok(owner) => owner.or_else(|| {
-            if !state.config.require_relay_membership {
-                super::relay_members::extract_nip_oa_owner(
-                    &pubkey_bytes,
-                    auth_tag,
-                    signed_auth_created_at,
-                )
-            } else {
-                None
-            }
-        }),
+        Ok(authorization) => authorization,
         Err(e) => {
             return SubmitOutcome::Err {
                 status: e.0,
@@ -948,6 +938,17 @@ async fn submit_event_authed(
             };
         }
     };
+    let nip_oa_owner = authorization.delegated_owner.or_else(|| {
+        if !state.config.require_relay_membership {
+            super::relay_members::extract_nip_oa_owner(
+                &pubkey_bytes,
+                auth_tag,
+                signed_auth_created_at,
+            )
+        } else {
+            None
+        }
+    });
     if let Some(owner) = nip_oa_owner {
         super::relay_members::materialize_nip_oa_owner(state, tenant, &pubkey, &owner).await;
     }
@@ -955,7 +956,7 @@ async fn submit_event_authed(
     let kind_u32 = buzz_core::kind::event_kind_u32(&event);
     let auth = IngestAuth::Http {
         pubkey,
-        scopes: buzz_auth::Scope::all_known(), // Pure Nostr: full scopes, channel access via membership
+        scopes: authorization.scopes,
         auth_method: crate::handlers::ingest::HttpAuthMethod::Nip98,
     };
 
@@ -1100,7 +1101,7 @@ async fn query_events_authed(
     let pubkey_bytes = pubkey.to_bytes().to_vec();
 
     let auth_tag = super::relay_members::extract_auth_tag_header(headers);
-    super::relay_members::enforce_relay_membership(
+    let authorization = super::relay_members::resolve_principal_authorization(
         state,
         tenant.community(),
         &pubkey_bytes,
@@ -1108,6 +1109,15 @@ async fn query_events_authed(
         signed_auth_created_at,
     )
     .await?;
+    if !authorization
+        .scopes
+        .contains(&buzz_auth::Scope::MessagesRead)
+    {
+        return Err(api_error(
+            StatusCode::FORBIDDEN,
+            "restricted: insufficient scope for event reads",
+        ));
+    }
 
     // Two-pass parse: preserve raw JSON for custom extension fields (before_id,
     // depth_limit, feed_types) that nostr::Filter silently drops.
@@ -1641,7 +1651,7 @@ async fn count_events_authed(
     let pubkey_bytes = pubkey.to_bytes().to_vec();
 
     let auth_tag = super::relay_members::extract_auth_tag_header(headers);
-    super::relay_members::enforce_relay_membership(
+    let authorization = super::relay_members::resolve_principal_authorization(
         state,
         tenant.community(),
         &pubkey_bytes,
@@ -1649,6 +1659,15 @@ async fn count_events_authed(
         signed_auth_created_at,
     )
     .await?;
+    if !authorization
+        .scopes
+        .contains(&buzz_auth::Scope::MessagesRead)
+    {
+        return Err(api_error(
+            StatusCode::FORBIDDEN,
+            "restricted: insufficient scope for event counts",
+        ));
+    }
 
     let filters: Vec<nostr::Filter> = serde_json::from_slice(body)
         .map_err(|e| api_error(StatusCode::BAD_REQUEST, &format!("invalid filters: {e}")))?;
@@ -3832,8 +3851,8 @@ mod postgres_tests {
     /// Build an AppState suitable for handler-level bridge tests.
     ///
     /// - `require_auth_token = false` → X-Pubkey dev-mode fallback active.
-    /// - `require_relay_membership = false` → membership check short-circuits to
-    ///   OpenRelay without a DB lookup.
+    /// - `require_relay_membership = false` → an absent direct role falls back to
+    ///   OpenRelay after the authoritative-role DB lookup.
     /// - `nip98_replay` replaced with an always-fresh guard → no Redis needed
     ///   for replay detection.
     /// - Redis pool points at the local dev instance for the admission check.
@@ -3894,6 +3913,16 @@ mod postgres_tests {
         pubkey_hex: &str,
         body: &[u8],
     ) -> axum::http::StatusCode {
+        post_bridge_route(state, host, pubkey_hex, "/events", body).await
+    }
+
+    async fn post_bridge_route(
+        state: Arc<crate::state::AppState>,
+        host: &str,
+        pubkey_hex: &str,
+        route: &str,
+        body: &[u8],
+    ) -> axum::http::StatusCode {
         use axum::body::Body;
         use axum::http::{header, Request};
         use tower::ServiceExt;
@@ -3902,7 +3931,7 @@ mod postgres_tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/events")
+                    .uri(route)
                     .header(header::HOST, host)
                     .header("x-pubkey", pubkey_hex)
                     .body(Body::from(body.to_vec()))
@@ -3911,6 +3940,60 @@ mod postgres_tests {
             .await
             .expect("router oneshot")
             .status()
+    }
+
+    /// Production router regression for the observer's entire HTTP bridge
+    /// contract: query and count remain usable, while event submission reaches
+    /// the real ingest scope gate and is denied.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn observer_http_bridge_reads_succeed_and_submission_is_denied() {
+        let state = bridge_handler_test_state()
+            .await
+            .expect("local Postgres and Redis are reachable");
+        let host = format!("observer-bridge-{}.local", uuid::Uuid::new_v4().simple());
+        let community = state
+            .db
+            .ensure_configured_community(&host)
+            .await
+            .expect("ensure observer test community")
+            .id;
+        let observer = Keys::generate();
+        state
+            .db
+            .add_relay_member(community, &observer.public_key().to_hex(), "observer", None)
+            .await
+            .expect("provision observer");
+
+        for route in ["/query", "/count"] {
+            assert_eq!(
+                post_bridge_route(
+                    Arc::clone(&state),
+                    &host,
+                    &observer.public_key().to_hex(),
+                    route,
+                    br#"[{"kinds":[1],"limit":1}]"#,
+                )
+                .await,
+                StatusCode::OK,
+                "observer must retain read access through {route}"
+            );
+        }
+
+        let event = EventBuilder::new(Kind::TextNote, "observer must not write")
+            .sign_with_keys(&observer)
+            .expect("sign observer event");
+        assert_eq!(
+            post_events(
+                state,
+                &host,
+                &observer.public_key().to_hex(),
+                &serde_json::to_vec(&event).expect("serialize observer event"),
+            )
+            .await,
+            StatusCode::FORBIDDEN,
+            "observer submission must be denied by the production HTTP route"
+        );
     }
 
     /// Collect buzz_events_rejected_total with (transport, reason) labels from

--- a/crates/buzz-relay/src/api/mod.rs
+++ b/crates/buzz-relay/src/api/mod.rs
@@ -51,8 +51,10 @@ pub mod relay_members {
     pub enum MembershipDecision {
         /// Relay membership enforcement is disabled.
         OpenRelay,
-        /// Caller is directly present in `relay_members`.
+        /// Caller is directly present in `relay_members` with ordinary authority.
         Member,
+        /// Caller is a directly provisioned read-only observer.
+        Observer,
         /// Caller is admitted through a NIP-OA owner that is a relay member.
         ViaOwner(nostr::PublicKey),
         /// Caller is not admitted.
@@ -84,18 +86,22 @@ pub mod relay_members {
         auth_tag_header: Option<&str>,
         signed_auth_created_at: Option<u64>,
     ) -> Result<MembershipDecision, String> {
-        if !state.config.require_relay_membership {
-            return Ok(MembershipDecision::OpenRelay);
-        }
-
         let pubkey_hex = hex::encode(pubkey_bytes);
-        let is_member = state
+        let member = state
             .db
-            .is_relay_member(community, &pubkey_hex)
+            .get_relay_member(community, &pubkey_hex)
             .await
             .map_err(|e| format!("relay membership check failed: {e}"))?;
-        if is_member {
-            return Ok(MembershipDecision::Member);
+        if let Some(member) = member {
+            return decision_for_direct_role(&member.role);
+        }
+
+        // Direct roles remain authoritative on an open relay. In particular,
+        // an operator-provisioned observer must not inherit open-relay write
+        // authority. The lookup therefore deliberately precedes this fallback;
+        // a lookup failure cannot silently upgrade an observer to OpenRelay.
+        if !state.config.require_relay_membership {
+            return Ok(MembershipDecision::OpenRelay);
         }
 
         if state.config.allow_nip_oa_auth {
@@ -114,18 +120,30 @@ pub mod relay_members {
                 ) {
                     Ok(owner_pubkey) => {
                         let owner_hex = owner_pubkey.to_hex();
-                        let owner_is_member = state
+                        let owner_member = state
                             .db
-                            .is_relay_member(community, &owner_hex)
+                            .get_relay_member(community, &owner_hex)
                             .await
-                            .map_err(|e| format!("relay membership check (owner) failed: {e}"))?;
-                        if owner_is_member {
-                            debug!(
-                                agent = %pubkey_hex,
-                                owner = %owner_hex,
-                                "NIP-OA membership granted via owner"
-                            );
-                            return Ok(MembershipDecision::ViaOwner(owner_pubkey));
+                            .map_err(|e| {
+                            format!("relay membership check (owner) failed: {e}")
+                        })?;
+                        if let Some(owner_member) = owner_member {
+                            return match owner_member.role.as_str() {
+                                "owner" | "admin" | "member" => {
+                                    debug!(
+                                        agent = %pubkey_hex,
+                                        owner = %owner_hex,
+                                        "NIP-OA membership granted via owner"
+                                    );
+                                    Ok(MembershipDecision::ViaOwner(owner_pubkey))
+                                }
+                                // Initial observer policy is deliberately direct-only:
+                                // a read-only principal cannot delegate even read authority.
+                                "observer" => Ok(MembershipDecision::Denied),
+                                role => Err(format!(
+                                    "relay membership check returned unknown owner role: {role}"
+                                )),
+                            };
                         }
                     }
                     Err(e) => {
@@ -138,14 +156,154 @@ pub mod relay_members {
         Ok(MembershipDecision::Denied)
     }
 
+    fn decision_for_direct_role(role: &str) -> Result<MembershipDecision, String> {
+        match role {
+            "owner" | "admin" | "member" => Ok(MembershipDecision::Member),
+            "observer" => Ok(MembershipDecision::Observer),
+            role => Err(format!(
+                "relay membership check returned unknown direct role: {role}"
+            )),
+        }
+    }
+
+    /// Authority resolved from one server-owned relay-membership lookup.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct PrincipalAuthorization {
+        /// Permission scopes for the authenticated transport.
+        pub scopes: Vec<buzz_auth::Scope>,
+        /// NIP-OA owner when ordinary membership was delegated by that owner.
+        pub delegated_owner: Option<nostr::PublicKey>,
+        /// Whether the principal is the directly provisioned observer role.
+        pub observer: bool,
+    }
+
+    /// Resolve a Nostr principal to its server-owned role and effective authority.
+    pub async fn resolve_principal_authorization(
+        state: &AppState,
+        community: CommunityId,
+        pubkey_bytes: &[u8],
+        auth_tag_header: Option<&str>,
+        signed_auth_created_at: Option<u64>,
+    ) -> Result<PrincipalAuthorization, (StatusCode, Json<serde_json::Value>)> {
+        let decision = check_relay_membership(
+            state,
+            community,
+            pubkey_bytes,
+            auth_tag_header,
+            signed_auth_created_at,
+        )
+        .await;
+        authorization_for_decision(decision)
+    }
+
+    /// Re-resolve a live WebSocket principal before accepting a write.
+    ///
+    /// The owner was cryptographically verified during NIP-42 authentication and
+    /// stored on the connection. Reusing that identity lets closed-relay NIP-OA
+    /// sessions revalidate the durable owner role without retaining credential
+    /// material. Direct roles remain authoritative, including on open relays.
+    pub async fn resolve_live_principal_authorization(
+        state: &AppState,
+        community: CommunityId,
+        pubkey_bytes: &[u8],
+        verified_owner: Option<&nostr::PublicKey>,
+    ) -> Result<PrincipalAuthorization, (StatusCode, Json<serde_json::Value>)> {
+        let pubkey_hex = hex::encode(pubkey_bytes);
+        let direct = state
+            .db
+            .get_relay_member(community, &pubkey_hex)
+            .await
+            .map_err(|e| {
+                tracing::error!("live relay membership check failed: {e}");
+                super::internal_error(&format!("live relay membership check failed: {e}"))
+            })?;
+        if let Some(member) = direct {
+            return authorization_for_decision(decision_for_direct_role(&member.role));
+        }
+
+        if !state.config.require_relay_membership {
+            return authorization_for_decision(Ok(MembershipDecision::OpenRelay));
+        }
+
+        let decision = if let Some(owner) = verified_owner {
+            let owner_member = state
+                .db
+                .get_relay_member(community, &owner.to_hex())
+                .await
+                .map_err(|e| {
+                    tracing::error!("live relay owner membership check failed: {e}");
+                    super::internal_error(&format!("live relay owner membership check failed: {e}"))
+                })?;
+            match owner_member.as_ref().map(|member| member.role.as_str()) {
+                Some("owner" | "admin" | "member") => Ok(MembershipDecision::ViaOwner(*owner)),
+                Some("observer") | None => Ok(MembershipDecision::Denied),
+                Some(role) => Err(format!(
+                    "live relay membership check returned unknown owner role: {role}"
+                )),
+            }
+        } else {
+            Ok(MembershipDecision::Denied)
+        };
+        authorization_for_decision(decision)
+    }
+
+    fn authorization_for_decision(
+        decision: Result<MembershipDecision, String>,
+    ) -> Result<PrincipalAuthorization, (StatusCode, Json<serde_json::Value>)> {
+        match decision {
+            Ok(MembershipDecision::OpenRelay) | Ok(MembershipDecision::Member) => {
+                Ok(PrincipalAuthorization {
+                    scopes: buzz_auth::Scope::all_known(),
+                    delegated_owner: None,
+                    observer: false,
+                })
+            }
+            Ok(MembershipDecision::Observer) => Ok(PrincipalAuthorization {
+                scopes: buzz_auth::Scope::observer_read_only(),
+                delegated_owner: None,
+                observer: true,
+            }),
+            Ok(MembershipDecision::ViaOwner(owner)) => Ok(PrincipalAuthorization {
+                scopes: buzz_auth::Scope::all_known(),
+                delegated_owner: Some(owner),
+                observer: false,
+            }),
+            Ok(MembershipDecision::Denied) => Err(membership_denied()),
+            Err(e) => {
+                tracing::error!("relay principal resolution errored: {e}");
+                Err(super::internal_error(&e))
+            }
+        }
+    }
+
+    fn membership_denied() -> (StatusCode, Json<serde_json::Value>) {
+        (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "relay_membership_required",
+                "message": "You must be a relay member to access this relay"
+            })),
+        )
+    }
+
+    fn observer_mutation_denied() -> (StatusCode, Json<serde_json::Value>) {
+        (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "observer_read_only",
+                "message": "Read-only observers cannot use this operation"
+            })),
+        )
+    }
+
     /// Enforce relay membership for a pubkey, with NIP-OA agent delegation fallback.
     ///
     /// Returns `Ok(Some(owner_pubkey))` when the agent is not a direct member but
     /// its NIP-OA owner *is* — access is granted via delegation.
     ///
-    /// On open relays (`require_relay_membership = false`), returns `Ok(None)`
-    /// immediately — no membership check is performed. Callers that need NIP-OA
-    /// owner extraction on open relays should call [`extract_nip_oa_owner`] directly.
+    /// On open relays (`require_relay_membership = false`), direct roles are checked
+    /// first so a provisioned observer cannot inherit open-relay write authority.
+    /// An absent direct role returns `Ok(None)` without attempting NIP-OA fallback.
     ///
     /// Returns `Ok(None)` when the caller is a direct member (closed relay) or when
     /// no NIP-OA tag is present/applicable (open relay without auth tag).
@@ -156,29 +314,18 @@ pub mod relay_members {
         auth_tag_header: Option<&str>,
         signed_auth_created_at: Option<u64>,
     ) -> Result<Option<nostr::PublicKey>, (StatusCode, Json<serde_json::Value>)> {
-        match check_relay_membership(
+        let authorization = resolve_principal_authorization(
             state,
             community,
             pubkey_bytes,
             auth_tag_header,
             signed_auth_created_at,
         )
-        .await
-        {
-            Ok(MembershipDecision::OpenRelay) | Ok(MembershipDecision::Member) => Ok(None),
-            Ok(MembershipDecision::ViaOwner(owner)) => Ok(Some(owner)),
-            Ok(MembershipDecision::Denied) => Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "relay_membership_required",
-                    "message": "You must be a relay member to access this relay"
-                })),
-            )),
-            Err(e) => {
-                tracing::error!("relay membership check errored: {e}");
-                Err(super::internal_error(&e))
-            }
+        .await?;
+        if authorization.observer {
+            return Err(observer_mutation_denied());
         }
+        Ok(authorization.delegated_owner)
     }
 
     /// Extract NIP-OA owner from an auth tag without membership enforcement.
@@ -284,6 +431,27 @@ pub mod relay_members {
         use axum::http::{HeaderMap, HeaderValue};
         use buzz_sdk::nip_oa::compute_auth_tag;
         use nostr::Keys;
+
+        #[test]
+        fn direct_role_resolution_is_fail_closed() {
+            assert_eq!(
+                decision_for_direct_role("owner"),
+                Ok(MembershipDecision::Member)
+            );
+            assert_eq!(
+                decision_for_direct_role("admin"),
+                Ok(MembershipDecision::Member)
+            );
+            assert_eq!(
+                decision_for_direct_role("member"),
+                Ok(MembershipDecision::Member)
+            );
+            assert_eq!(
+                decision_for_direct_role("observer"),
+                Ok(MembershipDecision::Observer)
+            );
+            assert!(decision_for_direct_role("future-role").is_err());
+        }
 
         #[test]
         fn auth_tag_header_must_be_unique() {

--- a/crates/buzz-relay/src/handlers/auth.rs
+++ b/crates/buzz-relay/src/handlers/auth.rs
@@ -215,8 +215,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 }
             }
 
-            // Relay membership gate — uses the shared helper with NIP-OA fallback.
-            let nip_oa_owner = match crate::api::relay_members::enforce_relay_membership(
+            // Resolve relay membership and role-derived authority once for this
+            // connection. Direct observers receive only the explicit read scope;
+            // unknown roles and observer delegation fail closed.
+            let authorization = match crate::api::relay_members::resolve_principal_authorization(
                 &state,
                 conn.tenant.community(),
                 pubkey.as_bytes(),
@@ -225,7 +227,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             )
             .await
             {
-                Ok(owner) => owner,
+                Ok(authorization) => authorization,
                 Err(e) => {
                     warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), error = ?e, "not a relay member");
                     metrics::counter!("buzz_auth_failures_total", "reason" => "not_relay_member")
@@ -239,12 +241,13 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     return;
                 }
             };
+            auth_ctx.scopes = authorization.scopes;
 
             // Open relay NIP-OA backfill: extract owner for agent→owner DB mapping
             // (needed for observer frame auth). Only runs on open relays — on closed
-            // relays, enforce_relay_membership already handles NIP-OA delegation.
+            // relays, the shared principal resolver already handles NIP-OA delegation.
             // No feature flag needed: NIP-OA is cryptographically self-proving.
-            let nip_oa_owner = nip_oa_owner.or_else(|| {
+            let nip_oa_owner = authorization.delegated_owner.or_else(|| {
                 if !state.config.require_relay_membership && auth_tag_json.is_some() {
                     crate::api::relay_members::extract_nip_oa_owner(
                         pubkey.as_bytes(),

--- a/crates/buzz-relay/src/handlers/count.rs
+++ b/crates/buzz-relay/src/handlers/count.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use nostr::Filter;
 use tracing::warn;
 
+use buzz_auth::Scope;
+
 use crate::connection::{AuthState, ConnectionState};
 use crate::handlers::req::{
     event_visible_to_reader, filter_can_match_result_gated_kinds,
@@ -26,6 +28,13 @@ pub async fn handle_count(
         let auth = conn.auth_state.read().await;
         match &*auth {
             AuthState::Authenticated(ctx) => {
+                if !ctx.scopes.is_empty() && !ctx.scopes.contains(&Scope::MessagesRead) {
+                    conn.send(RelayMessage::closed(
+                        &sub_id,
+                        "restricted: insufficient scope",
+                    ));
+                    return;
+                }
                 (ctx.pubkey.to_bytes().to_vec(), ctx.channel_ids.clone())
             }
             _ => {

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -631,7 +631,7 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
     )
     .increment(1);
 
-    let (conn_id, pubkey_bytes, auth_pubkey, scopes, channel_ids) = {
+    let (conn_id, pubkey_bytes, auth_pubkey, mut scopes, channel_ids, verified_owner) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
             AuthState::Authenticated(ctx) => (
@@ -640,6 +640,7 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
                 ctx.pubkey,
                 ctx.scopes.clone(),
                 ctx.channel_ids.clone(),
+                ctx.agent_owner_pubkey,
             ),
             _ => {
                 reject("auth");
@@ -652,6 +653,37 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
             }
         }
     };
+
+    // Pub/sub disconnects are an optimization, not the authorization boundary:
+    // another pod can miss a role-change control message. Re-read the durable role
+    // before every WS write and intersect it with the scopes granted at NIP-42
+    // authentication. A downgrade therefore takes effect even on a stale remote
+    // socket, while a promotion still requires reauthentication.
+    let current_authorization =
+        match crate::api::relay_members::resolve_live_principal_authorization(
+            &state,
+            conn.tenant.community(),
+            &pubkey_bytes,
+            verified_owner.as_ref(),
+        )
+        .await
+        {
+            Ok(authorization) => authorization,
+            Err((status, _)) => {
+                let (metric_reason, message) = if status.is_server_error() {
+                    ("error", "error: internal server error")
+                } else {
+                    (
+                        "authorization_changed",
+                        "restricted: authorization changed; reauthenticate",
+                    )
+                };
+                reject(metric_reason);
+                conn.send(RelayMessage::ok(&event_id_hex, false, message));
+                return;
+            }
+        };
+    scopes.retain(|scope| current_authorization.scopes.contains(scope));
 
     // Must run before both ephemeral and persistent branches. Persistent
     // events get a second check inside ingest_event() (step 3), but

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -517,7 +517,7 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         }
         KIND_NIP29_CREATE_GROUP | KIND_CANVAS => Ok(Scope::ChannelsWrite),
         KIND_NIP29_JOIN_REQUEST | KIND_NIP29_LEAVE_REQUEST | KIND_NIP43_LEAVE_REQUEST => {
-            Ok(Scope::ChannelsRead)
+            Ok(Scope::ChannelsWrite)
         }
         // Huddle lifecycle events + guidelines
         KIND_HUDDLE_STARTED
@@ -3716,6 +3716,22 @@ mod postgres_tests {
         // requires_h_channel_scope — it's handled separately in the pipeline
         // because it needs special "open-only" validation
         assert!(!requires_h_channel_scope(KIND_NIP29_JOIN_REQUEST));
+    }
+
+    #[test]
+    fn membership_mutations_require_channels_write() {
+        let event = make_dummy_event();
+        for kind in [
+            KIND_NIP29_JOIN_REQUEST,
+            KIND_NIP29_LEAVE_REQUEST,
+            KIND_NIP43_LEAVE_REQUEST,
+        ] {
+            assert_eq!(
+                required_scope_for_kind(kind, &event),
+                Ok(Scope::ChannelsWrite),
+                "membership mutation kind {kind} must never accept a read scope"
+            );
+        }
     }
 
     #[test]

--- a/crates/buzz-relay/src/handlers/relay_admin.rs
+++ b/crates/buzz-relay/src/handlers/relay_admin.rs
@@ -319,14 +319,17 @@ async fn execute_relay_admin_command(
             // Default role is "member" when no role tag is present.
             let role = extract_tag_value(event, "role").unwrap_or_else(|| "member".to_string());
 
-            // Owners can add admins or members; admins can only add members.
+            // Owners can add admins, members, or directly provisioned observers;
+            // admins can only add ordinary members.
             if role == "owner" {
                 return Err("invalid role: use kind:9032 to promote to owner".to_string());
             }
-            if role == "admin" && sender_role != "owner" {
-                return Err("actor not authorized: only owner can grant admin role".to_string());
+            if (role == "admin" || role == "observer") && sender_role != "owner" {
+                return Err(
+                    "actor not authorized: only owner can grant admin or observer role".to_string(),
+                );
             }
-            if role != "admin" && role != "member" {
+            if role != "admin" && role != "member" && role != "observer" {
                 return Err(format!("invalid role: {role}"));
             }
 
@@ -350,6 +353,15 @@ async fn execute_relay_admin_command(
             // Only publish NIP-43 announcements when the row was actually inserted —
             // skip on no-op re-adds to avoid spurious kind:8000 events.
             if was_inserted {
+                if role == "observer" {
+                    disconnect_relay_principal(
+                        tenant,
+                        state,
+                        &target_hex,
+                        &event.id.to_hex(),
+                        "restricted: relay role changed; reauthenticate",
+                    )?;
+                }
                 if let Err(e) = publish_nip43_member_added(tenant, state, &target_hex).await {
                     warn!(error = %e, "failed to publish NIP-43 member added event");
                 }
@@ -404,6 +416,14 @@ async fn execute_relay_admin_command(
                 }
             }
 
+            disconnect_relay_principal(
+                tenant,
+                state,
+                &target_hex,
+                &event.id.to_hex(),
+                "restricted: relay membership removed",
+            )?;
+
             info!(
                 sender = %sender_hex,
                 target = %target_hex,
@@ -439,7 +459,7 @@ async fn execute_relay_admin_command(
             if new_role == "owner" {
                 return Err("cannot set role to owner".to_string());
             }
-            if new_role != "admin" && new_role != "member" {
+            if new_role != "admin" && new_role != "member" && new_role != "observer" {
                 return Err(format!("invalid role: {new_role}"));
             }
 
@@ -463,6 +483,18 @@ async fn execute_relay_admin_command(
                 });
             }
 
+            // NIP-42 scopes are cached in the connection context. Force every
+            // role change through a fresh authorization decision so a member
+            // cannot retain write authority after becoming an observer (and an
+            // observer promoted to member does not remain artificially stale).
+            disconnect_relay_principal(
+                tenant,
+                state,
+                &target_hex,
+                &event.id.to_hex(),
+                "restricted: relay role changed; reauthenticate",
+            )?;
+
             info!(
                 sender = %sender_hex,
                 target = %target_hex,
@@ -480,6 +512,19 @@ async fn execute_relay_admin_command(
         }
     }
 
+    Ok(())
+}
+
+fn disconnect_relay_principal(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    pubkey_hex: &str,
+    event_id: &str,
+    reason: &str,
+) -> Result<(), String> {
+    let pubkey = hex::decode(pubkey_hex)
+        .map_err(|e| format!("invalid relay member pubkey during disconnect: {e}"))?;
+    state.disconnect_pubkey_clusterwide(tenant, &pubkey, event_id, reason);
     Ok(())
 }
 
@@ -894,6 +939,199 @@ mod postgres_tests {
         assert_eq!(
             stored_icon(&state, &tenant).await.as_deref(),
             Some("https://example.com/closed.png")
+        );
+    }
+
+    /// Production-seam regression for both observer-specific failure modes:
+    /// an open relay must honor the direct observer row, and changing a live
+    /// member to observer must revoke the socket that cached full scopes.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn open_relay_observer_downgrade_revokes_live_session_and_resolves_read_only() {
+        let host = format!(
+            "observer-open-downgrade-{}.example",
+            uuid::Uuid::new_v4().simple()
+        );
+        let (state, tenant) = workspace_profile_test_state(&host, false).await;
+        let owner = Keys::generate();
+        let target = Keys::generate();
+        for (keys, role) in [(&owner, "owner"), (&target, "member")] {
+            state
+                .db
+                .add_relay_member(tenant.community(), &keys.public_key().to_hex(), role, None)
+                .await
+                .expect("seed relay role");
+        }
+
+        let conn_id = uuid::Uuid::new_v4();
+        let (send_tx, _send_rx) = tokio::sync::mpsc::channel(1);
+        let (ctrl_tx, mut ctrl_rx) = tokio::sync::mpsc::channel(1);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        state.conn_manager.register(
+            conn_id,
+            send_tx,
+            ctrl_tx,
+            None,
+            cancel.clone(),
+            tenant.community(),
+            Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            3,
+        );
+        state
+            .conn_manager
+            .set_authenticated_pubkey(conn_id, target.public_key().to_bytes().to_vec());
+
+        let change = EventBuilder::new(Kind::Custom(RELAY_ADMIN_CHANGE_ROLE as u16), "")
+            .tags([
+                Tag::parse(["p", &target.public_key().to_hex()]).expect("p tag"),
+                Tag::parse(["role", "observer"]).expect("role tag"),
+            ])
+            .sign_with_keys(&owner)
+            .expect("sign role change");
+        handle_relay_admin_event(&tenant, &state, &change)
+            .await
+            .expect("owner changes member to observer");
+
+        assert!(
+            cancel.is_cancelled(),
+            "cached full-scope session is revoked"
+        );
+        let close = ctrl_rx.try_recv().expect("reauthentication reason is sent");
+        assert!(
+            format!("{close:?}").contains("relay role changed; reauthenticate"),
+            "disconnect carries the restrictive role-change reason"
+        );
+
+        let authorization = crate::api::relay_members::resolve_principal_authorization(
+            &state,
+            tenant.community(),
+            &target.public_key().to_bytes(),
+            None,
+            None,
+        )
+        .await
+        .expect("direct observer resolves on an open relay");
+        assert_eq!(authorization.scopes, buzz_auth::Scope::observer_read_only());
+        assert!(authorization.observer);
+
+        let denial = crate::api::relay_members::enforce_relay_membership(
+            &state,
+            tenant.community(),
+            &target.public_key().to_bytes(),
+            None,
+            None,
+        )
+        .await
+        .expect_err("membership-only mutation surfaces reject observer");
+        assert_eq!(denial.0, axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(denial.1 .0["error"], "observer_read_only");
+
+        // Simulate a socket on another pod that missed the Redis disconnect:
+        // it still carries the full scopes granted before the downgrade. The
+        // central EVENT seam must re-read the durable observer row and deny.
+        let stale_event = EventBuilder::new(Kind::TextNote, "must not be stored")
+            .sign_with_keys(&target)
+            .expect("sign stale-session event");
+        let stale_event_id = stale_event.id.to_hex();
+        let (send_tx, mut send_rx) = tokio::sync::mpsc::channel(1);
+        let (ctrl_tx, _ctrl_rx) = tokio::sync::mpsc::channel(1);
+        let stale_conn = Arc::new(crate::connection::ConnectionState {
+            conn_id: uuid::Uuid::new_v4(),
+            tenant: tenant.clone(),
+            remote_addr: "127.0.0.1:1234".parse().expect("socket addr"),
+            auth_state: tokio::sync::RwLock::new(crate::connection::AuthState::Authenticated(
+                buzz_auth::AuthContext {
+                    pubkey: target.public_key(),
+                    scopes: buzz_auth::Scope::all_known(),
+                    channel_ids: None,
+                    auth_method: buzz_auth::AuthMethod::Nip42,
+                    agent_owner_pubkey: None,
+                },
+            )),
+            subscriptions: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            send_tx,
+            ctrl_tx,
+            cancel: tokio_util::sync::CancellationToken::new(),
+            backpressure_count: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            grace_limit: 3,
+        });
+        crate::handlers::event::handle_event(stale_event, stale_conn, Arc::clone(&state)).await;
+        let axum::extract::ws::Message::Text(text) =
+            send_rx.try_recv().expect("stale session denial sent")
+        else {
+            panic!("expected text relay message");
+        };
+        let frame: serde_json::Value = serde_json::from_str(&text).expect("relay frame JSON");
+        assert_eq!(frame[0], "OK");
+        assert_eq!(frame[1], stale_event_id);
+        assert_eq!(frame[2], false);
+        assert_eq!(
+            frame[3],
+            "restricted: insufficient scope (need messages:write)"
+        );
+
+        // The same observer role remains usable through the production WS
+        // COUNT and REQ handlers. This pins both halves of the contract at the
+        // actual transport seams rather than only testing the scope resolver.
+        let (read_tx, mut read_rx) = tokio::sync::mpsc::channel(8);
+        let (read_ctrl_tx, _read_ctrl_rx) = tokio::sync::mpsc::channel(1);
+        let read_conn = Arc::new(crate::connection::ConnectionState {
+            conn_id: uuid::Uuid::new_v4(),
+            tenant: tenant.clone(),
+            remote_addr: "127.0.0.1:1235".parse().expect("socket addr"),
+            auth_state: tokio::sync::RwLock::new(crate::connection::AuthState::Authenticated(
+                buzz_auth::AuthContext {
+                    pubkey: target.public_key(),
+                    scopes: buzz_auth::Scope::observer_read_only(),
+                    channel_ids: None,
+                    auth_method: buzz_auth::AuthMethod::Nip42,
+                    agent_owner_pubkey: None,
+                },
+            )),
+            subscriptions: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            send_tx: read_tx,
+            ctrl_tx: read_ctrl_tx,
+            cancel: tokio_util::sync::CancellationToken::new(),
+            backpressure_count: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            grace_limit: 3,
+        });
+        let read_filter = nostr::Filter::new().kind(Kind::TextNote).limit(1);
+        crate::handlers::count::handle_count(
+            "observer-count".to_string(),
+            vec![read_filter.clone()],
+            Arc::clone(&read_conn),
+            Arc::clone(&state),
+        )
+        .await;
+        let axum::extract::ws::Message::Text(count_text) =
+            read_rx.try_recv().expect("observer COUNT response")
+        else {
+            panic!("expected text COUNT response");
+        };
+        let count_frame: serde_json::Value =
+            serde_json::from_str(&count_text).expect("COUNT frame JSON");
+        assert_eq!(count_frame[0], "COUNT");
+        assert_eq!(count_frame[1], "observer-count");
+
+        crate::handlers::req::handle_req(
+            "observer-req".to_string(),
+            vec![read_filter],
+            vec![None],
+            read_conn,
+            Arc::clone(&state),
+        )
+        .await;
+        let mut saw_eose = false;
+        while let Ok(axum::extract::ws::Message::Text(text)) = read_rx.try_recv() {
+            let frame: serde_json::Value = serde_json::from_str(&text).expect("REQ frame JSON");
+            if frame[0] == "EOSE" && frame[1] == "observer-req" {
+                saw_eose = true;
+            }
+        }
+        assert!(
+            saw_eose,
+            "observer REQ must complete successfully with EOSE"
         );
     }
 }

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -1925,9 +1925,9 @@ async fn emit_db_usage_metrics(
 
     // buzz_community_relay_members{community, role}
     // Zero-fill across all (community, role) pairs; relay_members.role is a
-    // CHECK constraint over {'owner', 'admin', 'member'}.
+    // CHECK constraint over {'owner', 'admin', 'member', 'observer'}.
     {
-        const RELAY_ROLES: &[&str] = &["owner", "admin", "member"];
+        const RELAY_ROLES: &[&str] = &["owner", "admin", "member", "observer"];
         let rows: HashMap<(Uuid, &str), i64> = relay_member_rows
             .into_iter()
             .filter_map(|r| {

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -1173,12 +1173,12 @@ impl AppState {
         }
     }
 
-    /// Enforce a live ban cluster-wide: close this pod's sockets for `pubkey`
-    /// now (fenced to `tenant`'s community) and fan the same disconnect out to
-    /// every other pod over the conn-control Redis channel.
+    /// Enforce a live access revocation cluster-wide: close this pod's sockets
+    /// for `pubkey` now (fenced to `tenant`'s community) and fan the same
+    /// disconnect out to every other pod over the conn-control Redis channel.
     ///
-    /// This is the single entry point for live ban enforcement (decision 4:
-    /// "a ban takes effect immediately, everywhere, including live sessions").
+    /// This is the single entry point for live ban, membership-removal, and
+    /// role-change enforcement.
     /// Callers must not invoke the pod-local `conn_manager.disconnect_pubkey`
     /// directly — doing so closes sockets only on the pod that processed the
     /// ban and silently drops the cluster-wide half. Pairing both halves here
@@ -1186,10 +1186,9 @@ impl AppState {
     ///
     /// Returns the number of sockets closed on *this* pod only — remote pods
     /// close asynchronously and do not report back, so callers must not treat
-    /// the count as cluster-wide truth. The cross-pod publish is fire-and-forget
-    /// (mirrors [`Self::spawn_cache_invalidation`]): the DB ban row is the
-    /// durable backstop, so a dropped publish still refuses the banned member's
-    /// next auth and next write.
+    /// the count as cluster-wide truth. The cross-pod publish is fire-and-forget;
+    /// the EVENT handler revalidates the durable authorization row before every
+    /// WebSocket write, so a dropped publish cannot preserve stale write access.
     pub fn disconnect_pubkey_clusterwide(
         &self,
         tenant: &TenantContext,
@@ -1211,9 +1210,9 @@ impl AppState {
             event_id: event_id.to_string(),
             reason: reason.to_string(),
         };
-        // This pre-existing ban path may remain fire-and-forget because the
-        // durable ban row rejects the member again at auth. Community archival
-        // is different: its API awaits publication and live sockets also have a
+        // This path may remain fire-and-forget because the durable authorization
+        // row is re-evaluated at the central WS write seam. Community archival is
+        // different: its API awaits publication and live sockets also have a
         // periodic durable-state revalidation backstop below.
         tokio::spawn(async move {
             if let Err(e) = pubsub.publish_conn_control(&tenant, &command).await {

--- a/migrations/0045_read_only_observer_role.sql
+++ b/migrations/0045_read_only_observer_role.sql
@@ -1,0 +1,8 @@
+-- Directly provisioned observers are relay members whose transport authority
+-- is restricted by the shared principal resolver to channel-event reads.
+ALTER TABLE relay_members
+    DROP CONSTRAINT relay_members_role_check;
+
+ALTER TABLE relay_members
+    ADD CONSTRAINT relay_members_role_check
+    CHECK (role IN ('owner', 'admin', 'member', 'observer'));

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -576,7 +576,7 @@ CREATE TABLE pubkey_allowlist (
 CREATE TABLE relay_members (
     community_id UUID NOT NULL REFERENCES communities(id),
     pubkey      TEXT NOT NULL,
-    role        TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member')),
+    role        TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member', 'observer')),
     added_by    TEXT,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -1892,4 +1892,3 @@ CREATE INDEX idx_relay_operator_audit_target
 
 INSERT INTO _operator_global_tables (table_name, reason) VALUES
     ('relay_operator_audit', 'deployment-global append-only roster mutation audit trail; no community_id intentionally');
-


### PR DESCRIPTION
## Summary

- add a directly provisioned `observer` relay role with exactly `messages:read`
- retain existing community and private-channel visibility filtering while denying event submission and every membership, media, Git, huddle, GIF, and workflow mutation path
- apply the same role-derived authority to WebSocket and HTTP transports
- re-read durable authorization before every WebSocket EVENT so a missed cross-pod disconnect cannot preserve stale write access after a downgrade
- restrict observer provisioning and role changes to the relay owner, publish observers in the NIP-43 membership snapshot, and expose operator CLI support
- add schema migration 0045, metrics coverage, protocol documentation, and production-seam regressions

## Acceptance coverage

- open relays still honor a direct observer row instead of upgrading it to open-relay authority
- observer WS REQ and COUNT succeed
- observer HTTP query and count succeed
- observer WS and HTTP event submission fail at production authorization seams
- member-to-observer downgrade revokes the local live session and a simulated remote stale session still fails closed
- observer NIP-OA delegation is denied
- observer role round-trips through the NIP-43 snapshot and reconciliation detects drift

## Validation

- `just ci` — passed, including Rust lint/unit suites, desktop and web checks/builds/tests, Flutter analysis, and 2,072 mobile tests
- focused Postgres production-seam tests for WS observer access/downgrade, HTTP read/write behavior, NIP-43 snapshot/reconciliation, and migration manifest — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

A full local `just test` also passed 15 named groups. Its two reported group failures both originate from the same pre-existing canonical-main source-policy test, `observability_source::p0_pool_acquisitions_use_typed_operation_pairs_without_other`, which rejects the unchanged `crates/buzz-db/src/store/event.rs:270`; this branch does not modify that file.

Closes #7462