### PR TITLE
fix(markdown): align mention chip wrapping

### DIFF
--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -50,10 +50,9 @@ type UserProfilePopoverProps = {
   pubkey: string;
   triggerElement?: "div" | "span";
   /**
-   * Extra classes for the inline-flex trigger wrapper. The wrapper is a flex
-   * item at most call sites, and its `min-width: auto` refuses to shrink below
-   * the nowrap width of truncating children — pass `min-w-0 max-w-full` when
-   * the trigger wraps truncating text so the ellipsis can engage.
+   * Extra classes for the trigger wrapper, which defaults to inline-flex.
+   * Use `min-w-0 max-w-full` when truncating flex content must shrink, or
+   * `inline` when prose content must fragment across lines.
    */
   triggerClassName?: string;
   /** Accessible name for interactive trigger content that is visually hidden. */

--- a/desktop/src/shared/styles/globals/markdown.css
+++ b/desktop/src/shared/styles/globals/markdown.css
@@ -87,17 +87,29 @@
   color: hsl(var(--primary));
 }
 
-.message-markdown .mention-chip.wrapping-inline-chip {
+.message-markdown .mention-chip.fragmentable-inline-chip {
   display: inline;
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: normal;
+}
+
+.message-markdown .mention-chip.wrapping-inline-chip {
   line-height: calc(
     1em +
     var(--inline-chip-padding-block-start) +
     var(--inline-chip-padding-block-end) +
     0.25rem
   );
-  overflow-wrap: anywhere;
-  text-align: left;
-  white-space: normal;
+}
+
+/* Mention fragments fill one conversation line, including their block padding. */
+.message-markdown [data-mention].fragmentable-inline-chip {
+  line-height: calc(
+    var(--conversation-message-line-height) -
+    var(--inline-chip-padding-block-start) -
+    var(--inline-chip-padding-block-end)
+  );
 }
 
 .message-markdown .mention-chip.buzz-link-unavailable,
@@ -188,11 +200,11 @@
   transform: translateY(-50%);
 }
 
-.message-markdown .wrapping-inline-chip.inline-chip-with-icon {
+.message-markdown .fragmentable-inline-chip.inline-chip-with-icon {
   padding-left: var(--inline-chip-padding-inline);
 }
 
-.message-markdown .wrapping-inline-chip.inline-chip-with-icon::before {
+.message-markdown .fragmentable-inline-chip.inline-chip-with-icon::before {
   display: none;
 }
 

--- a/desktop/src/shared/styles/globals/markdown.css
+++ b/desktop/src/shared/styles/globals/markdown.css
@@ -87,29 +87,23 @@
   color: hsl(var(--primary));
 }
 
-.message-markdown .mention-chip.fragmentable-inline-chip {
-  display: inline;
-  overflow-wrap: anywhere;
-  text-align: left;
-  white-space: normal;
-}
-
 .message-markdown .mention-chip.wrapping-inline-chip {
+  display: inline;
   line-height: calc(
     1em +
     var(--inline-chip-padding-block-start) +
     var(--inline-chip-padding-block-end) +
     0.25rem
   );
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: normal;
 }
 
-/* Mention fragments fill one conversation line, including their block padding. */
-.message-markdown [data-mention].fragmentable-inline-chip {
-  line-height: calc(
-    var(--conversation-message-line-height) -
-    var(--inline-chip-padding-block-start) -
-    var(--inline-chip-padding-block-end)
-  );
+/* Mentions use the prose rhythm while retaining cloned chip decoration. */
+.message-markdown [data-mention].wrapping-inline-chip {
+  padding-block: 0;
+  line-height: calc(var(--conversation-message-line-height) - 1px);
 }
 
 .message-markdown .mention-chip.buzz-link-unavailable,
@@ -200,11 +194,11 @@
   transform: translateY(-50%);
 }
 
-.message-markdown .fragmentable-inline-chip.inline-chip-with-icon {
+.message-markdown .wrapping-inline-chip.inline-chip-with-icon {
   padding-left: var(--inline-chip-padding-inline);
 }
 
-.message-markdown .fragmentable-inline-chip.inline-chip-with-icon::before {
+.message-markdown .wrapping-inline-chip.inline-chip-with-icon::before {
   display: none;
 }
 

--- a/desktop/src/shared/styles/globals/markdown.css
+++ b/desktop/src/shared/styles/globals/markdown.css
@@ -103,7 +103,7 @@
 /* Mentions use the prose rhythm while retaining cloned chip decoration. */
 .message-markdown [data-mention].wrapping-inline-chip {
   padding-block: 0;
-  line-height: calc(var(--conversation-message-line-height) - 1px);
+  line-height: calc(var(--conversation-message-line-height) - 2px);
 }
 
 .message-markdown .mention-chip.buzz-link-unavailable,

--- a/desktop/src/shared/ui/markdown.test.mjs
+++ b/desktop/src/shared/ui/markdown.test.mjs
@@ -1400,6 +1400,8 @@ test("resolved human mentions replace the authored at-sign with the shared icon"
   );
 
   assert.match(html, /data-mention=""/);
+  assert.match(html, /fragmentable-inline-chip/);
+  assert.doesNotMatch(html, /\bwrapping-inline-chip\b/);
   assert.match(
     html,
     /inline-chip-leading-fragment[^>]*inline-chip-icon-human[^>]*>alice<\/span>/,
@@ -1462,6 +1464,7 @@ test("renderEntityLinkAnchor renders Buzz entity links as chips", () => {
   assert.match(html, /role="button"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /data-buzz-link-kind="pr"/);
+  assert.match(html, /fragmentable-inline-chip/);
   assert.match(html, /wrapping-inline-chip/);
   assert.match(html, /inline-chip-leading-fragment[^>]*>buzz-</);
   assert.doesNotMatch(html, /\btruncate\b/);

--- a/desktop/src/shared/ui/markdown.test.mjs
+++ b/desktop/src/shared/ui/markdown.test.mjs
@@ -1400,8 +1400,7 @@ test("resolved human mentions replace the authored at-sign with the shared icon"
   );
 
   assert.match(html, /data-mention=""/);
-  assert.match(html, /fragmentable-inline-chip/);
-  assert.doesNotMatch(html, /\bwrapping-inline-chip\b/);
+  assert.match(html, /wrapping-inline-chip/);
   assert.match(
     html,
     /inline-chip-leading-fragment[^>]*inline-chip-icon-human[^>]*>alice<\/span>/,
@@ -1464,7 +1463,6 @@ test("renderEntityLinkAnchor renders Buzz entity links as chips", () => {
   assert.match(html, /role="button"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /data-buzz-link-kind="pr"/);
-  assert.match(html, /fragmentable-inline-chip/);
   assert.match(html, /wrapping-inline-chip/);
   assert.match(html, /inline-chip-leading-fragment[^>]*>buzz-</);
   assert.doesNotMatch(html, /\btruncate\b/);

--- a/desktop/src/shared/ui/markdown/MarkdownMention.tsx
+++ b/desktop/src/shared/ui/markdown/MarkdownMention.tsx
@@ -77,6 +77,7 @@ export function createMarkdownMention(interactive: boolean) {
         pubkey={pubkey}
         role={isAgentMention ? "bot" : undefined}
         triggerElement="span"
+        triggerClassName="inline"
       >
         {mentionNode}
       </UserProfilePopover>

--- a/desktop/src/shared/ui/markdown/MarkdownMention.tsx
+++ b/desktop/src/shared/ui/markdown/MarkdownMention.tsx
@@ -4,9 +4,9 @@ import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { cn } from "@/shared/lib/cn";
 import { formatMentionDisplayLabel } from "@/shared/lib/mentionDisplay";
 import {
-  FRAGMENTABLE_INLINE_CHIP_CLASSES,
   inlineChipIconClasses,
   inlineChipLeadingEnd,
+  WRAPPING_INLINE_CHIP_CLASSES,
 } from "@/shared/ui/mentionChip";
 import { InlineChip } from "@/shared/ui/InlineChip";
 import { useMarkdownRuntime } from "./runtimeContext";
@@ -49,7 +49,7 @@ export function createMarkdownMention(interactive: boolean) {
         data-mention-label={mentionLabel}
         data-mention-pubkey={pubkey}
         className={cn(
-          FRAGMENTABLE_INLINE_CHIP_CLASSES,
+          WRAPPING_INLINE_CHIP_CLASSES,
           isAgentMention && "agent-mention-highlight",
         )}
         title={mentionLabel}

--- a/desktop/src/shared/ui/markdown/MarkdownMention.tsx
+++ b/desktop/src/shared/ui/markdown/MarkdownMention.tsx
@@ -4,9 +4,9 @@ import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { cn } from "@/shared/lib/cn";
 import { formatMentionDisplayLabel } from "@/shared/lib/mentionDisplay";
 import {
+  FRAGMENTABLE_INLINE_CHIP_CLASSES,
   inlineChipIconClasses,
   inlineChipLeadingEnd,
-  WRAPPING_INLINE_CHIP_CLASSES,
 } from "@/shared/ui/mentionChip";
 import { InlineChip } from "@/shared/ui/InlineChip";
 import { useMarkdownRuntime } from "./runtimeContext";
@@ -49,7 +49,7 @@ export function createMarkdownMention(interactive: boolean) {
         data-mention-label={mentionLabel}
         data-mention-pubkey={pubkey}
         className={cn(
-          WRAPPING_INLINE_CHIP_CLASSES,
+          FRAGMENTABLE_INLINE_CHIP_CLASSES,
           isAgentMention && "agent-mention-highlight",
         )}
         title={mentionLabel}

--- a/desktop/src/shared/ui/mentionChip.ts
+++ b/desktop/src/shared/ui/mentionChip.ts
@@ -45,10 +45,7 @@ export function inlineChipLeadingEnd(label: string): number {
 }
 
 /** Allows a long chip to fragment into separately decorated line boxes. */
-export const FRAGMENTABLE_INLINE_CHIP_CLASSES = "fragmentable-inline-chip";
-
-/** Gives fragmentable entity links their roomier inter-line rhythm. */
-export const WRAPPING_INLINE_CHIP_CLASSES = `${FRAGMENTABLE_INLINE_CHIP_CLASSES} wrapping-inline-chip`;
+export const WRAPPING_INLINE_CHIP_CLASSES = "wrapping-inline-chip";
 
 export type InlineChipIconKind =
   | "agent"

--- a/desktop/src/shared/ui/mentionChip.ts
+++ b/desktop/src/shared/ui/mentionChip.ts
@@ -45,7 +45,10 @@ export function inlineChipLeadingEnd(label: string): number {
 }
 
 /** Allows a long chip to fragment into separately decorated line boxes. */
-export const WRAPPING_INLINE_CHIP_CLASSES = "wrapping-inline-chip";
+export const FRAGMENTABLE_INLINE_CHIP_CLASSES = "fragmentable-inline-chip";
+
+/** Gives fragmentable entity links their roomier inter-line rhythm. */
+export const WRAPPING_INLINE_CHIP_CLASSES = `${FRAGMENTABLE_INLINE_CHIP_CLASSES} wrapping-inline-chip`;
 
 export type InlineChipIconKind =
   | "agent"

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1623,13 +1623,12 @@ test("selecting a persona mention creates a channel agent before sending and sta
     .locator("[data-mention].agent-mention-highlight", { hasText: "Fizz" });
   await expect(mentionChip).toBeVisible();
   await expect(mentionChip).toHaveText("Fizz");
-  await expect(mentionChip).toHaveClass(/fragmentable-inline-chip/);
-  await expect(mentionChip).not.toHaveClass(/wrapping-inline-chip/);
+  await expect(mentionChip).toHaveClass(/wrapping-inline-chip/);
   const timelineLayout = await timelineChipLayout(mentionChip);
   expect(timelineLayout).toMatchObject({
     boxDecorationBreak: "clone",
-    chipHeight: 20,
-    chipLineHeight: 16,
+    chipHeight: 19,
+    chipLineHeight: 19,
     fragmentCount: 1,
     fragmentStep: null,
     paragraphHeight: 20,
@@ -4570,14 +4569,13 @@ test("mention text is highlighted in sent messages", async ({ page }) => {
   await expect(mentionChip).toBeVisible();
   await expect(mentionChip).toHaveText("bob");
   await expect(mentionChip).toHaveClass(/inline-chip-icon-human/);
-  await expect(mentionChip).toHaveClass(/fragmentable-inline-chip/);
-  await expect(mentionChip).not.toHaveClass(/wrapping-inline-chip/);
+  await expect(mentionChip).toHaveClass(/wrapping-inline-chip/);
 
   const timelineLayout = await timelineChipLayout(mentionChip);
   expect(timelineLayout).toMatchObject({
     boxDecorationBreak: "clone",
-    chipHeight: 20,
-    chipLineHeight: 16,
+    chipHeight: 19,
+    chipLineHeight: 19,
     fragmentCount: 1,
     fragmentStep: null,
     paragraphHeight: 20,
@@ -4595,15 +4593,12 @@ test("qualified mentions wrap without changing message line rhythm", async ({
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
   await waitForMockLiveSubscription(page, "general");
-  await emitMockMessage(page, "general", `before @${qualifiedLabel} after`, {
+  await emitMockMessage(page, "general", `@${qualifiedLabel}`, {
     mentionPubkeys: [pubkey],
   });
   await waitForTimelineSettled(page);
 
-  const row = page
-    .getByTestId("message-row")
-    .filter({ hasText: "before bob" })
-    .last();
+  const row = page.getByTestId("message-row").filter({ hasText: "bob" }).last();
   await row.evaluate((element) => {
     const prose = element.querySelector<HTMLElement>(".message-markdown");
     if (!prose)
@@ -4611,15 +4606,14 @@ test("qualified mentions wrap without changing message line rhythm", async ({
     prose.style.width = "8rem";
   });
   const mentionChip = row.locator("[data-mention]", { hasText: "bob" });
-  await expect(mentionChip).toHaveText(/bob \(bb22a529…f260\)/);
-  await expect(mentionChip).toHaveClass(/fragmentable-inline-chip/);
-  await expect(mentionChip).not.toHaveClass(/wrapping-inline-chip/);
+  await expect(mentionChip).toHaveText(/bob \(npub1hv3…tpuc\)/);
+  await expect(mentionChip).toHaveClass(/wrapping-inline-chip/);
 
   const layout = await timelineChipLayout(mentionChip);
   expect(layout.boxDecorationBreak).toBe("clone");
-  expect(layout.chipLineHeight).toBe(16);
-  expect(layout.fragmentCount).toBeGreaterThanOrEqual(2);
-  expect(layout.fragmentStep).toBe(16);
+  expect(layout.chipLineHeight).toBe(19);
+  expect(layout.fragmentCount).toBe(2);
+  expect(layout.fragmentStep).toBe(20);
   expect(layout.paragraphLineHeight).toBe(20);
   expect(layout.chipHeight).toBeLessThanOrEqual(
     layout.fragmentCount * layout.paragraphLineHeight,

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 
 import { truncateNpub } from "../../src/shared/lib/pubkey";
 import { waitForAnimations } from "../helpers/animations";
@@ -87,6 +87,46 @@ const JOIN_COLLAPSE_GROUPED_TEXT =
 const JOIN_COLLAPSE_CAPTURE_WIDTH = 560;
 const JOIN_COLLAPSE_CAPTURE_HEIGHT = 260;
 const JOIN_COLLAPSE_CAPTURE_VERTICAL_PADDING = 24;
+
+async function timelineChipLayout(chip: Locator) {
+  return chip.evaluate((element) => {
+    const paragraph = element.closest("p");
+    if (!paragraph) throw new Error("Timeline chip is missing its paragraph");
+    const chipBounds = element.getBoundingClientRect();
+    const paragraphBounds = paragraph.getBoundingClientRect();
+    const contentRange = document.createRange();
+    contentRange.selectNodeContents(element);
+    const visibleFragmentRects = Array.from(
+      contentRange.getClientRects(),
+    ).filter((rect) => rect.width > 0 && rect.height > 0);
+    const fragmentTops: number[] = [];
+    for (const rect of visibleFragmentRects.sort((a, b) => a.top - b.top)) {
+      if (
+        fragmentTops.length === 0 ||
+        rect.top - fragmentTops[fragmentTops.length - 1] > 2
+      ) {
+        fragmentTops.push(rect.top);
+      }
+    }
+    const chipStyle = getComputedStyle(element);
+    return {
+      boxDecorationBreak:
+        chipStyle.getPropertyValue("box-decoration-break") ||
+        chipStyle.getPropertyValue("-webkit-box-decoration-break"),
+      chipHeight: chipBounds.height,
+      chipLineHeight: Number.parseFloat(chipStyle.lineHeight),
+      fragmentCount: fragmentTops.length,
+      fragmentStep:
+        fragmentTops.length > 1
+          ? Math.round(fragmentTops[1] - fragmentTops[0])
+          : null,
+      paragraphHeight: paragraphBounds.height,
+      paragraphLineHeight: Number.parseFloat(
+        getComputedStyle(paragraph).lineHeight,
+      ),
+    };
+  });
+}
 
 /** Locator scoped to the mention autocomplete dropdown inside the composer. */
 function autocomplete(page: import("@playwright/test").Page) {
@@ -1583,6 +1623,18 @@ test("selecting a persona mention creates a channel agent before sending and sta
     .locator("[data-mention].agent-mention-highlight", { hasText: "Fizz" });
   await expect(mentionChip).toBeVisible();
   await expect(mentionChip).toHaveText("Fizz");
+  await expect(mentionChip).toHaveClass(/fragmentable-inline-chip/);
+  await expect(mentionChip).not.toHaveClass(/wrapping-inline-chip/);
+  const timelineLayout = await timelineChipLayout(mentionChip);
+  expect(timelineLayout).toMatchObject({
+    boxDecorationBreak: "clone",
+    chipHeight: 20,
+    chipLineHeight: 16,
+    fragmentCount: 1,
+    fragmentStep: null,
+    paragraphHeight: 20,
+    paragraphLineHeight: 20,
+  });
 });
 
 test("selecting a persona mention reuses an existing persona agent", async ({
@@ -4518,6 +4570,60 @@ test("mention text is highlighted in sent messages", async ({ page }) => {
   await expect(mentionChip).toBeVisible();
   await expect(mentionChip).toHaveText("bob");
   await expect(mentionChip).toHaveClass(/inline-chip-icon-human/);
+  await expect(mentionChip).toHaveClass(/fragmentable-inline-chip/);
+  await expect(mentionChip).not.toHaveClass(/wrapping-inline-chip/);
+
+  const timelineLayout = await timelineChipLayout(mentionChip);
+  expect(timelineLayout).toMatchObject({
+    boxDecorationBreak: "clone",
+    chipHeight: 20,
+    chipLineHeight: 16,
+    fragmentCount: 1,
+    fragmentStep: null,
+    paragraphHeight: 20,
+    paragraphLineHeight: 20,
+  });
+});
+
+test("qualified mentions wrap without changing message line rhythm", async ({
+  page,
+}) => {
+  const pubkey = TEST_IDENTITIES.bob.pubkey;
+  const qualifiedLabel = `bob (${pubkey})`;
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+  await emitMockMessage(page, "general", `before @${qualifiedLabel} after`, {
+    mentionPubkeys: [pubkey],
+  });
+  await waitForTimelineSettled(page);
+
+  const row = page
+    .getByTestId("message-row")
+    .filter({ hasText: "before bob" })
+    .last();
+  await row.evaluate((element) => {
+    const prose = element.querySelector<HTMLElement>(".message-markdown");
+    if (!prose)
+      throw new Error("Qualified mention is missing its prose wrapper");
+    prose.style.width = "8rem";
+  });
+  const mentionChip = row.locator("[data-mention]", { hasText: "bob" });
+  await expect(mentionChip).toHaveText(/bob \(bb22a529…f260\)/);
+  await expect(mentionChip).toHaveClass(/fragmentable-inline-chip/);
+  await expect(mentionChip).not.toHaveClass(/wrapping-inline-chip/);
+
+  const layout = await timelineChipLayout(mentionChip);
+  expect(layout.boxDecorationBreak).toBe("clone");
+  expect(layout.chipLineHeight).toBe(16);
+  expect(layout.fragmentCount).toBeGreaterThanOrEqual(2);
+  expect(layout.fragmentStep).toBe(16);
+  expect(layout.paragraphLineHeight).toBe(20);
+  expect(layout.chipHeight).toBeLessThanOrEqual(
+    layout.fragmentCount * layout.paragraphLineHeight,
+  );
 });
 
 test("clicking author name opens user profile panel", async ({ page }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -94,20 +94,9 @@ async function timelineChipLayout(chip: Locator) {
     if (!paragraph) throw new Error("Timeline chip is missing its paragraph");
     const chipBounds = element.getBoundingClientRect();
     const paragraphBounds = paragraph.getBoundingClientRect();
-    const contentRange = document.createRange();
-    contentRange.selectNodeContents(element);
-    const visibleFragmentRects = Array.from(
-      contentRange.getClientRects(),
-    ).filter((rect) => rect.width > 0 && rect.height > 0);
-    const fragmentTops: number[] = [];
-    for (const rect of visibleFragmentRects.sort((a, b) => a.top - b.top)) {
-      if (
-        fragmentTops.length === 0 ||
-        rect.top - fragmentTops[fragmentTops.length - 1] > 2
-      ) {
-        fragmentTops.push(rect.top);
-      }
-    }
+    const chipFragmentRects = Array.from(element.getClientRects())
+      .filter((rect) => rect.width > 0 && rect.height > 0)
+      .sort((a, b) => a.top - b.top);
     const chipStyle = getComputedStyle(element);
     return {
       boxDecorationBreak:
@@ -115,10 +104,18 @@ async function timelineChipLayout(chip: Locator) {
         chipStyle.getPropertyValue("-webkit-box-decoration-break"),
       chipHeight: chipBounds.height,
       chipLineHeight: Number.parseFloat(chipStyle.lineHeight),
-      fragmentCount: fragmentTops.length,
+      fragmentCount: chipFragmentRects.length,
+      fragmentGap:
+        chipFragmentRects.length > 1
+          ? Math.round(chipFragmentRects[1].top - chipFragmentRects[0].bottom)
+          : null,
+      fragmentHeight:
+        chipFragmentRects.length > 0
+          ? Math.round(chipFragmentRects[0].height)
+          : null,
       fragmentStep:
-        fragmentTops.length > 1
-          ? Math.round(fragmentTops[1] - fragmentTops[0])
+        chipFragmentRects.length > 1
+          ? Math.round(chipFragmentRects[1].top - chipFragmentRects[0].top)
           : null,
       paragraphHeight: paragraphBounds.height,
       paragraphLineHeight: Number.parseFloat(
@@ -1627,9 +1624,11 @@ test("selecting a persona mention creates a channel agent before sending and sta
   const timelineLayout = await timelineChipLayout(mentionChip);
   expect(timelineLayout).toMatchObject({
     boxDecorationBreak: "clone",
-    chipHeight: 19,
-    chipLineHeight: 19,
+    chipHeight: 17,
+    chipLineHeight: 18,
     fragmentCount: 1,
+    fragmentGap: null,
+    fragmentHeight: 17,
     fragmentStep: null,
     paragraphHeight: 20,
     paragraphLineHeight: 20,
@@ -4574,9 +4573,11 @@ test("mention text is highlighted in sent messages", async ({ page }) => {
   const timelineLayout = await timelineChipLayout(mentionChip);
   expect(timelineLayout).toMatchObject({
     boxDecorationBreak: "clone",
-    chipHeight: 19,
-    chipLineHeight: 19,
+    chipHeight: 17,
+    chipLineHeight: 18,
     fragmentCount: 1,
+    fragmentGap: null,
+    fragmentHeight: 17,
     fragmentStep: null,
     paragraphHeight: 20,
     paragraphLineHeight: 20,
@@ -4611,13 +4612,23 @@ test("qualified mentions wrap without changing message line rhythm", async ({
 
   const layout = await timelineChipLayout(mentionChip);
   expect(layout.boxDecorationBreak).toBe("clone");
-  expect(layout.chipLineHeight).toBe(19);
+  expect(layout.chipLineHeight).toBe(18);
   expect(layout.fragmentCount).toBe(2);
+  expect(layout.fragmentHeight).toBe(17);
+  expect(layout.fragmentGap).toBeGreaterThanOrEqual(1);
   expect(layout.fragmentStep).toBe(20);
   expect(layout.paragraphLineHeight).toBe(20);
   expect(layout.chipHeight).toBeLessThanOrEqual(
     layout.fragmentCount * layout.paragraphLineHeight,
   );
+
+  const trigger = mentionChip.locator("xpath=..");
+  await expect(trigger).toHaveCSS("display", "inline");
+  await expect(trigger).toHaveAttribute("role", "button");
+  await trigger.focus();
+  await expect(trigger).toBeFocused();
+  await trigger.press("Enter");
+  await expect(page.getByTestId("user-profile-panel")).toBeVisible();
 });
 
 test("clicking author name opens user profile panel", async ({ page }) => {

--- a/desktop/tests/e2e/navigation.spec.ts
+++ b/desktop/tests/e2e/navigation.spec.ts
@@ -577,7 +577,6 @@ test("composer Buzz chip labels wrap without orphaning their icons", async ({
     name: "Open repository relaytoolsobservabilityconsole-main",
   });
   await expect(sentChip).toBeVisible();
-  await expect(sentChip).toHaveClass(/fragmentable-inline-chip/);
   await expect(sentChip).toHaveClass(/wrapping-inline-chip/);
   await sentChip.evaluate((element) => {
     const container = element.parentElement;

--- a/desktop/tests/e2e/navigation.spec.ts
+++ b/desktop/tests/e2e/navigation.spec.ts
@@ -577,21 +577,39 @@ test("composer Buzz chip labels wrap without orphaning their icons", async ({
     name: "Open repository relaytoolsobservabilityconsole-main",
   });
   await expect(sentChip).toBeVisible();
+  await expect(sentChip).toHaveClass(/fragmentable-inline-chip/);
+  await expect(sentChip).toHaveClass(/wrapping-inline-chip/);
   await sentChip.evaluate((element) => {
     const container = element.parentElement;
     if (container) container.style.width = "220px";
   });
-  const fragmentRects = await sentChip.evaluate((element) =>
-    Array.from(element.getClientRects(), (rect) => ({
+  const fragmentMetrics = await sentChip.evaluate((element) => {
+    const chipStyle = getComputedStyle(element);
+    const rects = Array.from(element.getClientRects(), (rect) => ({
       bottom: rect.bottom,
       height: rect.height,
       left: rect.left,
       right: rect.right,
       top: rect.top,
       width: rect.width,
-    })).filter((rect) => rect.width > 0 && rect.height > 0),
-  );
-  expect(fragmentRects.length).toBeGreaterThanOrEqual(2);
+    })).filter((rect) => rect.width > 0 && rect.height > 0);
+    const fragmentTops = Array.from(
+      new Set(rects.map((rect) => Math.round(rect.top))),
+    ).sort((a, b) => a - b);
+    return {
+      boxDecorationBreak:
+        chipStyle.getPropertyValue("box-decoration-break") ||
+        chipStyle.getPropertyValue("-webkit-box-decoration-break"),
+      fragmentStep:
+        fragmentTops.length > 1 ? fragmentTops[1] - fragmentTops[0] : null,
+      lineHeight: Number.parseFloat(chipStyle.lineHeight),
+      rects,
+    };
+  });
+  expect(fragmentMetrics.boxDecorationBreak).toBe("clone");
+  expect(fragmentMetrics.lineHeight).toBe(22);
+  expect(fragmentMetrics.fragmentStep).toBe(22);
+  expect(fragmentMetrics.rects.length).toBeGreaterThanOrEqual(2);
 
   const tooltip = page.getByRole("tooltip");
   await sentChip.focus();


### PR DESCRIPTION
**Category:** fix
**User Impact:** Human and agent mentions now break across lines with the same cloned chip treatment as repository and permalink chips while preserving the conversation text rhythm.

**Problem:** Profile-backed rendered mentions sat inside an `inline-flex` popover trigger, unlike entity chips, so the wrapper interfered with true inline fragmentation. The browser-layout test measured text-range rows rather than the painted chip rectangles, allowing touching decorations to pass as “separate” fragments.

**Solution:** Keep the profile trigger interactive but override its layout to true `inline`, then give mention fragments 18px computed leading inside the message’s 20px prose rhythm. Chromium paints each fragment at 17px and advances it by 20px, leaving a visible gap between cloned rounded rectangles. The browser test now measures the chip’s own `getClientRects()` and asserts fragment count, height, gap, and step; entity links retain their existing 22px leading.

<details>
<summary>File changes</summary>

**desktop/src/features/profile/ui/UserProfilePopover.tsx**
Allows inline consumers to override the trigger wrapper’s layout without changing other profile-popover call sites.

**desktop/src/shared/styles/globals/markdown.css**
Keeps one shared wrapping-chip mechanic and gives mention decorations enough room to separate visibly within 20px prose.

**desktop/src/shared/ui/markdown.test.mjs**
Pins both rendered mentions and entity links to the shared wrapping-chip contract.

**desktop/src/shared/ui/markdown/MarkdownMention.tsx**
Makes the profile-popover trigger truly inline so the nested mention chip can fragment with surrounding prose.

**desktop/src/shared/ui/mentionChip.ts**
Keeps `wrapping-inline-chip` as the single contract for fragmenting decorated chips.

**desktop/tests/e2e/mentions.spec.ts**
Measures the painted chip rectangles, requires a positive fragment gap, and verifies the inline trigger remains mouse- and keyboard-operable.

**desktop/tests/e2e/navigation.spec.ts**
Keeps a wrapped repository chip as the control, asserting its existing 22px line height and fragment advance.

</details>

## Reproduction steps

1. Open a channel in Buzz Desktop using dark theme.
2. Send a message containing a human mention and another containing an agent mention; both chips should remain aligned with adjacent text on a 20px line.
3. Render a collision-qualified mention in a narrow message width; it should break into separately decorated fragments exactly like another wrapping chip, while each fragment follows the 20px prose rhythm.
4. Render a long repository or permalink chip in the same constrained width; it should retain its roomier 22px fragment spacing.

## Screenshot

The dark-theme production renderer shows the real qualified label (`bob (npub1hv3…tpuc)`) at an 8rem width. The two lines now paint as visibly separate rounded fragments rather than one continuous rectangle.

![Qualified human mention wrapping into two visibly separate rounded fragments in the dark-theme Buzz timeline](https://github.com/user-attachments/assets/ee6e7be5-937e-4022-9c82-cf71f8203470)

## Validation

At commit `2b063e1b4ade30e11f1616269ad4ba4190366885`:

- Pre-push desktop gates — file-size check, Biome/checks, typecheck, and 6,483 unit tests passed
- `pnpm --dir desktop build` — passed
- Focused Playwright coverage for single-line agent mention, single-line human mention, wrapped qualified mention including keyboard profile activation, and timeline mention click — 4 passed
- `git diff --check` — passed
