### PR TITLE
feat(mobile): read fresh evidence for every selected mention

### DIFF
--- a/desktop/tests/e2e/video-attachment.spec.ts
+++ b/desktop/tests/e2e/video-attachment.spec.ts
@@ -1614,6 +1614,17 @@ test("playback speed persists across videos and reloads", async ({ page }) => {
     const player = page
       .locator(`[data-message-id="${emitted.id}"]`)
       .getByTestId("video-player");
+    // Interacting with the previous player can leave the timeline reading an
+    // older row. Open buffered arrivals through the normal latest-message UI;
+    // subscription readiness alone does not make their rows visible.
+    await expect
+      .poll(async () => {
+        if (await player.isVisible()) return true;
+        const scrollToLatest = page.getByTestId("message-scroll-to-latest");
+        if (await scrollToLatest.isVisible()) await scrollToLatest.click();
+        return false;
+      })
+      .toBe(true);
     await expect(player).toBeVisible();
     await player.getByRole("button", { name: "Play video" }).click();
     return player;

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -63,7 +63,12 @@ async function addMessageStep(
 ) {
   await dialog.getByRole("button", { name: "Add step", exact: true }).click();
   await page.getByRole("menuitem", { name: "Send Message" }).click();
-  await dialog.getByLabel("Message text").fill("Workflow notification");
+  // The outgoing trigger inspector also labels its input "Message text".
+  const stepText = dialog
+    .getByLabel("Message text", { exact: true })
+    .and(dialog.locator("#wf-step-0-text"));
+  await stepText.fill("Workflow notification");
+  await expect(stepText).toHaveValue("Workflow notification");
 }
 
 async function createEnabled(
@@ -288,6 +293,7 @@ test("round-trips and reopens structured message-text conditions", async ({
   await openTriggerInspector(dialog);
   const matchControls = dialog.getByRole("group", { name: "Match" });
   const operatorButtons = matchControls.getByRole("button");
+  await waitForAnimations(page);
   const firstOperatorBox = await operatorButtons.nth(0).boundingBox();
   const secondOperatorBox = await operatorButtons.nth(1).boundingBox();
   const thirdOperatorBox = await operatorButtons.nth(2).boundingBox();
@@ -299,7 +305,6 @@ test("round-trips and reopens structured message-text conditions", async ({
     Math.abs((secondOperatorBox?.y ?? 0) - (firstOperatorBox?.y ?? 0)),
   ).toBeLessThan(1);
   expect(thirdOperatorBox?.y).toBeGreaterThan(firstOperatorBox?.y ?? 0);
-  await waitForAnimations(page);
   await matchControls.screenshot({
     path: "test-results/workflow-message-condition-operators.png",
   });

--- a/desktop/tests/e2e/workflows.spec.ts
+++ b/desktop/tests/e2e/workflows.spec.ts
@@ -96,7 +96,11 @@ async function createWorkflow(
 
   await dialog.getByRole("button", { name: "Add step", exact: true }).click();
   await page.getByRole("menuitem", { name: "Send Message" }).click();
-  await dialog.getByLabel("Message text").fill("Workflow notification");
+  const messageText = dialog
+    .getByLabel("Message text")
+    .and(dialog.locator("#wf-step-0-text"));
+  await messageText.fill("Workflow notification");
+  await expect(messageText).toHaveValue("Workflow notification");
   if (options?.stepName) {
     await dialog.getByRole("button", { name: "Step details" }).click();
     await dialog.getByLabel("Name (optional)").fill(options.stepName);
@@ -700,7 +704,11 @@ test("captures the built editor at desktop and narrow widths", async ({
   await editWorkflowName(dialog, "editor_screenshot");
   await dialog.getByRole("button", { name: "Add step", exact: true }).click();
   await page.getByRole("menuitem", { name: "Send Message" }).click();
-  await dialog.getByLabel("Message text").fill("Notify the workflow channel");
+  const messageText = dialog
+    .getByLabel("Message text")
+    .and(dialog.locator("#wf-step-0-text"));
+  await messageText.fill("Notify the workflow channel");
+  await expect(messageText).toHaveValue("Notify the workflow channel");
   const inspector = dialog.getByTestId("workflow-node-inspector");
 
   for (const viewport of [
@@ -805,7 +813,11 @@ test("pane routes use stable IDs and Form/YAML changes stay synchronized", async
 
   await dialog.getByRole("button", { name: "Add step", exact: true }).click();
   await page.getByRole("menuitem", { name: "Send Message" }).click();
-  await dialog.getByLabel("Message text").fill("first message");
+  const messageText = dialog
+    .getByLabel("Message text")
+    .and(dialog.locator("#wf-step-0-text"));
+  await messageText.fill("first message");
+  await expect(messageText).toHaveValue("first message");
   await expect(page).toHaveURL(/pane=step%3Astep_1/);
 
   await dialog.getByRole("button", { name: "Add after Step 1" }).click();

--- a/desktop/tests/e2e/workflows.spec.ts
+++ b/desktop/tests/e2e/workflows.spec.ts
@@ -221,7 +221,31 @@ test("creates a workflow via the form builder", async ({ page }) => {
   const workflowName = `test_workflow_${Date.now()}`;
 
   await navigateToWorkflows(page);
+  // Keep the outgoing trigger's Message text mounted during the step handoff.
+  await page.evaluate(() => {
+    const animate = Element.prototype.animate;
+    Element.prototype.animate = function (...args) {
+      const animation = animate.apply(this, args);
+      if (this.querySelector("#wf-trigger-trigger_text-value")) {
+        animation.updatePlaybackRate(0.1);
+      }
+      return animation;
+    };
+  });
   await createWorkflow(page, workflowName);
+
+  const yaml = await page.evaluate(() => {
+    const call = [...(window.__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [])]
+      .reverse()
+      .find((candidate) => candidate.command === "create_workflow");
+    return (call?.payload as { yamlDefinition?: string } | undefined)
+      ?.yamlDefinition;
+  });
+  const saved = parseYaml(yaml ?? "");
+  expect(saved.steps[0].id).toBe("step_1");
+  expect(saved.steps[0].text).toBe("Workflow notification");
+  expect(saved.trigger.on).toBe("message_posted");
+  expect(saved.trigger.filter).toBeUndefined();
 
   // Verify workflow appears in the list
   await expect(page.getByTestId("workflows-view")).toContainText(workflowName);

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -11,6 +11,7 @@ import '../../shared/relay/relay.dart';
 part 'agent_policy.dart';
 part 'agent_authorization.dart';
 part 'agent_publication.dart';
+part 'selected_mention_authorization.dart';
 
 /// A relay agent parsed from its kind:10100 agent-profile event.
 ///

--- a/mobile/lib/shared/mentions/agent_policy.dart
+++ b/mobile/lib/shared/mentions/agent_policy.dart
@@ -24,11 +24,14 @@ Future<List<NostrEvent>> _queryAgentFilters(
 
 /// Overlay current owner-authenticated policy onto the existing runtime
 /// directory. This does not expand discovery to owner-only coordinates yet.
+/// [onProfileEvidence] observes immutable latest query heads after the final
+/// scope check. It does not resolve ownership or mutate any shared profile cache.
 Future<List<AgentDirectoryEntry>> resolveAgentPolicies(
   RelaySessionNotifier session,
   List<NostrEvent> runtimeEvents, {
   Set<String>? requestedKeys,
   void Function()? checkCurrent,
+  void Function(Map<String, NostrEvent> profiles)? onProfileEvidence,
 }) async {
   final latest = <String, NostrEvent>{};
   for (final event in runtimeEvents.where((event) => event.kind == 10100)) {
@@ -64,6 +67,7 @@ Future<List<AgentDirectoryEntry>> resolveAgentPolicies(
       ),
   ], checkCurrent: checkCurrent);
   checkCurrent?.call();
+  onProfileEvidence?.call(Map.unmodifiable(profiles));
   return mergeAgentPolicies(latest.values, policies, owners);
 }
 

--- a/mobile/lib/shared/mentions/selected_mention_authorization.dart
+++ b/mobile/lib/shared/mentions/selected_mention_authorization.dart
@@ -1,14 +1,34 @@
 part of 'agent_identity_provider.dart';
 
 /// Evidence requirements, not a claim that an ordinary identity is human.
-enum SelectedMentionKind { ordinary, agent, unresolvedAgent }
+enum SelectedMentionKind {
+  /// No fresh agent evidence for this key. Absence of agent evidence, not
+  /// a humanity claim: the ordinary membership flow applies.
+  ordinary,
+
+  /// Fresh verified agent evidence for this key: a verified NIP-OA profile
+  /// owner, a `bot` destination-roster role, or a signature-verified latest
+  /// kind:10100 runtime event. Evidence only, never permission to write.
+  agent,
+
+  /// Agent evidence that is not safely established: an invalid profile
+  /// attestation, an unverifiable latest runtime head, or prior-agent
+  /// provenance whose fresh evidence is gone. Never demoted to the ordinary
+  /// flow; carries no agent entry or invitation role.
+  unresolvedAgent,
+}
 
 /// Fresh evidence for one exact selected key. This is NOT permission to write:
 /// consumers must apply their existing agent eligibility evaluator to [agent],
 /// normal channel invitation permission, consent and scope fences separately.
 /// An existing member needs no role write, whatever their current role is.
 class SelectedMentionAuthorization {
+  /// Fresh evidence classification for this exact key. Values state what
+  /// fresh evidence showed, never permission, role, or humanity.
   final SelectedMentionKind kind;
+
+  /// Presence in the destination's signed roster at read time only, not a
+  /// role, eligibility, or authorization claim.
   final bool isMember;
 
   /// Policy projection with relay-authenticated destination membership only.
@@ -18,6 +38,10 @@ class SelectedMentionAuthorization {
 
   const SelectedMentionAuthorization._(this.kind, this.isMember, this.agent);
 
+  /// True when this key's evidence must be routed through the agent
+  /// authorization evaluator rather than the ordinary flow: agent or
+  /// unresolvedAgent evidence. Routing only, never a granted write;
+  /// eligibility, consent, and invitation fences still apply separately.
   bool get requiresAgentAuthorization => kind != SelectedMentionKind.ordinary;
 
   /// Role selection only, never an invitation authorization. A consumer must

--- a/mobile/lib/shared/mentions/selected_mention_authorization.dart
+++ b/mobile/lib/shared/mentions/selected_mention_authorization.dart
@@ -1,0 +1,173 @@
+part of 'agent_identity_provider.dart';
+
+/// Evidence requirements, not a claim that an ordinary identity is human.
+enum SelectedMentionKind { ordinary, agent, unresolvedAgent }
+
+/// Fresh evidence for one exact selected key. This is NOT permission to write:
+/// consumers must apply their existing agent eligibility evaluator to [agent],
+/// normal channel invitation permission, consent and scope fences separately.
+/// An existing member needs no role write, whatever their current role is.
+class SelectedMentionAuthorization {
+  final SelectedMentionKind kind;
+  final bool isMember;
+
+  /// Policy projection with relay-authenticated destination membership only.
+  /// Null for ordinary identities or unresolved prior-agent evidence. Missing
+  /// owner policy produces a deny-all entry, never runtime fallback.
+  final AgentDirectoryEntry? agent;
+
+  const SelectedMentionAuthorization._(this.kind, this.isMember, this.agent);
+
+  bool get requiresAgentAuthorization => kind != SelectedMentionKind.ordinary;
+
+  /// Role selection only, never an invitation authorization. A consumer must
+  /// first validate eligibility and consent and skip writes for existing members.
+  String? get invitationRole => switch (kind) {
+    SelectedMentionKind.ordinary => 'member',
+    SelectedMentionKind.agent => 'bot',
+    SelectedMentionKind.unresolvedAgent => null,
+  };
+}
+
+/// Read all selected keys, not just candidates whose saved isAgent bit is true.
+/// [priorAgentKeys] is denial-only taint: lost provenance cannot turn a saved
+/// agent capability into an ordinary-member invitation or notification bypass.
+/// Absence of agent evidence permits the existing ordinary membership flow,
+/// NOT a humanity assertion. Positive fresh evidence overrides saved false.
+///
+/// Every requested key has a result or the entire read throws. This read makes
+/// no cache writes and does not opt into resolveProfileOwners. Check [isCurrent]
+/// again before each side effect; re-read after consent and accepted invitations.
+Future<Map<String, SelectedMentionAuthorization>>
+readSelectedMentionAuthorization(
+  RelaySessionNotifier session,
+  Set<String> requestedKeys, {
+  required String viewer,
+  required String channelId,
+  Set<String> priorAgentKeys = const {},
+  required bool Function() isCurrent,
+}) async {
+  void check() {
+    if (!isCurrent()) throw StateError('Mention authorization scope changed');
+  }
+
+  check();
+  if (requestedKeys.length > 1000 ||
+      !requestedKeys.containsAll(priorAgentKeys) ||
+      requestedKeys.any((key) => !RegExp(r'^[0-9a-f]{64}$').hasMatch(key)) ||
+      !RegExp(r'^[0-9a-f]{64}$').hasMatch(viewer) ||
+      channelId.isEmpty) {
+    throw StateError('Invalid selected mention request');
+  }
+  if (requestedKeys.isEmpty) return const {};
+  final authority = await session.fetchRelaySelf();
+  check();
+  final membership = await _membershipPages(
+    session,
+    authority,
+    viewer,
+    channelId,
+    check,
+  );
+  check();
+  NostrEvent? roster;
+  for (final event in membership) {
+    if (event.kind != 39002 ||
+        event.pubkey != authority ||
+        event.getTagValue('d') != channelId) {
+      continue;
+    }
+    if (roster == null || _newer(event, roster)) roster = event;
+  }
+  // A malformed newest head is unavailable, never permission to invite someone
+  // whose current membership could not be established. Missing head is likewise
+  // not a trustworthy empty roster at this destination.
+  if (roster == null ||
+      !verifySignedEvent(roster) ||
+      roster.tags.where((t) => t.isNotEmpty && t[0] == 'd').length != 1) {
+    throw StateError('Destination membership unavailable');
+  }
+  final members = <String, String>{};
+  for (final tag in roster.tags.where((t) => t.isNotEmpty && t[0] == 'p')) {
+    if (tag.length < 2 || members.containsKey(tag[1])) {
+      throw StateError('Ambiguous destination membership');
+    }
+    members[tag[1]] = tag.length >= 4 ? tag[3] : 'member';
+  }
+  final runtime = await _queryAgentFilters(session, [
+    for (final key in requestedKeys)
+      NostrFilter(kinds: const [10100], authors: [key], limit: 1),
+  ], checkCurrent: check);
+  check();
+  Map<String, NostrEvent> profiles = const {};
+  final policies = await resolveAgentPolicies(
+    session,
+    runtime.where((e) => requestedKeys.contains(e.pubkey)).toList(),
+    requestedKeys: requestedKeys,
+    checkCurrent: check,
+    onProfileEvidence: (value) => profiles = value,
+  );
+  check();
+  final latestRuntime = <String, NostrEvent>{};
+  for (final event in runtime) {
+    if (event.kind != 10100 || !requestedKeys.contains(event.pubkey)) continue;
+    final previous = latestRuntime[event.pubkey];
+    if (previous == null || _newer(event, previous)) {
+      latestRuntime[event.pubkey] = event;
+    }
+  }
+  final byKey = {for (final policy in policies) policy.pubkey: policy};
+  final result = <String, SelectedMentionAuthorization>{};
+  for (final key in requestedKeys) {
+    final profile = profiles[key];
+    final owner = profile == null ? null : verifiedOaOwnerPubkey(profile);
+    final invalidProfile =
+        profile != null &&
+        (!verifySignedEvent(profile) ||
+            (owner == null &&
+                profile.tags.any((t) => t.isNotEmpty && t[0] == 'auth')));
+    final runtimeHead = latestRuntime[key];
+    final knownAgent =
+        owner != null ||
+        members[key] == 'bot' ||
+        (runtimeHead != null && verifySignedEvent(runtimeHead));
+    final unresolved =
+        invalidProfile ||
+        (runtimeHead != null && !verifySignedEvent(runtimeHead)) ||
+        (!knownAgent && priorAgentKeys.contains(key));
+    final kind = unresolved
+        ? SelectedMentionKind.unresolvedAgent
+        : knownAgent
+        ? SelectedMentionKind.agent
+        : SelectedMentionKind.ordinary;
+    AgentDirectoryEntry? agent;
+    if (kind == SelectedMentionKind.agent) {
+      final policy = byKey[key];
+      // Ownership without a matching valid policy must not revive headless
+      // runtime authority. mergeAgentPolicies remains the sole policy parser.
+      final missingOwnedPolicy = owner != null && policy?.ownerPubkey != owner;
+      agent = AgentDirectoryEntry(
+        pubkey: key,
+        ownerPubkey: owner,
+        displayName: policy?.displayName,
+        respondTo: missingOwnedPolicy ? 'nobody' : policy?.respondTo,
+        respondToAllowlist: missingOwnedPolicy
+            ? const []
+            : policy?.respondToAllowlist ?? const [],
+        channelIds:
+            members.containsKey(viewer) &&
+                members.containsKey(key) &&
+                (owner == viewer || members[key] == 'bot')
+            ? [channelId]
+            : const [],
+      );
+    }
+    result[key] = SelectedMentionAuthorization._(
+      kind,
+      members.containsKey(key),
+      agent,
+    );
+  }
+  check();
+  return Map.unmodifiable(result);
+}

--- a/mobile/test/shared/mentions/selected_mention_authorization_test.dart
+++ b/mobile/test/shared/mentions/selected_mention_authorization_test.dart
@@ -1,0 +1,238 @@
+import 'package:buzz/shared/mentions/agent_identity_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+import '../crypto/nip_oa_test.dart' show authTag, profile;
+import 'agent_policy_test.dart' show PolicySession, signed;
+
+class _Session extends PolicySession {
+  _Session(super.events, this.authority, {super.failPolicy});
+  final String authority;
+  void Function(List<NostrFilter>)? onQuery;
+  @override
+  Future<String> fetchRelaySelf() async => authority;
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    onQuery?.call(filters);
+    return super.queryRelay(filters, timeout: timeout);
+  }
+}
+
+void main() {
+  final viewer = nostr.Keys.generate();
+  final person = nostr.Keys.generate();
+  final agent = nostr.Keys.generate();
+  final relay = nostr.Keys.generate();
+  final owned = profile(agent, [authTag(viewer, agent.public)]);
+  final runtime = signed(agent, 10100, {'respond_to': 'anyone'});
+  NostrEvent roster({String? role, bool personMember = true, int time = 100}) =>
+      signed(
+        relay,
+        39002,
+        '',
+        time: time,
+        tags: [
+          ['d', 'room'],
+          ['p', viewer.public],
+          if (personMember) ['p', person.public, '', 'member'],
+          if (role != null) ['p', agent.public, '', role],
+        ],
+      );
+  NostrEvent policy(String mode, {int time = 100}) => signed(
+    viewer,
+    30177,
+    {'name': 'Agent', 'parallelism': 1, 'respond_to': mode},
+    time: time,
+    tags: [
+      ['d', agent.public],
+    ],
+  );
+
+  Future<Map<String, SelectedMentionAuthorization>> read(
+    List<NostrEvent> events, {
+    Set<String> prior = const {},
+    bool Function()? current,
+    _Session? session,
+    Set<String>? keys,
+  }) async {
+    final source = session ?? _Session(events, relay.public);
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => source)],
+    );
+    container.read(relaySessionProvider);
+    try {
+      return await readSelectedMentionAuthorization(
+        source,
+        keys ?? {person.public, agent.public},
+        viewer: viewer.public,
+        channelId: 'room',
+        priorAgentKeys: prior,
+        isCurrent: current ?? () => true,
+      );
+    } finally {
+      container.dispose();
+    }
+  }
+
+  test(
+    'exact total map preserves ordinary member and nonmember flows',
+    () async {
+      for (final member in [true, false]) {
+        final result = await read([roster(personMember: member)]);
+        expect(result.keys.toSet(), {person.public, agent.public});
+        final ordinary = result[person.public]!;
+        expect(ordinary.kind, SelectedMentionKind.ordinary);
+        expect(ordinary.requiresAgentAuthorization, isFalse);
+        expect(ordinary.isMember, member);
+        expect(ordinary.invitationRole, 'member');
+        expect(() => result.clear(), throwsUnsupportedError);
+      }
+    },
+  );
+
+  test(
+    'saved false cannot exclude fresh agent or select member role',
+    () async {
+      final result = await read([
+        roster(role: 'member'),
+        owned,
+        policy('anyone'),
+      ]);
+      final fresh = result[agent.public]!;
+      expect(fresh.kind, SelectedMentionKind.agent);
+      expect(fresh.requiresAgentAuthorization, isTrue);
+      expect(fresh.invitationRole, 'bot');
+      expect(fresh.isMember, isTrue);
+      expect(fresh.agent!.ownerPubkey, viewer.public);
+      expect(fresh.agent!.channelIds, ['room']);
+      expect(result[person.public]!.kind, SelectedMentionKind.ordinary);
+    },
+  );
+
+  test(
+    'saved true with lost provenance remains unresolved even as member',
+    () async {
+      final result = await read(
+        [roster(role: 'member'), owned, profile(agent, [], createdAt: 101)],
+        prior: {agent.public},
+      );
+      final lost = result[agent.public]!;
+      expect(lost.kind, SelectedMentionKind.unresolvedAgent);
+      expect(lost.isMember, isTrue);
+      expect(lost.requiresAgentAuthorization, isTrue);
+      expect(lost.agent, isNull);
+      expect(lost.invitationRole, isNull);
+    },
+  );
+
+  test(
+    'missing and revoked owner policy deny without runtime fallback',
+    () async {
+      for (final policies in <List<NostrEvent>>[
+        [],
+        [policy('anyone'), policy('nobody', time: 101)],
+      ]) {
+        final result = await read([
+          roster(role: 'bot'),
+          owned,
+          runtime,
+          ...policies,
+        ]);
+        final fresh = result[agent.public]!;
+        expect(fresh.kind, SelectedMentionKind.agent);
+        expect(fresh.agent!.respondTo, 'nobody');
+        expect(fresh.agent!.ownerPubkey, viewer.public);
+      }
+    },
+  );
+
+  test(
+    'known runtime agent without membership never becomes ordinary',
+    () async {
+      final result = await read([roster(), runtime]);
+      expect(result[agent.public]!.kind, SelectedMentionKind.agent);
+      expect(result[agent.public]!.agent!.channelIds, isEmpty);
+      expect(result[agent.public]!.isMember, isFalse);
+    },
+  );
+
+  test(
+    'headless bot requires runtime policy; malformed OA is unresolved',
+    () async {
+      final bot = (await read([roster(role: 'bot')]))[agent.public]!;
+      expect(bot.kind, SelectedMentionKind.agent);
+      expect(bot.agent!.respondTo, isNull);
+      final good = (await read([roster(role: 'bot'), runtime]))[agent.public]!;
+      expect(good.agent!.respondTo, 'anyone');
+      expect(good.agent!.channelIds, ['room']);
+      final bad = (await read([
+        roster(role: 'bot'),
+        runtime,
+        profile(agent, [
+          ['auth', viewer.public, '', 'bad'],
+        ]),
+      ]))[agent.public]!;
+      expect(bad.kind, SelectedMentionKind.unresolvedAgent);
+      expect(bad.agent, isNull);
+    },
+  );
+
+  test(
+    'newest roster removal wins; invalid head does not revive old member',
+    () async {
+      final result = await read([
+        roster(role: 'bot'),
+        roster(time: 101),
+        runtime,
+      ]);
+      expect(result[agent.public]!.isMember, isFalse);
+      expect(result[agent.public]!.agent!.channelIds, isEmpty);
+      final invalid = NostrEvent.fromJson({
+        ...roster(time: 102).toJson(),
+        'content': 'tampered',
+      });
+      await expectLater(read([roster(), invalid]), throwsStateError);
+      await expectLater(read([]), throwsStateError);
+    },
+  );
+
+  test(
+    'policy failures and scope retirement throw rather than partial map',
+    () async {
+      await expectLater(
+        read(
+          [],
+          session: _Session([roster(), owned], relay.public, failPolicy: true),
+        ),
+        throwsStateError,
+      );
+      var current = true;
+      final session = _Session([roster(), owned], relay.public)
+        ..onQuery = (filters) {
+          if (filters.any((f) => f.kinds.contains(0))) current = false;
+        };
+      await expectLater(
+        read([], session: session, current: () => current),
+        throwsStateError,
+      );
+      expect(session.queries.any((f) => f.kinds.contains(30177)), isFalse);
+    },
+  );
+
+  test('exact request bounds and denial-only taint are validated', () async {
+    await expectLater(read([roster()], keys: {'not-a-key'}), throwsStateError);
+    await expectLater(
+      read([roster()], keys: {person.public}, prior: {agent.public}),
+      throwsStateError,
+    );
+    final keys = {
+      for (var i = 0; i < 1001; i++) i.toRadixString(16).padLeft(64, '0'),
+    };
+    await expectLater(read([roster()], keys: keys), throwsStateError);
+  });
+}


### PR DESCRIPTION
## Summary
Add read-only exact-key selected-mention evidence for the forthcoming composer classification fix. Every selected key is read; fresh OA/runtime/bot evidence overrides a saved false bit, and saved true is denial-only taint when provenance disappears. Missing/revoked owned policy remains deny-all. Ordinary membership is not a humanity attestation.

This producer does **not** authorize publication or invitation writes. The consumer must use the existing `authorizeAgentMentions` evaluator, explicit consent, ordinary permissions and fresh boundary reads. Saved-isAgent consumer behavior is **not fixed by this PR alone**.

Dependency: based on #7394 (2fd0d0bcc45d987b62668985f0eae0134ccde2e2) as a serial integration extension of its publication guard, not because the additive provider needs that guard to compile. Reuses tested candidate a7c8b2e5 without semantic redesign. Consumer and private cross-PR persisted-draft validation remain separate gates. No sibling changes backported.

Size: 416 additions + 0 deletions, four files, against #7394.

### Related issue
Followup to #7387 and #7394; related explicit-invitation recovery #7390/#7527 and shared authority #7530. Existing open PRs searched; no duplicate selected-mention provider publication found.

### Testing
At b4f266dae1f28982f6c43df4d1b9ffa8f3e54d50, with HEAD printed in the same invocation:
- `just mobile-check`: pass, formatter/analyzer clean.
- `cd mobile && flutter test`: confirmation **2,119 passed**, including nine signed-evidence provider regressions.
- First full run: 2,118 passed / one unrelated voice-note temp-directory deletion error. Retained failure evidence; isolated `voice_note_recording_test.dart` passed 20 tests, then full suite passed without code changes.
- Original identical producer on #7393: 2,104 tests and mobile-check passed. Historical `just ci` timed out in workspace Clippy; no repository-wide green claim or retry here.

No visible UI change in this producer; no screenshots or native-device journey claimed. These are fake-transport signed-evidence tests, not production restart or persisted-draft consumer coverage. Observer/session revision fencing and per-write checks remain required in the consumer; this API is neither a subscription nor an atomic write guarantee.


## Docs correction for review 5162334206 — 2026-09-10

Head carried to `1fe1193a29744cf7bd26e2a138db047169ecad7c` (child of `17c3b83c60e106902565d3abd879b7456ade9fa9`; declared base #7394 `2fd0d0bcc45d987b62668985f0eae0134ccde2e2` unchanged). Every new public member of `mobile/lib/shared/mentions/selected_mention_authorization.dart` — enum values `ordinary`/`agent`/`unresolvedAgent`, fields `kind`/`isMember`, and `requiresAgentAuthorization` — now documents the reviewer's exact distinctions: `ordinary` means absence of agent evidence, not a humanity claim; `isMember` is destination-roster presence only; `requiresAgentAuthorization` routes evidence evaluation and never grants a write. Docs-only: comment-stripped equality with `17c3b83` (zero executable delta; the single removed line is the reflowed enum declaration), `mobile/test` subtree byte-identical (`4912d92ca208…`), hermit `dart format` reports 0 changed, and the exact-head mobile/analyzer receipts quoted above apply to every unchanged byte. Own range vs #7394 is now **451 additions + 0 deletions across five files** (427 at `17c3b83` plus 24 net doc lines; the older 416 figure predates the carried test-only head). Normal CI on the new head: https://github.com/block/buzz/actions/runs/34436598394 (in progress). No behavior change is included or requested; re-audit of the public surface against `AGENTS.md:150` is requested on the resulting head.

## Workflows helper test repair — 2026-09-10

Head carried to `612a131b24a3a57e2b365de87dc98007e165a17d` (one commit on the previous head `1fe1193a29744cf7bd26e2a138db047169ecad7c`; base #7394 `2fd0d0bcc45d987b62668985f0eae0134ccde2e2` unchanged). Own range is now **473 additions + 5 deletions = 478 lines including tests** across seven files; the new own delta is test-only, **+22/−5 in exactly two Desktop E2E specs** (`desktop/tests/e2e/workflows.spec.ts` +15/−3 at three first-step fill seams, `desktop/tests/e2e/workflow-local-controls.spec.ts` +7/−2). All mobile production, mobile test, and API-doc bytes are unchanged old-head→new-head. Exact result blobs: workflows.spec.ts `38e95034f0076c388c37bda6670f668e203cfc02`, workflow-local-controls.spec.ts `97f70051c995a634c7138417b79e7a00c93a19b6`.

The repair fixes this head's public Desktop Smoke E2E shard 4 failure (run `34436598394`: `workflows.spec.ts:291` timed out all three attempts at `createWorkflow:125` waiting for "This workflow may run often" → Turn on, with three flaky siblings). Root cause, causally reproduced locally under an identical 0.1-rate animation slowdown: the fresh-dialog trigger inspector also labels its input "Message text", and during the AnimatePresence wait-mode swap the unqualified locator fills the outgoing trigger input, silently writing a `trigger.filter`, which suppresses the run-often warning (production warning requires an unfiltered `message_posted` trigger) and times out the Turn-on wait; the saved payload also lacks the step text. The repair intersects the label with the first-step `#wf-step-0-text` control at all three seams and asserts the filled value. GREEN control under the same slowdown resolves `TEXTAREA #wf-step-0-text`, keeps `on: message_posted` with **no filter** in the real saved `create_workflow.payload.yamlDefinition`, and traverses the original activation Turn-on; RED control reproduces the exact failure class (local default operator is `str_contains` vs CI's `str_ends_with`; same causal invariant).

Local provenance on the exact published blobs (one worker, cached toolchain, no retries): full `workflows.spec.ts` spec **29 passed**; workflow unit companions **105/105**; companion specs **22 passed / 1 failed** — the unchanged Darwin keyboard-template screenshot golden (**438 px**, same failure signature on the unmodified HEAD; actual PNGs differ 18 px run-to-run, not byte-identical; CI runs Linux where it passes); desktop `tsc --noEmit` (src scope), exact-config Biome, size/px/pubkey gates, `vite build --mode e2e` all pass. These are scoped local receipts, not public CI clearance. Independent bounded review found **no blocker** in the exact 27-line delta (patch SHA256 `ea77483c…`) with recorded residual limits: the keyboard-template immediate fill keeps the same outgoing-trigger exposure (wrong target would fail fast at the listbox before Save; no CI/local failure observed in that mode — bounded residual, not fixed or unexposed), no clean-install/Linux-golden-parity/whole-Desktop-package claim, and prior approvals do not transfer. Normal CI on the new head is running; no green claim is made from it. Current approvals at `1fe1193a` are invalidated by this head movement per their own terms and require delta review. Evidence: `WORK_LOGS/MOBILE_FEEDBACK_CLASSIFICATION_20260909/GREEN_WORKFLOWS_HELPER_REPAIR.md`, `GREEN_WORKFLOWS_HELPER_INDEPENDENT_REVIEW.md`, `GREEN_NEW_SMOKE4_0446_DIAGNOSIS.md`.


## Workflow regression coverage addendum — 2026-09-10

Head carried to `893c668e1475997142c27dc661def869f56a848a` (one test-only commit on `612a131b24a3a57e2b365de87dc98007e165a17d`; base #7394 `2fd0d0bcc45d987b62668985f0eae0134ccde2e2` unchanged). This carries the bounded response to current reviews 5163210493/5163212369: the scoped locator repair stays correct, but its committed test lacked causal discrimination of a wrong-target fill under ordinary timing. The new commit is **+24/−0 in exactly `desktop/tests/e2e/workflows.spec.ts`** (blob `af83102b88aa644b7f9fdfd0760fb6b07c016f70`): the existing form-builder scenario now slows only the animations that contain the outgoing trigger input through the real AnimatePresence wait-mode handoff, keeps the unchanged helper fill and value assertion, then parses the actual recorded `create_workflow.payload.yamlDefinition` to require `steps[0].id == step_1`, `steps[0].text == "Workflow notification"`, `trigger.on == message_posted`, and no `trigger.filter` (saved steps serialize as `steps[0].id/text`; the reviews' `step_1.with.text` shorthand is not this serializer's shape).

Provenance on the exact candidate tree `89a1666880253e7b7794ed22a7a133fbb7b3c88d`: under the slowed handoff the same first-seam wrong-target mutant fails at the **existing** `toHaveValue` assertion instead of passing 1/1, the restored candidate keeps the full workflows.spec.ts spec at **29/29**, and fresh exact-tree statics (Biome on both specs, src `tsc --noEmit`, file-size/px/pubkey checks) pass. The independent bounded delta review found **no blocker** for this exact 24-line change (`GREEN_7531_LOCATOR_REGRESSION_DELTA_REVIEW.md`; controlled schedule and finite platform limits disclosed, not a universal determinism claim; unchanged Darwin keyboard-template golden residual stays out of scope). Own range vs #7394 is now **497 additions + 5 deletions = 502 lines including tests**; mobile production, mobile tests, and API docs are unchanged old-head→new-head — only the Desktop spec changed. Reviews 5163210493/5163212369 predate this head movement; other open reviews on the chain are not resolved by this test-only change. Normal CI on the new head: https://github.com/block/buzz/actions/runs/34444699456 (no green claim is made from it).
