### PR TITLE
feat(desktop): name the last replier and preview the reply on thread summaries

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
         "**/thread-reply-anchor-roleplay.spec.ts",
         "**/threadpane-ultrawide.spec.ts",
         "**/thread-focus-mode.spec.ts",
+        "**/thread-summary-last-reply-screenshots.spec.ts",
         "**/animated-avatar.spec.ts",
         "**/reminders.spec.ts",
         "**/reminder-click-repro.spec.ts",

--- a/desktop/src/features/messages/lib/threadPanel.test.mjs
+++ b/desktop/src/features/messages/lib/threadPanel.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildDescendantStatsByMessageId,
   buildMainTimelineEntries,
+  buildReplyPreview,
   buildThreadPanelData,
   buildThreadPanelDataFromIndex,
   buildThreadPanelIndex,
@@ -631,6 +632,9 @@ test("buildMainTimelineEntries renders a relay-only thread summary", () => {
     threadHeadId: "root",
     replyCount: 4,
     lastReplyAt: 9,
+    // The relay summary carries no reply text, so the last replier is named
+    // from the most-recent participant and the preview stays null.
+    lastReply: { author: "Alice", createdAt: 9, preview: null },
     // Relay returns participants most-recent-first (["alice", "bob"]); the
     // facepile renders them oldest-first so the last replier lands rightmost.
     participants: [
@@ -700,4 +704,166 @@ test("buildMainTimelineEntries merges local knowledge over the relay floor", () 
     entry.summary?.participants.map((participant) => participant.id),
     ["relay", "local"],
   );
+});
+
+test("thread summary names the most recent replier and previews the reply", () => {
+  const root = message({ id: "root", createdAt: 1 });
+  const first = message({
+    id: "first",
+    createdAt: 2,
+    parentId: "root",
+    rootId: "root",
+    depth: 1,
+    pubkey: "bob",
+    author: "Bob",
+    body: "looking at it now",
+  });
+  const latest = message({
+    id: "latest",
+    createdAt: 5,
+    parentId: "root",
+    rootId: "root",
+    depth: 1,
+    pubkey: "ada",
+    author: "Ada",
+    body: "confirmed with the supplier, all good",
+  });
+
+  const [entry] = buildMainTimelineEntries([root, first, latest]);
+
+  assert.deepEqual(entry.summary?.lastReply, {
+    author: "Ada",
+    createdAt: 5,
+    preview: "confirmed with the supplier, all good",
+  });
+});
+
+test("thread summary takes the last reply from the deepest branch, not the shallowest", () => {
+  const root = message({ id: "root", createdAt: 1 });
+  const direct = message({
+    id: "direct",
+    createdAt: 2,
+    parentId: "root",
+    rootId: "root",
+    depth: 1,
+    author: "Bob",
+    body: "first",
+  });
+  const nested = message({
+    id: "nested",
+    createdAt: 9,
+    parentId: "direct",
+    rootId: "root",
+    depth: 2,
+    author: "Ada",
+    body: "nested and newest",
+  });
+
+  const stats = buildDescendantStatsByMessageId([root, direct, nested]);
+
+  assert.deepEqual(stats.get("root").lastReply, {
+    author: "Ada",
+    createdAt: 9,
+    preview: "nested and newest",
+  });
+});
+
+test("a locally known reply keeps its preview when a relay summary covers the same thread", () => {
+  const root = message({ id: "root", createdAt: 1 });
+  const reply = message({
+    id: "reply",
+    createdAt: 9,
+    parentId: "root",
+    rootId: "root",
+    depth: 1,
+    pubkey: "ada",
+    author: "Ada",
+    body: "the text the relay summary does not carry",
+  });
+  const summaries = new Map([
+    [
+      "root",
+      {
+        replyCount: 3,
+        descendantCount: 3,
+        lastReplyAt: 9,
+        participantPubkeys: ["ada", "bob"],
+      },
+    ],
+  ]);
+
+  const [entry] = buildMainTimelineEntries([root, reply], new Set(), summaries);
+
+  assert.equal(
+    entry.summary?.lastReply?.preview,
+    "the text the relay summary does not carry",
+  );
+});
+
+test("a newer relay reply outranks an older local one", () => {
+  const root = message({ id: "root", createdAt: 1 });
+  const stale = message({
+    id: "stale",
+    createdAt: 2,
+    parentId: "root",
+    rootId: "root",
+    depth: 1,
+    pubkey: "bob",
+    author: "Bob",
+    body: "old news",
+  });
+  const summaries = new Map([
+    [
+      "root",
+      {
+        replyCount: 4,
+        descendantCount: 4,
+        lastReplyAt: 40,
+        participantPubkeys: ["ada"],
+      },
+    ],
+  ]);
+  const profiles = { ada: { displayName: "Ada", avatarUrl: null } };
+
+  const [entry] = buildMainTimelineEntries(
+    [root, stale],
+    new Set(),
+    summaries,
+    profiles,
+  );
+
+  assert.deepEqual(entry.summary?.lastReply, {
+    author: "Ada",
+    createdAt: 40,
+    preview: null,
+  });
+});
+
+test("a thread with no replies has no last reply", () => {
+  const root = message({ id: "root", createdAt: 1 });
+
+  const [entry] = buildMainTimelineEntries([root]);
+
+  assert.equal(entry.summary, null);
+});
+
+test("buildReplyPreview keeps one line, collapses whitespace and truncates", () => {
+  assert.equal(buildReplyPreview("  hello   there  "), "hello there");
+  assert.equal(buildReplyPreview("\n\nfirst line\nsecond line"), "first line");
+  assert.equal(buildReplyPreview(""), null);
+  assert.equal(buildReplyPreview("   \n  "), null);
+  assert.equal(buildReplyPreview(undefined), null);
+  assert.equal(buildReplyPreview(null), null);
+
+  const long = "x".repeat(200);
+  const preview = buildReplyPreview(long);
+  assert.equal(preview.length, 123);
+  assert.ok(preview.endsWith("..."));
+});
+
+test("buildReplyPreview counts characters, not code units", () => {
+  const emoji = "🙂".repeat(200);
+  const preview = buildReplyPreview(emoji);
+
+  assert.equal([...preview].length, 123);
 });

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -18,10 +18,24 @@ export type TimelineThreadSummaryParticipant = {
   isAgent?: boolean;
 };
 
+/**
+ * The most recent reply in a thread, for the collapsed summary row.
+ *
+ * `preview` is null whenever the reply's text is not in hand. A relay-only
+ * summary carries counts and participants but no content, so an older thread
+ * scrolled into view shows the author and time without a snippet.
+ */
+export type TimelineThreadLastReply = {
+  author: string;
+  createdAt: number;
+  preview: string | null;
+};
+
 export type TimelineThreadSummary = {
   threadHeadId: string;
   replyCount: number;
   lastReplyAt: number | null;
+  lastReply: TimelineThreadLastReply | null;
   participants: TimelineThreadSummaryParticipant[];
 };
 
@@ -34,6 +48,7 @@ export type ThreadDescendantStats = {
   descendantCount: number;
   unreadDescendantCount: number;
   lastReplyAt: number | null;
+  lastReply: TimelineThreadLastReply | null;
   recentParticipantsNewestFirst: TimelineThreadSummaryParticipant[];
 };
 
@@ -117,6 +132,31 @@ function buildDirectChildrenByParentId(messages: TimelineMessage[]) {
   return childrenByParentId;
 }
 
+const REPLY_PREVIEW_MAX_LENGTH = 120;
+
+/**
+ * A single-line snippet of a reply body for the collapsed summary row.
+ *
+ * Keeps the first non-empty line so a multi-paragraph reply previews as its
+ * opening sentence rather than as flattened prose, and returns null for a
+ * body with no text of its own (an image or file reply, say) so the row can
+ * fall back to author and time.
+ */
+export function buildReplyPreview(
+  body: string | null | undefined,
+): string | null {
+  if (typeof body !== "string") return null;
+  const firstLine = body
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return null;
+  const normalized = firstLine.replace(/\s+/g, " ");
+  const characters = [...normalized];
+  if (characters.length <= REPLY_PREVIEW_MAX_LENGTH) return normalized;
+  return `${characters.slice(0, REPLY_PREVIEW_MAX_LENGTH).join("").trimEnd()}...`;
+}
+
 export function buildDescendantStatsByMessageId(
   messages: TimelineMessage[],
   unreadReplyIds: ReadonlySet<string> = new Set(),
@@ -131,6 +171,7 @@ export function buildDescendantStatsByMessageId(
         descendantCount: 0,
         unreadDescendantCount: 0,
         lastReplyAt: null,
+        lastReply: null,
         recentParticipantsNewestFirst: [],
       },
     ]),
@@ -177,6 +218,16 @@ export function buildDescendantStatsByMessageId(
         ancestorStats.lastReplyAt ?? 0,
         message.createdAt,
       );
+
+      // This walk runs newest first, so the first descendant to reach an
+      // ancestor is that thread's most recent reply.
+      if (ancestorStats.lastReply === null) {
+        ancestorStats.lastReply = {
+          author: message.author,
+          createdAt: message.createdAt,
+          preview: buildReplyPreview(message.body),
+        };
+      }
 
       if (
         ancestorStats.recentParticipantsNewestFirst.length <
@@ -226,6 +277,7 @@ function buildSummaryForDirectReplies(
     threadHeadId: messageId,
     replyCount: descendantStats.descendantCount,
     lastReplyAt: descendantStats.lastReplyAt,
+    lastReply: descendantStats.lastReply,
     participants: [...descendantStats.recentParticipantsNewestFirst].reverse(),
   };
 }
@@ -249,6 +301,7 @@ export function buildThreadSummaryFromVisibleEntries(
 ): TimelineThreadSummary | null {
   let replyCount = 0;
   let lastReplyAt: number | null = null;
+  let lastReply: TimelineThreadLastReply | null = null;
   const participantCandidates: SummaryParticipantCandidate[] = [];
 
   const addParticipantCandidate = (
@@ -265,6 +318,11 @@ export function buildThreadSummaryFromVisibleEntries(
   for (const entry of entries) {
     replyCount += 1;
     lastReplyAt = Math.max(lastReplyAt ?? 0, entry.message.createdAt);
+    lastReply = mergeLastReplies(lastReply, {
+      author: entry.message.author,
+      createdAt: entry.message.createdAt,
+      preview: buildReplyPreview(entry.message.body),
+    });
     addParticipantCandidate(
       participantFromMessage(entry.message),
       entry.message.createdAt,
@@ -275,6 +333,7 @@ export function buildThreadSummaryFromVisibleEntries(
       if (entry.summary.lastReplyAt != null) {
         lastReplyAt = Math.max(lastReplyAt ?? 0, entry.summary.lastReplyAt);
       }
+      lastReply = mergeLastReplies(lastReply, entry.summary.lastReply);
 
       const summaryTimestamp =
         entry.summary.lastReplyAt ?? entry.message.createdAt;
@@ -314,6 +373,7 @@ export function buildThreadSummaryFromVisibleEntries(
     threadHeadId,
     replyCount,
     lastReplyAt,
+    lastReply,
     participants: recentParticipantsNewestFirst.reverse(),
   };
 }
@@ -395,10 +455,26 @@ function buildRelayThreadSummary(
   summary: ChannelWindowThreadSummary,
   profiles: UserProfileLookup | undefined,
 ): TimelineThreadSummary {
+  const lastReplier = summary.participantPubkeys[0];
+  const lastReplierProfile = lastReplier
+    ? profiles?.[lastReplier.toLowerCase()]
+    : undefined;
+
   return {
     threadHeadId: messageId,
     replyCount: summary.descendantCount,
     lastReplyAt: summary.lastReplyAt,
+    // The relay summary carries no reply text, so this half can name the last
+    // replier but never preview them. A locally assembled summary for the same
+    // thread wins the merge below and brings the snippet with it.
+    lastReply:
+      lastReplier && summary.lastReplyAt != null
+        ? {
+            author: lastReplierProfile?.displayName ?? lastReplier,
+            createdAt: summary.lastReplyAt,
+            preview: null,
+          }
+        : null,
     // The relay returns `participantPubkeys` most-recent-first. Take the 3 most
     // recent, then reverse to oldest-first so the facepile renders the last
     // replier at the end (rightmost) — matching the client-assembled path
@@ -415,6 +491,22 @@ function buildRelayThreadSummary(
           : {}),
       })),
   };
+}
+
+/**
+ * Newer reply wins. On an equal timestamp the two halves describe the same
+ * reply, so prefer whichever one actually carries a preview (the local half).
+ */
+function mergeLastReplies(
+  local: TimelineThreadLastReply | null,
+  relay: TimelineThreadLastReply | null,
+): TimelineThreadLastReply | null {
+  if (!local) return relay;
+  if (!relay) return local;
+  if (local.createdAt !== relay.createdAt) {
+    return local.createdAt > relay.createdAt ? local : relay;
+  }
+  return local.preview !== null ? local : relay;
 }
 
 function mergeThreadSummaries(
@@ -434,6 +526,7 @@ function mergeThreadSummaries(
     replyCount: Math.max(local.replyCount, relay.replyCount),
     lastReplyAt:
       Math.max(local.lastReplyAt ?? 0, relay.lastReplyAt ?? 0) || null,
+    lastReply: mergeLastReplies(local.lastReply, relay.lastReply),
     participants: [...participants.values()].slice(-3),
   };
 }

--- a/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
@@ -94,8 +94,11 @@ export function MessageThreadSummaryRow({
     THREAD_SUMMARY_SURFACE_AVATAR_INSET_REM,
   )})`;
   const replyLabel = summary.replyCount === 1 ? "reply" : "replies";
+  const lastReplyAuthorLabel = summary.lastReply?.author
+    ? ` by ${summary.lastReply.author}`
+    : "";
   const summaryAriaLabel = summary.lastReplyAt
-    ? `View thread with ${summary.replyCount} ${replyLabel}, last reply ${formatThreadSummaryLastReplyTime(summary.lastReplyAt)}`
+    ? `View thread with ${summary.replyCount} ${replyLabel}, last reply${lastReplyAuthorLabel} ${formatThreadSummaryLastReplyTime(summary.lastReplyAt)}`
     : `View thread with ${summary.replyCount} ${replyLabel}`;
   const guideDepths = depthGuideDepths
     ? [...depthGuideDepths]
@@ -256,11 +259,31 @@ export function MessageThreadSummaryRow({
                 </span>
                 <span className="inline-grid font-normal text-muted-foreground/70">
                   <span
-                    className="col-start-1 row-start-1 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0"
+                    className="col-start-1 row-start-1 flex min-w-0 items-baseline gap-1"
                     data-testid="message-thread-summary-last-reply"
                   >
-                    last reply{" "}
-                    {formatThreadSummaryLastReplyTime(summary.lastReplyAt)}
+                    <span className="shrink-0 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0">
+                      {summary.lastReply?.author
+                        ? `last reply by ${summary.lastReply.author} `
+                        : "last reply "}
+                      {formatThreadSummaryLastReplyTime(summary.lastReplyAt)}
+                    </span>
+                    {summary.lastReply?.preview ? (
+                      <>
+                        <span
+                          aria-hidden="true"
+                          className="shrink-0 text-muted-foreground/50 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0"
+                        >
+                          ·
+                        </span>
+                        <span
+                          className="min-w-0 truncate text-muted-foreground/60 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0"
+                          data-testid="message-thread-summary-last-reply-preview"
+                        >
+                          {summary.lastReply.preview}
+                        </span>
+                      </>
+                    ) : null}
                   </span>
                   <span
                     className="col-start-1 row-start-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"

--- a/desktop/tests/e2e/thread-summary-last-reply-screenshots.spec.ts
+++ b/desktop/tests/e2e/thread-summary-last-reply-screenshots.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+import { TEST_IDENTITIES, installMockBridge } from "../helpers/bridge";
+
+const SHOTS = "test-results/thread-summary-last-reply";
+
+async function waitForMockLiveSubscription(
+  page: import("@playwright/test").Page,
+  channelName: string,
+) {
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        ({ ch }) =>
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({ channelName: ch }) ??
+          false,
+        { ch: channelName },
+      ),
+    )
+    .toBe(true);
+}
+
+async function emitMockReply(
+  page: import("@playwright/test").Page,
+  channelName: string,
+  content: string,
+  parentEventId: string,
+  pubkey: string,
+) {
+  await page.evaluate(
+    ({ ch, msg, parent, author }) =>
+      (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            parentEventId?: string | null;
+            pubkey?: string;
+            createdAt?: number;
+          }) => unknown;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: ch,
+        content: msg,
+        parentEventId: parent,
+        pubkey: author,
+        createdAt: Math.floor(Date.now() / 1000) - 10,
+      }),
+    { ch: channelName, msg: content, parent: parentEventId, author: pubkey },
+  );
+}
+
+test.describe("thread summary last reply", () => {
+  test("names the last replier and previews the reply", async ({ page }) => {
+    await installMockBridge(page);
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    await emitMockReply(
+      page,
+      "general",
+      "Taking a look now",
+      "mock-general-welcome",
+      TEST_IDENTITIES.bob.pubkey,
+    );
+    await emitMockReply(
+      page,
+      "general",
+      "Confirmed with the supplier, we are good to go",
+      "mock-general-welcome",
+      TEST_IDENTITIES.alice.pubkey,
+    );
+
+    const summary = page.getByTestId("message-thread-summary").first();
+    await expect(summary).toBeVisible();
+
+    const lastReply = summary.getByTestId("message-thread-summary-last-reply");
+    await expect(lastReply).toContainText("last reply by");
+    await expect(
+      summary.getByTestId("message-thread-summary-last-reply-preview"),
+    ).toHaveText("Confirmed with the supplier, we are good to go");
+
+    await summary.screenshot({ path: `${SHOTS}-after.png` });
+  });
+
+  test("falls back to the time alone when the reply text is unknown", async ({
+    page,
+  }) => {
+    // A thread the client only knows through a relay summary: counts and
+    // participants, no reply content. The row must still be complete.
+    await installMockBridge(page);
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+    const summaries = page.getByTestId("message-thread-summary");
+    if ((await summaries.count()) === 0) {
+      test.skip(true, "mock bridge seeds no relay-only thread summary");
+    }
+    await expect(
+      summaries.first().getByTestId("message-thread-summary-last-reply"),
+    ).toContainText("last reply");
+  });
+});


### PR DESCRIPTION
## Problem

The collapsed thread summary row shows a facepile, a reply count and `last reply 2h`. In a busy channel that is not enough to decide whether a thread needs you. The row cannot say who spoke last or what they said, so catching up means opening every thread that moved, and a reply on an older thread is easy to miss entirely (the timeline orders by the root message's time, so an active old thread never moves).

## What changes

The row now reads `3 replies · last reply by Ada 2h · Confirmed with the supplier`, with the snippet truncated to one line.

| | |
|---|---|
| Before | <img src="https://raw.githubusercontent.com/bryanmarsh77/buzz/pr-assets-thread-summary/before.png" width="420"> |
| After | <img src="https://raw.githubusercontent.com/bryanmarsh77/buzz/pr-assets-thread-summary/after.png" width="420"> |

## How

`buildDescendantStatsByMessageId` already walks descendants newest first, so it records the newest reply's author, timestamp and a one-line preview as it goes, and the summary builders pass a `lastReply` through.

The relay half of a summary (`buildRelayThreadSummary`) carries counts and participants but no reply text, so it names the last replier from `participantPubkeys[0]` (the relay orders those most-recent-first) and leaves `preview` null. A locally assembled summary for the same thread wins the merge and brings the snippet with it. So a thread known only from a relay summary shows author and time, which is exactly as much as the data supports, and no request or schema change is needed.

`buildReplyPreview` keeps the first non-empty line so a multi-paragraph reply previews as its opening sentence, collapses whitespace, truncates at 120 characters by code point, and returns null for a body with no text of its own (an image-only reply) so the row falls back cleanly.

Nothing is fetched that was not already in hand, and the row keeps its existing hover behaviour ("View thread" replaces the whole line).

## Testing

`pnpm typecheck`, `pnpm check` and `pnpm test` are clean in `desktop/`. One pre-existing failure on `main` is unrelated to this change (`useKnownAgentPubkeys.test.mjs`, "provenance context follows exact local inventory"); it fails identically on an unmodified checkout.

New unit tests cover last-replier selection across direct and nested branches, the relay-only path, both merge directions (newer relay reply outranks an older local one; equal timestamps prefer the half that has the preview), a thread with no replies, and the preview helper's edge cases (empty, whitespace-only, null, undefined, multi-line, and astral characters where code units would truncate mid-character). One existing deep-equal expectation gains the new field.

`tests/e2e/thread-summary-last-reply-screenshots.spec.ts` renders the row and produced the screenshots above.

Manual check: open a channel with an active thread, reply from a second identity, and the row names that identity and previews the text without opening the thread.

## Deferred

Full-fidelity previews for cold history would need the relay's thread metadata to carry a last-reply snippet. That is a schema change and is deliberately not in this PR; the null fallback above covers it.
