### PR TITLE
fix(mobile): stop inferring historical mentions from recipient tags

### DIFF
--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -18,6 +18,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:nostr/nostr.dart' as nostr;
 
 import '../../shared/mentions/agent_identity_provider.dart';
+import '../../shared/mentions/mention_bindings.dart';
 import '../../shared/huddle/huddle_session.dart';
 import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme.dart';

--- a/mobile/lib/features/channels/compose_bar/agent_mention_labels.dart
+++ b/mobile/lib/features/channels/compose_bar/agent_mention_labels.dart
@@ -1,10 +1,36 @@
 part of '../compose_bar.dart';
 
 Set<String> _agentMentionLabels({
-  required Iterable<MentionCandidate> candidates,
-}) {
-  return <String>{
-    for (final candidate in candidates)
-      if (candidate.isAgent) candidate.label,
+  required Map<String, MentionCandidate> bindings,
+}) => {
+  for (final entry in bindings.entries)
+    if (entry.value.isAgent) entry.key,
+};
+
+List<MentionCandidate> _resolveComposerMentions(
+  String text,
+  Map<String, MentionCandidate> selected,
+  List<MentionCandidate> members,
+) {
+  final candidates = <String, List<MentionCandidate>>{
+    for (final e in selected.entries) e.key.toLowerCase(): [e.value],
   };
+  final selectedNames = candidates.keys.toSet();
+  for (final member in members) {
+    final label = member.label.toLowerCase();
+    if (!selectedNames.contains(label)) (candidates[label] ??= []).add(member);
+  }
+  final winners = <String, MentionCandidate>{};
+  for (final range in mentionOccurrences(text, candidates.keys)) {
+    final identities = {
+      for (final c in candidates[range.label]!) c.pubkey.toLowerCase(): c,
+    };
+    if (identities.length > 1) {
+      throw FormatException(
+        'The mention @${range.label} is ambiguous. Choose a recipient from the mention picker.',
+      );
+    }
+    winners.addAll(identities);
+  }
+  return winners.values.toList();
 }

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -220,6 +220,10 @@ class ComposeBar extends HookConsumerWidget {
     // mentions. Used to pass resolved pubkeys directly to onSend and to attach
     // selected non-member agents before the message is published.
     final mentionMap = useRef(<String, MentionCandidate>{});
+    useEffect(() {
+      mentionMap.value.clear();
+      return null;
+    }, [draftIdentity, draftKey]);
 
     // Channel autocomplete state ----------------------------------------------
     final channelQuery = useState<String?>(null);
@@ -244,9 +248,7 @@ class ComposeBar extends HookConsumerWidget {
     // owners so @mention suggestions show names ("managed by …" included).
     final relayAgents = ref.watch(agentDirectoryProvider).asData?.value;
     final agentOwners = ref.watch(agentOwnersProvider).asData?.value;
-    final agentMentionLabels = _agentMentionLabels(
-      candidates: mentionMap.value.values,
-    );
+    final agentMentionLabels = _agentMentionLabels(bindings: mentionMap.value);
     final agentMentionLabelsKey = (agentMentionLabels.toList()..sort()).join(
       '\u0000',
     );
@@ -295,6 +297,15 @@ class ComposeBar extends HookConsumerWidget {
         final text = editingValue.text;
         final sel = editingValue.selection;
         final textChanged = text != previousValue.text;
+        if (textChanged) {
+          // Formatting/code edits may temporarily hide a binding without
+          // deleting its literal. Rendering and send extraction remain separate.
+          final retained = mentionOccurrences(
+            text.replaceAll('`', ' '),
+            mentionMap.value.keys,
+          ).map((range) => range.label).toSet();
+          mentionMap.value.removeWhere((label, _) => !retained.contains(label));
+        }
 
         // Broadcast typing indicator (throttled).
         if (textChanged && text.isNotEmpty) {
@@ -382,7 +393,10 @@ class ComposeBar extends HookConsumerWidget {
 
     // Insert a selected mention into the text field.
     void insertMention(MentionCandidate candidate) {
-      final name = candidate.label;
+      final name = selectedMentionLabel(candidate.label, candidate.pubkey, {
+        for (final entry in mentionMap.value.entries)
+          entry.key: entry.value.pubkey,
+      });
       // Track the resolved candidate so we can pass its pubkey and prepare
       // selected non-member agents at send time.
       mentionMap.value[name] = candidate;
@@ -470,10 +484,27 @@ class ComposeBar extends HookConsumerWidget {
       final messenger = ScaffoldMessenger.maybeOf(context);
 
       // Extract pubkeys for mentions present in the final text.
-      final selectedMentions = <MentionCandidate>[
-        for (final entry in mentionMap.value.entries)
-          if (hasMention(text, entry.key)) entry.value,
-      ];
+      List<MentionCandidate> selectedMentions;
+      try {
+        selectedMentions = _resolveComposerMentions(
+          text,
+          mentionMap.value,
+          buildMentionCandidates(
+            members: channelMembersForAutocomplete(
+              membersAsync: membersAsync,
+              sessionStatus: sessionStatus,
+              cachedMembers: cachedMembers,
+            ),
+            relayAgents: const [],
+            sharedChannelIds: const {},
+            userCache: userCache,
+            ownerByAgentPubkey: agentOwners ?? const {},
+          ),
+        );
+      } on FormatException catch (error) {
+        messenger?.showSnackBar(SnackBar(content: Text(error.message)));
+        return;
+      }
       final outgoing = _OutgoingMentions(selectedMentions);
       final scan = await _scanNonMemberMentions(
         ref,

--- a/mobile/lib/features/channels/compose_bar/markdown_editing_controller.dart
+++ b/mobile/lib/features/channels/compose_bar/markdown_editing_controller.dart
@@ -282,6 +282,16 @@ class _MarkdownEditingController extends TextEditingController {
       if (prefix.isNotEmpty) spans.add(TextSpan(text: prefix, style: style));
 
       final label = match.group(2)!;
+      if (RegExp(r'\([0-9a-f]{64}\)').hasMatch(label)) {
+        spans.add(
+          TextSpan(
+            text: '@$label',
+            style: style.copyWith(color: context.colors.primary),
+          ),
+        );
+        offset = match.end;
+        continue;
+      }
       spans.add(
         WidgetSpan(
           alignment: PlaceholderAlignment.baseline,

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -868,14 +868,11 @@ class _MentionMd extends InlineMd {
       RegExp(r'\(([0-9a-f]{64})\)'),
       (m) => '(${m[1]!.substring(0, 8)}…${m[1]!.substring(60)})',
     );
-    final pill = Semantics(
-      label: fullLabel,
-      excludeSemantics: true,
-      child: _MentionPill(
-        label: visibleLabel,
-        isAgent: isAgent,
-        textStyle: config.style,
-      ),
+    final pill = _MentionPill(
+      label: visibleLabel,
+      semanticsLabel: fullLabel,
+      isAgent: isAgent,
+      textStyle: config.style,
     );
 
     return WidgetSpan(
@@ -890,11 +887,13 @@ class _MentionMd extends InlineMd {
 
 class _MentionPill extends StatelessWidget {
   final String label;
+  final String? semanticsLabel;
   final bool isAgent;
   final TextStyle? textStyle;
 
   const _MentionPill({
     required this.label,
+    this.semanticsLabel,
     required this.isAgent,
     this.textStyle,
   });
@@ -941,7 +940,7 @@ class _MentionPill extends StatelessWidget {
               offset: const Offset(0, -Grid.quarter),
               child: Text('@', style: style),
             ),
-          Text(label, style: style),
+          Text(label, style: style, semanticsLabel: semanticsLabel),
         ],
       ),
     );

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:video_player/video_player.dart';
 
 import '../../shared/clipboard_utils.dart';
+import '../../shared/mentions/mention_bindings.dart';
 import '../../shared/deeplink/deep_link.dart';
 import '../../shared/deeplink/pending_deep_link_provider.dart';
 import '../../shared/relay/relay.dart';
@@ -159,6 +160,7 @@ class MessageContent extends HookConsumerWidget {
         baseStyle ??
         context.textTheme.bodyMedium?.copyWith(color: context.colors.onSurface);
     final resolvedMentionNames = mentionNames;
+    final mentionBindings = renderedMentionBindings(content, mentionNames);
     final resolvedAgentMentionPubkeys = {
       ...agentMentionPubkeys.map((pubkey) => pubkey.toLowerCase()),
     };
@@ -236,14 +238,15 @@ class MessageContent extends HookConsumerWidget {
           mentionBuf.write('`${mentionParts[i]}`');
         } else {
           var segment = mentionParts[i];
-          for (final name in resolvedMentionNames.values) {
-            if (name.contains(' ')) {
-              final normalizedName = _markdownMentionName(name);
-              segment = segment.replaceAllMapped(
-                RegExp('@${RegExp.escape(name)}', caseSensitive: false),
-                (m) => '@$normalizedName',
-              );
-            }
+          for (final range in mentionOccurrences(
+            segment,
+            mentionBindings.keys,
+          ).reversed) {
+            segment = segment.replaceRange(
+              range.start,
+              range.end,
+              '@${_markdownMentionName(range.label)}',
+            );
           }
           mentionBuf.write(segment);
         }
@@ -286,6 +289,14 @@ class MessageContent extends HookConsumerWidget {
         inlineComponents: [
           _MentionMd(
             mentionNames: resolvedMentionNames,
+            bindings: mentionBindings,
+            displayLabels: {
+              for (final range in mentionOccurrences(
+                content,
+                mentionBindings.keys,
+              ))
+                range.label: content.substring(range.start + 1, range.end),
+            },
             agentMentionPubkeys: resolvedAgentMentionPubkeys,
             onMentionTap: onMentionTap,
           ),
@@ -807,16 +818,20 @@ class _MessageCodeBlock extends HookWidget {
 }
 
 class _MentionMd extends InlineMd {
+  final Map<String, Set<String>> bindings;
+  final Map<String, String> displayLabels;
   final Map<String, String> mentionNames;
   final Set<String> agentMentionPubkeys;
   final void Function(String pubkey)? onMentionTap;
   late final RegExp _exp = _buildPrefixPattern(
     prefix: '@',
-    knownNames: _mentionAliases(mentionNames.values),
+    knownNames: bindings.keys.map(_markdownMentionName),
     genericTokenPattern: r'[A-Za-z0-9_][A-Za-z0-9_\u00A0-]*',
   );
 
   _MentionMd({
+    required this.bindings,
+    required this.displayLabels,
     required this.mentionNames,
     required this.agentMentionPubkeys,
     this.onMentionTap,
@@ -837,31 +852,37 @@ class _MentionMd extends InlineMd {
     }
 
     final name = raw.substring(1).replaceAll('\u00A0', ' ').toLowerCase();
-    String? displayName;
-    String? pubkey;
-    for (final entry in mentionNames.entries) {
-      final entryName = entry.value.toLowerCase();
-      final firstName = entryName.split(RegExp(r'\s+')).first;
-      if (entryName == name || firstName == name) {
-        displayName = entry.value;
-        pubkey = entry.key;
-        break;
-      }
+    final matches = bindings[name] ?? const <String>{};
+    final pubkey = matches.length == 1 ? matches.single : null;
+    if (bindings.containsKey(name) && matches.length != 1) {
+      return TextSpan(text: text, style: config.style);
     }
+    final displayName = name.contains(RegExp(r'\([0-9a-f]{64}\)'))
+        ? displayLabels[name]
+        : mentionNames[pubkey];
 
     final isAgent =
         pubkey != null && agentMentionPubkeys.contains(pubkey.toLowerCase());
-    final pill = _MentionPill(
-      label: displayName ?? raw.substring(1),
-      isAgent: isAgent,
-      textStyle: config.style,
+    final fullLabel = displayName ?? raw.substring(1);
+    final visibleLabel = fullLabel.replaceAllMapped(
+      RegExp(r'\(([0-9a-f]{64})\)'),
+      (m) => '(${m[1]!.substring(0, 8)}…${m[1]!.substring(60)})',
+    );
+    final pill = Semantics(
+      label: fullLabel,
+      excludeSemantics: true,
+      child: _MentionPill(
+        label: visibleLabel,
+        isAgent: isAgent,
+        textStyle: config.style,
+      ),
     );
 
     return WidgetSpan(
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
       child: pubkey != null && onMentionTap != null
-          ? GestureDetector(onTap: () => onMentionTap!(pubkey!), child: pill)
+          ? GestureDetector(onTap: () => onMentionTap!(pubkey), child: pill)
           : pill,
     );
   }
@@ -928,15 +949,3 @@ class _MentionPill extends StatelessWidget {
 }
 
 String _markdownMentionName(String name) => name.replaceAll(' ', '\u00A0');
-
-Iterable<String> _mentionAliases(Iterable<String> mentionNames) sync* {
-  for (final name in mentionNames) {
-    final trimmed = name.trim();
-    if (trimmed.isEmpty) continue;
-    yield _markdownMentionName(trimmed);
-    final firstName = trimmed.split(RegExp(r'\s+')).first;
-    if (firstName.isNotEmpty) {
-      yield firstName;
-    }
-  }
-}

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -940,7 +940,9 @@ class _MentionPill extends StatelessWidget {
               offset: const Offset(0, -Grid.quarter),
               child: Text('@', style: style),
             ),
-          Text(label, style: style, semanticsLabel: semanticsLabel),
+          Flexible(
+            child: Text(label, style: style, semanticsLabel: semanticsLabel),
+          ),
         ],
       ),
     );

--- a/mobile/lib/shared/mentions/mention_bindings.dart
+++ b/mobile/lib/shared/mentions/mention_bindings.dart
@@ -1,0 +1,104 @@
+/// Reserve an exact label without retargeting an earlier selection.
+String selectedMentionLabel(
+  String name,
+  String pubkey,
+  Map<String, String> bindings,
+) {
+  final normalized = {
+    for (final e in bindings.entries)
+      e.key.toLowerCase(): e.value.toLowerCase(),
+  };
+  bool conflicts(String label) =>
+      normalized.containsKey(label.toLowerCase()) &&
+      normalized[label.toLowerCase()] != pubkey.toLowerCase();
+  if (!conflicts(name)) return name;
+  final qualified = '$name (${pubkey.toLowerCase()})';
+  var label = qualified;
+  for (var suffix = 2; conflicts(label); suffix++) {
+    label = '$qualified $suffix';
+  }
+  return label;
+}
+
+/// Longest literal ranges win, including labels containing another @ sign.
+/// Recognition precedes eligibility: ambiguous labels still block shorter ones.
+List<({int start, int end, String label})> mentionOccurrences(
+  String text,
+  Iterable<String> labels,
+) {
+  final matches = <int, ({int start, int end, String label})>{};
+  for (final label in labels) {
+    if (label.isEmpty) continue;
+    final pattern = RegExp(
+      '(?:^|\\s|[*_]{1,3}|\\|\\|)(@${RegExp.escape(label)})(?=\\|\\||[\\s,;.!?:)\\]}*_]|\$)',
+      caseSensitive: false,
+    );
+    for (final match in pattern.allMatches(text)) {
+      final start = match.end - match.group(1)!.length;
+      if (matches[start] == null || matches[start]!.end < match.end) {
+        matches[start] = (start: start, end: match.end, label: label);
+      }
+    }
+  }
+  final result = <({int start, int end, String label})>[];
+  for (final match
+      in matches.values.toList()..sort((a, b) => a.start.compareTo(b.start))) {
+    if (result.isEmpty || match.start >= result.last.end) result.add(match);
+  }
+  return result;
+}
+
+/// Reconstruct display bindings only from event-tagged identities, never text
+/// alone. Qualified tagged labels survive profile renames; ambiguous aliases
+/// remain unbound. Mirrors Desktop's resolveMentionProps.
+Map<String, Set<String>> renderedMentionBindings(
+  String content,
+  Map<String, String> names,
+) {
+  final bindings = <String, Set<String>>{};
+  void add(String label, String key) =>
+      (bindings[label.toLowerCase()] ??= {}).add(key.toLowerCase());
+  for (final entry in names.entries) {
+    add(entry.value, entry.key);
+    add(entry.value.split(RegExp(r'\s+')).first, entry.key);
+  }
+  final keys = names.keys.map((key) => key.toLowerCase()).toSet();
+  final qualified = <({String label, String base, String key})>[];
+  for (final match in RegExp(
+    r'@([^@\r\n]+) \(([0-9a-f]{64})\)(?: ((?:[1-9][0-9]+|[2-9])))?',
+    caseSensitive: false,
+  ).allMatches(content)) {
+    final key = match.group(2)!.toLowerCase();
+    final label = match.group(0)!.substring(1).toLowerCase();
+    if (!keys.contains(key) ||
+        !mentionOccurrences(content, [
+          label,
+        ]).any((range) => range.start == match.start)) {
+      continue;
+    }
+    qualified.add((
+      label: label,
+      base: match.group(1)!.toLowerCase(),
+      key: key,
+    ));
+    add(label, key);
+  }
+  final winning = mentionOccurrences(
+    content,
+    bindings.keys,
+  ).map((range) => range.label).toSet();
+  for (final entry in bindings.entries) {
+    if (entry.value.length < 2) continue;
+    entry.value.removeAll(
+      qualified
+          .where(
+            (q) =>
+                q.base == entry.key &&
+                winning.contains(q.label) &&
+                bindings[q.label]?.length == 1,
+          )
+          .map((q) => q.key),
+    );
+  }
+  return bindings;
+}

--- a/mobile/lib/shared/mentions/mention_bindings.dart
+++ b/mobile/lib/shared/mentions/mention_bindings.dart
@@ -29,8 +29,14 @@ List<({int start, int end, String label})> mentionOccurrences(
   final matches = <int, ({int start, int end, String label})>{};
   for (final label in labels) {
     if (label.isEmpty) continue;
+    // A qualifier and reservation suffix belong to the literal even when no
+    // candidate binds it. Never fall back to a shorter, different recipient.
+    final suffix =
+        RegExp(r' \([0-9a-f]{64}\)$', caseSensitive: false).hasMatch(label)
+        ? r'(?! (?:[2-9]|[1-9][0-9]+)(?=[\s,;.!?:)\]}*_]|$))'
+        : '';
     final pattern = RegExp(
-      '(?:^|\\s|[*_]{1,3}|\\|\\|)(@${RegExp.escape(label)})(?=\\|\\||[\\s,;.!?:)\\]}*_]|\$)',
+      '(?:^|\\s|[*_]{1,3}|\\|\\|)(@${RegExp.escape(label)})(?! \\([0-9a-f]{64}\\))$suffix(?=\\|\\||[\\s,;.!?:)\\]}*_]|\$)',
       caseSensitive: false,
     );
     for (final match in pattern.allMatches(text)) {
@@ -70,12 +76,14 @@ Map<String, Set<String>> renderedMentionBindings(
   ).allMatches(content)) {
     final key = match.group(2)!.toLowerCase();
     final label = match.group(0)!.substring(1).toLowerCase();
-    if (!keys.contains(key) ||
-        !mentionOccurrences(content, [
-          label,
-        ]).any((range) => range.start == match.start)) {
+    if (!mentionOccurrences(content, [
+      label,
+    ]).any((range) => range.start == match.start)) {
       continue;
     }
+    // Untagged qualified literals are recognition blockers, not bindings.
+    bindings.putIfAbsent(label, () => <String>{});
+    if (!keys.contains(key)) continue;
     qualified.add((
       label: label,
       base: match.group(1)!.toLowerCase(),

--- a/mobile/lib/shared/mentions/mention_bindings.dart
+++ b/mobile/lib/shared/mentions/mention_bindings.dart
@@ -83,13 +83,12 @@ Map<String, Set<String>> renderedMentionBindings(
     }
     // Untagged qualified literals are recognition blockers, not bindings.
     bindings.putIfAbsent(label, () => <String>{});
-    if (!keys.contains(key)) continue;
     qualified.add((
       label: label,
       base: match.group(1)!.toLowerCase(),
       key: key,
     ));
-    add(label, key);
+    if (keys.contains(key)) add(label, key);
     bindings.putIfAbsent(match.group(1)!.toLowerCase(), () => <String>{});
   }
   final winning = mentionOccurrences(
@@ -98,17 +97,12 @@ Map<String, Set<String>> renderedMentionBindings(
   ).map((range) => range.label).toSet();
   final claimed = qualified.where((q) => winning.contains(q.label)).toList();
   final bases = claimed.map((q) => q.base).where(winning.contains).toSet();
-  final remaining = keys.difference(claimed.map((q) => q.key).toSet());
-  // Ordinary sibling mentions claim their own identities before recovering a
-  // historical namesake. Current aliases must not retarget that namesake.
-  for (final label in winning.difference(bases)) {
-    final candidates = bindings[label]!;
-    if (candidates.length == 1) remaining.removeAll(candidates);
-  }
   for (final base in bases) {
-    // Multiple historical labels or leftover tagged keys cannot be paired
-    // deterministically. Leave them as non-clickable references, not guesses.
-    bindings[base] = bases.length == 1 ? remaining.toSet() : <String>{};
+    // Recipient tags do not encode which literal selected a key. In DMs they
+    // also include non-mentioned recipients, and missing profiles can leave
+    // an unrelated singleton. Even current aliases cannot establish the
+    // historical plain target. Only the qualified literal supplies its key.
+    bindings[base] = <String>{};
   }
   return bindings;
 }

--- a/mobile/lib/shared/mentions/mention_bindings.dart
+++ b/mobile/lib/shared/mentions/mention_bindings.dart
@@ -90,23 +90,25 @@ Map<String, Set<String>> renderedMentionBindings(
       key: key,
     ));
     add(label, key);
+    bindings.putIfAbsent(match.group(1)!.toLowerCase(), () => <String>{});
   }
   final winning = mentionOccurrences(
     content,
     bindings.keys,
   ).map((range) => range.label).toSet();
-  for (final entry in bindings.entries) {
-    if (entry.value.length < 2) continue;
-    entry.value.removeAll(
-      qualified
-          .where(
-            (q) =>
-                q.base == entry.key &&
-                winning.contains(q.label) &&
-                bindings[q.label]?.length == 1,
-          )
-          .map((q) => q.key),
-    );
+  final claimed = qualified.where((q) => winning.contains(q.label)).toList();
+  final bases = claimed.map((q) => q.base).where(winning.contains).toSet();
+  final remaining = keys.difference(claimed.map((q) => q.key).toSet());
+  // Ordinary sibling mentions claim their own identities before recovering a
+  // historical namesake. Current aliases must not retarget that namesake.
+  for (final label in winning.difference(bases)) {
+    final candidates = bindings[label]!;
+    if (candidates.length == 1) remaining.removeAll(candidates);
+  }
+  for (final base in bases) {
+    // Multiple historical labels or leftover tagged keys cannot be paired
+    // deterministically. Leave them as non-clickable references, not guesses.
+    bindings[base] = bases.length == 1 ? remaining.toSet() : <String>{};
   }
   return bindings;
 }

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -30,6 +30,8 @@ import 'package:buzz/shared/widgets/anchored_popover_menu.dart';
 import 'package:buzz/shared/widgets/mobile_tab_footer_backdrop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+part 'compose_bar_test/exact_mention_tests.dart';
+
 final _pngBytes = Uint8List.fromList([
   0x89,
   0x50,
@@ -641,6 +643,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
 }
 
 void main() {
+  exactMentionTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() async {

--- a/mobile/test/features/channels/compose_bar_test/exact_mention_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/exact_mention_tests.dart
@@ -1,0 +1,87 @@
+part of '../compose_bar_test.dart';
+
+void exactMentionTests() {
+  final first = 'a' * 64;
+  final second = 'b' * 64;
+  List<ChannelMember> members() => [
+    for (final key in [first, second])
+      ChannelMember(
+        pubkey: key,
+        displayName: 'Scout',
+        role: 'member',
+        joinedAt: DateTime(2025),
+      ),
+  ];
+  testWidgets(
+    'same-name picker selections retain exact recipients through removal',
+    (tester) async {
+      List<String>? sent;
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(nostr.Keys.generate().nsec),
+          members: members(),
+          channels: [_makeCurrentChannel()],
+          onSend: (_, keys, {mediaTags = const []}) async {
+            sent = keys;
+          },
+        ),
+      );
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Scout').first);
+      await tester.pumpAndSettle();
+      final controller = tester
+          .widget<TextField>(find.byType(TextField))
+          .controller!;
+      expect(controller.text, '@Scout ');
+      await tester.enterText(find.byType(TextField), '@Scout @');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Scout').last);
+      await tester.pumpAndSettle();
+      expect(controller.text, '@Scout @Scout ($second) ');
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pumpAndSettle();
+      expect(sent, [first, second]);
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Scout').first);
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '@Scout @');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Scout').last);
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '@Scout ($second) ');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pumpAndSettle();
+      expect(sent, [second]);
+    },
+  );
+
+  testWidgets('ambiguous typed names fail visibly without clearing the draft', (
+    tester,
+  ) async {
+    var sent = false;
+    await tester.pumpWidget(
+      _buildComposeBar(
+        uploadService: _testUploadService(nostr.Keys.generate().nsec),
+        members: members(),
+        onSend: (_, _, {mediaTags = const []}) async {
+          sent = true;
+        },
+      ),
+    );
+    await _expandComposer(tester);
+    await tester.enterText(find.byType(TextField), '@Scout hello');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(LucideIcons.arrowUp));
+    await tester.pumpAndSettle();
+    expect(sent, isFalse);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      '@Scout hello',
+    );
+    expect(find.textContaining('is ambiguous'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/channels/compose_bar_test/exact_mention_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/exact_mention_tests.dart
@@ -59,6 +59,25 @@ void exactMentionTests() {
     },
   );
 
+  testWidgets('unbound qualified text cannot notify a shorter member alias', (
+    tester,
+  ) async {
+    List<String>? sent;
+    await tester.pumpWidget(
+      _buildComposeBar(
+        uploadService: _testUploadService(nostr.Keys.generate().nsec),
+        members: [members().first],
+        onSend: (_, keys, {mediaTags = const []}) async => sent = keys,
+      ),
+    );
+    await _expandComposer(tester);
+    await tester.enterText(find.byType(TextField), '@Scout ($second)');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(LucideIcons.arrowUp));
+    await tester.pumpAndSettle();
+    expect(sent, isEmpty);
+  });
+
   testWidgets('ambiguous typed names fail visibly without clearing the draft', (
     tester,
   ) async {

--- a/mobile/test/features/channels/message_content_exact_mentions_test.dart
+++ b/mobile/test/features/channels/message_content_exact_mentions_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/features/channels/message_content.dart';
+import '../../helpers/widget_helpers.dart';
+
+void main() {
+  testWidgets('namesake chips resolve exact tagged keys, not tag order', (
+    tester,
+  ) async {
+    final first = 'a' * 64;
+    final second = 'b' * 64;
+    String? tapped;
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        child: MessageContent(
+          content: '@Scout @Scout ($second)',
+          mentionNames: {second: 'Scout', first: 'Scout'},
+          onMentionTap: (key) => tapped = key,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Scout'));
+    expect(tapped, first);
+    await tester.tap(find.text('Scout (bbbbbbbb…bbbb)'));
+    expect(tapped, second);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/mobile/test/features/channels/message_content_exact_mentions_test.dart
+++ b/mobile/test/features/channels/message_content_exact_mentions_test.dart
@@ -6,6 +6,7 @@ void main() {
   testWidgets('namesake chips resolve exact tagged keys, not tag order', (
     tester,
   ) async {
+    final semantics = tester.ensureSemantics();
     final first = 'a' * 64;
     final second = 'b' * 64;
     String? tapped;
@@ -23,6 +24,8 @@ void main() {
     expect(tapped, first);
     await tester.tap(find.text('Scout (bbbbbbbb…bbbb)'));
     expect(tapped, second);
+    expect(find.bySemanticsLabel(RegExp('Scout.*$second')), findsOneWidget);
     expect(tester.takeException(), isNull);
+    semantics.dispose();
   });
 }

--- a/mobile/test/features/channels/message_content_exact_mentions_test.dart
+++ b/mobile/test/features/channels/message_content_exact_mentions_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:buzz/features/channels/message_content.dart';
 import '../../helpers/widget_helpers.dart';
@@ -17,6 +18,27 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text('Scout'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('qualified chips wrap in narrow layouts at large text sizes', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        child: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: MessageContent(
+            content: '@Scout (${'b' * 64})',
+            mentionNames: {'b' * 64: 'Scout'},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
   });
 

--- a/mobile/test/features/channels/message_content_exact_mentions_test.dart
+++ b/mobile/test/features/channels/message_content_exact_mentions_test.dart
@@ -1,16 +1,68 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:buzz/features/channels/message_content.dart';
+import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/message_mention_pubkeys.dart';
+import 'package:buzz/shared/mentions/mention_tags.dart';
 import '../../helpers/widget_helpers.dart';
 
 void main() {
+  testWidgets('DM recipients cannot supply a missing historical identity', (
+    tester,
+  ) async {
+    final first = 'a' * 64, second = 'b' * 64, bob = 'c' * 64;
+    final recipients = messageMentionPubkeys(
+      channel: Channel(
+        id: 'dm',
+        name: 'DM',
+        channelType: 'dm',
+        visibility: 'private',
+        description: '',
+        createdBy: 'self',
+        createdAt: DateTime(2026),
+        memberCount: 4,
+      ),
+      senderPubkey: 'self',
+      explicitMentions: [first, second],
+      dmRecipientPubkeys: [first, second, bob],
+    );
+    final keys = mentionedPubkeysFromTags([
+      for (final key in recipients) ['p', key],
+    ]);
+    // MessageBubble omits profiles with no displayName. Bob is only a DM
+    // recipient, not the author-selected plain Scout.
+    final profiles = {second: 'Scout', bob: 'Bob'};
+    String? tapped;
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        child: MessageContent(
+          content: '@Scout @Scout ($second)',
+          mentionNames: {
+            for (final key in keys)
+              if (profiles[key] != null) key: profiles[key]!,
+          },
+          onMentionTap: (key) => tapped = key,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    if (find.text('Bob').evaluate().isNotEmpty) {
+      await tester.tap(find.text('Bob'));
+    }
+    expect(tapped, isNot(bob));
+    expect(find.text('Bob'), findsNothing);
+    expect(find.text('Scout'), findsNothing);
+    await tester.tap(find.text('Scout (bbbbbbbb…bbbb)'));
+    expect(tapped, second);
+  });
+
   testWidgets('untagged qualifiers cannot become shorter clickable aliases', (
     tester,
   ) async {
     await tester.pumpWidget(
       WidgetHelpers.testable(
         child: MessageContent(
-          content: '@Scout (${'b' * 64})',
+          content: '@Scout @Scout (${'b' * 64})',
           mentionNames: {'a' * 64: 'Scout'},
           onMentionTap: (_) => fail('unbound text is not a profile target'),
         ),
@@ -42,7 +94,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('namesake chips resolve exact tagged keys, not tag order', (
+  testWidgets('only qualified namesake chips have an exact historical target', (
     tester,
   ) async {
     final semantics = tester.ensureSemantics();
@@ -59,54 +111,49 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Scout'));
-    expect(tapped, first);
+    expect(find.text('Scout'), findsNothing);
     await tester.tap(find.text('Scout (bbbbbbbb…bbbb)'));
     expect(tapped, second);
     expect(find.bySemanticsLabel(RegExp('Scout.*$second')), findsOneWidget);
     expect(tester.takeException(), isNull);
     semantics.dispose();
   });
-  testWidgets('historical namesakes preserve targets with ordinary siblings', (
-    tester,
-  ) async {
-    final first = 'a' * 64, second = 'b' * 64, sibling = 'c' * 64;
-    for (final firstName in ['Scout', 'Renamed Scout', first]) {
-      for (final secondName in ['Scout', 'Renamed Scout', second]) {
-        for (final reverse in [false, true]) {
-          for (final ambiguous in [false, true]) {
-            final entries = {
-              first: firstName,
-              second: secondName,
-              sibling: 'Alice',
-              if (ambiguous) 'd' * 64: 'Unknown',
-            }.entries.toList();
-            String? tapped;
-            await tester.pumpWidget(
-              WidgetHelpers.testable(
-                child: MessageContent(
-                  content: '@Scout @Scout ($second) @Alice',
-                  mentionNames: Map.fromEntries(
-                    reverse ? entries.reversed : entries,
+  testWidgets(
+    'historical plain namesakes stay unbound with ordinary siblings',
+    (tester) async {
+      final first = 'a' * 64, second = 'b' * 64, sibling = 'c' * 64;
+      for (final firstName in ['Scout', 'Renamed Scout', first]) {
+        for (final secondName in ['Scout', 'Renamed Scout', second]) {
+          for (final reverse in [false, true]) {
+            for (final ambiguous in [false, true]) {
+              final entries = {
+                first: firstName,
+                second: secondName,
+                sibling: 'Alice',
+                if (ambiguous) 'd' * 64: 'Unknown',
+              }.entries.toList();
+              String? tapped;
+              await tester.pumpWidget(
+                WidgetHelpers.testable(
+                  child: MessageContent(
+                    content: '@Scout @Scout ($second) @Alice',
+                    mentionNames: Map.fromEntries(
+                      reverse ? entries.reversed : entries,
+                    ),
+                    onMentionTap: (key) => tapped = key,
                   ),
-                  onMentionTap: (key) => tapped = key,
                 ),
-              ),
-            );
-            await tester.pumpAndSettle();
-            if (ambiguous) {
+              );
+              await tester.pumpAndSettle();
               expect(find.text(firstName), findsNothing);
-            } else {
-              await tester.tap(find.text(firstName));
-              expect(tapped, first);
+              await tester.tap(find.text('Scout (bbbbbbbb…bbbb)'));
+              expect(tapped, second);
+              await tester.tap(find.text('Alice'));
+              expect(tapped, sibling);
             }
-            await tester.tap(find.text('Scout (bbbbbbbb…bbbb)'));
-            expect(tapped, second);
-            await tester.tap(find.text('Alice'));
-            expect(tapped, sibling);
           }
         }
       }
-    }
-  });
+    },
+  );
 }

--- a/mobile/test/features/channels/message_content_exact_mentions_test.dart
+++ b/mobile/test/features/channels/message_content_exact_mentions_test.dart
@@ -3,6 +3,23 @@ import 'package:buzz/features/channels/message_content.dart';
 import '../../helpers/widget_helpers.dart';
 
 void main() {
+  testWidgets('untagged qualifiers cannot become shorter clickable aliases', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        child: MessageContent(
+          content: '@Scout (${'b' * 64})',
+          mentionNames: {'a' * 64: 'Scout'},
+          onMentionTap: (_) => fail('unbound text is not a profile target'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Scout'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('namesake chips resolve exact tagged keys, not tag order', (
     tester,
   ) async {

--- a/mobile/test/features/channels/message_content_exact_mentions_test.dart
+++ b/mobile/test/features/channels/message_content_exact_mentions_test.dart
@@ -67,4 +67,46 @@ void main() {
     expect(tester.takeException(), isNull);
     semantics.dispose();
   });
+  testWidgets('historical namesakes preserve targets with ordinary siblings', (
+    tester,
+  ) async {
+    final first = 'a' * 64, second = 'b' * 64, sibling = 'c' * 64;
+    for (final firstName in ['Scout', 'Renamed Scout', first]) {
+      for (final secondName in ['Scout', 'Renamed Scout', second]) {
+        for (final reverse in [false, true]) {
+          for (final ambiguous in [false, true]) {
+            final entries = {
+              first: firstName,
+              second: secondName,
+              sibling: 'Alice',
+              if (ambiguous) 'd' * 64: 'Unknown',
+            }.entries.toList();
+            String? tapped;
+            await tester.pumpWidget(
+              WidgetHelpers.testable(
+                child: MessageContent(
+                  content: '@Scout @Scout ($second) @Alice',
+                  mentionNames: Map.fromEntries(
+                    reverse ? entries.reversed : entries,
+                  ),
+                  onMentionTap: (key) => tapped = key,
+                ),
+              ),
+            );
+            await tester.pumpAndSettle();
+            if (ambiguous) {
+              expect(find.text(firstName), findsNothing);
+            } else {
+              await tester.tap(find.text(firstName));
+              expect(tapped, first);
+            }
+            await tester.tap(find.text('Scout (bbbbbbbb…bbbb)'));
+            expect(tapped, second);
+            await tester.tap(find.text('Alice'));
+            expect(tapped, sibling);
+          }
+        }
+      }
+    }
+  });
 }

--- a/mobile/test/shared/mentions/mention_bindings_test.dart
+++ b/mobile/test/shared/mentions/mention_bindings_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/shared/mentions/mention_bindings.dart';
+
+void main() {
+  final first = 'a' * 64;
+  final second = 'b' * 64;
+  test('qualification is case-insensitive and collision-safe', () {
+    final bindings = {'Scout': first, 'Scout ($second)': first};
+    expect(selectedMentionLabel('scout', first, bindings), 'scout');
+    expect(
+      selectedMentionLabel('Scout', second, bindings),
+      'Scout ($second) 2',
+    );
+  });
+  test('longest occurrences block shorter and interior recipients', () {
+    expect(
+      mentionOccurrences('@Scout ($second) 2', [
+        'Scout',
+        'Scout ($second)',
+        'Scout ($second) 2',
+      ]).single.label,
+      'Scout ($second) 2',
+    );
+    expect(mentionOccurrences('@A @B', ['A @B', 'B']).single.label, 'A @B');
+    expect(mentionOccurrences('mail@Scout', ['Scout']), isEmpty);
+  });
+  test(
+    'tagged qualified identity narrows a namesake independently of tag order',
+    () {
+      for (final names in [
+        {'a': 'Scout', second: 'Scout'},
+        {second: 'Scout', 'a': 'Scout'},
+      ]) {
+        final bindings = renderedMentionBindings(
+          '@Scout @Scout ($second)',
+          names,
+        );
+        expect(bindings['scout'], {'a'});
+        expect(bindings['scout ($second)'], {second});
+      }
+      expect(
+        renderedMentionBindings('@Scout', {
+          first: 'Scout',
+          second: 'Scout',
+        })['scout'],
+        {first, second},
+      );
+      expect(
+        renderedMentionBindings('@Scout ($second)', {
+          first: 'Scout',
+        })['scout ($second)'],
+        isNull,
+      );
+      expect(
+        renderedMentionBindings('@Old ($second)', {
+          second: 'New',
+        })['old ($second)'],
+        {second},
+      );
+    },
+  );
+}

--- a/mobile/test/shared/mentions/mention_bindings_test.dart
+++ b/mobile/test/shared/mentions/mention_bindings_test.dart
@@ -29,39 +29,51 @@ void main() {
       isEmpty,
     );
   });
-  test(
-    'tagged qualified identity narrows a namesake independently of tag order',
-    () {
-      for (final names in [
-        {'a': 'Scout', second: 'Scout'},
-        {second: 'Scout', 'a': 'Scout'},
-      ]) {
-        final bindings = renderedMentionBindings(
-          '@Scout @Scout ($second)',
-          names,
-        );
-        expect(bindings['scout'], {'a'});
-        expect(bindings['scout ($second)'], {second});
-      }
-      expect(
-        renderedMentionBindings('@Scout', {
-          first: 'Scout',
-          second: 'Scout',
-        })['scout'],
-        {first, second},
+  test('multiple historical bases remain unbound despite current aliases', () {
+    final bindings = renderedMentionBindings(
+      '@Scout @Scout ($second) @Zed @Zed ($first)',
+      {
+        first: 'Old Zed',
+        second: 'Old Scout',
+        'c' * 64: 'Scout',
+        'd' * 64: 'Zed',
+      },
+    );
+    expect(bindings['scout'], isEmpty);
+    expect(bindings['zed'], isEmpty);
+    expect(bindings['scout ($second)'], {second});
+    expect(bindings['zed ($first)'], {first});
+  });
+  test('qualified identity does not authorize an inferred plain namesake', () {
+    for (final names in [
+      {'a': 'Scout', second: 'Scout'},
+      {second: 'Scout', 'a': 'Scout'},
+    ]) {
+      final bindings = renderedMentionBindings(
+        '@Scout @Scout ($second)',
+        names,
       );
-      expect(
-        renderedMentionBindings('@Scout ($second)', {
-          first: 'Scout',
-        })['scout ($second)'],
-        isEmpty,
-      );
-      expect(
-        renderedMentionBindings('@Old ($second)', {
-          second: 'New',
-        })['old ($second)'],
-        {second},
-      );
-    },
-  );
+      expect(bindings['scout'], isEmpty);
+      expect(bindings['scout ($second)'], {second});
+    }
+    expect(
+      renderedMentionBindings('@Scout', {
+        first: 'Scout',
+        second: 'Scout',
+      })['scout'],
+      {first, second},
+    );
+    expect(
+      renderedMentionBindings('@Scout ($second)', {
+        first: 'Scout',
+      })['scout ($second)'],
+      isEmpty,
+    );
+    expect(
+      renderedMentionBindings('@Old ($second)', {
+        second: 'New',
+      })['old ($second)'],
+      {second},
+    );
+  });
 }

--- a/mobile/test/shared/mentions/mention_bindings_test.dart
+++ b/mobile/test/shared/mentions/mention_bindings_test.dart
@@ -23,6 +23,11 @@ void main() {
     );
     expect(mentionOccurrences('@A @B', ['A @B', 'B']).single.label, 'A @B');
     expect(mentionOccurrences('mail@Scout', ['Scout']), isEmpty);
+    expect(mentionOccurrences('@Scout ($second)', ['Scout']), isEmpty);
+    expect(
+      mentionOccurrences('@Scout ($second) 2', ['Scout ($second)']),
+      isEmpty,
+    );
   });
   test(
     'tagged qualified identity narrows a namesake independently of tag order',
@@ -49,7 +54,7 @@ void main() {
         renderedMentionBindings('@Scout ($second)', {
           first: 'Scout',
         })['scout ($second)'],
-        isNull,
+        isEmpty,
       );
       expect(
         renderedMentionBindings('@Old ($second)', {


### PR DESCRIPTION
## Summary

Dependent correction to #7385; closest related PRs: #7385 and its persistence sibling #7387. No merges or persistence/provider changes.

- Stop assigning a historical plain namesake to a leftover event recipient. Recipient membership does not establish the literal→key identity, even if exactly one labeled key remains.
- Keep qualified, event-tagged full-key literals clickable through renames; plain siblings remain text, even when the qualifier’s profile is unavailable (recognition is not binding authority). Ordinary mentions outside this historical namesake ambiguity retain existing behavior.
- Add a production MessageContent tap regression fed by the real DM recipient helper and tag reader, with the actual missing-profile intake shape. Cover multiple historical bases and retain the 36-case rename/order/extra-recipient matrix with conservative plain-label expectations.

### Evidence and tradeoff

F1 is a real wrong-target bug, not an accepted residual: with `@Scout @Scout (bbb…)`, Scout A unavailable, and unrelated DM recipient Bob available, the parent resolver opens Bob. Both reproduction and restoring the parent resolver against the final regression fail with Bob's exact key as the actual tap target.

Mobile sends merge explicit and DM recipients into identical `p` tags. Existing `mention` tags can also carry non-text agent-address recipients. Neither membership list establishes a historical label→key map; no new protocol is proposed. Therefore unqualified historical namesakes cannot safely be reconstructed, even in apparently unambiguous old messages. Explicit tagged qualifiers retain the safe rename behavior; no claim is made to recover information absent from the event.

## Testing

At `446f9b14f6a0bfafad9ea575da2da1d89c44b0e4`:
- `just mobile-test`: **2,084 passed**, exit 0.
- `just mobile-check`: formatter/analyzer passed, exit 0.
- Focused resolver/render suite: 9 passed.
- Parent-resolver mutation: regression fails on actual wrong Bob tap; production restored cleanly.
- `git diff --check`: passed; dependent delta **138 additions + 85 deletions = 223**, strictly below 600 including tests.

Unchanged non-mobile evidence reused from https://github.com/block/buzz/pull/7385#issuecomment-5574635836; no new repository-wide `just ci`, native-device, simulator, VoiceOver, security review or CI-green claim. CI monitoring is separate. Existing #7385/#7387 descriptions and screenshots are preserved; this change alters no layout and commits no screenshots.

## Next gate

Renewed narrow independent review of inferred identity authority and conservative plain-label behavior. #7387 remains an unchanged sibling based on #7385; this correction must also be integrated for the stack to include the safety fix. Saved-`isAgent` eligibility remains SEND-owned. Not merge-ready; no fabricated approval.
