### PR TITLE
fix(mobile): resolve plain-text @mentions never tapped in the picker

### DIFF
--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -61,10 +61,19 @@ class SendMessage {
     List<List<String>> mediaTags = const [],
   }) async {
     _ensureDeliveryValid();
-    // Use explicitly passed pubkeys, or resolve @mentions against
-    // channel members to avoid matching the wrong user.
-    final explicitMentions =
-        mentionPubkeys ?? await _resolveMentions(content, channelId);
+    // Merge explicitly passed pubkeys (picker taps) with any "@Name" typed
+    // as plain text that was never tapped in the picker. The compose bar
+    // always calls this with a concrete (possibly empty) list, never null,
+    // so the old `mentionPubkeys ?? _resolveMentions(...)` fallback never
+    // ran from the interactive send path — only from callers that pass
+    // null explicitly. Union, never replace: a caller-supplied pubkey is
+    // never dropped.
+    final tapped = mentionPubkeys ?? const <String>[];
+    final textResolved = await _resolveMentions(content, channelId);
+    final explicitMentions = <String>{
+      ...tapped.map((pk) => pk.toLowerCase()),
+      ...textResolved,
+    }.toList();
     final authorPubkey = _signedEventRelay.pubkey;
     final dmRecipientPubkeys = channel?.isDm == true
         ? await _fetchDmRecipientPubkeys(channelId, channel!, authorPubkey)
@@ -158,13 +167,22 @@ class SendMessage {
   ///
   /// Fetches channel members from the relay and matches @names only
   /// against members of that channel. Falls back to the full user cache
-  /// if the member fetch fails.
+  /// if the member fetch fails. Two safety rules, both added now that
+  /// this fallback is reachable from the interactive send path (see
+  /// [call]):
+  /// - Code spans/fences and blockquoted lines are stripped before
+  ///   extraction — mirrors the SDK's "remove code regions before @name
+  ///   extraction" fix (block/buzz#2684); a quoted or sample "@name" is
+  ///   not the sender's live intent to mention anyone.
+  /// - A name matching more than one channel member resolves to nobody
+  ///   rather than an arbitrary pick — same "avoid matching the wrong
+  ///   user" contract this method already documented, made explicit.
   Future<List<String>> _resolveMentions(
     String content,
     String channelId,
   ) async {
     final mentionPattern = RegExp(r'@(\w+)');
-    final matches = mentionPattern.allMatches(content);
+    final matches = mentionPattern.allMatches(_stripCodeAndQuotes(content));
     if (matches.isEmpty) return const [];
 
     // Try to get channel member pubkeys for scoped resolution.
@@ -183,6 +201,7 @@ class SendMessage {
       final name = match.group(1)?.toLowerCase();
       if (name == null || name.isEmpty) continue;
 
+      final candidates = <String>{};
       for (final profile in cache.values) {
         final displayName = profile.displayName?.toLowerCase();
         if (displayName == null) continue;
@@ -197,12 +216,27 @@ class SendMessage {
           continue;
         }
 
-        pubkeys.add(profile.pubkey);
-        break;
+        candidates.add(profile.pubkey.toLowerCase());
       }
+
+      // Exactly one channel member answers to this name: safe to resolve.
+      // Zero or several: skip rather than guess or notify more than one.
+      if (candidates.length == 1) pubkeys.add(candidates.single);
     }
 
     return pubkeys.toList();
+  }
+
+  /// Removes fenced code blocks, inline code spans, and blockquoted lines
+  /// before mention extraction. See [_resolveMentions] doc above.
+  static String _stripCodeAndQuotes(String content) {
+    var stripped = content.replaceAll(RegExp(r'```.*?```', dotAll: true), ' ');
+    stripped = stripped.replaceAll(RegExp(r'`[^`]*`'), ' ');
+    stripped = stripped
+        .split('\n')
+        .where((line) => !line.trimLeft().startsWith('>'))
+        .join('\n');
+    return stripped;
   }
 
   /// Build `e`-tags for a thread reply, matching the desktop convention:

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:nostr/nostr.dart' as nostr;
 import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/send_message_provider.dart';
+import 'package:buzz/shared/profile/user_profile.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
@@ -211,6 +212,197 @@ void main() {
       ['p', recipientOne],
       ['p', recipientTwo],
     ]);
+
+    session.accept();
+    await result;
+  });
+
+  test(
+    'resolves a plain-text @mention never tapped in the picker (non-DM channel)',
+    () async {
+      // Reproduces #7449: the compose bar always passes a concrete list to
+      // `mentionPubkeys` (never null), even when the user typed "@Name"
+      // without selecting it from the picker. That silently suppressed the
+      // text-resolution fallback.
+      final session = _PendingPublishRelaySession();
+      final signingKey = nostr.Keys.generate().nsec;
+      final sender = nostr.Keys(
+        nostr.Nip19.decode(payload: signingKey).data,
+      ).public;
+      final alice = 'n' * 64;
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(session: session, nsec: signingKey),
+        fetchMembers: (_) async => [_member(sender), _member(alice)],
+        readUserCache: () => {
+          alice: UserProfile(pubkey: alice, displayName: 'Alice'),
+        },
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      final result = send(
+        channelId: _channelId,
+        content: '@Alice hi',
+        // Exactly what the compose bar sends today when nothing was
+        // tapped in the mention picker: empty, not null.
+        mentionPubkeys: const [],
+      );
+      await session.published;
+
+      expect(session.event.tags.where((tag) => tag.first == 'p').toList(), [
+        ['p', alice],
+      ]);
+
+      session.accept();
+      await result;
+    },
+  );
+
+  test(
+    'does not duplicate a pubkey tapped in the picker AND present as text',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final signingKey = nostr.Keys.generate().nsec;
+      final sender = nostr.Keys(
+        nostr.Nip19.decode(payload: signingKey).data,
+      ).public;
+      final alice = 'n' * 64;
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(session: session, nsec: signingKey),
+        fetchMembers: (_) async => [_member(sender), _member(alice)],
+        readUserCache: () => {
+          alice: UserProfile(pubkey: alice, displayName: 'Alice'),
+        },
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      // The picker already resolved "@Alice" to a tap-selected pubkey; the
+      // same name is also present as text. The union must not double-tag.
+      final result = send(
+        channelId: _channelId,
+        content: '@Alice hi',
+        mentionPubkeys: [alice],
+      );
+      await session.published;
+
+      expect(session.event.tags.where((tag) => tag.first == 'p').toList(), [
+        ['p', alice],
+      ]);
+
+      session.accept();
+      await result;
+    },
+  );
+
+  test(
+    'preserves a picker-tapped recipient the text resolver cannot see',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final signingKey = nostr.Keys.generate().nsec;
+      final sender = nostr.Keys(
+        nostr.Nip19.decode(payload: signingKey).data,
+      ).public;
+      final alice = 'n' * 64;
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(session: session, nsec: signingKey),
+        fetchMembers: (_) async => [_member(sender), _member(alice)],
+        // Empty cache: the text resolver has nothing to match against, so
+        // it would contribute zero pubkeys on its own. The picker's tap
+        // must still make it through untouched.
+        readUserCache: () => const {},
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      final result = send(
+        channelId: _channelId,
+        content: '@Alice hi',
+        mentionPubkeys: [alice],
+      );
+      await session.published;
+
+      expect(session.event.tags.where((tag) => tag.first == 'p').toList(), [
+        ['p', alice],
+      ]);
+
+      session.accept();
+      await result;
+    },
+  );
+
+  test('an ambiguous name shared by two members notifies neither via text '
+      'resolution', () async {
+    final session = _PendingPublishRelaySession();
+    final signingKey = nostr.Keys.generate().nsec;
+    final sender = nostr.Keys(
+      nostr.Nip19.decode(payload: signingKey).data,
+    ).public;
+    final aliceA = 'a' * 64;
+    final aliceB = 'b' * 64;
+    final send = SendMessage(
+      signedEventRelay: SignedEventRelay(session: session, nsec: signingKey),
+      fetchMembers: (_) async => [
+        _member(sender),
+        _member(aliceA),
+        _member(aliceB),
+      ],
+      readUserCache: () => {
+        aliceA: UserProfile(pubkey: aliceA, displayName: 'Alice'),
+        aliceB: UserProfile(pubkey: aliceB, displayName: 'Alice'),
+      },
+      addLocalMessage: (_, _) {},
+      completeLocalMessage: (_, _) {},
+      removeLocalMessage: (_, _) {},
+    );
+
+    // Two distinct members named "Alice" in the same channel: resolving
+    // to either one would be a guess, and guessing wrong pings the
+    // wrong agent/person. Neither gets tagged.
+    final result = send(
+      channelId: _channelId,
+      content: '@Alice hi',
+      mentionPubkeys: const [],
+    );
+    await session.published;
+
+    expect(session.event.tags.where((tag) => tag.first == 'p').toList(), []);
+
+    session.accept();
+    await result;
+  });
+
+  test('ignores an @name that only appears inside a code span or a quoted '
+      'line', () async {
+    final session = _PendingPublishRelaySession();
+    final signingKey = nostr.Keys.generate().nsec;
+    final sender = nostr.Keys(
+      nostr.Nip19.decode(payload: signingKey).data,
+    ).public;
+    final alice = 'n' * 64;
+    final send = SendMessage(
+      signedEventRelay: SignedEventRelay(session: session, nsec: signingKey),
+      fetchMembers: (_) async => [_member(sender), _member(alice)],
+      readUserCache: () => {
+        alice: UserProfile(pubkey: alice, displayName: 'Alice'),
+      },
+      addLocalMessage: (_, _) {},
+      completeLocalMessage: (_, _) {},
+      removeLocalMessage: (_, _) {},
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content:
+          'sample: `@Alice hi` and\n> quoting @Alice from before\nno real mention here',
+      mentionPubkeys: const [],
+    );
+    await session.published;
+
+    expect(session.event.tags.where((tag) => tag.first == 'p').toList(), []);
 
     session.accept();
     await result;


### PR DESCRIPTION
## Summary

Typing `@Name` and sending **without tapping the autocomplete suggestion** produced a signed event with zero `p` tags in non-DM channels — silently. The relay correctly declined to route it (subscriptions filter on `#p`), so nothing looked broken until you inspected raw tags.

Root cause: the compose bar always passes a concrete (possibly empty) list to `mentionPubkeys`, never `null`, so the `mentionPubkeys ?? _resolveMentions(...)` fallback never ran from the interactive send path — only from callers that pass `null` explicitly. A type mismatch (`[]` vs `null`) making working code unreachable.

Fix:
- Union picker-tapped pubkeys with text-resolved mentions (a `Set` union; a tapped pubkey is never dropped, no duplicate `p` tags).
- `_resolveMentions`, now actually reachable, gets two safety rules consistent with its own existing contract: ambiguous names (2+ members) resolve to nobody; code spans/fences and blockquoted lines are stripped before extraction (mirrors the Rust CLI parser fix from #2684, which mobile never had).

No signature changes; no other call sites affected (forum posts don't go through `SendMessage`).

## Testing

- `flutter test test/features/channels/send_message_provider_test.dart`: **12/12 pass** (7 existing + 5 new: reported bug, tapped+text duplicate, tapped-only preserved, ambiguous name, code/quote exclusion).
- `flutter analyze` on both changed files: no issues.
- `dart format`: applied.

Fixes #7449