### PR TITLE
fix(mobile): render push notification sender identity as npub

### DIFF
--- a/mobile/ios/BuzzPushKit/Sources/BuzzPushKit/Bech32.swift
+++ b/mobile/ios/BuzzPushKit/Sources/BuzzPushKit/Bech32.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Minimal bech32 (BIP-173) codec backing NIP-19 npub sender labels.
+///
+/// Only what push notification presentation needs is implemented: encoding
+/// 32-byte public keys as npub and validating npub inputs well enough to
+/// canonicalize them. Segwit addresses and bech32m are out of scope; NIP-19
+/// uses the original bech32 checksum.
+enum Bech32 {
+  /// Bech32 data charset from BIP-173, indexed by 5-bit value.
+  private static let charset: [Character] = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+  /// Bech32 charset lookup, built once for decoding.
+  private static let valueByCharacter: [Character: UInt8] = Dictionary(
+    uniqueKeysWithValues: charset.enumerated().map { ($1, UInt8($0)) })
+  /// Generator polynomial coefficients from BIP-173.
+  private static let generator: [UInt32] = [
+    0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3,
+  ]
+  /// Checksum length in 5-bit values, from BIP-173.
+  private static let checksumLength = 6
+  /// Maximum bech32 string length, from BIP-173.
+  private static let maximumLength = 90
+
+  // MARK: Codec
+
+  /// Encodes 5-bit values under a human-readable part (hrp), appending the
+  /// bech32 checksum. Returns nil for an invalid hrp or out-of-range values.
+  static func encode(hrp: String, values: [UInt8]) -> String? {
+    let valuesInRange = values.allSatisfy { $0 < 32 }
+    guard isPrintableASCII(hrp), valuesInRange,
+      hrp.count + 1 + values.count + checksumLength <= maximumLength
+    else { return nil }
+    let checksum = checksum(hrp: hrp, values: values)
+    return hrp + "1" + String((values + checksum).map { charset[Int($0)] })
+  }
+
+  /// Decodes a bech32 string into its hrp and 5-bit values, checksum-verified
+  /// and stripped. Follows BIP-173: characters must be printable ASCII, the
+  /// string must be entirely lowercase or entirely uppercase and at most 90
+  /// characters long, and it must end in a valid checksum.
+  static func decode(_ string: String) -> (hrp: String, values: [UInt8])? {
+    guard !string.isEmpty, string.count <= maximumLength, isPrintableASCII(string)
+    else { return nil }
+    let lowercased = string.lowercased()
+    guard lowercased == string || lowercased.uppercased() == string,
+      let separator = lowercased.lastIndex(of: "1"),
+      separator != lowercased.startIndex
+    else { return nil }
+    let hrp = String(lowercased[..<separator])
+    var allValues: [UInt8] = []
+    for character in lowercased[lowercased.index(after: separator)...] {
+      guard let value = valueByCharacter[character] else { return nil }
+      allValues.append(value)
+    }
+    guard allValues.count >= checksumLength,
+      polymod(hrpExpanded(hrp) + allValues.map(UInt32.init)) == 1
+    else { return nil }
+    return (hrp, Array(allValues.dropLast(checksumLength)))
+  }
+
+  // MARK: NIP-19
+
+  /// The npub of a 32-byte public key, or nil for any other length.
+  static func npub(from bytes: [UInt8]) -> String? {
+    guard bytes.count == 32,
+      let values = convertBits(bytes, fromBits: 8, toBits: 5, padding: true)
+    else { return nil }
+    return encode(hrp: "npub", values: values)
+  }
+
+  /// The 32-byte public key encoded by a valid npub, or nil for anything
+  /// else — an `npub1…` prefix alone is never trusted: the bech32 checksum
+  /// must validate and the payload must decode to exactly 32 bytes.
+  static func npubBytes(from string: String) -> [UInt8]? {
+    guard let (hrp, values) = decode(string), hrp == "npub",
+      let bytes = convertBits(values, fromBits: 5, toBits: 8, padding: false),
+      bytes.count == 32
+    else { return nil }
+    return bytes
+  }
+
+  /// The canonical npub for a public key supplied as 64-digit hex or as an
+  /// existing npub (including the uppercase bech32 form, which BIP-173
+  /// decoders must accept). Returns nil for anything else; callers must fall
+  /// back to a neutral label rather than raw key material.
+  static func canonicalNpub(from identifier: String) -> String? {
+    if let bytes = VerifiedNostrEvent.hexBytes(identifier.lowercased()), bytes.count == 32 {
+      return npub(from: bytes)
+    }
+    return npubBytes(from: identifier).flatMap { npub(from: $0) }
+  }
+
+  // MARK: Internals
+
+  private static func isPrintableASCII(_ string: String) -> Bool {
+    !string.isEmpty && string.allSatisfy { (33...126).contains($0.asciiValue ?? 0) }
+  }
+
+  private static func checksum(hrp: String, values: [UInt8]) -> [UInt8] {
+    let expanded =
+      hrpExpanded(hrp) + values.map(UInt32.init)
+      + [UInt32](repeating: 0, count: checksumLength)
+    let polymod = polymod(expanded) ^ 1
+    return (0..<checksumLength).map { index in
+      let shift = 5 * (checksumLength - 1 - index)
+      return UInt8((polymod >> shift) & 31)
+    }
+  }
+
+  private static func polymod(_ values: [UInt32]) -> UInt32 {
+    var accumulator: UInt32 = 1
+    for value in values {
+      let top = accumulator >> 25
+      accumulator = ((accumulator & 0x1ffffff) << 5) ^ value
+      for (index, coefficient) in generator.enumerated() where (top >> index) & 1 == 1 {
+        accumulator ^= coefficient
+      }
+    }
+    return accumulator
+  }
+
+  private static func hrpExpanded(_ hrp: String) -> [UInt32] {
+    let scalars = hrp.unicodeScalars.map { $0.value }
+    return scalars.map { $0 >> 5 } + [0] + scalars.map { $0 & 31 }
+  }
+
+  /// Regroups a byte string between bit widths, as in BIP-173's `convertbits`.
+  /// With padding disabled, a nonzero remainder is rejected instead of padded.
+  private static func convertBits(
+    _ bytes: [UInt8], fromBits: Int, toBits: Int, padding: Bool
+  ) -> [UInt8]? {
+    var accumulator: UInt32 = 0
+    var accumulated = 0
+    var result: [UInt8] = []
+    result.reserveCapacity((bytes.count * fromBits + toBits - 1) / toBits)
+    let maxValue: UInt32 = (1 << toBits) - 1
+    let maxAccumulator: UInt32 = (1 << (fromBits + toBits - 1)) - 1
+    let maxInput: Int = 1 << fromBits
+    for byte in bytes {
+      guard Int(byte) < maxInput else { return nil }
+      accumulator = ((accumulator << fromBits) | UInt32(byte)) & maxAccumulator
+      accumulated += fromBits
+      while accumulated >= toBits {
+        accumulated -= toBits
+        result.append(UInt8((accumulator >> accumulated) & maxValue))
+      }
+    }
+    if padding {
+      if accumulated > 0 {
+        result.append(UInt8((accumulator << (toBits - accumulated)) & maxValue))
+      }
+    } else if accumulated >= fromBits
+      || ((accumulator << (toBits - accumulated)) & maxValue) != 0
+    {
+      return nil
+    }
+    return result
+  }
+}

--- a/mobile/ios/BuzzPushKit/Sources/BuzzPushKit/Bech32.swift
+++ b/mobile/ios/BuzzPushKit/Sources/BuzzPushKit/Bech32.swift
@@ -79,18 +79,38 @@ enum Bech32 {
     return bytes
   }
 
-  /// The canonical npub for a public key supplied as 64-digit hex or as an
-  /// existing npub (including the uppercase bech32 form, which BIP-173
-  /// decoders must accept). Returns nil for anything else; callers must fall
-  /// back to a neutral label rather than raw key material.
+  /// The canonical npub for a public key supplied as exactly 64 ASCII hex
+  /// digits or as an existing npub (including the uppercase bech32 form,
+  /// which BIP-173 decoders must accept). Returns nil for anything else;
+  /// callers must fall back to a neutral label rather than raw key material.
   static func canonicalNpub(from identifier: String) -> String? {
-    if let bytes = VerifiedNostrEvent.hexBytes(identifier.lowercased()), bytes.count == 32 {
+    if isHexKey(identifier),
+      let bytes = VerifiedNostrEvent.hexBytes(identifier.lowercased()), bytes.count == 32
+    {
       return npub(from: bytes)
     }
     return npubBytes(from: identifier).flatMap { npub(from: $0) }
   }
 
   // MARK: Internals
+
+  /// Whether `value` is exactly 64 ASCII hex digits (0-9, A-F, a-f).
+  ///
+  /// `VerifiedNostrEvent.hexBytes` parses pairs with `UInt8(_:radix: 16)`,
+  /// which also accepts a leading sign — "+a" parses as 10 and "-0" as 0 —
+  /// so strings like "+a"×32 would otherwise decode to 32 bytes. The hex
+  /// branch of `canonicalNpub` gates on this literal key shape before any
+  /// hex parsing or allocation; every other input must arrive as a strictly
+  /// checksummed npub.
+  private static func isHexKey(_ value: String) -> Bool {
+    guard value.count == 64 else { return false }
+    return value.allSatisfy { character in
+      guard let ascii = character.asciiValue else { return false }
+      return (48...57).contains(ascii)  // 0-9
+        || (65...70).contains(ascii)  // A-F
+        || (97...102).contains(ascii)  // a-f
+    }
+  }
 
   private static func isPrintableASCII(_ string: String) -> Bool {
     !string.isEmpty && string.allSatisfy { (33...126).contains($0.asciiValue ?? 0) }

--- a/mobile/ios/BuzzPushKit/Sources/BuzzPushKit/BuzzPushNotificationResolver.swift
+++ b/mobile/ios/BuzzPushKit/Sources/BuzzPushKit/BuzzPushNotificationResolver.swift
@@ -611,8 +611,15 @@ public final class BuzzPushNotificationResolver: BuzzPushNotificationResolving {
       ? String(result.prefix(177)).trimmingCharacters(in: .whitespacesAndNewlines) + "…" : result
   }
 
+  /// Compact sender label for unnamed senders: the first 8 and last 4
+  /// characters of the sender's full npub, matching the compact npub shape
+  /// used across Buzz. A key that cannot be encoded as an npub falls back to
+  /// the neutral "Someone" identity so malformed payloads leak no key
+  /// material while the notification keeps a useful title.
   static func shortPubkey(_ pubkey: String) -> String {
-    pubkey.count > 8 ? String(pubkey.prefix(8)) + "…" : pubkey
+    guard let npub = Bech32.canonicalNpub(from: pubkey) else { return "Someone" }
+    return npub.count > 12
+      ? String(npub.prefix(8)) + "…" + String(npub.suffix(4)) : npub
   }
 
   private func loadCommunities() -> [PushLeaseCommunity] {

--- a/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/Bech32Tests.swift
+++ b/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/Bech32Tests.swift
@@ -53,6 +53,13 @@ final class Bech32Tests: XCTestCase {
       Bech32.canonicalNpub(
         from: "NPUB14F8USEJL26TWX0DHUXJH9CAS7KEAV9VR0V8NVTWTRJQX3VYCC76QQH9NSY"),
       "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy")
+    // Letter case within a hex key stays valid input; digits are caseless,
+    // so mixed-case letters still canonicalize to the lowercase npub.
+    let mixedCaseHex = String(
+      Self.npubVectors[0].hex.enumerated().map {
+        $0.offset.isMultiple(of: 2) ? $0.element : Character($0.element.uppercased())
+      })
+    XCTAssertEqual(Bech32.canonicalNpub(from: mixedCaseHex), Self.npubVectors[0].npub)
   }
 
   func testCanonicalNpubRejectsInvalidAndLookalikeKeys() {
@@ -65,6 +72,11 @@ final class Bech32Tests: XCTestCase {
       // Hex that is not a 32-byte key.
       String(repeating: "ab", count: 31),
       String(repeating: "ab", count: 33),
+      // Signed radix-16 chunks ("+a"→10, "-0"→0) parse via UInt8(_:radix:)
+      // but are not literal ASCII hex digits, so never 32-byte keys.
+      String(repeating: "+a", count: 32),
+      String(repeating: "+A", count: 32),
+      String(repeating: "-0", count: 32),
       // Valid npub with the checksum's final character mutated.
       "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujma",
       // Mixed case is never valid bech32.

--- a/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/Bech32Tests.swift
+++ b/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/Bech32Tests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import BuzzPushKit
+
+/// Bech32 codec tests against known independent vectors: the NIP-19 example
+/// key, the nostr crate 0.44 test suite, and the test vectors published with
+/// BIP-173 itself.
+final class Bech32Tests: XCTestCase {
+  /// Hex public keys with their published npub equivalents.
+  static let npubVectors: [(hex: String, npub: String)] = [
+    // nostr-rs 0.44 key test: aa4fc866… ↔ npub14f8usejl…qqh9nsy.
+    (
+      "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4",
+      "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy"
+    ),
+    // The NIP-19 spec's example profile key.
+    (
+      "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+      "npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"
+    ),
+    // secp256k1 generator points, used as sender keys by the resolver tests.
+    (
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      "npub10xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqpkge6d"
+    ),
+    (
+      "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+      "npub1ccz8l9zpa47k6vz9gphftsrumpw80rjt3nhnefat4symjhrsnmjs38mnyd"
+    ),
+    // Degenerate key material still encodes.
+    (String(repeating: "00", count: 32), "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujme"),
+    (String(repeating: "ff", count: 32), "npub1lllllllllllllllllllllllllllllllllllllllllllllllllllsq7lrjw"),
+  ]
+
+  func testNpubEncodingMatchesKnownVectors() throws {
+    for vector in Self.npubVectors {
+      let bytes = try XCTUnwrap(VerifiedNostrEvent.hexBytes(vector.hex))
+      XCTAssertEqual(bytes.count, 32)
+      XCTAssertEqual(Bech32.npub(from: bytes), vector.npub, "hex: \(vector.hex)")
+      XCTAssertEqual(Bech32.canonicalNpub(from: vector.hex), vector.npub, "hex: \(vector.hex)")
+    }
+  }
+
+  func testCanonicalNpubValidatesAndCanonicalizesNpubInputs() throws {
+    for vector in Self.npubVectors {
+      let npub = try XCTUnwrap(Bech32.canonicalNpub(from: vector.npub))
+      XCTAssertEqual(npub, vector.npub, "npub: \(vector.npub)")
+      XCTAssertEqual(
+        Bech32.npubBytes(from: npub).map(VerifiedNostrEvent.hex), vector.hex,
+        "npub: \(vector.npub)")
+    }
+    // Uppercase bech32 is valid per BIP-173; canonical output is lowercase.
+    XCTAssertEqual(
+      Bech32.canonicalNpub(
+        from: "NPUB14F8USEJL26TWX0DHUXJH9CAS7KEAV9VR0V8NVTWTRJQX3VYCC76QQH9NSY"),
+      "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy")
+  }
+
+  func testCanonicalNpubRejectsInvalidAndLookalikeKeys() {
+    let rejected = [
+      // Junk and empty payloads.
+      "",
+      "author-pubkey",
+      String(repeating: "a", count: 63),
+      "0",
+      // Hex that is not a 32-byte key.
+      String(repeating: "ab", count: 31),
+      String(repeating: "ab", count: 33),
+      // Valid npub with the checksum's final character mutated.
+      "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujma",
+      // Mixed case is never valid bech32.
+      "Npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy",
+      // Valid checksum but the wrong payload length for a key.
+      "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqk7h3rf",
+      "npub1llllllllllllllllllllllllllllllllllllllllllllllllllll7w6tc2n",
+      // Valid bech32 under a different human-readable part.
+      "nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwkhnav",
+    ]
+    for string in rejected {
+      XCTAssertNil(Bech32.canonicalNpub(from: string), "expected rejection: \(string)")
+      XCTAssertNil(Bech32.npubBytes(from: string), "expected rejection: \(string)")
+    }
+  }
+
+  func testNpubRejectsNon32ByteKeys() {
+    XCTAssertNil(Bech32.npub(from: [UInt8](repeating: 0, count: 16)))
+    XCTAssertNil(Bech32.npub(from: [UInt8](repeating: 0xff, count: 33)))
+    XCTAssertNil(Bech32.npub(from: []))
+  }
+
+  func testDecodeAcceptsPublishedBip173Vectors() {
+    let valid = [
+      "A12UEL5L",
+      "a12uel5l",
+      "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+      "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+      "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+      "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+      "?1ezyfcl",
+    ]
+    for string in valid {
+      XCTAssertNotNil(Bech32.decode(string), "expected valid: \(string)")
+    }
+    // Uppercase forms decode to the lowercase canonical hrp.
+    XCTAssertEqual(Bech32.decode("A12UEL5L")?.hrp, "a")
+    XCTAssertEqual(Bech32.decode("A12UEL5L")?.values, [])
+  }
+
+  func testDecodeRejectsPublishedBip173Vectors() {
+    let invalid = [
+      "pzry9x0s0muk",  // no separator character
+      "1pzry9x0s0muk",  // empty hrp
+      "x1b4n0q5v",  // invalid data character
+      "li1dgmt3",  // too short checksum
+      "A1G7SGD8",  // checksum calculated with uppercase form of hrp
+      "10a06t8",  // empty hrp
+      "1qzzf3qj",  // empty hrp
+      "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxx",  // bad checksum
+    ]
+    for string in invalid {
+      XCTAssertNil(Bech32.decode(string), "expected invalid: \(string)")
+    }
+  }
+
+  func testDecodeRejectsNonPrintableAndNonASCIICharacters() {
+    XCTAssertNil(Bech32.decode("a\u{1f}1b4n0q5v"))
+    XCTAssertNil(Bech32.decode("a1b4n0q5v "))
+    XCTAssertNil(Bech32.decode("Ω1ezyfcl"))
+    XCTAssertNil(Bech32.decode("a1özyfcl"))
+  }
+}

--- a/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/Bech32Tests.swift
+++ b/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/Bech32Tests.swift
@@ -1,9 +1,13 @@
 import XCTest
 @testable import BuzzPushKit
 
-/// Bech32 codec tests against known independent vectors: the NIP-19 example
-/// key, the nostr crate 0.44 test suite, and the test vectors published with
-/// BIP-173 itself.
+/// Bech32 codec tests against independently published npub vectors — the
+/// NIP-19 spec example key and the nostr crate 0.44 test suite — plus
+/// degenerate key material for the padding and payload-length boundaries.
+/// Generic BIP-173 conformance is not asserted here: nothing outside the
+/// codec calls raw decode, so alphabet, checksum, case, and length
+/// rejection are pinned at canonicalNpub/npubBytes, the npub seam Buzz
+/// actually uses.
 final class Bech32Tests: XCTestCase {
   /// Hex public keys with their published npub equivalents.
   static let npubVectors: [(hex: String, npub: String)] = [
@@ -17,18 +21,8 @@ final class Bech32Tests: XCTestCase {
       "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
       "npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"
     ),
-    // secp256k1 generator points, used as sender keys by the resolver tests.
-    (
-      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-      "npub10xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqpkge6d"
-    ),
-    (
-      "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
-      "npub1ccz8l9zpa47k6vz9gphftsrumpw80rjt3nhnefat4symjhrsnmjs38mnyd"
-    ),
-    // Degenerate key material still encodes.
+    // Degenerate key material still encodes (and exercises 5-bit padding).
     (String(repeating: "00", count: 32), "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujme"),
-    (String(repeating: "ff", count: 32), "npub1lllllllllllllllllllllllllllllllllllllllllllllllllllsq7lrjw"),
   ]
 
   func testNpubEncodingMatchesKnownVectors() throws {
@@ -77,6 +71,9 @@ final class Bech32Tests: XCTestCase {
       String(repeating: "+a", count: 32),
       String(repeating: "+A", count: 32),
       String(repeating: "-0", count: 32),
+      // Npub-shaped payload with a character outside the bech32 alphabet
+      // ("b" never appears in the charset).
+      "npub1bqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujme",
       // Valid npub with the checksum's final character mutated.
       "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujma",
       // Mixed case is never valid bech32.
@@ -97,46 +94,5 @@ final class Bech32Tests: XCTestCase {
     XCTAssertNil(Bech32.npub(from: [UInt8](repeating: 0, count: 16)))
     XCTAssertNil(Bech32.npub(from: [UInt8](repeating: 0xff, count: 33)))
     XCTAssertNil(Bech32.npub(from: []))
-  }
-
-  func testDecodeAcceptsPublishedBip173Vectors() {
-    let valid = [
-      "A12UEL5L",
-      "a12uel5l",
-      "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
-      "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
-      "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
-      "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
-      "?1ezyfcl",
-    ]
-    for string in valid {
-      XCTAssertNotNil(Bech32.decode(string), "expected valid: \(string)")
-    }
-    // Uppercase forms decode to the lowercase canonical hrp.
-    XCTAssertEqual(Bech32.decode("A12UEL5L")?.hrp, "a")
-    XCTAssertEqual(Bech32.decode("A12UEL5L")?.values, [])
-  }
-
-  func testDecodeRejectsPublishedBip173Vectors() {
-    let invalid = [
-      "pzry9x0s0muk",  // no separator character
-      "1pzry9x0s0muk",  // empty hrp
-      "x1b4n0q5v",  // invalid data character
-      "li1dgmt3",  // too short checksum
-      "A1G7SGD8",  // checksum calculated with uppercase form of hrp
-      "10a06t8",  // empty hrp
-      "1qzzf3qj",  // empty hrp
-      "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxx",  // bad checksum
-    ]
-    for string in invalid {
-      XCTAssertNil(Bech32.decode(string), "expected invalid: \(string)")
-    }
-  }
-
-  func testDecodeRejectsNonPrintableAndNonASCIICharacters() {
-    XCTAssertNil(Bech32.decode("a\u{1f}1b4n0q5v"))
-    XCTAssertNil(Bech32.decode("a1b4n0q5v "))
-    XCTAssertNil(Bech32.decode("Ω1ezyfcl"))
-    XCTAssertNil(Bech32.decode("a1özyfcl"))
   }
 }

--- a/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/BuzzPushNotificationResolverTests.swift
+++ b/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/BuzzPushNotificationResolverTests.swift
@@ -171,6 +171,25 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
     XCTAssertEqual(result?.0.senderPubkey, "author-pubkey")
   }
 
+  func testDecodeResolutionUsesNeutralIdentityForSignedChunkSenderKey() {
+    // Impostors like "+a"×32 parse through radix-16 hex pairs ("+a"→10,
+    // "-0"→0) without being 64 ASCII hex digits: the presentation contract
+    // still demands the neutral identity, while internal payload fields —
+    // sender pubkey, thread, body — pass through untouched.
+    for impostor in [String(repeating: "+a", count: 32), String(repeating: "-0", count: 32)] {
+      let result = BuzzPushNotificationResolver.decodeResolution(
+        events: [event(pubkey: impostor, content: "Preview")],
+        community: community()
+      )
+
+      XCTAssertEqual(result?.0.title, "Someone", "impostor: \(impostor)")
+      XCTAssertEqual(result?.0.body, "Preview", "impostor: \(impostor)")
+      XCTAssertEqual(result?.0.subtitle, "Community", "impostor: \(impostor)")
+      XCTAssertEqual(result?.0.senderPubkey, impostor, "impostor: \(impostor)")
+      XCTAssertEqual(result?.0.threadIdentifier, "community-id", "impostor: \(impostor)")
+    }
+  }
+
   func testShortPubkeyRendersCompactNpub() {
     // First 8 and last 4 characters of the entire npub string.
     XCTAssertEqual(
@@ -195,6 +214,9 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
       "author-pubkey",
       String(repeating: "a", count: 63),
       String(repeating: "ab", count: 33),
+      // Signed radix-16 chunks ("+a"→10, "-0"→0) are not literal hex keys.
+      String(repeating: "+a", count: 32),
+      String(repeating: "-0", count: 32),
       // Valid npub with a mutated checksum character.
       "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujma",
       // Valid checksums that are not keys: wrong payload length or hrp.

--- a/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/BuzzPushNotificationResolverTests.swift
+++ b/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/BuzzPushNotificationResolverTests.swift
@@ -133,97 +133,32 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
     XCTAssertEqual(result?.0.body, "lower ID")
   }
 
-  func testDecodeResolutionTitlesUnnamedSenderWithCompactNpub() {
-    let result = BuzzPushNotificationResolver.decodeResolution(
-      events: [event(pubkey: Self.unnamedSenderHex, content: "Preview")],
-      community: community()
-    )
-
-    XCTAssertEqual(result?.0.title, "npub14f8…9nsy")
-    XCTAssertEqual(result?.0.body, "Preview")
-  }
-
-  func testDecodeResolutionCanonicalizesNpubSenderAtBoundary() {
-    // A sender key that arrives as an npub is validated by checksum and
-    // payload, never by its prefix, and renders the same compact label.
-    let result = BuzzPushNotificationResolver.decodeResolution(
-      events: [
-        event(pubkey: Self.unnamedSenderNpub, content: "Preview"),
-        event(pubkey: "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqk7h3rf", content: "Dropped"),
-      ],
-      community: community()
-    )
-
-    XCTAssertEqual(result?.0.title, "npub14f8…9nsy")
-    XCTAssertEqual(result?.0.body, "Preview")
-  }
-
-  func testDecodeResolutionUsesNeutralIdentityForMalformedSenderKey() {
-    let result = BuzzPushNotificationResolver.decodeResolution(
-      events: [event(pubkey: "author-pubkey", content: "Preview")],
-      community: community()
-    )
-
-    // Unverifiable keys never leak raw key material into the title.
-    XCTAssertEqual(result?.0.title, "Someone")
-    XCTAssertEqual(result?.0.body, "Preview")
-    XCTAssertEqual(result?.0.subtitle, "Community")
-    XCTAssertEqual(result?.0.senderPubkey, "author-pubkey")
-  }
-
-  func testDecodeResolutionUsesNeutralIdentityForSignedChunkSenderKey() {
-    // Impostors like "+a"×32 parse through radix-16 hex pairs ("+a"→10,
-    // "-0"→0) without being 64 ASCII hex digits: the presentation contract
-    // still demands the neutral identity, while internal payload fields —
-    // sender pubkey, thread, body — pass through untouched.
-    for impostor in [String(repeating: "+a", count: 32), String(repeating: "-0", count: 32)] {
+  func testDecodeResolutionSenderTitlesCanonicalizeKeysOrFallBackToNeutral() {
+    // The sender-identity presentation boundary: a verifiable key renders
+    // as the same compact npub whether it arrives as hex or as an npub, and
+    // an unverifiable key — including radix impostors like "+a"×32 that
+    // parse as hex pairs but are not literal hex keys — gets the neutral
+    // identity, never raw key material, while body, subtitle, and internal
+    // payload fields pass through untouched. Malformed-input classification
+    // itself is pinned at the codec (Bech32Tests); named senders winning
+    // over these labels is covered by the cached-profile resolve tests.
+    let senders: [(pubkey: String, title: String)] = [
+      (Self.unnamedSenderHex, "npub14f8…9nsy"),
+      (Self.unnamedSenderNpub, "npub14f8…9nsy"),
+      ("author-pubkey", "Someone"),
+      (String(repeating: "+a", count: 32), "Someone"),
+    ]
+    for sender in senders {
       let result = BuzzPushNotificationResolver.decodeResolution(
-        events: [event(pubkey: impostor, content: "Preview")],
+        events: [event(pubkey: sender.pubkey, content: "Preview")],
         community: community()
       )
 
-      XCTAssertEqual(result?.0.title, "Someone", "impostor: \(impostor)")
-      XCTAssertEqual(result?.0.body, "Preview", "impostor: \(impostor)")
-      XCTAssertEqual(result?.0.subtitle, "Community", "impostor: \(impostor)")
-      XCTAssertEqual(result?.0.senderPubkey, impostor, "impostor: \(impostor)")
-      XCTAssertEqual(result?.0.threadIdentifier, "community-id", "impostor: \(impostor)")
-    }
-  }
-
-  func testShortPubkeyRendersCompactNpub() {
-    // First 8 and last 4 characters of the entire npub string.
-    XCTAssertEqual(
-      BuzzPushNotificationResolver.shortPubkey(Self.unnamedSenderHex), "npub14f8…9nsy")
-    XCTAssertEqual(
-      BuzzPushNotificationResolver.shortPubkey(String(repeating: "00", count: 32)),
-      "npub1qqq…ujme")
-    XCTAssertEqual(
-      BuzzPushNotificationResolver.shortPubkey(String(repeating: "ff", count: 32)),
-      "npub1lll…lrjw")
-    // Uppercase hex and npub inputs canonicalize to the same label.
-    XCTAssertEqual(
-      BuzzPushNotificationResolver.shortPubkey(Self.unnamedSenderHex.uppercased()),
-      "npub14f8…9nsy")
-    XCTAssertEqual(
-      BuzzPushNotificationResolver.shortPubkey(Self.unnamedSenderNpub), "npub14f8…9nsy")
-  }
-
-  func testShortPubkeyFallsBackToNeutralIdentityWithoutLeakingKeyMaterial() {
-    for malformed in [
-      "",
-      "author-pubkey",
-      String(repeating: "a", count: 63),
-      String(repeating: "ab", count: 33),
-      // Signed radix-16 chunks ("+a"→10, "-0"→0) are not literal hex keys.
-      String(repeating: "+a", count: 32),
-      String(repeating: "-0", count: 32),
-      // Valid npub with a mutated checksum character.
-      "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujma",
-      // Valid checksums that are not keys: wrong payload length or hrp.
-      "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqk7h3rf",
-      "nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwkhnav",
-    ] {
-      XCTAssertEqual(BuzzPushNotificationResolver.shortPubkey(malformed), "Someone")
+      XCTAssertEqual(result?.0.title, sender.title, "pubkey: \(sender.pubkey)")
+      XCTAssertEqual(result?.0.body, "Preview", "pubkey: \(sender.pubkey)")
+      XCTAssertEqual(result?.0.subtitle, "Community", "pubkey: \(sender.pubkey)")
+      XCTAssertEqual(result?.0.senderPubkey, sender.pubkey, "pubkey: \(sender.pubkey)")
+      XCTAssertEqual(result?.0.threadIdentifier, "community-id", "pubkey: \(sender.pubkey)")
     }
   }
 

--- a/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/BuzzPushNotificationResolverTests.swift
+++ b/mobile/ios/BuzzPushKit/Tests/BuzzPushKitTests/BuzzPushNotificationResolverTests.swift
@@ -18,6 +18,10 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
   static let relayPrivateKey = String(repeating: "0", count: 63) + "3"
   static let gatewayBody = "Reconnect to your relay now"
   static let channelID = "123e4567-e89b-42d3-a456-426614174000"
+  static let unnamedSenderHex =
+    "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4"
+  static let unnamedSenderNpub =
+    "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy"
 
   override func setUp() {
     super.setUp()
@@ -129,6 +133,78 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
     XCTAssertEqual(result?.0.body, "lower ID")
   }
 
+  func testDecodeResolutionTitlesUnnamedSenderWithCompactNpub() {
+    let result = BuzzPushNotificationResolver.decodeResolution(
+      events: [event(pubkey: Self.unnamedSenderHex, content: "Preview")],
+      community: community()
+    )
+
+    XCTAssertEqual(result?.0.title, "npub14f8…9nsy")
+    XCTAssertEqual(result?.0.body, "Preview")
+  }
+
+  func testDecodeResolutionCanonicalizesNpubSenderAtBoundary() {
+    // A sender key that arrives as an npub is validated by checksum and
+    // payload, never by its prefix, and renders the same compact label.
+    let result = BuzzPushNotificationResolver.decodeResolution(
+      events: [
+        event(pubkey: Self.unnamedSenderNpub, content: "Preview"),
+        event(pubkey: "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqk7h3rf", content: "Dropped"),
+      ],
+      community: community()
+    )
+
+    XCTAssertEqual(result?.0.title, "npub14f8…9nsy")
+    XCTAssertEqual(result?.0.body, "Preview")
+  }
+
+  func testDecodeResolutionUsesNeutralIdentityForMalformedSenderKey() {
+    let result = BuzzPushNotificationResolver.decodeResolution(
+      events: [event(pubkey: "author-pubkey", content: "Preview")],
+      community: community()
+    )
+
+    // Unverifiable keys never leak raw key material into the title.
+    XCTAssertEqual(result?.0.title, "Someone")
+    XCTAssertEqual(result?.0.body, "Preview")
+    XCTAssertEqual(result?.0.subtitle, "Community")
+    XCTAssertEqual(result?.0.senderPubkey, "author-pubkey")
+  }
+
+  func testShortPubkeyRendersCompactNpub() {
+    // First 8 and last 4 characters of the entire npub string.
+    XCTAssertEqual(
+      BuzzPushNotificationResolver.shortPubkey(Self.unnamedSenderHex), "npub14f8…9nsy")
+    XCTAssertEqual(
+      BuzzPushNotificationResolver.shortPubkey(String(repeating: "00", count: 32)),
+      "npub1qqq…ujme")
+    XCTAssertEqual(
+      BuzzPushNotificationResolver.shortPubkey(String(repeating: "ff", count: 32)),
+      "npub1lll…lrjw")
+    // Uppercase hex and npub inputs canonicalize to the same label.
+    XCTAssertEqual(
+      BuzzPushNotificationResolver.shortPubkey(Self.unnamedSenderHex.uppercased()),
+      "npub14f8…9nsy")
+    XCTAssertEqual(
+      BuzzPushNotificationResolver.shortPubkey(Self.unnamedSenderNpub), "npub14f8…9nsy")
+  }
+
+  func testShortPubkeyFallsBackToNeutralIdentityWithoutLeakingKeyMaterial() {
+    for malformed in [
+      "",
+      "author-pubkey",
+      String(repeating: "a", count: 63),
+      String(repeating: "ab", count: 33),
+      // Valid npub with a mutated checksum character.
+      "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqujma",
+      // Valid checksums that are not keys: wrong payload length or hrp.
+      "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqk7h3rf",
+      "nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwkhnav",
+    ] {
+      XCTAssertEqual(BuzzPushNotificationResolver.shortPubkey(malformed), "Someone")
+    }
+  }
+
   func testResolveSucceedsAndMutatesGatewayContent() throws {
     let event = try JSONDecoder().decode(
       VerifiedNostrEvent.self,
@@ -146,7 +222,7 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
 
     XCTAssertNotEqual(result.title, Self.gatewayBody)
     XCTAssertNotEqual(result.body, Self.gatewayBody)
-    XCTAssertEqual(result.title, String(event.pubkey.prefix(8)) + "…")
+    XCTAssertEqual(result.title, "npub1ccz…mnyd")
     XCTAssertEqual(result.body, "Hello Buzz")
     XCTAssertEqual(result.subtitle, "Community")
     XCTAssertEqual(
@@ -559,7 +635,7 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
       )
     )
 
-    XCTAssertEqual(result.title, String(message.pubkey.prefix(8)) + "…")
+    XCTAssertEqual(result.title, "npub1ccz…mnyd")
     XCTAssertNil(result.conversationDisplayName)
     XCTAssertEqual(result.subtitle, "Community")
     XCTAssertEqual(result.body, "Fallback content")
@@ -602,7 +678,7 @@ final class BuzzPushNotificationResolverTests: XCTestCase {
       )
     )
 
-    XCTAssertEqual(result.title, String(message.pubkey.prefix(8)) + "…")
+    XCTAssertEqual(result.title, "npub1ccz…mnyd")
     XCTAssertNil(result.conversationDisplayName)
     XCTAssertEqual(result.body, "Bounded fallback")
     XCTAssertEqual(URLProtocolStub.requests.count, 2)


### PR DESCRIPTION
🤖

## Summary

When an iOS push notification comes from someone the app has no cached name for, the notification title showed the first characters of the sender's raw public key — for example `aa4fc866…`. That fragment is unreadable and doesn't match how the same person appears anywhere else in Buzz. This PR changes that title to the compact form of the sender's npub (npub is the human-readable encoding of a Nostr public key): first 8 and last 4 characters — for example `npub14f8…9nsy`, the same identity shape used across the desktop and mobile apps.

- Unnamed senders: raw hex fragment → compact npub.
- Named senders: unchanged — a sender the app has a display name for still titles the notification with that name.
- Unverifiable sender identities (malformed keys, or lookalike strings that are not literal 64-hex-digit keys) now render a neutral "Someone" instead of partial raw key material.
- Everything else about the notification is unchanged: body text, subtitle, thread matching and grouping, deep-link navigation, thread identifiers, and the internal hex public key the resolver matches on.

The native iOS notification-service package (`BuzzPushKit`) gains a minimal in-house bech32 codec (bech32 is the checksummed string encoding npubs use) — checksum-validated, 32-byte keys only, and no new external dependency. The hex input branch accepts exactly a 64 ASCII hex digit key before any parsing, so strings that merely parse like hex (for example a run of `+a` pairs) cannot become a displayed identity; this is input validation for presentation. Event signature verification is untouched.

### Related issue

Fixes: N/A. Searched existing issues/PRs for push-notification npub identity — closest related: none found.

### Testing

At head `3e3f2813b8864b76257ccb50dea3a4b31fa4de0d` (base `44316ff72f5f7de014c66b01cbf534298a70c249`; 4 files, +321/−4):

- CI `Mobile Swift` lane, at this exact head — all passed: `swift test` (73 tests, 0 failures), the SwiftPM debug and release builds of `mobile/ios/BuzzPushKit`, and the unsigned iOS release build.
- Test coverage: npub encoding cross-checked against independent nostr-rs/NIP-19 vectors; rejection of bad checksums, mixed case, wrong lengths, invalid alphabet, padding, and non-32-byte payloads; resolver boundary matrix — hex/npub/invalid sender keys render compact npub or "Someone" while body, subtitle, sender key, and thread identifier pass through; named senders keep cached display names.

### Task provenance

Buzz channel: `1f0e4a3d-7e01-4efe-bb16-843b357f85c9`

Task: buzz://message?channel=1f0e4a3d-7e01-4efe-bb16-843b357f85c9&id=86b34eb4bd84a1472419e9af22636c011c0fe273e3c196f967d7a36996e149b6
