### PR TITLE
fix(mobile): disclose irreversible invitation completion

### DIFF
--- a/mobile/lib/features/channels/channel_management_actions.dart
+++ b/mobile/lib/features/channels/channel_management_actions.dart
@@ -77,10 +77,14 @@ class ChannelActions {
     return _refreshChannelsAndRead(channelId);
   }
 
+  /// Reports each acknowledged write before checking continuation scope.
+  /// [onAccepted] records irreversible outcomes; it must not mutate scope caches.
+  /// The community and enclosing operation scope also fence queued writes.
   Future<void> addMembers({
     required String channelId,
     required List<String> pubkeys,
     String role = 'member',
+    ValueChanged<String>? onAccepted,
   }) async {
     final normalizedRole = role.trim();
     if (normalizedRole.isEmpty) {
@@ -100,18 +104,23 @@ class ChannelActions {
       // add, not be recorded as this pubkey's rejection.
       _ensureCommunityValid();
       try {
-        await _signedEventRelay.submit(
-          kind: 9000,
-          content: '',
-          tags: [
-            ['h', channelId],
-            ['p', pubkey],
-            ['role', normalizedRole],
-          ],
+        await withRelayPublicationGuard(
+          _ensureCommunityValid,
+          () => _signedEventRelay.submit(
+            kind: 9000,
+            content: '',
+            tags: [
+              ['h', channelId],
+              ['p', pubkey],
+              ['role', normalizedRole],
+            ],
+          ),
         );
       } catch (error) {
         failures[pubkey] = _relayErrorMessage(error);
+        continue;
       }
+      onAccepted?.call(pubkey);
     }
     _ensureCommunityValid();
     _ref.invalidate(channelMembersProvider(channelId));

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -82,6 +82,7 @@ class ComposeBar extends HookConsumerWidget {
     final uploadingCount = useState(0);
     final uploadProgress = useState(0.0);
     final uploadGeneration = useRef(0);
+    final invitationStarted = useState(false);
     final activeUploadCancellation = useRef<UploadCancellationToken?>(null);
     final voiceNote = _useComposerVoiceNote(
       context: context,
@@ -473,6 +474,7 @@ class ComposeBar extends HookConsumerWidget {
           uploadingCount.value > 0) {
         return;
       }
+      invitationStarted.value = false;
       final attempt = Object();
       authorizationAttempt.value = attempt;
       isSending.value = true;
@@ -536,7 +538,10 @@ class ComposeBar extends HookConsumerWidget {
           for (final entry in mentionMap.value.entries)
             if (hasMention(text, entry.key)) entry.value,
         ];
-        final outgoing = _OutgoingMentions(selectedMentions);
+        final outgoing = _OutgoingMentions(
+          selectedMentions,
+          '${ref.read(relayConfigProvider).baseUrl} / $channelId',
+        );
         final intendedAgentKeys = {
           for (final mention in selectedMentions)
             if (mention.isAgent) mention.pubkey.toLowerCase(),
@@ -580,6 +585,8 @@ class ComposeBar extends HookConsumerWidget {
         Future<void> addMentionedNonMembers() async {
           final keys = intendedAgentKeys.intersection(outgoing.pubkeys.toSet());
           await authorize(keys, prepare: true);
+          ensureAuthorizationCurrent();
+          invitationStarted.value = true;
           await outgoing.addNonMembers(
             channelActions,
             scan: scan,
@@ -646,6 +653,7 @@ class ComposeBar extends HookConsumerWidget {
         final delivery = onSend;
         unawaited(() async {
           var retainedForRetry = false;
+          var delivered = false;
           try {
             final uploaded = <BlobDescriptor>[];
             for (var index = 0; index < queuedAttachments.length; index++) {
@@ -685,6 +693,7 @@ class ComposeBar extends HookConsumerWidget {
               outgoing.pubkeys,
               mediaTags: [...payload.mediaTags, ...outgoing.referenceTags],
             );
+            delivered = true;
           } on _ComposeAuthorizationCancelled {
             // Keep the newer draft without displaying a false access error.
           } catch (error) {
@@ -706,6 +715,8 @@ class ComposeBar extends HookConsumerWidget {
               focusNode.requestFocus();
             }
           } finally {
+            if (!delivered) outgoing.reportIncomplete(messenger);
+            if (ownsSource()) invitationStarted.value = false;
             final sourceRetainsFiles =
                 preparingAgents &&
                 context.mounted &&
@@ -747,6 +758,7 @@ class ComposeBar extends HookConsumerWidget {
       } finally {
         if (context.mounted && authorizationAttempt.value == attempt) {
           authorizationAttempt.value = null;
+          if (uploadingCount.value == 0) invitationStarted.value = false;
           isSending.value = false;
         }
       }
@@ -1065,6 +1077,7 @@ class ComposeBar extends HookConsumerWidget {
             visible: hasPendingUploads,
             progress: uploadProgress.value,
             reducedMotion: reducedMotion,
+            cancelLabel: invitationStarted.value ? 'Stop remaining' : 'Cancel',
             onCancel: () {
               activeUploadCancellation.value?.cancel();
               uploadGeneration.value += 1;

--- a/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
+++ b/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
@@ -19,6 +19,7 @@ Future<void> _sendTextOnlyDraft({
   required ComposeBarOnSend onSend,
   required ScaffoldMessengerState? messenger,
 }) async {
+  var delivered = false;
   TextEditingValue? clearedDraftText;
   Map<String, MentionCandidate>? clearedDraftMentions;
   int? clearedDraftRevision;
@@ -55,6 +56,7 @@ Future<void> _sendTextOnlyDraft({
       outgoing.pubkeys,
       mediaTags: [...payload.mediaTags, ...outgoing.referenceTags],
     );
+    delivered = true;
   } on _ComposeAuthorizationCancelled {
     restoreClearedDraft();
   } on StateError {
@@ -64,9 +66,13 @@ Future<void> _sendTextOnlyDraft({
     // The caller runs unawaited, so surface publish failures and restore the
     // sent draft unless the user has already started a new one.
     restoreClearedDraft();
-    messenger?.showSnackBar(
-      SnackBar(content: Text(_composeSendErrorMessage(error))),
-    );
+    if (outgoing.acceptedInvitations == 0) {
+      messenger?.showSnackBar(
+        SnackBar(content: Text(_composeSendErrorMessage(error))),
+      );
+    }
+  } finally {
+    if (!delivered) outgoing.reportIncomplete(messenger);
   }
 }
 

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -342,7 +342,8 @@ Future<_NonMemberMentionChoice?> _promptNonMemberMention(
       content: Text(
         canInvite
             ? '${names.join(', ')} $verb not in this channel. Invite them to '
-                  'the channel, or send without inviting them.'
+                  'the channel, or send without inviting them. Invitations take effect '
+                  'immediately and remain if the message is stopped or fails.'
             : '${names.join(', ')} $verb not in this channel. '
                   '$privateChannelAddDeniedMessage You can still send without '
                   'inviting them.',
@@ -448,6 +449,7 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
   required List<String> humanPubkeys,
   required bool canAddMembers,
   required VoidCallback ensureCurrent,
+  required VoidCallback onAccepted,
 }) async {
   final pending = [
     for (final pubkey in agentPubkeys) ([pubkey], 'bot'),
@@ -473,6 +475,7 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
         channelId: channelId,
         pubkeys: pubkeys,
         role: role,
+        onAccepted: (_) => onAccepted(),
       );
       ensureCurrent();
     } on _ComposeAuthorizationCancelled {
@@ -574,9 +577,26 @@ class _OutgoingMentions {
   final List<List<String>> referenceTags = [];
   List<String> _invitedHumanPubkeys = const [];
   bool _inviteAgents = false;
+  int acceptedInvitations = 0;
+  final String sourceDestination;
 
-  _OutgoingMentions(List<MentionCandidate> selectedMentions)
-    : pubkeys = LinkedHashSet<String>.from(
+  void reportIncomplete(ScaffoldMessengerState? messenger) {
+    if (acceptedInvitations == 0) return;
+    messenger?.showSnackBar(
+      SnackBar(
+        content: Text(
+          'Message not sent. $acceptedInvitations invitation(s) completed and remain '
+          'in effect in $sourceDestination. Review channel members before retrying. '
+          'Check your draft; attachments may need reattaching after leaving.',
+        ),
+      ),
+    );
+  }
+
+  _OutgoingMentions(
+    List<MentionCandidate> selectedMentions,
+    this.sourceDestination,
+  ) : pubkeys = LinkedHashSet<String>.from(
         selectedMentions.map((candidate) => candidate.pubkey.toLowerCase()),
       ).toList();
 
@@ -623,6 +643,7 @@ class _OutgoingMentions {
       humanPubkeys: _invitedHumanPubkeys,
       canAddMembers: scan.canAddMembers,
       ensureCurrent: ensureCurrent,
+      onAccepted: () => acceptedInvitations++,
     );
     if (outcome.notAdded.isNotEmpty) {
       throw Exception('Message not sent. ${outcome.errors.join(' ')}');

--- a/mobile/lib/features/channels/compose_bar/upload_progress_pill.dart
+++ b/mobile/lib/features/channels/compose_bar/upload_progress_pill.dart
@@ -5,12 +5,14 @@ class _UploadProgressMotion extends StatelessWidget {
   final double progress;
   final bool reducedMotion;
   final VoidCallback onCancel;
+  final String cancelLabel;
 
   const _UploadProgressMotion({
     required this.visible,
     required this.progress,
     required this.reducedMotion,
     required this.onCancel,
+    this.cancelLabel = 'Cancel',
   });
 
   @override
@@ -47,6 +49,7 @@ class _UploadProgressMotion extends StatelessWidget {
                 progress: progress,
                 reducedMotion: reducedMotion,
                 onCancel: onCancel,
+                cancelLabel: cancelLabel,
               ),
             )
           : const SizedBox.shrink(
@@ -62,11 +65,13 @@ class _UploadProgressPill extends HookConsumerWidget {
   final double progress;
   final bool reducedMotion;
   final VoidCallback onCancel;
+  final String cancelLabel;
 
   const _UploadProgressPill({
     required this.progress,
     required this.reducedMotion,
     required this.onCancel,
+    this.cancelLabel = 'Cancel',
   });
 
   @override
@@ -172,7 +177,7 @@ class _UploadProgressPill extends HookConsumerWidget {
                                   vertical: Grid.quarter,
                                 ),
                                 child: Text(
-                                  'Cancel',
+                                  cancelLabel,
                                   style: context.textTheme.labelMedium
                                       ?.copyWith(
                                         color: context.colors.onSurface,

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -97,15 +97,18 @@ class SendMessage {
     _ensureDeliveryValid();
     NostrEvent? localMessage;
     try {
-      await _signedEventRelay.submit(
-        kind: EventKind.streamMessage,
-        content: content,
-        tags: tags,
-        onSigned: (event) {
-          localMessage = event;
-          _markLocalMessageForAnimation(channelId, event.id);
-          _addLocalMessage(channelId, event);
-        },
+      await withRelayPublicationGuard(
+        _ensureDeliveryValid,
+        () => _signedEventRelay.submit(
+          kind: EventKind.streamMessage,
+          content: content,
+          tags: tags,
+          onSigned: (event) {
+            localMessage = event;
+            _markLocalMessageForAnimation(channelId, event.id);
+            _addLocalMessage(channelId, event);
+          },
+        ),
       );
       final event = localMessage;
       if (event != null) _completeLocalMessage(channelId, event.id);

--- a/mobile/lib/shared/mentions/agent_publication.dart
+++ b/mobile/lib/shared/mentions/agent_publication.dart
@@ -67,3 +67,30 @@ Future<void> authorizeAgentMentions(
     throw Exception(message);
   }
 }
+
+/// Session-bound all-key evidence reader. Saved agent keys are denial-only taint.
+typedef SelectedMentionAuthorizationReader =
+    Future<Map<String, SelectedMentionAuthorization>> Function(
+      Set<String> keys,
+      Set<String> priorAgentKeys,
+      String viewer,
+      String channelId,
+      bool Function() isCurrent,
+      void Function(Map<String, NostrEvent>) onProfileEvidence,
+    );
+
+/// Read-only publication seam; does not populate suggestion/profile caches.
+final selectedMentionAuthorizationReaderProvider =
+    Provider<SelectedMentionAuthorizationReader>((ref) {
+      final session = ref.watch(relaySessionProvider.notifier);
+      return (keys, prior, viewer, channel, current, observed) =>
+          readSelectedMentionAuthorization(
+            session,
+            keys,
+            viewer: viewer,
+            channelId: channel,
+            priorAgentKeys: prior,
+            isCurrent: current,
+            onProfileEvidence: observed,
+          );
+    });

--- a/mobile/lib/shared/mentions/selected_mention_authorization.dart
+++ b/mobile/lib/shared/mentions/selected_mention_authorization.dart
@@ -36,7 +36,8 @@ class SelectedMentionAuthorization {
   /// owner policy produces a deny-all entry, never runtime fallback.
   final AgentDirectoryEntry? agent;
 
-  const SelectedMentionAuthorization._(this.kind, this.isMember, this.agent);
+  /// Construct evidence, not a publication or role-write capability.
+  const SelectedMentionAuthorization(this.kind, this.isMember, this.agent);
 
   /// True when this key's evidence must be routed through the agent
   /// authorization evaluator rather than the ordinary flow: agent or
@@ -70,6 +71,7 @@ readSelectedMentionAuthorization(
   required String channelId,
   Set<String> priorAgentKeys = const {},
   required bool Function() isCurrent,
+  void Function(Map<String, NostrEvent>)? onProfileEvidence,
 }) async {
   void check() {
     if (!isCurrent()) throw StateError('Mention authorization scope changed');
@@ -131,6 +133,7 @@ readSelectedMentionAuthorization(
     checkCurrent: check,
     onProfileEvidence: (value) => profiles = value,
   );
+  onProfileEvidence?.call(profiles);
   check();
   final latestRuntime = <String, NostrEvent>{};
   for (final event in runtime) {
@@ -186,7 +189,7 @@ readSelectedMentionAuthorization(
             : const [],
       );
     }
-    result[key] = SelectedMentionAuthorization._(
+    result[key] = SelectedMentionAuthorization(
       kind,
       members.containsKey(key),
       agent,

--- a/mobile/lib/shared/profile/user_cache_provider.dart
+++ b/mobile/lib/shared/profile/user_cache_provider.dart
@@ -31,6 +31,10 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
     return {};
   }
 
+  /// Latest observed profile revision; read-only fencing for publication.
+  ({int createdAt, String eventId})? profileEventOrder(String key) =>
+      _profileEventOrders[key];
+
   /// Request a profile for [pubkey]. Returns immediately from cache if
   /// available, otherwise schedules a batch fetch.
   UserProfile? get(String pubkey) {

--- a/mobile/lib/shared/relay/relay_rate_limit_gate.dart
+++ b/mobile/lib/shared/relay/relay_rate_limit_gate.dart
@@ -21,6 +21,9 @@ class RelayRateLimitGate {
 
   final DateTime Function() _now;
   final RelayTimerFactory _timerFactory;
+
+  /// Monotonic revision of admitted capacity pauses, including extensions.
+  int epoch = 0;
   DateTime? _expiresAt;
   Timer? _timer;
   Completer<void>? _completer;
@@ -53,6 +56,7 @@ class RelayRateLimitGate {
     final currentExpiry = _expiresAt;
     if (currentExpiry != null && !newExpiry.isAfter(currentExpiry)) return;
 
+    epoch++;
     _expiresAt = newExpiry;
     _timer?.cancel();
     _completer ??= Completer<void>();

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -24,6 +24,26 @@ export 'relay_session_types.dart';
 
 part 'relay_session_auth.dart';
 
+final _publicationGuardKey = Object();
+
+/// Carries a synchronous local operation fence through async delivery adapters.
+/// The fence runs after transport backpressure and before socket enqueue only;
+/// it never changes how an already transmitted event's ACK is accounted for.
+/// Nested scopes retain their enclosing operation fence. Other callers need not
+/// opt in. This is not atomic authorization against unobserved remote changes.
+T withRelayPublicationGuard<T>(void Function() check, T Function() deliver) {
+  final enclosing = Zone.current[_publicationGuardKey] as void Function()?;
+  return runZoned(
+    deliver,
+    zoneValues: {
+      _publicationGuardKey: () {
+        enclosing?.call();
+        check();
+      },
+    },
+  );
+}
+
 class _HistorySubscription {
   final List<NostrEvent> events = [];
   final Completer<List<NostrEvent>> completer;
@@ -327,6 +347,8 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     return () => _unsubscribe(subId);
   }
 
+  /// Publishes after backpressure; the operation scope may synchronously abort.
+  /// Once enqueued, ACKs settle normally even if the operation later expires.
   Future<NostrEvent> publish(
     NostrEvent event, {
     Duration timeout = const Duration(seconds: 8),
@@ -337,6 +359,9 @@ class RelaySessionNotifier extends Notifier<SessionState> {
       throw StateError('Relay session is not connected');
     }
 
+    // No await between the operation fence and the actual socket enqueue.
+    // This is local observed currentness, not network-atomic authorization.
+    (Zone.current[_publicationGuardKey] as void Function()?)?.call();
     final completer = Completer<NostrEvent>();
 
     final timer = Timer(timeout, () {
@@ -381,7 +406,22 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   void debugDispose() => _dispose();
 
   @visibleForTesting
-  void debugSupersedeConnection() => _connectionGeneration++;
+  void debugSupersedeConnection() => _supersedeConnection();
+
+  int _supersedeConnection() {
+    return ++_connectionGeneration;
+  }
+
+  /// Selected evidence cannot cross socket replacement or a capacity pause.
+  bool Function() retainPublicationEvidence() {
+    final generation = _connectionGeneration;
+    final epoch = _rateLimitGate.epoch;
+    final admitted = !_rateLimitGate.isActive;
+    return () =>
+        admitted &&
+        _isActiveConnection(generation) &&
+        epoch == _rateLimitGate.epoch;
+  }
 
   @visibleForTesting
   void debugHandleDisconnected([Object? error]) {
@@ -494,7 +534,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   Future<void> _connect(RelayConfig config) async {
     if (_disposed) return;
 
-    final generation = ++_connectionGeneration;
+    final generation = _supersedeConnection();
     state = SessionState(
       status: _hasConnectedOnce
           ? SessionStatus.reconnecting

--- a/mobile/lib/shared/relay/signed_event_relay.dart
+++ b/mobile/lib/shared/relay/signed_event_relay.dart
@@ -28,7 +28,8 @@ class SignedEventRelay {
 
   /// Sign and submit an event. Returns the relay's OK response as a [NostrEvent]
   /// whose `content` field contains the OK message (e.g. `"response:{...}"`
-  /// for command kinds).
+  /// for command kinds). Publication retains any [withRelayPublicationGuard]
+  /// scope through transport waits, without discarding accepted ACKs.
   Future<NostrEvent> submit({
     required int kind,
     required String content,

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -14561,8 +14561,12 @@ class _FakeChannelActions extends ChannelActions {
     required String channelId,
     required List<String> pubkeys,
     String role = 'member',
+    ValueChanged<String>? onAccepted,
   }) async {
     await onAddMembers?.call(channelId, pubkeys);
+    for (final pubkey in pubkeys) {
+      onAccepted?.call(pubkey);
+    }
   }
 
   @override

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -29,6 +29,9 @@ import 'package:buzz/shared/theme/theme.dart';
 import 'package:buzz/shared/widgets/anchored_popover_menu.dart';
 import 'package:buzz/shared/widgets/mobile_tab_footer_backdrop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+// Shared fixture prerequisite; production-observation rows land in the child PR.
+// ignore: unused_import
+import '../../shared/mentions/agent_policy_test.dart' show signed;
 
 part 'compose_bar_test/publication_tests.dart';
 part 'compose_bar_test/send_lifecycle_tests.dart';
@@ -180,6 +183,10 @@ Widget _buildComposeBar({
   Future<List<ChannelMember>>? membersFuture,
   Future<List<ChannelMember>> Function()? membersLoader,
   AgentAuthorizationReader? authorizationReader,
+  SelectedMentionAuthorizationReader? selectedReader,
+  RelayRateLimitGate? rateLimitGate,
+  http.Client? relayHttpClient,
+  void Function(NostrEvent)? beforePublish,
   List<AgentDirectoryEntry> relayAgents = const <AgentDirectoryEntry>[],
   List<Channel> channels = const <Channel>[],
   List<ChannelMember> cachedMembers = const <ChannelMember>[],
@@ -202,6 +209,14 @@ Widget _buildComposeBar({
 }) {
   return ProviderScope(
     overrides: [
+      if (rateLimitGate != null || relayHttpClient != null)
+        relaySessionProvider.overrideWith(
+          () => _BeforePublishSession(
+            rateLimitGate: rateLimitGate,
+            httpClient: relayHttpClient,
+            beforePublish: beforePublish,
+          ),
+        ),
       customEmojiListProvider.overrideWithValue(customEmoji),
       mediaUploadServiceProvider.overrideWithValue(uploadService),
       if (voiceNoteRecorderFactory != null)
@@ -230,6 +245,49 @@ Widget _buildComposeBar({
                 ),
             ],
       ),
+      if (relayHttpClient == null || selectedReader != null)
+        selectedMentionAuthorizationReaderProvider.overrideWithValue(
+          selectedReader ??
+              (keys, prior, viewer, channel, current, observed) async {
+                final roster =
+                    await (membersLoader?.call() ??
+                        membersFuture ??
+                        Future.value(members));
+                final agentKeys = {
+                  ...prior,
+                  for (final agent in relayAgents)
+                    if (keys.contains(agent.pubkey)) agent.pubkey,
+                };
+                final agents = agentKeys.isEmpty
+                    ? <AgentDirectoryEntry>[]
+                    : await (authorizationReader?.call(
+                            agentKeys,
+                            viewer,
+                            channel,
+                            current,
+                          ) ??
+                          Future.value([
+                            for (final key in agentKeys)
+                              AgentDirectoryEntry(
+                                pubkey: key,
+                                respondTo: 'anyone',
+                                ownerPubkey: viewer,
+                                channelIds: [channel],
+                              ),
+                          ]));
+                return {
+                  for (final key in keys)
+                    key: SelectedMentionAuthorization(
+                      agentKeys.contains(key)
+                          ? SelectedMentionKind.agent
+                          : SelectedMentionKind.ordinary,
+                      roster.any((member) => member.pubkey == key) ||
+                          channels.any((c) => c.id == channel && c.isDm),
+                      agents.where((agent) => agent.pubkey == key).firstOrNull,
+                    ),
+                };
+              },
+        ),
       agentDirectoryProvider.overrideWith((ref) async => relayAgents),
       agentOwnersProvider.overrideWith((ref) async => const <String, String>{}),
       relayClientProvider.overrideWithValue(
@@ -578,6 +636,33 @@ class _SwitchableRelayConfigNotifier extends RelayConfigNotifier {
   @override
   RelayConfig build() => initial;
 }
+
+// Shared fixture prerequisite; production-observation rows land in the child PR.
+// ignore: unused_element
+http.Client _selectedRosterClient(
+  String authority,
+  NostrEvent Function() rosterEvent, {
+  List<NostrEvent> Function()? extraEvents,
+}) => http_testing.MockClient((request) async {
+  if (request.method == 'GET') {
+    return http.Response(jsonEncode({'self': authority}), 200);
+  }
+  final filters = jsonDecode(request.body) as List;
+  return http.Response(
+    jsonEncode([
+      if (filters.any((f) => (f['kinds'] as List).contains(39002)))
+        rosterEvent().toJson(),
+      for (final event in extraEvents?.call() ?? <NostrEvent>[])
+        if (filters.any(
+          (f) =>
+              (f['kinds'] as List).contains(event.kind) &&
+              (f['authors'] as List).contains(event.pubkey),
+        ))
+          event.toJson(),
+    ]),
+    200,
+  );
+});
 
 class _RecordingRelaySocket extends RelaySocket {
   final List<Map<String, dynamic>> events;
@@ -5673,4 +5758,23 @@ Channel _makeChannel({required String name, required String channelType}) {
     createdAt: DateTime(2024),
     memberCount: 5,
   );
+}
+
+// Observe the real signing→session boundary without supplying a validity guard.
+class _BeforePublishSession extends RelaySessionNotifier {
+  _BeforePublishSession({
+    super.rateLimitGate,
+    super.httpClient,
+    this.beforePublish,
+  });
+  final void Function(NostrEvent)? beforePublish;
+
+  @override
+  Future<NostrEvent> publish(
+    NostrEvent event, {
+    Duration timeout = const Duration(seconds: 8),
+  }) {
+    beforePublish?.call(event);
+    return super.publish(event, timeout: timeout);
+  }
 }

--- a/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/send_lifecycle_tests.dart
@@ -84,7 +84,12 @@ void sendLifecycleTests() {
       }
     });
   }
-  for (final action in ['revisit', 'cancel', 'partial refusal']) {
+  for (final action in [
+    'revisit',
+    'cancel',
+    'partial refusal',
+    'accepted scope switch',
+  ]) {
     testWidgets('$action cannot finish an old membership batch', (
       tester,
     ) async {
@@ -98,6 +103,9 @@ void sendLifecycleTests() {
       Widget build({String? thread}) => _buildComposeBar(
         uploadService: service,
         currentPubkey: signer.public,
+        relayConfig: () => _SwitchableRelayConfigNotifier(
+          RelayConfig(baseUrl: 'https://relay.example', nsec: signer.nsec),
+        ),
         relayAgents: [
           _testAgent('b' * 64),
           AgentDirectoryEntry(
@@ -126,6 +134,11 @@ void sendLifecycleTests() {
             if (event['kind'] == 9000) await gate.future;
           },
           onEventAcknowledged: (event) {
+            if (action == 'accepted scope switch' && event['kind'] == 9000) {
+              container
+                  .read(relayConfigProvider.notifier)
+                  .update(baseUrl: 'https://other.example', nsec: signer.nsec);
+            }
             if (action == 'partial refusal' && event['kind'] == 9000) {
               session.debugAttachSocketForTest(
                 _RecordingRelaySocket(
@@ -138,10 +151,11 @@ void sendLifecycleTests() {
           },
         ),
       );
-      if (action == 'cancel') {
+      if (action == 'cancel' || action == 'revisit') {
         await _openAttachmentMenu(tester);
         await tester.tap(find.text('Video'));
         await tester.pumpAndSettle();
+        expect(find.byTooltip('Remove attachment'), findsOneWidget);
       }
       await _expandComposer(tester);
       await tester.enterText(find.byType(TextField), '@hel');
@@ -155,11 +169,14 @@ void sendLifecycleTests() {
       await tester.tap(find.byIcon(LucideIcons.arrowUp));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
+      expect(find.textContaining('Invitations take effect'), findsOneWidget);
       await tester.tap(find.text('Invite'));
       await tester.pump();
       expect(events.where((e) => e['kind'] == 9000), hasLength(1));
       if (action == 'cancel') {
         await tester.pump(const Duration(milliseconds: 300));
+        expect(find.text('Cancel'), findsNothing);
+        expect(find.text('Stop remaining'), findsOneWidget);
         await tester.tap(find.byKey(const ValueKey('compose-upload-cancel')));
       } else if (action == 'revisit') {
         await tester.pumpWidget(build(thread: 'other'));
@@ -167,9 +184,33 @@ void sendLifecycleTests() {
       }
       gate.complete();
       await tester.pumpAndSettle();
+      if (action == 'accepted scope switch') {
+        await tester.pump(const Duration(seconds: 5));
+        await tester.pumpAndSettle();
+      }
+      expect(
+        find.textContaining('1 invitation(s) completed and remain in effect'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Your draft is kept'), findsNothing);
+      expect(
+        find.textContaining('https://relay.example / channel-1'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('attachments may need reattaching'),
+        findsOneWidget,
+      );
+      if (action == 'revisit') {
+        expect(find.byTooltip('Remove attachment'), findsNothing);
+      }
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
       expect(sends, 0);
+      if (action == 'accepted scope switch') {
+        expect(events.where((e) => e['kind'] == 9000), hasLength(1));
+        return;
+      }
       await tester.tap(find.text('@Helper Bot @Other Bot'));
       await tester.pumpAndSettle();
       expect(

--- a/mobile/test/shared/relay/relay_enqueue_fence_test.dart
+++ b/mobile/test/shared/relay/relay_enqueue_fence_test.dart
@@ -1,0 +1,191 @@
+import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:buzz/features/channels/send_message_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+void main() {
+  // Each row binds to the production object's own validity callback —
+  // ChannelActions.isCommunityValid for kind:9000 and
+  // SendMessage.isDeliveryValid for messages — exactly as
+  // channelActionsProvider/sendMessageProvider wire them. There is no
+  // test-authored outer guard here, so removing either production
+  // `withRelayPublicationGuard` wrapper must fail its own rows.
+  for (final kind in [9000, EventKind.streamMessage]) {
+    for (final cancel in [false, true]) {
+      test(
+        'queued kind:$kind cancellation=$cancel via the owning guard',
+        () async {
+          final gate = RelayRateLimitGate();
+          final session = RelaySessionNotifier(rateLimitGate: gate);
+          final socket = _Socket();
+          session.debugAttachSocketForTest(socket);
+          final relay = SignedEventRelay(
+            session: session,
+            nsec: nostr.Keys.generate().nsec,
+          );
+          var valid = true;
+          var accepted = 0;
+          final container = ProviderContainer();
+          addTearDown(container.dispose);
+          final actions = container.read(
+            Provider(
+              (ref) => ChannelActions(
+                ref: ref,
+                session: session,
+                signedEventRelay: relay,
+                currentPubkey: relay.pubkey,
+                isCommunityValid: () => valid,
+              ),
+            ),
+          );
+          gate.activate(10);
+          // Real production signing/session/backpressure and ChannelActions for
+          // kind9000. No query/selected-reader or publication recorder substitutes.
+          final pending = kind == 9000
+              ? actions.addMembers(
+                  channelId: 'channel',
+                  pubkeys: ['target'],
+                  onAccepted: (_) => accepted++,
+                )
+              : SendMessage(
+                  signedEventRelay: relay,
+                  fetchMembers: (_) async => const [],
+                  readUserCache: () => const {},
+                  addLocalMessage: (_, _) {},
+                  completeLocalMessage: (_, _) => accepted++,
+                  removeLocalMessage: (_, _) {},
+                  isDeliveryValid: () => valid,
+                )(channelId: 'channel', content: '', mentionPubkeys: const []);
+          Object? error;
+          final settled = pending.then<void>(
+            (_) {},
+            onError: (Object e) {
+              error = e;
+            },
+          );
+          expect(socket.messages, isEmpty);
+          // Invalidate the owning production object's own callback while the
+          // real rate-limit gate still holds the publish.
+          valid = !cancel;
+          gate.reset();
+          await Future<void>.delayed(Duration.zero);
+          final sent = socket.messages
+              .where((p) => p.first == 'EVENT')
+              .toList();
+          if (sent.isNotEmpty) {
+            // Invalidation after the socket write must not erase accepted ACKs.
+            valid = false;
+            session.debugHandleMessage([
+              'OK',
+              (sent.single[1] as Map)['id'],
+              true,
+              '',
+            ]);
+          }
+          await settled;
+          expect(sent, hasLength(cancel ? 0 : 1));
+          expect(accepted, cancel ? 0 : 1);
+          if (kind == 9000) {
+            // The membership object reports its own fence after the loop; the
+            // irreversible write above still counts as accepted.
+            expect(error, isA<StateError>());
+          } else {
+            // A message send that reached the socket is completed, not
+            // cancelled, even though the operation expired after the enqueue.
+            expect(error, cancel ? isA<StateError>() : isNull);
+          }
+        },
+      );
+    }
+  }
+
+  // The composer wraps ChannelActions in its own operation fence, so the
+  // enqueue fence must consult the enclosing scope and the production
+  // object's own callback. This is the only test-authored outer guard, and
+  // it exists explicitly for that nesting contract.
+  test('nested operation fences compose at actual enqueue', () async {
+    for (final outerInvalid in [true, false]) {
+      final gate = RelayRateLimitGate();
+      final session = RelaySessionNotifier(rateLimitGate: gate);
+      final socket = _Socket();
+      session.debugAttachSocketForTest(socket);
+      final relay = SignedEventRelay(
+        session: session,
+        nsec: nostr.Keys.generate().nsec,
+      );
+      var outerValid = true;
+      var innerValid = true;
+      var accepted = 0;
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final actions = container.read(
+        Provider(
+          (ref) => ChannelActions(
+            ref: ref,
+            session: session,
+            signedEventRelay: relay,
+            currentPubkey: relay.pubkey,
+            isCommunityValid: () => innerValid,
+          ),
+        ),
+      );
+      void ensureOuter() {
+        if (!outerValid) throw StateError('outer operation expired');
+      }
+
+      gate.activate(10);
+      final pending = withRelayPublicationGuard(
+        ensureOuter,
+        () => actions.addMembers(
+          channelId: 'channel',
+          pubkeys: ['target'],
+          onAccepted: (_) => accepted++,
+        ),
+      );
+      Object? error;
+      final settled = pending.then<void>(
+        (_) {},
+        onError: (Object e) {
+          error = e;
+        },
+      );
+      expect(socket.messages, isEmpty);
+      if (outerInvalid) {
+        outerValid = false; // Enclosing operation expires during the wait.
+      } else {
+        innerValid = false; // Production object's own fence expires.
+      }
+      gate.reset();
+      await Future<void>.delayed(Duration.zero);
+      expect(socket.messages.where((p) => p.first == 'EVENT'), isEmpty);
+      await settled;
+      expect(accepted, 0);
+      if (outerInvalid) {
+        // The enclosing fence's failure is recorded per-pubkey and the
+        // membership object surfaces it as an AddMembersException.
+        final failure = error as AddMembersException;
+        expect(failure.failures['target'], contains('outer operation expired'));
+      } else {
+        // The inner fence's failure aborts the whole add before the
+        // per-pubkey failure report.
+        expect(error, isA<StateError>());
+      }
+    }
+  });
+}
+
+class _Socket extends RelaySocket {
+  _Socket()
+    : super(
+        wsUrl: 'wss://relay.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+  final messages = <List<dynamic>>[];
+  @override
+  void send(List<dynamic> payload) => messages.add(payload);
+}


### PR DESCRIPTION
## Summary
Inviting mentioned people or agents changes channel membership even if the message later stops or fails. Make that commitment explicit before Invite, relabel the media action to **Stop remaining** when invitations start, and report how many acknowledged invitations remain in effect when delivery does not finish. Direct the sender to review members in the original community/channel and check the remaining draft before retrying; attachments may need reattaching after leaving.

This does not claim a multi-event transaction or remove independently valid members. Stopping can prevent remaining work, not undo an invitation already accepted (including an acknowledgement that arrives after Stop).

### Related issue (historical allocation)
Dependent followup to #7390 and its requested-change review https://github.com/block/buzz/pull/7390#pullrequestreview-5142815420 . Closest existing work is #7390; this delta requires its explicit invitation and source-lifecycle fencing. Base remains `fix/mobile-invitations-20260905`, now rebased onto #7531. Historical own ranges: #7390 466 lines; this followup 115 lines. All original invitation/lifecycle tests are retained. #7394 is included by the chosen serial integration sequence, not an inherent dependency of the historical invitation feature. Fresh persisted agent classification (#7387) is separate and not claimed fixed here.

### Testing (historical candidate)
- At historical `97147e9a9f0aae7421067ca121d34701cda7d224`: `just mobile-check` passes and full `flutter test` **2,132 passed**. Historical 2,085-test evidence applies only to old `a6b55f919`.
- Production-composer regressions cover accepted first invitation followed by Stop, media source revisit, later invitation refusal, or scope switch immediately after successful relay OK. Assert no message, text retention when still available, actual accepted-prefix event count, disclosure, Stop remaining label, original destination and truthful recovery wording. The media revisit test verifies its selected attachment is absent on return; no complete durable-media retention is promised. Moving acceptance accounting below ChannelActions’ scope fence makes the new scope-switch test fail.
- No device/simulator journey or screenshots captured; widget coverage only. Repository-wide `just ci` not run. Independent review and exact-head CI remain gates; no merge requested.


### Historical serial integration carry (2026-09-09)

Historical HEAD `97147e9a9f0aae7421067ca121d34701cda7d224`; own PR range **115 changed lines**, including tests. Existing PR retained; no duplicate feature patch or merge. Declared integration sequence: #7393 → #7394 → #7531 → #7390 → #7527 → forthcoming classification consumer. This is an integration order, not a claim that the historical root features inherently depended on each other.

Final carried HEAD: `just mobile-check` passes; full `flutter test`: **2132 passed**. These supersede prior standalone counts for this head. No new screenshot or composed runtime capture claimed. Repository-wide just-ci and final persisted classification workflow are not claimed green by these package checks.

Composition retains the #7394 authorization/cancellation guard and combines invitation visit/upload fences with it, retains explicit consent and source-draft listener/recovery ownership. #7527 retains successful ACK accounting before ChannelActions scope fences. Saved-isAgent classification/restart repair is still forthcoming; this carry alone does not resolve #7387.


## Published SEND correction — 2026-09-10

Head `2943008ec56589140cccd37f507a1393e64a4671`; declared base `069c8b71a4b43edc3dae946e14d2523fc8a16d29`; actual own churn **540 including tests**, strictly below600. Supersedes historical candidate pins and coverage below/above. Normal CI: https://github.com/block/buzz/actions/runs/34431155737 (completion pending).

Cumulative coverage remains conditional on the existing stack: #7527 owns scope/transport and capacity/generation foundation, #7534 classification, #7536 complete observed-evidence binding, and #7539 production-boundary journeys. This is not standalone authorization completeness at an intermediate parent or a backport to #7387. The original reviewed parents' gaps are acknowledged rather than relabeled as already fixed there.

R1/R2: empty latest required audience retires obsolete recipient proof only after successful operation-scope validation; retained recipients remain protected. Genuine community changes use a typed error and invitation StateError revalidates actual scope. Unavailable authority is not falsely described as a community switch. Accepted invitation prefixes remain irreversible and accounted for. A downstream onSend adapter can still encounter generic disconnected-session failure before the typed guard: no enqueue, but the specific community explanation is not exhaustive.

The 41-row matrix includes nine added real-boundary journeys. Production rows use the actual default provider/HTTP reader and real SendMessage → signed-event relay → session. Removing reader currentness or composer aggregation independently leaks kind9; invitation counterparts leak accepted kind9000. Removing only composer guardedDelivery leaks kind9 after real draft editing while SendMessage's wrapper remains. Removing default-provider profile forwarding fails consent/post-ACK continuity (first failing assertion is unwanted kind9, not an independently logged kind9000 failure). Pure capacity and no-capacity profile-revocation rows isolate those causes; the waiting-revocation row does not independently separate coordinates from aged capacity. EMPTY/TYPED mutations fail their observable delivery/UI assertions. Source was restored. These are local mutation receipts on equivalent production, not new published-head mutation executions.

Validation: exact reviewed candidate full-mobile suites passed 2137/2152/2162/2188 for #7527/#7534/#7536/#7539. All mobile production AND test tree objects are byte-identical after mechanical Desktop-only carry; no unnecessary mobile full rerun is claimed. Own-range source-size gates pass after carry; format/analyzer receipts apply to unchanged mobile bytes. Desktop JS package 6450/6450 passed; forum 19+63 and video 7 E2E / 4 buffering unit cases are scoped receipts on identical runtime inputs, not complete Playwright/CI passes.

Private16 is now `79d3a431d08413225dda88f7fea7ca48d2a69e25`: same mobile tree as reviewed `0a28720e89b5319ebc682ea98ef73fae53f5e0d0` (full2231); forum/video test repairs carried once each. Production correspondence to public SEND was independently byte-verified. Earlier same-production restart11 (ten classification plus original exact-draft) and mounted provenance1 receipts are reused, not new final-head executions. Public versus former `668f1ffb` and private versus `cc6c3210` mobile growth is +19/-6 production and +343/-200 tests; allocation is not a net saving. This is 16 constituents, not all20, native/live-relay/VoiceOver or release acceptance. #7391's independent critique is not closed by composition.

Independent delta review e6ec accepted the exact mobile candidates with the qualifications above; old GitHub approvals are not transferred. Normal push-triggered CI is running, not yet green; security skips are not a security verdict. No rerun wave, dispatch, merge or new PR. Evidence: `WORK_LOGS/MOBILE_FEEDBACK_CLASSIFICATION_20260909/GREEN_SEND_DELTA_REVIEW_D231.md`, `GREEN_SEND_IMPLEMENTATION.md`, and `GREEN_STACK_INTEGRATION.md` / `GREEN_6A5/`.


## Mechanical docs-carry note — 2026-09-10

Head mechanically carried to `84f61093be51f2824debdf4b65e76d12652acfbf` (corrected parent #7390 `d080eccb1…` + this PR's original own commits, zero conflicts, original messages/authors/DCO preserved). The carry is docs-only — the #7531 review-5162334206 `///` correction on `mobile/lib/shared/mentions/selected_mention_authorization.dart` (comment-stripped file equality; `mobile/test` bytes identical to `2943008ec56589140cccd37f507a1393e64a4671`); earlier "Head `2943008ec56589140cccd37f507a1393e64a4671`"/current-HEAD mappings above are dated receipts for their pre-carry heads, including their CI links. Own churn is unchanged at **540 including tests** (inherited docs are not counted as own); no executable delta. Normal CI on the carried head: https://github.com/block/buzz/actions/runs/34436598895.

## Workflows helper test carry — 2026-09-10

Head rebased to `f098f9aa877235320dade5a76ae1b2ac02e4fe70` (single carry commit, author and message preserved, on corrected parent #7390 `5f8744a3fb571b6dd9a6d3853ae254694ab9eeea`); no conflicts, no merge commits. Own range vs the corrected parent is unchanged at **508 additions + 32 deletions = 540 lines including tests**; the only old-head→new-head content delta is the carried #7531 Desktop E2E test repair in `desktop/tests/e2e/workflows.spec.ts` (+15/−3) and `desktop/tests/e2e/workflow-local-controls.spec.ts` (+7/−2) — mobile production, mobile tests, and API docs are byte-identical old→new. This PR's semantic review requirements (resolved merge unit, reviewed-unit allocation) remain open and are not affected by this test-only carry. Current-head review 5162591539 predates this head movement. Normal CI on the new head is running; no green claim is made here.


## Workflow regression test carry — 2026-09-10

Head rebased to `44d06b378b3c7a95ad2d036fa65d950a5442eb7a` (single carry commit, author and message preserved, on parent #7390 `c93d15ebc48f48aa96e3a6eed157bb1b18967d0d`); no conflicts, no merge commits. Own range vs the new parent is unchanged at **508 additions + 32 deletions = 540 lines including tests**; the only old-head→new-head content delta is the carried #7531 test-only +24/−0 regression coverage in `desktop/tests/e2e/workflows.spec.ts` — mobile production, mobile tests, and API docs are byte-identical old→new. This PR's semantic review requirements remain open and are not affected by this test-only carry. Current-head review 5163162674 predates this head movement. Normal CI on the new head: https://github.com/block/buzz/actions/runs/34444699895 (no green claim is made here).
