### PR TITLE
feat: experimental signed interaction prompts and responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -336,3 +336,6 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # BUZZ_TERMS_OF_SERVICE_MARKDOWN="# Terms of Service\n\nFull terms here."
 # BUZZ_PRIVACY_POLICY_MARKDOWN="# Privacy Policy\n\nFull policy here."
 # BUZZ_AGE_ATTESTATION_REQUIRED=true
+
+# Experimental signed buttons/forms/polls; see docs/experimental-interactions.md
+BUZZ_EXPERIMENTAL_INTERACTIONS=false

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ identity.key
 
 # Helm dependency tarballs — regenerable from Chart.lock via `helm dependency build`
 deploy/charts/*/charts/*.tgz
+
+# Standalone experimental interaction demonstration
+desktop/dist-interaction-preview/

--- a/crates/buzz-acp/src/interaction_author.rs
+++ b/crates/buzz-acp/src/interaction_author.rs
@@ -1,0 +1,180 @@
+//! Preserve the asker's authority when an interaction is projected as text.
+
+use buzz_core::{interaction::single_tag, kind::KIND_STREAM_MESSAGE};
+use nostr::{Event, EventId, PublicKey};
+
+/// Resolve the principal before applying the existing owner/allowlist policy.
+pub(super) fn effective_prompt_author(
+    event: &Event,
+    relay_self: Option<&str>,
+    agent_pubkey_hex: &str,
+) -> String {
+    super::verified_workflow_owner(event, relay_self, agent_pubkey_hex)
+        .or_else(|| verified_interaction_author(event, relay_self))
+        .unwrap_or_else(|| event.pubkey.to_hex())
+}
+
+fn verified_interaction_author(event: &Event, relay_self: Option<&str>) -> Option<String> {
+    if event.kind.as_u16() as u32 != KIND_STREAM_MESSAGE
+        || event.pubkey != PublicKey::from_hex(relay_self?).ok()?
+        || event.verify().is_err()
+    {
+        return None;
+    }
+    // Only the relay's exact projection contract conveys authority. Ordinary
+    // client-signed messages cannot borrow the actor tag's identity.
+    let prompt = single_tag(event, "interaction").ok()??;
+    if EventId::from_hex(prompt).ok()?.to_hex() != prompt {
+        return None;
+    }
+    let actor = single_tag(event, "actor").ok()??;
+    let canonical = PublicKey::from_hex(actor).ok()?.to_hex();
+    (canonical == actor).then_some(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::RespondTo, pool, relay, InboundAuthorGate, OwnerCache};
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+    use std::collections::{HashMap, HashSet};
+
+    fn projection(keys: &Keys, actor: &str, extra: Vec<Tag>) -> Event {
+        let mut tags = vec![
+            Tag::parse(["interaction", &"ab".repeat(32)]).unwrap(),
+            Tag::parse(["actor", actor]).unwrap(),
+        ];
+        tags.extend(extra);
+        EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "Approve?")
+            .tags(tags)
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    #[test]
+    fn interaction_attribution_requires_verified_canonical_relay_provenance() {
+        let relay = Keys::generate();
+        let attacker = Keys::generate();
+        let actor = Keys::generate().public_key().to_hex();
+        let relay_hex = relay.public_key().to_hex();
+        let event = projection(&relay, &actor, vec![]);
+        assert_eq!(
+            verified_interaction_author(&event, Some(&relay_hex)),
+            Some(actor.clone())
+        );
+        assert_eq!(verified_interaction_author(&event, None), None);
+        assert_eq!(
+            verified_interaction_author(&projection(&attacker, &actor, vec![]), Some(&relay_hex)),
+            None
+        );
+        for extra in [
+            Tag::parse(["actor", &actor]).unwrap(),
+            Tag::parse(["interaction", &"ab".repeat(32)]).unwrap(),
+        ] {
+            assert_eq!(
+                verified_interaction_author(
+                    &projection(&relay, &actor, vec![extra]),
+                    Some(&relay_hex)
+                ),
+                None
+            );
+        }
+        let mut tampered = event.clone();
+        tampered.content.push('!');
+        assert_eq!(
+            verified_interaction_author(&tampered, Some(&relay_hex)),
+            None
+        );
+        let wrong_kind = EventBuilder::new(Kind::Custom(40010), event.content.clone())
+            .tags(event.tags.clone())
+            .sign_with_keys(&relay)
+            .unwrap();
+        assert_eq!(
+            verified_interaction_author(&wrong_kind, Some(&relay_hex)),
+            None
+        );
+        for (tag_name, replacement) in [
+            ("actor", "not-a-key"),
+            ("interaction", "bad-id"),
+            ("interaction", &"AB".repeat(32)),
+        ] {
+            let tags = event
+                .tags
+                .iter()
+                .map(|tag| {
+                    if tag.as_slice()[0] == tag_name {
+                        Tag::parse([tag_name, replacement]).unwrap()
+                    } else {
+                        tag.clone()
+                    }
+                })
+                .collect::<Vec<_>>();
+            let malformed = EventBuilder::new(event.kind, "Approve?")
+                .tags(tags)
+                .sign_with_keys(&relay)
+                .unwrap();
+            assert_eq!(
+                verified_interaction_author(&malformed, Some(&relay_hex)),
+                None
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn connected_interaction_gate_applies_policy_to_the_asker_not_the_relay() {
+        let relay_keys = Keys::generate();
+        let relay_hex = relay_keys.public_key().to_hex();
+        let owner = Keys::generate().public_key().to_hex();
+        let outsider = Keys::generate().public_key().to_hex();
+        let agent = Keys::generate().public_key().to_hex();
+        let (rest, server) =
+            crate::author_gate_tests::nip11_server(serde_json::json!({"self":relay_hex})).await;
+        let mut gate = InboundAuthorGate::connect(&rest, &agent, "interaction-test").await;
+        let cache = OwnerCache::new(Some(owner.clone()));
+        cache.cache_sibling(outsider.clone(), false);
+        cache.cache_sibling(relay_hex.clone(), false);
+        let channel_id = uuid::Uuid::new_v4();
+        let channels = pool::ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                relay::ChannelInfo {
+                    name: "interaction".into(),
+                    channel_type: "stream".into(),
+                    description: None,
+                },
+            )]),
+            rest.clone(),
+        );
+        for (actor, policy, allowlist, expected) in [
+            (
+                &outsider,
+                RespondTo::Allowlist,
+                HashSet::from([relay_hex.clone()]),
+                false,
+            ),
+            (
+                &outsider,
+                RespondTo::Allowlist,
+                HashSet::from([outsider.clone()]),
+                true,
+            ),
+            (&owner, RespondTo::OwnerOnly, HashSet::new(), true),
+            (&outsider, RespondTo::OwnerOnly, HashSet::new(), false),
+        ] {
+            let event = relay::BuzzEvent {
+                connection_generation: 0,
+                channel_id,
+                event: projection(&relay_keys, actor, vec![Tag::parse(["p", &agent]).unwrap()]),
+            };
+            let decision = gate
+                .evaluate_listener_event(&event, &policy, &allowlist, &cache, &channels, &rest)
+                .await;
+            assert_eq!(decision.effective_author, *actor);
+            assert_eq!(
+                decision.allowed, expected,
+                "policy must follow the original asker"
+            );
+        }
+        server.abort();
+    }
+}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4,6 +4,7 @@ mod acp;
 mod config;
 mod engram_fetch;
 mod filter;
+mod interaction_author;
 mod observer;
 mod pi_launcher;
 mod pool;
@@ -39,6 +40,7 @@ use config::{
 };
 use filter::SubscriptionRule;
 use futures_util::FutureExt;
+use interaction_author::effective_prompt_author;
 use nostr::{PublicKey, ToBech32};
 use pool::{
     AgentPool, ControlSignal, IdleSwitchResult, OwnedAgent, PromptContext, PromptOutcome,
@@ -307,16 +309,6 @@ fn verified_workflow_owner(
     }
 
     Some(owner)
-}
-
-/// Resolve the author principal used by the inbound author gate.
-fn effective_prompt_author(
-    event: &nostr::Event,
-    relay_self: Option<&str>,
-    agent_pubkey_hex: &str,
-) -> String {
-    verified_workflow_owner(event, relay_self, agent_pubkey_hex)
-        .unwrap_or_else(|| event.pubkey.to_hex())
 }
 
 /// Owns the verified relay signing identity for a listener's lifetime and

--- a/crates/buzz-cli/src/commands/interactions.rs
+++ b/crates/buzz-cli/src/commands/interactions.rs
@@ -1,0 +1,454 @@
+//! Experimental signed interaction commands over the existing HTTP event bridge.
+
+use std::{io::Read, time::Duration};
+
+use buzz_core::interaction::{Prompt, EXTENSION, MAX_LIFETIME};
+use buzz_core::kind::*;
+use clap::{Args, Subcommand};
+use nostr::{Event, EventBuilder, EventId, Kind, PublicKey, Tag, Timestamp};
+use serde_json::{json, Value};
+
+use crate::{
+    client::{normalize_write_response, BuzzClient},
+    error::CliError,
+};
+
+#[derive(Subcommand)]
+/// Commands for the relay's experimental signed interaction capability.
+pub enum InteractionsCmd {
+    /// Post a signed buttons/form prompt (requires experimental relay capability)
+    Ask(AskArgs),
+    /// Post a poll (default close: expiry)
+    Poll(AskArgs),
+    /// Answer a prompt; repeat --choice or --value for multiple inputs
+    Answer {
+        #[arg(long)]
+        prompt: String,
+        #[arg(long = "choice")]
+        choices: Vec<String>,
+        #[arg(long = "value")]
+        values: Vec<String>,
+        #[arg(long, default_value = "")]
+        comment: String,
+    },
+    /// Read canonical signed prompt and current relay state as a JSON array
+    Get {
+        #[arg(long)]
+        prompt: String,
+    },
+    /// Wait for close; print the signed final state as a one-element JSON array
+    Wait {
+        #[arg(long)]
+        prompt: String,
+        #[arg(long, default_value = "24h")]
+        timeout: String,
+    },
+    /// Close a prompt as its asker, preserving its event and decision history
+    Close {
+        #[arg(long)]
+        prompt: String,
+    },
+}
+
+#[derive(Args)]
+/// Schema and delivery options for a prompt, or an unsigned JSON envelope.
+pub struct AskArgs {
+    #[arg(long, required_unless_present = "json")]
+    channel: Option<String>,
+    #[arg(long, required_unless_present = "json")]
+    text: Option<String>,
+    #[arg(long = "type", default_value = "buttons")]
+    itype: String,
+    /// id:label[:primary|danger|default]
+    #[arg(long = "option")]
+    options: Vec<String>,
+    /// id:label:type:required|optional
+    #[arg(long = "field")]
+    fields: Vec<String>,
+    /// field=value1,value2 (use --json for labels different from IDs)
+    #[arg(long = "select")]
+    selects: Vec<String>,
+    #[arg(long, default_value = "members")]
+    responders: String,
+    #[arg(long = "responder")]
+    listed: Vec<String>,
+    #[arg(long)]
+    min: Option<usize>,
+    #[arg(long)]
+    max: Option<usize>,
+    #[arg(long)]
+    closes: Option<String>,
+    #[arg(long, default_value = "24h")]
+    expires: String,
+    #[arg(long)]
+    reply_to: Option<String>,
+    /// Raw unsigned {content,tags}; inline JSON, @path, or - for stdin
+    #[arg(long, conflicts_with_all = ["channel", "text", "options", "fields", "selects", "listed", "reply_to", "min", "max", "closes"])]
+    json: Option<String>,
+}
+
+fn usage(error: impl std::fmt::Display) -> CliError {
+    CliError::Usage(error.to_string())
+}
+fn parse_tag(parts: Vec<String>) -> Result<Tag, CliError> {
+    Tag::parse(parts).map_err(usage)
+}
+fn pair(name: &str, value: impl ToString) -> Result<Tag, CliError> {
+    parse_tag(vec![name.into(), value.to_string()])
+}
+fn duration(value: &str) -> Result<Duration, CliError> {
+    let (number, multiplier) = match value.chars().last() {
+        Some('s') => (&value[..value.len() - 1], 1),
+        Some('m') => (&value[..value.len() - 1], 60),
+        Some('h') => (&value[..value.len() - 1], 3600),
+        Some('d') => (&value[..value.len() - 1], 86400),
+        _ => (value, 1),
+    };
+    let seconds = number
+        .parse::<u64>()
+        .ok()
+        .and_then(|n| n.checked_mul(multiplier))
+        .filter(|n| *n > 0 && *n <= MAX_LIFETIME)
+        .ok_or_else(|| usage("duration must be 1s to 30d"))?;
+    Ok(Duration::from_secs(seconds))
+}
+
+async fn capability(client: &BuzzClient) -> Result<PublicKey, CliError> {
+    let raw = client.get_public("/info").await?;
+    let info: Value = serde_json::from_str(&raw).map_err(usage)?;
+    relay_identity(&info)
+}
+fn relay_identity(info: &Value) -> Result<PublicKey, CliError> {
+    if !info
+        .get("supported_extensions")
+        .and_then(Value::as_array)
+        .is_some_and(|extensions| extensions.iter().any(|v| v == EXTENSION))
+    {
+        return Err(usage(format!(
+            "relay has not enabled {EXTENSION} (BUZZ_EXPERIMENTAL_INTERACTIONS=true)"
+        )));
+    }
+    let key = info
+        .get("self")
+        .and_then(Value::as_str)
+        .ok_or_else(|| usage("relay does not advertise its state signing key"))?;
+    PublicKey::from_hex(key).map_err(usage)
+}
+
+async fn read_prompt(client: &BuzzClient, id: &str) -> Result<(Event, Prompt), CliError> {
+    let id = EventId::from_hex(id).map_err(usage)?;
+    let raw = client
+        .query(&json!({"kinds":[KIND_INTERACTION_PROMPT],"ids":[id.to_hex()],"limit":1}))
+        .await?;
+    let events: Vec<Event> = serde_json::from_str(&raw).map_err(usage)?;
+    let event = events
+        .into_iter()
+        .find(|e| e.id == id && e.kind.as_u16() as u32 == KIND_INTERACTION_PROMPT)
+        .ok_or_else(|| CliError::NotFound("prompt not found or inaccessible".into()))?;
+    event.verify().map_err(usage)?;
+    let schema = Prompt::parse(&event).map_err(usage)?;
+    Ok((event, schema))
+}
+async fn read_state(
+    client: &BuzzClient,
+    prompt: &Event,
+    schema: &Prompt,
+    relay: PublicKey,
+) -> Result<Option<Event>, CliError> {
+    let raw = client.query(&json!({"kinds":[KIND_INTERACTION_STATE],"authors":[relay.to_hex()],"#d":[prompt.id.to_hex()],"#h":[schema.channel.to_string()],"limit":1})).await?;
+    let events: Vec<Event> = serde_json::from_str(&raw).map_err(usage)?;
+    let Some(event) = events.into_iter().next() else {
+        return Ok(None);
+    };
+    event.verify().map_err(usage)?;
+    if event.pubkey != relay
+        || event.kind.as_u16() as u32 != KIND_INTERACTION_STATE
+        || buzz_core::interaction::single_tag(&event, "d").map_err(usage)?
+            != Some(prompt.id.to_hex().as_str())
+        || buzz_core::interaction::channel(&event).map_err(usage)? != schema.channel
+    {
+        return Err(usage(
+            "relay returned a state for the wrong signer or prompt",
+        ));
+    }
+    Ok(Some(event))
+}
+
+async fn ask_builder(
+    client: &BuzzClient,
+    args: AskArgs,
+    poll: bool,
+) -> Result<EventBuilder, CliError> {
+    if let Some(input) = args.json {
+        let raw = if input == "-" {
+            let mut raw = String::new();
+            std::io::stdin()
+                .take(65_537)
+                .read_to_string(&mut raw)
+                .map_err(usage)?;
+            raw
+        } else if let Some(path) = input.strip_prefix('@') {
+            let file = std::fs::File::open(path).map_err(usage)?;
+            let mut raw = String::new();
+            file.take(65_537).read_to_string(&mut raw).map_err(usage)?;
+            raw
+        } else {
+            input
+        };
+        if raw.len() > 65_536 {
+            return Err(usage("prompt JSON exceeds 64 KiB"));
+        }
+        #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Input {
+            content: String,
+            tags: Vec<Vec<String>>,
+        }
+        let input: Input = serde_json::from_str(&raw).map_err(usage)?;
+        let tags = input
+            .tags
+            .into_iter()
+            .map(parse_tag)
+            .collect::<Result<Vec<_>, _>>()?;
+        return Ok(
+            EventBuilder::new(Kind::Custom(KIND_INTERACTION_PROMPT as u16), input.content)
+                .tags(tags),
+        );
+    }
+    let channel = args.channel.ok_or_else(|| usage("--channel is required"))?;
+    let channel = uuid::Uuid::parse_str(&channel).map_err(usage)?;
+    let text = args.text.ok_or_else(|| usage("--text is required"))?;
+    let itype = if poll { "poll" } else { &args.itype };
+    let expires = Timestamp::now().as_secs() + duration(&args.expires)?.as_secs();
+    let mut tags = vec![
+        pair("h", channel)?,
+        pair("itype", itype)?,
+        pair("responders", args.responders)?,
+        pair("visibility", "public")?,
+        pair(
+            "closes",
+            args.closes
+                .as_deref()
+                .unwrap_or(if poll { "expiry" } else { "first" }),
+        )?,
+        pair("deadline", expires)?,
+    ];
+    for option in args.options {
+        let parts: Vec<_> = option.splitn(3, ':').map(str::to_owned).collect();
+        if parts.len() < 2 {
+            return Err(usage("--option requires id:label[:style]"));
+        }
+        tags.push(parse_tag(
+            std::iter::once("opt".into()).chain(parts).collect(),
+        )?);
+    }
+    for field in args.fields {
+        let parts: Vec<_> = field.split(':').map(str::to_owned).collect();
+        if parts.len() != 4 {
+            return Err(usage("--field requires id:label:type:required|optional"));
+        }
+        tags.push(parse_tag(
+            std::iter::once("field".into()).chain(parts).collect(),
+        )?);
+    }
+    for select in args.selects {
+        let (field, options) = select
+            .split_once('=')
+            .ok_or_else(|| usage("--select requires field=value1,value2"))?;
+        for option in options.split(',') {
+            tags.push(parse_tag(vec![
+                "optsel".into(),
+                field.into(),
+                option.into(),
+            ])?);
+        }
+    }
+    for pk in args.listed {
+        tags.push(pair("p", PublicKey::parse(&pk).map_err(usage)?.to_hex())?);
+    }
+    if let Some(min) = args.min {
+        tags.push(pair("min", min)?);
+    }
+    if let Some(max) = args.max {
+        tags.push(pair("max", max)?);
+    }
+    if let Some(parent) = args.reply_to {
+        let id = EventId::from_hex(&parent).map_err(usage)?;
+        let raw = client.query(&json!({"kinds":[KIND_STREAM_MESSAGE,KIND_STREAM_MESSAGE_V2,KIND_FORUM_POST,KIND_FORUM_COMMENT,KIND_INTERACTION_PROMPT],"ids":[id.to_hex()],"#h":[channel.to_string()],"limit":1})).await?;
+        let events: Vec<Event> = serde_json::from_str(&raw).map_err(usage)?;
+        let parent = events
+            .into_iter()
+            .find(|e| e.id == id)
+            .ok_or_else(|| CliError::NotFound("reply parent not found in channel".into()))?;
+        let root = buzz_core::nip10::parse_thread_markers(&parent.tags)
+            .resolve()
+            .map(|(root, _)| root)
+            .unwrap_or_else(|| id.to_hex());
+        if root != id.to_hex() {
+            tags.push(parse_tag(vec!["e".into(), root, "".into(), "root".into()])?);
+        }
+        tags.push(parse_tag(vec![
+            "e".into(),
+            id.to_hex(),
+            "".into(),
+            "reply".into(),
+        ])?);
+    }
+    Ok(EventBuilder::new(Kind::Custom(KIND_INTERACTION_PROMPT as u16), text).tags(tags))
+}
+
+/// Execute an interaction command using the shared authenticated HTTP bridge.
+pub async fn dispatch(cmd: InteractionsCmd, client: &BuzzClient) -> Result<(), CliError> {
+    let relay = capability(client).await?;
+    let cmd = match cmd {
+        InteractionsCmd::Poll(mut args) => {
+            args.itype = "poll".into();
+            InteractionsCmd::Ask(args)
+        }
+        other => other,
+    };
+    match cmd {
+        InteractionsCmd::Ask(args) | InteractionsCmd::Poll(args) => {
+            let poll = args.itype == "poll";
+            let event = client.sign_event(ask_builder(client, args, poll).await?)?;
+            let schema = Prompt::parse(&event).map_err(usage)?;
+            if poll && schema.itype != "poll" {
+                return Err(usage("poll JSON must declare itype=poll"));
+            }
+            schema
+                .validate_lifetime(Timestamp::now().as_secs())
+                .map_err(usage)?;
+            let result = client.submit_event(event).await?;
+            println!("{}", normalize_write_response(&result));
+        }
+        InteractionsCmd::Answer {
+            prompt,
+            choices,
+            values,
+            comment,
+        } => {
+            let (event, schema) = read_prompt(client, &prompt).await?;
+            let mut tags = vec![
+                pair("h", schema.channel)?,
+                parse_tag(vec![
+                    "e".into(),
+                    event.id.to_hex(),
+                    "".into(),
+                    "prompt".into(),
+                ])?,
+            ];
+            for choice in choices {
+                tags.push(pair("choice", choice)?);
+            }
+            for value in values {
+                let (id, value) = value
+                    .split_once('=')
+                    .ok_or_else(|| usage("--value requires field=value"))?;
+                tags.push(parse_tag(vec!["value".into(), id.into(), value.into()])?);
+            }
+            let mut builder =
+                EventBuilder::new(Kind::Custom(KIND_INTERACTION_RESPONSE as u16), comment)
+                    .tags(tags);
+            // Ensure a user's deliberate edit in the same second beats their last
+            // accepted answer. Avoids gambling on the NIP-01 lower-ID tie break.
+            if let Some(state) = read_state(client, &event, &schema, relay).await? {
+                let summary: Value = serde_json::from_str(&state.content).map_err(usage)?;
+                if summary["status"] == "closed" {
+                    return Err(usage("prompt is closed"));
+                }
+                let me = client.keys().public_key().to_hex();
+                let previous = summary["responders"]
+                    .as_array()
+                    .and_then(|responders| responders.iter().find(|r| r["pubkey"] == me))
+                    .and_then(|r| r["created_at"].as_u64());
+                if let Some(previous) = previous {
+                    builder = builder.custom_created_at(Timestamp::from(
+                        Timestamp::now().as_secs().max(previous.saturating_add(1)),
+                    ));
+                }
+            }
+            let response = client.sign_event(builder)?;
+            schema.answer(&response).map_err(usage)?;
+            println!(
+                "{}",
+                normalize_write_response(&client.submit_event(response).await?)
+            );
+        }
+        InteractionsCmd::Get { prompt } => {
+            let (event, schema) = read_prompt(client, &prompt).await?;
+            let state = read_state(client, &event, &schema, relay).await?;
+            let mut events = vec![event];
+            if let Some(state) = state {
+                events.push(state);
+            }
+            println!("{}", serde_json::to_string(&events).map_err(usage)?);
+        }
+        InteractionsCmd::Wait { prompt, timeout } => {
+            let timeout = duration(&timeout)?;
+            let (event, schema) = read_prompt(client, &prompt).await?;
+            let wait = async {
+                loop {
+                    if let Some(state) = read_state(client, &event, &schema, relay).await? {
+                        let summary: Value = serde_json::from_str(&state.content).map_err(usage)?;
+                        if summary["status"] == "closed" {
+                            println!("{}", serde_json::to_string(&[state]).map_err(usage)?);
+                            return Ok::<(), CliError>(());
+                        }
+                    }
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            };
+            tokio::time::timeout(timeout, wait).await.map_err(|_| {
+                CliError::Other(
+                    "timed out waiting for interaction close; no decision inferred".into(),
+                )
+            })??;
+        }
+        InteractionsCmd::Close { prompt } => {
+            let (event, schema) = read_prompt(client, &prompt).await?;
+            let builder =
+                EventBuilder::new(Kind::Custom(KIND_INTERACTION_CLOSE as u16), "").tags([
+                    pair("h", schema.channel)?,
+                    parse_tag(vec![
+                        "e".into(),
+                        event.id.to_hex(),
+                        "".into(),
+                        "prompt".into(),
+                    ])?,
+                ]);
+            println!(
+                "{}",
+                normalize_write_response(&client.submit_event(client.sign_event(builder)?).await?)
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "interactions_http_tests.rs"]
+mod http_tests;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn durations_are_bounded_and_do_not_overflow() {
+        for value in ["0", "0s", "-1h", "31d", "18446744073709551615d", "x"] {
+            assert!(duration(value).is_err(), "{value}");
+        }
+        assert_eq!(duration("24h").unwrap().as_secs(), 86400);
+        assert_eq!(duration("30d").unwrap().as_secs(), MAX_LIFETIME);
+    }
+    #[test]
+    fn capability_requires_both_the_extension_and_relay_identity() {
+        let key = nostr::Keys::generate().public_key();
+        assert!(relay_identity(&json!({"self":key.to_hex()})).is_err());
+        assert!(relay_identity(&json!({"supported_extensions":[EXTENSION]})).is_err());
+        assert_eq!(
+            relay_identity(&json!({"supported_extensions":[EXTENSION],"self":key.to_hex()}))
+                .unwrap(),
+            key
+        );
+    }
+}

--- a/crates/buzz-cli/src/commands/interactions_http_tests.rs
+++ b/crates/buzz-cli/src/commands/interactions_http_tests.rs
@@ -1,0 +1,180 @@
+//! Exercise actual clap parsing, dispatch, signing and HTTP requests. The remote
+//! fixture returns known signed states; relay state-machine behavior is tested
+//! separately through the DB's acceptance seam.
+use super::*;
+use axum::{
+    extract::State,
+    routing::{get, post},
+    Json, Router,
+};
+use clap::Parser;
+use nostr::Keys;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+#[derive(Parser)]
+struct Command {
+    #[command(subcommand)]
+    cmd: InteractionsCmd,
+}
+
+struct Bridge {
+    relay: Keys,
+    enabled: AtomicBool,
+    closed: AtomicBool,
+    foreign_state: AtomicBool,
+    posted: Mutex<Vec<Event>>,
+    filters: Mutex<Vec<Value>>,
+}
+
+async fn info(State(s): State<Arc<Bridge>>) -> Json<Value> {
+    Json(
+        json!({"self":s.relay.public_key().to_hex(),"supported_extensions":if s.enabled.load(Ordering::SeqCst) {vec![EXTENSION]} else {vec![]}}),
+    )
+}
+
+async fn submit(State(s): State<Arc<Bridge>>, Json(event): Json<Event>) -> Json<Value> {
+    event.verify().unwrap();
+    let id = event.id.to_hex();
+    if event.kind.as_u16() as u32 == KIND_INTERACTION_RESPONSE {
+        assert_eq!(
+            buzz_core::interaction::single_tag(&event, "choice").unwrap(),
+            Some("approve")
+        );
+        s.closed.store(true, Ordering::SeqCst);
+    }
+    s.posted.lock().unwrap().push(event);
+    Json(json!({"event_id":id,"accepted":true,"message":""}))
+}
+
+async fn query(State(s): State<Arc<Bridge>>, Json(filters): Json<Vec<Value>>) -> Json<Vec<Event>> {
+    assert_eq!(filters.len(), 1);
+    let filter = filters[0].clone();
+    s.filters.lock().unwrap().push(filter.clone());
+    let posted = s.posted.lock().unwrap();
+    let Some(prompt) = posted
+        .iter()
+        .find(|e| e.kind.as_u16() as u32 == KIND_INTERACTION_PROMPT)
+    else {
+        return Json(vec![]);
+    };
+    if filter["kinds"][0] == KIND_INTERACTION_PROMPT {
+        assert_eq!(filter["ids"][0], prompt.id.to_hex());
+        return Json(vec![prompt.clone()]);
+    }
+    assert_eq!(filter["kinds"][0], KIND_INTERACTION_STATE);
+    assert_eq!(filter["authors"][0], s.relay.public_key().to_hex());
+    assert_eq!(filter["#d"][0], prompt.id.to_hex());
+    let channel = buzz_core::interaction::channel(prompt).unwrap().to_string();
+    assert_eq!(filter["#h"][0], channel);
+    let closed = s.closed.load(Ordering::SeqCst);
+    let foreign = Keys::generate();
+    let event = EventBuilder::new(Kind::Custom(KIND_INTERACTION_STATE as u16),json!({"version":1,"revision":if closed {1} else {0},"status":if closed {"closed"} else {"open"},"close_reason":if closed {Some("first")} else {None},"winner":if closed {Some("approve")} else {None},"tally":{"approve":if closed {1} else {0},"deny":0},"responders":[]}).to_string())
+        .tags([pair("d",prompt.id).unwrap(),pair("h",channel).unwrap()])
+        .sign_with_keys(if s.foreign_state.load(Ordering::SeqCst) { &foreign } else { &s.relay }).unwrap();
+    Json(vec![event])
+}
+
+#[tokio::test]
+async fn interactions_dispatch_round_trip_and_capability_failure() {
+    let state = Arc::new(Bridge {
+        relay: Keys::generate(),
+        enabled: AtomicBool::new(false),
+        closed: AtomicBool::new(false),
+        foreign_state: AtomicBool::new(false),
+        posted: Mutex::new(vec![]),
+        filters: Mutex::new(vec![]),
+    });
+    let app = Router::new()
+        .route("/info", get(info))
+        .route("/events", post(submit))
+        .route("/query", post(query))
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+    let channel = uuid::Uuid::new_v4().to_string();
+    let ask = || {
+        Command::try_parse_from([
+            "interactions",
+            "ask",
+            "--channel",
+            &channel,
+            "--text",
+            "Render E001?",
+            "--option",
+            "approve:Approve:primary",
+            "--option",
+            "deny:Deny:danger",
+            "--expires",
+            "1h",
+        ])
+        .unwrap()
+        .cmd
+    };
+    assert!(dispatch(ask(), &client).await.is_err());
+    assert!(state.posted.lock().unwrap().is_empty());
+    state.enabled.store(true, Ordering::SeqCst);
+    dispatch(ask(), &client).await.unwrap();
+    let prompt = state.posted.lock().unwrap()[0].clone();
+    assert_eq!(prompt.pubkey, client.keys().public_key());
+    assert_eq!(Prompt::parse(&prompt).unwrap().options.len(), 2);
+    let id = prompt.id.to_hex();
+    let answer = Command::try_parse_from([
+        "interactions",
+        "answer",
+        "--prompt",
+        &id,
+        "--choice",
+        "approve",
+        "--comment",
+        "Ready",
+    ])
+    .unwrap()
+    .cmd;
+    dispatch(answer, &client).await.unwrap();
+    let response = state.posted.lock().unwrap()[1].clone();
+    assert_eq!(response.pubkey, client.keys().public_key());
+    assert_eq!(response.content, "Ready");
+    assert_eq!(
+        buzz_core::interaction::prompt_id(&response).unwrap(),
+        prompt.id
+    );
+    dispatch(InteractionsCmd::Get { prompt: id.clone() }, &client)
+        .await
+        .unwrap();
+    dispatch(
+        InteractionsCmd::Wait {
+            prompt: id.clone(),
+            timeout: "1s".into(),
+        },
+        &client,
+    )
+    .await
+    .unwrap();
+    state.foreign_state.store(true, Ordering::SeqCst);
+    assert!(
+        dispatch(InteractionsCmd::Get { prompt: id.clone() }, &client)
+            .await
+            .is_err()
+    );
+    state.foreign_state.store(false, Ordering::SeqCst);
+    state.closed.store(false, Ordering::SeqCst);
+    assert!(matches!(
+        dispatch(
+            InteractionsCmd::Wait {
+                prompt: id,
+                timeout: "1s".into()
+            },
+            &client
+        )
+        .await,
+        Err(CliError::Other(_))
+    ));
+    server.abort();
+}

--- a/crates/buzz-cli/src/commands/mod.rs
+++ b/crates/buzz-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod dms;
 pub mod emoji;
 pub mod feed;
 pub mod gifs;
+pub mod interactions;
 pub mod issues;
 pub mod mem;
 pub mod messages;

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -174,6 +174,9 @@ pub enum OutputFormat {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Experimental signed buttons, forms and polls
+    #[command(subcommand)]
+    Interactions(commands::interactions::InteractionsCmd),
     /// Draft owner-reviewed agent creation and updates
     #[command(subcommand)]
     Agents(AgentsCmd),
@@ -2102,6 +2105,7 @@ async fn run(cli: Cli) -> Result<(), CliError> {
     let client = BuzzClient::new(relay_url, keys, auth_tag, auth_tag_json)?;
 
     match cli.command {
+        Cmd::Interactions(sub) => commands::interactions::dispatch(sub, &client).await,
         Cmd::Agents(sub) => commands::agents::dispatch(sub, &client).await,
         Cmd::Messages(sub) => commands::messages::dispatch(sub, &client, &cli.format).await,
         Cmd::Channels(sub) => commands::channels::dispatch(sub, &client, &cli.format).await,
@@ -2259,6 +2263,7 @@ mod tests {
             "emoji",
             "feed",
             "gifs",
+            "interactions",
             "issues",
             "media",
             "mem",
@@ -2442,6 +2447,10 @@ mod tests {
             vec!["assign", "create", "get", "list", "status", "unassign"]
         );
         assert_eq!(names(&cmd, "media"), vec!["get"]);
+        assert_eq!(
+            names(&cmd, "interactions"),
+            vec!["answer", "ask", "close", "get", "poll", "wait"]
+        );
         assert_eq!(names(&cmd, "upload"), vec!["file"]);
         assert_eq!(names(&cmd, "pack"), vec!["inspect", "validate"]);
         assert_eq!(
@@ -2468,6 +2477,7 @@ mod tests {
             ("dms", 4),
             ("emoji", 5),
             ("feed", 1),
+            ("interactions", 6),
             ("issues", 6),
             ("media", 1),
             ("messages", 8),

--- a/crates/buzz-core/src/interaction.rs
+++ b/crates/buzz-core/src/interaction.rs
@@ -1,0 +1,591 @@
+//! Experimental interaction protocol v1. See docs/experimental-interactions.md.
+//!
+//! Validation is shared by the relay and event builders. Visibility is public
+//! *within the channel's existing access boundary*. Private ballots and secret
+//! fields are rejected until every read/notification surface can protect them.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use nostr::{Event, EventBuilder, EventId, Kind, PublicKey, Tag, Timestamp};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::kind::{KIND_INTERACTION_PROMPT, KIND_INTERACTION_RESPONSE, KIND_INTERACTION_STATE};
+
+/// NIP-11 feature-detection token; changes when the experimental wire contract changes.
+pub const EXTENSION: &str = "buzz-interactions-v1";
+/// Maximum prompt lifetime (30 days).
+pub const MAX_LIFETIME: u64 = 30 * 24 * 60 * 60;
+/// Maximum distinct responders to one experimental prompt.
+pub const MAX_RESPONDERS: usize = 256;
+
+/// Invalid or unsupported interaction input.
+#[derive(Debug, thiserror::Error)]
+#[error("invalid: {0}")]
+pub struct InteractionError(pub String);
+
+type Result<T> = std::result::Result<T, InteractionError>;
+fn invalid(message: impl Into<String>) -> InteractionError {
+    InteractionError(message.into())
+}
+
+/// Parsed, bounded prompt schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Prompt {
+    /// Channel UUID, including for DMs.
+    pub channel: Uuid,
+    /// buttons, poll, or form.
+    pub itype: String,
+    /// Stable choice IDs with display labels and style hints.
+    pub options: Vec<Choice>,
+    /// Optional additional fields on buttons; required on forms.
+    pub fields: Vec<Field>,
+    /// members, listed, role:owner, or role:admin (community roles).
+    pub responders: String,
+    /// Eligible public keys when responders is listed.
+    pub listed: BTreeSet<String>,
+    /// Minimum choices per answer.
+    pub min: usize,
+    /// Maximum choices per answer.
+    pub max: usize,
+    /// first, quorum:N, manual, or expiry.
+    pub closes: String,
+    /// Absolute Unix deadline, evaluated using relay time.
+    pub deadline: u64,
+}
+
+/// One selectable option.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Choice {
+    /// Stable identifier used in answers.
+    pub id: String,
+    /// Human-readable label.
+    pub label: String,
+    /// primary, danger, or default.
+    pub style: String,
+}
+
+/// One non-secret input field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Field {
+    /// Stable identifier used in answers.
+    pub id: String,
+    /// Human-readable label.
+    pub label: String,
+    /// text, number, select, boolean, or date.
+    pub kind: String,
+    /// Whether an answer must include a value.
+    pub required: bool,
+    /// Stable value IDs with labels, for select fields only.
+    pub options: BTreeMap<String, String>,
+}
+
+/// Canonical parsed answer. Wire values remain strings; field types are validated.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Answer {
+    /// Unique choice IDs.
+    pub choices: BTreeSet<String>,
+    /// Field ID to validated wire value.
+    pub values: BTreeMap<String, String>,
+}
+
+/// Latest answer from one attributable actor, retained for replacements/audit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Vote {
+    /// The signed response event, or original signed message for text fallback.
+    pub source: Event,
+    /// Validated answer.
+    pub answer: Answer,
+}
+
+/// Durable state under the database's per-prompt lock.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InteractionState {
+    /// Number of committed transitions, for ordering same-second state events.
+    pub revision: u64,
+    /// None while open; first, quorum, manual, or expiry when closed.
+    pub close_reason: Option<String>,
+    /// Latest answer by actor public key (not the fallback relay signer).
+    pub votes: BTreeMap<String, Vote>,
+}
+
+fn tags<'a>(event: &'a Event, name: &'a str) -> impl Iterator<Item = &'a [String]> {
+    event
+        .tags
+        .iter()
+        .map(Tag::as_slice)
+        .filter(move |t| t.first().is_some_and(|s| s == name))
+}
+
+/// Read a unique two-element tag, rejecting duplicates and malformed instances.
+pub fn single_tag<'a>(event: &'a Event, name: &str) -> Result<Option<&'a str>> {
+    let mut found = None;
+    for t in event.tags.iter().map(Tag::as_slice) {
+        if t.first().is_some_and(|s| s == name) {
+            if t.len() != 2 || found.is_some() {
+                return Err(invalid(format!("expected one {name} tag with one value")));
+            }
+            found = Some(t[1].as_str());
+        }
+    }
+    Ok(found)
+}
+
+fn required_tag<'a>(event: &'a Event, name: &str) -> Result<&'a str> {
+    single_tag(event, name)?.ok_or_else(|| invalid(format!("missing {name} tag")))
+}
+
+fn identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"_-.".contains(&b))
+}
+fn label(value: &str) -> bool {
+    !value.trim().is_empty() && value.len() <= 256 && !value.chars().any(char::is_control)
+}
+/// Bound client interaction payloads and reject reserved relay provenance.
+pub fn validate_envelope(event: &Event) -> Result<()> {
+    if tags(event, "expiration").next().is_some() {
+        return Err(invalid(
+            "use deadline on the prompt; NIP-40 expiration would hide the signed decision",
+        ));
+    }
+    if event.content.len() > 16_384
+        || event.tags.len() > 128
+        || event
+            .tags
+            .iter()
+            .flat_map(Tag::as_slice)
+            .map(String::len)
+            .sum::<usize>()
+            > 32_768
+    {
+        return Err(invalid("interaction exceeds content or tag limits"));
+    }
+    // These tags assert relay provenance and are never accepted from clients.
+    if ["via", "actor", "interaction"]
+        .iter()
+        .any(|name| tags(event, name).next().is_some())
+    {
+        return Err(invalid("relay provenance tags are reserved"));
+    }
+    Ok(())
+}
+
+/// Resolve exactly one canonical channel tag.
+pub fn channel(event: &Event) -> Result<Uuid> {
+    let value = required_tag(event, "h")?;
+    let id = Uuid::parse_str(value).map_err(|_| invalid("h must be a channel UUID"))?;
+    if id.to_string() != value {
+        return Err(invalid("h must be a canonical channel UUID"));
+    }
+    Ok(id)
+}
+
+/// Resolve exactly one prompt-marked e tag. Thread root tags are separate.
+pub fn prompt_id(event: &Event) -> Result<EventId> {
+    let refs: Vec<_> = tags(event, "e")
+        .filter(|t| t.get(3).is_some_and(|m| m == "prompt"))
+        .collect();
+    if refs.len() != 1 || refs[0].len() != 4 {
+        return Err(invalid("expected one e tag marked prompt"));
+    }
+    EventId::from_hex(&refs[0][1]).map_err(|_| invalid("invalid prompt event ID"))
+}
+
+impl Prompt {
+    /// Parse a prompt's schema. Validation of its lifetime is separate for history reads.
+    pub fn parse(event: &Event) -> Result<Self> {
+        validate_envelope(event)?;
+        if event.kind.as_u16() as u32 != KIND_INTERACTION_PROMPT || event.content.trim().is_empty()
+        {
+            return Err(invalid("expected a prompt with nonempty question text"));
+        }
+        let channel = channel(event)?;
+        let itype = required_tag(event, "itype")?.to_string();
+        if !["buttons", "poll", "form"].contains(&itype.as_str()) {
+            return Err(invalid("unsupported itype"));
+        }
+        if single_tag(event, "visibility")?.unwrap_or("public") != "public" {
+            return Err(invalid(
+                "experimental v1 supports public channel-visible answers only",
+            ));
+        }
+        let mut options = Vec::new();
+        let mut ids = BTreeSet::new();
+        let mut labels = BTreeSet::new();
+        for t in tags(event, "opt") {
+            if !(3..=4).contains(&t.len()) || !identifier(&t[1]) || !label(&t[2]) {
+                return Err(invalid("opt requires id, label, and optional style"));
+            }
+            if !ids.insert(t[1].to_lowercase()) || !labels.insert(t[2].trim().to_lowercase()) {
+                return Err(invalid(
+                    "option IDs and labels must be unique ignoring case",
+                ));
+            }
+            let style = t.get(3).map(String::as_str).unwrap_or("default");
+            if !["default", "primary", "danger"].contains(&style) {
+                return Err(invalid("unknown option style"));
+            }
+            options.push(Choice {
+                id: t[1].clone(),
+                label: t[2].clone(),
+                style: style.into(),
+            });
+        }
+        // A label must not name another option's ID: fallback must be unambiguous.
+        for a in &options {
+            if options
+                .iter()
+                .any(|b| a.id != b.id && a.label.trim().eq_ignore_ascii_case(&b.id))
+            {
+                return Err(invalid("option label collides with another option ID"));
+            }
+        }
+        let mut fields = Vec::new();
+        let mut field_ids = BTreeSet::new();
+        for t in tags(event, "field") {
+            if t.len() != 5
+                || !identifier(&t[1])
+                || !label(&t[2])
+                || !field_ids.insert(t[1].clone())
+            {
+                return Err(invalid(
+                    "field requires unique id, label, type, required|optional",
+                ));
+            }
+            if !["text", "number", "select", "boolean", "date"].contains(&t[3].as_str()) {
+                return Err(invalid(
+                    "unsupported field type (secret fields are not supported)",
+                ));
+            }
+            if !["required", "optional"].contains(&t[4].as_str()) {
+                return Err(invalid("invalid field requirement"));
+            }
+            fields.push(Field {
+                id: t[1].clone(),
+                label: t[2].clone(),
+                kind: t[3].clone(),
+                required: t[4] == "required",
+                options: BTreeMap::new(),
+            });
+        }
+        for t in tags(event, "optsel") {
+            if !(3..=4).contains(&t.len()) || !identifier(&t[2]) {
+                return Err(invalid("optsel requires field, value, optional label"));
+            }
+            let field = fields
+                .iter_mut()
+                .find(|f| f.id == t[1] && f.kind == "select")
+                .ok_or_else(|| invalid("optsel must reference a select field"))?;
+            let display = t.get(3).unwrap_or(&t[2]);
+            if !label(display)
+                || field
+                    .options
+                    .insert(t[2].clone(), display.clone())
+                    .is_some()
+            {
+                return Err(invalid("invalid or duplicate select option"));
+            }
+        }
+        if fields
+            .iter()
+            .any(|f| f.kind == "select" && !(1..=12).contains(&f.options.len()))
+        {
+            return Err(invalid("select fields need 1 to 12 options"));
+        }
+        if fields.len() > 12
+            || (itype == "form" && (fields.is_empty() || !options.is_empty()))
+            || (itype == "poll" && (!(2..=12).contains(&options.len()) || !fields.is_empty()))
+            || (itype == "buttons" && !(1..=8).contains(&options.len()))
+        {
+            return Err(invalid(
+                "options/fields do not satisfy the interaction type limits",
+            ));
+        }
+        let default_min = if itype == "form" { "0" } else { "1" };
+        let min = single_tag(event, "min")?
+            .unwrap_or(default_min)
+            .parse::<usize>()
+            .map_err(|_| invalid("min must be an integer"))?;
+        let max = single_tag(event, "max")?
+            .unwrap_or(default_min)
+            .parse::<usize>()
+            .map_err(|_| invalid("max must be an integer"))?;
+        if min > max
+            || max > options.len()
+            || (itype == "buttons" && (min != 1 || max != 1))
+            || (itype == "poll" && min == 0)
+        {
+            return Err(invalid("invalid min/max choices"));
+        }
+        let responders = single_tag(event, "responders")?
+            .unwrap_or("members")
+            .to_string();
+        if !["members", "listed", "role:owner", "role:admin"].contains(&responders.as_str()) {
+            return Err(invalid("unsupported responder rule"));
+        }
+        let mut listed = BTreeSet::new();
+        for t in tags(event, "p") {
+            if t.len() < 2 {
+                return Err(invalid("p tag requires a public key"));
+            }
+            let pk =
+                PublicKey::from_hex(&t[1]).map_err(|_| invalid("invalid responder public key"))?;
+            listed.insert(pk.to_hex());
+        }
+        if listed.len() > MAX_RESPONDERS || (responders == "listed" && listed.is_empty()) {
+            return Err(invalid("listed responders need 1 to 256 public keys"));
+        }
+        let closes = required_tag(event, "closes")?.to_string();
+        let quorum = closes
+            .strip_prefix("quorum:")
+            .and_then(|n| n.parse::<usize>().ok());
+        if !["first", "manual", "expiry"].contains(&closes.as_str())
+            && !quorum.is_some_and(|n| (1..=MAX_RESPONDERS).contains(&n))
+        {
+            return Err(invalid(
+                "closes must be first, quorum:1..256, manual, or expiry",
+            ));
+        }
+        if itype == "poll" && !["manual", "expiry"].contains(&closes.as_str()) {
+            return Err(invalid("polls close manually or at expiry"));
+        }
+        let deadline = required_tag(event, "deadline")?
+            .parse::<u64>()
+            .map_err(|_| invalid("deadline must be Unix seconds"))?;
+        Ok(Self {
+            channel,
+            itype,
+            options,
+            fields,
+            responders,
+            listed,
+            min,
+            max,
+            closes,
+            deadline,
+        })
+    }
+
+    /// Require an unexpired prompt with a bounded deadline when it is first posted.
+    pub fn validate_lifetime(&self, now: u64) -> Result<()> {
+        if self.deadline <= now || self.deadline.saturating_sub(now) > MAX_LIFETIME {
+            return Err(invalid("deadline must be in the next 30 days"));
+        }
+        Ok(())
+    }
+
+    /// Validate an answer against the complete schema, including duplicate/unknown fields.
+    pub fn answer(&self, event: &Event) -> Result<Answer> {
+        validate_envelope(event)?;
+        if event.kind.as_u16() as u32 != KIND_INTERACTION_RESPONSE
+            || channel(event)? != self.channel
+        {
+            return Err(invalid("response must be in the prompt's channel"));
+        }
+        prompt_id(event)?;
+        let mut answer = Answer::default();
+        for t in tags(event, "choice") {
+            if t.len() != 2 || !self.options.iter().any(|o| o.id == t[1]) {
+                return Err(invalid("choice not in prompt"));
+            }
+            if !answer.choices.insert(t[1].clone()) {
+                return Err(invalid("duplicate choice"));
+            }
+        }
+        if answer.choices.len() < self.min || answer.choices.len() > self.max {
+            return Err(invalid("answer violates min/max choices"));
+        }
+        let mut value_bytes = 0;
+        for t in tags(event, "value") {
+            if t.len() != 3 {
+                return Err(invalid("value requires field ID and value"));
+            }
+            let field = self
+                .fields
+                .iter()
+                .find(|f| f.id == t[1])
+                .ok_or_else(|| invalid("unknown field ID"))?;
+            field.validate(&t[2])?;
+            value_bytes += t[2].len();
+            if value_bytes > 8192 || answer.values.insert(t[1].clone(), t[2].clone()).is_some() {
+                return Err(invalid("duplicate field or values exceed 8192 bytes"));
+            }
+        }
+        if self
+            .fields
+            .iter()
+            .any(|f| f.required && !answer.values.contains_key(&f.id))
+        {
+            return Err(invalid("required field missing"));
+        }
+        Ok(answer)
+    }
+
+    /// Exact whole-reply fallback. Punctuation and prose are intentionally not stripped.
+    pub fn text_answer(&self, content: &str) -> Option<Answer> {
+        if self.itype == "form" || self.fields.iter().any(|f| f.required) {
+            return None;
+        }
+        let matches: Vec<_> = self
+            .options
+            .iter()
+            .filter(|o| {
+                o.id.to_lowercase() == content.trim().to_lowercase()
+                    || o.label.trim().to_lowercase() == content.trim().to_lowercase()
+            })
+            .collect();
+        if matches.len() != 1 || self.min > 1 {
+            return None;
+        }
+        Some(Answer {
+            choices: BTreeSet::from([matches[0].id.clone()]),
+            values: BTreeMap::new(),
+        })
+    }
+}
+
+impl Field {
+    fn validate(&self, value: &str) -> Result<()> {
+        if value.len() > 4096 || (self.required && value.trim().is_empty()) {
+            return Err(invalid(format!("invalid value for {}", self.id)));
+        }
+        let valid = match self.kind.as_str() {
+            "text" => true,
+            "number" => value.parse::<f64>().is_ok_and(f64::is_finite),
+            "boolean" => ["true", "false"].contains(&value),
+            "date" => chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .is_ok_and(|d| d.format("%Y-%m-%d").to_string() == value),
+            "select" => self.options.contains_key(value),
+            _ => false,
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(invalid(format!(
+                "invalid {} value for {}",
+                self.kind, self.id
+            )))
+        }
+    }
+}
+
+impl InteractionState {
+    /// Apply one validated, authorized response. Equal timestamps follow NIP-01's lower-ID tie break.
+    pub fn respond(
+        &mut self,
+        prompt: &Prompt,
+        source: Event,
+        answer: Answer,
+        now: u64,
+    ) -> Result<bool> {
+        let actor = source.pubkey.to_hex();
+        if self
+            .votes
+            .get(&actor)
+            .is_some_and(|v| v.source.id == source.id)
+        {
+            return Ok(false);
+        }
+        if self.close_reason.is_some() || now >= prompt.deadline {
+            return Err(invalid("prompt is closed"));
+        }
+        if let Some(previous) = self.votes.get(&actor) {
+            if source.created_at < previous.source.created_at
+                || (source.created_at == previous.source.created_at
+                    && source.id > previous.source.id)
+            {
+                return Err(invalid("response superseded by a newer answer"));
+            }
+        } else if self.votes.len() >= MAX_RESPONDERS {
+            return Err(invalid("prompt responder limit reached"));
+        }
+        self.votes.insert(actor, Vote { source, answer });
+        self.revision += 1;
+        if prompt.closes == "first" {
+            self.close_reason = Some("first".into());
+        }
+        if prompt
+            .closes
+            .strip_prefix("quorum:")
+            .and_then(|n| n.parse::<usize>().ok())
+            .is_some_and(|n| self.votes.len() >= n)
+        {
+            self.close_reason = Some("quorum".into());
+        }
+        Ok(true)
+    }
+
+    /// Close exactly once. Expiry is also enforced synchronously on answer ingest.
+    pub fn close(&mut self, reason: &str) -> bool {
+        if self.close_reason.is_some() {
+            return false;
+        }
+        self.close_reason = Some(reason.into());
+        self.revision += 1;
+        true
+    }
+
+    /// Public channel-visible state. Ties have no winner. The values shortcut is
+    /// present only for one responder; event IDs identify every signed answer.
+    pub fn summary(&self, prompt: &Prompt) -> serde_json::Value {
+        let mut tally: BTreeMap<_, usize> =
+            prompt.options.iter().map(|o| (o.id.clone(), 0)).collect();
+        for vote in self.votes.values() {
+            for choice in &vote.answer.choices {
+                if let Some(count) = tally.get_mut(choice) {
+                    *count += 1;
+                }
+            }
+        }
+        let high = tally.values().copied().max().unwrap_or(0);
+        let winners: Vec<_> = tally
+            .iter()
+            .filter(|(_, n)| **n == high && high > 0)
+            .map(|(id, _)| id)
+            .collect();
+        let winner =
+            if self.close_reason.is_some() && winners.len() == 1 && prompt.itype == "buttons" {
+                Some(winners[0])
+            } else {
+                None
+            };
+        serde_json::json!({
+            "version": 1, "revision": self.revision,
+            "status": if self.close_reason.is_some() { "closed" } else { "open" },
+            "close_reason": self.close_reason, "tally": tally, "winner": winner,
+            "values": if self.votes.len() == 1 { self.votes.values().next().map(|v| &v.answer.values) } else { None },
+            "responders": self.votes.iter().map(|(pk, v)| serde_json::json!({"pubkey": pk, "event_id": v.source.id.to_hex(), "created_at": v.source.created_at.as_secs(), "choices": v.answer.choices})).collect::<Vec<_>>(),
+        })
+    }
+
+    /// Build a relay-signed state projection. The caller supplies its monotonic timestamp.
+    pub fn event_builder(
+        &self,
+        prompt_id: EventId,
+        prompt: &Prompt,
+        timestamp: u64,
+    ) -> Result<EventBuilder> {
+        let tags = [
+            ["d".to_string(), prompt_id.to_hex()],
+            ["h".to_string(), prompt.channel.to_string()],
+        ]
+        .into_iter()
+        .map(Tag::parse)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| invalid(e.to_string()))?;
+        Ok(EventBuilder::new(
+            Kind::Custom(KIND_INTERACTION_STATE as u16),
+            self.summary(prompt).to_string(),
+        )
+        .tags(tags)
+        .custom_created_at(Timestamp::from(timestamp)))
+    }
+}
+
+#[cfg(test)]
+#[path = "interaction_tests.rs"]
+mod tests;

--- a/crates/buzz-core/src/interaction_tests.rs
+++ b/crates/buzz-core/src/interaction_tests.rs
@@ -1,0 +1,208 @@
+use super::*;
+use nostr::Keys;
+
+fn event(kind: u32, content: &str, extra: &[&[&str]], keys: &Keys, time: u64) -> Event {
+    let mut ts = vec![Tag::parse(["h", "00000000-0000-0000-0000-000000000001"]).unwrap()];
+    ts.extend(extra.iter().map(|t| Tag::parse(t.iter().copied()).unwrap()));
+    EventBuilder::new(Kind::Custom(kind as u16), content)
+        .tags(ts)
+        .custom_created_at(Timestamp::from(time))
+        .sign_with_keys(keys)
+        .unwrap()
+}
+fn prompt(extra: &[&[&str]]) -> Event {
+    let mut ts = vec![
+        &["itype", "buttons"][..],
+        &["opt", "approve", "Approve", "primary"],
+        &["opt", "deny", "Deny", "danger"],
+        &["closes", "first"],
+        &["deadline", "2000"],
+    ];
+    ts.extend_from_slice(extra);
+    event(
+        KIND_INTERACTION_PROMPT,
+        "Render?",
+        &ts,
+        &Keys::generate(),
+        1000,
+    )
+}
+fn response(pk: &Keys, choice: &str, time: u64) -> Event {
+    event(
+        KIND_INTERACTION_RESPONSE,
+        "",
+        &[&["e", &"a".repeat(64), "", "prompt"], &["choice", choice]],
+        pk,
+        time,
+    )
+}
+
+#[test]
+fn schema_rejects_ambiguous_or_unsafe_prompts() {
+    assert!(Prompt::parse(&prompt(&[])).is_ok());
+    for extra in [
+        vec![&["itype", "poll"][..]],
+        vec![&["visibility", "asker-only"][..]],
+        vec![&["visibility", "tallies-only"][..]],
+        vec![&["expiration", "2000"][..]],
+        vec![&["field", "password", "Password", "secret", "required"][..]],
+        vec![&["opt", "APPROVE", "Other"][..]],
+        vec![&["opt", "other", "Approve"][..]],
+        vec![&["opt", "other", "deny"][..]],
+        vec![&["responders", "listed"][..]],
+        vec![&["max", "2"][..]],
+        vec![&["via", "forged"][..]],
+    ] {
+        assert!(
+            Prompt::parse(&prompt(&extra)).is_err(),
+            "accepted {extra:?}"
+        );
+    }
+    let p = Prompt::parse(&prompt(&[])).unwrap();
+    assert!(p.validate_lifetime(1000).is_ok());
+    assert!(p.validate_lifetime(2000).is_err());
+    assert!(p.text_answer(" \nAPPROVE\t").is_some());
+    for text in ["approve!", "approve but revise", "approved", ""] {
+        assert!(p.text_answer(text).is_none());
+    }
+}
+
+#[test]
+fn validation_and_replacement_have_one_actor_one_vote() {
+    let mut p = Prompt::parse(&prompt(&[])).unwrap();
+    p.closes = "manual".into();
+    let k = Keys::generate();
+    let mut state = InteractionState::default();
+    let a = response(&k, "approve", 1000);
+    assert!(state
+        .respond(&p, a.clone(), p.answer(&a).unwrap(), 1000)
+        .unwrap());
+    assert!(!state
+        .respond(&p, a.clone(), p.answer(&a).unwrap(), 1000)
+        .unwrap());
+    let b = response(&k, "deny", 1001);
+    state
+        .respond(&p, b.clone(), p.answer(&b).unwrap(), 1001)
+        .unwrap();
+    assert_eq!(state.summary(&p)["tally"]["approve"], 0);
+    assert_eq!(state.summary(&p)["tally"]["deny"], 1);
+    assert_eq!(state.votes.len(), 1);
+    assert!(state
+        .respond(&p, a.clone(), p.answer(&a).unwrap(), 1002)
+        .is_err());
+    assert!(p.answer(&response(&k, "maybe", 1001)).is_err());
+    state.close("manual");
+    assert!(state
+        .respond(&p, response(&k, "approve", 1003), Answer::default(), 1003)
+        .is_err());
+    assert!(!state.close("expiry"));
+}
+
+#[test]
+fn close_rules_ties_and_deadline_are_deterministic() {
+    let p = Prompt::parse(&prompt(&[])).unwrap();
+    let a = response(&Keys::generate(), "approve", 1000);
+    let b = response(&Keys::generate(), "deny", 1001);
+    let mut state = InteractionState::default();
+    state
+        .respond(&p, a.clone(), p.answer(&a).unwrap(), 1000)
+        .unwrap();
+    assert_eq!(state.summary(&p)["winner"], "approve");
+    assert!(state
+        .respond(&p, b.clone(), p.answer(&b).unwrap(), 1001)
+        .is_err());
+    let mut p = p;
+    p.closes = "quorum:2".into();
+    let mut state = InteractionState::default();
+    state
+        .respond(&p, a.clone(), p.answer(&a).unwrap(), 1000)
+        .unwrap();
+    assert!(state.close_reason.is_none());
+    state
+        .respond(&p, b.clone(), p.answer(&b).unwrap(), 1001)
+        .unwrap();
+    assert_eq!(state.close_reason.as_deref(), Some("quorum"));
+    assert!(state.summary(&p)["winner"].is_null());
+    assert!(InteractionState::default()
+        .respond(&p, a.clone(), p.answer(&a).unwrap(), 2000)
+        .is_err());
+}
+
+#[test]
+fn forms_validate_real_values_and_required_fields() {
+    let k = Keys::generate();
+    let ev = event(
+        KIND_INTERACTION_PROMPT,
+        "Details?",
+        &[
+            &["itype", "form"],
+            &["closes", "first"],
+            &["deadline", "2000"],
+            &["field", "amount", "Amount", "number", "required"],
+            &["field", "date", "Date", "date", "optional"],
+            &["field", "ready", "Ready", "boolean", "optional"],
+            &["field", "size", "Size", "select", "optional"],
+            &["optsel", "size", "small", "Small"],
+        ],
+        &k,
+        1000,
+    );
+    let p = Prompt::parse(&ev).unwrap();
+    let make = |values: &[&[&str]]| {
+        let id = ev.id.to_hex();
+        let mut ts = vec![vec!["e", id.as_str(), "", "prompt"]];
+        ts.extend(values.iter().map(|t| t.to_vec()));
+        event(
+            KIND_INTERACTION_RESPONSE,
+            "",
+            &ts.iter().map(Vec::as_slice).collect::<Vec<_>>(),
+            &k,
+            1000,
+        )
+    };
+    assert!(p
+        .answer(&make(&[
+            &["value", "amount", "12.5"],
+            &["value", "date", "2026-09-08"],
+            &["value", "ready", "false"],
+            &["value", "size", "small"]
+        ]))
+        .is_ok());
+    for values in [
+        vec![],
+        vec![&["value", "amount", "NaN"][..]],
+        vec![&["value", "amount", "inf"][..]],
+        vec![&["value", "unknown", "12"][..]],
+        vec![&["value", "amount", "12"][..], &["value", "amount", "13"]],
+        vec![
+            &["value", "amount", "12"][..],
+            &["value", "date", "2026-02-30"],
+        ],
+        vec![&["value", "amount", "12"][..], &["value", "ready", "yes"]],
+        vec![&["value", "amount", "12"][..], &["value", "size", "large"]],
+    ] {
+        assert!(p.answer(&make(&values)).is_err(), "accepted {values:?}");
+    }
+}
+
+#[test]
+fn same_second_tie_break_is_independent_of_arrival_order() {
+    let mut p = Prompt::parse(&prompt(&[])).unwrap();
+    p.closes = "manual".into();
+    let k = Keys::generate();
+    let mut events = [response(&k, "approve", 1000), response(&k, "deny", 1000)];
+    events.sort_by_key(|e| e.id);
+    let mut state = InteractionState::default();
+    for ev in events.iter().rev() {
+        state
+            .respond(&p, ev.clone(), p.answer(ev).unwrap(), 1000)
+            .unwrap();
+    }
+    assert_eq!(
+        state.votes[&k.public_key().to_hex()].source.id,
+        events[0].id
+    );
+    assert!(state
+        .respond(&p, events[1].clone(), p.answer(&events[1]).unwrap(), 1000)
+        .is_err());
+}

--- a/crates/buzz-core/src/interaction_tests.rs
+++ b/crates/buzz-core/src/interaction_tests.rs
@@ -206,3 +206,85 @@ fn same_second_tie_break_is_independent_of_arrival_order() {
         .respond(&p, events[1].clone(), p.answer(&events[1]).unwrap(), 1000)
         .is_err());
 }
+
+/// A hand-authored control trace: Discord-style multi-choice selection, then
+/// GroupMe-style vote replacement before close. Expected counts are independent
+/// of the implementation's tally calculation; see docs/interaction-controls.md.
+#[test]
+fn poll_control_trace_replaces_the_entire_selection_and_keeps_evidence() {
+    let asker = Keys::generate();
+    let prompt_event = event(
+        KIND_INTERACTION_PROMPT,
+        "Choose a thumbnail",
+        &[
+            &["itype", "poll"],
+            &["opt", "a", "Door"],
+            &["opt", "b", "Key"],
+            &["opt", "c", "Hall"],
+            &["min", "1"],
+            &["max", "2"],
+            &["closes", "manual"],
+            &["deadline", "2000"],
+        ],
+        &asker,
+        1000,
+    );
+    let p = Prompt::parse(&prompt_event).unwrap();
+    let alice = Keys::generate();
+    let bob = Keys::generate();
+    let make = |key: &Keys, choices: &[&str], time| {
+        let mut tags = vec![vec![
+            "e".to_string(),
+            prompt_event.id.to_hex(),
+            "".into(),
+            "prompt".into(),
+        ]];
+        tags.extend(choices.iter().map(|id| vec!["choice".into(), (*id).into()]));
+        let tags: Vec<Vec<&str>> = tags
+            .iter()
+            .map(|t| t.iter().map(String::as_str).collect())
+            .collect();
+        event(
+            KIND_INTERACTION_RESPONSE,
+            "",
+            &tags.iter().map(Vec::as_slice).collect::<Vec<_>>(),
+            key,
+            time,
+        )
+    };
+    for choices in [vec![], vec!["a", "b", "c"], vec!["a", "a"], vec!["unknown"]] {
+        assert!(p.answer(&make(&alice, &choices, 1001)).is_err());
+    }
+    let first = make(&alice, &["a", "b"], 1001);
+    let other = make(&bob, &["b"], 1001);
+    let revised = make(&alice, &["c"], 1002);
+    let mut state = InteractionState::default();
+    for (ev, tally) in [
+        (&first, serde_json::json!({"a":1,"b":1,"c":0})),
+        (&other, serde_json::json!({"a":1,"b":2,"c":0})),
+        (&revised, serde_json::json!({"a":0,"b":1,"c":1})),
+    ] {
+        ev.verify().unwrap();
+        state
+            .respond(&p, ev.clone(), p.answer(ev).unwrap(), 1002)
+            .unwrap();
+        let summary = state.summary(&p);
+        assert_eq!(summary["tally"], tally);
+        assert_eq!(summary["status"], "open");
+        assert!(summary["winner"].is_null());
+    }
+    assert_eq!(state.votes.len(), 2);
+    assert_eq!(
+        state.votes[&alice.public_key().to_hex()].source.id,
+        revised.id
+    );
+    state.close("manual");
+    let late = make(&bob, &["a"], 1003);
+    assert!(state
+        .respond(&p, late.clone(), p.answer(&late).unwrap(), 1003)
+        .is_err());
+    assert_eq!(
+        state.summary(&p)["tally"],
+        serde_json::json!({"a":0,"b":1,"c":1})
+    );
+}

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -491,6 +491,14 @@ pub const KIND_STREAM_MESSAGE_SCHEDULED: u32 = 40006;
 pub const KIND_STREAM_REMINDER: u32 = 40007;
 /// A diff/patch message showing file changes (unified diff format).
 pub const KIND_STREAM_MESSAGE_DIFF: u32 = 40008;
+/// Experimental channel interaction prompt (typed schema in tags).
+pub const KIND_INTERACTION_PROMPT: u32 = 40010;
+/// Experimental responder-signed interaction answer.
+pub const KIND_INTERACTION_RESPONSE: u32 = 40011;
+/// Experimental asker-signed close command; does not delete the prompt.
+pub const KIND_INTERACTION_CLOSE: u32 = 40012;
+/// Experimental relay-signed, addressable interaction state; d = prompt ID.
+pub const KIND_INTERACTION_STATE: u32 = 39010;
 /// Canvas (shared document) for a channel.
 pub const KIND_CANVAS: u32 = 40100;
 /// System message for channel state changes (join, leave, rename, etc.).
@@ -635,6 +643,10 @@ pub const KIND_PROJECT: u32 = 30621;
 
 /// All registered kind constants — used for duplicate detection and iteration.
 pub const ALL_KINDS: &[u32] = &[
+    KIND_INTERACTION_PROMPT,
+    KIND_INTERACTION_RESPONSE,
+    KIND_INTERACTION_CLOSE,
+    KIND_INTERACTION_STATE,
     KIND_PROFILE,
     KIND_TEXT_NOTE,
     KIND_CONTACT_LIST,
@@ -834,6 +846,7 @@ pub const fn is_relay_only_kind(kind: u32) -> bool {
     matches!(
         kind,
         KIND_NIP43_MEMBERSHIP_LIST
+            | KIND_INTERACTION_STATE
             | KIND_CHANNEL_SUMMARY
             | KIND_PRESENCE_SNAPSHOT
             | KIND_DM_VISIBILITY

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -20,6 +20,8 @@ pub mod event;
 pub mod filter;
 /// Git permission types — ref patterns, protection rules, policy evaluation.
 pub mod git_perms;
+/// Experimental signed questions, answers, and authoritative state.
+pub mod interaction;
 /// Shared invite-link contract constants.
 pub mod invite;
 /// Buzz kind number registry — custom event type constants.

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -48,9 +48,9 @@ pub(crate) use runtime::{
 };
 pub use store::{
     admin_moderation, allowlist, api_token, archived_identities, channel, channel_members,
-    community, deletion, dm, event, feed, git_repo, moderation, partition, product_feedback, push,
-    reaction, relay_admin_actions, relay_invite, relay_members, relay_operators, reminder,
-    replaceable, thread, usage, user, workflow,
+    community, deletion, dm, event, feed, git_repo, interaction, moderation, partition,
+    product_feedback, push, reaction, relay_admin_actions, relay_invite, relay_members,
+    relay_operators, reminder, replaceable, thread, usage, user, workflow,
 };
 
 pub use allowlist::AllowlistEntry;

--- a/crates/buzz-db/src/runtime/migration.rs
+++ b/crates/buzz-db/src/runtime/migration.rs
@@ -702,7 +702,8 @@ mod postgres_tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 44);
+        assert_eq!(migrations.len(), 45);
+        assert_eq!(migrations[44].version, 45);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]

--- a/crates/buzz-db/src/store/deletion.rs
+++ b/crates/buzz-db/src/store/deletion.rs
@@ -65,6 +65,8 @@ pub const EXPECTED_SCOPED_TABLES: &[&str] = &[
     "event_mentions",
     "events",
     "git_repo_names",
+    "interaction_outbox",
+    "interactions",
     "join_policy_acceptances",
     "moderation_actions",
     "moderation_reports",
@@ -87,6 +89,8 @@ pub const EXPECTED_SCOPED_TABLES: &[&str] = &[
 
 /// Foreign-key-safe child-before-parent order for the PostgreSQL purge.
 pub const PURGE_SCOPED_TABLES: &[&str] = &[
+    "interaction_outbox",
+    "interactions",
     "workflow_approvals",
     "scheduled_workflow_fires",
     "workflow_runs",

--- a/crates/buzz-db/src/store/interaction.rs
+++ b/crates/buzz-db/src/store/interaction.rs
@@ -1,0 +1,535 @@
+//! Transactional experimental interactions. Every decision and its signed state
+//! commit together. The prompt row is the serialization point across relay pods.
+
+use buzz_core::interaction::{self, Answer, InteractionState, Prompt};
+use buzz_core::kind::{
+    KIND_INTERACTION_CLOSE, KIND_INTERACTION_PROMPT, KIND_INTERACTION_RESPONSE, KIND_STREAM_MESSAGE,
+};
+use buzz_core::{CommunityId, StoredEvent};
+use nostr::{Event, EventBuilder, Keys, Kind, Tag};
+use sqlx::{Postgres, Row, Transaction};
+use uuid::Uuid;
+
+use crate::{event::ThreadMetadataParams, Db, DbError, Result};
+
+struct StateUpdate<'a> {
+    prompt: &'a Event,
+    schema: &'a Prompt,
+    state: &'a InteractionState,
+    timestamp: u64,
+}
+
+fn invalid(error: impl std::fmt::Display) -> DbError {
+    DbError::InvalidData(error.to_string())
+}
+fn tag(parts: Vec<String>) -> Result<Tag> {
+    Tag::parse(parts).map_err(invalid)
+}
+fn sign(builder: EventBuilder, keys: &Keys) -> Result<Event> {
+    builder.sign_with_keys(keys).map_err(invalid)
+}
+
+async fn now(tx: &mut Transaction<'_, Postgres>) -> Result<u64> {
+    let seconds: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()))::bigint")
+            .fetch_one(&mut **tx)
+            .await?;
+    Ok(seconds as u64)
+}
+
+async fn active_member(
+    tx: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    channel: Uuid,
+    author: &nostr::PublicKey,
+) -> Result<()> {
+    // Holding the actual row prevents removal from committing during acceptance.
+    let member: Option<Vec<u8>> = sqlx::query_scalar("SELECT pubkey FROM channel_members WHERE community_id=$1 AND channel_id=$2 AND pubkey=$3 AND removed_at IS NULL FOR SHARE")
+        .bind(community.as_uuid()).bind(channel).bind(author.to_bytes().as_slice()).fetch_optional(&mut **tx).await?;
+    if member.is_none() {
+        return Err(DbError::AccessDenied(
+            "interactions require current channel membership".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn allowed(
+    tx: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    p: &Prompt,
+    actor: &nostr::PublicKey,
+) -> Result<()> {
+    active_member(tx, community, p.channel, actor).await?;
+    let yes = match p.responders.as_str() {
+        "members" => true,
+        "listed" => p.listed.contains(&actor.to_hex()),
+        rule => {
+            let role: Option<String> = sqlx::query_scalar(
+                "SELECT role FROM relay_members WHERE community_id=$1 AND pubkey=$2 FOR SHARE",
+            )
+            .bind(community.as_uuid())
+            .bind(actor.to_hex())
+            .fetch_optional(&mut **tx)
+            .await?;
+            match rule {
+                "role:owner" => role.as_deref() == Some("owner"),
+                "role:admin" => matches!(role.as_deref(), Some("owner" | "admin")),
+                _ => false,
+            }
+        }
+    };
+    if yes {
+        Ok(())
+    } else {
+        Err(DbError::AccessDenied("not an eligible responder".into()))
+    }
+}
+
+async fn queue(
+    tx: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    channel: Uuid,
+    event: &Event,
+) -> Result<()> {
+    sqlx::query("INSERT INTO interaction_outbox (community_id,event_id,channel_id,event) VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING")
+        .bind(community.as_uuid()).bind(event.id.as_bytes().as_slice()).bind(channel).bind(serde_json::to_value(event)?).execute(&mut **tx).await?;
+    Ok(())
+}
+
+async fn store(
+    tx: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    channel: Uuid,
+    event: &Event,
+    meta: Option<ThreadMetadataParams<'_>>,
+) -> Result<StoredEvent> {
+    let (stored, inserted) = crate::event::insert_event_with_thread_metadata_tx(
+        tx,
+        community,
+        event,
+        Some(channel),
+        meta,
+    )
+    .await?;
+    if inserted {
+        crate::insert_mentions_in_transaction(tx, community, event, Some(channel)).await?;
+        queue(tx, community, channel, event).await?;
+    }
+    Ok(stored)
+}
+
+fn projection(prompt: &Event, p: &Prompt, keys: &Keys) -> Result<Event> {
+    let mut content = format!("{}\n\n", prompt.content);
+    for option in &p.options {
+        content.push_str(&format!("• {} — {}\n", option.id, option.label));
+    }
+    if p.itype == "form" || p.fields.iter().any(|f| f.required) {
+        content.push_str("Answer with buzz interactions answer (this prompt has form fields).");
+    } else {
+        content.push_str("Reply directly to this message with one option ID or label to answer.");
+    }
+    content.push_str(&format!(
+        "\nExperimental interaction · channel-visible answers · prompt {}",
+        prompt.id
+    ));
+    let mut ts: Vec<Tag> = prompt
+        .tags
+        .iter()
+        .filter(|t| ["h", "e", "p"].contains(&t.kind().to_string().as_str()))
+        .cloned()
+        .collect();
+    ts.push(tag(vec!["interaction".into(), prompt.id.to_hex()])?);
+    ts.push(tag(vec!["actor".into(), prompt.pubkey.to_hex()])?);
+    sign(
+        EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), content)
+            .tags(ts)
+            .custom_created_at(prompt.created_at),
+        keys,
+    )
+}
+
+fn fallback_response(
+    source: &Event,
+    prompt: &Event,
+    p: &Prompt,
+    answer: &Answer,
+    keys: &Keys,
+) -> Result<Event> {
+    let mut ts = vec![
+        tag(vec![
+            "e".into(),
+            prompt.id.to_hex(),
+            "".into(),
+            "prompt".into(),
+        ])?,
+        tag(vec!["h".into(), p.channel.to_string()])?,
+        tag(vec!["via".into(), source.id.to_hex()])?,
+        tag(vec!["actor".into(), source.pubkey.to_hex()])?,
+    ];
+    for choice in &answer.choices {
+        ts.push(tag(vec!["choice".into(), choice.clone()])?);
+    }
+    sign(
+        EventBuilder::new(Kind::Custom(KIND_INTERACTION_RESPONSE as u16), "")
+            .tags(ts)
+            .custom_created_at(source.created_at),
+        keys,
+    )
+}
+
+impl Db {
+    /// Accept a prompt, answer, close, or exact ordinary-message fallback.
+    ///
+    /// None means an ordinary message was not an eligible answer and should
+    /// continue through normal message ingest. Some(empty) is an exact replay.
+    /// All authorization reads use the writer inside the decision transaction.
+    pub async fn accept_interaction(
+        &self,
+        community: CommunityId,
+        event: &Event,
+        keys: &Keys,
+        meta: Option<ThreadMetadataParams<'_>>,
+    ) -> Result<Option<Vec<StoredEvent>>> {
+        let kind = event.kind.as_u16() as u32;
+        let fallback = ![
+            KIND_INTERACTION_PROMPT,
+            KIND_INTERACTION_RESPONSE,
+            KIND_INTERACTION_CLOSE,
+        ]
+        .contains(&kind);
+        if fallback {
+            if interaction::validate_envelope(event).is_err() {
+                return Ok(None);
+            }
+        } else {
+            interaction::validate_envelope(event).map_err(invalid)?;
+        }
+        let target = if kind == KIND_INTERACTION_PROMPT {
+            event.id.to_bytes().to_vec()
+        } else if fallback {
+            if event.pubkey == keys.public_key() {
+                return Ok(None);
+            }
+            let Some((_, parent)) = buzz_core::nip10::parse_thread_markers(&event.tags).resolve()
+            else {
+                return Ok(None);
+            };
+            hex::decode(parent).map_err(invalid)?
+        } else {
+            interaction::prompt_id(event)
+                .map_err(invalid)?
+                .to_bytes()
+                .to_vec()
+        };
+        let channel = match interaction::channel(event) {
+            Ok(channel) => channel,
+            Err(_) if fallback => return Ok(None),
+            Err(error) => return Err(invalid(error)),
+        };
+        let mut tx = self.begin_event_write_transaction().await?;
+        let mut emitted = Vec::new();
+        if kind == KIND_INTERACTION_PROMPT {
+            let p = Prompt::parse(event).map_err(invalid)?;
+            // Stable lock ordering: author rate-limit lock, then channel cap lock.
+            for scope in [
+                format!("interaction-author:{community}:{}", event.pubkey),
+                format!("interaction-channel:{community}:{channel}"),
+            ] {
+                sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1,0))")
+                    .bind(scope)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM interactions WHERE community_id=$1 AND prompt_id=$2)",
+            )
+            .bind(community.as_uuid())
+            .bind(&target)
+            .fetch_one(&mut *tx)
+            .await?;
+            if exists {
+                return Ok(Some(emitted));
+            }
+            let clock = now(&mut tx).await?;
+            p.validate_lifetime(clock).map_err(invalid)?;
+            active_member(&mut tx, community, channel, &event.pubkey).await?;
+            let active: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM channels WHERE community_id=$1 AND id=$2 AND archived_at IS NULL AND deleted_at IS NULL)").bind(community.as_uuid()).bind(channel).fetch_one(&mut *tx).await?;
+            if !active {
+                return Err(DbError::AccessDenied("channel is unavailable".into()));
+            }
+            let recent: i64 = sqlx::query_scalar("SELECT count(*) FROM interactions WHERE community_id=$1 AND author=$2 AND received_at > now()-interval '1 minute'").bind(community.as_uuid()).bind(event.pubkey.to_bytes().as_slice()).fetch_one(&mut *tx).await?;
+            let open: i64 = sqlx::query_scalar("SELECT count(*) FROM interactions WHERE community_id=$1 AND channel_id=$2 AND NOT closed AND expiration>$3").bind(community.as_uuid()).bind(channel).bind(clock as i64).fetch_one(&mut *tx).await?;
+            if recent >= 10 || open >= 32 {
+                return Err(DbError::AccessDenied(
+                    "interaction prompt limit reached (10/minute/key, 32 open/channel)".into(),
+                ));
+            }
+            let text = projection(event, &p, keys)?;
+            let projection_meta = meta.as_ref().map(|m| ThreadMetadataParams {
+                event_id: text.id.as_bytes(),
+                event_created_at: m.event_created_at,
+                channel_id: m.channel_id,
+                parent_event_id: m.parent_event_id,
+                parent_event_created_at: m.parent_event_created_at,
+                root_event_id: m.root_event_id,
+                root_event_created_at: m.root_event_created_at,
+                depth: m.depth,
+                broadcast: m.broadcast,
+            });
+            // Only the ordinary message projection contributes to timeline counters.
+            emitted.push(store(&mut tx, community, channel, &text, projection_meta).await?);
+            emitted.push(store(&mut tx, community, channel, event, None).await?);
+            let state = InteractionState::default();
+            sqlx::query("INSERT INTO interactions (community_id,prompt_id,channel_id,author,prompt,state,projection_id,state_timestamp,expiration) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)")
+                .bind(community.as_uuid()).bind(&target).bind(channel).bind(event.pubkey.to_bytes().as_slice()).bind(serde_json::to_value(event)?).bind(serde_json::to_value(&state)?).bind(text.id.as_bytes().as_slice()).bind(clock as i64).bind(p.deadline as i64).execute(&mut *tx).await?;
+            emitted.push(
+                self.persist_interaction_state(
+                    &mut tx,
+                    community,
+                    StateUpdate {
+                        prompt: event,
+                        schema: &p,
+                        state: &state,
+                        timestamp: clock,
+                    },
+                    keys,
+                )
+                .await?,
+            );
+        } else {
+            let row = sqlx::query("SELECT i.prompt,i.state,i.state_timestamp FROM interactions i WHERE i.community_id=$1 AND (i.prompt_id=$2 OR i.projection_id=$2) AND i.channel_id=$3 FOR UPDATE")
+                .bind(community.as_uuid()).bind(&target).bind(channel).fetch_optional(&mut *tx).await?;
+            let Some(row) = row else {
+                return if fallback {
+                    Ok(None)
+                } else {
+                    Err(invalid("prompt not found in channel"))
+                };
+            };
+            let prompt: Event = serde_json::from_value(row.try_get("prompt")?)?;
+            // A response/close must reference the signed prompt, never its projection.
+            if !fallback && target != prompt.id.as_bytes().as_slice() {
+                return Err(invalid("reference the prompt event ID"));
+            }
+            let p = Prompt::parse(&prompt).map_err(invalid)?;
+            let mut state: InteractionState = serde_json::from_value(row.try_get("state")?)?;
+            let clock = now(&mut tx).await?;
+            let duplicate: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM events WHERE community_id=$1 AND id=$2)",
+            )
+            .bind(community.as_uuid())
+            .bind(event.id.as_bytes().as_slice())
+            .fetch_one(&mut *tx)
+            .await?;
+            if duplicate {
+                return Ok(Some(emitted));
+            }
+            let visible: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM events e JOIN channels c ON c.community_id=e.community_id AND c.id=e.channel_id WHERE e.community_id=$1 AND e.id=$2 AND e.deleted_at IS NULL AND c.archived_at IS NULL AND c.deleted_at IS NULL)").bind(community.as_uuid()).bind(prompt.id.as_bytes().as_slice()).fetch_one(&mut *tx).await?;
+            if !visible {
+                return if fallback {
+                    Ok(None)
+                } else {
+                    Err(invalid("prompt is unavailable"))
+                };
+            }
+            if kind == KIND_INTERACTION_CLOSE {
+                if event.pubkey != prompt.pubkey {
+                    return Err(DbError::AccessDenied(
+                        "only the asker may close a prompt".into(),
+                    ));
+                }
+                active_member(&mut tx, community, channel, &event.pubkey).await?;
+                // Parse the same reserved provenance and size envelope as responses.
+                for reserved in ["via", "actor", "interaction", "choice", "value"] {
+                    if event.tags.iter().any(|t| t.kind().to_string() == reserved) {
+                        return Err(invalid("close carries invalid tags"));
+                    }
+                }
+                if !state.close(if clock >= p.deadline {
+                    "expiry"
+                } else {
+                    "manual"
+                }) {
+                    return Err(invalid("prompt is closed"));
+                }
+            } else {
+                let answer = if fallback {
+                    let Some(answer) = p.text_answer(&event.content) else {
+                        return Ok(None);
+                    };
+                    answer
+                } else {
+                    p.answer(event).map_err(invalid)?
+                };
+                if let Err(error) = allowed(&mut tx, community, &p, &event.pubkey).await {
+                    return if fallback && matches!(error, DbError::AccessDenied(_)) {
+                        Ok(None)
+                    } else {
+                        Err(error)
+                    };
+                }
+                if state.revision >= 4096 {
+                    if fallback {
+                        return Ok(None);
+                    }
+                    return Err(invalid("interaction transition limit reached"));
+                }
+                if let Err(error) = state.respond(&p, event.clone(), answer.clone(), clock) {
+                    return if fallback {
+                        Ok(None)
+                    } else {
+                        Err(invalid(error))
+                    };
+                }
+                if fallback {
+                    let response = fallback_response(event, &prompt, &p, &answer, keys)?;
+                    emitted.push(store(&mut tx, community, channel, &response, None).await?);
+                }
+            }
+            emitted.push(store(&mut tx, community, channel, event, meta).await?);
+            let previous: i64 = row.try_get("state_timestamp")?;
+            let timestamp = clock.max(previous as u64 + 1);
+            emitted.push(
+                self.persist_interaction_state(
+                    &mut tx,
+                    community,
+                    StateUpdate {
+                        prompt: &prompt,
+                        schema: &p,
+                        state: &state,
+                        timestamp,
+                    },
+                    keys,
+                )
+                .await?,
+            );
+        }
+        tx.commit().await?;
+        Ok(Some(emitted))
+    }
+
+    async fn persist_interaction_state(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        community: CommunityId,
+        update: StateUpdate<'_>,
+        keys: &Keys,
+    ) -> Result<StoredEvent> {
+        let StateUpdate {
+            prompt,
+            schema: p,
+            state,
+            timestamp,
+        } = update;
+        let event = sign(
+            state
+                .event_builder(prompt.id, p, timestamp)
+                .map_err(invalid)?,
+            keys,
+        )?;
+        let result = self
+            .replace_parameterized_event_in_transaction(
+                tx,
+                community,
+                &event,
+                &prompt.id.to_hex(),
+                Some(p.channel),
+                crate::replaceable::ParameterizedReplacePrecondition::Unconditional,
+            )
+            .await?;
+        if result.status != crate::replaceable::ParameterizedReplaceStatus::Inserted {
+            return Err(invalid("interaction state did not advance"));
+        }
+        sqlx::query("UPDATE interactions SET state=$3, state_timestamp=$4, closed=$5 WHERE community_id=$1 AND prompt_id=$2")
+            .bind(community.as_uuid()).bind(prompt.id.as_bytes().as_slice()).bind(serde_json::to_value(state)?).bind(timestamp as i64).bind(state.close_reason.is_some()).execute(&mut **tx).await?;
+        queue(tx, community, p.channel, &event).await?;
+        Ok(result.event)
+    }
+
+    /// Close a bounded batch of expired prompts, atomically and safely across pods.
+    /// Authoritative deadlines are checked again after taking each row lock.
+    pub async fn expire_interactions(&self, keys: &Keys) -> Result<usize> {
+        let mut tx = self.begin_event_write_transaction().await?;
+        let clock = now(&mut tx).await?;
+        let rows = sqlx::query("SELECT i.community_id,i.prompt,i.state,i.state_timestamp FROM interactions i JOIN communities c ON c.id=i.community_id WHERE NOT i.closed AND i.expiration<=$1 AND c.deletion_state='active' AND c.archived_at IS NULL ORDER BY i.expiration LIMIT 100 FOR UPDATE OF i SKIP LOCKED")
+            .bind(clock as i64).fetch_all(&mut *tx).await?;
+        for row in &rows {
+            let community = CommunityId::from_uuid(row.try_get("community_id")?);
+            let prompt: Event = serde_json::from_value(row.try_get("prompt")?)?;
+            let p = Prompt::parse(&prompt).map_err(invalid)?;
+            let mut state: InteractionState = serde_json::from_value(row.try_get("state")?)?;
+            state.close("expiry");
+            let previous: i64 = row.try_get("state_timestamp")?;
+            self.persist_interaction_state(
+                &mut tx,
+                community,
+                StateUpdate {
+                    prompt: &prompt,
+                    schema: &p,
+                    state: &state,
+                    timestamp: clock.max(previous as u64 + 1),
+                },
+                keys,
+            )
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(rows.len())
+    }
+
+    /// Read a bounded, deployment-wide delivery batch, labelled with each row's tenant.
+    pub async fn pending_interaction_events(&self) -> Result<Vec<InteractionDelivery>> {
+        let mut tx = self.begin_event_write_transaction().await?;
+        // Replacement or moderation may remove a queued event before delivery.
+        // Do not resurrect it from the outbox's retained signed payload.
+        sqlx::query("DELETE FROM interaction_outbox WHERE (community_id,event_id) IN (SELECT o.community_id,o.event_id FROM interaction_outbox o WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.community_id=o.community_id AND e.id=o.event_id AND e.deleted_at IS NULL) ORDER BY o.queued_at LIMIT 100)")
+            .execute(&mut *tx).await?;
+        let rows = sqlx::query("SELECT o.community_id,c.host,o.channel_id,o.event FROM interaction_outbox o JOIN communities c ON c.id=o.community_id JOIN channels ch ON ch.community_id=o.community_id AND ch.id=o.channel_id WHERE c.deletion_state='active' AND c.archived_at IS NULL AND ch.archived_at IS NULL AND ch.deleted_at IS NULL ORDER BY o.queued_at LIMIT 100").fetch_all(&mut *tx).await?;
+        let deliveries = rows
+            .into_iter()
+            .map(|r| {
+                Ok(InteractionDelivery {
+                    community: CommunityId::from_uuid(r.try_get("community_id")?),
+                    host: r.try_get("host")?,
+                    channel: r.try_get("channel_id")?,
+                    event: serde_json::from_value(r.try_get("event")?)?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        tx.commit().await?;
+        Ok(deliveries)
+    }
+
+    /// Acknowledge successful Redis publication. Failures leave the event retryable.
+    pub async fn acknowledge_interaction_event(
+        &self,
+        community: CommunityId,
+        event: &Event,
+    ) -> Result<()> {
+        let mut tx = self.begin_event_write_transaction().await?;
+        sqlx::query("DELETE FROM interaction_outbox WHERE community_id=$1 AND event_id=$2")
+            .bind(community.as_uuid())
+            .bind(event.id.as_bytes().as_slice())
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+}
+
+/// Durable event delivery addressed to its server-resolved community.
+pub struct InteractionDelivery {
+    /// Tenant ID from the stored row.
+    pub community: CommunityId,
+    /// Current community host.
+    pub host: String,
+    /// Channel boundary for fan-out.
+    pub channel: Uuid,
+    /// Exact committed, signed event.
+    pub event: Event,
+}
+
+#[cfg(test)]
+#[path = "interaction_postgres_tests.rs"]
+mod postgres_tests;

--- a/crates/buzz-db/src/store/interaction.rs
+++ b/crates/buzz-db/src/store/interaction.rs
@@ -485,7 +485,9 @@ impl Db {
         // Do not resurrect it from the outbox's retained signed payload.
         sqlx::query("DELETE FROM interaction_outbox WHERE (community_id,event_id) IN (SELECT o.community_id,o.event_id FROM interaction_outbox o WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.community_id=o.community_id AND e.id=o.event_id AND e.deleted_at IS NULL) ORDER BY o.queued_at LIMIT 100)")
             .execute(&mut *tx).await?;
-        let rows = sqlx::query("SELECT o.community_id,c.host,o.channel_id,o.event FROM interaction_outbox o JOIN communities c ON c.id=o.community_id JOIN channels ch ON ch.community_id=o.community_id AND ch.id=o.channel_id WHERE c.deletion_state='active' AND c.archived_at IS NULL AND ch.archived_at IS NULL AND ch.deleted_at IS NULL ORDER BY o.queued_at LIMIT 100").fetch_all(&mut *tx).await?;
+        // Pruning is bounded, so more removed rows may remain in the queue.
+        // Independently require a live event for every delivery in this batch.
+        let rows = sqlx::query("SELECT o.community_id,c.host,o.channel_id,o.event FROM interaction_outbox o JOIN events e ON e.community_id=o.community_id AND e.id=o.event_id AND e.deleted_at IS NULL JOIN communities c ON c.id=o.community_id JOIN channels ch ON ch.community_id=o.community_id AND ch.id=o.channel_id WHERE c.deletion_state='active' AND c.archived_at IS NULL AND ch.archived_at IS NULL AND ch.deleted_at IS NULL ORDER BY o.queued_at LIMIT 100").fetch_all(&mut *tx).await?;
         let deliveries = rows
             .into_iter()
             .map(|r| {

--- a/crates/buzz-db/src/store/interaction.rs
+++ b/crates/buzz-db/src/store/interaction.rs
@@ -535,3 +535,7 @@ pub struct InteractionDelivery {
 #[cfg(test)]
 #[path = "interaction_postgres_tests.rs"]
 mod postgres_tests;
+
+#[cfg(test)]
+#[path = "interaction_unit_tests.rs"]
+mod tests;

--- a/crates/buzz-db/src/store/interaction_postgres_tests.rs
+++ b/crates/buzz-db/src/store/interaction_postgres_tests.rs
@@ -1,0 +1,329 @@
+use super::*;
+use buzz_core::kind::KIND_INTERACTION_STATE;
+use nostr::Timestamp;
+
+struct Fixture {
+    db: Db,
+    community: CommunityId,
+    channel: Uuid,
+    asker: Keys,
+    alice: Keys,
+    bob: Keys,
+    relay: Keys,
+}
+impl Fixture {
+    async fn new() -> Self {
+        let pool = sqlx::PgPool::connect(&crate::test_support::database_url())
+            .await
+            .unwrap();
+        let db = Db::from_pool(pool.clone());
+        let community = CommunityId::from_uuid(Uuid::new_v4());
+        let channel = Uuid::new_v4();
+        let asker = Keys::generate();
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        sqlx::query("INSERT INTO communities(id,host) VALUES($1,$2)")
+            .bind(community.as_uuid())
+            .bind(format!("interactions-{}.test", Uuid::new_v4()))
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO channels(id,community_id,name,created_by) VALUES($1,$2,'interactions',$3)",
+        )
+        .bind(channel)
+        .bind(community.as_uuid())
+        .bind(asker.public_key().to_bytes().as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+        for key in [&asker, &alice, &bob] {
+            sqlx::query(
+                "INSERT INTO channel_members(community_id,channel_id,pubkey) VALUES($1,$2,$3)",
+            )
+            .bind(community.as_uuid())
+            .bind(channel)
+            .bind(key.public_key().to_bytes().as_slice())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        Self {
+            db,
+            community,
+            channel,
+            asker,
+            alice,
+            bob,
+            relay: Keys::generate(),
+        }
+    }
+    fn prompt(&self, closes: &str, responders: &str) -> Event {
+        self.event(
+            &self.asker,
+            KIND_INTERACTION_PROMPT,
+            "Choose",
+            vec![
+                vec!["itype", "buttons"],
+                vec!["opt", "yes", "Yes"],
+                vec!["opt", "no", "No"],
+                vec!["closes", closes],
+                vec!["responders", responders],
+                vec!["deadline", &(Timestamp::now().as_secs() + 3600).to_string()],
+            ],
+        )
+    }
+    fn event(&self, keys: &Keys, kind: u32, content: &str, ts: Vec<Vec<&str>>) -> Event {
+        let mut tags = vec![Tag::parse(["h", &self.channel.to_string()]).unwrap()];
+        tags.extend(ts.into_iter().map(|t| Tag::parse(t).unwrap()));
+        EventBuilder::new(Kind::Custom(kind as u16), content)
+            .tags(tags)
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+    fn answer(&self, key: &Keys, p: &Event, choice: &str) -> Event {
+        self.event(
+            key,
+            KIND_INTERACTION_RESPONSE,
+            "",
+            vec![
+                vec!["e", &p.id.to_hex(), "", "prompt"],
+                vec!["choice", choice],
+            ],
+        )
+    }
+    async fn accept(&self, e: &Event) -> Result<Option<Vec<StoredEvent>>> {
+        self.db
+            .accept_interaction(self.community, e, &self.relay, None)
+            .await
+    }
+    async fn state(&self, p: &Event) -> InteractionState {
+        let value: serde_json::Value = sqlx::query_scalar(
+            "SELECT state FROM interactions WHERE community_id=$1 AND prompt_id=$2",
+        )
+        .bind(self.community.as_uuid())
+        .bind(p.id.as_bytes().as_slice())
+        .fetch_one(&self.db.pool)
+        .await
+        .unwrap();
+        serde_json::from_value(value).unwrap()
+    }
+    async fn stored(&self, e: &Event) -> bool {
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM events WHERE community_id=$1 AND id=$2)")
+            .bind(self.community.as_uuid())
+            .bind(e.id.as_bytes().as_slice())
+            .fetch_one(&self.db.pool)
+            .await
+            .unwrap()
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn concurrent_first_answers_commit_exactly_one_decision() {
+    let f = Fixture::new().await;
+    let p = f.prompt("first", "members");
+    let emitted = f.accept(&p).await.unwrap().unwrap();
+    assert_eq!(emitted.len(), 3);
+    assert_eq!(
+        emitted
+            .iter()
+            .filter(|e| e.event.kind.as_u16() as u32 == KIND_STREAM_MESSAGE)
+            .count(),
+        1
+    );
+    let a = f.answer(&f.alice, &p, "yes");
+    let b = f.answer(&f.bob, &p, "no");
+    let (a_result, b_result) = tokio::join!(f.accept(&a), f.accept(&b));
+    assert_ne!(a_result.is_ok(), b_result.is_ok());
+    assert_ne!(f.stored(&a).await, f.stored(&b).await);
+    let state = f.state(&p).await;
+    assert_eq!(state.votes.len(), 1);
+    assert_eq!(state.close_reason.as_deref(), Some("first"));
+    let winner = if a_result.is_ok() { &a } else { &b };
+    assert!(f.accept(winner).await.unwrap().unwrap().is_empty());
+    let count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM events WHERE community_id=$1 AND kind=$2 AND deleted_at IS NULL",
+    )
+    .bind(f.community.as_uuid())
+    .bind(KIND_INTERACTION_STATE as i32)
+    .fetch_one(&f.db.pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn rejected_answers_are_not_stored_and_roles_are_live() {
+    let f = Fixture::new().await;
+    let p = f.prompt("manual", "role:owner");
+    f.accept(&p).await.unwrap();
+    let a = f.answer(&f.alice, &p, "yes");
+    assert!(f.accept(&a).await.is_err());
+    assert!(!f.stored(&a).await);
+    sqlx::query("INSERT INTO relay_members(community_id,pubkey,role) VALUES($1,$2,'owner')")
+        .bind(f.community.as_uuid())
+        .bind(f.alice.public_key().to_hex())
+        .execute(&f.db.pool)
+        .await
+        .unwrap();
+    f.accept(&a).await.unwrap();
+    let stranger = f.answer(&Keys::generate(), &p, "yes");
+    assert!(f.accept(&stranger).await.is_err());
+    let invalid = f.answer(&f.alice, &p, "maybe");
+    assert!(f.accept(&invalid).await.is_err());
+    assert!(!f.stored(&invalid).await);
+    let other = Fixture::new().await;
+    assert!(other
+        .db
+        .accept_interaction(other.community, &a, &other.relay, None)
+        .await
+        .is_err());
+    let close = f.event(
+        &f.bob,
+        KIND_INTERACTION_CLOSE,
+        "",
+        vec![vec!["e", &p.id.to_hex(), "", "prompt"]],
+    );
+    assert!(f.accept(&close).await.is_err());
+    sqlx::query("UPDATE channel_members SET removed_at=now() WHERE community_id=$1 AND channel_id=$2 AND pubkey=$3").bind(f.community.as_uuid()).bind(f.channel).bind(f.alice.public_key().to_bytes().as_slice()).execute(&f.db.pool).await.unwrap();
+    let changed = f.answer(&f.alice, &p, "no");
+    assert!(f.accept(&changed).await.is_err());
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn text_fallback_preserves_signed_source_and_actor_deduplication() {
+    let f = Fixture::new().await;
+    let p = f.prompt("manual", "members");
+    let rows = f.accept(&p).await.unwrap().unwrap();
+    let projection = rows
+        .iter()
+        .find(|e| e.event.kind.as_u16() as u32 == KIND_STREAM_MESSAGE)
+        .unwrap();
+    let reply = f.event(
+        &f.alice,
+        KIND_STREAM_MESSAGE,
+        " YES \n",
+        vec![vec!["e", &projection.event.id.to_hex(), "", "reply"]],
+    );
+    let accepted = f.accept(&reply).await.unwrap().unwrap();
+    let synthetic = accepted
+        .iter()
+        .find(|e| e.event.kind.as_u16() as u32 == KIND_INTERACTION_RESPONSE)
+        .unwrap();
+    assert_eq!(synthetic.event.pubkey, f.relay.public_key());
+    synthetic.event.verify().unwrap();
+    assert_eq!(
+        interaction::single_tag(&synthetic.event, "via").unwrap(),
+        Some(reply.id.to_hex().as_str())
+    );
+    assert_eq!(
+        f.state(&p).await.votes[&f.alice.public_key().to_hex()].source,
+        reply
+    );
+    let prose = f.event(
+        &f.bob,
+        KIND_STREAM_MESSAGE,
+        "yes but revise",
+        vec![vec!["e", &projection.event.id.to_hex(), "", "reply"]],
+    );
+    assert!(f.accept(&prose).await.unwrap().is_none());
+    let later = EventBuilder::new(Kind::Custom(KIND_INTERACTION_RESPONSE as u16), "")
+        .tags(f.answer(&f.alice, &p, "no").tags.to_vec())
+        .custom_created_at(Timestamp::from(reply.created_at.as_secs() + 1))
+        .sign_with_keys(&f.alice)
+        .unwrap();
+    f.accept(&later).await.unwrap();
+    assert_eq!(f.state(&p).await.votes.len(), 1);
+    assert_eq!(
+        f.state(&p).await.summary(&Prompt::parse(&p).unwrap())["tally"]["yes"],
+        0
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn state_failure_rolls_back_response_and_tally() {
+    let f = Fixture::new().await;
+    let p = f.prompt("manual", "members");
+    f.accept(&p).await.unwrap();
+    // A newer authoritative coordinate forces the production replacement seam
+    // to reject our next state. The answer INSERT must roll back with it.
+    let schema = Prompt::parse(&p).unwrap();
+    let future = InteractionState::default()
+        .event_builder(p.id, &schema, Timestamp::now().as_secs() + 100)
+        .unwrap()
+        .sign_with_keys(&f.relay)
+        .unwrap();
+    f.db.replace_parameterized_event(f.community, &future, &p.id.to_hex(), Some(f.channel))
+        .await
+        .unwrap();
+    let answer = f.answer(&f.alice, &p, "yes");
+    assert!(f.accept(&answer).await.is_err());
+    assert!(!f.stored(&answer).await);
+    assert!(f.state(&p).await.votes.is_empty());
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn expiry_is_durable_and_rejects_answers_before_sweep() {
+    let f = Fixture::new().await;
+    let base = f.prompt("manual", "members");
+    let mut tags = base.tags.clone().to_vec();
+    tags.retain(|t| t.kind().to_string() != "deadline");
+    tags.push(Tag::parse(["deadline", &(Timestamp::now().as_secs() + 2).to_string()]).unwrap());
+    let p = EventBuilder::new(base.kind, base.content)
+        .tags(tags)
+        .sign_with_keys(&f.asker)
+        .unwrap();
+    f.accept(&p).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let answer = f.answer(&f.alice, &p, "yes");
+    assert!(f.accept(&answer).await.is_err());
+    assert!(!f.stored(&answer).await);
+    assert!(f.db.expire_interactions(&f.relay).await.unwrap() >= 1);
+    assert_eq!(f.state(&p).await.close_reason.as_deref(), Some("expiry"));
+    assert_eq!(f.db.expire_interactions(&f.relay).await.unwrap(), 0);
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn outbox_retains_unacknowledged_work_and_discards_removed_events() {
+    let f = Fixture::new().await;
+    let p = f.prompt("first", "members");
+    let initial = f.accept(&p).await.unwrap().unwrap();
+    let initial_state = initial
+        .iter()
+        .find(|e| e.event.kind.as_u16() as u32 == KIND_INTERACTION_STATE)
+        .unwrap();
+    let answer = f.answer(&f.alice, &p, "yes");
+    f.accept(&answer).await.unwrap();
+    f.db.soft_delete_event(f.community, p.id.as_bytes())
+        .await
+        .unwrap();
+    let pending = f.db.pending_interaction_events().await.unwrap();
+    let ours: Vec<_> = pending
+        .iter()
+        .filter(|e| e.community == f.community)
+        .collect();
+    assert!(ours.iter().any(|e| e.event.id == answer.id));
+    assert!(!ours
+        .iter()
+        .any(|e| e.event.id == p.id || e.event.id == initial_state.event.id));
+    let repeated = f.db.pending_interaction_events().await.unwrap();
+    assert!(repeated
+        .iter()
+        .any(|e| e.community == f.community && e.event.id == answer.id));
+    f.db.acknowledge_interaction_event(f.community, &answer)
+        .await
+        .unwrap();
+    assert!(!f
+        .db
+        .pending_interaction_events()
+        .await
+        .unwrap()
+        .iter()
+        .any(|e| e.community == f.community && e.event.id == answer.id));
+}

--- a/crates/buzz-db/src/store/interaction_postgres_tests.rs
+++ b/crates/buzz-db/src/store/interaction_postgres_tests.rs
@@ -327,3 +327,50 @@ async fn outbox_retains_unacknowledged_work_and_discards_removed_events() {
         .iter()
         .any(|e| e.community == f.community && e.event.id == answer.id));
 }
+
+#[tokio::test]
+#[ignore = "requires Postgres"]
+async fn removed_outbox_backlog_cannot_escape_the_bounded_prune() {
+    let f = Fixture::new().await;
+    let p = f.prompt("first", "members");
+    f.accept(&p).await.unwrap();
+    let mut tx = f.db.begin_event_write_transaction().await.unwrap();
+    let mut removed = Vec::new();
+    for index in 0..105 {
+        let event = f.event(
+            &f.alice,
+            KIND_STREAM_MESSAGE,
+            &format!("removed {index}"),
+            vec![],
+        );
+        store(&mut tx, f.community, f.channel, &event, None)
+            .await
+            .unwrap();
+        removed.push(event.id.to_bytes().to_vec());
+    }
+    sqlx::query("UPDATE events SET deleted_at=now() WHERE community_id=$1 AND id=ANY($2)")
+        .bind(f.community.as_uuid())
+        .bind(&removed)
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let pending = f.db.pending_interaction_events().await.unwrap();
+    assert!(pending.iter().any(|row| row.event.id == p.id));
+    assert!(pending
+        .iter()
+        .all(|row| !removed.contains(&row.event.id.to_bytes().to_vec())));
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM interaction_outbox WHERE community_id=$1 AND event_id=ANY($2)",
+    )
+    .bind(f.community.as_uuid())
+    .bind(&removed)
+    .fetch_one(&f.db.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        remaining, 5,
+        "the regression must exceed the 100-row pruning batch"
+    );
+}

--- a/crates/buzz-db/src/store/interaction_unit_tests.rs
+++ b/crates/buzz-db/src/store/interaction_unit_tests.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+#[test]
+fn text_projection_preserves_the_asker_for_agent_authorization() {
+    let asker = Keys::generate();
+    let relay = Keys::generate();
+    let agent = Keys::generate().public_key().to_hex();
+    let channel = Uuid::new_v4().to_string();
+    let prompt = EventBuilder::new(Kind::Custom(KIND_INTERACTION_PROMPT as u16), "Approve?")
+        .tags([
+            Tag::parse(["h", &channel]).unwrap(),
+            Tag::parse(["p", &agent]).unwrap(),
+            Tag::parse(["itype", "buttons"]).unwrap(),
+            Tag::parse(["opt", "approve", "Approve"]).unwrap(),
+            Tag::parse(["closes", "first"]).unwrap(),
+            Tag::parse(["deadline", "2000000000"]).unwrap(),
+        ])
+        .sign_with_keys(&asker)
+        .unwrap();
+    let schema = Prompt::parse(&prompt).unwrap();
+    let message = projection(&prompt, &schema, &relay).unwrap();
+    message.verify().unwrap();
+    assert_eq!(message.pubkey, relay.public_key());
+    assert_eq!(
+        interaction::single_tag(&message, "actor").unwrap(),
+        Some(asker.public_key().to_hex().as_str())
+    );
+    assert_eq!(
+        interaction::single_tag(&message, "interaction").unwrap(),
+        Some(prompt.id.to_hex().as_str())
+    );
+    assert_eq!(
+        interaction::single_tag(&message, "p").unwrap(),
+        Some(agent.as_str())
+    );
+}

--- a/crates/buzz-db/src/store/mod.rs
+++ b/crates/buzz-db/src/store/mod.rs
@@ -24,6 +24,8 @@ pub mod event;
 pub mod feed;
 /// Git repository name registry (NIP-34 kind:30617).
 pub mod git_repo;
+/// Experimental signed interaction persistence.
+pub mod interaction;
 /// Community moderation: reports, bans/timeouts, audit actions.
 pub mod moderation;
 /// Monthly table partition management.

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -116,6 +116,8 @@ pub const MAX_DRAIN_JITTER_MS: u64 = 20_000;
 /// Relay runtime configuration, loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct Config {
+    /// Enable experimental signed interaction prompts and answers (default false).
+    pub experimental_interactions: bool,
     /// Address the relay HTTP/WebSocket server binds to.
     pub bind_addr: SocketAddr,
     /// Postgres database connection URL.
@@ -809,6 +811,16 @@ impl Config {
             .collect();
 
         let relay_private_key = std::env::var("BUZZ_RELAY_PRIVATE_KEY").ok();
+        let experimental_interactions = parse_bool("BUZZ_EXPERIMENTAL_INTERACTIONS", false)?;
+        if experimental_interactions
+            && relay_private_key
+                .as_deref()
+                .is_none_or(|key| key.trim().is_empty())
+        {
+            return Err(ConfigError::InvalidValue(
+                "BUZZ_EXPERIMENTAL_INTERACTIONS requires a stable BUZZ_RELAY_PRIVATE_KEY".into(),
+            ));
+        }
 
         let uds_path = std::env::var("BUZZ_UDS_PATH")
             .ok()
@@ -1239,6 +1251,7 @@ impl Config {
             media_max_concurrent_uploads_per_pubkey,
             media_uploads_per_minute,
             audit_enabled,
+            experimental_interactions,
             ephemeral_ttl_override,
             git_repo_path,
             git_pack_cache_path,

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -517,6 +517,18 @@ async fn dispatch_persistent_event_inner(
         .await;
     }
 
+    trigger_event_workflows(tenant, state, stored_event, kind_u32);
+
+    matches.len()
+}
+
+/// Preserve the ordinary workflow trigger path for transactionally stored messages.
+pub(crate) fn trigger_event_workflows(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    stored_event: &StoredEvent,
+    kind_u32: u32,
+) {
     // Skip workflow triggering for workflow-execution kinds and relay-signed workflow messages.
     let is_relay_workflow_msg = stored_event.event.pubkey == state.relay_keypair.public_key()
         && stored_event
@@ -556,11 +568,9 @@ async fn dispatch_persistent_event_inner(
             }
         });
     }
-
-    matches.len()
 }
 
-async fn enqueue_event_created_audit(
+pub(crate) async fn enqueue_event_created_audit(
     tenant: &TenantContext,
     state: &Arc<AppState>,
     stored_event: &StoredEvent,

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -21,7 +21,8 @@ use buzz_core::kind::{
     KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED, KIND_GIT_STATUS_OPEN,
     KIND_HUDDLE_ENDED, KIND_HUDDLE_GUIDELINES, KIND_HUDDLE_PARTICIPANT_JOINED,
     KIND_HUDDLE_PARTICIPANT_LEFT, KIND_HUDDLE_STARTED, KIND_IA_ARCHIVE_REQUEST,
-    KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
+    KIND_IA_UNARCHIVE_REQUEST, KIND_INTERACTION_CLOSE, KIND_INTERACTION_PROMPT,
+    KIND_INTERACTION_RESPONSE, KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
     KIND_MEMBER_REMOVED_NOTIFICATION, KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT,
     KIND_MODERATION_TIMEOUT, KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_MUTE_LIST,
     KIND_NIP29_CREATE_GROUP, KIND_NIP29_DELETE_EVENT, KIND_NIP29_DELETE_GROUP,
@@ -467,6 +468,7 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         | KIND_EMOJI_SET
         | KIND_EMOJI_LIST
         | KIND_AGENT_PROFILE => Ok(Scope::UsersWrite),
+        KIND_INTERACTION_PROMPT | KIND_INTERACTION_RESPONSE | KIND_INTERACTION_CLOSE => Ok(Scope::MessagesWrite),
         KIND_DELETION
         | KIND_REACTION
         | KIND_GIFT_WRAP
@@ -707,7 +709,8 @@ pub(crate) fn is_global_only_kind(kind: u32) -> bool {
 pub(crate) fn requires_h_channel_scope(kind: u32) -> bool {
     matches!(
         kind,
-        KIND_STREAM_MESSAGE
+        KIND_INTERACTION_PROMPT | KIND_INTERACTION_RESPONSE | KIND_INTERACTION_CLOSE
+            | KIND_STREAM_MESSAGE
             | KIND_STREAM_MESSAGE_V2
             | KIND_STREAM_MESSAGE_EDIT
             | KIND_STREAM_MESSAGE_PINNED
@@ -2189,6 +2192,8 @@ async fn ingest_event_inner(
             .await,
     )?;
 
+    super::interactions::check_enabled(state.config.experimental_interactions, kind_u32)?;
+
     if kind_u32 == KIND_AUTH {
         return Err(IngestError::Rejected(
             "invalid: AUTH events cannot be submitted".into(),
@@ -3009,6 +3014,44 @@ async fn ingest_event_inner(
     } else {
         None
     };
+
+    if state.config.experimental_interactions {
+        if let Some(result) = super::interactions::try_ingest(
+            tenant,
+            state,
+            &event,
+            thread_meta.as_ref().map(|m| m.as_params()),
+        )
+        .await?
+        {
+            if let Some(channel) = channel_id {
+                let claimed_community = claimed_community_from_event(&event);
+                let action = if result.message == "duplicate" {
+                    TraceAction::WriteDuplicate {
+                        msg_id: msg_id_label(event.id.as_bytes()),
+                        channel: channel_label(channel),
+                        claimed_community,
+                    }
+                } else {
+                    TraceAction::WriteInsert {
+                        msg_id: msg_id_label(event.id.as_bytes()),
+                        channel: channel_label(channel),
+                        claimed_community,
+                    }
+                };
+                emit(tracer, action, state_for_request(tenant, auth.pubkey()));
+            }
+            if let Some(meta) = &thread_meta {
+                crate::handlers::side_effects::emit_live_thread_summary(
+                    tenant,
+                    state,
+                    meta.channel_id,
+                    meta.root_event_id.clone(),
+                );
+            }
+            return Ok(result);
+        }
+    }
 
     // Pre-validate kind:0 content before storage so we don't store an event
     // whose profile sync will silently fail in the side-effect handler.

--- a/crates/buzz-relay/src/handlers/interactions.rs
+++ b/crates/buzz-relay/src/handlers/interactions.rs
@@ -1,0 +1,166 @@
+//! One experimental gate shared by HTTP and WebSocket ingest.
+
+use std::{sync::Arc, time::Duration};
+
+use buzz_core::{kind::*, tenant::TenantContext, StoredEvent};
+use nostr::Event;
+
+use super::ingest::{IngestError, IngestResult};
+use crate::state::AppState;
+
+pub(crate) fn check_enabled(enabled: bool, kind: u32) -> Result<(), IngestError> {
+    if !enabled
+        && matches!(
+            kind,
+            KIND_INTERACTION_PROMPT
+                | KIND_INTERACTION_RESPONSE
+                | KIND_INTERACTION_CLOSE
+                | KIND_INTERACTION_STATE
+        )
+    {
+        return Err(IngestError::Rejected(
+            "restricted: experimental interactions are disabled".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) async fn try_ingest(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    event: &Event,
+    meta: Option<buzz_db::event::ThreadMetadataParams<'_>>,
+) -> Result<Option<IngestResult>, IngestError> {
+    let kind = event_kind_u32(event);
+    if !matches!(
+        kind,
+        KIND_INTERACTION_PROMPT
+            | KIND_INTERACTION_RESPONSE
+            | KIND_INTERACTION_CLOSE
+            | KIND_STREAM_MESSAGE
+            | KIND_STREAM_MESSAGE_V2
+            | KIND_FORUM_COMMENT
+    ) {
+        return Ok(None);
+    }
+    if !matches!(
+        kind,
+        KIND_INTERACTION_PROMPT | KIND_INTERACTION_RESPONSE | KIND_INTERACTION_CLOSE
+    ) && buzz_core::nip10::parse_thread_markers(&event.tags)
+        .resolve()
+        .is_none()
+    {
+        return Ok(None);
+    }
+    let result = state
+        .db
+        .accept_interaction(tenant.community(), event, &state.relay_keypair, meta)
+        .await
+        .map_err(|e| match e {
+            buzz_db::DbError::InvalidData(message) => {
+                IngestError::Rejected(format!("invalid: {message}"))
+            }
+            buzz_db::DbError::AccessDenied(message) => {
+                IngestError::Rejected(format!("restricted: {message}"))
+            }
+            other => IngestError::Internal(format!("error: accepting interaction: {other}")),
+        })?;
+    let Some(events) = result else {
+        return Ok(None);
+    };
+    // A matched text answer remains an ordinary message, including its existing
+    // workflow triggers. Run once on insertion, never on outbox retries/replays.
+    for stored in &events {
+        if matches!(
+            event_kind_u32(&stored.event),
+            KIND_STREAM_MESSAGE | KIND_STREAM_MESSAGE_V2 | KIND_FORUM_COMMENT
+        ) {
+            super::event::trigger_event_workflows(
+                tenant,
+                state,
+                stored,
+                event_kind_u32(&stored.event),
+            );
+        }
+    }
+    // No fire-and-forget dependency: accepted events are in the durable outbox.
+    // The worker publishes them with tenant labels and the ordinary access gates.
+    Ok(Some(IngestResult {
+        event_id: event.id.to_hex(),
+        accepted: true,
+        message: if events.is_empty() {
+            "duplicate".into()
+        } else {
+            String::new()
+        },
+    }))
+}
+
+/// Run bounded expiry and at-least-once Redis delivery. All failures retain
+/// durable work; restart and multiple pods are safe (event IDs deduplicate).
+pub async fn run_worker(state: Arc<AppState>) {
+    let mut ticks = 0u64;
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        ticks += 1;
+        if ticks.is_multiple_of(5) {
+            if let Err(error) = state.db.expire_interactions(&state.relay_keypair).await {
+                tracing::error!(%error, "interaction expiry failed; will retry");
+            }
+        }
+        if let Err(error) = deliver_pending(&state).await {
+            tracing::error!(%error, "interaction delivery failed; durable outbox retained");
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    }
+}
+
+async fn deliver_pending(state: &Arc<AppState>) -> anyhow::Result<()> {
+    for row in state.db.pending_interaction_events().await? {
+        let tenant = TenantContext::resolved(row.community, row.host);
+        state
+            .pubsub
+            .publish_event(
+                &tenant,
+                buzz_pubsub::EventTopic::Channel(row.channel),
+                &row.event,
+            )
+            .await?;
+        let stored = StoredEvent::new(row.event.clone(), Some(row.channel));
+        super::event::enqueue_event_created_audit(
+            &tenant,
+            state,
+            &stored,
+            event_kind_u32(&row.event),
+            &row.event.pubkey.to_hex(),
+            &row.event.id.to_hex(),
+        )
+        .await;
+        state
+            .db
+            .acknowledge_interaction_event(row.community, &row.event)
+            .await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn experimental_gate_is_closed_for_every_new_write_kind_only() {
+        for k in [
+            KIND_INTERACTION_PROMPT,
+            KIND_INTERACTION_RESPONSE,
+            KIND_INTERACTION_CLOSE,
+            KIND_INTERACTION_STATE,
+        ] {
+            assert!(check_enabled(false, k).is_err());
+            assert!(check_enabled(true, k).is_ok());
+        }
+        for k in [KIND_STREAM_MESSAGE, KIND_REACTION, KIND_APPROVAL_GRANT] {
+            assert!(check_enabled(false, k).is_ok());
+        }
+        assert!(is_relay_only_kind(KIND_INTERACTION_STATE));
+    }
+}

--- a/crates/buzz-relay/src/handlers/mod.rs
+++ b/crates/buzz-relay/src/handlers/mod.rs
@@ -20,6 +20,8 @@ pub mod identity_archive;
 pub mod imeta;
 /// Transport-neutral event ingestion pipeline.
 pub mod ingest;
+/// Experimental interaction ingest and durable delivery.
+pub mod interactions;
 /// Community moderation authorization seam (capability helper).
 pub mod moderation_authz;
 /// Community moderation command handler (kinds 9040–9044).

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -721,6 +721,12 @@ async fn run_relay_main(boot: BootTracker) -> anyhow::Result<()> {
     let wf_cron = Arc::clone(&workflow_engine);
     tokio::spawn(async move { wf_cron.run().await });
 
+    if state.config.experimental_interactions {
+        tokio::spawn(buzz_relay::handlers::interactions::run_worker(Arc::clone(
+            &state,
+        )));
+    }
+
     // Ephemeral channel reaper — archives channels whose TTL deadline has passed.
     // Runs every 60s, matching the workflow cron loop pattern. The SQL UPDATE
     // uses `archived_at IS NULL` as a guard, so concurrent runs from multiple

--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -293,6 +293,11 @@ pub(crate) async fn nip11_document(state: &crate::state::AppState, raw_host: &st
         admin_api.as_deref(),
         state.config.klipy.as_ref().map(|_| "klipy"),
     );
+    if state.config.experimental_interactions {
+        info.supported_extensions
+            .get_or_insert_default()
+            .push(buzz_core::interaction::EXTENSION.to_string());
+    }
     let tenant_host = if state.config.push_enabled {
         crate::tenant::bind_community(&state.db, raw_host)
             .await

--- a/desktop/biome.json
+++ b/desktop/biome.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["../biome.json"]
+  "extends": ["../biome.json"],
+  "files": {
+    "includes": ["**", "!**/dist-interaction-preview"]
+  }
 }

--- a/desktop/interaction-preview/bootstrap.ts
+++ b/desktop/interaction-preview/bootstrap.ts
@@ -1,0 +1,195 @@
+/** Local demonstration only. Production builds never import this entry point. */
+import { FEATURE_OVERRIDES_STORAGE_KEY } from "../tests/helpers/features";
+
+const relay = "a".repeat(64);
+const viewer = "deadbeef".repeat(8);
+const relayUrl = "ws://localhost:3000";
+const communityId = "e2e-default-community";
+// Select the repository's mock browser bridge. No real identity is loaded.
+window.__BUZZ_E2E__ = { mode: "mock", mock: { relaySelf: relay } };
+localStorage.setItem(
+  "buzz-communities",
+  JSON.stringify([
+    {
+      id: communityId,
+      name: "Interaction preview",
+      relayUrl,
+      pubkey: viewer,
+      addedAt: new Date().toISOString(),
+    },
+  ]),
+);
+localStorage.setItem("buzz-active-community-id", communityId);
+localStorage.setItem(`buzz-onboarding-complete.v1:${viewer}`, "true");
+localStorage.setItem(
+  `buzz-welcome-channel-ensured.v2:${encodeURIComponent(relayUrl)}:${viewer}`,
+  "true",
+);
+localStorage.setItem(
+  FEATURE_OVERRIDES_STORAGE_KEY,
+  JSON.stringify({ interactions: true }),
+);
+await import("../src/main");
+
+const banner = document.createElement("aside");
+banner.setAttribute("aria-label", "Preview information");
+banner.style.cssText =
+  "position:fixed;right:16px;bottom:16px;z-index:99999;max-width:360px;padding:12px 16px;border:1px solid #908bfb;border-radius:12px;background:#19182a;color:white;font:13px/1.5 system-ui;box-shadow:0 8px 30px #0004";
+banner.textContent =
+  "Interaction preview · Simulated data. Open #engineering to try buttons, a form and a poll. No decisions are sent to a real relay. ";
+const reset = document.createElement("button");
+reset.textContent = "Reset examples";
+reset.style.cssText = "text-decoration:underline;cursor:pointer";
+reset.onclick = () => location.reload();
+banner.append(reset);
+document.body.append(banner);
+
+const deadline = Math.floor(Date.now() / 1000) + 3600;
+const examples = [
+  {
+    id: "a1".padStart(64, "0"),
+    projection: "a2".padStart(64, "0"),
+    type: "buttons",
+    text: "Render **The Door**? 12 stills, 2 hero clips, about 55 GPU minutes.",
+    options: [
+      ["approve", "Approve", "primary"],
+      ["revise", "Send back"],
+      ["deny", "Deny", "danger"],
+    ],
+    fields: [["field", "note", "Note for the writer", "text", "optional"]],
+  },
+  {
+    id: "b1".padStart(64, "0"),
+    projection: "b2".padStart(64, "0"),
+    type: "form",
+    text: "What should the next episode include?",
+    options: [],
+    fields: [
+      ["field", "title", "Episode title", "text", "required"],
+      ["field", "length", "Length", "select", "required"],
+      ["optsel", "length", "60s", "60 seconds"],
+      ["optsel", "length", "6min", "6 minutes"],
+      ["field", "ready", "Ready to review?", "boolean", "required"],
+    ],
+  },
+  {
+    id: "c1".padStart(64, "0"),
+    projection: "c2".padStart(64, "0"),
+    type: "poll",
+    text: "Which thumbnails should we test? Choose up to two; you can change your answer until this poll closes.",
+    options: [
+      ["door", "The door"],
+      ["key", "The key"],
+      ["hall", "The hallway"],
+    ],
+    fields: [],
+  },
+];
+const states = new Map<
+  string,
+  {
+    revision: number;
+    status: string;
+    close_reason: string | null;
+    winner: string | null;
+    tally: Record<string, number>;
+    responders: unknown[];
+  }
+>();
+let seeded = false;
+let processed = 0;
+let serial = 100;
+function emitState(id: string) {
+  window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+    channelName: "engineering",
+    id: "beef".repeat(8) + (++serial).toString(16).padStart(32, "0"),
+    kind: 39010,
+    pubkey: relay,
+    content: JSON.stringify({ version: 1, ...states.get(id) }),
+    extraTags: [["d", id]],
+  });
+}
+setInterval(() => {
+  const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+  if (
+    !emit ||
+    !window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+      channelName: "engineering",
+    })
+  )
+    return;
+  if (!seeded) {
+    seeded = true;
+    for (const example of examples) {
+      emit({
+        channelName: "engineering",
+        id: example.id,
+        kind: 40010,
+        content: example.text,
+        extraTags: [
+          ["itype", example.type],
+          ["closes", example.type === "poll" ? "manual" : "first"],
+          ["deadline", String(deadline)],
+          ["min", example.type === "form" ? "0" : "1"],
+          [
+            "max",
+            example.type === "form" ? "0" : example.type === "poll" ? "2" : "1",
+          ],
+          ...example.options.map((o) => ["opt", ...o]),
+          ...example.fields,
+        ],
+      });
+      emit({
+        channelName: "engineering",
+        id: example.projection,
+        kind: 9,
+        pubkey: relay,
+        content: `${example.text}\n${example.options.map((o) => `${o[0]}: ${o[1]}`).join("\n")}\nEnable Interaction cards in Experimental Features to try the controls.`,
+        extraTags: [["interaction", example.id]],
+      });
+      states.set(example.id, {
+        revision: 0,
+        status: "open",
+        close_reason: null,
+        winner: null,
+        tally: Object.fromEntries(example.options.map((o) => [o[0], 0])),
+        responders: [],
+      });
+      emitState(example.id);
+    }
+  }
+  // Demonstration responses are simulated. No signing keys, network calls or
+  // replacement for the Rust relay's acceptance/authorization rules live here.
+  const events = window.__BUZZ_E2E_SIGNED_EVENTS__ ?? [];
+  for (const event of events.slice(processed)) {
+    const id = event.tags.find((t) => t[0] === "e" && t[3] === "prompt")?.[1];
+    const example = examples.find((e) => e.id === id);
+    const state = id && states.get(id);
+    if (!example || !state || state.status === "closed") continue;
+    const choices = event.tags
+      .filter((t) => t[0] === "choice")
+      .map((t) => t[1]);
+    state.revision++;
+    if (event.kind === 40012 || example.type !== "poll") {
+      state.status = "closed";
+      state.close_reason = event.kind === 40012 ? "manual" : "first";
+    }
+    if (event.kind === 40011) {
+      state.tally = Object.fromEntries(
+        example.options.map((o) => [o[0], Number(choices.includes(o[0]))]),
+      );
+      state.responders = [
+        {
+          pubkey: viewer,
+          event_id:
+            "beef".repeat(8) + (++serial).toString(16).padStart(32, "0"),
+          created_at: event.createdAt ?? Math.floor(Date.now() / 1000),
+          choices,
+        },
+      ];
+      if (example.type === "buttons") state.winner = choices[0] ?? null;
+    }
+    emitState(example.id);
+  }
+  processed = events.length;
+}, 300);

--- a/desktop/interaction-preview/index.html
+++ b/desktop/interaction-preview/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/buzz.svg?v=20260610" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title></title>
+    <!--
+      Boot background: the document must be painted before the app bundle (and
+      its stylesheets) load so cold boot never flashes ahead of the loading
+      gate. The window itself is also painted pre-document via `backgroundColor`
+      in tauri.conf.json. The body paints its own themed background once the app
+      CSS loads, so this never shows through after boot.
+
+      The linked stylesheet (boot.css) applies the initial black background.
+      Kept as a <link> rather than an inline <style> to avoid Tauri's nonce
+      injection for style-src (see boot.css for the full rationale).
+
+      The inline script below reads the cached theme background (same
+      `buzz-theme-cache` entry ThemeProvider writes) and applies it synchronously
+      so the boot color matches the themed loading gate — no black flash on light
+      themes. On the first-ever launch (no cache yet) it seeds the light/dark
+      class from the OS color scheme, matching the Buzz theme in System mode
+      that ThemeProvider applies moments later — no wrong-scheme flash before
+      it loads.
+    -->
+    <link rel="stylesheet" href="/boot.css" />
+    <script>
+      (() => {
+        var cached, bg, parsed;
+        try {
+          cached = window.localStorage.getItem("buzz-theme-cache");
+          if (!cached) {
+            // No stored theme: the default is Buzz following the OS scheme,
+            // so seed the matching class (and backdrop) now. Otherwise the
+            // setup gate would paint the wrong scheme until ThemeProvider
+            // loads asynchronously.
+            if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+              document.documentElement.classList.add("dark");
+            } else {
+              document.documentElement.classList.add("light");
+              document.documentElement.style.backgroundColor = "#fff";
+            }
+            return;
+          }
+          parsed = JSON.parse(cached);
+          bg = parsed.vars["--background"];
+          if (bg) document.documentElement.style.backgroundColor = `hsl(${bg})`;
+          // Match the cached light/dark class so themed vars resolve correctly
+          // before ThemeProvider mounts.
+          document.documentElement.classList.add(parsed.isDark ? "dark" : "light");
+        } catch {
+          /* fall back to the black default above */
+        }
+      })();
+    </script>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/interaction-preview/bootstrap.ts"></script>
+  </body>
+</html>

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && node ./scripts/build-protected-feature-artifacts.mjs",
+    "build:interaction-preview": "tsc && node ./scripts/build-interaction-preview.mjs",
     "build:e2e": "tsc && vite build --mode e2e",
     "typecheck": "tsc --noEmit",
     "check:file-sizes": "node ./scripts/check-file-sizes.mjs",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -160,6 +160,7 @@ export default defineConfig({
         "**/signout-confirmation.spec.ts",
         "**/settings-section-layout.spec.ts",
         "**/experimental-features.spec.ts",
+        "**/interactions.spec.ts",
         "**/agent-provider-dropdowns.spec.ts",
         "**/agent-lifecycle-feedback.spec.ts",
         "**/agent-access-warning.spec.ts",

--- a/desktop/scripts/build-interaction-preview.mjs
+++ b/desktop/scripts/build-interaction-preview.mjs
@@ -1,0 +1,11 @@
+import { build } from "vite";
+
+// Separate output and entry point keep every demo transport out of app bundles.
+await build({
+  configFile: "vite.config.ts",
+  mode: "e2e",
+  build: {
+    outDir: "dist-interaction-preview",
+    rolldownOptions: { input: "interaction-preview/index.html" },
+  },
+});

--- a/desktop/src/features/interactions/InteractionCard.tsx
+++ b/desktop/src/features/interactions/InteractionCard.tsx
@@ -41,16 +41,37 @@ export function InteractionCard({
   const [choices, setChoices] = useState<string[]>([]);
   const [values, setValues] = useState<Record<string, string>>({});
   const [dirty, setDirty] = useState(false);
+  const [now, setNow] = useState(Date.now);
+  const submitting = useRef(false);
   const generation = useRef(0);
   const inputId = useId();
   const myAnswer = state?.responders.find((r) => r.pubkey === currentPubkey);
-  const expired = prompt ? Date.now() / 1000 >= prompt.deadline : false;
+  const expired = prompt ? now / 1000 >= prompt.deadline : false;
   const closed = state?.status === "closed" || expired;
   const disabled = pending || closed || !state || !currentPubkey;
 
   useEffect(() => {
     if (!dirty) setChoices(myAnswer?.choices ?? []);
   }, [myAnswer, dirty]);
+
+  useEffect(() => {
+    if (!prompt) return;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      clearTimeout(timer);
+      const current = Date.now();
+      setNow(current);
+      const remaining = prompt.deadline * 1000 - current;
+      if (remaining > 0) timer = setTimeout(tick, Math.min(remaining, 60_000));
+    };
+    tick();
+    // Recheck after sleep/background throttling as well as at the deadline.
+    window.addEventListener("focus", tick);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("focus", tick);
+    };
+  }, [prompt]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: retry explicitly restarts a failed subscription.
   useEffect(() => {
@@ -112,7 +133,12 @@ export function InteractionCard({
   }, [promptId, channelId, signer, relay, retry]);
 
   async function submit(selected: string[], close = false) {
-    if (!prompt || !relay || disabled) return;
+    if (!prompt || !relay || disabled || submitting.current) return;
+    if (Date.now() / 1000 >= prompt.deadline) {
+      setNow(Date.now());
+      return;
+    }
+    submitting.current = true;
     const version = generation.current;
     const tags = [
       ["h", channelId],
@@ -163,6 +189,7 @@ export function InteractionCard({
     } catch (reason) {
       if (generation.current === version) setError(String(reason));
     } finally {
+      submitting.current = false;
       if (generation.current === version) setPending(false);
     }
   }
@@ -221,6 +248,11 @@ export function InteractionCard({
           <legend className="sr-only">Your answer</legend>
           {prompt.type === "poll" && (
             <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                {prompt.max === 1
+                  ? "Choose one answer."
+                  : `Choose ${prompt.min}–${prompt.max} answers.`}
+              </p>
               {prompt.options.map((option) => (
                 <label
                   key={option.id}
@@ -230,6 +262,11 @@ export function InteractionCard({
                     type={prompt.max === 1 ? "radio" : "checkbox"}
                     name={`${inputId}-choice`}
                     checked={choices.includes(option.id)}
+                    disabled={
+                      prompt.max > 1 &&
+                      !choices.includes(option.id) &&
+                      choices.length >= prompt.max
+                    }
                     onChange={(e) => {
                       setDirty(true);
                       setChoices(
@@ -331,11 +368,13 @@ export function InteractionCard({
       >
         {pending
           ? "Sending answer…"
-          : closed
+          : state?.status === "closed"
             ? `Closed${state?.winner ? ` · ${prompt.options.find((o) => o.id === state.winner)?.label ?? state.winner}` : ""}${state?.close_reason ? ` (${state.close_reason})` : ""}`
-            : !state
-              ? "Loading decision state…"
-              : `${state.responders.length} answered${myAnswer ? " · Your answer is recorded" : ""}`}
+            : expired
+              ? "Voting ended · Waiting for the relay’s final result"
+              : !state
+                ? "Loading decision state…"
+                : `${state.responders.length} answered${myAnswer ? " · Your answer is recorded" : ""}`}
       </p>
       {!eligible && (
         <p className="text-xs text-muted-foreground">

--- a/desktop/src/features/interactions/InteractionCard.tsx
+++ b/desktop/src/features/interactions/InteractionCard.tsx
@@ -1,0 +1,369 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { useRelaySelfQuery } from "@/features/moderation/hooks";
+import { relayClient } from "@/shared/api/relayClient";
+import { Markdown } from "@/shared/ui/markdown";
+import { signRelayEvent } from "@/shared/api/tauri";
+import type { RelayEvent } from "@/shared/api/types";
+import {
+  KIND_INTERACTION_CLOSE,
+  KIND_INTERACTION_PROMPT,
+  KIND_INTERACTION_RESPONSE,
+  KIND_INTERACTION_STATE,
+} from "@/shared/constants/kinds";
+import {
+  parseInteractionPrompt,
+  parseInteractionState,
+  type InteractionPrompt,
+  type InteractionSummary,
+} from "./protocol";
+
+/** Opt-in card mounted on the relay's ordinary-message projection. */
+export function InteractionCard({
+  promptId,
+  channelId,
+  signer,
+  currentPubkey,
+  fallback,
+}: {
+  promptId: string;
+  channelId: string;
+  signer?: string;
+  currentPubkey?: string;
+  fallback: string;
+}) {
+  const relayQuery = useRelaySelfQuery();
+  const relay = relayQuery.data;
+  const [prompt, setPrompt] = useState<InteractionPrompt | null>(null);
+  const [state, setState] = useState<InteractionSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [retry, setRetry] = useState(0);
+  const [pending, setPending] = useState(false);
+  const [choices, setChoices] = useState<string[]>([]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [dirty, setDirty] = useState(false);
+  const generation = useRef(0);
+  const inputId = useId();
+  const myAnswer = state?.responders.find((r) => r.pubkey === currentPubkey);
+  const expired = prompt ? Date.now() / 1000 >= prompt.deadline : false;
+  const closed = state?.status === "closed" || expired;
+  const disabled = pending || closed || !state || !currentPubkey;
+
+  useEffect(() => {
+    if (!dirty) setChoices(myAnswer?.choices ?? []);
+  }, [myAnswer, dirty]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retry explicitly restarts a failed subscription.
+  useEffect(() => {
+    const version = ++generation.current;
+    let unsubscribe: (() => void) | undefined;
+    let cancelled = false;
+    setPrompt(null);
+    setState(null);
+    setError(null);
+    setPending(false);
+    setDirty(false);
+    setValues({});
+    if (!relay) return;
+    if (signer !== relay || !/^[a-f0-9]{64}$/.test(promptId)) {
+      setError("This message is not a verified relay interaction.");
+      return;
+    }
+    const receive = (event: RelayEvent) => {
+      if (cancelled || generation.current !== version) return;
+      const next = parseInteractionState(event, promptId, channelId, relay);
+      if (next)
+        setState((previous) =>
+          !previous || next.revision > previous.revision ? next : previous,
+        );
+    };
+    const load = async () => {
+      const events = await relayClient.fetchEvents({
+        kinds: [KIND_INTERACTION_PROMPT],
+        ids: [promptId],
+        "#h": [channelId],
+        limit: 1,
+      });
+      if (cancelled || generation.current !== version) return;
+      if (!events[0]) throw new Error("This prompt is unavailable.");
+      setPrompt(parseInteractionPrompt(events[0], promptId, channelId));
+      // One history + live subscription; no gap between a backfill and watching.
+      const stop = await relayClient.subscribeLive(
+        {
+          kinds: [KIND_INTERACTION_STATE],
+          authors: [relay],
+          "#d": [promptId],
+          "#h": [channelId],
+          limit: 1,
+        },
+        receive,
+      );
+      if (cancelled || generation.current !== version) stop();
+      else unsubscribe = stop;
+    };
+    void load().catch((reason: unknown) => {
+      if (!cancelled && generation.current === version)
+        setError(String(reason));
+    });
+    return () => {
+      cancelled = true;
+      generation.current++;
+      unsubscribe?.();
+    };
+  }, [promptId, channelId, signer, relay, retry]);
+
+  async function submit(selected: string[], close = false) {
+    if (!prompt || !relay || disabled) return;
+    const version = generation.current;
+    const tags = [
+      ["h", channelId],
+      ["e", promptId, "", "prompt"],
+    ];
+    if (!close) {
+      for (const choice of selected) tags.push(["choice", choice]);
+      for (const field of prompt.fields) {
+        const value = values[field.id];
+        if (value !== undefined && value !== "")
+          tags.push(["value", field.id, value]);
+      }
+    }
+    setPending(true);
+    setError(null);
+    try {
+      const response = await signRelayEvent({
+        kind: close ? KIND_INTERACTION_CLOSE : KIND_INTERACTION_RESPONSE,
+        content: "",
+        tags,
+        createdAt: Math.max(
+          Math.floor(Date.now() / 1000),
+          (myAnswer?.created_at ?? 0) + 1,
+        ),
+      });
+      if (generation.current !== version) return;
+      await relayClient.publishEvent(
+        response,
+        "Timed out sending your answer.",
+        "Your answer was not accepted.",
+      );
+      const events = await relayClient.fetchEvents({
+        kinds: [KIND_INTERACTION_STATE],
+        authors: [relay],
+        "#d": [promptId],
+        "#h": [channelId],
+        limit: 1,
+      });
+      if (generation.current !== version) return;
+      const next =
+        events[0] &&
+        parseInteractionState(events[0], promptId, channelId, relay);
+      if (next)
+        setState((previous) =>
+          !previous || next.revision > previous.revision ? next : previous,
+        );
+      setDirty(false);
+    } catch (reason) {
+      if (generation.current === version) setError(String(reason));
+    } finally {
+      if (generation.current === version) setPending(false);
+    }
+  }
+
+  if (!prompt)
+    return (
+      <div className="space-y-2">
+        <p className="whitespace-pre-wrap text-message">{fallback}</p>
+        {(error || relayQuery.isError) && (
+          <p role="alert" className="text-sm text-red-500">
+            {error ?? "Unable to verify the relay identity."}{" "}
+            <button
+              type="button"
+              className="underline"
+              onClick={() => {
+                if (relayQuery.isError) void relayQuery.refetch();
+                setRetry((r) => r + 1);
+              }}
+            >
+              Retry
+            </button>
+          </p>
+        )}
+      </div>
+    );
+  const listed =
+    prompt.event.tags.find((t) => t[0] === "responders")?.[1] === "listed";
+  const eligible =
+    !listed ||
+    prompt.event.tags.some((t) => t[0] === "p" && t[1] === currentPubkey);
+  const buttonClass =
+    "rounded-md border px-3 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50";
+  return (
+    <section
+      className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-3"
+      aria-label="Interaction"
+      data-testid="interaction-card"
+    >
+      <Markdown content={prompt.event.content} />
+      <p className="text-xs text-muted-foreground">
+        {prompt.type === "poll" ? "Poll" : "Request for input"} · Answers are
+        visible in this channel
+      </p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          const button = (e.nativeEvent as SubmitEvent).submitter;
+          void submit(
+            prompt.type === "buttons" && button instanceof HTMLButtonElement
+              ? [button.value]
+              : choices,
+          );
+        }}
+      >
+        <fieldset disabled={disabled || !eligible} className="space-y-3">
+          <legend className="sr-only">Your answer</legend>
+          {prompt.type === "poll" && (
+            <div className="space-y-2">
+              {prompt.options.map((option) => (
+                <label
+                  key={option.id}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <input
+                    type={prompt.max === 1 ? "radio" : "checkbox"}
+                    name={`${inputId}-choice`}
+                    checked={choices.includes(option.id)}
+                    onChange={(e) => {
+                      setDirty(true);
+                      setChoices(
+                        prompt.max === 1
+                          ? [option.id]
+                          : e.target.checked
+                            ? [...choices, option.id]
+                            : choices.filter((c) => c !== option.id),
+                      );
+                    }}
+                  />
+                  {option.label}
+                  <span className="ml-auto tabular-nums">
+                    {state?.tally[option.id] ?? 0}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+          {prompt.fields.map((field) => (
+            <div key={field.id} className="space-y-1">
+              <label
+                className="block text-sm"
+                htmlFor={`${inputId}-${field.id}`}
+              >
+                {field.label}
+                {field.required ? " (required)" : " (optional)"}
+              </label>
+              {field.type === "select" || field.type === "boolean" ? (
+                <select
+                  id={`${inputId}-${field.id}`}
+                  className="w-full rounded border bg-background p-2 text-sm"
+                  required={field.required}
+                  value={values[field.id] ?? ""}
+                  onChange={(e) =>
+                    setValues({ ...values, [field.id]: e.target.value })
+                  }
+                >
+                  <option value="">Choose…</option>
+                  {(field.type === "boolean"
+                    ? [
+                        { id: "true", label: "Yes" },
+                        { id: "false", label: "No" },
+                      ]
+                    : field.options
+                  ).map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  id={`${inputId}-${field.id}`}
+                  className="w-full rounded border bg-background p-2 text-sm"
+                  type={field.type}
+                  step={field.type === "number" ? "any" : undefined}
+                  maxLength={4096}
+                  required={field.required}
+                  value={values[field.id] ?? ""}
+                  onChange={(e) =>
+                    setValues({ ...values, [field.id]: e.target.value })
+                  }
+                />
+              )}
+            </div>
+          ))}
+          {prompt.type === "buttons" ? (
+            <div className="flex flex-wrap gap-2">
+              {prompt.options.map((option) => (
+                <button
+                  key={option.id}
+                  type="submit"
+                  value={option.id}
+                  className={`${buttonClass} ${option.style === "danger" ? "border-red-500 text-red-500" : option.style === "primary" ? "bg-primary text-primary-foreground" : "bg-background"}`}
+                >
+                  {option.label}
+                  {myAnswer?.choices.includes(option.id) ? " ✓" : ""}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <button
+              type="submit"
+              className={buttonClass}
+              disabled={
+                choices.length < prompt.min || choices.length > prompt.max
+              }
+            >
+              {myAnswer ? "Update answer" : "Submit answer"}
+            </button>
+          )}
+        </fieldset>
+      </form>
+      <p
+        className="text-xs text-muted-foreground"
+        role="status"
+        aria-live="polite"
+      >
+        {pending
+          ? "Sending answer…"
+          : closed
+            ? `Closed${state?.winner ? ` · ${prompt.options.find((o) => o.id === state.winner)?.label ?? state.winner}` : ""}${state?.close_reason ? ` (${state.close_reason})` : ""}`
+            : !state
+              ? "Loading decision state…"
+              : `${state.responders.length} answered${myAnswer ? " · Your answer is recorded" : ""}`}
+      </p>
+      {!eligible && (
+        <p className="text-xs text-muted-foreground">
+          This request is addressed to other members.
+        </p>
+      )}
+      {prompt.event.pubkey === currentPubkey && !closed && (
+        <button
+          type="button"
+          disabled={disabled}
+          className="text-xs underline"
+          onClick={() => void submit([], true)}
+        >
+          Close request
+        </button>
+      )}
+      {(error || !state) && (
+        <p role="alert" className="text-sm text-red-500">
+          {error}{" "}
+          <button
+            type="button"
+            className="underline"
+            onClick={() => setRetry((r) => r + 1)}
+          >
+            Reload request
+          </button>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/desktop/src/features/interactions/protocol.test.mjs
+++ b/desktop/src/features/interactions/protocol.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseInteractionPrompt, parseInteractionState } from "./protocol.ts";
+const relay = "a".repeat(64);
+const prompt = "b".repeat(64);
+const channel = "00000000-0000-0000-0000-000000000001";
+const state = {
+  id: "c".repeat(64),
+  pubkey: relay,
+  kind: 39010,
+  created_at: 1,
+  tags: [
+    ["d", prompt],
+    ["h", channel],
+  ],
+  content: JSON.stringify({
+    version: 1,
+    revision: 2,
+    status: "closed",
+    close_reason: "first",
+    winner: "yes",
+    tally: { yes: 1 },
+    responders: [
+      {
+        pubkey: "d".repeat(64),
+        event_id: "e".repeat(64),
+        created_at: 1,
+        choices: ["yes"],
+      },
+    ],
+  }),
+  sig: "",
+};
+test("only matching relay state can authorize a decision card", () => {
+  assert.equal(
+    parseInteractionState(state, prompt, channel, relay)?.winner,
+    "yes",
+  );
+  for (const patch of [
+    { pubkey: "f".repeat(64) },
+    { kind: 40011 },
+    {
+      tags: [
+        ["d", "f".repeat(64)],
+        ["h", channel],
+      ],
+    },
+    {
+      tags: [
+        ["d", prompt],
+        ["h", "other"],
+      ],
+    },
+    { content: "{" },
+    {
+      content: JSON.stringify({
+        version: 1,
+        revision: -1,
+        status: "open",
+        responders: [],
+        tally: {},
+      }),
+    },
+  ])
+    assert.equal(
+      parseInteractionState({ ...state, ...patch }, prompt, channel, relay),
+      null,
+    );
+});
+test("unsupported form privacy and fields fail closed", () => {
+  const event = {
+    ...state,
+    id: prompt,
+    kind: 40010,
+    tags: [
+      ["h", channel],
+      ["itype", "form"],
+      ["field", "note", "Note", "text", "required"],
+      ["deadline", "2000"],
+    ],
+    content: "Details?",
+  };
+  assert.equal(
+    parseInteractionPrompt(event, prompt, channel).fields[0].type,
+    "text",
+  );
+  assert.throws(() =>
+    parseInteractionPrompt(
+      { ...event, tags: [...event.tags, ["visibility", "asker-only"]] },
+      prompt,
+      channel,
+    ),
+  );
+  assert.throws(() =>
+    parseInteractionPrompt(
+      {
+        ...event,
+        tags: [...event.tags, ["field", "key", "Key", "secret", "required"]],
+      },
+      prompt,
+      channel,
+    ),
+  );
+});

--- a/desktop/src/features/interactions/protocol.ts
+++ b/desktop/src/features/interactions/protocol.ts
@@ -1,0 +1,148 @@
+import type { RelayEvent } from "@/shared/api/types";
+import {
+  KIND_INTERACTION_PROMPT,
+  KIND_INTERACTION_STATE,
+} from "@/shared/constants/kinds";
+
+export type InteractionField = {
+  id: string;
+  label: string;
+  type: "text" | "number" | "select" | "boolean" | "date";
+  required: boolean;
+  options: { id: string; label: string }[];
+};
+export type InteractionPrompt = {
+  event: RelayEvent;
+  type: string;
+  options: { id: string; label: string; style: string }[];
+  fields: InteractionField[];
+  min: number;
+  max: number;
+  deadline: number;
+};
+export type InteractionSummary = {
+  revision: number;
+  status: "open" | "closed";
+  close_reason: string | null;
+  winner: string | null;
+  tally: Record<string, number>;
+  responders: {
+    pubkey: string;
+    event_id: string;
+    created_at: number;
+    choices: string[];
+  }[];
+};
+
+export const eventTag = (event: RelayEvent, name: string) =>
+  event.tags.find((t) => t[0] === name)?.[1];
+
+/** Fail closed on unsupported schemas; the original message remains available. */
+export function parseInteractionPrompt(
+  event: RelayEvent,
+  id: string,
+  channel: string,
+): InteractionPrompt {
+  if (
+    event.id !== id ||
+    event.kind !== KIND_INTERACTION_PROMPT ||
+    eventTag(event, "h") !== channel ||
+    ![undefined, "public"].includes(eventTag(event, "visibility")) ||
+    eventTag(event, "expiration") !== undefined
+  )
+    throw new Error("Invalid interaction prompt.");
+  const type = eventTag(event, "itype") ?? "";
+  if (!["buttons", "poll", "form"].includes(type))
+    throw new Error("This interaction type is not supported.");
+  const options = event.tags
+    .filter((t) => t[0] === "opt")
+    .map((t) => ({ id: t[1], label: t[2], style: t[3] ?? "default" }));
+  const fields: InteractionField[] = event.tags
+    .filter((t) => t[0] === "field")
+    .map((t) => {
+      if (!["text", "number", "select", "boolean", "date"].includes(t[3]))
+        throw new Error("This field type is not supported.");
+      return {
+        id: t[1],
+        label: t[2],
+        type: t[3] as InteractionField["type"],
+        required: t[4] === "required",
+        options: event.tags
+          .filter((o) => o[0] === "optsel" && o[1] === t[1])
+          .map((o) => ({ id: o[2], label: o[3] ?? o[2] })),
+      };
+    });
+  if (
+    options.length > 12 ||
+    fields.length > 12 ||
+    options.some((o) => !o.id || !o.label)
+  )
+    throw new Error("Malformed interaction schema.");
+  const min = Number(eventTag(event, "min") ?? (type === "form" ? 0 : 1));
+  const max = Number(eventTag(event, "max") ?? (type === "form" ? 0 : 1));
+  const deadline = Number(eventTag(event, "deadline"));
+  if (
+    !Number.isSafeInteger(min) ||
+    !Number.isSafeInteger(max) ||
+    min < 0 ||
+    max < min ||
+    max > options.length ||
+    !Number.isSafeInteger(deadline) ||
+    deadline <= 0
+  )
+    throw new Error("Malformed interaction limits or deadline.");
+  return {
+    event,
+    type,
+    options,
+    fields,
+    min,
+    max,
+    deadline,
+  };
+}
+
+/** Only the active relay's state for this prompt may enable decision controls. */
+export function parseInteractionState(
+  event: RelayEvent,
+  prompt: string,
+  channel: string,
+  relay: string,
+): InteractionSummary | null {
+  if (
+    event.kind !== KIND_INTERACTION_STATE ||
+    event.pubkey !== relay ||
+    eventTag(event, "d") !== prompt ||
+    eventTag(event, "h") !== channel
+  )
+    return null;
+  try {
+    const state = JSON.parse(event.content) as InteractionSummary & {
+      version?: number;
+    };
+    if (
+      state.version !== 1 ||
+      !Number.isSafeInteger(state.revision) ||
+      state.revision < 0 ||
+      !["open", "closed"].includes(state.status) ||
+      !Array.isArray(state.responders) ||
+      !state.tally ||
+      typeof state.tally !== "object"
+    )
+      return null;
+    if (
+      state.responders.some(
+        (r) =>
+          typeof r.pubkey !== "string" ||
+          !Array.isArray(r.choices) ||
+          !Number.isSafeInteger(r.created_at),
+      )
+    )
+      return null;
+    if (Object.values(state.tally).some((n) => !Number.isInteger(n) || n < 0))
+      return null;
+    return state;
+  } catch {
+    return null;
+  }
+}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { useFeatureEnabled } from "@/shared/features";
+import { InteractionCard } from "@/features/interactions/InteractionCard";
 import { AlertTriangle } from "lucide-react";
 import {
   depthGuideActionsEqual,
@@ -364,10 +366,24 @@ export const MessageRow = React.memo(
         collapseDepthGuideActions.map((action) => [action.depth, action]),
       );
     }, [collapseDepthGuideActions]);
+    const interactionsEnabled = useFeatureEnabled("interactions");
     const getTag = (name: string) =>
       message.tags?.find((tag) => tag[0] === name)?.[1];
 
     const renderBody = () => {
+      const promptId = getTag("interaction");
+      if (interactionsEnabled && promptId && channelId) {
+        return (
+          <InteractionCard
+            key={promptId}
+            promptId={promptId}
+            channelId={channelId}
+            signer={message.signerPubkey}
+            currentPubkey={currentPubkey}
+            fallback={message.body}
+          />
+        );
+      }
       switch (message.kind) {
         case KIND_STREAM_MESSAGE_DIFF:
           return (

--- a/desktop/src/features/messages/ui/TimelineMessageRow.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageRow.tsx
@@ -143,6 +143,7 @@ export function MessageRowItem({
       >
         <MessageRow
           channelId={channelId}
+          currentPubkey={currentPubkey}
           highlighted={false}
           hoverBackground={false}
           huddleMemberPubkeys={huddleMemberPubkeys}
@@ -202,6 +203,7 @@ export function MessageRowItem({
     >
       <MessageRow
         channelId={channelId}
+        currentPubkey={currentPubkey}
         highlighted={message.id === highlightedMessageId || isSearchActive}
         huddleMemberPubkeys={huddleMemberPubkeys}
         huddleMemberPubkeysPending={huddleMemberPubkeysPending}

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -174,3 +174,9 @@ const NON_CONVERSATIONAL_UNREAD_KINDS: ReadonlySet<number> = new Set([
 export function isConversationalUnreadKind(kind: number | undefined): boolean {
   return kind === undefined || !NON_CONVERSATIONAL_UNREAD_KINDS.has(kind);
 }
+
+// Experimental interactions (buzz-core/src/kind.rs).
+export const KIND_INTERACTION_PROMPT = 40010;
+export const KIND_INTERACTION_RESPONSE = 40011;
+export const KIND_INTERACTION_CLOSE = 40012;
+export const KIND_INTERACTION_STATE = 39010;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -64,6 +64,7 @@ import {
   KIND_GIT_STATUS_MERGED,
   KIND_GIT_STATUS_OPEN,
   KIND_HUDDLE_STARTED,
+  KIND_INTERACTION_STATE,
   KIND_MEMBER_ADDED_NOTIFICATION,
   KIND_MEMBER_REMOVED_NOTIFICATION,
   KIND_PERSONA,
@@ -4903,6 +4904,18 @@ function emitMockHistory(
   const events = channelIds
     .flatMap((channelId) => getMockMessageStore(channelId))
     .filter((event) => {
+      // Interaction cards query individual prompts and addressable summaries;
+      // returning another card's first event would invalidate the control.
+      if (filter.ids && !filter.ids.includes(event.id)) return false;
+      if (filter.authors && !filter.authors.includes(event.pubkey))
+        return false;
+      if (
+        filter["#d"] &&
+        !event.tags.some(
+          (tag) => tag[0] === "d" && filter["#d"]?.includes(tag[1]),
+        )
+      )
+        return false;
       if (filter.kinds && !filter.kinds.includes(event.kind)) {
         return false;
       }
@@ -10879,6 +10892,12 @@ function sendToMockSocket(args: {
         kinds: kinds.size > 0 ? [...kinds] : null,
         ownerPubkeys: [...ownerPubkeys],
       });
+      // Interaction cards use one history + live REQ, including on remount.
+      for (const filter of filters) {
+        if (filter.kinds?.includes(KIND_INTERACTION_STATE)) {
+          emitMockHistory(socket, subId, [...channelIds], filter);
+        }
+      }
       sendWsText(socket.handler, ["EOSE", subId]);
       return;
     }

--- a/desktop/tests/e2e/interactions.spec.ts
+++ b/desktop/tests/e2e/interactions.spec.ts
@@ -12,6 +12,7 @@ async function seed(
   type = "buttons",
   fields: string[][] = [],
   enabled = true,
+  extraTags: string[][] = [],
 ) {
   await installMockBridge(
     page,
@@ -31,7 +32,7 @@ async function seed(
     )
     .toBe(true);
   await page.evaluate(
-    ({ relay, prompt, projection, question, type, fields }) => {
+    ({ relay, prompt, projection, question, type, fields, extraTags }) => {
       const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
       const opts =
         type === "form"
@@ -48,9 +49,14 @@ async function seed(
         extraTags: [
           ["itype", type],
           ["closes", type === "poll" ? "expiry" : "first"],
-          ["deadline", String(Math.floor(Date.now() / 1000) + 3600)],
+          [
+            "deadline",
+            extraTags.find((t) => t[0] === "deadline")?.[1] ??
+              String(Math.floor(Date.now() / 1000) + 3600),
+          ],
           ...opts,
           ...fields,
+          ...extraTags.filter((t) => t[0] !== "deadline"),
         ],
       });
       emit?.({
@@ -69,6 +75,7 @@ async function seed(
       question: QUESTION,
       type,
       fields,
+      extraTags,
     },
   );
   if (enabled) {
@@ -92,9 +99,10 @@ async function updateState(
   revision: number,
   closed: boolean,
   signer = RELAY,
+  answer?: { choices: string[]; tally: Record<string, number> },
 ) {
   await page.evaluate(
-    ({ prompt, revision, closed, signer }) => {
+    ({ prompt, revision, closed, signer, answer }) => {
       window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
         channelName: "engineering",
         id: String(revision + 1)
@@ -108,13 +116,22 @@ async function updateState(
           status: closed ? "closed" : "open",
           close_reason: closed ? "first" : null,
           winner: closed ? "approve" : null,
-          tally: { approve: closed ? 1 : 0, deny: 0 },
-          responders: [],
+          tally: answer?.tally ?? { approve: closed ? 1 : 0, deny: 0 },
+          responders: answer
+            ? [
+                {
+                  pubkey: "deadbeef".repeat(8),
+                  event_id: "e".repeat(64),
+                  created_at: Math.floor(Date.now() / 1000),
+                  choices: answer.choices,
+                },
+              ]
+            : [],
         }),
         extraTags: [["d", prompt]],
       });
     },
-    { prompt: PROMPT, revision, closed, signer },
+    { prompt: PROMPT, revision, closed, signer, answer },
   );
 }
 
@@ -212,4 +229,236 @@ test("default-off clients retain the readable reply fallback", async ({
     .getByTestId("message-row")
     .filter({ hasText: QUESTION })
     .screenshot({ path: "test-results/interactions-fallback.png" });
+});
+
+// Controls are derived from the vendor behavior documented in
+// docs/interaction-controls.md; the mock supplies transport, not the UI logic.
+test("Discord control: a recorded poll vote can be changed while open", async ({
+  page,
+}) => {
+  await seed(page, "poll");
+  const card = page.getByTestId("interaction-card");
+  await updateState(page, 1, false, RELAY, {
+    choices: ["approve"],
+    tally: { approve: 1, deny: 0 },
+  });
+  await expect(card.getByRole("radio", { name: /Approve/ })).toBeChecked();
+  await expect(card.getByRole("status")).toContainText(
+    "Your answer is recorded",
+  );
+  await card.getByRole("radio", { name: /Deny/ }).check();
+  // An unrelated live tally must not erase a person's unsubmitted change.
+  await updateState(page, 2, false, RELAY, {
+    choices: ["approve"],
+    tally: { approve: 2, deny: 3 },
+  });
+  await expect(card.getByRole("radio", { name: /Deny/ })).toBeChecked();
+  await card.getByRole("button", { name: "Update answer" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_SIGNED_EVENTS__
+            ?.filter((e) => e.kind === 40011)
+            .at(-1)?.tags,
+      ),
+    )
+    .toContainEqual(["choice", "deny"]);
+  await updateState(page, 3, false, RELAY, {
+    choices: ["deny"],
+    tally: { approve: 1, deny: 4 },
+  });
+  await expect(card.getByRole("radio", { name: /Deny/ })).toBeChecked();
+  await expect(card.getByRole("radio", { name: /Deny/ })).toHaveAccessibleName(
+    "Deny 4",
+  );
+});
+
+test("Discord select control: enforce min/max without trapping the current selection", async ({
+  page,
+}) => {
+  await seed(page, "poll", [], true, [
+    ["opt", "revise", "Revise"],
+    ["min", "2"],
+    ["max", "2"],
+  ]);
+  const card = page.getByTestId("interaction-card");
+  const submit = card.getByRole("button", { name: "Submit answer" });
+  await expect(submit).toBeDisabled();
+  await card.getByRole("checkbox", { name: /Approve/ }).check();
+  await expect(submit).toBeDisabled();
+  await card.getByRole("checkbox", { name: /Deny/ }).check();
+  await expect(submit).toBeEnabled();
+  await expect(card.getByRole("checkbox", { name: /Revise/ })).toBeDisabled();
+  await card.getByRole("checkbox", { name: /Deny/ }).uncheck();
+  await card.getByRole("checkbox", { name: /Revise/ }).check();
+  await submit.click();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.__BUZZ_E2E_SIGNED_EVENTS__
+          ?.filter((e) => e.kind === 40011)
+          .at(-1)
+          ?.tags.filter((t) => t[0] === "choice"),
+      ),
+    )
+    .toEqual([
+      ["choice", "approve"],
+      ["choice", "revise"],
+    ]);
+});
+
+test("Teams close control: an idle card stops accepting input at the deadline without inventing a result", async ({
+  page,
+}) => {
+  const deadline = Math.floor(Date.now() / 1000) + 3600;
+  await page.clock.install();
+  await seed(page, "poll", [], true, [["deadline", String(deadline)]]);
+  const card = page.getByTestId("interaction-card");
+  await expect(card.getByRole("radio", { name: /Approve/ })).toBeEnabled();
+  await page.clock.fastForward(3_601_000);
+  await expect(card.getByRole("status")).toContainText("Voting ended");
+  await expect(card.getByRole("status")).toContainText("Waiting for the relay");
+  await expect(card.getByRole("radio", { name: /Approve/ })).toBeDisabled();
+  await updateState(page, 1, true);
+  await expect(card.getByRole("status")).toContainText("Closed · Approve");
+});
+
+test("audience control: listed responders restrict answering while the channel can read", async ({
+  page,
+}) => {
+  await seed(page, "buttons", [], true, [
+    ["responders", "listed"],
+    ["p", "f".repeat(64)],
+  ]);
+  const card = page.getByTestId("interaction-card");
+  await expect(card.getByText(QUESTION)).toBeVisible();
+  await expect(
+    card.getByRole("button", { name: "Approve", exact: true }),
+  ).toBeDisabled();
+  await expect(
+    card.getByText("This request is addressed to other members."),
+  ).toBeVisible();
+});
+
+test("Slack form control: pending feedback, failure and retry preserve the user's input", async ({
+  page,
+}) => {
+  await seed(page, "form", [["field", "note", "Note", "text", "required"]]);
+  await page.evaluate(() => {
+    const bridge = (
+      window as unknown as {
+        __TAURI_INTERNALS__: {
+          invoke: (command: string, ...args: unknown[]) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__;
+    const invoke = bridge.invoke.bind(bridge);
+    let fail = true;
+    bridge.invoke = async (command, ...args) => {
+      if (command === "sign_event" && fail) {
+        fail = false;
+        await new Promise((resolve) => setTimeout(resolve, 700));
+        throw new Error("Control: signer temporarily unavailable");
+      }
+      return invoke(command, ...args);
+    };
+  });
+  const card = page.getByTestId("interaction-card");
+  await card.getByLabel("Note (required)").fill("Keep the second take");
+  await card.getByRole("button", { name: "Submit answer" }).click();
+  await expect(card.getByRole("status")).toHaveText("Sending answer…");
+  await expect(
+    card.getByRole("button", { name: "Submit answer" }),
+  ).toBeDisabled();
+  await expect(card.getByRole("alert")).toContainText(
+    "signer temporarily unavailable",
+  );
+  await expect(card.getByLabel("Note (required)")).toHaveValue(
+    "Keep the second take",
+  );
+  await expect(card.getByRole("status")).not.toContainText("recorded");
+  await card.getByRole("button", { name: "Submit answer" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_SIGNED_EVENTS__
+            ?.filter((e) => e.kind === 40011)
+            .at(-1)?.tags,
+      ),
+    )
+    .toContainEqual(["value", "note", "Keep the second take"]);
+});
+
+test("independent cards load their own prompt and pre-existing state in one channel", async ({
+  page,
+}) => {
+  await seed(page);
+  const second = "2".repeat(64);
+  await page.evaluate(
+    ({ relay, second }) => {
+      const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+      emit?.({
+        channelName: "engineering",
+        id: second,
+        kind: 40010,
+        content: "Second decision",
+        extraTags: [
+          ["itype", "buttons"],
+          ["opt", "continue", "Continue"],
+          ["closes", "first"],
+          ["deadline", String(Math.floor(Date.now() / 1000) + 3600)],
+        ],
+      });
+      emit?.({
+        channelName: "engineering",
+        id: "3".repeat(64),
+        kind: 39010,
+        pubkey: relay,
+        content: JSON.stringify({
+          version: 1,
+          revision: 0,
+          status: "open",
+          close_reason: null,
+          winner: null,
+          tally: { continue: 0 },
+          responders: [],
+        }),
+        extraTags: [["d", second]],
+      });
+      emit?.({
+        channelName: "engineering",
+        id: "4".repeat(64),
+        kind: 9,
+        pubkey: relay,
+        content: "Second decision. Reply Continue.",
+        extraTags: [["interaction", second]],
+      });
+    },
+    { relay: RELAY, second },
+  );
+  const other = page
+    .getByTestId("interaction-card")
+    .filter({ hasText: "Second decision" });
+  await expect(
+    other.getByRole("button", { name: "Continue", exact: true }),
+  ).toBeEnabled();
+  await other.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_SIGNED_EVENTS__
+            ?.filter((e) => e.kind === 40011)
+            .at(-1)?.tags,
+      ),
+    )
+    .toContainEqual(["e", second, "", "prompt"]);
+  const first = page
+    .getByTestId("interaction-card")
+    .filter({ hasText: QUESTION });
+  await expect(
+    first.getByRole("button", { name: "Approve", exact: true }),
+  ).toBeEnabled();
 });

--- a/desktop/tests/e2e/interactions.spec.ts
+++ b/desktop/tests/e2e/interactions.spec.ts
@@ -1,0 +1,215 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+
+const RELAY = "a".repeat(64);
+const PROMPT = "b".repeat(64);
+const PROJECTION = "c".repeat(64);
+const QUESTION = "Render The Door That Refused the Umbral Key?";
+
+async function seed(
+  page: Page,
+  type = "buttons",
+  fields: string[][] = [],
+  enabled = true,
+) {
+  await installMockBridge(
+    page,
+    { relaySelf: RELAY },
+    { seedPreviewFeatures: enabled },
+  );
+  await page.goto("/");
+  await page.getByTestId("channel-engineering").click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: "engineering",
+          }) ?? false,
+      ),
+    )
+    .toBe(true);
+  await page.evaluate(
+    ({ relay, prompt, projection, question, type, fields }) => {
+      const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+      const opts =
+        type === "form"
+          ? []
+          : [
+              ["opt", "approve", "Approve", "primary"],
+              ["opt", "deny", "Deny", "danger"],
+            ];
+      emit?.({
+        channelName: "engineering",
+        id: prompt,
+        kind: 40010,
+        content: question,
+        extraTags: [
+          ["itype", type],
+          ["closes", type === "poll" ? "expiry" : "first"],
+          ["deadline", String(Math.floor(Date.now() / 1000) + 3600)],
+          ...opts,
+          ...fields,
+        ],
+      });
+      emit?.({
+        channelName: "engineering",
+        id: projection,
+        kind: 9,
+        pubkey: relay,
+        content: `${question}\nApprove / Deny\nReply with an option.`,
+        extraTags: [["interaction", prompt]],
+      });
+    },
+    {
+      relay: RELAY,
+      prompt: PROMPT,
+      projection: PROJECTION,
+      question: QUESTION,
+      type,
+      fields,
+    },
+  );
+  if (enabled) {
+    await expect(page.getByTestId("interaction-card")).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+              channelName: "engineering",
+              kind: 39010,
+            }) ?? false,
+        ),
+      )
+      .toBe(true);
+    await updateState(page, 0, false);
+  }
+}
+async function updateState(
+  page: Page,
+  revision: number,
+  closed: boolean,
+  signer = RELAY,
+) {
+  await page.evaluate(
+    ({ prompt, revision, closed, signer }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "engineering",
+        id: String(revision + 1)
+          .repeat(64)
+          .slice(0, 64),
+        kind: 39010,
+        pubkey: signer,
+        content: JSON.stringify({
+          version: 1,
+          revision,
+          status: closed ? "closed" : "open",
+          close_reason: closed ? "first" : null,
+          winner: closed ? "approve" : null,
+          tally: { approve: closed ? 1 : 0, deny: 0 },
+          responders: [],
+        }),
+        extraTags: [["d", prompt]],
+      });
+    },
+    { prompt: PROMPT, revision, closed, signer },
+  );
+}
+
+test("buttons sign a decision and follow authoritative close; stale or foreign state is ignored", async ({
+  page,
+}) => {
+  await seed(page);
+  const card = page.getByTestId("interaction-card");
+  const approve = card.getByRole("button", { name: "Approve", exact: true });
+  await expect(approve).toBeEnabled();
+  await updateState(page, 50, true, "f".repeat(64));
+  await expect(approve).toBeEnabled();
+  await approve.focus();
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_SIGNED_EVENTS__
+            ?.filter((e) => e.kind === 40011)
+            .at(-1)?.tags,
+      ),
+    )
+    .toContainEqual(["choice", "approve"]);
+  await updateState(page, 2, true);
+  await expect(card.getByRole("status")).toContainText("Closed · Approve");
+  await updateState(page, 1, false);
+  await expect(approve).toBeDisabled();
+  await waitForAnimations(page);
+  await card.screenshot({ path: "test-results/interactions-closed.png" });
+});
+
+test("forms retain validation and send typed values", async ({ page }) => {
+  await seed(page, "form", [
+    ["field", "title", "Episode title", "text", "required"],
+    ["field", "length", "Length", "select", "required"],
+    ["optsel", "length", "60s", "60 seconds"],
+    ["optsel", "length", "6min", "6 minutes"],
+  ]);
+  const card = page.getByTestId("interaction-card");
+  await card.getByRole("button", { name: "Submit answer" }).click();
+  expect(
+    await page.evaluate(
+      () =>
+        window.__BUZZ_E2E_SIGNED_EVENTS__?.filter((e) => e.kind === 40011)
+          .length ?? 0,
+    ),
+  ).toBe(0);
+  await card.getByLabel("Episode title (required)").fill("The Door");
+  await card.getByLabel("Length (required)").selectOption("6min");
+  await waitForAnimations(page);
+  await card.screenshot({ path: "test-results/interactions-form.png" });
+  await card.getByRole("button", { name: "Submit answer" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_SIGNED_EVENTS__
+            ?.filter((e) => e.kind === 40011)
+            .at(-1)?.tags,
+      ),
+    )
+    .toContainEqual(["value", "length", "6min"]);
+});
+
+test("polls show relay tallies and publish selected choices", async ({
+  page,
+}) => {
+  await seed(page, "poll");
+  const card = page.getByTestId("interaction-card");
+  await card.getByRole("radio", { name: /Deny/ }).check();
+  await card.getByRole("button", { name: "Submit answer" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_SIGNED_EVENTS__
+            ?.filter((e) => e.kind === 40011)
+            .at(-1)?.tags,
+      ),
+    )
+    .toContainEqual(["choice", "deny"]);
+});
+
+test("default-off clients retain the readable reply fallback", async ({
+  page,
+}) => {
+  await seed(page, "buttons", [], false);
+  await expect(page.getByTestId("interaction-card")).toHaveCount(0);
+  await expect(
+    page.getByText("Reply with an option.", { exact: false }),
+  ).toBeVisible();
+  await waitForAnimations(page);
+  await page
+    .getByTestId("message-row")
+    .filter({ hasText: QUESTION })
+    .screenshot({ path: "test-results/interactions-fallback.png" });
+});

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -27,6 +27,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "interaction-preview"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/docs/experimental-interactions.md
+++ b/docs/experimental-interactions.md
@@ -182,6 +182,10 @@ workflow editor, ACP/Hermes transport adapters, interaction-specific push
 navigation, native mobile cards, and any encrypted/private ballot protocol.
 Agents can already use the CLI's ask/answer/wait path without an adapter.
 An automatic agent action must still enforce its existing author allow list.
+Upgrade `buzz-acp` with the relay before targeting agents: this slice verifies
+the relay's text projection and applies the existing author gate to its original
+asker. It does not treat the relay signer as the person making the request.
+Structured ACP question/permission tool-result handling remains follow-up work.
 The initial card shows your recorded choice and the outcome; named responder
 history and rehydrating previously submitted form fields after a remount are
 follow-up UI work. Signed responses remain queryable through the bridge/CLI.

--- a/docs/experimental-interactions.md
+++ b/docs/experimental-interactions.md
@@ -182,6 +182,9 @@ workflow editor, ACP/Hermes transport adapters, interaction-specific push
 navigation, native mobile cards, and any encrypted/private ballot protocol.
 Agents can already use the CLI's ask/answer/wait path without an adapter.
 An automatic agent action must still enforce its existing author allow list.
+The initial card shows your recorded choice and the outcome; named responder
+history and rehydrating previously submitted form fields after a remount are
+follow-up UI work. Signed responses remain queryable through the bridge/CLI.
 
 Before removing the experiment gate, settle kind allocation with maintainers,
 define prompt/projection moderation as one user-visible action, add relay-key
@@ -195,8 +198,9 @@ both tables and the outbox. Community deletion includes both tables.
 Core tests exercise schema errors, form types, replacement, deduplication,
 first/quorum/expiry and deterministic equal-timestamp ordering. PostgreSQL tests
 bind `Db::accept_interaction` and cover concurrent first-close, authorization,
-tenant/channel isolation, fallback identity, rollback on failed state writes
-and expiry before the worker runs. Run them with the repository's real database:
+tenant/channel isolation, fallback identity, rollback on failed state writes,
+expiry before the worker runs, and removed outbox backlogs larger than one
+cleanup batch. Run them with the repository's real database:
 
 ```sh
 BUZZ_TEST_DATABASE_URL=postgres://... \

--- a/docs/experimental-interactions.md
+++ b/docs/experimental-interactions.md
@@ -1,0 +1,216 @@
+# Experimental interaction events (v1)
+
+Signed buttons, polls and forms let a human or agent ask for a typed decision in
+a Buzz channel. This contribution implements the first protocol/relay/CLI slice
+and opt-in desktop cards. It is disabled by default and is not a stable NIP.
+
+## Enable and try it
+
+Set both variables on **every relay pod**, using the same existing relay identity:
+
+```dotenv
+BUZZ_EXPERIMENTAL_INTERACTIONS=true
+BUZZ_RELAY_PRIVATE_KEY=<your existing persistent relay private key>
+```
+
+Startup rejects enabling the experiment without a persistent key. Do not rotate
+that identity while prompts are open: state addresses include its public key.
+The normal migrations create the storage tables even while the flag is off.
+When off, new interaction writes are rejected, fallback matching and the worker
+are disabled, and the capability is not advertised. Existing history is retained.
+Re-enabling processes overdue prompts and pending delivery records.
+
+In desktop Settings → Experimental Features, enable **Interaction cards**. The
+relay flag controls acceptance; the desktop toggle controls rendering only.
+Clients can discover `buzz-interactions-v1` in `/info`'s
+`supported_extensions` and the relay's public key in `self`.
+
+```sh
+buzz interactions ask --channel "$CHANNEL_ID" --type buttons \
+  --text 'Render E001?' \
+  --option approve:Approve:primary --option revise:'Send back' \
+  --option deny:Deny:danger --field note:Note:text:optional \
+  --responders role:owner --closes first --expires 24h
+
+# Use the returned event_id, which identifies the original signed prompt.
+buzz interactions answer --prompt "$PROMPT_ID" --choice approve
+buzz interactions get --prompt "$PROMPT_ID"
+buzz interactions wait --prompt "$PROMPT_ID" --timeout 24h
+
+buzz interactions poll --channel "$CHANNEL_ID" --text 'Which thumbnail?' \
+  --option 1:A --option 2:B --option 3:C --max 1 --expires 2h
+
+buzz interactions ask --channel "$CHANNEL_ID" --type form \
+  --text 'Episode details' --field title:Title:text:required \
+  --field length:Length:select:required --select length=60s,6min,9min
+buzz interactions answer --prompt "$PROMPT_ID" \
+  --value 'title=The Door' --value length=6min
+buzz interactions close --prompt "$PROMPT_ID"
+```
+
+`ask --json @prompt.json` (also inline JSON or `--json -`) accepts an unsigned
+`{"content":"Question", "tags":[...]}` envelope, capped at 64 KiB. The CLI sets
+the prompt kind and signs locally. This avoids delimiter escaping in complex
+labels. `--reply-to` uses the normal channel thread parent and root markers.
+For listed responders, use `--responders listed --responder <pubkey>` repeatedly.
+
+Writes use the existing `{event_id, accepted, message}` JSON contract. `get`
+returns `[signed_prompt, signed_state]`, or just the prompt if no state was
+returned. `wait` returns `[signed_final_state]`; its content is a JSON string.
+It uses bounded HTTP polling and returns exit code 4 on timeout, never an
+inferred denial or approval. Other exit codes follow the existing CLI contract.
+The original response event IDs in state can be queried through the ordinary
+Nostr bridge to inspect comments, form values and signatures.
+
+## Source review of the September 8 outline
+
+The signed prompt/response primitive fits Buzz's Nostr-first API and agent-first
+vision. Several assumptions in the outline differ from this source tree:
+
+| Outline assumption | Source finding and implementation decision |
+| --- | --- |
+| Three 4xxxx kinds, with addressable state | NIP-33 addressable kinds are 30000–39999. The central registry allocates **40010 prompt**, **40011 response**, **40012 close**, **39010 state**. The state kind is relay-only. |
+| Unknown clients automatically display a new prompt kind | Timeline clients subscribe to explicit message kinds. Each prompt therefore atomically creates a relay-signed kind-9 text projection. Aware desktop clients upgrade that projection to a card. |
+| A DM has no `h` tag | Buzz DMs are channel-scoped. All four kinds require one canonical channel UUID in `h`, including a DM channel. This experiment provides channel privacy, not end-to-end encryption. |
+| A root-only tag anchors a thread | Buzz's NIP-10 resolver needs a reply parent. CLI creation preserves the parent and derives its root. Only the text projection increments timeline thread counters. |
+| A relay-signed fallback counts as the responder | That would collapse every text answer onto the relay key. Acceptance instead keys votes by the **original signed message author**, retaining that event as evidence. A synthetic response has `via` and `actor` provenance. Clients cannot supply those tags on typed interactions. |
+| Hidden responder lists make private polls private | Raw responses, queries and notifications would still reveal the answers. V1 accepts only `visibility=public`, meaning visible to readers of the channel. Listed responders restrict answering, not reading. |
+| NIP-40 expiration only closes the prompt | NIP-40 tells clients to ignore expired events and relays not to deliver them, which would hide the original question. V1 uses a separate `deadline` Unix timestamp and rejects `expiration` on prompts. Decision deadlines and event retention are separate policies. |
+| A secret field can simply use gift-wrap | The HTTP ingest bridge rejects gift-wrap, and there is no field-level encrypted envelope with a validation contract. V1 rejects `secret`, `asker-only` and `tallies-only` rather than storing them as plaintext. |
+| `request_approval` already durably suspends a workflow | `buzz-workflow` currently finalizes this action as `approval_not_supported` (WF-08). Durable suspension, resumption and transactional consumption of a decision need a separate change; existing approval kinds and workflow YAML are untouched. |
+| ACP permission requests are interchangeable with user questions | `buzz-acp` currently handles permission options in `handle_permission_request`, including its allow-once behavior. Mapping them needs explicit timeout, cancellation and permission policy; it is not a generic AskUserQuestion transport. No permission behavior changes here. |
+
+Protocol references: [NIP-01 event kinds](https://github.com/nostr-protocol/nips/blob/master/01.md) and
+[NIP-40 expiration](https://github.com/nostr-protocol/nips/blob/master/40.md).
+
+Relevant source: [kind registry](../crates/buzz-core/src/kind.rs),
+[shared ingest](../crates/buzz-relay/src/handlers/ingest.rs),
+[thread markers](../crates/buzz-core/src/nip10.rs),
+[workflow engine](../crates/buzz-workflow/src/lib.rs),
+[ACP harness](../crates/buzz-acp/src/acp.rs). The related community discussion is
+[block/buzz#3261](https://github.com/block/buzz/issues/3261); that discussion does
+not constitute acceptance of these experimental kind allocations.
+
+## Wire contract
+
+Prompt content is Markdown. Schema tags follow the proposed `itype`, `opt`,
+`field`, `optsel`, `responders`, `p`, `min`, `max`, `closes`, `deadline`,
+`visibility` and optional `ref` shape. Option and field IDs are stable ASCII
+identifiers. Unknown provenance tags such as `ref` are preserved by signatures
+but do not grant authority or execute a workflow.
+
+* Buttons have 1–8 options and exactly one selected choice. They can carry
+  accompanying form fields, such as the outline's optional note.
+* Polls have 2–12 options, bounded min/max selection counts and no form fields.
+  They close manually or on expiry.
+* Forms have 1–12 fields: text, finite number, select, boolean (`true`/`false`),
+  or ISO date (`YYYY-MM-DD`). Select values come from `optsel` tags. Required
+  fields cannot be omitted; unknown or repeated fields and choices are rejected.
+
+Each prompt must expire within 30 days. A first or quorum close can happen
+earlier; the asker may explicitly close any open prompt using kind 40012 with
+`["e", "<prompt-id>", "", "prompt"]` and `h`. Expiry is a response deadline;
+it does not delete the audit trail. `quorum:N` counts distinct eligible keys,
+not votes for a particular option. Eligibility is rechecked on each new answer:
+current channel membership plus members/listed/community-owner/admin rules.
+An owner's earlier accepted answer remains recorded if they later leave.
+
+Typed responses use that same `e` marker and channel, repeated `choice` or
+`value` tags, and optional comment content. They are signed by the answering
+key. One effective answer per key may change while open. A newer `created_at`
+wins; equal timestamps use the lower event ID, matching Nostr ordering.
+All accepted historical events remain stored. Exact retries are idempotent,
+including a retry after close. A different answer after close is rejected.
+
+State is addressed by `(39010, relay_pubkey, d=prompt_id)` and also has `h`.
+Its JSON content contains `version`, monotonic `revision`, `status`,
+`close_reason`, `tally`, `winner`, `values` and `responders`. A unique leading
+button choice becomes `winner` only on close; ties and zero votes yield null.
+`values` is a convenience object only when exactly one responder exists;
+otherwise it is null. Each responder entry identifies the signed source event,
+its author, timestamp and choices. A quorum form's per-person values remain in
+those source events.
+
+State creation timestamps advance by at least one second per transition to
+avoid same-second addressable replacement races. During a burst they may lead
+wall time. Readers render by **revision**; they do not count raw response events
+or treat the state timestamp as the time of a person's decision. A prompt caps
+at 256 distinct responders and 4096 answer transitions to bound snapshot growth
+and clock advancement. Content is capped at 16 KiB and schema tags at 32 KiB;
+answer values total at most 8 KiB. Prompt creation is limited to ten per minute
+per key and 32 unexpired open prompts per channel.
+
+## Compatibility, persistence and failure behavior
+
+The kind-9 projection includes the question, option IDs and labels, fallback
+instructions and the prompt ID. A direct reply to either it or the original
+prompt is eligible for fallback only if the **whole trimmed reply**, matched
+case-insensitively, is one declared option label or ID. Punctuation is
+significant. `approve but tighten the hook` stays a comment. Forms, required
+fields and polls requiring multiple choices cannot be answered this way.
+Unknown, unauthorized, ambiguous, stale or closed-prompt replies still follow
+the ordinary message path and do not cast a vote.
+
+The original message and relay synthesis are separate, verifiable signatures.
+A later typed answer replaces that same author's text answer. The relay never
+signs as a user. The projection is an explanation of the prompt; the original
+signed prompt remains the authoritative question and schema.
+
+The shared HTTP/WebSocket ingest path authenticates the event and checks the
+experiment before the interaction transaction. A row lock serializes answers
+and close operations; membership/role rows are read on the writer and locked
+during acceptance. The source event, updated snapshot, signed state and delivery
+records commit together. A durable outbox retries Redis publication after
+failure or restart. Delivery is at least once; consumers deduplicate by event ID
+and state revision. Historical reads work independently of delivery progress.
+Queued events removed by replacement or moderation are discarded rather than
+replayed. Community and channel boundaries are carried through delivery and the
+existing recipient access gate. The standard event audit path is reused.
+
+Expiry uses a bounded worker with `FOR UPDATE SKIP LOCKED` across pods. Every
+answer checks the database clock after acquiring the prompt lock, so a delayed
+sweep cannot accept a late vote. Text answers retain ordinary message workflow
+triggers with the existing post-commit semantics. Native interaction workflow
+triggers are not introduced in this slice.
+
+## Follow-up slices
+
+This contribution intentionally does **not** claim all five rollout phases are
+complete. Remaining work includes durable `request_input` workflow suspension
+and outputs, migration of approvals, desktop `/ask` and `/poll` authoring and a
+workflow editor, ACP/Hermes transport adapters, interaction-specific push
+navigation, native mobile cards, and any encrypted/private ballot protocol.
+Agents can already use the CLI's ask/answer/wait path without an adapter.
+An automatic agent action must still enforce its existing author allow list.
+
+Before removing the experiment gate, settle kind allocation with maintainers,
+define prompt/projection moderation as one user-visible action, add relay-key
+rotation migration, and exercise multi-pod races against native PostgreSQL and
+Redis. The durable interaction snapshot is separate from ordinary event
+retention; a retention policy and any privacy extension must explicitly cover
+both tables and the outbox. Community deletion includes both tables.
+
+## Validation
+
+Core tests exercise schema errors, form types, replacement, deduplication,
+first/quorum/expiry and deterministic equal-timestamp ordering. PostgreSQL tests
+bind `Db::accept_interaction` and cover concurrent first-close, authorization,
+tenant/channel isolation, fallback identity, rollback on failed state writes
+and expiry before the worker runs. Run them with the repository's real database:
+
+```sh
+BUZZ_TEST_DATABASE_URL=postgres://... \
+  cargo test -p buzz-db --lib store::interaction::postgres_tests -- --ignored
+```
+
+Desktop tests exercise keyboard button submission, native form validation,
+poll selection, foreign/stale state and the default-off text fallback:
+
+```sh
+cd desktop
+pnpm build:e2e
+pnpm exec playwright test --project=smoke interactions.spec.ts
+```
+
+Run `just ci` and the repository's relay integration suite (`just test`) before
+merging. Embedded PostgreSQL substitutes do not validate row-lock concurrency.

--- a/docs/interaction-controls.md
+++ b/docs/interaction-controls.md
@@ -49,6 +49,9 @@ mobile cards or runtime permission prompts.
   the custom kinds; exact whole-reply fallback retains original signed evidence.
 - Isolation/privacy: channel and tenant boundaries, unauthorized replies remain
   comments, relay-only state, and rejection of unsupported private/secret forms.
+- Agent authority: a verified text projection is attributed to its original
+  asker before the harness applies its existing owner/allowlist policy. An
+  allowlisted relay signer must not confer its authority on an unlisted asker.
 - Delivery: bounded expiry work, durable at-least-once outbox, and pruning of
   queued events removed by moderation or addressable replacement.
 

--- a/docs/interaction-controls.md
+++ b/docs/interaction-controls.md
@@ -1,0 +1,82 @@
+# Interaction controls and acceptance criteria
+
+Reviewed against vendor documentation on 2026-09-08. The controls below are
+**emulated behavioral examples**, not recordings of tests run inside Slack,
+Discord or Teams accounts. Their expected outcomes were written separately from
+Buzz's implementation. Browser tests mount the production Buzz timeline/card and
+substitute the transport; Rust tests exercise the production schema/state code.
+Neither substitutes for the PostgreSQL concurrency and Redis integration gates.
+
+## Control examples
+
+| Control and source | Expected behavior in Buzz | Executable evidence |
+| --- | --- | --- |
+| [Slack buttons](https://docs.slack.dev/reference/block-kit/block-elements/button-element/) | A named action is keyboard-operable; primary/danger distinguish intent; the choice ID is sent. | `interactions.spec.ts`: keyboard approval and authoritative close |
+| [Slack interaction acknowledgement](https://docs.slack.dev/interactivity/handling-user-interaction/) | Show immediate pending feedback; prevent repeat submission; show an error if delivery/signing fails; do not claim a recorded answer prematurely. | `Slack form control`: delayed signer failure and retry |
+| [Slack form errors](https://docs.slack.dev/surfaces/modals/#display-errors-in-views) | Required fields prevent submission. Failure leaves entered values available to correct/retry. | `forms retain validation`; `Slack form control` |
+| [Discord components](https://docs.discord.com/developers/components/reference) | Multi-select obeys min/max. At the maximum, selected items remain removable; extra unselected items are disabled. | `Discord select control` |
+| [Discord polls](https://support.discord.com/hc/en-us/articles/22163184112407-Polls-FAQ) | Explicit submission, a visible recorded choice, and the ability to change that choice while voting remains open. Live results do not overwrite an unsubmitted selection. | `Discord control`: recorded vote → draft change → unrelated tally → submit → revised state |
+| [Teams poll lifecycle](https://support.microsoft.com/en-us/forms/poll-attendees-during-a-teams-meeting) | Clearly distinguish open voting from closed results; disable controls when voting ends. Buzz waits for a relay-authored result after its local deadline. | `Teams close control`: clock advances with no incoming close, then authoritative close arrives |
+| [GroupMe vote changes](https://support.microsoft.com/en-us/groupme/how-do-i-add-a-poll-to-a-groupme-chat) | A changed vote replaces the entire prior selection before closure. A subsequent attempt after closure cannot change the result. | `poll_control_trace_replaces_the_entire_selection_and_keeps_evidence` in `buzz-core` |
+
+Concrete poll control: Alice selects Door + Key, Bob selects Key, then Alice
+changes to Hall. Expected counts are respectively `(1,1,0)`, `(1,2,0)` and
+`(0,1,1)`, with two respondents and Alice's newer signed event as her evidence.
+Duplicate choices, undeclared choices and selections above the maximum are
+rejected. Closing the poll freezes those counts.
+
+Intentional differences: Slack/Discord's three-second acknowledgement contracts
+belong to their HTTP interaction APIs; Buzz immediately displays pending status
+and waits for its existing relay acknowledgement. Buzz uses signed events and
+relay-authored state, direct answer replacement instead of Discord's remove-vote
+step, and inline forms instead of a modal. V1 has channel-visible answers only.
+It does not claim private/anonymous ballot parity, re-opening polls, native
+mobile cards or runtime permission prompts.
+
+## General acceptance criteria
+
+- Off by default: relay writes require the flag and persistent relay identity;
+  desktop controls require the separate experimental toggle.
+- Decision integrity: current membership/role authorization on the writer,
+  immutable source signatures, actor-based replacement, deterministic ordering,
+  exact-retry idempotency, and transactional source/state/outbox writes.
+- Lifecycle: first/quorum/manual/deadline rules, no acceptance after deadline,
+  one counted response per actor, and no client-inferred final outcome.
+- Accessibility and recovery: labeled native controls, keyboard operation,
+  visible pending/error/closed states, retained form input on failure, bounded
+  selection, and live updates that preserve drafts.
+- Compatibility: ordinary text projections for clients that do not subscribe to
+  the custom kinds; exact whole-reply fallback retains original signed evidence.
+- Isolation/privacy: channel and tenant boundaries, unauthorized replies remain
+  comments, relay-only state, and rejection of unsupported private/secret forms.
+- Delivery: bounded expiry work, durable at-least-once outbox, and pruning of
+  queued events removed by moderation or addressable replacement.
+
+The experiment must remain gated until native PostgreSQL races and the full
+repository CI jobs pass. Passing browser controls alone does not establish
+production readiness or completion of the outline's later workflow/harness
+phases. See [the protocol review](experimental-interactions.md) for scope.
+
+## Run the controls
+
+```sh
+cargo test -p buzz-core --lib interaction::tests
+cd desktop
+pnpm build:e2e
+pnpm exec playwright test --project=smoke interactions.spec.ts
+```
+
+## Try the browser preview
+
+```sh
+cd desktop
+pnpm build:interaction-preview
+python3 -m http.server 4173 --bind 127.0.0.1 -d dist-interaction-preview
+# Open http://127.0.0.1:4173/interaction-preview/index.html
+```
+
+Open **#engineering**. The separate preview includes three examples and a
+permanent simulated-data notice. It uses the actual desktop application and
+cards with the repository's mock browser bridge. Replies update an in-memory
+demonstration state; they are not real relay decisions. Reload to reset. This
+entry point is excluded from normal desktop builds.

--- a/migrations/0045_experimental_interactions.sql
+++ b/migrations/0045_experimental_interactions.sql
@@ -1,0 +1,33 @@
+-- Runtime-gated by BUZZ_EXPERIMENTAL_INTERACTIONS (off by default).
+-- Signed events remain in events; this table serializes one prompt's transitions.
+CREATE TABLE interactions (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    prompt_id BYTEA NOT NULL CHECK (octet_length(prompt_id) = 32),
+    channel_id UUID NOT NULL,
+    author BYTEA NOT NULL,
+    prompt JSONB NOT NULL,
+    state JSONB NOT NULL,
+    projection_id BYTEA NOT NULL,
+    state_timestamp BIGINT NOT NULL,
+    expiration BIGINT NOT NULL,
+    closed BOOLEAN NOT NULL DEFAULT FALSE,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (community_id, prompt_id),
+    FOREIGN KEY (community_id, channel_id) REFERENCES channels (community_id, id) ON DELETE CASCADE
+);
+CREATE INDEX idx_interactions_open ON interactions (expiration) WHERE NOT closed;
+CREATE INDEX idx_interactions_channel ON interactions (community_id, channel_id) WHERE NOT closed;
+CREATE INDEX idx_interactions_author ON interactions (community_id, author, received_at);
+CREATE UNIQUE INDEX idx_interactions_projection ON interactions (community_id, projection_id);
+
+-- Durable at-least-once Redis delivery. Repeated event IDs are harmless to clients.
+CREATE TABLE interaction_outbox (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    event_id BYTEA NOT NULL,
+    channel_id UUID NOT NULL,
+    event JSONB NOT NULL,
+    queued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (community_id, event_id),
+    FOREIGN KEY (community_id, channel_id) REFERENCES channels (community_id, id) ON DELETE CASCADE
+);
+CREATE INDEX idx_interaction_outbox_queued ON interaction_outbox (queued_at);

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -34,6 +34,11 @@ abstract final class EventKind {
   static const channelWindowBounds = 39006;
   static const streamMessageEdit = 40003;
   static const streamMessageDiff = 40008;
+  // Experimental interaction protocol; mobile uses message projections.
+  static const interactionPrompt = 40010;
+  static const interactionResponse = 40011;
+  static const interactionClose = 40012;
+  static const interactionState = 39010;
   static const systemMessage = 40099;
   static const jobRequest = 43001;
   static const jobAccepted = 43002;

--- a/preview-features.json
+++ b/preview-features.json
@@ -36,6 +36,12 @@
       "name": "Agent-managed profiles",
       "description": "Let agents manage their own relay name and avatar instead of restoring the desktop copy",
       "platforms": ["desktop"]
+    },
+    {
+      "id": "interactions",
+      "name": "Interaction cards",
+      "description": "Experimental signed buttons, forms and polls on supporting relays",
+      "platforms": ["desktop"]
     }
   ]
 }

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1893,3 +1893,37 @@ CREATE INDEX idx_relay_operator_audit_target
 INSERT INTO _operator_global_tables (table_name, reason) VALUES
     ('relay_operator_audit', 'deployment-global append-only roster mutation audit trail; no community_id intentionally');
 
+
+-- Runtime-gated by BUZZ_EXPERIMENTAL_INTERACTIONS (off by default).
+-- Signed events remain in events; this table serializes one prompt's transitions.
+CREATE TABLE interactions (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    prompt_id BYTEA NOT NULL CHECK (octet_length(prompt_id) = 32),
+    channel_id UUID NOT NULL,
+    author BYTEA NOT NULL,
+    prompt JSONB NOT NULL,
+    state JSONB NOT NULL,
+    projection_id BYTEA NOT NULL,
+    state_timestamp BIGINT NOT NULL,
+    expiration BIGINT NOT NULL,
+    closed BOOLEAN NOT NULL DEFAULT FALSE,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (community_id, prompt_id),
+    FOREIGN KEY (community_id, channel_id) REFERENCES channels (community_id, id) ON DELETE CASCADE
+);
+CREATE INDEX idx_interactions_open ON interactions (expiration) WHERE NOT closed;
+CREATE INDEX idx_interactions_channel ON interactions (community_id, channel_id) WHERE NOT closed;
+CREATE INDEX idx_interactions_author ON interactions (community_id, author, received_at);
+CREATE UNIQUE INDEX idx_interactions_projection ON interactions (community_id, projection_id);
+
+-- Durable at-least-once Redis delivery. Repeated event IDs are harmless to clients.
+CREATE TABLE interaction_outbox (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    event_id BYTEA NOT NULL,
+    channel_id UUID NOT NULL,
+    event JSONB NOT NULL,
+    queued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (community_id, event_id),
+    FOREIGN KEY (community_id, channel_id) REFERENCES channels (community_id, id) ON DELETE CASCADE
+);
+CREATE INDEX idx_interaction_outbox_queued ON interaction_outbox (queued_at);


### PR DESCRIPTION
## Summary

Agents currently need to parse prose or reactions to obtain a structured decision.
This draft introduces opt-in, signed interaction prompts and responses with
relay-authored state, so the responder and the resulting decision remain attributable.

- Add bounded button, poll and non-secret form schemas; prompt/response/close kinds
  40010/40011/40012 and relay-only addressable state kind 39010.
- Gate relay writes and advertisement with `BUZZ_EXPERIMENTAL_INTERACTIONS=false`
  by default, requiring a persistent `BUZZ_RELAY_PRIVATE_KEY` when enabled.
- Validate and authorize using the writer's current membership/roles, serialize
  decisions under a prompt-row lock, and commit source/state/outbox together.
  Support replacements, first/quorum/manual/deadline closure and durable delivery.
- Project ordinary messages for older clients and attribute exact text answers
  to their original signed message, with explicit relay provenance.
- Add signed HTTP-bridge CLI ask/poll/answer/get/wait/close commands and desktop
  cards behind the separate, default-off Interaction cards experimental toggle.
- Preserve the original asker in the ACP author gate for verified relay text
  projections, so the relay signer cannot confer its own allowlist authority.
- Add documented behavioral controls based on Slack, Discord, Teams and GroupMe,
  including selection limits, pending/error recovery, keyboard use, draft retention
  and idle deadline handling. Provide a separate browser preview build entry point.

This is a first experimental slice. It does not add durable workflow suspension,
workflow approval migration, ACP question/permission and Hermes adapters,
composer commands, private ballots, secret fields, interaction push navigation or native mobile cards.
Unsupported privacy modes are rejected. Kind allocation, retention, key rotation,
and unified prompt/projection moderation need maintainer review before promotion.
See `docs/experimental-interactions.md` and `docs/interaction-controls.md`.

### Related issue

Refs #3261. Searched existing issues and PRs for interaction prompts; #3261 is the
closest feature request. No duplicate implementation was found in that search.

### Testing

Draft status is intentional: full CI is not green in the available environment.
Native PostgreSQL and supported-platform CI results are required before promotion.

- All 6,452 desktop unit tests pass.
- All 10 interaction browser controls pass against the production timeline/card
  with the repository's mock transport. Their vendor expectations are emulated
  from primary documentation; no live Slack/Discord/Teams tenant was exercised.
- Final `just test-unit` passes all 14 groups, including 261 core, 466 CLI,
  123 DB and 917 ACP unit tests. The ACP tests exercise the connected author gate
  and reject an unlisted asker even when the relay signer is allowlisted.
- Desktop frontend, web, preview and Linux CLI/relay/admin/ACP builds pass.
  The packaged preview verifies approval, form, vote, manual close and reset without page errors.
- Native PostgreSQL/Redis and relay integration gates remain blocked. Seven
  interaction PostgreSQL tests are included, covering first-answer races,
  authorization/isolation, attribution, rollback, expiry and outbox pruning.
- `just ci` reaches the Tauri gate and fails on unavailable GTK/GIO system libraries.
  Mobile dependency resolution is blocked; macOS/Windows platform jobs were not run.
- Complete desktop smoke run (1,414 cases): 1,329 passed, 82 failed, 3 skipped, 0 flaky.
  All 10 interaction controls pass in that run. This environment used Chromium
  149, six workers and video disabled, so supported-runner verification is required.
- A six-case comparison against unmodified upstream produced the same four passes
  and two failures on both versions. Other failures remain untriaged; this result
  does not establish that every failure is pre-existing.

UI evidence prepared: text fallback, closed approval, required-fields form and
three-card preview screenshots. GitHub screenshot upload remains blocked: the required
`scripts/post-screenshots.sh` needs authenticated `gh` and upstream branch-write
access, which this environment does not have. Screenshots are included in the
contribution package supplied to the contributor.

### Published source

Published through the GitHub connector with Codex co-author attribution and DCO
trailers. Commit IDs differ from the local build because GitHub supplies author/time
metadata; every uploaded source tree was checked against its corresponding local
commit. Final source tree: `17834844f3da37b9c0841f3c29faa854746c0f2a`.
The branch is based on `3c7f288c60d67df78577b237e27c3dfc8831aaa1`;
a merge-tree check against upstream `86c189e8571d4254726f4d0519a500df9b9d947e`
reported no conflicts. The combined upstream merge has not been retested locally.

### GitHub checks after publication

DCO Check passed. [CI](https://github.com/block/buzz/actions/runs/34236825815),
[Desktop Release Candidate](https://github.com/block/buzz/actions/runs/34236825468)
and [Docker image](https://github.com/block/buzz/actions/runs/34236825459)
currently report `action_required` for this fork contribution; maintainer approval
is needed before their results can be evaluated. These are not passing test results.
