### PR TITLE
fix(desktop): show macOS Dock badge for ordinary channel unreads

### DIFF
--- a/desktop/src-tauri/src/macos_notifications.rs
+++ b/desktop/src-tauri/src/macos_notifications.rs
@@ -196,7 +196,9 @@ fn request_notification_access_sync() -> Result<NotificationPermissionState, Str
     });
     UNUserNotificationCenter::currentNotificationCenter()
         .requestAuthorizationWithOptions_completionHandler(
-            UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
+            UNAuthorizationOptions::Alert
+                | UNAuthorizationOptions::Sound
+                | UNAuthorizationOptions::Badge,
             &handler,
         );
 

--- a/desktop/src/features/notifications/lib/desktop.ts
+++ b/desktop/src/features/notifications/lib/desktop.ts
@@ -329,18 +329,29 @@ export async function setDesktopAppBadge(state: AppBadgeState): Promise<void> {
   }
 
   try {
+    const currentWindow = getCurrentWindow();
     if (state.kind === "count") {
-      await getCurrentWindow().setBadgeCount(state.count);
+      // Clear any prior label so a previous "dot" can't stick on macOS.
+      if (isMacPlatform()) {
+        await currentWindow.setBadgeLabel("");
+      }
+      await currentWindow.setBadgeCount(state.count);
     } else if (state.kind === "dot" && isMacPlatform()) {
-      await getCurrentWindow().setBadgeLabel(" ");
+      // macOS Dock badges are numeric in practice. A blank badgeLabel (" ") was
+      // used to request a "dot", but it does not produce a visible Dock badge,
+      // so ordinary channel unreads never lit the icon. Use a minimal count so
+      // the product intent (any unread → Dock indicator) is actually visible.
+      await currentWindow.setBadgeLabel("");
+      await currentWindow.setBadgeCount(1);
     } else {
       if (isMacPlatform()) {
-        await getCurrentWindow().setBadgeLabel("");
+        await currentWindow.setBadgeLabel("");
       }
-      await getCurrentWindow().setBadgeCount(undefined);
+      await currentWindow.setBadgeCount(undefined);
     }
-  } catch {
-    // Ignore unsupported platforms and best-effort badge sync failures.
+  } catch (error) {
+    // Best-effort: unsupported platforms / transient Tauri failures.
+    console.warn("Failed to sync desktop app badge", error);
   }
 }
 


### PR DESCRIPTION
## Summary
Ordinary channel unreads used a blank Dock `badgeLabel` ("dot") that does not render on macOS, so the Dock icon never showed unread activity. This switches that path to a minimal badge count and requests Badge notification authorization so Dock updates are allowed. E2E still sees state `"dot"`; only the native Dock call changes.

## Test plan
- [ ] Run Buzz Dev via `just desktop-standalone` (separate from production Buzz.app)
- [ ] Allow notifications/badge if prompted
- [ ] Ordinary channel unread (no notification count) → Dock badge appears
- [ ] Clear unreads → badge clears
- [ ] Notification-count unreads still show a numeric badge
