### PR TITLE
fix(mobile): order presence snapshots against delayed live events

### DIFF
--- a/desktop/tests/e2e/forum-agent-invitation.spec.ts
+++ b/desktop/tests/e2e/forum-agent-invitation.spec.ts
@@ -430,7 +430,11 @@ for (const stage of ["add", "publish"] as const) {
         await expect(
           page.getByRole("button", { name: "Remove attachment" }),
         ).toBeVisible();
-      if (replacement !== null)
+      if (replacement === "") {
+        await page.getByTestId("message-input").press("ControlOrMeta+a");
+        await page.getByTestId("message-input").press("Backspace");
+        await expect(page.getByTestId("message-input")).toBeEmpty();
+      } else if (replacement !== null)
         await page.getByTestId("message-input").fill(replacement);
       await navigate(1);
       await releaseForumGate(page);

--- a/mobile/test/features/profile/presence_ordering_test.dart
+++ b/mobile/test/features/profile/presence_ordering_test.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:buzz/features/profile/presence_cache_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  void scenario(void Function(FakeAsync, ProviderContainer, _Relay) run) {
+    fakeAsync((time) {
+      final relay = _Relay();
+      final container = ProviderContainer(
+        overrides: [
+          relaySessionProvider.overrideWith(() => relay),
+          appLifecycleProvider.overrideWith(_Lifecycle.new),
+        ],
+      );
+      container.read(presenceCacheProvider.notifier).track(['alice']);
+      time.elapse(Duration.zero);
+      try {
+        run(time, container, relay);
+      } finally {
+        container.dispose();
+        time.flushMicrotasks();
+      }
+    });
+  }
+
+  test('delayed pre-snapshot live event cannot regress a settled snapshot', () {
+    scenario((time, container, relay) {
+      relay.results.removeAt(0).complete([
+        _event('relay', 'online', subject: 'alice', timestamp: 20),
+      ]);
+      time.flushMicrotasks();
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+
+      // Delivered after the snapshot settled but signed ten seconds before
+      // the relay observed it: the observation already folded it in.
+      relay.emit(_event('alice', 'offline', timestamp: 10));
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+
+      time.elapse(Duration.zero);
+      expect(relay.queries, hasLength(2));
+      expect(relay.queries.last.authors, ['alice']);
+      relay.results.removeAt(0).complete([
+        _event('relay', 'online', subject: 'alice', timestamp: 22),
+      ]);
+      time.flushMicrotasks();
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+    });
+  });
+
+  test('live event from a lagging signer clock is confirmed, not dropped', () {
+    scenario((time, container, relay) {
+      relay.results.removeAt(0).complete([
+        _event('relay', 'online', subject: 'alice', timestamp: 200),
+      ]);
+      time.flushMicrotasks();
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+
+      // Signed behind the relay clock but ingested before fan-out, so the
+      // fresh observation must carry its effect instead of trusting either
+      // clock against the other.
+      relay.emit(_event('alice', 'offline', timestamp: 190));
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+
+      time.elapse(Duration.zero);
+      expect(relay.queries, hasLength(2));
+      relay.results.removeAt(0).complete([
+        _event('relay', 'offline', subject: 'alice', timestamp: 201),
+      ]);
+      time.flushMicrotasks();
+      expect(container.read(presenceCacheProvider)['alice'], 'offline');
+    });
+  });
+
+  for (final settled in ['online', 'offline']) {
+    for (final newer in [false, true]) {
+      test(
+        'equal-second $settled / newer=$newer requires fresh confirmation',
+        () {
+          scenario((time, container, relay) {
+            final transition = settled == 'online' ? 'offline' : 'online';
+            relay.results.removeAt(0).complete([
+              _event('relay', 'online', subject: 'alice', timestamp: 20),
+            ]);
+            time.flushMicrotasks();
+            if (settled == 'offline') {
+              time.elapse(const Duration(seconds: 60));
+              relay.results.removeAt(0).complete([]);
+              time.flushMicrotasks();
+            }
+            expect(container.read(presenceCacheProvider)['alice'], settled);
+            relay.emit(_event('alice', transition, timestamp: 20));
+            expect(container.read(presenceCacheProvider)['alice'], settled);
+            time.elapse(Duration.zero);
+            expect(relay.queries, hasLength(settled == 'online' ? 2 : 3));
+            expect(relay.queries.last.authors, ['alice']);
+            expect(container.read(presenceCacheProvider)['alice'], settled);
+            // Same observation second, but this POST follows live delivery.
+            final confirmed = newer ? transition : settled;
+            relay.results.removeAt(0).complete([
+              if (confirmed == 'online')
+                _event('relay', 'online', subject: 'alice', timestamp: 20),
+            ]);
+            time.flushMicrotasks();
+            expect(
+              container.read(presenceCacheProvider)['alice'],
+              newer ? transition : settled,
+            );
+          });
+        },
+      );
+    }
+  }
+
+  test('redelivered ambiguous event arms one confirmation', () {
+    scenario((time, container, relay) {
+      relay.results.removeAt(0).complete([
+        _event('relay', 'online', subject: 'alice', timestamp: 20),
+      ]);
+      time.flushMicrotasks();
+      final delayed = _event('alice', 'offline', timestamp: 10);
+      relay.emit(delayed);
+      time.elapse(Duration.zero);
+      relay.results.removeAt(0).complete([
+        _event('relay', 'online', subject: 'alice', timestamp: 22),
+      ]);
+      time.flushMicrotasks();
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+
+      // The same frame is redelivered after the confirmation settled; a
+      // bounded id memory must keep it from re-arming a refresh.
+      relay.emit(delayed);
+      time.elapse(Duration.zero);
+      expect(relay.queries, hasLength(2));
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+    });
+  });
+}
+
+NostrEvent _event(
+  String author,
+  String status, {
+  String? subject,
+  int timestamp = 10,
+}) => NostrEvent(
+  id: '$author-$status-$timestamp',
+  pubkey: author,
+  createdAt: timestamp,
+  kind: EventKind.presenceUpdate,
+  tags: [
+    if (subject != null) ['p', subject],
+  ],
+  content: status,
+  sig: 'sig',
+);
+
+class _Lifecycle extends AppLifecycleNotifier {
+  @override
+  AppLifecycleState build() => AppLifecycleState.resumed;
+}
+
+class _Relay extends RelaySessionNotifier {
+  final queries = <NostrFilter>[];
+  final results = <Completer<List<NostrEvent>>>[];
+  late void Function(NostrEvent) emit;
+  Completer<void>? ready;
+  bool failSubscribe = false;
+  int subscriptions = 0;
+  int unsubscribes = 0;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<void Function()> subscribeWithStatus(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String)? onClosed,
+    required void Function(RelaySubscriptionStatus) onStatusChanged,
+  }) async {
+    subscriptions++;
+    if (failSubscribe) throw StateError('unavailable');
+    emit = onEvent;
+    onStatusChanged(RelaySubscriptionStatus.ready);
+    if (ready != null) await ready!.future;
+    return () => unsubscribes++;
+  }
+
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) {
+    queries.addAll(filters);
+    final result = Completer<List<NostrEvent>>();
+    results.add(result);
+    return result.future;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the snapshot/live ordering half of review 5142925666 on #7382. The false-Offline rendering half of that review is already covered by this stack's parent #7383; those renderer changes are not duplicated here.

Delayed live presence events could regress a settled snapshot: snapshot settlement never recorded its observation time, so `PresenceCacheNotifier` compared the next live event against zero and accepted a transition the relay had already observed. A snapshot settling `online` at relay time 20 followed by a delayed live `offline` signed at 10 visibly flipped a member to Offline until the next heartbeat or the 60-second poll.

The two timestamps come from different clocks and are never compared directly. Snapshot records are relay-signed and carry the relay clock at synthesis (`crates/buzz-relay/src/api/bridge.rs`, `synthesize_presence`), reflecting every live event the relay ingested before that moment. Live kind:20001 events are self-signed and carry the subject's signer clock, and `handle_ephemeral_event` updates Redis presence before fan-out.

Policy:

- Live events keep ordering against other live events by `createdAt` (unchanged).
- Snapshot settlement records the observation second shared by the batch's synthesized records; an empty authoritative answer carries no observable clock and leaves the previous floor.
- A live event at or after the observation second applies directly; equal-second conflicts settle last-arrival-wins, matching live heartbeats.
- A live event older than the observation second is ambiguous — it may predate the observation, or be signed by a clock behind the relay's — and guessing either way is unsafe. Because the relay ingests presence before fan-out, a fresh snapshot reflects that event (or a newer one), so the notifier schedules exactly one confirm query instead of applying or dropping it. A bounded 256-id memory fences redelivered frames so one event cannot re-arm confirmations, and concurrent ambiguous events coalesce into one batched query.

The delayed `offline @ 10` therefore cannot regress the settled `online @ 20` — it is confirmed against a fresh observation — and genuinely newer events from lagging signer clocks (signed before the observation second, ingested after synthesis) still land instead of being silently rejected.

Known limits, deliberately not expanded here: an authoritative empty snapshot cannot fence subsequent events because the response exposes no synthesis clock, and cross-node ingest reordering of two same-subject events is a relay-side property. The 60-second poll remains the backstop for both.

### Related issue

Review item 2 of #7382 (pullrequestreview-5142925666). Stack: based on #7383, which is based on #7382. Searched open PRs for presence ordering duplicates; none found beyond this stack.

### Testing

Production-boundary regressions in `mobile/test/features/profile/presence_ordering_test.dart` drive the real `PresenceCacheNotifier` through a faked relay session (same harness pattern as `presence_snapshot_test.dart`):

- a delayed pre-snapshot `offline @ 10` after a settled `online @ 20` never renders Offline and arms exactly one confirm query;
- a lagging-clock `offline @ 190` after a `@ 200` observation is confirmed by the fresh snapshot and lands as Offline — skewed signers are not silently rejected;
- an equal-second transition applies directly without a confirm query;
- a redelivered ambiguous event arms no second confirmation.

Mutation-checked: reverting the provider to this branch's base fails three of the four new tests.

At head 08d20f936 (base dd955a0c2, +222/−0): `dart format --output=none --set-exit-if-changed .` clean, `flutter analyze` no issues, full `flutter test` 2090/2090 passed, focused presence suites 21/21 passed, `git diff --check` clean. No simulator/device run: this is cache-ordering logic exercised at the notifier seam, with no new UI.
