### PR TITLE
fix(mobile): keep discovery ownership and policy readiness consistent

### DIFF
--- a/desktop/tests/e2e/forum-agent-invitation.spec.ts
+++ b/desktop/tests/e2e/forum-agent-invitation.spec.ts
@@ -430,7 +430,11 @@ for (const stage of ["add", "publish"] as const) {
         await expect(
           page.getByRole("button", { name: "Remove attachment" }),
         ).toBeVisible();
-      if (replacement !== null)
+      if (replacement === "") {
+        await page.getByTestId("message-input").press("ControlOrMeta+a");
+        await page.getByTestId("message-input").press("Backspace");
+        await expect(page.getByTestId("message-input")).toBeEmpty();
+      } else if (replacement !== null)
         await page.getByTestId("message-input").fill(replacement);
       await navigate(1);
       await releaseForumGate(page);

--- a/desktop/tests/e2e/profile-custom-emoji-status.spec.ts
+++ b/desktop/tests/e2e/profile-custom-emoji-status.spec.ts
@@ -196,13 +196,13 @@ test("set status dialog uses the desktop modal with shared status choices", asyn
 test("keeps an open status draft when the saved status expires", async ({
   page,
 }) => {
-  // Freeze the browser clock before navigation so the seeded two-second
-  // status cannot expire while the popover/editor setup runs, and so the
-  // seeded node-side timestamps match the browser clock exactly. Expiry is
-  // crossed deliberately below, after the editor owns the saved draft.
+  // Pin the browser Date before navigation so the seeded two-second status
+  // cannot expire while the popover/editor setup runs, however slow the
+  // machine; timers, network, and rendering keep running, and the seeded
+  // node-side timestamps match the pinned Date exactly.
   const seededAt = new Date("2026-09-10T12:00:00.000Z");
   const nowSeconds = Math.floor(seededAt.getTime() / 1_000);
-  await page.clock.install({ time: seededAt });
+  await page.clock.setFixedTime(seededAt);
   await page.goto("/");
   await seedMockStatus(page, {
     text: "Original draft",
@@ -225,6 +225,8 @@ test("keeps an open status draft when the saved status expires", async ({
     0,
   );
   await dialog.getByTestId("set-status-input").fill("Unsaved draft");
+  // Advance the pinned Date past the deadline, then fire the pending timer.
+  await page.clock.setFixedTime(new Date(seededAt.getTime() + 3_000));
   await page.clock.fastForward(2_500);
   await expect(page.getByTestId("sidebar-profile-user-status")).toHaveCount(0, {
     timeout: 5_000,
@@ -249,13 +251,13 @@ test("keeps an open status draft when the saved status expires", async ({
 test("opens a fresh editor when the saved status expired before opening", async ({
   page,
 }) => {
-  // Causal control for the setup ordering above: the same frozen clock and
+  // Causal control for the setup ordering above: the same pinned clock and
   // seed, but the deadline is crossed before the editor opens. The dialog
   // must then be a new-status editor — the saved-editor precondition
   // assertions above would fail under this wrong ordering.
   const seededAt = new Date("2026-09-10T12:00:00.000Z");
   const nowSeconds = Math.floor(seededAt.getTime() / 1_000);
-  await page.clock.install({ time: seededAt });
+  await page.clock.setFixedTime(seededAt);
   await page.goto("/");
   await seedMockStatus(page, {
     text: "Original draft",
@@ -263,6 +265,7 @@ test("opens a fresh editor when the saved status expired before opening", async 
     expiresAt: nowSeconds + 2,
     createdAt: nowSeconds,
   });
+  await page.clock.setFixedTime(new Date(seededAt.getTime() + 5_000));
   await page.clock.fastForward(5_000);
   await expect(page.getByTestId("sidebar-profile-user-status")).toHaveCount(0);
   await page.getByTestId("profile-popover-set-status").click();

--- a/desktop/tests/e2e/profile-custom-emoji-status.spec.ts
+++ b/desktop/tests/e2e/profile-custom-emoji-status.spec.ts
@@ -196,8 +196,14 @@ test("set status dialog uses the desktop modal with shared status choices", asyn
 test("keeps an open status draft when the saved status expires", async ({
   page,
 }) => {
+  // Freeze the browser clock before navigation so the seeded two-second
+  // status cannot expire while the popover/editor setup runs, and so the
+  // seeded node-side timestamps match the browser clock exactly. Expiry is
+  // crossed deliberately below, after the editor owns the saved draft.
+  const seededAt = new Date("2026-09-10T12:00:00.000Z");
+  const nowSeconds = Math.floor(seededAt.getTime() / 1_000);
+  await page.clock.install({ time: seededAt });
   await page.goto("/");
-  const nowSeconds = Math.floor(Date.now() / 1_000);
   await seedMockStatus(page, {
     text: "Original draft",
     emoji: "📝",
@@ -206,7 +212,20 @@ test("keeps an open status draft when the saved status expires", async ({
   });
   await page.getByTestId("profile-popover-set-status").click();
   const dialog = page.getByTestId("set-status-dialog");
+  // The editor opened on the still-saved status, not on a fresh one.
+  await expect(dialog.getByTestId("set-status-input")).toHaveValue(
+    "Original draft",
+  );
+  await expect(dialog.getByTestId("set-status-duration")).toContainText(
+    "Custom",
+  );
+  await expect(dialog.getByLabel("Choose a status emoji")).toContainText("📝");
+  await expect(dialog.getByTestId("set-status-clear")).toBeVisible();
+  await expect(dialog.getByText("Quick statuses", { exact: true })).toHaveCount(
+    0,
+  );
   await dialog.getByTestId("set-status-input").fill("Unsaved draft");
+  await page.clock.fastForward(2_500);
   await expect(page.getByTestId("sidebar-profile-user-status")).toHaveCount(0, {
     timeout: 5_000,
   });
@@ -225,6 +244,37 @@ test("keeps an open status draft when the saved status expires", async ({
     0,
   );
   await expect(dialog.getByTestId("set-status-clear")).toBeVisible();
+});
+
+test("opens a fresh editor when the saved status expired before opening", async ({
+  page,
+}) => {
+  // Causal control for the setup ordering above: the same frozen clock and
+  // seed, but the deadline is crossed before the editor opens. The dialog
+  // must then be a new-status editor — the saved-editor precondition
+  // assertions above would fail under this wrong ordering.
+  const seededAt = new Date("2026-09-10T12:00:00.000Z");
+  const nowSeconds = Math.floor(seededAt.getTime() / 1_000);
+  await page.clock.install({ time: seededAt });
+  await page.goto("/");
+  await seedMockStatus(page, {
+    text: "Original draft",
+    emoji: "📝",
+    expiresAt: nowSeconds + 2,
+    createdAt: nowSeconds,
+  });
+  await page.clock.fastForward(5_000);
+  await expect(page.getByTestId("sidebar-profile-user-status")).toHaveCount(0);
+  await page.getByTestId("profile-popover-set-status").click();
+  const dialog = page.getByTestId("set-status-dialog");
+  await expect(dialog.getByTestId("set-status-input")).toHaveValue("");
+  await expect(dialog.getByTestId("set-status-duration")).toContainText(
+    "Today",
+  );
+  await expect(
+    dialog.getByText("Quick statuses", { exact: true }),
+  ).toBeVisible();
+  await expect(dialog.getByTestId("set-status-clear")).toHaveCount(0);
 });
 
 test("new statuses default to expiring at local midnight", async ({ page }) => {

--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -57,6 +57,7 @@ List<MentionCandidate> buildMentionCandidates({
   required Map<String, String> ownerByAgentPubkey,
   List<UserProfile> searchResults = const [],
   String? currentPubkey,
+  bool directoryReady = true,
 }) {
   final candidates = <MentionCandidate>[];
   final seen = <String>{};
@@ -68,8 +69,10 @@ List<MentionCandidate> buildMentionCandidates({
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile?.ownerPubkey;
     final isAgent = member.isBot || ownerPubkey != null;
     final policy = relayAgents.where((agent) => agent.pubkey == pk).firstOrNull;
-    if (policy?.ownerPubkey != null &&
-        !agentIsSharedWithUser(policy!, sharedChannelIds, currentPubkey)) {
+    if (ownerPubkey != null &&
+        (!directoryReady ||
+            policy?.ownerPubkey == null ||
+            !agentIsSharedWithUser(policy!, sharedChannelIds, currentPubkey))) {
       continue;
     }
     candidates.add(
@@ -98,6 +101,7 @@ List<MentionCandidate> buildMentionCandidates({
   }
 
   for (final agent in relayAgents) {
+    if (!directoryReady && agent.ownerPubkey != null) continue;
     final pk = agent.pubkey;
     if (seen.contains(pk)) continue;
     if (!sharedAgentPubkeys.contains(pk)) continue;
@@ -135,7 +139,10 @@ List<MentionCandidate> buildMentionCandidates({
       final policy = relayAgents
           .where((agent) => agent.pubkey == pk)
           .firstOrNull;
-      if (policy?.ownerPubkey != null && !sharedAgentPubkeys.contains(pk)) {
+      if (ownerPubkey != null &&
+          (!directoryReady ||
+              policy?.ownerPubkey == null ||
+              !sharedAgentPubkeys.contains(pk))) {
         continue;
       }
       if (!ownedByCurrentUser && !sharedAgentPubkeys.contains(pk)) {

--- a/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
@@ -77,9 +77,9 @@ final mentionCandidatesProvider = Provider.family
         sessionStatus: sessionStatus,
         cachedMembers: cachedMembers,
       );
+      final directory = ref.watch(agentDirectoryProvider);
       final relayAgents =
-          ref.watch(agentDirectoryProvider).asData?.value ??
-          const <AgentDirectoryEntry>[];
+          directory.asData?.value ?? const <AgentDirectoryEntry>[];
       final owners = ref.watch(agentOwnersProvider).asData?.value ?? const {};
       final channels = channelsAsync.asData?.value ?? const <Channel>[];
       final userCache = ref.watch(userCacheProvider);
@@ -96,6 +96,7 @@ final mentionCandidatesProvider = Provider.family
       final candidates = buildMentionCandidates(
         members: members,
         relayAgents: relayAgents,
+        directoryReady: !directory.isLoading && !directory.hasError,
         sharedChannelIds: sharedChannelIds,
         userCache: userCache,
         ownerByAgentPubkey: owners,

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../shared/crypto/nip_oa.dart';
 import '../../shared/profile/user_cache_provider.dart';
 import '../../shared/profile/user_profile.dart';
 import '../../shared/relay/relay.dart';
@@ -69,9 +68,7 @@ final profileAvatarHandoffProvider =
 /// WebSocket. Returns null when no nsec is configured or when the user has
 /// not yet published a profile.
 class ProfileNotifier extends AsyncNotifier<UserProfile?> {
-  Map<String, dynamic> _metadata = {};
   bool _hasHydrated = false;
-  int _lastCreatedAt = 0;
   Future<void> _patchQueue = Future.value();
 
   @override
@@ -92,37 +89,19 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
     final myPk = context.pubkey;
     if (myPk == null) {
       _requireCurrentWriteContext(context);
-      _metadata = {};
-      _lastCreatedAt = 0;
       _hasHydrated = true;
       return null;
     }
 
     final session = context.session;
     final events = await session.fetchHistory(NostrFilters.profile(myPk));
-    if (events.isEmpty) {
-      _requireCurrentWriteContext(context);
-      _metadata = {};
-      _lastCreatedAt = 0;
-      _hasHydrated = true;
-      return null;
-    }
-    final latest = _latestProfileEvent(events)!;
-    final metadata = _decodeProfileMetadata(latest);
-    final data = ProfileData.fromEvent(latest);
-    final profile = UserProfile(
-      pubkey: data.pubkey,
-      displayName: data.displayName,
-      avatarUrl: data.avatarUrl,
-      about: data.about,
-      nip05Handle: data.nip05,
-      ownerPubkey: verifiedOaOwnerPubkey(latest),
-    );
     _requireCurrentWriteContext(context);
-    _metadata = metadata;
-    _lastCreatedAt = latest.createdAt;
+    final cache = ref.read(userCacheProvider.notifier);
+    for (final event in events) {
+      cache.cacheProfileEvent(event);
+    }
     _hasHydrated = true;
-    return profile;
+    return ref.read(userCacheProvider)[myPk.toLowerCase()];
   }
 
   Future<void> refresh() async {
@@ -182,9 +161,12 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
       NostrFilters.profile(pubkey),
     );
     _requireCurrentWriteContext(context);
-    final currentHead = _latestProfileEvent(currentEvents);
-    if (_lastCreatedAt > 0 &&
-        (currentHead == null || currentHead.createdAt < _lastCreatedAt)) {
+    final cache = ref.read(userCacheProvider.notifier);
+    for (final event in currentEvents) {
+      cache.cacheProfileEvent(event);
+    }
+    final currentHead = cache.profileEvent(pubkey);
+    if (currentHead?.id != _latestProfileEvent(currentEvents)?.id) {
       throw StateError('Cannot confirm the latest profile metadata.');
     }
     final currentMetadata = currentHead == null
@@ -199,10 +181,7 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
     final relay = SignedEventRelay(session: session, nsec: context.config.nsec);
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final currentCreatedAt = currentHead?.createdAt ?? 0;
-    final previousCreatedAt = currentCreatedAt > _lastCreatedAt
-        ? currentCreatedAt
-        : _lastCreatedAt;
-    final createdAt = now > previousCreatedAt ? now : previousCreatedAt + 1;
+    final createdAt = now > currentCreatedAt ? now : currentCreatedAt + 1;
     NostrEvent? signedEvent;
     await relay.submit(
       kind: EventKind.profile,
@@ -216,27 +195,20 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
     if (submittedEvent == null) {
       throw StateError('Profile update was not signed.');
     }
-    final verifiedHead = _latestProfileEvent(
-      await session.fetchHistory(NostrFilters.profile(pubkey)),
+    final verification = await session.fetchHistory(
+      NostrFilters.profile(pubkey),
     );
     _requireCurrentWriteContext(context);
+    for (final event in verification) {
+      cache.cacheProfileEvent(event);
+    }
+    final verifiedHead = _latestProfileEvent(verification);
     if (verifiedHead?.id != submittedEvent.id) {
       throw StateError('Profile changed before the update could be confirmed.');
     }
 
-    _metadata = nextMetadata;
-    _lastCreatedAt = createdAt;
-    final profile = UserProfile(
-      pubkey: pubkey,
-      displayName:
-          _metadata['display_name'] as String? ?? _metadata['name'] as String?,
-      avatarUrl: _metadata['picture'] as String?,
-      about: _metadata['about'] as String?,
-      nip05Handle: _metadata['nip05'] as String?,
-      ownerPubkey: verifiedOaOwnerPubkey(submittedEvent),
-    );
-    state = AsyncData(profile);
-    ref.read(userCacheProvider.notifier).put(profile);
+    cache.cacheProfileEvent(submittedEvent);
+    state = AsyncData(ref.read(userCacheProvider)[pubkey.toLowerCase()]);
   }
 
   void _requireCurrentWriteContext(_ProfileWriteContext context) {

--- a/mobile/lib/shared/mentions/agent_authorization.dart
+++ b/mobile/lib/shared/mentions/agent_authorization.dart
@@ -2,12 +2,16 @@ part of 'agent_identity_provider.dart';
 
 /// Fresh exact-key policy and relay-signed membership. Directory entries are
 /// hints; only this read may authorize agent mentions at a destination.
+/// [resolveProfileOwners] optionally folds fetched profiles into an ordered,
+/// session-bound cache after the scope check and returns its current verified
+/// owners. Omit it for side-effect-free send-time reads.
 Future<List<AgentDirectoryEntry>> readAgentAuthorization(
   RelaySessionNotifier session,
   Set<String> requestedKeys, {
   required String? viewer,
   String? channelId,
   required bool Function() isCurrent,
+  Map<String, String> Function(Iterable<NostrEvent>)? resolveProfileOwners,
 }) async {
   void check() {
     if (!isCurrent()) throw StateError('Agent authorization scope changed');
@@ -66,6 +70,7 @@ Future<List<AgentDirectoryEntry>> readAgentAuthorization(
     runtime.where((e) => requestedKeys.contains(e.pubkey)).toList(),
     requestedKeys: requestedKeys,
     checkCurrent: check,
+    resolveProfileOwners: resolveProfileOwners,
   );
   check();
   final latest = <String, NostrEvent>{};

--- a/mobile/lib/shared/mentions/agent_discovery.dart
+++ b/mobile/lib/shared/mentions/agent_discovery.dart
@@ -110,6 +110,10 @@ class _AgentDirectoryUpdates extends Notifier<int> {
             ),
             (event) {
               if (!current()) return;
+              if (disposed) return;
+              if (event.kind == 0) {
+                ref.read(userCacheProvider.notifier).cacheProfileEvent(event);
+              }
               if (event.kind == 5 && !_isAgentCoordinateDeletion(event)) return;
               changed();
             },

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../shared/crypto/nip_oa.dart';
 import '../../shared/crypto/signed_event.dart';
 import '../../shared/relay/relay.dart';
+import '../profile/user_cache_provider.dart';
 
 part 'agent_policy.dart';
 part 'agent_authorization.dart';
@@ -92,9 +93,26 @@ final agentDirectoryProvider = FutureProvider<List<AgentDirectoryEntry>>((
   if (!current()) return [];
   return readAgentAuthorization(
     session,
-    {...owned, ...events.map((event) => event.pubkey)},
+    {
+      ...owned, ...events.map((event) => event.pubkey),
+      // Refresh previously authenticated owners even after runtime/policy
+      // discovery stops returning them (for example across reconnect).
+      for (final profile in ref.read(userCacheProvider).values)
+        if (profile.ownerPubkey != null) profile.pubkey,
+    },
     viewer: viewer,
     isCurrent: current,
+    resolveProfileOwners: (profiles) {
+      if (!current()) throw StateError('Profile authority scope changed');
+      final cache = ref.read(userCacheProvider.notifier);
+      for (final profile in profiles) {
+        cache.cacheProfileEvent(profile);
+      }
+      return {
+        for (final profile in ref.read(userCacheProvider).values)
+          if (profile.ownerPubkey != null) profile.pubkey: profile.ownerPubkey!,
+      };
+    },
   );
 });
 
@@ -102,18 +120,14 @@ final agentDirectoryProvider = FutureProvider<List<AgentDirectoryEntry>>((
 /// profiles. An entry exists only when the `auth` tag verifies — mirrors
 /// desktop's `profile_valid_oa_owner_pubkey`.
 final agentOwnersProvider = FutureProvider<Map<String, String>>((ref) async {
-  final agents = await ref.watch(agentDirectoryProvider.future);
-  if (agents.isEmpty) return const {};
-  final session = ref.read(relaySessionProvider.notifier);
-  final events = await session.fetchHistory(
-    NostrFilters.profilesBatch([for (final agent in agents) agent.pubkey]),
-  );
-  final owners = <String, String>{};
-  for (final event in latestProfileEvents(events).values) {
-    final owner = verifiedOaOwnerPubkey(event);
-    if (owner != null) owners[event.pubkey.toLowerCase()] = owner;
-  }
-  return owners;
+  await ref.watch(agentDirectoryProvider.future);
+  // The profile cache is the single ordered ownership source for lifecycle,
+  // provenance and mention fallbacks; never re-query a parallel owner snapshot.
+  final profiles = ref.watch(userCacheProvider);
+  return {
+    for (final profile in profiles.values)
+      if (profile.ownerPubkey != null) profile.pubkey: profile.ownerPubkey!,
+  };
 });
 
 /// Pubkeys currently known to represent agents across the active relay.

--- a/mobile/lib/shared/mentions/agent_policy.dart
+++ b/mobile/lib/shared/mentions/agent_policy.dart
@@ -23,11 +23,16 @@ Future<List<NostrEvent>> _queryAgentFilters(
 }
 
 /// Overlay current owner-authenticated policy onto the existing runtime
-/// directory. This does not expand discovery to owner-only coordinates yet.
+/// directory, optionally including exact [requestedKeys] without a runtime.
+/// [resolveProfileOwners] receives snapshot profiles after [checkCurrent] and
+/// returns verified owners from the caller's ordered authority cache, so an
+/// older snapshot cannot undo a newer live revocation. Without the callback,
+/// ownership derives solely from this fresh query; no cache writes occur.
 Future<List<AgentDirectoryEntry>> resolveAgentPolicies(
   RelaySessionNotifier session,
   List<NostrEvent> runtimeEvents, {
   Set<String>? requestedKeys,
+  Map<String, String> Function(Iterable<NostrEvent>)? resolveProfileOwners,
   void Function()? checkCurrent,
 }) async {
   final latest = <String, NostrEvent>{};
@@ -44,12 +49,19 @@ Future<List<AgentDirectoryEntry>> resolveAgentPolicies(
         NostrFilter(kinds: const [0], authors: [key], limit: 1),
     ], checkCurrent: checkCurrent),
   );
+  checkCurrent?.call();
   final owners = <String, String>{};
   for (final profile in profiles.values) {
     final owner = verifiedOaOwnerPubkey(profile);
     if (owner != null && keys.contains(profile.pubkey)) {
       owners[profile.pubkey] = owner;
     }
+  }
+  if (resolveProfileOwners != null) {
+    final currentOwners = resolveProfileOwners(profiles.values);
+    owners
+      ..clear()
+      ..addEntries(currentOwners.entries.where((e) => keys.contains(e.key)));
   }
   checkCurrent?.call();
   final policies = await _queryAgentFilters(session, [

--- a/mobile/lib/shared/profile/user_cache_provider.dart
+++ b/mobile/lib/shared/profile/user_cache_provider.dart
@@ -15,7 +15,7 @@ import 'user_profile.dart';
 class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
   final Set<String> _pending = {};
   int _generation = 0;
-  final Map<String, ({int createdAt, String eventId})> _profileEventOrders = {};
+  final Map<String, NostrEvent> _profileEvents = {};
   Timer? _batchTimer;
   Completer<bool>? _batchCompleter;
 
@@ -25,7 +25,7 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
     ref.watch(myPubkeyProvider);
     _generation++;
     _pending.clear();
-    _profileEventOrders.clear();
+    _profileEvents.clear();
     ref.onDispose(() {
       _generation++;
       _batchTimer?.cancel();
@@ -45,10 +45,18 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
     return null;
   }
 
-  /// Stores a profile that was fetched or updated outside the batch loader.
+  /// Seeds an absent profile for local display before signed evidence arrives.
+  /// Never replaces existing state; fetched/confirmed profiles must use
+  /// [cacheProfileEvent] so ownership and event metadata advance together.
   void put(UserProfile profile) {
-    state = {...state, profile.pubkey.toLowerCase(): profile};
+    final pubkey = profile.pubkey.toLowerCase();
+    if (state.containsKey(pubkey)) return;
+    state = {...state, pubkey: profile};
   }
+
+  /// The governing kind:0 event, including metadata needed for profile edits.
+  NostrEvent? profileEvent(String pubkey) =>
+      _profileEvents[pubkey.toLowerCase()];
 
   /// Preload profiles for a list of pubkeys (e.g. channel members).
   /// Returns whether the batch completed successfully.
@@ -85,13 +93,11 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
       );
       if (generation != _generation) return false;
       final updated = Map<String, UserProfile>.from(state);
-      final updatedOrders = Map<String, ({int createdAt, String eventId})>.from(
-        _profileEventOrders,
-      );
+      final updatedOrders = Map<String, NostrEvent>.from(_profileEvents);
       for (final event in events) {
         _cacheProfileEvent(event, updated, updatedOrders);
       }
-      _profileEventOrders
+      _profileEvents
         ..clear()
         ..addAll(updatedOrders);
       state = updated;
@@ -138,14 +144,12 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
 
       if (generation != _generation) return;
       final updated = Map<String, UserProfile>.from(state);
-      final updatedOrders = Map<String, ({int createdAt, String eventId})>.from(
-        _profileEventOrders,
-      );
+      final updatedOrders = Map<String, NostrEvent>.from(_profileEvents);
       for (final event in events) {
         _cacheProfileEvent(event, updated, updatedOrders);
       }
 
-      _profileEventOrders
+      _profileEvents
         ..clear()
         ..addAll(updatedOrders);
       state = updated;
@@ -163,21 +167,21 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
   bool _cacheProfileEvent(
     NostrEvent event,
     Map<String, UserProfile> profiles, [
-    Map<String, ({int createdAt, String eventId})>? orders,
+    Map<String, NostrEvent>? orders,
   ]) {
     if (event.kind != 0) return false;
-    final eventOrders = orders ?? _profileEventOrders;
+    final eventOrders = orders ?? _profileEvents;
     final pubkey = event.pubkey.toLowerCase();
     final current = eventOrders[pubkey];
     final isNewer =
         current == null ||
         event.createdAt > current.createdAt ||
         (event.createdAt == current.createdAt &&
-            event.id.compareTo(current.eventId) < 0);
+            event.id.compareTo(current.id) < 0);
     if (!isNewer) return false;
 
     profiles[pubkey] = _profileFromEvent(event);
-    eventOrders[pubkey] = (createdAt: event.createdAt, eventId: event.id);
+    eventOrders[pubkey] = event;
     return true;
   }
 

--- a/mobile/lib/shared/profile/user_cache_provider.dart
+++ b/mobile/lib/shared/profile/user_cache_provider.dart
@@ -14,6 +14,7 @@ import 'user_profile.dart';
 /// kind:0 batch query (NIP-01 `authors` filter) every 50ms.
 class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
   final Set<String> _pending = {};
+  int _generation = 0;
   final Map<String, ({int createdAt, String eventId})> _profileEventOrders = {};
   Timer? _batchTimer;
   Completer<bool>? _batchCompleter;
@@ -21,8 +22,12 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
   @override
   Map<String, UserProfile> build() {
     ref.watch(relayConfigProvider);
+    ref.watch(myPubkeyProvider);
+    _generation++;
+    _pending.clear();
     _profileEventOrders.clear();
     ref.onDispose(() {
+      _generation++;
       _batchTimer?.cancel();
       _batchTimer = null;
       _batchCompleter?.complete(false);
@@ -72,11 +77,13 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
         .toSet()
         .toList();
     if (normalized.isEmpty) return true;
+    final generation = _generation;
     try {
       final session = ref.read(relaySessionProvider.notifier);
       final events = await session.fetchHistory(
         NostrFilters.profilesBatch(normalized),
       );
+      if (generation != _generation) return false;
       final updated = Map<String, UserProfile>.from(state);
       final updatedOrders = Map<String, ({int createdAt, String eventId})>.from(
         _profileEventOrders,
@@ -121,6 +128,7 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
     _batchCompleter = null;
 
     var succeeded = false;
+    final generation = _generation;
     try {
       final communityID = ref.read(activeCommunityProvider).value?.id;
       final session = ref.read(relaySessionProvider.notifier);
@@ -128,6 +136,7 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
         NostrFilters.profilesBatch(pubkeys),
       );
 
+      if (generation != _generation) return;
       final updated = Map<String, UserProfile>.from(state);
       final updatedOrders = Map<String, ({int createdAt, String eventId})>.from(
         _profileEventOrders,

--- a/mobile/test/features/channels/mentions/mention_candidates_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_test.dart
@@ -169,7 +169,13 @@ void main() {
       final ownedAgent = '2' * 64;
       final candidates = buildMentionCandidates(
         members: const [],
-        relayAgents: const [],
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: ownedAgent,
+            ownerPubkey: userPubkey,
+            respondTo: 'owner-only',
+          ),
+        ],
         sharedChannelIds: const {},
         userCache: const {},
         ownerByAgentPubkey: const {},
@@ -186,6 +192,41 @@ void main() {
       expect(candidates, hasLength(1));
       expect(candidates.single.isAgent, isTrue);
       expect(candidates.single.ownerPubkey, userPubkey);
+    });
+
+    test('owned members and search fail closed without ready policy', () {
+      final ownedAgent = '2' * 64;
+      for (final ready in [false, true]) {
+        for (final isMember in [false, true]) {
+          final candidates = buildMentionCandidates(
+            members: isMember ? [member(ownedAgent)] : [],
+            relayAgents: [],
+            directoryReady: ready,
+            sharedChannelIds: {},
+            userCache: {},
+            ownerByAgentPubkey: {ownedAgent: userPubkey},
+            searchResults: isMember ? [] : [UserProfile(pubkey: ownedAgent)],
+            currentPubkey: userPubkey,
+          );
+          expect(candidates, isEmpty);
+        }
+      }
+      final denied = buildMentionCandidates(
+        members: [member(ownedAgent)],
+        directoryReady: false,
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: ownedAgent,
+            ownerPubkey: userPubkey,
+            respondTo: 'owner-only',
+          ),
+        ],
+        sharedChannelIds: {},
+        userCache: {},
+        ownerByAgentPubkey: {ownedAgent: userPubkey},
+        currentPubkey: userPubkey,
+      );
+      expect(denied, isEmpty);
     });
 
     test('search results hide non-shared agents owned by someone else', () {

--- a/mobile/test/features/channels/mentions/mention_readiness_test.dart
+++ b/mobile/test/features/channels/mentions/mention_readiness_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/features/channels/channels_provider.dart';
+import 'package:buzz/features/channels/mentions/mention_candidates_provider.dart';
+import 'package:buzz/shared/mentions/agent_identity_provider.dart';
+import 'package:buzz/shared/profile/user_profile.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../shared/mentions/agent_policy_test.dart' show PolicySession;
+
+class _Channels extends ChannelsNotifier {
+  @override
+  Future<List<Channel>> build() async => [];
+}
+
+void main() {
+  test(
+    'production picker preserves policy loading/error instead of empty success',
+    () async {
+      final viewer = 'a' * 64;
+      final agent = 'b' * 64;
+      final human = 'c' * 64;
+      for (final member in [false, true]) {
+        final directory = Completer<List<AgentDirectoryEntry>>();
+        final c = ProviderContainer(
+          overrides: [
+            relaySessionProvider.overrideWith(() => PolicySession([])),
+            channelsProvider.overrideWith(_Channels.new),
+            currentPubkeyProvider.overrideWithValue(viewer),
+            agentDirectoryProvider.overrideWith((ref) => directory.future),
+            agentOwnersProvider.overrideWith((ref) async => {agent: viewer}),
+            channelMembersProvider('room').overrideWith(
+              (ref) async => [
+                ChannelMember(
+                  pubkey: human,
+                  role: 'member',
+                  joinedAt: DateTime(2024),
+                ),
+                if (member)
+                  ChannelMember(
+                    pubkey: agent,
+                    role: 'bot',
+                    joinedAt: DateTime(2024),
+                  ),
+              ],
+            ),
+            mentionUserSearchProvider('').overrideWith(
+              (ref) async => [
+                if (!member) UserProfile(pubkey: agent, ownerPubkey: viewer),
+              ],
+            ),
+          ],
+        );
+        final picker = mentionCandidatesProvider((
+          channelId: 'room',
+          query: '',
+        ));
+        final subscription = c.listen(picker, (_, _) {});
+        await c.read(channelsProvider.future);
+        await c.read(agentOwnersProvider.future);
+        await c.read(channelMembersProvider('room').future);
+        await c.read(mentionUserSearchProvider('').future);
+        expect(c.read(picker).map((candidate) => candidate.pubkey), [human]);
+        directory.completeError(StateError('policy unavailable'));
+        await expectLater(
+          c.read(agentDirectoryProvider.future),
+          throwsStateError,
+        );
+        await c.pump();
+        expect(c.read(picker).map((candidate) => candidate.pubkey), [human]);
+        subscription.close();
+        c.dispose();
+      }
+    },
+  );
+}

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -77,6 +77,89 @@ void main() {
     );
   });
 
+  test(
+    'late confirmed publication retains newer cache authority and metadata',
+    () async {
+      final keys = nostr.Keys.generate();
+      final owner = nostr.Keys.generate();
+      final initial = NostrEvent.fromJson(
+        nostr.Event.from(
+          secretKey: keys.secret,
+          createdAt: 1,
+          kind: 0,
+          tags: [_authTag(owner, keys.public)],
+          content: jsonEncode({'display_name': 'Owned'}),
+        ).toMap(),
+      );
+      final session = _ProfileRelaySession(initial);
+      final container = _profileContainer(keys.nsec, session);
+      addTearDown(container.dispose);
+      final cache = container.read(userCacheProvider.notifier);
+      await container.read(profileProvider.future);
+      expect(cache.profileEvent(keys.public)?.id, initial.id);
+      NostrEvent? revoked;
+      session.beforeHistoryReturn = () {
+        if (session.published.length != 1) return;
+        revoked = NostrEvent.fromJson(
+          nostr.Event.from(
+            secretKey: keys.secret,
+            createdAt: session.published.single.createdAt + 1,
+            kind: 0,
+            tags: const [],
+            content: jsonEncode({'display_name': 'Revoked', 'custom': 'new'}),
+          ).toMap(),
+        );
+        cache.cacheProfileEvent(revoked!);
+      };
+      await container.read(profileProvider.notifier).updateAbout('Late');
+      expect(
+        container.read(profileProvider).requireValue?.displayName,
+        'Revoked',
+      );
+      final submitted = session.published.single;
+      cache.put(
+        UserProfile(
+          pubkey: keys.public,
+          displayName: 'Unordered',
+          ownerPubkey: owner.public,
+        ),
+      );
+      cache.cacheProfileEvent(submitted);
+      cache.cacheProfileEvent(revoked!);
+      expect(cache.profileEvent(keys.public)?.id, revoked!.id);
+      expect(
+        container.read(userCacheProvider)[keys.public]?.ownerPubkey,
+        isNull,
+      );
+      expect(
+        container.read(profileProvider).requireValue?.displayName,
+        'Revoked',
+      );
+      // A stale hydration response must use the same governing event, not
+      // recreate detached state or lower the metadata used by the next edit.
+      session.beforeHistoryReturn = null;
+      await container.read(profileProvider.notifier).refresh();
+      expect(
+        container.read(profileProvider).requireValue?.displayName,
+        'Revoked',
+      );
+      await expectLater(
+        container.read(profileProvider.notifier).updateAbout('Unsafe'),
+        throwsStateError,
+      );
+      expect(session.published, hasLength(1));
+      session.profile = revoked!;
+      await container.read(profileProvider.notifier).updateAbout('Safe');
+      final next = session.published.last;
+      expect(next.createdAt, greaterThan(revoked!.createdAt));
+      expect(next.tags, isEmpty);
+      expect(jsonDecode(next.content)['custom'], 'new');
+      expect(cache.profileEvent(keys.public)?.id, next.id);
+      cache.cacheProfileEvent(revoked!);
+      expect(cache.profileEvent(keys.public)?.id, next.id);
+    },
+  );
+
   test('clearing a display name restores the pubkey label fallback', () async {
     final keys = nostr.Keys.generate();
     final relaySession = _ProfileRelaySession(
@@ -607,7 +690,8 @@ class _MutableRelayConfigNotifier extends RelayConfigNotifier {
 class _ProfileRelaySession extends RelaySessionNotifier {
   _ProfileRelaySession(this.profile);
 
-  final NostrEvent profile;
+  NostrEvent profile;
+  void Function()? beforeHistoryReturn;
   final List<NostrEvent> published = [];
 
   @override
@@ -617,7 +701,11 @@ class _ProfileRelaySession extends RelaySessionNotifier {
   Future<List<NostrEvent>> fetchHistory(
     NostrFilter filter, {
     Duration timeout = const Duration(seconds: 8),
-  }) async => [profile, ...published];
+  }) async {
+    final result = [profile, ...published];
+    beforeHistoryReturn?.call();
+    return result;
+  }
 
   @override
   Future<NostrEvent> publish(

--- a/mobile/test/shared/mentions/agent_discovery_test.dart
+++ b/mobile/test/shared/mentions/agent_discovery_test.dart
@@ -1,6 +1,8 @@
 import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
+import 'package:buzz/shared/profile/user_cache_provider.dart';
 import 'package:buzz/features/channels/mentions/mention_candidates.dart';
+import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
@@ -274,6 +276,64 @@ void main() {
       c2.dispose();
       await tester.pump(const Duration(milliseconds: 300));
       expect(retired.attempts, 1);
+    },
+  );
+
+  test(
+    'live revocation advances shared profiles and owners; replay cannot restore',
+    () async {
+      final events = [owned, policy];
+      final session = _Session(events, relay.public);
+      final c = container(session);
+      final ownerSubscription = c.listen(agentOwnersProvider, (_, _) {});
+      addTearDown(ownerSubscription.close);
+      addTearDown(c.dispose);
+      expect(await c.read(agentOwnersProvider.future), {
+        agent.public: owner.public,
+      });
+      expect(
+        c.read(userCacheProvider)[agent.public]?.ownerPubkey,
+        owner.public,
+      );
+      final revoked = profile(agent, [], createdAt: 101);
+      events.add(revoked);
+      session.deliver(revoked);
+      await Future<void>.delayed(const Duration(milliseconds: 180));
+      expect(await c.read(agentOwnersProvider.future), isEmpty);
+      expect(c.read(userCacheProvider)[agent.public]?.ownerPubkey, isNull);
+      events.remove(
+        revoked,
+      ); // stale snapshot must lose to delivered revocation
+      session.deliver(owned);
+      session.status!(RelaySubscriptionStatus.ready);
+      await Future<void>.delayed(const Duration(milliseconds: 180));
+      expect(await c.read(agentOwnersProvider.future), isEmpty);
+      expect(c.read(userCacheProvider)[agent.public]?.ownerPubkey, isNull);
+      // Ordinary-channel member fallback must not resurrect revoked ownership.
+      final choices = buildMentionCandidates(
+        members: [
+          ChannelMember(
+            pubkey: agent.public,
+            role: 'bot',
+            joinedAt: DateTime(2024),
+          ),
+        ],
+        relayAgents: await c.read(agentDirectoryProvider.future),
+        sharedChannelIds: {'room'},
+        userCache: c.read(userCacheProvider),
+        ownerByAgentPubkey: await c.read(agentOwnersProvider.future),
+        currentPubkey: owner.public,
+      );
+      expect(choices.single.ownerPubkey, isNull);
+      final retiredCallback = session.changed!;
+      c.updateOverrides([
+        relaySessionProvider.overrideWith(() => session),
+        myPubkeyProvider.overrideWithValue(relay.public),
+      ]);
+      c.read(agentDirectoryProvider);
+      expect(c.read(userCacheProvider), isEmpty);
+      retiredCallback(owned);
+      expect(c.read(userCacheProvider), isEmpty);
     },
   );
 

--- a/mobile/test/shared/mentions/agent_owners_test.dart
+++ b/mobile/test/shared/mentions/agent_owners_test.dart
@@ -1,6 +1,7 @@
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
+import 'package:buzz/shared/profile/user_cache_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
@@ -29,6 +30,10 @@ void main() {
       ],
     );
     try {
+      final cache = container.read(userCacheProvider.notifier);
+      for (final event in events) {
+        cache.cacheProfileEvent(event);
+      }
       return await container.read(agentOwnersProvider.future);
     } finally {
       container.dispose();

--- a/mobile/test/shared/profile/user_cache_provider_test.dart
+++ b/mobile/test/shared/profile/user_cache_provider_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:buzz/shared/profile/user_cache_provider.dart';
+import 'package:buzz/shared/profile/user_profile.dart';
 import 'package:buzz/shared/relay/relay.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -175,6 +176,34 @@ void main() {
     expect(await cache.refresh(const ['agent']), isTrue);
     expect(cache.state['agent']?.displayName, 'Valid');
   });
+
+  test(
+    'unordered seed is first hydration only and cannot replace an event',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final cache = container.read(userCacheProvider.notifier);
+      cache.put(const UserProfile(pubkey: 'AGENT', displayName: 'Local'));
+      expect(cache.state['agent']?.displayName, 'Local');
+      expect(cache.profileEvent('agent'), isNull);
+      cache.cacheProfileEvent(
+        _profileEvent(id: 'b', createdAt: 2, name: 'New'),
+      );
+      cache.put(
+        const UserProfile(
+          pubkey: 'agent',
+          displayName: 'Late',
+          ownerPubkey: 'owner',
+        ),
+      );
+      cache.cacheProfileEvent(
+        _profileEvent(id: 'a', createdAt: 1, name: 'Old'),
+      );
+      expect(cache.state['agent']?.displayName, 'New');
+      expect(cache.state['agent']?.ownerPubkey, isNull);
+      expect(cache.profileEvent('AGENT')?.id, 'b');
+    },
+  );
 
   test('same-second profile tie keeps the lowest event id', () {
     final container = ProviderContainer();

--- a/mobile/test/shared/profile/user_cache_provider_test.dart
+++ b/mobile/test/shared/profile/user_cache_provider_test.dart
@@ -114,6 +114,40 @@ void main() {
     expect(cache.state[agent.public]?.ownerPubkey, isNull);
   });
 
+  test(
+    'retired account refresh and preload cannot write into the next cache',
+    () async {
+      for (final preload in [false, true]) {
+        final result = Completer<List<NostrEvent>>();
+        final session = _RecordingProfileSession(result: result.future);
+        final c = ProviderContainer(
+          overrides: [
+            relaySessionProvider.overrideWith(() => session),
+            myPubkeyProvider.overrideWithValue('first'),
+          ],
+        );
+        final cache = c.read(userCacheProvider.notifier);
+        final pending = preload
+            ? cache.preload(['agent'])
+            : cache.refresh(['agent']);
+        if (preload) {
+          await Future<void>.delayed(const Duration(milliseconds: 60));
+        }
+        c.updateOverrides([
+          relaySessionProvider.overrideWith(() => session),
+          myPubkeyProvider.overrideWithValue('second'),
+        ]);
+        expect(c.read(userCacheProvider), isEmpty);
+        result.complete([
+          _profileEvent(id: 'old', createdAt: 2, name: 'Old scope'),
+        ]);
+        expect(await pending, isFalse);
+        expect(c.read(userCacheProvider), isEmpty);
+        c.dispose();
+      }
+    },
+  );
+
   test('non-profile history cannot poison profile order', () async {
     final session = _RecordingProfileSession(
       results: [


### PR DESCRIPTION
## Summary

An owner revocation could refresh the mobile agent directory while leaving the loaded profile—and therefore lifecycle ownership, provenance, or ordinary-channel mention fallback—unchanged. Owned agents could also reappear in autocomplete while policy was loading or failed.

- Feed live and snapshot profiles through the same ordered user cache. Derive lifecycle owners from that cache instead of a second independent profile query; stale snapshots/replays cannot restore a newer revoked owner.
- Fence asynchronous profile-cache loads by account/community generation. Retired subscription callbacks cannot write into the new scope.
- Preserve directory readiness in autocomplete: authenticated-owned identities require a loaded eligible policy, including member and search results. Deliberately headless bot members remain compatible.
- Keep fresh authorization reads backward compatible and side-effect free by default. Discovery alone opts into the documented ordered-profile owner resolver.

### Related issue

N/A; requested-change followup for #7389, #7391 and #7392. Closest existing PRs are #7395 (discovery lifecycle) and those three review targets; exact-branch search found no existing followup.

**Dependency graph:** based on published #7395 (`b829496e0bf363939afd6b54fc67b4b08716b35b`), which depends on #7393 → #7392 → #7389. #7391 is a separate child of #7389: its provenance renderers need this shared-cache fix integrated alongside them, not backported into the earlier slices. #7390/#7394 remain rollout prerequisites for discovery's invitation/publication workflow, not compile dependencies of this PR. No changes to the promised #7393 or SEND bases.

- Confirmed local publication and ordinary profile hydration now use that same ordered cache. Retain the governing event for edit metadata/tags/timestamps; unordered `put` only seeds absent local display state and cannot overwrite newer ownership evidence.

### Testing

At exact `e9c8be29e2b59080f8e9529a67853d950d8c6a0c`, based on unchanged corrected #7395 `b829496e0bf363939afd6b54fc67b4b08716b35b` (+451/−86 = 537 lines):
- `just mobile-check`: passed (format/analyzer).
- `just mobile-test`: full mobile suite, **2,109 passed**.
- `just file-size-check`: passed.
- Production discovery subscription regression: live revocation → shared profile/owner removal → stale snapshot/replay → ordinary-channel fallback remains without ownership; retired account callback cannot repopulate cache.
- Production picker provider regression: loading/error policy hides authenticated-owned member/search identities while preserving human candidates; narrow pure tests preserve headless compatibility.
- New production ProfileNotifier regression: newer signed revocation arrives during older publish confirmation; profile/cache and governing event remain newer after stale hydration, unordered put and replay. Next edit refuses unconfirmed older history, then preserves current custom metadata, removed owner tags and monotonic event time. Detached-publication mutation and unordered-write mutation both fail. First local hydration/seed remains supported.
- Cache regressions fence both preload and explicit refresh across account changes. Existing cache ordering tests remain green.
- `just ci`: the bounded 90-second local attempt at corrected parent head `b829496e0` was terminated during workspace clippy, and that limitation carries forward — **repository-wide CI completion is not claimed** at this head. Full mobile suite above is the executed evidence here.

No layout change or native device/simulator validation; tests cover authority delivery and picker eligibility, not an integrated native #7391 provenance journey. Existing #7391 widget evidence remains renderer-only. No screenshots added to Git.


### Desktop status-expiry smoke correction (2026-09-10)

Smoke3 at `68b042a73a714edd0fca04283300bcb09974b497` (run 34431095101, job 102726723382) failed `profile-custom-emoji-status.spec.ts` "keeps an open status draft when the saved status expires": the seeded two-second status expired during popover/editor setup (retry1 opened the editor ~14 ms before the deadline; typing began after expiry), so the dialog opened as a new-status editor and the expired-duration alert never appeared. Source inspection found no product defect — the dialog's open-capture effect and the user-status expiration timer behave as designed.

`4d83496d61f5c5945030ac3b5b1351dcb1ff8cf5` (own churn 595→598 vs base) repairs the test with the repository's existing Playwright clock idiom: `clock.setFixedTime` pins the browser Date before navigation (timers, network, and rendering keep running), so the saved editor state asserted before editing (input/emoji, Duration "Custom", Clear present, no presets) holds however slow the machine is; the draft is edited, the pinned Date is advanced past the same seeded two-second deadline, and the pending expiration timer is fired with `clock.fastForward`, keeping every existing alert/draft/save assertion unchanged. An earlier attempt on this lane (`7d5409f37`, +51/−1) used `clock.install({ time })`, but that only sets the fake clock's epoch — installed Playwright 1.60.0 keeps fake time flowing with real time, and a diagnostic 3s real delay before opening the editor reproduced the fresh-editor failure — so it was corrected rather than left racing the deadline on slow CI. A sibling control test crosses the deadline before opening and asserts the opposite new-status editor; reordering the main test locally fails the saved-editor precondition (empty input), so the precondition is falsifiable. Local validation: full spec 9/9 passing on an isolated runner (retries 0), `tsc --noEmit` and Biome clean. Published CI on the new head supplies package-level evidence; no full-package claim is made from this spec alone, and no mobile or production files changed.
