### PR TITLE
fix(acp): classify Windows resolver failures by code, not by message

### DIFF
--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -3526,19 +3526,73 @@ fn jittered_duration(base: Duration) -> Duration {
     base.mul_f64(factor)
 }
 
+/// Classify a Windows Sockets error code as a `getaddrinfo` resolution failure.
+///
+/// Windows surfaces resolver failures as raw `WSA*` codes on the underlying
+/// `io::Error`, and `FormatMessage` renders their text in the machine's display
+/// language. Matching the code rather than the message keeps the classification
+/// working on non-English installs.
+///
+/// - `11001` `WSAHOST_NOT_FOUND` — the name does not resolve.
+/// - `11002` `WSATRY_AGAIN` — an authoritative server did not answer. Explicitly
+///   temporary, so it is the case the flat retry exists for.
+/// - `11004` `WSANO_DATA` — the name is valid but carries no record of the
+///   requested type, which is what a partially propagated or split-horizon zone
+///   returns during a brownout.
+///
+/// `11003` `WSANO_RECOVERY` is deliberately excluded. It reports a
+/// non-recoverable resolver failure, so retrying it flat and forever in
+/// `wait_for_reconnect` would be the wrong response.
+///
+/// Kept free of `cfg(windows)` so it compiles and is asserted on every platform.
+pub(crate) fn is_windows_dns_errno(code: i32) -> bool {
+    matches!(code, 11001 | 11002 | 11004)
+}
+
 /// Classify a `RelayError` as a DNS resolution failure.
 ///
-/// Matches the OS-level "name not found" strings surfaced by the platform's
-/// resolver, covering macOS (`nodename nor servname`), Linux (`Name or service not
-/// known`), and common BSD/Windows variants (`No such host`,
-/// `failed to lookup address`). These are transient on brownouts and must NOT
-/// consume a backoff ladder rung — they retry on a flat `DNS_RETRY_INTERVAL`.
+/// Two independent signals, either one is sufficient.
+///
+/// 1. The raw OS error code, when the error wraps an `io::Error`. This is the
+///    reliable signal on Windows and it does not depend on the display language.
+/// 2. The OS-level "name not found" strings surfaced by the platform's resolver,
+///    covering macOS (`nodename nor servname`), Linux (`Name or service not
+///    known`) and the English Windows and BSD variants. This is the only signal
+///    available once an error has been flattened into `RelayError::Http`.
+///
+/// These are transient on brownouts and must NOT consume a backoff ladder rung —
+/// they retry on a flat `DNS_RETRY_INTERVAL`.
 pub(crate) fn is_dns_error(err: &RelayError) -> bool {
+    if let Some(code) = relay_error_raw_os_error(err) {
+        if is_windows_dns_errno(code) {
+            return true;
+        }
+    }
+
     let msg = err.to_string();
     msg.contains("nodename nor servname")
         || msg.contains("Name or service not known")
         || msg.contains("No such host")
         || msg.contains("failed to lookup address")
+        // Windows, English. The code check above is the primary signal; these
+        // cover a resolver error that reached us as an already-formatted string.
+        || msg.contains("no data of the requested type")
+        || msg.contains("temporary error during hostname resolution")
+}
+
+/// Extract the raw OS error code from a `RelayError`, if it wraps one.
+///
+/// `connect_async` surfaces a failed resolution as
+/// `RelayError::WebSocket(tungstenite::Error::Io(_))`, which is the shape that
+/// carries a usable `raw_os_error()`.
+fn relay_error_raw_os_error(err: &RelayError) -> Option<i32> {
+    match err {
+        RelayError::WebSocket(ws) => match ws.as_ref() {
+            tokio_tungstenite::tungstenite::Error::Io(io_err) => io_err.raw_os_error(),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 /// Shutdown-aware fixed-duration sleep for REQ pacing in `resubscribe_after_reconnect`.
@@ -6770,6 +6824,70 @@ mod tests {
         assert!(!is_dns_error(&RelayError::ConnectionClosed));
         assert!(!is_dns_error(&RelayError::Http(
             "connection refused".into()
+        )));
+    }
+
+    /// The Windows resolver codes are classified from the code, not the message.
+    ///
+    /// Asserted on every platform. `is_windows_dns_errno` is a pure function of
+    /// the code precisely so this coverage does not depend on the host OS.
+    #[test]
+    fn windows_dns_errnos_are_classified() {
+        // WSAHOST_NOT_FOUND, WSATRY_AGAIN, WSANO_DATA.
+        assert!(is_windows_dns_errno(11001));
+        assert!(is_windows_dns_errno(11002));
+        assert!(is_windows_dns_errno(11004));
+
+        // WSANO_RECOVERY is a non-recoverable resolver failure. It must take the
+        // backoff ladder rather than retry flat and forever.
+        assert!(!is_windows_dns_errno(11003));
+
+        // WSAECONNREFUSED is a connection error, not a resolution failure.
+        assert!(!is_windows_dns_errno(10061));
+        assert!(!is_windows_dns_errno(0));
+    }
+
+    /// Production shape: `connect_async` fails resolution and the code survives
+    /// as `raw_os_error` on a WebSocket-wrapped `io::Error`.
+    ///
+    /// `from_raw_os_error` preserves the code on every platform, so this drives
+    /// the real classification path on Linux CI as well as on Windows.
+    #[test]
+    fn windows_dns_errno_classified_through_websocket_io_error() {
+        use tokio_tungstenite::tungstenite;
+
+        for code in [11001, 11002, 11004] {
+            let err = RelayError::WebSocket(Box::new(tungstenite::Error::Io(
+                std::io::Error::from_raw_os_error(code),
+            )));
+            assert!(
+                is_dns_error(&err),
+                "WSA code {code} must be classified as DNS"
+            );
+        }
+
+        // WSAECONNREFUSED through the same shape must NOT be a DNS error, or the
+        // flat retry would swallow a genuinely refused connection.
+        let refused = RelayError::WebSocket(Box::new(tungstenite::Error::Io(
+            std::io::Error::from_raw_os_error(10061),
+        )));
+        assert!(
+            !is_dns_error(&refused),
+            "WSAECONNREFUSED must not be classified as DNS"
+        );
+    }
+
+    /// The English Windows resolver messages are also matched, for the case
+    /// where the error reached us already flattened into a string.
+    #[test]
+    fn windows_dns_message_fallback_is_classified() {
+        // WSANO_DATA, 11004.
+        assert!(is_dns_error(&RelayError::Http(
+            "The requested name is valid, but no data of the requested type was found. (os error 11004)".into()
+        )));
+        // WSATRY_AGAIN, 11002.
+        assert!(is_dns_error(&RelayError::Http(
+            "This is usually a temporary error during hostname resolution and means that the local server did not receive a response from an authoritative server. (os error 11002)".into()
         )));
     }
 


### PR DESCRIPTION
Closes #7512.

`is_dns_error` decided what counts as a name resolution failure by matching four English strings. That covers exactly one of the four Windows Sockets `getaddrinfo` failures, so `WSATRY_AGAIN` (11002) and `WSANO_DATA` (11004) fell through to the connection error arm and consumed a backoff ladder rung.

## What made me look

Seven managed agents on one Windows 11 host lost the relay in the same second. Six of them logged `DNS failure (1/10), flat retry in 2.0s` against os error 11001. The seventh logged `attempt 1 failed` against os error 11004 and climbed the ladder instead. Same box, same hostname, same outage, same second. Full timeline in the issue.

Nobody was hurt on that particular incident, and the issue says so. The reason it is worth fixing is `wait_for_reconnect`. `relay.rs:3301` persists the ladder position across reconnects so a flapping link keeps its elevated place, and the DNS arm at `relay.rs:3287` reaches a `continue` before that line. A correctly classified DNS failure therefore never elevates the ladder. A misclassified one does, and it stays elevated until 60 seconds of stable connection reset it. A resolution blip gets recorded as link instability and the next drop pays for it.

## The change

Classify on the raw OS error code, and keep the strings as a fallback.

```rust
pub(crate) fn is_windows_dns_errno(code: i32) -> bool {
    matches!(code, 11001 | 11002 | 11004)
}
```

`connect_async` surfaces a failed resolution as `RelayError::WebSocket(tungstenite::Error::Io(_))`, which is the shape that still carries a usable `raw_os_error()`. `is_dns_error` now reads that first and falls back to string matching, which is still needed for errors that arrive already flattened into `RelayError::Http`.

Three decisions worth calling out, since each of them could reasonably have gone the other way.

**11003 `WSANO_RECOVERY` is excluded on purpose.** It reports a non-recoverable resolver failure. The DNS arm in `wait_for_reconnect` is unbounded, so classifying a non-recoverable error as DNS would retry it flat and forever instead of letting it take the ladder. It is asserted as `false` in the tests so nobody widens it by accident.

**No `cfg(windows)`.** A `cfg` gated test does not compile or run on Linux CI, and I shipped exactly that mistake on #6029, so I am not repeating it. `is_windows_dns_errno` is a pure function of an `i32` and `std::io::Error::from_raw_os_error` preserves the code on every platform, so the tests drive the real classification path on Linux runners as well as on Windows.

**Matching the code rather than the message is the point, not an implementation detail.** `FormatMessage` renders in the machine's display language. Every string in the old function is English, so on a Windows install running any other display language the classifier matched nothing at all, including the 11001 that works today. I have not put a localized box in front of this, so treat that as the reasoning behind the design rather than a measured second bug.

I also added the two English Windows strings to the fallback list, which costs nothing and covers the `RelayError::Http` path where no code survives.

## Tests

Three new tests in `crates/buzz-acp/src/relay.rs`.

- `windows_dns_errnos_are_classified` asserts the pure classifier. 11001, 11002 and 11004 true. 11003, 10061 and 0 false.
- `windows_dns_errno_classified_through_websocket_io_error` builds the production shape, `RelayError::WebSocket(tungstenite::Error::Io(io::Error::from_raw_os_error(code)))`, and drives `is_dns_error` end to end for all three DNS codes. It also asserts `WSAECONNREFUSED` (10061) through the identical shape is **not** DNS, so the flat retry cannot swallow a genuinely refused connection.
- `windows_dns_message_fallback_is_classified` covers the string path for 11002 and 11004.

The existing `is_dns_error_classification` test is unchanged and still passes, which is the check that the fallback strings and the negative cases did not move.

## Verification

Run on `x86_64-pc-windows-gnu`. Reporting the awkward parts rather than leaving you to find them.

```
cargo test -p buzz-acp --lib dns                      4 passed, 0 failed
rustfmt --check crates/buzz-acp/src/relay.rs          clean (pinned 1.95.0 toolchain)
git diff --check                                      clean
```

**The full crate suite does not come back clean on this host, and it does not come back clean without my change either.** Numbers, since that claim is worth checking rather than taking:

```
baseline, c045321a7 unmodified    842 passed, 85 failed
with this change                  845 passed, 85 failed
```

Same 85 failures either side, and the delta is exactly the 3 tests this PR adds. Those 85 are a pre-existing property of running this suite on a Windows GNU host, not something this change introduced. I ran the baseline by reverting the file in place and restoring it from a hashed copy, and I verified the restored file hashes identical to what is committed here.

Clippy is in the same position. `cargo clippy -p buzz-acp --all-targets -- -D warnings` reports 2 errors, both `question_mark` on a `match` in the mention parsing code around `queue.rs:1159`, and both are present at the unmodified baseline. My clippy is 1.97 and this repo pins 1.95, so I read that as a newer lint firing on untouched code rather than anything to fix here. I have not touched it.

**Mutation check, because three passing tests prove nothing on their own.** I reverted `is_dns_error` to its pre-fix body, kept the new tests, and re-ran:

```
windows_dns_errno_classified_through_websocket_io_error   FAILED  ("WSA code 11002 must be classified as DNS")
windows_dns_message_fallback_is_classified                FAILED
windows_dns_errnos_are_classified                         ok
is_dns_error_classification                               ok
```

The two that failed are the two that drive `is_dns_error`, and the first one failed on 11002 rather than 11001, which is the old classifier correctly still matching `No such host` and correctly still missing everything else. `windows_dns_errnos_are_classified` passing under mutation is expected, since it asserts the new pure function directly and I left that function in place. The pre-existing `is_dns_error_classification` passing under both is the check that I did not move the old behaviour.

One thing I could not do. I have no MSVC toolchain and no working Linux builder on this machine, so I have not run this on Linux myself. The reason the tests are written against `from_raw_os_error` and a `cfg`-free helper is precisely so CI can do that for me on a runner rather than me claiming a platform I did not compile on.

