### PR TITLE
fix(read-state): gate passive read marking on window focus and app foreground

### DIFF
--- a/desktop/src/features/channels/ui/useChannelOpenReadState.focus.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelOpenReadState.focus.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { JSDOM } from "jsdom";
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { useChannelOpenReadState } from "./useChannelOpenReadState.ts";
+import { AppShellProvider } from "@/app/AppShellContext";
+
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+const originalHTMLElement = globalThis.HTMLElement;
+const originalActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
+
+function installFocusDom() {
+  const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>");
+  let focused = true;
+  Object.defineProperty(dom.window.document, "hasFocus", {
+    configurable: true,
+    value: () => focused,
+  });
+  Object.defineProperty(dom.window.document, "visibilityState", {
+    configurable: true,
+    value: "visible",
+  });
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+  return {
+    dom,
+    blur() {
+      focused = false;
+    },
+    focus() {
+      focused = true;
+    },
+  };
+}
+
+test("passive read marking is gated on app focus", async () => {
+  const stub = installFocusDom();
+  const markedRead = [];
+  const undone = [];
+
+  function Harness({ channelId, readAt }) {
+    useChannelOpenReadState(channelId, true, readAt);
+    return null;
+  }
+
+  const shellValue = {
+    feedItemState: { undoUnread: (id) => undone.push(id) },
+    locallyUnreadFeedItems: [],
+    markChannelRead: (channelId, readAt, options) =>
+      markedRead.push([channelId, readAt, options]),
+  };
+
+  const root = createRoot(document.getElementById("root"));
+
+  await act(async () =>
+    root.render(
+      React.createElement(
+        AppShellProvider,
+        { value: shellValue },
+        React.createElement(Harness, { channelId: "general", readAt: "2026-09-07T22:58:33.000Z" }),
+      ),
+    ),
+  );
+  assert.deepEqual(markedRead, [
+    ["general", "2026-09-07T22:58:33.000Z", { topLevelOnly: true }],
+  ]);
+
+  // Window loses focus. A newer top-level message arrives and activeReadAt
+  // advances — the marker must NOT advance while unfocused.
+  stub.blur();
+  await act(async () =>
+    window.dispatchEvent(new window.Event("blur")),
+  );
+  await act(async () =>
+    root.render(
+      React.createElement(
+        AppShellProvider,
+        { value: shellValue },
+        React.createElement(Harness, { channelId: "general", readAt: "2026-09-07T22:58:40.000Z" }),
+      ),
+    ),
+  );
+  assert.equal(
+    markedRead.length,
+    1,
+    "read marker must not advance while the window is unfocused",
+  );
+
+  // Window regains focus — the effect re-runs and catches the marker up
+  // in one tick.
+  stub.focus();
+  await act(async () =>
+    window.dispatchEvent(new window.Event("focus")),
+  );
+  await act(
+    async () => new Promise((resolve) => window.setTimeout(resolve, 10)),
+  );
+  assert.deepEqual(markedRead, [
+    ["general", "2026-09-07T22:58:33.000Z", { topLevelOnly: true }],
+    ["general", "2026-09-07T22:58:40.000Z", { topLevelOnly: true }],
+  ]);
+
+  await act(async () => root.unmount());
+
+  if (originalDocument === undefined) delete globalThis.document;
+  else globalThis.document = originalDocument;
+  if (originalWindow === undefined) delete globalThis.window;
+  else globalThis.window = originalWindow;
+  if (originalHTMLElement === undefined) delete globalThis.HTMLElement;
+  else globalThis.HTMLElement = originalHTMLElement;
+  if (originalActEnvironment === undefined) delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+  else globalThis.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment;
+  stub.dom.window.close();
+});

--- a/desktop/src/features/channels/ui/useChannelOpenReadState.ts
+++ b/desktop/src/features/channels/ui/useChannelOpenReadState.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { useAppShell } from "@/app/AppShellContext";
 import { isThreadReply } from "@/features/messages/lib/threading";
+import { useAppFocused } from "@/shared/lib/useDocumentVisible";
 import type { FeedItem } from "@/shared/api/types";
 
 /**
@@ -25,8 +26,17 @@ export function useChannelOpenReadState(
   const { feedItemState, locallyUnreadFeedItems, markChannelRead } =
     useAppShell();
 
+  // Only advance the read marker while the app is actually focused and
+  // visible. A backgrounded or occluded window must not mark arriving
+  // messages read: NIP-RS markers are monotonic and sync across devices,
+  // so a parked desktop would otherwise silently clear the unread state on
+  // the user's phone (#7470). When the app regains focus, the effect
+  // re-runs with the same activeReadAt and catches the marker up.
+  const appFocused = useAppFocused();
+
   React.useEffect(() => {
     if (!activeChannelId || isChannelMember === false) return;
+    if (!appFocused) return;
     for (const itemId of getTopLevelInboxUnreadOverrideIds(
       locallyUnreadFeedItems,
       activeChannelId,
@@ -37,6 +47,7 @@ export function useChannelOpenReadState(
   }, [
     activeChannelId,
     activeReadAt,
+    appFocused,
     feedItemState.undoUnread,
     isChannelMember,
     locallyUnreadFeedItems,

--- a/desktop/src/features/channels/ui/useHuddleReadMarker.ts
+++ b/desktop/src/features/channels/ui/useHuddleReadMarker.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { getThreadReference } from "@/features/messages/lib/threading";
+import { useAppFocused } from "@/shared/lib/useDocumentVisible";
 import type { RelayEvent } from "@/shared/api/types";
 
 type MarkChannelRead = (
@@ -64,8 +65,14 @@ export function useHuddleReadMarker({
     : activeReadAt;
   const lastHuddleReadKeyRef = React.useRef<string | null>(null);
 
+  // Same focus gate as useChannelOpenReadState: never advance the read
+  // marker from a backgrounded or occluded window (#7470). On regaining
+  // focus the effect re-runs and catches the marker up.
+  const appFocused = useAppFocused();
+
   React.useEffect(() => {
     if (!activeChannelId || activeChannelIsMember === false) return;
+    if (!appFocused) return;
     const huddleReadKey = hasFlattenedHuddleReplies
       ? `${activeChannelId}:${huddleReadAt}`
       : null;
@@ -82,6 +89,7 @@ export function useHuddleReadMarker({
   }, [
     activeChannelId,
     activeChannelIsMember,
+    appFocused,
     hasFlattenedHuddleReplies,
     huddleReadAt,
     markChannelRead,

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -554,8 +554,19 @@ class ChannelDetailPage extends HookConsumerWidget {
       ],
     );
 
+    // Gate passive read-state advance on the app being foregrounded.
+    // NIP-RS markers are monotonic and sync across devices, so a
+    // backgrounded app must not mark arriving messages read — that would
+    // silently clear the unread state on the user's other devices (#7470).
+    // When the app is resumed, this effect re-runs with the same
+    // readTimestamp and catches the marker up.
+    final appLifecycle = ref.watch(appLifecycleProvider);
+
     useEffect(() {
       if (!readState.isReady || readTimestamp == null) {
+        return null;
+      }
+      if (appLifecycle != AppLifecycleState.resumed) {
         return null;
       }
       return deferReadStateUpdate(context, () {
@@ -566,7 +577,7 @@ class ChannelDetailPage extends HookConsumerWidget {
             .read(channelsProvider.notifier)
             .clearObservedUnreadCoveredByRead(channel.id, readTimestamp);
       });
-    }, [channel.id, readState.isReady, readTimestamp]);
+    }, [channel.id, readState.isReady, readTimestamp, appLifecycle]);
 
     return FrostedScaffold(
       resizeToAvoidBottomInset:

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -678,12 +678,17 @@ class ThreadDetailPage extends HookConsumerWidget {
       return null;
     }, [hasFetchedReplies, replies.length, settleGeometry]);
     final readState = ref.watch(readStateProvider);
+    // Gate passive read-state advance on the app being foregrounded —
+    // mirrors the channel-detail gate (#7470). A backgrounded app must
+    // not mark replies read; on resume the effect re-runs and catches up.
+    final appLifecycle = ref.watch(appLifecycleProvider);
     final visibleReplyReadKey = replies
         .map((reply) => '${reply.id}:${reply.createdAt}')
         .join(',');
 
     useEffect(() {
       if (!readState.isReady || replies.isEmpty) return null;
+      if (appLifecycle != AppLifecycleState.resumed) return null;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         for (final reply in replies) {
           ref
@@ -692,7 +697,7 @@ class ThreadDetailPage extends HookConsumerWidget {
         }
       });
       return null;
-    }, [threadHead.id, readState.isReady, visibleReplyReadKey]);
+    }, [threadHead.id, readState.isReady, visibleReplyReadKey, appLifecycle]);
 
     // Thread-scoped typing indicators (exclude self).
     final allTyping = ref.watch(channelTypingProvider(channelId));


### PR DESCRIPTION
## Summary

An open channel currently marks **every arriving top-level message read within seconds of arrival**, with no check that the window is focused or even visible. NIP-RS read markers are monotonic and sync across devices, so one parked desktop also silently clears the unread state on the user's phone — and 'mark unread' cannot recover it (local-only flag, never reaches the relay). An agent replying while the user is away makes every downstream unread signal go silent.

This gates every **passive** read-marker advance (option 1 from the issue — matches Slack/Discord/iMessage):

- Desktop `useChannelOpenReadState`: skip `markChannelRead` and Inbox override consumption while the app is unfocused, via the existing `useAppFocused()` store (visibilitychange + focus/blur). On refocus the effect re-runs with the same `activeReadAt` and catches up in one tick.
- Desktop `useHuddleReadMarker`: same gate for huddle transcript marking.
- Mobile `channel_detail_page`: only advance `markContextRead` while `AppLifecycleState.resumed`, via the existing `appLifecycleProvider`.
- Mobile `thread_detail_page`: same gate for thread-reply marking.

Explicit user actions (mark-as-read shortcuts, Inbox triage taps, channel-list mark-read) are intentionally **not** gated — they are deliberate actions, not passive observation.

## Testing

- Desktop: full unit suite `pnpm test` → **6457/6457 pass**; `tsc --noEmit` clean.
- New JSDOM hook test `useChannelOpenReadState.focus.test.mjs` covering the gate: marker holds while blurred even as `activeReadAt` advances, catches up on refocus. Verified RED against the un-gated upstream hook, GREEN with the fix.
- Mobile: `flutter analyze` → no issues (full app).

Fixes #7470