### PR TITLE
fix(buzz-cli): deliver documents as file cards instead of broken images

### DIFF
--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -37,7 +37,11 @@ pub struct BlobDescriptor {
 }
 
 /// Build an `imeta` tag array from a BlobDescriptor (NIP-92 media metadata).
-pub fn build_imeta_tag(d: &BlobDescriptor) -> Vec<String> {
+///
+/// `filename` is the original file name. Buzz Desktop reads it to label the
+/// download on a generic-file card, so omitting it leaves non-media
+/// attachments with only the opaque blob hash to show the recipient.
+pub fn build_imeta_tag(d: &BlobDescriptor, filename: Option<&str>) -> Vec<String> {
     let mut tag = vec![
         "imeta".to_string(),
         format!("url {}", d.url),
@@ -45,6 +49,9 @@ pub fn build_imeta_tag(d: &BlobDescriptor) -> Vec<String> {
         format!("x {}", d.sha256),
         format!("size {}", d.size),
     ];
+    if let Some(name) = filename.map(str::trim).filter(|n| !n.is_empty()) {
+        tag.push(format!("filename {name}"));
+    }
     if let Some(ref dim) = d.dim {
         tag.push(format!("dim {dim}"));
     }
@@ -67,6 +74,19 @@ const ALLOWED_MIMES: &[&str] = &[
     "image/gif",
     "image/webp",
     "video/mp4",
+    // Documents and archives. The relay's `/upload` route already sniffs these
+    // onto its generic-file path (`buzz-media::validation`, deny-list only) and
+    // serves them as downloads, so refusing them here made the CLI stricter than
+    // the server and blocked agents from attaching any non-image artifact.
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.ms-excel",
+    "application/msword",
+    "text/csv",
+    "text/plain",
+    "application/zip",
 ];
 
 /// Maximum file size for image uploads (50 MB).
@@ -1705,6 +1725,50 @@ mod retry_policy_tests {
         let addr: SocketAddr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
         (format!("http://{addr}"), counter)
+    }
+
+    use super::{build_imeta_tag, BlobDescriptor, ALLOWED_MIMES};
+
+    #[test]
+    fn imeta_carries_filename_for_download_labels() {
+        let desc = BlobDescriptor {
+            url: "https://relay.example/blob/abc".into(),
+            sha256: "abc".into(),
+            size: 42,
+            mime_type: "application/pdf".into(),
+            uploaded: 0,
+            dim: None,
+            blurhash: None,
+            thumb: None,
+            duration: None,
+        };
+        let tag = build_imeta_tag(&desc, Some("quote.pdf"));
+        assert!(
+            tag.contains(&"filename quote.pdf".to_string()),
+            "imeta must carry the original filename so the client can label the download \
+             instead of showing the blob hash: {tag:?}"
+        );
+
+        // No filename available: the tag stays well-formed with no empty entry.
+        let bare = build_imeta_tag(&desc, None);
+        assert!(
+            !bare.iter().any(|part| part.starts_with("filename")),
+            "absent filename must not emit an empty entry: {bare:?}"
+        );
+    }
+
+    #[test]
+    fn documents_are_uploadable() {
+        // The relay's generic-file path accepts these; refusing them here made the
+        // CLI stricter than the server it talks to.
+        for mime in [
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "text/csv",
+            "application/zip",
+        ] {
+            assert!(ALLOWED_MIMES.contains(&mime), "{mime} must be uploadable");
+        }
     }
 
     fn test_client(base_url: &str) -> BuzzClient {

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -608,6 +608,35 @@ pub struct SendMessageParams {
     pub mentions: Vec<String>,
 }
 
+/// Format one uploaded attachment as a leading-newline markdown line.
+///
+/// Images and video embed inline. Everything else is a generic file and must use
+/// a plain `[label](url)` link, which Buzz Desktop recognises as a non-media blob
+/// and upgrades to a download card. Announcing a document as `![image](url)`
+/// instead renders a permanently broken image in the recipient's client, while
+/// the sender still sees `accepted: true` — the relay accepted the upload, only
+/// the embed was wrong.
+fn format_media_markdown(mime_type: &str, url: &str, filename: Option<&str>) -> String {
+    if mime_type.starts_with("video/") {
+        return format!("\n![video]({url})");
+    }
+    if mime_type.starts_with("image/") {
+        return format!("\n![image]({url})");
+    }
+    // Escape the markdown link-label metacharacters so a name containing `[`,
+    // `]`, or `\` still renders as a card with the correct label rather than
+    // breaking the link.
+    let label = filename
+        .map(|n| {
+            n.replace('\\', "\\\\")
+                .replace('[', "\\[")
+                .replace(']', "\\]")
+        })
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| "file".to_string());
+    format!("\n[{label}]({url})")
+}
+
 pub async fn cmd_send_message(
     client: &BuzzClient,
     mut p: SendMessageParams,
@@ -655,14 +684,11 @@ pub async fn cmd_send_message(
             .upload_file(file_path)
             .await
             .map_err(|e| CliError::Other(format!("upload failed for {file_path}: {e}")))?;
-        media_tags.push(crate::client::build_imeta_tag(&desc));
-        if desc.mime_type.starts_with("video/") {
-            media_content.push_str("\n![video](");
-        } else {
-            media_content.push_str("\n![image](");
-        }
-        media_content.push_str(&desc.url);
-        media_content.push(')');
+        let filename = std::path::Path::new(file_path)
+            .file_name()
+            .and_then(|n| n.to_str());
+        media_tags.push(crate::client::build_imeta_tag(&desc, filename));
+        media_content.push_str(&format_media_markdown(&desc.mime_type, &desc.url, filename));
     }
     let final_content = if media_content.is_empty() {
         p.content.clone()
@@ -1085,8 +1111,8 @@ pub async fn dispatch(
 mod tests {
     use super::{
         channel_id_from_event, cmd_get_thread, cmd_send_message, event_mention_pubkeys,
-        find_root_from_tags, format_events, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        find_root_from_tags, format_events, format_media_markdown, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys, resolve_thread_target, thread_ref_from_event,
         thread_ref_from_parent_tags, BuzzClient, CliError, Uuid,
     };
@@ -1887,5 +1913,49 @@ mod tests {
             emoji_tags.is_empty(),
             "palette-error fallback must produce no emoji tags, got: {emoji_tags:?}"
         );
+    }
+
+    #[test]
+    fn documents_embed_as_file_links_not_images() {
+        // Regression for the `![image](…)` catch-all: a document announced as an
+        // image renders as a permanently broken image in Buzz Desktop.
+        let line = format_media_markdown(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "https://relay.example/blob/abc",
+            Some("quote.xlsx"),
+        );
+        assert_eq!(line, "\n[quote.xlsx](https://relay.example/blob/abc)");
+        assert!(
+            !line.contains("!["),
+            "generic files must not use an inline embed: {line}"
+        );
+    }
+
+    #[test]
+    fn images_and_video_still_embed_inline() {
+        assert_eq!(
+            format_media_markdown("image/png", "https://relay.example/i", Some("a.png")),
+            "\n![image](https://relay.example/i)"
+        );
+        assert_eq!(
+            format_media_markdown("video/mp4", "https://relay.example/v", Some("a.mp4")),
+            "\n![video](https://relay.example/v)"
+        );
+    }
+
+    #[test]
+    fn file_label_escapes_markdown_metacharacters() {
+        // `a].pdf` would otherwise close the link label early and render as text.
+        let line =
+            format_media_markdown("application/pdf", "https://relay.example/p", Some("a].pdf"));
+        assert_eq!(line, "\n[a\\].pdf](https://relay.example/p)");
+    }
+
+    #[test]
+    fn file_label_falls_back_when_filename_is_unusable() {
+        for name in [None, Some("")] {
+            let line = format_media_markdown("application/zip", "https://relay.example/z", name);
+            assert_eq!(line, "\n[file](https://relay.example/z)", "name={name:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

`buzz-cli` is both stricter and less correct than the relay it talks to when
attaching a non-image file, so an agent cannot deliver any document to a
conversation. Two defects, neither visible to the sender.

Fixes #3083
Fixes #7324

## 1. Uploads were rejected client-side (#3083)

`ALLOWED_MIMES` listed only four image types plus `video/mp4`, so anything else
failed with `unsupported file type: …` before the request reached the relay.

The relay's `/upload` route already sniffs documents, archives, text and data
onto its generic-file path (`buzz-media::validation`, a deny-list that blocks
only active content and executables) and serves them with
`Content-Disposition: attachment`. Desktop users could attach a PDF; agents
could not.

## 2. Everything non-video was announced as an image (#7324)

The markdown embed came from a two-way branch: `video/*` got `![video](…)` and
*everything else* got `![image](…)`. A document was therefore announced to the
client as an image and rendered as a permanently broken image placeholder —
while the send returned `accepted: true`, so the failure only ever appeared in
the recipient's client.

Generic files now use the same plain `[filename](url)` form Buzz Desktop emits
(`imetaMediaMarkdown.ts::formatImetaMediaLine`), which the renderer recognises
as a non-media blob and upgrades to a download card. The `imeta` tag carries
`filename` so the card has a label instead of the blob hash, and markdown
metacharacters in the label are escaped so a name like `a].pdf` cannot break
the link.

## Testing

The embed choice is extracted into `format_media_markdown` so tests bind the
production branch rather than a copy of it. Reverting either fix turns the new
tests red — verified by re-introducing the `![image](…)` catch-all, which fails
three of them.

- `cargo test -p buzz-cli --lib` — 469 passed
- `cargo fmt --check -p buzz-cli`, `cargo clippy -p buzz-cli --all-targets` — clean

Reproduced end to end against a self-hosted relay: a headless `buzz-acp` agent
generating an `.xlsx` could not attach it at all before this change, and
delivers it as a working download card after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
