### PR TITLE
Add gateway-managed Codex auth for OpenShell agents

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -309,6 +309,7 @@ test-unit:
     #!/usr/bin/env bash
     set -euo pipefail
     ./scripts/test-ensure-local-relay-key.sh
+    ./scripts/test-openshell-codex-auth.sh
     if command -v cargo-nextest &>/dev/null; then
         cargo nextest run -p buzz-core -p buzz-auth --lib
         cargo nextest run -p buzz-voice --lib

--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -1,0 +1,120 @@
+# Codex authentication for OpenShell agents
+
+Do not copy a host `~/.codex/auth.json` into Buzz agent sandboxes. A copied
+ChatGPT login shares revocable refresh material with the host, exposes live
+tokens in every workspace, and stops every copy when that login is revoked.
+
+For several unattended agents, use one OpenShell provider backed by a dedicated
+Codex login. OpenShell keeps the refresh token as gateway-only secret material,
+rotates the short-lived access token, and injects only opaque, endpoint-bound
+placeholders into attached sandboxes. Codex still gets its expected
+`auth.json` shape, but that file contains no usable OpenAI credential.
+
+This requires OpenShell provider refresh support (available in OpenShell
+0.0.116). If provider refresh is unavailable, log in independently inside each
+persistent sandbox with `codex login --device-auth`; OpenAI documents copying
+`auth.json` only as a fallback for headless environments.
+
+## Configure the provider
+
+Create a dedicated temporary Codex home so the gateway does not share the
+host CLI's refresh-token lineage:
+
+```bash
+auth_home="$(mktemp -d)"
+CODEX_HOME="$auth_home" codex login --device-auth
+deploy/openshell/configure-codex-provider.sh \
+  --auth-file "$auth_home/auth.json" \
+  --gateway my-gateway
+```
+
+After the script reports a successful rotation, remove the temporary directory
+or keep it in encrypted operator storage for disaster recovery. Never commit
+it. A future reauthorization uses a fresh dedicated login followed by
+`--reset-refresh`.
+
+The script imports `providers/codex-buzz.yaml`, stores the bootstrap access token
+and account ID in the gateway, stores the refresh token as non-injectable secret
+refresh material, and forces an initial rotation. It does not put token values
+on the command line or upload the source auth file.
+
+## Create or migrate sandboxes
+
+Prefer attaching the provider when the sandbox is created. The base policy must
+not also contain the image's generic L4-only `codex` rule; the provider supplies
+the inspected Codex endpoints and binaries:
+
+```bash
+openshell sandbox create \
+  --name kestrel \
+  --from your-buzz-agent-image \
+  --policy your-buzz-agent-policy.yaml \
+  --provider codex-buzz \
+  --no-auto-providers \
+  --detach
+```
+
+OpenShell 0.0.116 rejects provider attachment when an existing sandbox was
+created with an L4-only Codex rule, even after that rule is replaced in a live
+policy revision. Recreate such a sandbox from its source configuration with the
+provider attached at creation time; preserve its Buzz identity and any intended
+workspace artifacts through the normal backup/restore path. Do not bypass this
+guard with `allow_uninspected_credentials`.
+
+For a sandbox whose original policy already has no overlapping Codex rule, an
+attachment followed by a restart is sufficient:
+
+```bash
+openshell sandbox provider attach kestrel codex-buzz
+openshell sandbox stop kestrel
+openshell sandbox start kestrel
+```
+
+Include `materialize-codex-auth.mjs` in the sandbox image and run it immediately
+before starting `codex-acp`:
+
+```bash
+export CODEX_HOME=/sandbox/runtime/.codex
+node /opt/buzz/materialize-codex-auth.mjs
+exec buzz-acp
+```
+
+The materializer refuses raw credentials and writes `auth.json` atomically with
+mode `0600`. Its access token and account ID are OpenShell placeholders; its
+refresh token is a sentinel because refresh belongs exclusively to the gateway.
+The provider policy permits those placeholders only for Codex/Node processes
+and the declared OpenAI endpoints.
+
+Verify without displaying credentials:
+
+```bash
+openshell provider refresh status codex-buzz \
+  --credential-key CODEX_AUTH_ACCESS_TOKEN
+openshell sandbox exec -n kestrel -- codex login status
+openshell sandbox exec -n kestrel -- codex exec --skip-git-repo-check \
+  'Reply with AUTH_OK only.'
+```
+
+## Reauthorize
+
+If refresh status says `reauthorization_required`, make a new temporary
+dedicated login and replace the gateway-owned refresh state explicitly:
+
+```bash
+auth_home="$(mktemp -d)"
+CODEX_HOME="$auth_home" codex login --device-auth
+deploy/openshell/configure-codex-provider.sh \
+  --auth-file "$auth_home/auth.json" \
+  --gateway my-gateway \
+  --reset-refresh
+```
+
+Opaque placeholders remain stable, so attached sandboxes do not need a new
+`auth.json`. Restart the long-running agent process only if it has retained a
+failed Codex child.
+
+## References
+
+- [OpenAI Codex authentication](https://developers.openai.com/codex/auth)
+- [OpenShell provider profiles and gateway-managed refresh](https://github.com/NVIDIA/OpenShell/blob/main/docs/providers/profiles.mdx)
+- [OpenShell's Codex Gator provider example](https://github.com/NVIDIA/OpenShell/tree/main/scripts/agents/gator)

--- a/deploy/openshell/configure-codex-provider.sh
+++ b/deploy/openshell/configure-codex-provider.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly profile_file="$script_dir/providers/codex-buzz.yaml"
+readonly profile_id=codex-buzz
+readonly codex_oauth_client_id=app_EMoamEEZ73f0CkXaXp7hrann
+
+provider_name=codex-buzz
+auth_file="${CODEX_HOME:-${HOME:?HOME is required}/.codex}/auth.json"
+gateway=""
+reset_refresh=0
+
+usage() {
+  cat <<'EOF'
+Usage: configure-codex-provider.sh [options]
+
+Create or reconcile an OpenShell provider whose gateway owns Codex OAuth
+access-token refresh. The auth file is read once as bootstrap material; it is
+never uploaded to a sandbox.
+
+Options:
+  --provider NAME   Provider instance name (default: codex-buzz)
+  --auth-file PATH  Codex auth file (default: $CODEX_HOME/auth.json or ~/.codex/auth.json)
+  --gateway NAME    OpenShell gateway name (default: active gateway)
+  --reset-refresh   Replace gateway refresh state from the supplied auth file
+  -h, --help        Show this help
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while (($#)); do
+  case "$1" in
+    --provider)
+      (($# >= 2)) || fail "--provider requires a value"
+      provider_name=$2
+      shift 2
+      ;;
+    --auth-file)
+      (($# >= 2)) || fail "--auth-file requires a value"
+      auth_file=$2
+      shift 2
+      ;;
+    --gateway)
+      (($# >= 2)) || fail "--gateway requires a value"
+      gateway=$2
+      shift 2
+      ;;
+    --reset-refresh)
+      reset_refresh=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+command -v jq >/dev/null || fail "jq is required"
+command -v openshell >/dev/null || fail "openshell is required"
+[[ -f "$auth_file" ]] || fail "Codex auth file not found: $auth_file"
+[[ ! -L "$auth_file" ]] || fail "refusing symlinked Codex auth file: $auth_file"
+
+openshell_cmd() {
+  if [[ -n "$gateway" ]]; then
+    openshell --gateway "$gateway" "$@"
+  else
+    openshell "$@"
+  fi
+}
+
+import_or_update_profile() {
+  local exported resource_version temporary_dir temporary_profile
+  if ! exported="$(openshell_cmd provider profile export --output json "$profile_id" 2>/dev/null)"; then
+    openshell_cmd provider profile lint --file "$profile_file" >/dev/null
+    openshell_cmd provider profile import --file "$profile_file" >/dev/null
+    return
+  fi
+
+  resource_version="$(jq -er '.resource_version | select(type == "number" and . > 0)' <<<"$exported")" \
+    || fail "existing $profile_id profile has no resource version"
+  temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/buzz-codex-profile.XXXXXX")"
+  temporary_profile="$temporary_dir/profile.yaml"
+  trap 'rm -rf "${temporary_dir:-}"' RETURN
+  awk -v version="$resource_version" \
+    '{ print; if (!inserted && $0 ~ /^id:/) { print "resource_version: " version; inserted=1 } }' \
+    "$profile_file" >"$temporary_profile"
+  openshell_cmd provider profile update "$profile_id" --file "$temporary_profile" >/dev/null
+  rm -f "$temporary_profile"
+  rmdir "$temporary_dir"
+  trap - RETURN
+}
+
+access_token="$(jq -er '.tokens.access_token | select(type == "string" and length > 0)' "$auth_file")" \
+  || fail "Codex auth file has no access token; run a fresh Codex login"
+refresh_token="$(jq -er '.tokens.refresh_token | select(type == "string" and length > 0)' "$auth_file")" \
+  || fail "Codex auth file has no refresh token; use ChatGPT login, not API-key login"
+account_id="$(jq -er '.tokens.account_id | select(type == "string" and length > 0)' "$auth_file")" \
+  || fail "Codex auth file has no account ID; run a fresh Codex login"
+export CODEX_AUTH_ACCESS_TOKEN="$access_token"
+export CODEX_AUTH_ACCOUNT_ID="$account_id"
+export BUZZ_CODEX_REFRESH_TOKEN="$refresh_token"
+
+import_or_update_profile
+
+provider_exists=0
+if openshell_cmd provider get "$provider_name" >/dev/null 2>&1; then
+  provider_exists=1
+fi
+
+refresh_exists=0
+if ((provider_exists)); then
+  if refresh_status="$(openshell_cmd provider refresh status "$provider_name" \
+    --credential-key CODEX_AUTH_ACCESS_TOKEN 2>&1)"; then
+    [[ "$refresh_status" == *"No refresh configuration found"* ]] || refresh_exists=1
+  elif [[ "$refresh_status" != *"No refresh configuration found"* ]]; then
+    printf '%s\n' "$refresh_status" >&2
+    fail "could not inspect provider refresh state"
+  fi
+fi
+
+if ((reset_refresh && refresh_exists)); then
+  openshell_cmd provider refresh delete "$provider_name" \
+    --credential-key CODEX_AUTH_ACCESS_TOKEN >/dev/null
+  refresh_exists=0
+fi
+
+if ((!provider_exists)); then
+  openshell_cmd provider create --name "$provider_name" --type "$profile_id" \
+    --credential CODEX_AUTH_ACCESS_TOKEN \
+    --credential CODEX_AUTH_ACCOUNT_ID >/dev/null
+elif ((!refresh_exists)); then
+  openshell_cmd provider update "$provider_name" \
+    --credential CODEX_AUTH_ACCESS_TOKEN \
+    --credential CODEX_AUTH_ACCOUNT_ID >/dev/null
+fi
+
+if ((!refresh_exists)); then
+  openshell_cmd provider refresh configure "$provider_name" \
+    --credential-key CODEX_AUTH_ACCESS_TOKEN \
+    --strategy oauth2-refresh-token \
+    --material "client_id=$codex_oauth_client_id" \
+    --secret-material-env refresh_token=BUZZ_CODEX_REFRESH_TOKEN >/dev/null
+fi
+
+if ! openshell_cmd provider refresh rotate "$provider_name" \
+  --credential-key CODEX_AUTH_ACCESS_TOKEN >/dev/null; then
+  fail "gateway rotation failed; obtain a fresh dedicated login and retry with --reset-refresh"
+fi
+
+printf "Codex provider '%s' is configured with gateway-managed refresh.\n" "$provider_name"
+openshell_cmd provider refresh status "$provider_name" \
+  --credential-key CODEX_AUTH_ACCESS_TOKEN

--- a/deploy/openshell/materialize-codex-auth.mjs
+++ b/deploy/openshell/materialize-codex-auth.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function requiredPlaceholder(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`missing required OpenShell provider value: ${name}`);
+  }
+  if (!value.startsWith("openshell:resolve:env:")) {
+    throw new Error(`${name} is not an opaque OpenShell provider placeholder`);
+  }
+  return value;
+}
+
+function base64url(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+const codexHome = process.env.CODEX_HOME ?? path.join(process.env.HOME ?? "", ".codex");
+if (!path.isAbsolute(codexHome)) {
+  throw new Error("CODEX_HOME (or HOME) must resolve to an absolute path");
+}
+
+const accessToken = requiredPlaceholder("CODEX_AUTH_ACCESS_TOKEN");
+const accountId = requiredPlaceholder("CODEX_AUTH_ACCOUNT_ID");
+const now = Math.floor(Date.now() / 1000);
+const fallbackIdToken = [
+  base64url({ alg: "none", typ: "JWT" }),
+  base64url({
+    iss: "https://auth.openai.com",
+    aud: "codex",
+    sub: "openshell-agent",
+    email: "agent@openshell.local",
+    iat: now,
+    exp: now + 3600,
+  }),
+  "placeholder",
+].join(".");
+
+const auth = {
+  auth_mode: "chatgpt",
+  OPENAI_API_KEY: null,
+  tokens: {
+    id_token: fallbackIdToken,
+    access_token: accessToken,
+    refresh_token: "gateway-managed-refresh-token",
+    account_id: accountId,
+  },
+  last_refresh: new Date().toISOString(),
+};
+
+fs.mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+fs.chmodSync(codexHome, 0o700);
+const authPath = path.join(codexHome, "auth.json");
+if (fs.existsSync(authPath) && fs.lstatSync(authPath).isSymbolicLink()) {
+  throw new Error(`refusing to replace symlink: ${authPath}`);
+}
+const temporaryPath = path.join(codexHome, `.auth.json.${process.pid}.tmp`);
+try {
+  fs.writeFileSync(temporaryPath, `${JSON.stringify(auth, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  fs.renameSync(temporaryPath, authPath);
+  fs.chmodSync(authPath, 0o600);
+} finally {
+  fs.rmSync(temporaryPath, { force: true });
+}
+
+process.stderr.write(`materialized gateway-backed Codex auth at ${authPath}\n`);

--- a/deploy/openshell/providers/codex-buzz.yaml
+++ b/deploy/openshell/providers/codex-buzz.yaml
@@ -1,0 +1,64 @@
+id: codex-buzz
+display_name: Codex for Buzz agents
+description: Codex CLI with gateway-managed OAuth access-token refresh
+category: agent
+inference_capable: true
+credentials:
+  - name: access_token
+    description: Short-lived Codex OAuth access token managed by the gateway
+    env_vars: [CODEX_AUTH_ACCESS_TOKEN]
+    required: true
+    auth_style: bearer
+    header_name: authorization
+    refresh:
+      strategy: oauth2_refresh_token
+      token_url: https://auth.openai.com/oauth/token
+      refresh_before_seconds: 300
+      max_lifetime_seconds: 3600
+      material:
+        - name: client_id
+          description: Public Codex OAuth client ID
+          required: true
+        - name: refresh_token
+          description: Codex OAuth refresh token
+          required: true
+          secret: true
+  - name: account_id
+    description: Codex account identifier
+    env_vars: [CODEX_AUTH_ACCOUNT_ID]
+    required: true
+discovery:
+  credentials: [access_token, account_id]
+endpoints:
+  - host: api.openai.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+  - host: auth.openai.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+  - host: chatgpt.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+  - host: ab.chatgpt.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+  - host: files.openai.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+binaries:
+  - /usr/bin/codex
+  - /usr/local/bin/codex
+  - /usr/bin/node
+  - /usr/local/bin/node
+  - /usr/lib/node_modules/@openai/**
+  - /usr/local/lib/node_modules/@openai/**

--- a/scripts/test-openshell-codex-auth.sh
+++ b/scripts/test-openshell-codex-auth.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly configure="$repo_root/deploy/openshell/configure-codex-provider.sh"
+readonly materialize="$repo_root/deploy/openshell/materialize-codex-auth.mjs"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin" "$test_dir/codex-home"
+cat >"$test_dir/auth.json" <<'JSON'
+{
+  "tokens": {
+    "access_token": "test-access-secret",
+    "refresh_token": "test-refresh-secret",
+    "account_id": "test-account-secret"
+  }
+}
+JSON
+
+cat >"$test_dir/bin/openshell" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "$@" >>"$MOCK_LOG"
+printf '\n' >>"$MOCK_LOG"
+case " $* " in
+  *" provider profile export "*)
+    if [[ "${MOCK_EXISTING:-0}" == 1 ]]; then
+      printf '%s\n' '{"resource_version":7}'
+    else
+      exit 1
+    fi
+    ;;
+  *" provider get "*)
+    [[ "${MOCK_EXISTING:-0}" == 1 ]]
+    ;;
+  *" provider refresh status "*)
+    printf '%s\n' 'STATUS refreshed'
+    ;;
+esac
+MOCK
+chmod +x "$test_dir/bin/openshell"
+
+MOCK_LOG="$test_dir/openshell.log" \
+PATH="$test_dir/bin:$PATH" \
+  "$configure" --auth-file "$test_dir/auth.json" --gateway test-gateway \
+  >"$test_dir/configure.out"
+
+grep -q "provider profile import" "$test_dir/openshell.log"
+grep -q "provider create" "$test_dir/openshell.log"
+grep -q "provider refresh configure" "$test_dir/openshell.log"
+grep -q -- "--secret-material-env refresh_token=BUZZ_CODEX_REFRESH_TOKEN" \
+  "$test_dir/openshell.log"
+grep -q "provider refresh rotate" "$test_dir/openshell.log"
+if grep -Eq 'test-(access|refresh|account)-secret' "$test_dir/openshell.log"; then
+  printf '%s\n' 'credential value leaked into openshell argv' >&2
+  exit 1
+fi
+
+: >"$test_dir/openshell.log"
+MOCK_LOG="$test_dir/openshell.log" \
+MOCK_EXISTING=1 \
+PATH="$test_dir/bin:$PATH" \
+  "$configure" --auth-file "$test_dir/auth.json" --gateway test-gateway \
+  >"$test_dir/configure-existing.out"
+grep -q "provider profile update" "$test_dir/openshell.log"
+grep -q "provider refresh rotate" "$test_dir/openshell.log"
+if grep -q "provider refresh configure" "$test_dir/openshell.log"; then
+  printf '%s\n' 'existing gateway refresh state was overwritten' >&2
+  exit 1
+fi
+
+CODEX_HOME="$test_dir/codex-home" \
+CODEX_AUTH_ACCESS_TOKEN='openshell:resolve:env:s123_CODEX_AUTH_ACCESS_TOKEN' \
+CODEX_AUTH_ACCOUNT_ID='openshell:resolve:env:s456_CODEX_AUTH_ACCOUNT_ID' \
+  node "$materialize" >/dev/null 2>"$test_dir/materialize.err"
+
+jq -e '.auth_mode == "chatgpt"' "$test_dir/codex-home/auth.json" >/dev/null
+jq -e '.tokens.refresh_token == "gateway-managed-refresh-token"' \
+  "$test_dir/codex-home/auth.json" >/dev/null
+jq -e '.tokens.access_token | startswith("openshell:resolve:env:")' \
+  "$test_dir/codex-home/auth.json" >/dev/null
+if mode="$(stat -c '%a' "$test_dir/codex-home/auth.json" 2>/dev/null)"; then
+  :
+else
+  mode="$(stat -f '%Lp' "$test_dir/codex-home/auth.json")"
+fi
+[[ "$mode" == 600 ]]
+
+if CODEX_HOME="$test_dir/raw-codex-home" \
+  CODEX_AUTH_ACCESS_TOKEN='raw-secret' \
+  CODEX_AUTH_ACCOUNT_ID='raw-account' \
+  node "$materialize" >/dev/null 2>&1; then
+  printf '%s\n' 'materializer accepted raw credentials' >&2
+  exit 1
+fi
+
+printf '%s\n' 'OpenShell Codex auth tests passed'


### PR DESCRIPTION
## Summary

- add an OpenShell Codex provider profile with gateway-owned OAuth refresh
- add an idempotent bootstrap/reconciliation script that never places token values in argv or uploads the source auth file
- add a sandbox materializer that refuses raw credentials and atomically writes only opaque OpenShell placeholders
- document dedicated device-login bootstrap, safe reauthorization, and the OpenShell 0.0.116 creation-time policy migration constraint
- run the auth contract test in `just test-unit`

## Validation

- `./scripts/test-openshell-codex-auth.sh`
- `bash -n deploy/openshell/configure-codex-provider.sh scripts/test-openshell-codex-auth.sh`
- `openshell provider profile lint --file deploy/openshell/providers/codex-buzz.yaml` (before import)
- `just file-size-check`
- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- live OpenShell 0.0.116 canary using the Kestrel image:
  - `codex login status` reported ChatGPT login with a mode-0600 placeholder-only auth file
  - a real `gpt-5.6-sol` request returned `AUTH_OK`
  - forced gateway rotation left the sandbox auth-file hash unchanged
  - a second real request returned `ROTATION_OK`
- the existing Kestrel sandbox was restarted, reconnected to three Buzz channels, published online presence, and returned `KESTREL_OK` with its current auth preserved

`just ci` was also attempted. Formatting passed, then clippy stopped during dependency setup because this DGX host does not have the OpenSSL development package (`openssl.pc` / `libssl-dev`).

## Migration note

OpenShell 0.0.116 rejects attaching a credentialed provider to an existing sandbox whose immutable creation-time policy contains the generic L4-only Codex rule, even after a live policy revision replaces that rule. The runbook therefore requires affected agents to be recreated from their source configuration with `--provider codex-buzz`; it explicitly rejects the weaker `allow_uninspected_credentials` workaround.
