### PR TITLE
fix(acp): bound retained worker sessions and recover nested CLI exits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -247,6 +247,14 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # Max turns per session before proactive rotation. 0 = disabled (rotate only
 # on MaxTokens / MaxTurnRequests). Recommended: 50 for long-running agents.
 # BUZZ_ACP_MAX_TURNS_PER_SESSION=0
+# Bound retained provider sessions and MCP children per worker. Cleanup happens
+# only between turns; relay connection and queued messages remain intact.
+# Idle expiry is checked at least every 30s. A recycled worker reconstructs its
+# conversation context from the relay on the next turn. Set either limit to 0
+# to disable that bound. Live model overrides survive planned recycling.
+# BUZZ_ACP_WORKER_IDLE_TTL=300
+# BUZZ_ACP_WORKER_MAX_SESSIONS=4
+
 
 # ── Prompts ──────────────────────────────────────────────────────────────────
 # System prompt injected into every agent session (inline text).

--- a/Dockerfile.sprig
+++ b/Dockerfile.sprig
@@ -21,7 +21,7 @@ RUN cargo build --locked --profile sprig -p sprig \
 
 FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 
-RUN apk add --no-cache bash ca-certificates curl git \
+RUN apk add --no-cache bash bubblewrap ca-certificates curl git \
     && adduser -D -h /home/agent agent \
     && install -d -o agent -g agent /workspace /home/agent \
     && git config --system gpg.format x509 \

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -110,6 +110,26 @@ pub enum AcpError {
     AgentError { code: i64, message: String },
 }
 
+impl AcpError {
+    /// An adapter may survive after its nested CLI dies. Reusing that pipe
+    /// cannot recover the session. Keep provider/model/auth errors separate.
+    pub(crate) fn requires_respawn(&self) -> bool {
+        match self {
+            Self::AgentExited
+            | Self::Io(_)
+            | Self::WriteTimeout(_)
+            | Self::Timeout(_)
+            | Self::Protocol(_) => true,
+            Self::AgentError { code, message } => {
+                (*code == 1001 && message.starts_with("Codex process has exited"))
+                    || (*code == -32603
+                        && message.contains("The Claude Agent process exited unexpectedly"))
+            }
+            _ => false,
+        }
+    }
+}
+
 /// Build an [`AcpError::AgentError`] from a JSON-RPC error object,
 /// preserving the numeric code. When the `message` field is missing or
 /// non-string, fall back to the full JSON object so provider-specific
@@ -139,6 +159,7 @@ fn build_initialize_params() -> serde_json::Value {
 /// One `AcpClient` per agent process. Multiple sessions can be created on the
 /// same client via repeated calls to [`session_new`](AcpClient::session_new).
 pub struct AcpClient {
+    pub(crate) retention: crate::worker_retention::WorkerRetention,
     /// The agent child process (kept alive to prevent zombie).
     child: Child,
     /// Write end of the agent's stdin pipe.
@@ -546,6 +567,7 @@ impl AcpClient {
             .ok_or_else(|| AcpError::Protocol("failed to open agent stdout".into()))?;
 
         Ok(Self {
+            retention: Default::default(),
             child,
             stdin,
             reader: FramedRead::new(stdout, LinesCodec::new_with_max_length(MAX_LINE_SIZE)),
@@ -673,6 +695,7 @@ impl AcpClient {
             // Merge — _meta may already carry systemPrompt from ClaudeMeta above.
             params["_meta"]["sessionTitle"] = serde_json::Value::String(title.to_owned());
         }
+        self.retention.session_created();
         let result = self.send_request("session/new", params).await?;
         let session_id = result["sessionId"]
             .as_str()
@@ -3021,6 +3044,22 @@ mod tests {
             msg.contains("Hard turn timeout"),
             "HardTimeout display: {msg}"
         );
+    }
+
+    #[test]
+    fn provider_errors_are_not_misclassified_as_dead_processes() {
+        for (code, message) in [
+            (-32603, "Internal error"),
+            (-32603, "Model is not supported"),
+            (-32000, "API Error: 401"),
+            (1001, "A different adapter's application error"),
+        ] {
+            assert!(!AcpError::AgentError {
+                code,
+                message: message.into()
+            }
+            .requires_respawn());
+        }
     }
 
     async fn spawn_script(script: &str) -> AcpClient {

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -517,6 +517,16 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_IDLE_POOL_SLEEP", default_value_t = 0)]
     pub idle_pool_sleep: u64,
 
+    /// Recycle an idle worker after this many seconds, releasing cached CLI
+    /// sessions and their MCP children. 0 disables the idle bound.
+    #[arg(long, env = "BUZZ_ACP_WORKER_IDLE_TTL", default_value_t = 300)]
+    pub worker_idle_ttl: u64,
+
+    /// Recycle a worker between turns after this many session creations.
+    /// Counts rotated/invalidated sessions too. 0 disables the session bound.
+    #[arg(long, env = "BUZZ_ACP_WORKER_MAX_SESSIONS", default_value_t = 4)]
+    pub worker_max_sessions: u32,
+
     /// Unix-seconds replay floor for the startup watermark. A publish-first
     /// mention send publishes the triggering message and then spawns this
     /// harness, passing the send timestamp here so the first REQ replays past
@@ -614,6 +624,8 @@ pub struct Config {
     /// woken lazy pool is torn back down to the empty-slot state. 0 = disabled.
     /// Only meaningful when `lazy_pool` is true.
     pub idle_pool_sleep_secs: u64,
+    pub worker_idle_ttl_secs: u64,
+    pub worker_max_sessions: u32,
     /// Optional unix-seconds replay floor for the startup watermark
     /// (`--replay-floor` / `BUZZ_ACP_REPLAY_FLOOR`), set by a publish-first
     /// mention send so the first REQ replays past the already-published
@@ -1200,6 +1212,8 @@ impl Config {
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
             idle_pool_sleep_secs: args.idle_pool_sleep,
+            worker_idle_ttl_secs: args.worker_idle_ttl,
+            worker_max_sessions: args.worker_max_sessions,
             replay_floor_unix: args.replay_floor,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
@@ -1576,6 +1590,8 @@ mod tests {
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             idle_pool_sleep_secs: 0,
+            worker_idle_ttl_secs: 300,
+            worker_max_sessions: 4,
             replay_floor_unix: None,
             agent_owner: None,
             no_base_prompt: false,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -15,6 +15,7 @@ mod relay;
 mod scope;
 mod setup_mode;
 mod usage;
+mod worker_retention;
 
 pub use usage::TurnUsage;
 
@@ -1935,6 +1936,8 @@ struct SlotCircuit {
     /// Prevents duplicate spawns from maintenance ticks that fire before the
     /// previous spawn_and_init completes.
     respawn_in_flight: bool,
+    /// Keep live model choices across failed planned replacement attempts.
+    model_state: Option<WorkerModelState>,
 }
 
 /// Result of [`SlotCircuit::record_crash`].
@@ -2319,6 +2322,7 @@ mod idle_pool_sleep_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight,
+            model_state: None,
         }
     }
 
@@ -2909,6 +2913,7 @@ async fn tokio_main() -> Result<()> {
     // starved by the biased select. Slot refill spawns background tasks so
     // spawn_and_init never blocks the main loop.
     let maintenance_interval = Duration::from_secs(30);
+    let mut maintenance_wake = tokio::time::interval(maintenance_interval);
     let mut last_maintenance = std::time::Instant::now();
 
     // Channel for background respawn tasks to return completed agents.
@@ -2993,6 +2998,7 @@ async fn tokio_main() -> Result<()> {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         })
         .collect();
 
@@ -3048,6 +3054,14 @@ async fn tokio_main() -> Result<()> {
         if pool_ready && last_maintenance.elapsed() >= maintenance_interval {
             last_maintenance = std::time::Instant::now();
             queue.compact_expired_state();
+            recycle_idle_workers(
+                &mut pool,
+                &config,
+                &mut crash_history,
+                &respawn_tx,
+                &mut respawn_tasks,
+                observer.clone(),
+            );
 
             // Slot refill: spawn background tasks for empty slots whose
             // circuit breaker allows it. spawn_and_init runs off the main
@@ -3110,6 +3124,10 @@ async fn tokio_main() -> Result<()> {
                         goose_system_prompt_supported: None,
                         protocol_version,
                     };
+                    let mut agent = agent;
+                    if let Some(model_state) = crash_history[rr.index].model_state.take() {
+                        model_state.restore(&mut agent);
+                    }
                     pool.return_agent(agent);
                     tracing::info!(agent = rr.index, "respawn complete");
                     respawn_collected = true;
@@ -3153,6 +3171,7 @@ async fn tokio_main() -> Result<()> {
             let (result_rx, join_set) = pool.rx_and_join_set();
             tokio::select! {
                 biased;
+                _ = maintenance_wake.tick() => None,
                 // recv() returning None means all senders dropped (pool was torn down).
                 // Break cleanly instead of panicking.
                 r = result_rx.recv(), if pool_ready => match r {
@@ -5009,13 +5028,7 @@ fn handle_prompt_result(
             pool.return_agent(result.agent);
         }
         PromptOutcome::Error(ref e) => {
-            let is_transport_error = matches!(
-                e,
-                acp::AcpError::Io(_)
-                    | acp::AcpError::WriteTimeout(_)
-                    | acp::AcpError::Timeout(_)
-                    | acp::AcpError::Protocol(_)
-            );
+            let is_transport_error = e.requires_respawn();
             let error_code = match &e {
                 acp::AcpError::AgentError { code, .. } => Some(*code),
                 _ => None,
@@ -5039,7 +5052,7 @@ fn handle_prompt_result(
                     slot_history,
                     respawn_tx,
                     respawn_tasks,
-                    observer,
+                    observer.clone(),
                 ) && pool.live_count() == 0
                     && !any_respawn_in_flight(crash_history)
                 {
@@ -5060,6 +5073,14 @@ fn handle_prompt_result(
             }
         }
     }
+    recycle_idle_workers(
+        pool,
+        config,
+        crash_history,
+        respawn_tx,
+        respawn_tasks,
+        observer,
+    );
     LoopAction::Continue
 }
 
@@ -5356,6 +5377,71 @@ fn default_heartbeat_prompt() -> String {
          Do not run `buzz channels list` or `buzz messages search` unless you have a specific reason.\n\
          Do not invent work — only act on items surfaced by the feed commands."
     )
+}
+
+/// Live model choices must survive routine resource reclamation.
+struct WorkerModelState {
+    desired_model: Option<String>,
+    overridden: bool,
+    request_id: Option<String>,
+    pending_ack: bool,
+    effort: Option<String>,
+}
+
+impl WorkerModelState {
+    fn take(agent: &mut OwnedAgent) -> Self {
+        Self {
+            desired_model: agent.desired_model.take(),
+            overridden: agent.model_overridden,
+            request_id: agent.desired_model_request_id.take(),
+            pending_ack: agent.desired_model_pending_ack,
+            effort: agent.startup_effort.take(),
+        }
+    }
+    fn restore(self, agent: &mut OwnedAgent) {
+        agent.desired_model = self.desired_model;
+        agent.model_overridden = self.overridden;
+        agent.desired_model_request_id = self.request_id;
+        agent.desired_model_pending_ack = self.pending_ack;
+        agent.startup_effort = self.effort;
+    }
+}
+
+/// Reclaim provider sessions (including ones removed from the session registry)
+/// and MCP descendants without disconnecting from the relay or losing its queue.
+/// Only idle slots are eligible. Shutdown and initialization run off the relay loop.
+fn recycle_idle_workers(
+    pool: &mut AgentPool,
+    config: &Config,
+    slots: &mut [SlotCircuit],
+    respawn_tx: &mpsc::Sender<RespawnResult>,
+    tasks: &mut tokio::task::JoinSet<()>,
+    observer: Option<observer::ObserverHandle>,
+) {
+    for mut old in pool.take_expired_workers(
+        Duration::from_secs(config.worker_idle_ttl_secs),
+        config.worker_max_sessions,
+    ) {
+        let index = old.index;
+        slots[index].respawn_in_flight = true;
+        // Planned maintenance is not a crash and must not trip the breaker.
+        let guard = RespawnGuard::new(index, respawn_tx.clone());
+        slots[index].model_state = Some(WorkerModelState::take(&mut old));
+        let cmd = config.agent_command.clone();
+        let args = config.agent_args.clone();
+        let env = config.persona_env_vars.clone();
+        let has_codex = config.has_generated_codex_config;
+        let observer = observer.clone();
+        tracing::info!(
+            agent = index,
+            "recycling idle worker to release retained sessions"
+        );
+        tasks.spawn(async move {
+            old.acp.shutdown().await;
+            drop(old);
+            guard.send(spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await);
+        });
+    }
 }
 
 /// Spawn a background respawn task for a crashed agent slot.
@@ -9178,6 +9264,8 @@ mod build_mcp_servers_tests {
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             idle_pool_sleep_secs: 0,
+            worker_idle_ttl_secs: 300,
+            worker_max_sessions: 4,
             replay_floor_unix: None,
             agent_owner: None,
             no_base_prompt: false,
@@ -9404,6 +9492,8 @@ mod error_outcome_emission_tests {
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             idle_pool_sleep_secs: 0,
+            worker_idle_ttl_secs: 300,
+            worker_max_sessions: 4,
             replay_floor_unix: None,
             agent_owner: None,
             no_base_prompt: false,
@@ -9449,6 +9539,140 @@ mod error_outcome_emission_tests {
             // non-systemPrompt path, the simplest valid value.
             protocol_version: 1,
         }
+    }
+
+    #[tokio::test]
+    async fn nested_cli_death_replaces_worker_and_preserves_failed_message() {
+        for (code, message) in [
+            (1001, "Codex process has exited with code 0: startup warning"),
+            (-32603, "Internal error: The Claude Agent process exited unexpectedly. Please start a new session."),
+        ] {
+            let channel_id = Uuid::new_v4();
+            let scope = scope::SessionScope::Conversation { channel_id };
+            let event = EventBuilder::new(Kind::Custom(9), "keep this request")
+                .sign_with_keys(&Keys::generate()).unwrap();
+            let batch = FlushBatch {
+                channel_id, scope: scope.clone(),
+                events: vec![BatchEvent { event, prompt_tag: "test".into(), received_at: std::time::Instant::now() }],
+                cancelled_events: vec![], cancel_reason: None,
+            };
+            let mut pool = AgentPool::from_slots(vec![None]);
+            let task_id = pool.join_set.spawn(async {}).id();
+            pool.task_map_mut().insert(task_id, crate::pool::TaskMeta {
+                agent_index: 0, channel_id: Some(channel_id), scope: Some(scope.clone()),
+                turn_id: "test".into(), recoverable_batch: None, control_tx: None,
+                steer_tx: None, successful_steer_deliveries: HashSet::new(),
+            });
+            let mut queue = EventQueue::new(config::DedupMode::Queue);
+            let mut circuits = vec![SlotCircuit { crash_times: vec![], open_until: None, respawn_in_flight: false, model_state: None }];
+            let (tx, _rx) = mpsc::channel(1);
+            let mut tasks = tokio::task::JoinSet::new();
+            handle_prompt_result(&mut pool, &mut queue, &test_config(), PromptResult {
+                agent: dummy_agent(0).await, source: PromptSource::Channel(scope),
+                turn_id: "test".into(), outcome: PromptOutcome::Error(acp::AcpError::AgentError { code, message: message.into() }), batch: Some(batch),
+            }, &mut false, &HashSet::new(), &mut circuits, &tx, &mut tasks, None, None);
+            assert!(!pool.any_idle(), "dead adapter must not be returned for reuse");
+            assert!(circuits[0].respawn_in_flight);
+            assert_eq!(queue.queued_event_count(channel_id), 1);
+            tasks.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn retention_never_takes_checked_out_workers_or_churns_unused_slots() {
+        let mut busy = dummy_agent(0).await;
+        busy.acp.retention.session_created();
+        let unused = dummy_agent(1).await;
+        let mut pool = AgentPool::from_slots(vec![Some(busy), Some(unused)]);
+        let checked_out = pool.try_claim(None).unwrap();
+        assert!(pool.take_expired_workers(Duration::ZERO, 1).is_empty());
+        pool.return_agent(checked_out);
+        let mut expired = pool.take_expired_workers(Duration::ZERO, 1);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].index, 0);
+        assert!(pool.any_idle(), "unused worker remains available");
+        expired[0].acp.shutdown().await;
+        shutdown_agent_pool(&mut pool).await;
+    }
+
+    #[tokio::test]
+    async fn planned_recycle_initializes_replacement_and_preserves_live_model() {
+        let mut agent = dummy_agent(0).await;
+        agent.acp.retention.session_created();
+        agent.desired_model = Some("live-override".into());
+        agent.model_overridden = true;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        pool.return_agent(agent);
+        let mut config = test_config();
+        config.worker_max_sessions = 1;
+        config.agent_command = "sh".into();
+        config.agent_args = vec!["-c".into(),
+            r#"read line; echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentInfo":{"name":"test-adapter"}}}'; cat"#.into()];
+        let mut circuits = vec![SlotCircuit {
+            crash_times: vec![],
+            open_until: None,
+            respawn_in_flight: false,
+            model_state: None,
+        }];
+        let (tx, mut rx) = mpsc::channel(1);
+        let mut tasks = tokio::task::JoinSet::new();
+        recycle_idle_workers(&mut pool, &config, &mut circuits, &tx, &mut tasks, None);
+        let rr = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let (mut acp, version, name) = rr.result.unwrap();
+        assert_eq!(rr.index, 0);
+        assert_eq!(version, 1);
+        assert_eq!(name, "test-adapter");
+        assert!(!acp
+            .retention
+            .expired(std::time::Instant::now(), Duration::ZERO, 1));
+        let mut replacement = dummy_agent(0).await;
+        circuits[0]
+            .model_state
+            .take()
+            .unwrap()
+            .restore(&mut replacement);
+        assert_eq!(replacement.desired_model.as_deref(), Some("live-override"));
+        assert!(replacement.model_overridden);
+        assert!(circuits[0].crash_times.is_empty());
+        acp.shutdown().await;
+        replacement.acp.shutdown().await;
+        tasks.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn planned_recycle_preserves_queue_and_does_not_count_as_crash() {
+        let mut agent = dummy_agent(0).await;
+        agent.acp.retention.session_created();
+        agent.desired_model = Some("custom-model".into());
+        agent.model_overridden = true;
+        agent.startup_effort = Some("high".into());
+        let mut pool = AgentPool::from_slots(vec![None]);
+        pool.return_agent(agent);
+        let mut config = test_config();
+        config.worker_max_sessions = 1;
+        let mut circuits = vec![SlotCircuit {
+            crash_times: vec![],
+            open_until: None,
+            respawn_in_flight: false,
+            model_state: None,
+        }];
+        let (tx, _rx) = mpsc::channel(1);
+        let mut tasks = tokio::task::JoinSet::new();
+        recycle_idle_workers(&mut pool, &config, &mut circuits, &tx, &mut tasks, None);
+        assert!(!pool.any_idle());
+        assert!(circuits[0].respawn_in_flight);
+        assert!(circuits[0].crash_times.is_empty());
+        let saved = circuits[0].model_state.as_ref().unwrap();
+        assert_eq!(saved.desired_model.as_deref(), Some("custom-model"));
+        assert!(saved.overridden);
+        assert_eq!(saved.effort.as_deref(), Some("high"));
+        // Failed initialization must not discard the live model override.
+        circuits[0].mark_spawn_failed();
+        assert!(circuits[0].model_state.is_some());
+        tasks.shutdown().await;
     }
 
     fn bind_agent_scope_owner(
@@ -9508,6 +9732,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -9588,6 +9813,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -9709,6 +9935,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -9774,6 +10001,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -9858,6 +10086,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -9951,6 +10180,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: Some(std::time::Instant::now() + Duration::from_secs(3600)),
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10044,6 +10274,7 @@ mod error_outcome_emission_tests {
                 crash_times: Vec::new(),
                 open_until: None,
                 respawn_in_flight: false,
+                model_state: None,
             }];
             let (respawn_tx, _respawn_rx) = mpsc::channel(8);
             let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10141,6 +10372,7 @@ mod error_outcome_emission_tests {
                 crash_times: Vec::new(),
                 open_until: None,
                 respawn_in_flight: false,
+                model_state: None,
             }];
             let (respawn_tx, _respawn_rx) = mpsc::channel(8);
             let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10249,6 +10481,7 @@ mod error_outcome_emission_tests {
                 crash_times: Vec::new(),
                 open_until: None,
                 respawn_in_flight: false,
+                model_state: None,
             }];
             let (respawn_tx, _respawn_rx) = mpsc::channel(8);
             let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10327,6 +10560,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10423,6 +10657,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10555,6 +10790,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10686,6 +10922,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10820,6 +11057,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -10975,6 +11213,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();
@@ -11063,6 +11302,7 @@ mod error_outcome_emission_tests {
             crash_times: Vec::new(),
             open_until: None,
             respawn_in_flight: false,
+            model_state: None,
         }];
         let (respawn_tx, _respawn_rx) = mpsc::channel(8);
         let mut respawn_tasks = tokio::task::JoinSet::new();

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -975,6 +975,7 @@ impl AgentPool {
 
     /// Return an agent to its slot after a task completes.
     pub fn return_agent(&mut self, mut agent: OwnedAgent) {
+        agent.acp.retention.mark_idle(std::time::Instant::now());
         let stale_scopes: Vec<SessionScope> = agent
             .state
             .sessions
@@ -1007,6 +1008,29 @@ impl AgentPool {
             );
         }
         self.agents[idx] = Some(agent);
+    }
+
+    /// Take only idle workers whose retained provider resources reached a
+    /// bound. Checked-out workers and queued messages are never touched.
+    pub fn take_expired_workers(
+        &mut self,
+        idle_ttl: Duration,
+        max_sessions: u32,
+    ) -> Vec<OwnedAgent> {
+        let now = std::time::Instant::now();
+        let mut expired = Vec::new();
+        for slot in &mut self.agents {
+            if slot
+                .as_ref()
+                .is_some_and(|a| a.acp.retention.expired(now, idle_ttl, max_sessions))
+            {
+                let agent = slot.take().unwrap();
+                self.session_owners
+                    .retain(|_, owner| owner.agent_index != agent.index);
+                expired.push(agent);
+            }
+        }
+        expired
     }
 
     /// Whether any agent is currently idle (sitting in its slot).

--- a/crates/buzz-acp/src/worker_retention.rs
+++ b/crates/buzz-acp/src/worker_retention.rs
@@ -1,0 +1,59 @@
+//! Resource lifetime of one serialized ACP worker (not the relay connection).
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+pub(crate) struct WorkerRetention {
+    sessions_created: u32,
+    idle_since: Option<Instant>,
+}
+
+impl WorkerRetention {
+    pub(crate) fn session_created(&mut self) {
+        self.sessions_created = self.sessions_created.saturating_add(1);
+    }
+
+    pub(crate) fn mark_idle(&mut self, now: Instant) {
+        self.idle_since = Some(now);
+    }
+
+    pub(crate) fn expired(&self, now: Instant, ttl: Duration, max_sessions: u32) -> bool {
+        // Fresh pool workers have no provider sessions to release. Do not churn.
+        self.sessions_created > 0
+            && self.idle_since.is_some_and(|idle_since| {
+                (max_sessions > 0 && self.sessions_created >= max_sessions)
+                    || (!ttl.is_zero() && now.saturating_duration_since(idle_since) >= ttl)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounds_retained_sessions_even_after_the_registry_forgets_them() {
+        let now = Instant::now();
+        let mut worker = WorkerRetention::default();
+        for _ in 0..4 {
+            worker.session_created();
+        }
+        assert!(!worker.expired(now, Duration::from_secs(300), 4));
+        worker.mark_idle(now);
+        assert!(worker.expired(now, Duration::from_secs(300), 4));
+    }
+
+    #[test]
+    fn idle_expiry_resets_after_a_turn_and_never_churns_unused_workers() {
+        let now = Instant::now();
+        let ttl = Duration::from_secs(300);
+        let mut worker = WorkerRetention::default();
+        worker.mark_idle(now);
+        assert!(!worker.expired(now + ttl, ttl, 4));
+        worker.session_created();
+        assert!(!worker.expired(now + ttl - Duration::from_secs(1), ttl, 4));
+        assert!(worker.expired(now + ttl, ttl, 4));
+        worker.mark_idle(now + ttl);
+        assert!(!worker.expired(now + ttl, ttl, 4));
+        assert!(!worker.expired(now + ttl * 10, Duration::ZERO, 0));
+    }
+}


### PR DESCRIPTION
When a nested Codex or Claude CLI exits while its ACP adapter stays alive, Buzz returns the adapter to the idle pool and retries requests against an unrecoverable process/session. Long-lived workers also retain provider sessions and MCP children after session-cache invalidation, allowing memory use to accumulate across channels and rotations.

Recognize the specific nested-process exit errors and use the existing respawn/backoff path, preserving failed batches for retry. Bound retained resources by recycling idle workers after five minutes or four session creations (both configurable, with zero disabling each bound). Recycling runs between turns, off the relay loop, keeps the relay connection and queue, preserves live model/effort choices across failed replacement attempts, and does not count as a crash. Fresh unused workers are not recycled. Replacement sessions reconstruct conversation context from the relay; local provider session caches are intentionally released. The Sprig image also installs the distro bubblewrap package; namespace policy remains an operator setting.

Validation covers nested-process errors retaining queued messages, active-worker exclusion, idle and creation limits, replacement initialization, model preservation, and separation of planned maintenance from crash accounting. Full `buzz-acp` library suite and a separately tested backport to the deployed `560fea7` revision; static musl binary startup verified in Alpine.

Duplicate issue/PR searches for retained sessions, session-close memory, and Codex process exits found no matching existing work. The originating Lingual operational work acknowledges [[lingual-release-process]]; no Lingual application release is part of this change.
