### PR TITLE
fix(desktop): make starter profiles optional and removable

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       name: "smoke",
       testMatch: [
         "**/smoke.spec.ts",
+        "**/removable-defaults.spec.ts",
         "**/owned-agent-discovery.spec.ts",
         "**/thread-head-stale-edit.spec.ts",
         "**/sidebar-offcanvas-rail.spec.ts",

--- a/desktop/src-tauri/src/commands/teams/mod.rs
+++ b/desktop/src-tauri/src/commands/teams/mod.rs
@@ -512,6 +512,21 @@ pub async fn update_team(input: UpdateTeamRequest, app: AppHandle) -> Result<Tea
     .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
+// Keep the authoritative delete and its publication policy at one testable seam.
+fn delete_team_and_retain(
+    team: &TeamRecord,
+    delete: impl FnOnce() -> Result<Vec<String>, String>,
+    retain: impl FnOnce(&str),
+) -> Result<Vec<String>, String> {
+    let cascaded = delete()?;
+    // Built-in teams are device-local templates, not owner-published records.
+    // Removing one must not delete another device's customized copy.
+    if !team.is_builtin {
+        retain(&team.id);
+    }
+    Ok(cascaded)
+}
+
 #[tauri::command]
 pub async fn delete_team(id: String, app: AppHandle) -> Result<(), String> {
     use tauri::Manager;
@@ -521,16 +536,18 @@ pub async fn delete_team(id: String, app: AppHandle) -> Result<(), String> {
             .managed_agents_store_lock
             .lock()
             .map_err(|error| error.to_string())?;
-        let cascaded_persona_d_tags = delete_team_with_cascade(&app, &id)?;
-        // delete_team_with_cascade rejects built-in teams via validate_team_deletion,
-        // so reaching here means this team was owner-published — tombstone it. The
-        // d_tag is the team id, captured before the record left the store.
-        tombstone_team_pending(&app, &state, &id);
-        // The catalog projection is a separate coordinate with its own
-        // retained head, so the 30176 tombstone above does not retract it.
-        // Without this, deleting a shared team would leave a live catalog
-        // entry the owner can no longer see or unshare.
-        pending::tombstone_team_catalog_pending(&app, &state, &id);
+        let team = load_teams(&app)?
+            .into_iter()
+            .find(|team| team.id == id)
+            .ok_or_else(|| format!("team {id} not found"))?;
+        let cascaded_persona_d_tags = delete_team_and_retain(
+            &team,
+            || delete_team_with_cascade(&app, &id),
+            |id| {
+                tombstone_team_pending(&app, &state, id);
+                pending::tombstone_team_catalog_pending(&app, &state, id);
+            },
+        )?;
         // Tombstone the cascaded personas too, so their orphaned kind:30175 heads
         // don't linger on the relay (F4). Each d-tag was captured pre-removal.
         for persona_d_tag in &cascaded_persona_d_tags {

--- a/desktop/src-tauri/src/commands/teams/tests.rs
+++ b/desktop/src-tauri/src/commands/teams/tests.rs
@@ -9,6 +9,53 @@ use buzz_core_pkg::kind::KIND_TEAM;
 use nostr::JsonUtil;
 use std::path::{Path, PathBuf};
 
+#[test]
+fn builtin_delete_is_local_only_and_durable_while_custom_delete_retains_tombstone() {
+    use tauri::Manager;
+    let dir = tempfile::tempdir().unwrap();
+    let mut context = tauri::test::mock_context(tauri::test::noop_assets());
+    context.config_mut().identifier = dir.path().join("app").to_string_lossy().into_owned();
+    let app = tauri::test::mock_builder().build(context).unwrap();
+    assert_eq!(app.path().app_data_dir().unwrap(), dir.path().join("app"));
+    let keys = nostr::Keys::generate();
+    let db = dir.path().join("retention.db");
+    let conn = open_retention_db(&db).unwrap();
+    let mut welcome = team();
+    welcome.id = "builtin-team:welcome".into();
+    welcome.name = "Welcome Team".into();
+    welcome.source_dir = None;
+    welcome.is_builtin = true;
+    let mut custom = welcome.clone();
+    custom.id = "custom:lookalike".into();
+    custom.is_builtin = false;
+    save_teams(app.handle(), &[welcome.clone(), custom.clone()]).unwrap();
+    delete_team_and_retain(
+        &welcome,
+        || delete_team_with_cascade(app.handle(), &welcome.id),
+        |id| tombstone_team_at(&db, &keys, id).unwrap(),
+    )
+    .unwrap();
+    let reloaded = load_teams(app.handle()).unwrap();
+    assert_eq!(reloaded.len(), 1);
+    assert_eq!(reloaded[0].id, custom.id);
+    assert!(
+        get_pending_sync(&conn).unwrap().is_empty(),
+        "local built-in opt-out must never publish an owner deletion"
+    );
+    delete_team_and_retain(
+        &custom,
+        || delete_team_with_cascade(app.handle(), &custom.id),
+        |id| tombstone_team_at(&db, &keys, id).unwrap(),
+    )
+    .unwrap();
+    assert!(load_teams(app.handle()).unwrap().is_empty());
+    assert_eq!(
+        get_pending_sync(&conn).unwrap().len(),
+        1,
+        "custom owner deletion still syncs"
+    );
+}
+
 fn team() -> TeamRecord {
     TeamRecord {
         id: "team-abc".to_string(),

--- a/desktop/src-tauri/src/managed_agents/personas.rs
+++ b/desktop/src-tauri/src/managed_agents/personas.rs
@@ -47,7 +47,7 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
         ],
         model: None,
         runtime: None,
-        default_active: true,
+        default_active: false,
     },
     BuiltInPersona {
         id: "builtin:honey",
@@ -57,7 +57,7 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
         name_pool: &["Honey"],
         model: None,
         runtime: None,
-        default_active: true,
+        default_active: false,
     },
     BuiltInPersona {
         id: POLLEN_PERSONA_ID,
@@ -67,7 +67,7 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
         name_pool: &[POLLEN_DISPLAY_NAME],
         model: None,
         runtime: None,
-        default_active: true,
+        default_active: false,
     },
 ];
 

--- a/desktop/src-tauri/src/managed_agents/personas/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/personas/tests.rs
@@ -34,7 +34,7 @@ fn custom_persona(id: &str, display_name: &str) -> AgentDefinition {
 }
 
 #[test]
-fn merge_personas_adds_missing_built_ins() {
+fn merge_personas_adds_missing_built_ins_as_optional_templates() {
     let (records, changed) = merge_personas(Vec::new(), "2026-03-19T00:00:00Z");
 
     assert!(changed);
@@ -53,9 +53,9 @@ fn merge_personas_adds_missing_built_ins() {
         .filter(|record| record.is_active)
         .map(|record| record.id.as_str())
         .collect();
-    assert_eq!(
-        active_ids,
-        vec!["builtin:fizz", "builtin:honey", "builtin:bumble"]
+    assert!(
+        active_ids.is_empty(),
+        "starter templates must be explicitly added"
     );
 }
 
@@ -124,7 +124,10 @@ fn merge_personas_adds_fizz_and_retires_old_builtins_for_existing_store() {
         .find(|record| record.id == "builtin:fizz")
         .expect("fizz built-in should exist");
     assert!(fizz.is_builtin);
-    assert!(fizz.is_active);
+    assert!(
+        !fizz.is_active,
+        "upgrades must not activate new starter templates"
+    );
 
     let solo = records
         .iter()
@@ -411,4 +414,50 @@ fn fizz_builtin_resolves_to_buzz_agent() {
         "buzz-agent",
         "Fizz must resolve to buzz-agent specifically"
     );
+}
+
+#[test]
+fn optional_templates_survive_real_store_reload_and_keep_custom_profiles() {
+    use tauri::Manager;
+    let dir = tempfile::tempdir().unwrap();
+    let mut context = tauri::test::mock_context(tauri::test::noop_assets());
+    // Absolute identifier confines Tauri's joined app_data_dir to this tempdir
+    // without mutating process environment or reaching the user's installation.
+    context.config_mut().identifier = dir
+        .path()
+        .join("isolated-app")
+        .to_string_lossy()
+        .into_owned();
+    let app = tauri::test::mock_builder().build(context).unwrap();
+    assert_eq!(
+        app.path().app_data_dir().unwrap(),
+        dir.path().join("isolated-app")
+    );
+    let mut personas = super::load_personas(app.handle()).unwrap();
+    assert!(personas.iter().all(|p| !p.is_active));
+    let fizz = personas
+        .iter_mut()
+        .find(|p| p.id == "builtin:fizz")
+        .unwrap();
+    fizz.is_active = true;
+    fizz.display_name = "My customized starter".into();
+    personas.push(custom_persona("custom:lookalike", "Fizz"));
+    super::save_personas(app.handle(), &personas).unwrap();
+    let mut personas = super::load_personas(app.handle()).unwrap();
+    let fizz = personas
+        .iter_mut()
+        .find(|p| p.id == "builtin:fizz")
+        .unwrap();
+    validate_persona_activation_change(fizz, false, false, false).unwrap();
+    fizz.is_active = false;
+    super::save_personas(app.handle(), &personas).unwrap();
+    for _ in 0..2 {
+        let reloaded = super::load_personas(app.handle()).unwrap();
+        let fizz = reloaded.iter().find(|p| p.id == "builtin:fizz").unwrap();
+        assert!(!fizz.is_active);
+        assert_eq!(fizz.display_name, "My customized starter");
+        assert!(reloaded
+            .iter()
+            .any(|p| p.id == "custom:lookalike" && p.is_active));
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/teams.rs
+++ b/desktop/src-tauri/src/managed_agents/teams.rs
@@ -76,7 +76,7 @@ fn built_in_team_order(built_ins: &[BuiltInTeam], id: &str) -> Option<usize> {
     built_ins.iter().position(|team| team.id == id)
 }
 
-/// Add missing built-in teams, purge pristine retired teams, demote stale
+/// Purge pristine retired teams, demote stale
 /// built-ins, and preserve any user customizations to existing built-in teams
 /// (name, description, persona membership). Returns the merged list and whether
 /// the store changed.
@@ -92,7 +92,7 @@ fn merge_teams_impl(
 ) -> (Vec<TeamRecord>, bool) {
     let mut changed = false;
 
-    // Seed missing built-ins / re-promote existing ones that were downgraded.
+    // Preserve existing built-ins, but never recreate a deleted or unselected team.
     for built_in in built_in_team_records(built_ins, now) {
         if let Some(existing) = stored.iter_mut().find(|record| record.id == built_in.id) {
             if !existing.is_builtin {
@@ -100,9 +100,6 @@ fn merge_teams_impl(
                 existing.updated_at = now.to_string();
                 changed = true;
             }
-        } else {
-            stored.push(built_in);
-            changed = true;
         }
     }
 
@@ -143,13 +140,20 @@ fn merge_teams_impl(
     (stored, changed)
 }
 
-/// Reject deletion of built-in teams. Mirrors `validate_persona_deletion`
-/// for personas — built-ins always come back via `merge_teams` on the
-/// next load, so blocking the delete avoids a confusing "keeps coming
-/// back" UX.
-pub fn validate_team_deletion(team: &TeamRecord) -> Result<(), String> {
-    if team.is_builtin {
-        return Err("Built-in teams cannot be deleted.".to_string());
+/// Reject deletion while managed instances still depend on the team.
+/// Built-in status is provenance, not a deletion restriction.
+pub fn validate_team_deletion(
+    team: &TeamRecord,
+    agents: &[ManagedAgentRecord],
+) -> Result<(), String> {
+    let referencing = agents_referencing_team(agents, team);
+    if !referencing.is_empty() {
+        return Err(format!(
+            "Cannot delete team \"{}\": {} agent(s) still reference it ({}). Delete or reconfigure them first.",
+            team.name,
+            referencing.len(),
+            referencing.join(", ")
+        ));
     }
     Ok(())
 }
@@ -244,25 +248,18 @@ fn agents_referencing_team<'a>(
 /// vec is empty. For catalog-adopted teams (`catalog_source` present), member
 /// copies matching this publication's provenance are deactivated (re-activatable
 /// on re-add), not deleted.
-pub fn delete_team_with_cascade(app: &AppHandle, team_id: &str) -> Result<Vec<String>, String> {
+pub fn delete_team_with_cascade<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    team_id: &str,
+) -> Result<Vec<String>, String> {
     let mut teams = load_teams(app)?;
     let team = teams
         .iter()
         .find(|record| record.id == team_id)
         .ok_or_else(|| format!("team {team_id} not found"))?;
 
-    validate_team_deletion(team)?;
-
     let agents = crate::managed_agents::load_managed_agents(app)?;
-    let referencing = agents_referencing_team(&agents, team);
-    if !referencing.is_empty() {
-        return Err(format!(
-            "Cannot delete team \"{team_id}\": {} agent(s) still reference it ({}). \
-             Delete or reconfigure them first.",
-            referencing.len(),
-            referencing.join(", ")
-        ));
-    }
+    validate_team_deletion(team, &agents)?;
 
     let mut cascaded_persona_d_tags = Vec::new();
 

--- a/desktop/src-tauri/src/managed_agents/teams_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/teams_tests.rs
@@ -56,7 +56,7 @@ fn sort_teams_empty_is_noop() {
 }
 
 #[test]
-fn merge_teams_adds_missing_built_ins() {
+fn merge_teams_does_not_add_missing_built_ins() {
     let synthetic = BuiltInTeam {
         id: "builtin-team:test",
         name: "Test Team",
@@ -67,10 +67,8 @@ fn merge_teams_adds_missing_built_ins() {
     let (records, changed) =
         merge_teams_impl(&[synthetic], &[], Vec::new(), "2026-05-07T00:00:00Z");
 
-    assert!(changed);
-    assert_eq!(records.len(), 1);
-    assert!(records.iter().all(|r| r.is_builtin));
-    assert_eq!(records[0].id, "builtin-team:test");
+    assert!(!changed);
+    assert!(records.is_empty());
 }
 
 #[test]
@@ -111,7 +109,7 @@ fn merge_teams_preserves_unrelated_user_teams() {
         merge_teams_impl(&[synthetic], &[], vec![user_team], "2026-05-07T00:00:00Z");
 
     assert!(records.iter().any(|t| t.id == "user-uuid"));
-    assert!(records.iter().any(|t| t.id == "builtin-team:test"));
+    assert!(!records.iter().any(|t| t.id == "builtin-team:test"));
 }
 
 #[test]
@@ -155,12 +153,11 @@ fn merge_teams_repromotes_existing_builtin_marked_as_custom() {
 }
 
 #[test]
-fn validate_team_deletion_rejects_built_ins() {
+fn validate_team_deletion_allows_built_ins() {
     let mut built_in = team("builtin-team:fizz", "Fizz");
     built_in.is_builtin = true;
 
-    let err = validate_team_deletion(&built_in).unwrap_err();
-    assert_eq!(err, "Built-in teams cannot be deleted.");
+    assert!(validate_team_deletion(&built_in, &[]).is_ok());
 }
 
 // ── agents_referencing_team ─────────────────────────────────────────────
@@ -331,10 +328,17 @@ fn migration_customized_fizz_is_demoted_to_user_team() {
 }
 
 #[test]
-fn welcome_team_is_seeded_and_idempotent() {
-    let (records, changed) = merge_teams(Vec::new(), "2026-07-01T00:00:00Z");
+fn welcome_team_is_optional_and_empty_store_stays_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("teams.json");
+    assert!(load_teams_readonly(&path).unwrap().is_empty());
+    std::fs::write(&path, b"[]").unwrap();
+    assert!(load_teams_readonly(&path).unwrap().is_empty());
+}
 
-    assert!(changed);
+#[test]
+fn welcome_team_template_is_preserved_and_idempotent() {
+    let records = super::built_in_team_records(super::BUILT_IN_TEAMS, "2026-07-01T00:00:00Z");
     assert_eq!(records.len(), 1);
     let welcome = &records[0];
     assert_eq!(welcome.id, "builtin-team:welcome");
@@ -364,7 +368,7 @@ fn welcome_team_is_seeded_and_idempotent() {
 
 #[test]
 fn welcome_team_seed_does_not_overwrite_customization() {
-    let (mut records, _) = merge_teams(Vec::new(), "2026-07-01T00:00:00Z");
+    let mut records = super::built_in_team_records(super::BUILT_IN_TEAMS, "2026-07-01T00:00:00Z");
     let welcome = records
         .iter_mut()
         .find(|team| team.id == "builtin-team:welcome")
@@ -401,9 +405,8 @@ fn load_teams_readonly_absent_file_performs_no_write() {
 
     let records = load_teams_readonly(&path).unwrap();
 
-    // Returns the merged built-in list without persisting it.
-    assert_eq!(records.len(), 1);
-    assert_eq!(records[0].id, "builtin-team:welcome");
+    // A fresh store has no selected teams, and reads do not opt in.
+    assert!(records.is_empty());
 
     // The file must still NOT exist — no write-on-load side effect.
     assert!(

--- a/desktop/src-tauri/src/migration/fold.rs
+++ b/desktop/src-tauri/src/migration/fold.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 /// ([`AgentDefinition::into_agent_record`]) appended to `managed-agents.json`
 /// via the definition-preserving save; the old file is renamed to
 /// `personas.json.bak` so a second boot is a no-op and the data survives for
-/// manual recovery. Built-ins are skipped — `merge_personas` regenerates them
-/// from code on every load, exactly as before.
+/// manual recovery. Built-ins are folded too: their local activation choices
+/// and authored configuration must survive the store transition.
 ///
 /// Ordering (see `run_boot_migrations`): runs after the JSON-level
 /// `personas.json` migrations (which must see the legacy file) and BEFORE
@@ -63,9 +63,9 @@ fn fold_personas_in_dir(base_dir: &Path) -> Result<Option<usize>, String> {
 
     let mut folded = 0usize;
     for persona in personas {
-        // Built-ins regenerate from code; a slug already in the store means
-        // a previous partial fold got that far — never duplicate.
-        if persona.is_builtin || existing.contains(&persona.id) {
+        // A slug already in the store means a previous partial fold got
+        // that far — never duplicate or overwrite its newer local state.
+        if existing.contains(&persona.id) {
             continue;
         }
         all.push(persona.into_agent_record());
@@ -202,10 +202,10 @@ mod tests {
 
         let base = dir.path().join("agents");
         let folded = fold_personas_in_dir(&base).unwrap();
-        assert_eq!(folded, Some(1), "custom folds, builtin skipped");
+        assert_eq!(folded, Some(2), "custom and built-in choices both fold");
 
         let records = read_agents_json(dir.path());
-        assert_eq!(records.len(), 2, "definition + preserved instance");
+        assert_eq!(records.len(), 3, "definitions + preserved instance");
         let def = records
             .iter()
             .find(|r| r.get("slug").is_some())
@@ -219,6 +219,26 @@ mod tests {
 
         assert!(!base.join("personas.json").exists(), "source retired");
         assert!(base.join("personas.json.bak").exists(), ".bak left behind");
+    }
+
+    #[test]
+    fn fold_preserves_builtin_opt_out_and_customization() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut persona = custom_persona_json("builtin:fizz", "goose");
+        persona["is_builtin"] = serde_json::json!(true);
+        persona["is_active"] = serde_json::json!(false);
+        persona["display_name"] = serde_json::json!("My Fizz");
+        write_personas_json(dir.path(), &serde_json::json!([persona]));
+        let base = dir.path().join("agents");
+        assert_eq!(fold_personas_in_dir(&base).unwrap(), Some(1));
+        let records = read_agents_json(dir.path());
+        let definition: crate::managed_agents::ManagedAgentRecord =
+            serde_json::from_value(records[0].clone()).unwrap();
+        let view = definition.to_definition_view().unwrap();
+        assert!(!view.is_active);
+        assert_eq!(view.display_name, "My Fizz");
+        assert_eq!(view.runtime.as_deref(), Some("goose"));
+        assert_eq!(fold_personas_in_dir(&base).unwrap(), None);
     }
 
     #[test]

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -146,6 +146,37 @@ export function AgentsView() {
           <PageHeader
             action={
               <>
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={isActionPending}
+                    >
+                      Starter templates
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {(personas.personasQuery.data ?? [])
+                      .filter((persona) => persona.isBuiltIn)
+                      .map((persona) => (
+                        <DropdownMenuItem
+                          key={persona.id}
+                          disabled={persona.isActive || isActionPending}
+                          onClick={() => {
+                            void personas.handleSetActive(
+                              persona,
+                              true,
+                              "library",
+                            );
+                          }}
+                        >
+                          {persona.isActive ? "Added" : "Add"}{" "}
+                          {persona.displayName}
+                        </DropdownMenuItem>
+                      ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
                 <div className="flex flex-wrap justify-end gap-2 [@container(max-width:40rem)]:hidden">
                   <Button
                     data-testid="agent-defaults-button"

--- a/desktop/src/features/onboarding/welcomeGuide.ts
+++ b/desktop/src/features/onboarding/welcomeGuide.ts
@@ -12,7 +12,8 @@ import {
 import { discoverAcpRuntimes } from "@/shared/api/tauriAcpDiscovery";
 import { getAgentAccessOwnerOnly } from "@/shared/api/tauriAgentAccess";
 import { getGlobalAgentConfig } from "@/shared/api/tauriGlobalAgentConfig";
-import { listPersonas, setPersonaActive } from "@/shared/api/tauriPersonas";
+import { listPersonas } from "@/shared/api/tauriPersonas";
+import { listTeams } from "@/shared/api/tauriTeams";
 import type {
   AcpRuntime,
   AgentPersona,
@@ -49,7 +50,10 @@ export const WELCOME_TEAM_STARTERS = [
 
 export type WelcomeTeamAgents = [ManagedAgent, ManagedAgent, ManagedAgent];
 
-const welcomeTeamPromises = new Map<string, Promise<WelcomeTeamAgents>>();
+const welcomeTeamPromises = new Map<
+  string,
+  Promise<WelcomeTeamAgents | null>
+>();
 
 function normalizeRelayUrl(relayUrl: string | null | undefined) {
   return relayUrl?.trim().replace(/\/+$/, "") ?? null;
@@ -155,29 +159,6 @@ export async function activateWelcomeTeamPersonasSequentially(
   for (const personaId of inactivePersonaIds) {
     await activate(personaId);
   }
-}
-
-async function ensureWelcomeTeamPersonasActive() {
-  const personas = await listPersonas();
-  const personasById = new Map(
-    personas.map((persona) => [persona.id, persona]),
-  );
-
-  for (const starter of WELCOME_TEAM_STARTERS) {
-    if (!personasById.has(starter.personaId)) {
-      throw new Error(`${starter.name} agent not found.`);
-    }
-  }
-
-  // Persona activation is a read-modify-write operation over one shared file.
-  // Run these sequentially so concurrent writes cannot lose a teammate's
-  // activation and leave Welcome provisioning permanently partial.
-  await activateWelcomeTeamPersonasSequentially(
-    WELCOME_TEAM_STARTERS.filter(
-      ({ personaId }) => !personasById.get(personaId)?.isActive,
-    ).map(({ personaId }) => personaId),
-    (personaId) => setPersonaActive(personaId, true),
-  );
 }
 
 async function ensureWelcomeTeamMembership(
@@ -322,12 +303,20 @@ export function welcomeTeammateAccessUpdate(
 async function provisionWelcomeTeam(
   channelId: string,
   relayUrl?: string | null,
-): Promise<WelcomeTeamAgents> {
+): Promise<WelcomeTeamAgents | null> {
+  // Absence is an intentional opt-out, not missing bootstrap data.
+  const teams = await listTeams();
+  if (!teams.some((team) => team.id === WELCOME_TEAM_ID)) return null;
+  const personas = await listPersonas();
+  if (
+    !WELCOME_TEAM_STARTERS.every(({ personaId }) =>
+      personas.some((persona) => persona.id === personaId && persona.isActive),
+    )
+  )
+    return null;
   const existingAgents = await listManagedAgents();
-  await ensureWelcomeTeamPersonasActive();
-  const [personas, runtimeCatalog, globalConfig, agentAccessOwnerOnly] =
+  const [runtimeCatalog, globalConfig, agentAccessOwnerOnly] =
     await Promise.all([
-      listPersonas(),
       discoverAcpRuntimes(),
       getGlobalAgentConfig(),
       getAgentAccessOwnerOnly(),
@@ -395,7 +384,7 @@ async function provisionWelcomeTeam(
 export function ensureWelcomeTeam(
   channelId: string,
   relayUrl?: string | null,
-): Promise<WelcomeTeamAgents> {
+): Promise<WelcomeTeamAgents | null> {
   const key = `${normalizeRelayUrl(relayUrl) ?? ""}:${channelId}`;
   const current = welcomeTeamPromises.get(key);
   if (current) return current;

--- a/desktop/src/features/onboarding/welcomeKickoff.ts
+++ b/desktop/src/features/onboarding/welcomeKickoff.ts
@@ -579,6 +579,7 @@ export function useWelcomeKickoff(
           channelId,
           activeCommunity?.relayUrl,
         );
+        if (!welcomeTeam) return;
         await queryClient.invalidateQueries({
           queryKey: managedAgentsQueryKey,
         });

--- a/desktop/src/features/onboarding/welcomeTeamOptOut.test.mjs
+++ b/desktop/src/features/onboarding/welcomeTeamOptOut.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
+import { ensureWelcomeTeam } from "./welcomeGuide.ts";
+
+globalThis.window = {};
+const starterIds = ["builtin:fizz", "builtin:honey", "builtin:bumble"];
+const welcomeTeam = {
+  id: "builtin-team:welcome",
+  name: "Welcome Team",
+  persona_ids: starterIds,
+};
+
+afterEach(() => {
+  clearMocks();
+});
+
+test("Welcome bootstrap respects a removed starter instead of reactivating it", async () => {
+  const calls = [];
+  mockIPC((command) => {
+    calls.push(command);
+    if (command === "list_teams") return [welcomeTeam];
+    if (command === "list_managed_agents") return [];
+    if (command === "list_personas")
+      return starterIds.map((id) => ({
+        id,
+        display_name: id,
+        is_builtin: true,
+        is_active: id !== "builtin:fizz",
+      }));
+    throw new Error(`Unexpected mutation or discovery: ${command}`);
+  });
+  assert.equal(
+    await ensureWelcomeTeam("welcome", "ws://isolated.invalid"),
+    null,
+  );
+  assert.deepEqual(calls, ["list_teams", "list_personas"]);
+});
+
+test("Welcome bootstrap does not provision a removed or unselected team", async () => {
+  const calls = [];
+  mockIPC((command) => {
+    calls.push(command);
+    if (command === "list_teams" || command === "list_managed_agents")
+      return [];
+    if (command === "list_personas") return [];
+    throw new Error(`Unexpected mutation or discovery: ${command}`);
+  });
+  assert.equal(
+    await ensureWelcomeTeam("welcome", "ws://isolated.invalid"),
+    null,
+  );
+  assert.deepEqual(calls, ["list_teams"]);
+});

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -168,6 +168,7 @@ type MockPersonaSeed = {
 
 type MockTeamSeed = {
   id?: string;
+  isBuiltin?: boolean;
   name: string;
   description?: string | null;
   personaIds: string[];
@@ -2738,7 +2739,7 @@ function resetMockTeams(config?: E2eConfig) {
       name: team.name,
       description: team.description ?? null,
       persona_ids: [...team.personaIds],
-      is_builtin: false,
+      is_builtin: team.isBuiltin ?? false,
       source_dir: null,
       is_symlink: false,
       symlink_target: null,
@@ -2747,6 +2748,10 @@ function resetMockTeams(config?: E2eConfig) {
       updated_at: now,
     });
   }
+  const deleted: string[] = JSON.parse(
+    localStorage.getItem("buzz-e2e-deleted-teams") ?? "[]",
+  );
+  mockTeams = mockTeams.filter((team) => !deleted.includes(team.id));
 }
 
 function seedMockSearchProfiles(config?: E2eConfig) {
@@ -9216,11 +9221,14 @@ async function handleUpdateTeam(args: {
 }
 
 async function handleDeleteTeam(args: { id: string }): Promise<void> {
-  const team = mockTeams.find((candidate) => candidate.id === args.id);
-  if (team?.is_builtin) {
-    throw new Error("Built-in teams cannot be deleted.");
-  }
   mockTeams = mockTeams.filter((candidate) => candidate.id !== args.id);
+  const deleted: string[] = JSON.parse(
+    localStorage.getItem("buzz-e2e-deleted-teams") ?? "[]",
+  );
+  localStorage.setItem(
+    "buzz-e2e-deleted-teams",
+    JSON.stringify([...deleted, args.id]),
+  );
 }
 
 // ── Team catalog (kind:30178) ───────────────────────────────────────────────

--- a/desktop/tests/e2e/removable-defaults.spec.ts
+++ b/desktop/tests/e2e/removable-defaults.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+import { installMockBridge } from "../helpers/bridge";
+import { invokeMockCommand } from "../helpers/welcomeTeam";
+
+test("starter templates are an explicit choice and can be removed again", async ({
+  page,
+}, testInfo) => {
+  await installMockBridge(page, { activePersonaIds: [] });
+  await page.goto("/");
+  await page.getByTestId("open-agents-view").click();
+  await expect(
+    page.getByRole("button", { name: "Starter templates" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("persona-agent-row-builtin:fizz")).toHaveCount(
+    0,
+  );
+  await page.screenshot({
+    animations: "disabled",
+    path: testInfo.outputPath("01-empty.png"),
+  });
+  await page.getByRole("button", { name: "Starter templates" }).click();
+  await page.getByRole("menuitem", { name: "Add Fizz", exact: true }).click();
+  await expect(
+    page.getByTestId("persona-agent-row-builtin:fizz"),
+  ).toBeVisible();
+  await page.getByLabel("Open actions for Fizz").click();
+  await page.screenshot({
+    animations: "disabled",
+    path: testInfo.outputPath("02-delete-menu.png"),
+  });
+  await page.getByRole("menuitem", { name: "Delete", exact: true }).click();
+  await expect(page.getByTestId("persona-agent-row-builtin:fizz")).toHaveCount(
+    0,
+  );
+  const saved = await invokeMockCommand<
+    Array<{ id: string; is_active: boolean }>
+  >(page, "list_personas");
+  expect(
+    saved.find((persona) => persona.id === "builtin:fizz")?.is_active,
+  ).toBe(false);
+  await page.reload();
+  await page.getByTestId("open-agents-view").click();
+  await expect(
+    page.getByRole("button", { name: "Starter templates" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("persona-agent-row-builtin:fizz")).toHaveCount(
+    0,
+  );
+  await expect(
+    page.getByRole("button", { name: "Starter templates" }),
+  ).toBeVisible();
+  await page.screenshot({
+    animations: "disabled",
+    path: testInfo.outputPath("03-reload-empty.png"),
+  });
+});
+
+test("Welcome Team can be deleted without deleting a custom lookalike", async ({
+  page,
+}, testInfo) => {
+  await installMockBridge(page, {
+    teams: [
+      {
+        id: "builtin-team:welcome",
+        isBuiltin: true,
+        name: "Welcome Team",
+        personaIds: ["builtin:fizz"],
+      },
+      { id: "custom:welcome", name: "Welcome Team", personaIds: [] },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("open-agents-view").click();
+  await expect(
+    page.getByRole("button", { name: "Starter templates" }),
+  ).toBeVisible();
+  const welcome = page.getByTestId("team-card-builtin-team:welcome");
+  await welcome
+    .getByRole("button", { name: "Welcome Team team actions" })
+    .click();
+  await page.getByRole("menuitem", { name: "Delete", exact: true }).click();
+  await page.screenshot({
+    animations: "disabled",
+    path: testInfo.outputPath("04-team-delete.png"),
+  });
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Delete", exact: true })
+    .click();
+  await expect(welcome).toHaveCount(0);
+  await expect(page.getByTestId("team-card-custom:welcome")).toBeVisible();
+  await page.reload();
+  await page.getByTestId("open-agents-view").click();
+  await expect(
+    page.getByRole("button", { name: "Starter templates" }),
+  ).toBeVisible();
+  await expect(welcome).toHaveCount(0);
+  await expect(page.getByTestId("team-card-custom:welcome")).toBeVisible();
+  await page.screenshot({
+    animations: "disabled",
+    path: testInfo.outputPath("05-team-reload.png"),
+  });
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -109,6 +109,7 @@ type MockPersonaSeed = {
 
 type MockTeamSeed = {
   id?: string;
+  isBuiltin?: boolean;
   name: string;
   description?: string | null;
   personaIds: string[];


### PR DESCRIPTION
## Summary

Starter personas and the built-in Welcome Team are currently forced into every user's inventory and re-created after removal. This PR keeps the templates available by explicit choice instead.

- New built-in personas start inactive; existing activation choices and customizations are preserved.
- The startup fold preserves inactive/customized built-ins instead of discarding their opt-out state.
- Missing Welcome Teams are not automatically recreated, and onboarding respects absent teams or inactive starters instead of activating and launching them again.
- The Agents screen gets an explicit **Starter templates** menu. Stock profiles and the Welcome Team can be removed through the ordinary delete controls and stay removed across reload.
- Removing a local built-in team does not queue kind:30176 or catalog deletion events (built-in templates are never owner-published, so a synchronized tombstone could delete another device's customized copy). Owner-authored custom teams keep normal synchronized deletion. Existing dependency/reference guards and same-named custom teams are preserved.

Independent of #7419. Based on `3c7f288c60d67df78577b237e27c3dfc8831aaa1`. No change to agent runtime/harness configuration, no second profile store, and the stock template definitions themselves are not removed.

### Related issue

Fixes #5553 (allow hiding or disabling built-in personas and the Welcome Team). Adjacent, not duplicates: #5979 (channel-membership repair after a completed kickoff; this PR touches `welcomeKickoff.ts` on one line and should compose with it), #5319 / #6211 (per-device duplicate agents).

### Testing

- Native desktop library: **3,013 passed, 0 failed, 15 ignored** (`cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib --locked`). Native regressions cover local-only built-in deletion, custom-team tombstone retention through the same production seam, opt-out survival through the real startup migration/fold, and no automatic Welcome Team re-creation.
- Desktop JS: **6,452 passed, 0 failed** (`pnpm test`, both globs).
- `pnpm build:e2e` (TypeScript check + mock-bridge build) passed.
- Browser (Playwright smoke, `tests/e2e/removable-defaults.spec.ts`): **2 passed**: starter templates are opt-in and can be removed again; deleting the built-in Welcome Team leaves a custom look-alike team intact.
- Rust fmt, Biome on touched frontend files, `git diff --check`, and `just file-size-check` pass.

Verified on Windows (x86_64-pc-windows-msvc). The full `just ci` on this host surfaced a set of pre-existing Windows-only Clippy/test-fixture issues on `main` that are unrelated to this change; I have those fixed locally and will open them as a separate PR so this one stays scoped.

Screenshots (mock bridge):

| Starter templates control, no forced profiles | Delete on a starter profile |
|---|---|
| ![starter templates opt-in](https://raw.githubusercontent.com/JackHunzicker/buzz/809f89b543dc696a453cb69963f999123c3127b8/defaults/01-starter-templates-opt-in.png) | ![delete menu](https://raw.githubusercontent.com/JackHunzicker/buzz/809f89b543dc696a453cb69963f999123c3127b8/defaults/02-delete-menu.png) |

| Stays removed after reload | Custom look-alike team survives built-in team deletion |
|---|---|
| ![reload stays removed](https://raw.githubusercontent.com/JackHunzicker/buzz/809f89b543dc696a453cb69963f999123c3127b8/defaults/03-reload-stays-removed.png) | ![custom lookalike survives](https://raw.githubusercontent.com/JackHunzicker/buzz/809f89b543dc696a453cb69963f999123c3127b8/defaults/04-custom-lookalike-team-survives.png) |
