### PR TITLE
fix(cli): allow PDF uploads

### DIFF
--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -67,6 +67,7 @@ const ALLOWED_MIMES: &[&str] = &[
     "image/gif",
     "image/webp",
     "video/mp4",
+    "application/pdf",
 ];
 
 /// Maximum file size for image uploads (50 MB).
@@ -2269,6 +2270,50 @@ mod retry_policy_tests {
             auths.iter().all(|a| a.contains("Nostr ")),
             "each attempt must carry Nostr auth"
         );
+    }
+
+    #[tokio::test]
+    async fn upload_accepts_pdf() {
+        use std::io::Write;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        let pdf = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n%%EOF";
+        tmp.write_all(pdf).unwrap();
+        let file_path = tmp.path().to_str().unwrap().to_string();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut request = vec![0u8; 8192];
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                stream.read(&mut request),
+            )
+            .await;
+            let body = format!(
+                r#"{{"url":"https://relay.test/media/aabbcc.pdf","sha256":"aabbcc","size":{},"type":"application/pdf","uploaded":0}}"#,
+                pdf.len()
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+        let client = test_client(&format!("http://{addr}"));
+
+        let descriptor = client
+            .upload_file(&file_path)
+            .await
+            .expect("PDF upload should reach and succeed against the relay");
+
+        assert_eq!(descriptor.mime_type, "application/pdf");
+        assert_eq!(descriptor.size, pdf.len() as u64);
     }
 
     /// When all retry attempts for a stored event end with a partial body (200

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -76,6 +76,19 @@ const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
 /// Maximum file size for video uploads (500 MB).
 const MAX_VIDEO_BYTES: u64 = 500 * 1024 * 1024;
 
+/// Maximum file size for generic document uploads (100 MB).
+const MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
+
+fn max_upload_bytes(mime: &str) -> u64 {
+    if mime.starts_with("video/") {
+        MAX_VIDEO_BYTES
+    } else if mime.starts_with("image/") {
+        MAX_IMAGE_BYTES
+    } else {
+        MAX_FILE_BYTES
+    }
+}
+
 /// Sign a NIP-98 HTTP auth event (kind:27235) and return the Authorization header value.
 ///
 /// The event includes:
@@ -1181,11 +1194,7 @@ impl BuzzClient {
         }
 
         // 3. Size check
-        let max = if mime.starts_with("video/") {
-            MAX_VIDEO_BYTES
-        } else {
-            MAX_IMAGE_BYTES
-        };
+        let max = max_upload_bytes(&mime);
         if bytes.len() as u64 > max {
             return Err(CliError::Usage(format!(
                 "file too large: {} bytes (max {})",
@@ -2314,6 +2323,14 @@ mod retry_policy_tests {
 
         assert_eq!(descriptor.mime_type, "application/pdf");
         assert_eq!(descriptor.size, pdf.len() as u64);
+    }
+
+    #[test]
+    fn pdf_uses_generic_file_size_limit() {
+        assert_eq!(
+            super::max_upload_bytes("application/pdf"),
+            100 * 1024 * 1024
+        );
     }
 
     /// When all retry attempts for a stored event end with a partial body (200

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -608,6 +608,34 @@ pub struct SendMessageParams {
     pub mentions: Vec<String>,
 }
 
+fn attachment_filename(file_path: &str) -> Option<&str> {
+    let filename = std::path::Path::new(file_path).file_name()?.to_str()?;
+    if filename.is_empty() || filename.len() > 255 || filename.chars().any(char::is_control) {
+        return None;
+    }
+    Some(filename)
+}
+
+fn attachment_imeta_tag(desc: &crate::client::BlobDescriptor, file_path: &str) -> Vec<String> {
+    let mut tag = crate::client::build_imeta_tag(desc);
+    if let Some(filename) = attachment_filename(file_path) {
+        tag.push(format!("filename {filename}"));
+    }
+    tag
+}
+
+fn append_attachment_markdown(content: &mut String, desc: &crate::client::BlobDescriptor) {
+    if desc.mime_type.starts_with("video/") {
+        content.push_str("\n![video](");
+    } else if desc.mime_type.starts_with("image/") {
+        content.push_str("\n![image](");
+    } else {
+        content.push_str("\n[file](");
+    }
+    content.push_str(&desc.url);
+    content.push(')');
+}
+
 pub async fn cmd_send_message(
     client: &BuzzClient,
     mut p: SendMessageParams,
@@ -655,14 +683,8 @@ pub async fn cmd_send_message(
             .upload_file(file_path)
             .await
             .map_err(|e| CliError::Other(format!("upload failed for {file_path}: {e}")))?;
-        media_tags.push(crate::client::build_imeta_tag(&desc));
-        if desc.mime_type.starts_with("video/") {
-            media_content.push_str("\n![video](");
-        } else {
-            media_content.push_str("\n![image](");
-        }
-        media_content.push_str(&desc.url);
-        media_content.push(')');
+        media_tags.push(attachment_imeta_tag(&desc, file_path));
+        append_attachment_markdown(&mut media_content, &desc);
     }
     let final_content = if media_content.is_empty() {
         p.content.clone()
@@ -1084,12 +1106,14 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        channel_id_from_event, cmd_get_thread, cmd_send_message, event_mention_pubkeys,
-        find_root_from_tags, format_events, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
-        resolve_names_to_pubkeys, resolve_thread_target, thread_ref_from_event,
-        thread_ref_from_parent_tags, BuzzClient, CliError, Uuid,
+        append_attachment_markdown, attachment_imeta_tag, channel_id_from_event, cmd_get_thread,
+        cmd_send_message, event_mention_pubkeys, find_root_from_tags, format_events,
+        match_profiles_by_name, merge_message_mentions, missing_members,
+        normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
+        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
+        CliError, Uuid,
     };
+    use crate::client::BlobDescriptor;
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
@@ -1099,6 +1123,39 @@ mod tests {
     const ID_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const ID_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     const PUBKEY: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+    fn attachment_descriptor(mime_type: &str) -> BlobDescriptor {
+        BlobDescriptor {
+            url: "https://buzz.example/media/aabbcc.pdf".into(),
+            sha256: "a".repeat(64),
+            size: 42,
+            mime_type: mime_type.into(),
+            uploaded: 1,
+            dim: None,
+            blurhash: None,
+            thumb: None,
+            duration: None,
+        }
+    }
+
+    #[test]
+    fn pdf_attachment_uses_file_link_and_preserves_filename() {
+        let desc = attachment_descriptor("application/pdf");
+        let mut content = String::new();
+        append_attachment_markdown(&mut content, &desc);
+        let tag = attachment_imeta_tag(&desc, "/tmp/quarterly report.pdf");
+
+        assert_eq!(content, "\n[file](https://buzz.example/media/aabbcc.pdf)");
+        assert!(tag.contains(&"filename quarterly report.pdf".to_string()));
+    }
+
+    #[test]
+    fn image_attachment_keeps_inline_image_markdown() {
+        let desc = attachment_descriptor("image/png");
+        let mut content = String::new();
+        append_attachment_markdown(&mut content, &desc);
+        assert_eq!(content, "\n![image](https://buzz.example/media/aabbcc.pdf)");
+    }
 
     // Three real pubkeys (lowercase 64-char hex) used by parse_member_pubkeys tests.
     // See the test's own comment on what `PublicKey::from_hex` actually validates.


### PR DESCRIPTION
## Summary

- allow `application/pdf` through the CLI upload MIME gate
- render PDFs as file attachments rather than broken inline images
- preserve the original filename in `imeta` metadata
- use the relay-aligned 100 MiB generic-file size limit for PDFs
- add regressions for PDF upload, rendering, filename metadata, image rendering, and size selection

The relay already accepts PDFs on its generic file path; the CLI was rejecting them before sending the request.

Fixes #2963.

Closest existing work: #6364 is broader and currently blocked; this PR is the minimal PDF-only fix for a reproduced user-facing failure.

## Verification

- `cargo test -p buzz-cli` — 467 passed
- `cargo clippy -p buzz-cli --all-targets -- -D warnings` — passed
- `cargo fmt -p buzz-cli` — passed
- `git diff --check` — passed