### PR TITLE
feat(agent): optional BUZZ_AGENT_STRICT_TOOLS to mark function tools strict

### DIFF
--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -626,6 +626,20 @@ pub struct Config {
     /// Databricks gateway does not auto-cache, so without this the surfaced
     /// `cache_read_input_tokens` is structurally always 0.
     pub prompt_caching: bool,
+    /// Mark every function tool `strict` on OpenAI-compatible routes. Off by default.
+    /// Enable with `BUZZ_AGENT_STRICT_TOOLS=1`.
+    ///
+    /// Some OpenAI-compatible servers attach a tool-call grammar only when a tool opts in.
+    /// vLLM is one: `get_model_structural_tag()` returns `None` for
+    /// `tool_choice: "auto"` unless at least one tool sets `strict`, so the model decodes
+    /// tool calls free-form. When that drifts the reply is still HTTP 200 with
+    /// `finish_reason: "stop"` and `tool_calls: null`, and the malformed call is left in
+    /// `content` — an agent loop reads that as "the model is done" rather than as an error.
+    ///
+    /// Off by default because `strict` implies a JSON-Schema subset (no unconstrained
+    /// `additionalProperties`, every property required) that not every provider or tool
+    /// schema satisfies, and some providers reject unknown request fields outright.
+    pub strict_tools: bool,
 }
 
 impl Config {
@@ -745,6 +759,7 @@ impl Config {
                 env("BUZZ_AGENT_THINKING_SUMMARY").as_deref(),
             )?,
             prompt_caching: parse_env("BUZZ_AGENT_PROMPT_CACHING", 1u8)? != 0,
+            strict_tools: parse_env("BUZZ_AGENT_STRICT_TOOLS", 0u8)? != 0,
         };
         cfg.validate()?;
         Ok(cfg)
@@ -797,6 +812,7 @@ impl Config {
             thinking_effort: None,
             thinking_summary: ThinkingSummary::Auto,
             prompt_caching: false,
+            strict_tools: false,
         }
     }
 

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -789,10 +789,12 @@ fn openai_body(
     let tools_json: Vec<Value> = tools
         .iter()
         .map(|t| {
-            json!({
-        "type": "function",
-        "function": { "name": t.name, "description": t.description,
-            "parameters": t.input_schema } })
+            let mut function = json!({ "name": t.name, "description": t.description,
+                "parameters": t.input_schema });
+            if cfg.strict_tools {
+                function["strict"] = json!(true);
+            }
+            json!({ "type": "function", "function": function })
         })
         .collect();
     let mut body = json!({ "model": effective_model, "stream": false,
@@ -905,12 +907,16 @@ fn responses_body(
     let tools_json: Vec<Value> = tools
         .iter()
         .map(|t| {
-            json!({
+            let mut tool = json!({
                 "type": "function",
                 "name": t.name,
                 "description": t.description,
                 "parameters": t.input_schema,
-            })
+            });
+            if cfg.strict_tools {
+                tool["strict"] = json!(true);
+            }
+            tool
         })
         .collect();
 
@@ -2615,6 +2621,7 @@ mod tests {
             thinking_effort: None,
             thinking_summary: ThinkingSummary::Auto,
             prompt_caching: true,
+            strict_tools: false,
         }
     }
 
@@ -2960,6 +2967,62 @@ mod tests {
             "Responses tool schema is flat"
         );
         assert_eq!(body["tool_choice"], "auto");
+    }
+
+    fn strict_tools_fixture() -> Vec<ToolDef> {
+        vec![ToolDef {
+            name: "dev__shell".into(),
+            description: "run a shell command".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+            }),
+        }]
+    }
+
+    #[test]
+    fn tools_are_not_strict_by_default() {
+        let tools = strict_tools_fixture();
+        let history = [HistoryItem::User("hi".into())];
+
+        let body = openai_body(&cfg(Provider::OpenAi), "system", &history, &tools, "model", None);
+        assert!(
+            body["tools"][0]["function"].get("strict").is_none(),
+            "strict must be absent unless BUZZ_AGENT_STRICT_TOOLS is set — some providers \
+             reject unknown request fields"
+        );
+
+        let body = responses_body(&cfg_responses(), "system", &history, &tools, "model", None);
+        assert!(body["tools"][0].get("strict").is_none());
+    }
+
+    #[test]
+    fn strict_tools_marks_every_function_tool() {
+        let tools = strict_tools_fixture();
+        let history = [HistoryItem::User("hi".into())];
+
+        // Chat Completions: `strict` belongs INSIDE the function object.
+        let mut c = cfg(Provider::OpenAi);
+        c.strict_tools = true;
+        let body = openai_body(&c, "system", &history, &tools, "model", None);
+        let sent = body["tools"].as_array().unwrap();
+        assert!(!sent.is_empty());
+        for tool in sent {
+            assert_eq!(tool["function"]["strict"], true);
+            // Marking a tool strict must not disturb the rest of its schema.
+            assert_eq!(tool["function"]["name"], "dev__shell");
+            assert!(tool["function"]["parameters"].is_object());
+        }
+        assert_eq!(body["tool_choice"], "auto");
+
+        // Responses: the function tool is flat, so `strict` sits alongside `name`.
+        let mut c = cfg_responses();
+        c.strict_tools = true;
+        let body = responses_body(&c, "system", &history, &tools, "model", None);
+        for tool in body["tools"].as_array().unwrap() {
+            assert_eq!(tool["strict"], true);
+            assert!(tool.get("function").is_none(), "Responses tool schema is flat");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an opt-in `BUZZ_AGENT_STRICT_TOOLS=1` that marks every function tool `strict` on the OpenAI-compatible routes.

Some OpenAI-compatible servers attach a tool-call grammar **only** when a tool opts in via `strict`. vLLM is one — `get_model_structural_tag()` returns `None` for `tool_choice: "auto"` unless at least one tool sets it:

```python
if tool_choice == "auto" and not _any_tool_strict(tools):
    return None
```

`buzz-agent` never sets `strict`, so against those servers every request takes the unconstrained path. When the model then drifts, the response is still **HTTP 200** with `finish_reason: "stop"` and `tool_calls: null`, and the malformed call is left in `content`. An agent loop reads that as a *finished turn* rather than an error, so it fails silently instead of retrying — which is worse than a wrong answer.

Off by default: `strict` implies a JSON-Schema subset (no unconstrained `additionalProperties`, every property required) that not every provider or tool schema satisfies, and some providers reject unknown request fields outright.

Covers both OpenAI shapes — the field goes **inside** `function` for Chat Completions, and **alongside** `name` for Responses.

### Related issue

None found — searched open issues and PRs for `strict`, `tool_choice`, `structural tag`, and `grammar`.

### Testing

`cargo test -p buzz-agent --lib` → **528 passed, 0 failed** (2 new tests, no existing test changed).

New tests:
- `tools_are_not_strict_by_default` — asserts `strict` is absent on both shapes unless enabled, so the default wire format is unchanged.
- `strict_tools_marks_every_function_tool` — asserts placement on both shapes and that the rest of each tool schema is untouched.

Measured end-to-end against vLLM 0.28.1 serving Qwen3.8-Flash-Next (NVFP4, TP2), one prompt, n=12 per arm, on a real 60-tool surface:

| | real `tool_calls` | median latency | HTTP errors |
|---|---|---|---|
| unmarked (today) | **7/12** | 2.01 s | 0 |
| `strict: true` | **12/12** | 1.98 s | 0 |

Observed drift on the unmarked arm: `{"function": "read_file", ...}` (wrong key) and `{"name": "read_file", "path": "/etc/hosts"}` (arguments flattened away) — both returned HTTP 200 with `tool_calls: null`.

Also checked that the grammar actually compiles for a wide surface: all 60 tools produced a single `StructuralTag` (85,719 chars, 120 tags) with no request errors.