### PR TITLE
fix(relay): warn at startup when relay membership is unenforced

### DIFF
--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -801,6 +801,14 @@ impl Config {
             );
         }
 
+        if !require_relay_membership {
+            warn!(
+                "BUZZ_REQUIRE_RELAY_MEMBERSHIP is false — the relay member roster is not \
+                 enforced, so any pubkey that authenticates may join. BUZZ_PUBKEY_ALLOWLIST, \
+                 if enabled, still applies. Set to true for production."
+            );
+        }
+
         let cors_origins = std::env::var("BUZZ_CORS_ORIGINS")
             .unwrap_or_default()
             .split(',')
@@ -1797,6 +1805,46 @@ mod tests {
             Err(ConfigError::InvalidValue(ref message))
                 if message.contains("must be valid Unicode")
         ));
+    }
+
+    /// The membership gate is opt-in and fails **open**: only an exact `true`
+    /// or `1` enables it, so a typo'd `TRUE` or a plausible `yes` silently
+    /// leaves the roster unenforced. That fail-open direction is why
+    /// `Config::from_env` warns whenever the flag resolves to false.
+    #[test]
+    fn require_relay_membership_enables_only_on_true_or_one() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous = std::env::var_os("BUZZ_REQUIRE_RELAY_MEMBERSHIP");
+
+        std::env::set_var("BUZZ_REQUIRE_RELAY_MEMBERSHIP", "true");
+        let word = Config::from_env().expect("config").require_relay_membership;
+
+        std::env::set_var("BUZZ_REQUIRE_RELAY_MEMBERSHIP", "1");
+        let numeric = Config::from_env().expect("config").require_relay_membership;
+
+        std::env::set_var("BUZZ_REQUIRE_RELAY_MEMBERSHIP", "false");
+        let disabled = Config::from_env().expect("config").require_relay_membership;
+
+        std::env::set_var("BUZZ_REQUIRE_RELAY_MEMBERSHIP", "TRUE");
+        let uppercase = Config::from_env().expect("config").require_relay_membership;
+
+        std::env::remove_var("BUZZ_REQUIRE_RELAY_MEMBERSHIP");
+        let unset = Config::from_env().expect("config").require_relay_membership;
+
+        if let Some(value) = previous {
+            std::env::set_var("BUZZ_REQUIRE_RELAY_MEMBERSHIP", value);
+        } else {
+            std::env::remove_var("BUZZ_REQUIRE_RELAY_MEMBERSHIP");
+        }
+
+        assert!(word, "`true` must enforce the member roster");
+        assert!(numeric, "`1` must enforce the member roster");
+        assert!(!disabled, "`false` must leave the relay open");
+        assert!(
+            !uppercase,
+            "`TRUE` is not recognized and must leave the relay open"
+        );
+        assert!(!unset, "unset must leave the relay open");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`BUZZ_REQUIRE_RELAY_MEMBERSHIP` is validated aggressively when it is **on**, and says nothing at all when it is **off** — which is the default.

When the flag is `true`, `crates/buzz-relay/src/main.rs` refuses to start across six separate paths: missing/invalid `RELAY_OWNER_PUBKEY`, missing `BUZZ_RELAY_PRIVATE_KEY`, an underivable community host, and failures to ensure the deployment community, backfill the allowlist, or bootstrap the owner.

When it is `false` or unset, the relay starts with the member roster unenforced and emits **no** startup diagnostic. The well-guarded direction is the safe one; the silent direction is the permissive one.

## Why a warning rather than a default change

Changing the default is a breaking change for existing deployments. The repo already has an accepted pattern for exactly this shape — `BUZZ_REQUIRE_AUTH_TOKEN` warns when false — and this change mirrors it, including its scoping discipline (that warning is careful to note "WebSocket protocol auth is unaffected").

The wording here is scoped the same way: `BUZZ_PUBKEY_ALLOWLIST` is an independent gate (`handlers/auth.rs`) that still applies when enabled, so the warning says the roster is unenforced rather than implying nothing restricts connections.

## A related fail-open worth flagging

The parse is an exact match:

```rust
std::env::var("BUZZ_REQUIRE_RELAY_MEMBERSHIP")
    .map(|v| v == "true" || v == "1")
    .unwrap_or(false)
```

So `BUZZ_REQUIRE_RELAY_MEMBERSHIP=TRUE` — or a plausible `yes` — resolves to **false**. An operator who believes they enabled enforcement gets an open relay and trips none of the six hard-failure paths, because the flag reads false.

That makes the missing warning meaningfully worse: it is the only signal available in precisely the case where the operator is most confident they are protected.

**This PR does not widen the parser.** That is a behaviour change and the maintainers' call. The added test pins the current matrix, including `TRUE → false`, and documents the fail-open direction rather than blessing it.

## Test

`require_relay_membership_enables_only_on_true_or_one` covers `true` / `1` / `false` / `TRUE` / unset, and restores any pre-existing value under the existing `ENV_MUTEX`.

Verified falsifiable: mutating the parser to `eq_ignore_ascii_case("true")` makes the test fail, and reverting restores green — so it binds the production parser, not a test helper.

## Gates

```
cargo fmt --check -p buzz-relay          exit 0
cargo clippy -p buzz-relay --all-targets exit 0 (no warnings)
cargo test -p buzz-relay --lib config    70 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
