### PR TITLE
fix(cli): reject empty message content in buzz messages send

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -606,6 +606,11 @@ pub struct SendMessageParams {
     pub broadcast: bool,
     pub files: Vec<String>,
     pub mentions: Vec<String>,
+    pub allow_empty: bool,
+    /// True when the caller passed `--content -`. Captured by the dispatcher
+    /// before `read_or_stdin` replaces the `-` sentinel, so the emptiness
+    /// guard can name stdin as the likely source of a pipeline failure.
+    pub content_from_stdin: bool,
 }
 
 pub async fn cmd_send_message(
@@ -618,6 +623,24 @@ pub async fn cmd_send_message(
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
     validate_content_size(&p.content)?;
+
+    // Refuse to publish an empty message. Empty content has no recipient
+    // value, and on the stdin path it almost always means an upstream
+    // pipeline step failed — the caller needs a non-zero exit, not a
+    // successful publish of a ghost bubble. A `--file` send is exempt because
+    // media assembly below appends the attachment to `final_content`.
+    if !p.allow_empty && p.files.is_empty() && p.content.trim().is_empty() {
+        return Err(CliError::Usage(if p.content_from_stdin {
+            "refusing to publish an empty message from stdin (an upstream pipeline step \
+             likely failed). Pass --allow-empty to confirm."
+                .into()
+        } else {
+            "refusing to publish an empty message: --content is empty or whitespace-only. \
+             Pass --allow-empty to confirm."
+                .into()
+        }));
+    }
+
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
     }
@@ -945,7 +968,9 @@ pub async fn dispatch(
             broadcast,
             files,
             mentions,
+            allow_empty,
         } => {
+            let content_from_stdin = content == "-";
             cmd_send_message(
                 client,
                 SendMessageParams {
@@ -956,6 +981,8 @@ pub async fn dispatch(
                     broadcast,
                     files,
                     mentions,
+                    allow_empty,
+                    content_from_stdin,
                 },
             )
             .await
@@ -1717,6 +1744,8 @@ mod tests {
             broadcast: false,
             files: vec![],
             mentions: vec![],
+            allow_empty: false,
+            content_from_stdin: false,
         }
     }
 
@@ -1886,6 +1915,149 @@ mod tests {
         assert!(
             emoji_tags.is_empty(),
             "palette-error fallback must produce no emoji tags, got: {emoji_tags:?}"
+        );
+    }
+
+    // ── cmd_send_message — empty-content guard ─────────────────────────────
+    //
+    // These drive the production path through the same fake relay as the tests
+    // above and assert `captured_event` stays `None`, so a guard that only
+    // lives in a helper cannot satisfy them. Removing the guard at
+    // `cmd_send_message` makes each of these fail.
+
+    #[tokio::test]
+    async fn cmd_send_message_rejects_empty_content() {
+        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+
+        let err = cmd_send_message(&client, send_params(""))
+            .await
+            .expect_err("empty content must be rejected");
+
+        assert!(
+            matches!(err, CliError::Usage(_)),
+            "expected Usage, got {err:?}"
+        );
+        assert!(
+            captured_event.lock().unwrap().is_none(),
+            "no event may be published for empty content"
+        );
+    }
+
+    #[tokio::test]
+    async fn cmd_send_message_rejects_whitespace_only_content() {
+        for content in ["\n", "   ", "\t\n "] {
+            let (url, _query_count, captured_event) =
+                fake_send_relay(send_palette_response()).await;
+            let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+
+            let err = cmd_send_message(&client, send_params(content))
+                .await
+                .expect_err("whitespace-only content must be rejected");
+
+            assert!(
+                matches!(err, CliError::Usage(_)),
+                "expected Usage for {content:?}, got {err:?}"
+            );
+            assert!(
+                captured_event.lock().unwrap().is_none(),
+                "no event may be published for {content:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cmd_send_message_rejects_empty_content_before_mention_preflight() {
+        // `--mention` forces a relay membership fetch. The emptiness guard must
+        // run first, so an unreachable or unhelpful relay cannot replace the
+        // empty-content diagnosis with an unrelated failure.
+        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let mut params = send_params("");
+        params.mentions = vec!["a".repeat(64)];
+
+        let err = cmd_send_message(&client, params)
+            .await
+            .expect_err("empty content must be rejected before the mention preflight");
+
+        // The message must be the empty-content diagnosis, not the membership
+        // failure the preflight would otherwise raise.
+        let CliError::Usage(msg) = &err else {
+            panic!("expected the empty-content Usage error, got {err:?}");
+        };
+        assert!(
+            msg.contains("empty message"),
+            "expected the empty-content diagnosis, got {msg:?}"
+        );
+        assert!(
+            !msg.contains("not channel members"),
+            "the mention preflight must not run first, got {msg:?}"
+        );
+        assert!(
+            captured_event.lock().unwrap().is_none(),
+            "no event may be published"
+        );
+    }
+
+    #[tokio::test]
+    async fn cmd_send_message_publishes_empty_content_with_allow_empty() {
+        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let mut params = send_params("");
+        params.allow_empty = true;
+
+        cmd_send_message(&client, params)
+            .await
+            .expect("--allow-empty must permit an empty publish");
+
+        assert!(
+            captured_event.lock().unwrap().is_some(),
+            "the event must be published when --allow-empty is set"
+        );
+    }
+
+    #[tokio::test]
+    async fn cmd_send_message_names_stdin_when_it_produced_the_emptiness() {
+        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let mut params = send_params("\n");
+        params.content_from_stdin = true;
+
+        let err = cmd_send_message(&client, params)
+            .await
+            .expect_err("stdin whitespace must be rejected");
+
+        let CliError::Usage(msg) = &err else {
+            panic!("expected Usage, got {err:?}");
+        };
+        assert!(
+            msg.contains("upstream pipeline step"),
+            "the stdin path must name the likely cause, got {msg:?}"
+        );
+        assert!(
+            captured_event.lock().unwrap().is_none(),
+            "no event may be published"
+        );
+    }
+
+    #[tokio::test]
+    async fn cmd_send_message_does_not_apply_empty_guard_to_file_sends() {
+        // A caption-less `--file` send carries empty text but publishes
+        // non-empty content. The guard must not fire, so the send proceeds to
+        // the upload and fails there instead.
+        let (url, _query_count, _captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let mut params = send_params("");
+        params.files = vec!["/nonexistent/attachment.png".to_string()];
+
+        let err = cmd_send_message(&client, params)
+            .await
+            .expect_err("uploading a missing file must fail");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("upload failed"),
+            "the empty-content guard must not fire on a file send, got {msg:?}"
         );
     }
 }

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -598,6 +598,13 @@ fn match_profiles_by_name(events: &[serde_json::Value], name: &str) -> Vec<(Stri
     matches
 }
 
+/// True when `content` is the `-` sentinel that asks [`read_or_stdin`] to read
+/// the body from stdin. Named so the provenance the emptiness guard reports
+/// cannot drift from the sentinel the reader itself acts on.
+fn content_comes_from_stdin(content: &str) -> bool {
+    content == "-"
+}
+
 pub struct SendMessageParams {
     pub channel_id: String,
     pub content: String,
@@ -628,8 +635,10 @@ pub async fn cmd_send_message(
     // value, and on the stdin path it almost always means an upstream
     // pipeline step failed — the caller needs a non-zero exit, not a
     // successful publish of a ghost bubble. A `--file` send is exempt because
-    // media assembly below appends the attachment to `final_content`.
-    if !p.allow_empty && p.files.is_empty() && p.content.trim().is_empty() {
+    // media assembly below appends the attachment to `final_content`; a blank
+    // `--file` value is not an attachment, so it does not exempt the guard.
+    let has_usable_file = p.files.iter().any(|f| !f.trim().is_empty());
+    if !p.allow_empty && !has_usable_file && p.content.trim().is_empty() {
         return Err(CliError::Usage(if p.content_from_stdin {
             "refusing to publish an empty message from stdin (an upstream pipeline step \
              likely failed). Pass --allow-empty to confirm."
@@ -970,7 +979,7 @@ pub async fn dispatch(
             mentions,
             allow_empty,
         } => {
-            let content_from_stdin = content == "-";
+            let content_from_stdin = content_comes_from_stdin(&content);
             cmd_send_message(
                 client,
                 SendMessageParams {
@@ -1111,9 +1120,9 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        channel_id_from_event, cmd_get_thread, cmd_send_message, event_mention_pubkeys,
-        find_root_from_tags, format_events, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        channel_id_from_event, cmd_get_thread, cmd_send_message, content_comes_from_stdin,
+        event_mention_pubkeys, find_root_from_tags, format_events, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys, resolve_thread_target, thread_ref_from_event,
         thread_ref_from_parent_tags, BuzzClient, CliError, Uuid,
     };
@@ -1925,18 +1934,41 @@ mod tests {
     // lives in a helper cannot satisfy them. Removing the guard at
     // `cmd_send_message` makes each of these fail.
 
+    /// Client bound to a fake relay, for the send-path tests below.
+    fn send_test_client(url: String) -> BuzzClient {
+        BuzzClient::new(url, Keys::generate(), None, None).unwrap()
+    }
+
+    #[test]
+    fn content_comes_from_stdin_matches_only_the_reader_sentinel() {
+        assert!(content_comes_from_stdin("-"));
+        assert!(!content_comes_from_stdin(""));
+        assert!(!content_comes_from_stdin("--"));
+        assert!(!content_comes_from_stdin("- "));
+        assert!(!content_comes_from_stdin("hello"));
+    }
+
     #[tokio::test]
     async fn cmd_send_message_rejects_empty_content() {
         let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
-        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let client = send_test_client(url);
 
         let err = cmd_send_message(&client, send_params(""))
             .await
             .expect_err("empty content must be rejected");
 
+        // The inline case must not claim the stdin diagnosis, or R2 loses its
+        // only distinguishing signal.
+        let CliError::Usage(msg) = &err else {
+            panic!("expected Usage, got {err:?}");
+        };
         assert!(
-            matches!(err, CliError::Usage(_)),
-            "expected Usage, got {err:?}"
+            msg.contains("empty message"),
+            "expected the empty-content diagnosis, got {msg:?}"
+        );
+        assert!(
+            !msg.contains("upstream pipeline step"),
+            "inline emptiness must not report the stdin cause, got {msg:?}"
         );
         assert!(
             captured_event.lock().unwrap().is_none(),
@@ -1946,11 +1978,10 @@ mod tests {
 
     #[tokio::test]
     async fn cmd_send_message_rejects_whitespace_only_content() {
-        for content in ["\n", "   ", "\t\n "] {
-            let (url, _query_count, captured_event) =
-                fake_send_relay(send_palette_response()).await;
-            let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = send_test_client(url);
 
+        for content in ["\n", "   ", "\t\n "] {
             let err = cmd_send_message(&client, send_params(content))
                 .await
                 .expect_err("whitespace-only content must be rejected");
@@ -1967,12 +1998,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cmd_send_message_publishes_whitespace_content_with_allow_empty() {
+        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = send_test_client(url);
+        let mut params = send_params("   ");
+        params.allow_empty = true;
+
+        cmd_send_message(&client, params)
+            .await
+            .expect("--allow-empty must permit whitespace-only content");
+
+        assert!(
+            captured_event.lock().unwrap().is_some(),
+            "the event must be published when --allow-empty is set"
+        );
+    }
+
+    #[tokio::test]
     async fn cmd_send_message_rejects_empty_content_before_mention_preflight() {
         // `--mention` forces a relay membership fetch. The emptiness guard must
         // run first, so an unreachable or unhelpful relay cannot replace the
         // empty-content diagnosis with an unrelated failure.
-        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
-        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let (url, query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = send_test_client(url);
         let mut params = send_params("");
         params.mentions = vec!["a".repeat(64)];
 
@@ -1993,6 +2041,11 @@ mod tests {
             !msg.contains("not channel members"),
             "the mention preflight must not run first, got {msg:?}"
         );
+        assert_eq!(
+            query_count.load(Ordering::Relaxed),
+            0,
+            "the guard must reject before the mention preflight issues a relay query"
+        );
         assert!(
             captured_event.lock().unwrap().is_none(),
             "no event may be published"
@@ -2002,7 +2055,7 @@ mod tests {
     #[tokio::test]
     async fn cmd_send_message_publishes_empty_content_with_allow_empty() {
         let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
-        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let client = send_test_client(url);
         let mut params = send_params("");
         params.allow_empty = true;
 
@@ -2019,7 +2072,7 @@ mod tests {
     #[tokio::test]
     async fn cmd_send_message_names_stdin_when_it_produced_the_emptiness() {
         let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
-        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let client = send_test_client(url);
         let mut params = send_params("\n");
         params.content_from_stdin = true;
 
@@ -2046,7 +2099,7 @@ mod tests {
         // non-empty content. The guard must not fire, so the send proceeds to
         // the upload and fails there instead.
         let (url, _query_count, _captured_event) = fake_send_relay(send_palette_response()).await;
-        let client = BuzzClient::new(url, Keys::generate(), None, None).unwrap();
+        let client = send_test_client(url);
         let mut params = send_params("");
         params.files = vec!["/nonexistent/attachment.png".to_string()];
 
@@ -2058,6 +2111,33 @@ mod tests {
         assert!(
             msg.contains("upload failed"),
             "the empty-content guard must not fire on a file send, got {msg:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cmd_send_message_treats_a_blank_file_value_as_no_attachment() {
+        // A blank `--file` value is not an attachment, so it must not exempt
+        // the guard and mask the empty-content diagnosis behind an upload
+        // failure.
+        let (url, _query_count, captured_event) = fake_send_relay(send_palette_response()).await;
+        let client = send_test_client(url);
+        let mut params = send_params("");
+        params.files = vec!["   ".to_string()];
+
+        let err = cmd_send_message(&client, params)
+            .await
+            .expect_err("a blank --file value must not exempt the guard");
+
+        let CliError::Usage(msg) = &err else {
+            panic!("expected Usage, got {err:?}");
+        };
+        assert!(
+            msg.contains("empty message"),
+            "expected the empty-content diagnosis, got {msg:?}"
+        );
+        assert!(
+            captured_event.lock().unwrap().is_none(),
+            "no event may be published"
         );
     }
 }

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -398,6 +398,11 @@ pub enum MessagesCmd {
         /// Pubkey to mention (hex or npub; repeatable). Supplying any explicit identity permits unresolved or ambiguous @Name text as presentation-only; uniquely resolved member names still notify.
         #[arg(long = "mention")]
         mentions: Vec<String>,
+        /// Publish even when the message content is empty or whitespace-only.
+        /// Without this, empty content is rejected to catch upstream pipeline
+        /// failures that would otherwise publish a ghost message.
+        #[arg(long, default_value_t = false)]
+        allow_empty: bool,
     },
     /// Send a code diff / patch to a channel
     SendDiff {

--- a/crates/buzz-cli/tests/empty_content_guard.rs
+++ b/crates/buzz-cli/tests/empty_content_guard.rs
@@ -1,0 +1,80 @@
+//! Process-level coverage for the `messages send` empty-content guard.
+//!
+//! The guard fires before any relay call, so these tests need no
+//! infrastructure. They bind the production wiring end to end: argv parsing,
+//! the `--content -` sentinel, the guard, and the exit-code/stderr contract.
+//! Replacing the guard's sentinel derivation with a constant, or removing the
+//! guard, fails at least one of these.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Run `buzz messages send --channel <uuid> --content -` with `stdin_body`.
+///
+/// Returns the exit code and stderr. The relay URL is deliberately
+/// unreachable: a send that clears the guard must fail at the network layer,
+/// not silently succeed.
+fn send_with_stdin(stdin_body: &str, extra: &[&str]) -> (Option<i32>, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_buzz"))
+        .args([
+            "messages",
+            "send",
+            "--channel",
+            "123e4567-e89b-12d3-a456-426614174000",
+            "--content",
+            "-",
+        ])
+        .args(extra)
+        .env("BUZZ_RELAY_URL", "http://127.0.0.1:9")
+        // A syntactically valid secp256k1 secret key; the zero scalar is not.
+        .env("BUZZ_PRIVATE_KEY", format!("{}1", "0".repeat(63)))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the buzz binary");
+
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(stdin_body.as_bytes())
+        .expect("write stdin");
+    // Dropping the handle closes the pipe so the child sees EOF.
+
+    let output = child.wait_with_output().expect("wait for buzz");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn empty_stdin_exits_1_with_the_stdin_diagnosis() {
+    let (code, stderr) = send_with_stdin("\n", &[]);
+    assert_eq!(code, Some(1), "expected exit 1, stderr: {stderr}");
+    assert!(
+        stderr.contains("upstream pipeline step"),
+        "the stdin path must name the likely cause, got: {stderr}"
+    );
+}
+
+#[test]
+fn whitespace_only_stdin_exits_1() {
+    let (code, stderr) = send_with_stdin("   ", &[]);
+    assert_eq!(code, Some(1), "expected exit 1, stderr: {stderr}");
+}
+
+#[test]
+fn allow_empty_passes_the_guard_and_reaches_the_relay() {
+    let (code, stderr) = send_with_stdin("", &["--allow-empty"]);
+    assert_eq!(
+        code,
+        Some(2),
+        "the send must clear the guard and fail at the network layer, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("upstream pipeline step"),
+        "--allow-empty must not produce the empty-content diagnosis: {stderr}"
+    );
+}

--- a/docs/residual-review-findings/fix-cli-messages-send-empty-content.md
+++ b/docs/residual-review-findings/fix-cli-messages-send-empty-content.md
@@ -1,0 +1,30 @@
+# Residual Review Findings
+
+Source: `ce-code-review` run `20260909-000039-a2c85fbf` (mode:agent, local-aligned vs `44316ff`), branch `fix/cli-messages-send-empty-content`, head `f34cd26e`.
+
+Run artifacts: `/tmp/compound-engineering-501/ce-code-review/20260909-000039-a2c85fbf/`
+
+## Actionable (not applied — out of this change's scope)
+
+- P2 / confidence 100 / `crates/buzz-cli/src/commands/messages.rs:903` (agent-native, downstream-resolver) — **`messages edit --content ""` still publishes an empty message.** `cmd_edit_message` runs only `validate_hex64` + `validate_content_size`, so an empty edit passes and `build_edit` accepts it. Desktop routes an empty edit to its delete confirmation (`desktop/src/features/channels/useChannelPaneHandlers.ts:189-196`), so the CLI diverges. The plan defers this path (`docs/plans/2026-09-08-001-fix-cli-messages-send-empty-content-plan.md`, Scope Boundaries). Follow-up: apply the same emptiness decision to `cmd_edit_message` with an `--allow-empty` opt-out, or route it to the delete primitive. No ticket filed in this run; recorded here as the durable sink.
+
+## Report-only observations
+
+- P3 / confidence 100 / `messages.rs:639` (adversarial, advisory/human) — **zero-width-only content still publishes.** `trim()` uses Unicode White_Space, which excludes U+200B, U+2060, U+00AD and U+FEFF, so a pipeline emitting only those bytes publishes a blank message. Plan-deferred; `crates/buzz-sdk/src/builders.rs:1047` uses the same rule, so the CLI is consistent with the SDK.
+- P3 / confidence 75 / `messages.rs:633` (agent-native, advisory) — **error contract is prose while a sibling failure in the same function returns JSON.** The mention-preflight failure at `messages.rs:662-671` returns a structured `Usage` payload; the new guard returns prose, so an agent must substring-match to choose a recovery.
+- P3 / confidence 75 / `crates/buzz-cli/src/lib.rs:405` (agent-native, advisory) — **`crates/buzz-acp/src/base_prompt.md:27`, the `after_help` examples and `crates/buzz-cli/TESTING.md:210-213` still teach stdin piping without the new contract.**
+- P3 / confidence 100 / `messages.rs:624` (agent-native, `pre_existing`) — **the send path buffers stdin unbounded** before `validate_content_size`, unlike the capped reads in `notes set` (`notes.rs:500-509`) and `mem set` (`mem.rs:327-337`).
+- anchor 50 / `messages.rs:616` (project-standards) — `pub allow_empty` has no doc comment; suppressed because `mod commands;` is private, `buzz-cli` has no `#![warn(missing_docs)]`, and sibling fields are undocumented.
+
+## Testing gaps (not closed)
+
+- No positive test for AE2: the `--file` exemption is proven only negatively (the guard did not fire before a failing upload). A passing-upload case would need a media-upload route in the fake relay.
+- No clap-level test for `--allow-empty` parsing or help output (verified manually).
+- No test for `--allow-empty` against a relay that rejects empty content.
+
+## Residual risks
+
+- The relay still accepting empty kind-9 events is a plan assumption; a deferred relay-side rejection would change what `--allow-empty` can promise.
+- `crates/buzz-agent/src/agent.rs:139` counts any command text containing `messages send` as a published turn and ignores exit status, so a guard-rejected send does not re-arm the reply guard.
+- `messages send-diff --diff -` shares the empty-content class and stays out of scope.
+- Caller completeness for "no existing caller sends empty content" rests on a repo-wide search; runtime-assembled commands cannot be enumerated.


### PR DESCRIPTION
## Summary

`buzz messages send --content -` published a whitespace-only kind-9 message when stdin carried only whitespace. It exited 0 and reported `"message": ""`, so a caller whose pipeline had failed got a success response and a ghost empty bubble in the channel.

The command now refuses to publish empty or whitespace-only content:

- **Before:** `printf '%s\n' "$UNSET_VAR" | buzz messages send --channel <UUID> --content -` -> exit 0, empty message published.
- **After:** the same command -> exit 1, `{"error":"user_error","message":"refusing to publish an empty message from stdin (an upstream pipeline step likely failed). Pass --allow-empty to confirm.","retryable":false}`, nothing published.

Key decisions:

- The guard reads the **trimmed** content, not raw emptiness. The reported repro produces `"\n"`, so an `is_empty()` check would have missed it.
- It runs before the mention preflight and before any upload, so a rejected send costs no relay round-trip.
- It applies to content from **any** source, including a literal `--content ""`. That is deliberately stronger than the `notes set` / `mem set` guards, which only check their stdin branch.
- A send that attaches a real file stays valid with empty text, because media assembly makes the published content non-empty. A blank `--file` value is not an attachment and does not exempt the guard.
- `--allow-empty` is the escape hatch, matching `notes set` and `mem set`.
- `read_or_stdin` is unchanged, so the other commands that share it are unaffected.

### Related issue

Fixes #7448.

No existing PR addresses this issue (open and closed PRs searched).

### Testing

- `cargo test -p buzz-cli` -> 472 unit tests and 3 process-level tests pass.
- `cargo fmt --all -- --check` and `cargo clippy -p buzz-cli --all-targets -- -D warnings` are clean.
- `crates/buzz-cli/tests/empty_content_guard.rs` runs the real binary with piped stdin and asserts the exit code and stderr contract for empty, whitespace-only, and `--allow-empty` sends. Flipping the guard's sentinel derivation, or removing the guard, fails it.
- Manual, against an unreachable relay: empty and whitespace-only stdin exit 1 with the stdin diagnosis; `--content ""` exits 1 with the inline diagnosis; `--content "" --allow-empty` clears the guard and fails at the network layer; `--content "" --file /nonexistent` still reports `upload failed`; `--content "" --mention <hex64>` reports the empty-content error rather than the membership error.

### Follow-up work deferred to a future PR

- `messages edit --content ""` and `messages send-diff --diff -` still publish empty content.
- Content made only of zero-width characters (`U+200B`, `U+FEFF`) passes `trim()` and still publishes.
- `messages send` buffers stdin unbounded before the size check, unlike the capped reads in `notes set` and `mem set`.
