### PR TITLE
docs(readme): label squareup/buzz-releases link as Block-internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ See [here](https://engineering.block.xyz/blog/run-your-own-buzz-relay) for detai
 
 Don't build from source, and don't use the OSS release — use the internal build. It comes pre-wired to the Block relay and agent provider, so it works out of the box with nothing to configure.
 
-Download the latest build from [`squareup/buzz-releases` releases](https://github.com/squareup/buzz-releases/releases/latest) and install it.
+Download the latest build from the internal [`squareup/buzz-releases`](https://github.com/squareup/buzz-releases/releases/latest) releases (Block-internal repo — sign in with your Block GitHub account; the link returns 404 for non-Block accounts) and install it.
 
 ### I want to build & run from source
 


### PR DESCRIPTION
## Summary

The releases link in the 'I work at Block' section points at `squareup/buzz-releases`, an internal repository, so it returns 404 for everyone outside Block. Multiple users reported it as a broken link.

Keep the link — its audience is Block employees, for whom it resolves — but state plainly that it is a Block-internal repo requiring a Block GitHub account, so non-Block readers know the 404 is expected access control rather than a dead link.

## Testing

- Renders correctly in GitHub markdown preview.
- Link target unchanged; only surrounding text clarifies visibility.

Fixes #7463