### PR TITLE
fix(mobile): authorize all selected mentions from fresh evidence

### DIFF
--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -49,6 +49,7 @@ import 'voice_note_composer_recorder.dart';
 import 'voice_note_recording.dart';
 
 part 'compose_bar/helpers.dart';
+part 'compose_bar/selected_mention_preparation.dart';
 part 'compose_bar/agent_mention_labels.dart';
 part 'compose_bar/markdown_editing_controller.dart';
 part 'compose_bar/draft_lifecycle.dart';

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -485,49 +485,59 @@ class ComposeBar extends HookConsumerWidget {
         var authorizationRevision = submittedDraftRevision;
         final visit = authorizationVisit.value;
         final config = ref.read(relayConfigProvider);
-        final readAuthorization = ref.read(agentAuthorizationReaderProvider);
+        // Equivalent refreshes retain scope; destination/credentials do not.
+        bool isConfigScopeCurrent() {
+          final current = ref.read(relayConfigProvider);
+          return current.baseUrl == config.baseUrl &&
+              current.nsec == config.nsec;
+        }
+
+        final readSelected = ref.read(
+          selectedMentionAuthorizationReaderProvider,
+        );
+        final session = ref.read(relaySessionProvider.notifier);
+        final observedProfiles = <String, NostrEvent>{};
+        final observedKeys = <String>{};
+        bool profilesCurrent() => observedProfiles.entries.every((entry) {
+          final order = ref
+              .read(userCacheProvider.notifier)
+              .profileEventOrder(entry.key);
+          final event = entry.value;
+          return order == null ||
+              order.createdAt < event.createdAt ||
+              (order.createdAt == event.createdAt &&
+                  order.eventId.compareTo(event.id) >= 0);
+        });
         bool ownsSource() =>
             context.mounted &&
             visit == authorizationVisit.value &&
-            identical(config, ref.read(relayConfigProvider));
+            isConfigScopeCurrent();
         bool isAuthorizationCurrent() =>
             ownsSource() &&
+            identical(session, ref.read(relaySessionProvider.notifier)) &&
+            currentPubkey == ref.read(currentPubkeyProvider) &&
+            profilesCurrent() &&
             submittedUploadGeneration == uploadGeneration.value &&
             authorizationRevision == draftRevision.value &&
-            identical(config, ref.read(relayConfigProvider));
+            isConfigScopeCurrent();
         void ensureAuthorizationCurrent() {
           if (!context.mounted) throw const _ComposeAuthorizationCancelled();
-          if (!identical(config, ref.read(relayConfigProvider))) {
-            throw StateError('Community changed during authorization');
+          if (!isConfigScopeCurrent()) {
+            throw const _ComposeCommunityChanged();
           }
           if (submittedUploadGeneration != uploadGeneration.value ||
               visit != authorizationVisit.value ||
               authorizationRevision != draftRevision.value) {
             throw const _ComposeAuthorizationCancelled();
           }
+          if (!identical(session, ref.read(relaySessionProvider.notifier)) ||
+              currentPubkey != ref.read(currentPubkeyProvider) ||
+              !profilesCurrent()) {
+            throw Exception('Mention evidence changed; retry the draft');
+          }
         }
 
         checkPreparationCurrent = ensureAuthorizationCurrent;
-
-        Future<void> authorize(Set<String> keys, {bool prepare = false}) async {
-          if (keys.isEmpty) return;
-          ensureAuthorizationCurrent();
-          try {
-            await authorizeAgentMentions(
-              readAuthorization,
-              keys,
-              currentPubkey,
-              channelId,
-              isAuthorizationCurrent,
-              prepare: prepare,
-            );
-          } catch (_) {
-            // A stale request is cancellation, not an access decision.
-            ensureAuthorizationCurrent();
-            rethrow;
-          }
-          ensureAuthorizationCurrent();
-        }
 
         // Resolved before any await: see
         // `_reportSendCancelledByCommunitySwitch`.
@@ -542,15 +552,34 @@ class ComposeBar extends HookConsumerWidget {
           selectedMentions,
           '${ref.read(relayConfigProvider).baseUrl} / $channelId',
         );
-        final intendedAgentKeys = {
+        final selectedKeys = outgoing.pubkeys.toSet();
+        final priorAgentKeys = {
           for (final mention in selectedMentions)
             if (mention.isAgent) mention.pubkey.toLowerCase(),
         };
+        Future<Map<String, SelectedMentionAuthorization>> authorize(
+          Set<String> keys, {
+          bool prepare = false,
+        }) => _authorizeSelectedMentions(
+          keys,
+          readSelected: readSelected,
+          priorAgentKeys: priorAgentKeys,
+          observedKeys: observedKeys,
+          observedProfiles: observedProfiles,
+          currentPubkey: currentPubkey,
+          channelId: channelId,
+          ensureAuthorizationCurrent: ensureAuthorizationCurrent,
+          isAuthorizationCurrent: isAuthorizationCurrent,
+          prepare: prepare,
+        );
+
+        final initialEvidence = await authorize(selectedKeys, prepare: true);
         final scan = await _scanNonMemberMentions(
           ref,
           channelId: channelId,
           selectedMentions: selectedMentions,
           currentPubkey: currentPubkey,
+          evidence: initialEvidence,
         );
 
         ensureAuthorizationCurrent();
@@ -583,7 +612,18 @@ class ComposeBar extends HookConsumerWidget {
 
         // Agent failures stop publication; the original draft keeps its keys.
         Future<void> addMentionedNonMembers() async {
-          final keys = intendedAgentKeys.intersection(outgoing.pubkeys.toSet());
+          final keys = outgoing.pubkeys.toSet();
+          Future<bool> authorizeWrite(String key, String role) async {
+            final evidence = await authorize(keys, prepare: true);
+            final fresh = evidence[key]!;
+            if (fresh.invitationRole != role) {
+              throw Exception(
+                'Mention classification changed; retry invitation consent',
+              );
+            }
+            return !fresh.isMember;
+          }
+
           await authorize(keys, prepare: true);
           ensureAuthorizationCurrent();
           invitationStarted.value = true;
@@ -592,6 +632,7 @@ class ComposeBar extends HookConsumerWidget {
             scan: scan,
             messenger: messenger,
             ensureCurrent: ensureAuthorizationCurrent,
+            authorizeWrite: authorizeWrite,
           );
           if (!outgoing.pubkeys.toSet().containsAll(keys)) {
             throw Exception(
@@ -600,7 +641,7 @@ class ComposeBar extends HookConsumerWidget {
           }
           await authorize(keys);
           if (queuedAttachments.isEmpty ||
-              (intendedAgentKeys.isNotEmpty ||
+              (selectedKeys.isNotEmpty ||
                   scan.humans.isNotEmpty ||
                   scan.agentPubkeys.isNotEmpty)) {
             ensureAuthorizationCurrent();
@@ -639,7 +680,7 @@ class ComposeBar extends HookConsumerWidget {
         );
         // Agent authorization is preparation, not a detached background send.
         final preparingAgents =
-            intendedAgentKeys.isNotEmpty || scan.humans.isNotEmpty;
+            selectedKeys.isNotEmpty || scan.humans.isNotEmpty;
         if (!preparingAgents) clearComposer();
         final clearedDraftRevision = draftRevision.value;
         authorizationRevision = clearedDraftRevision;
@@ -697,8 +738,11 @@ class ComposeBar extends HookConsumerWidget {
           } on _ComposeAuthorizationCancelled {
             // Keep the newer draft without displaying a false access error.
           } catch (error) {
-            if (cancellation.isCancelled) return;
-            if (error is StateError) {
+            if (cancellation.isCancelled &&
+                error is! _ComposeCommunityChanged) {
+              return;
+            }
+            if (error is _ComposeCommunityChanged) {
               _reportSendCancelledByCommunitySwitch(messenger);
             } else if (context.mounted) {
               uploadError.value = _formatUploadError(error);
@@ -735,25 +779,8 @@ class ComposeBar extends HookConsumerWidget {
           }
         }());
       } catch (error) {
-        var communityChanged = false;
-        // Failed awaits need the same scope/edit classification as success.
-        try {
-          checkPreparationCurrent?.call();
-          if (error is _ComposeAuthorizationCancelled) return;
-        } on _ComposeAuthorizationCancelled {
-          return;
-        } on StateError {
-          communityChanged = true;
-        }
         if (context.mounted) {
-          final messenger = ScaffoldMessenger.maybeOf(context);
-          if (communityChanged) {
-            _reportSendCancelledByCommunitySwitch(messenger);
-          } else {
-            messenger?.showSnackBar(
-              SnackBar(content: Text(_composeSendErrorMessage(error))),
-            );
-          }
+          _reportComposeSendError(context, error, checkPreparationCurrent);
         }
       } finally {
         if (context.mounted && authorizationAttempt.value == attempt) {

--- a/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
+++ b/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
@@ -4,6 +4,10 @@ class _ComposeAuthorizationCancelled implements Exception {
   const _ComposeAuthorizationCancelled();
 }
 
+class _ComposeCommunityChanged implements Exception {
+  const _ComposeCommunityChanged();
+}
+
 Future<void> _sendTextOnlyDraft({
   required BuildContext context,
   required _MarkdownEditingController controller,
@@ -59,7 +63,7 @@ Future<void> _sendTextOnlyDraft({
     delivered = true;
   } on _ComposeAuthorizationCancelled {
     restoreClearedDraft();
-  } on StateError {
+  } on _ComposeCommunityChanged {
     restoreClearedDraft();
     _reportSendCancelledByCommunitySwitch(messenger);
   } catch (error) {

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -1,5 +1,35 @@
 part of '../compose_bar.dart';
 
+void _reportComposeSendError(
+  BuildContext context,
+  Object error,
+  VoidCallback? checkPreparationCurrent,
+) {
+  var displayError = error;
+  var communityChanged = false;
+  // Failed awaits need the same scope/edit classification as success.
+  try {
+    checkPreparationCurrent?.call();
+    if (error is _ComposeAuthorizationCancelled) return;
+  } on _ComposeAuthorizationCancelled {
+    return;
+  } on _ComposeCommunityChanged {
+    communityChanged = true;
+  } on Exception catch (currentError) {
+    displayError = currentError;
+  }
+  if (context.mounted) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (communityChanged) {
+      _reportSendCancelledByCommunitySwitch(messenger);
+    } else {
+      messenger?.showSnackBar(
+        SnackBar(content: Text(_composeSendErrorMessage(displayError))),
+      );
+    }
+  }
+}
+
 String _composerDraftIdentity(WidgetRef ref) =>
     '${ref.watch(relayConfigProvider).baseUrl}'
     ':${ref.watch(myPubkeyProvider) ?? 'anon'}';
@@ -450,6 +480,7 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
   required bool canAddMembers,
   required VoidCallback ensureCurrent,
   required VoidCallback onAccepted,
+  required Future<bool> Function(String, String) authorizeWrite,
 }) async {
   final pending = [
     for (final pubkey in agentPubkeys) ([pubkey], 'bot'),
@@ -469,8 +500,10 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
   final notAdded = <String>[];
   final errors = <String>[];
   for (final (pubkeys, role) in pending) {
+    ensureCurrent();
+    if (!await authorizeWrite(pubkeys.single, role)) continue;
+    ensureCurrent();
     try {
-      ensureCurrent();
       await channelActions.addMembers(
         channelId: channelId,
         pubkeys: pubkeys,
@@ -480,7 +513,10 @@ Future<_NonMemberAddOutcome> _addMentionedNonMembers(
       ensureCurrent();
     } on _ComposeAuthorizationCancelled {
       rethrow;
+    } on _ComposeCommunityChanged {
+      rethrow;
     } on StateError {
+      ensureCurrent();
       rethrow;
     } catch (error) {
       notAdded.addAll(
@@ -517,6 +553,7 @@ Future<_NonMemberMentionScan> _scanNonMemberMentions(
   required String channelId,
   required List<MentionCandidate> selectedMentions,
   required String? currentPubkey,
+  required Map<String, SelectedMentionAuthorization> evidence,
 }) async {
   final none = _NonMemberMentionScan(
     channelId: channelId,
@@ -533,9 +570,6 @@ Future<_NonMemberMentionScan> _scanNonMemberMentions(
   ).wait;
   final channel = channels.firstWhere((candidate) => candidate.id == channelId);
   if (channel.isDm) return none;
-  final memberPubkeys = {
-    for (final member in members) member.pubkey.toLowerCase(),
-  };
   String? selfRole;
   if (currentPubkey != null) {
     final self = currentPubkey.toLowerCase();
@@ -552,8 +586,9 @@ Future<_NonMemberMentionScan> _scanNonMemberMentions(
   final seen = <String>{};
   for (final candidate in selectedMentions) {
     final pubkey = candidate.pubkey.toLowerCase();
-    if (memberPubkeys.contains(pubkey) || !seen.add(pubkey)) continue;
-    if (candidate.isAgent) {
+    final fresh = evidence[pubkey]!;
+    if (fresh.isMember || !seen.add(pubkey)) continue;
+    if (fresh.invitationRole == 'bot') {
       agentPubkeys.add(pubkey);
     } else {
       humans.add(candidate);
@@ -621,8 +656,7 @@ class _OutgoingMentions {
       case _NonMemberMentionChoice.invite:
         _inviteAgents = true;
         _invitedHumanPubkeys = [
-          for (final candidate in nonMembers)
-            if (!candidate.isAgent) candidate.pubkey.toLowerCase(),
+          for (final candidate in nonMembers) candidate.pubkey.toLowerCase(),
         ];
       case _NonMemberMentionChoice.sendWithoutInviting:
         demote(nonMembers.map((candidate) => candidate.pubkey));
@@ -635,15 +669,19 @@ class _OutgoingMentions {
     required _NonMemberMentionScan scan,
     required ScaffoldMessengerState? messenger,
     required VoidCallback ensureCurrent,
+    required Future<bool> Function(String, String) authorizeWrite,
   }) async {
     final outcome = await _addMentionedNonMembers(
       channelActions,
       channelId: scan.channelId,
       agentPubkeys: _inviteAgents ? scan.agentPubkeys : const [],
-      humanPubkeys: _invitedHumanPubkeys,
+      humanPubkeys: _invitedHumanPubkeys
+          .where((key) => !scan.agentPubkeys.contains(key))
+          .toList(),
       canAddMembers: scan.canAddMembers,
       ensureCurrent: ensureCurrent,
       onAccepted: () => acceptedInvitations++,
+      authorizeWrite: authorizeWrite,
     );
     if (outcome.notAdded.isNotEmpty) {
       throw Exception('Message not sent. ${outcome.errors.join(' ')}');

--- a/mobile/lib/features/channels/compose_bar/selected_mention_preparation.dart
+++ b/mobile/lib/features/channels/compose_bar/selected_mention_preparation.dart
@@ -1,0 +1,61 @@
+part of '../compose_bar.dart';
+
+// One preparation owner retains the exact evidence and denial-only taint across
+// consent, individual invitations and final publication reads.
+Future<Map<String, SelectedMentionAuthorization>> _authorizeSelectedMentions(
+  Set<String> keys, {
+  required SelectedMentionAuthorizationReader readSelected,
+  required Set<String> priorAgentKeys,
+  required Set<String> observedKeys,
+  required Map<String, NostrEvent> observedProfiles,
+  required String? currentPubkey,
+  required String channelId,
+  required VoidCallback ensureAuthorizationCurrent,
+  required bool Function() isAuthorizationCurrent,
+  bool prepare = false,
+}) async {
+  ensureAuthorizationCurrent();
+  if (keys.isEmpty) return const {};
+  try {
+    final evidence = await readSelected(
+      keys,
+      priorAgentKeys.intersection(keys),
+      currentPubkey ?? '',
+      channelId,
+      isAuthorizationCurrent,
+      (profiles) {
+        for (final key in keys) {
+          if (observedKeys.contains(key) &&
+              observedProfiles[key]?.id != profiles[key]?.id) {
+            throw Exception('Mention evidence changed; retry the draft');
+          }
+        }
+        observedKeys.addAll(keys);
+        observedProfiles.addAll(profiles);
+      },
+    );
+    ensureAuthorizationCurrent();
+    if (evidence.length != keys.length ||
+        !evidence.keys.toSet().containsAll(keys)) {
+      throw Exception('Incomplete selected mention evidence');
+    }
+    final agents = {
+      for (final key in keys)
+        if (evidence[key]!.requiresAgentAuthorization) key,
+    };
+    priorAgentKeys.addAll(agents);
+    await authorizeAgentMentions(
+      (_, _, _, _) async => [for (final key in agents) ?evidence[key]!.agent],
+      agents,
+      currentPubkey,
+      channelId,
+      isAuthorizationCurrent,
+      prepare: prepare,
+    );
+    ensureAuthorizationCurrent();
+    return evidence;
+  } catch (_) {
+    ensureAuthorizationCurrent();
+    rethrow;
+  }
+}

--- a/mobile/lib/shared/relay/relay_evidence_clock.dart
+++ b/mobile/lib/shared/relay/relay_evidence_clock.dart
@@ -1,0 +1,91 @@
+import '../crypto/signed_event.dart';
+import 'nostr_models.dart';
+
+typedef _Coordinate = (int, String, String?);
+typedef _Order = (int, String);
+
+bool _newer(_Order a, _Order b) =>
+    a.$1 > b.$1 || (a.$1 == b.$1 && a.$2.compareTo(b.$2) < 0);
+
+class _EvidenceCell {
+  _Order? latest;
+  bool retired = false;
+}
+
+/// Bounded session-local observation order, not an authorization/profile cache.
+/// Only signed events observed on this session can invalidate a query snapshot.
+/// Eviction retires just the affected coordinate's outstanding capabilities.
+class RelayEvidenceClock {
+  final _cells = <_Coordinate, _EvidenceCell>{};
+  static const _capacity = 8192;
+
+  _EvidenceCell _cell(_Coordinate key) {
+    final cell = _cells.remove(key) ?? _EvidenceCell();
+    _cells[key] = cell;
+    while (_cells.length > _capacity) {
+      _cells.remove(_cells.keys.first)!.retired = true;
+    }
+    return cell;
+  }
+
+  /// Retire outstanding capabilities on session rebuild/identity changes.
+  void clear() {
+    for (final cell in _cells.values) {
+      cell.retired = true;
+    }
+    _cells.clear();
+  }
+
+  /// Observe immediately on socket receipt, before UI batching/debouncing.
+  void observe(NostrEvent event) {
+    if (!const [0, 10100, 30177, 39002].contains(event.kind) ||
+        !verifySignedEvent(event)) {
+      return;
+    }
+    final identifiers = event.kind >= 30000
+        ? event.tags
+              .where((t) => t.length >= 2 && t[0] == 'd')
+              .map((t) => t[1])
+              .toSet()
+        : <String?>{null};
+    for (final identifier in identifiers) {
+      final cell = _cell((event.kind, event.pubkey, identifier));
+      final order = (event.createdAt, event.id);
+      if (cell.latest == null || _newer(order, cell.latest!)) {
+        cell.latest = order;
+      }
+    }
+  }
+
+  /// Retain a coordinate across an in-flight read. Capacity eviction fails
+  /// that read closed instead of making lost evidence look absent again.
+  bool Function() retain(int kind, String author, String? identifier) {
+    final cell = _cell((kind, author, identifier));
+    return () => !cell.retired;
+  }
+
+  /// Fence an exact query's newest head, including negative/absent evidence.
+  /// Unrelated authors/coordinates never invalidate this capability. Capturing
+  /// after query completion still compares against events observed during it.
+  bool Function() snapshot(
+    int kind,
+    String author,
+    String? identifier,
+    Iterable<NostrEvent> events,
+  ) {
+    final cell = _cell((kind, author, identifier));
+    _Order? head;
+    for (final event in events) {
+      if (event.kind != kind ||
+          event.pubkey != author ||
+          (kind >= 30000 && event.getTagValue('d') != identifier)) {
+        continue;
+      }
+      final order = (event.createdAt, event.id);
+      if (head == null || _newer(order, head)) head = order;
+    }
+    return () =>
+        !cell.retired &&
+        (cell.latest == null || (head != null && !_newer(cell.latest!, head)));
+  }
+}

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -34,6 +34,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../shared/mentions/agent_policy_test.dart' show signed;
 
 part 'compose_bar_test/publication_tests.dart';
+part 'compose_bar_test/classification_tests.dart';
 part 'compose_bar_test/send_lifecycle_tests.dart';
 part 'compose_bar_test/invitation_tests.dart';
 
@@ -232,18 +233,6 @@ Widget _buildComposeBar({
       channelMembersProvider('channel-1').overrideWith(
         (ref) =>
             membersLoader?.call() ?? membersFuture ?? Future.value(members),
-      ),
-      agentAuthorizationReaderProvider.overrideWithValue(
-        authorizationReader ??
-            (keys, viewer, channel, current) async => [
-              for (final key in keys)
-                AgentDirectoryEntry(
-                  pubkey: key,
-                  respondTo: 'anyone',
-                  ownerPubkey: viewer,
-                  channelIds: [channel],
-                ),
-            ],
       ),
       if (relayHttpClient == null || selectedReader != null)
         selectedMentionAuthorizationReaderProvider.overrideWithValue(
@@ -760,6 +749,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
 
 void main() {
   _publicationTests();
+  classificationTests();
   sendLifecycleTests();
   invitationTests();
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/mobile/test/features/channels/compose_bar_test/classification_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/classification_tests.dart
@@ -1,0 +1,213 @@
+part of '../compose_bar_test.dart';
+
+void classificationTests() {
+  for (final mode in [
+    'equivalent config',
+    'credential change',
+    'relay change',
+    'ordinary member',
+    'ordinary invite',
+    'fresh agent',
+    'denied agent',
+    'tainted unknown',
+    'missing key',
+    'consent change',
+    'perwrite change',
+    'revision change',
+    'policy change',
+    'accepted prefix',
+    'accepted cancellation',
+  ]) {
+    testWidgets('fresh selected classification $mode', (tester) async {
+      final signer = nostr.Keys.generate();
+      final key = 'a' * 64;
+      final savedAgent = mode == 'tainted unknown';
+      final events = <Map<String, dynamic>>[];
+      final prefix = mode.startsWith('accepted');
+      var reads = 0;
+      var accepted = false;
+      late TextEditingController controller;
+      List<String>? sent;
+      final roster = [
+        ChannelMember(
+          pubkey: key,
+          displayName: 'Alice',
+          role: 'member',
+          joinedAt: DateTime(2025),
+        ),
+      ];
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(signer.nsec),
+          currentPubkey: signer.public,
+          relayConfig: () => _SwitchableRelayConfigNotifier(
+            RelayConfig(baseUrl: 'https://relay.example', nsec: signer.nsec),
+          ),
+          members: savedAgent ? [] : roster,
+          relayAgents: savedAgent ? [_testAgent(key)] : [],
+          channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
+          selectedReader:
+              (keys, prior, viewer, channel, current, observed) async {
+                expect(keys, {key});
+                if (reads == 0) expect(prior, savedAgent ? {key} : isEmpty);
+                expect(current(), isTrue);
+                reads++;
+                if (mode == 'revision change') {
+                  observed({
+                    key: NostrEvent(
+                      id: '$reads',
+                      pubkey: key,
+                      createdAt: reads,
+                      kind: 0,
+                      tags: [],
+                      content: '{}',
+                      sig: '',
+                    ),
+                  });
+                }
+                if (mode == 'missing key') return {};
+                final agent =
+                    mode == 'fresh agent' ||
+                    mode == 'denied agent' ||
+                    mode == 'policy change' ||
+                    (mode == 'consent change' && reads >= 2) ||
+                    (mode == 'perwrite change' && reads >= 3);
+                return {
+                  key: SelectedMentionAuthorization(
+                    savedAgent || prefix && accepted
+                        ? SelectedMentionKind.unresolvedAgent
+                        : agent
+                        ? SelectedMentionKind.agent
+                        : SelectedMentionKind.ordinary,
+                    mode == 'ordinary member' || accepted,
+                    agent
+                        ? AgentDirectoryEntry(
+                            pubkey: key,
+                            ownerPubkey: viewer,
+                            respondTo:
+                                (mode == 'denied agent' ||
+                                    mode == 'policy change' && reads >= 2)
+                                ? 'nobody'
+                                : 'anyone',
+                            channelIds: accepted ? [channel] : [],
+                          )
+                        : null,
+                  ),
+                };
+              },
+          onSend: (_, keys, {mediaTags = const []}) async {
+            expect(mediaTags.where((tag) => tag.first == 'mention'), isEmpty);
+            sent = keys;
+          },
+        ),
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ComposeBar)),
+      );
+      final session = container.read(relaySessionProvider.notifier);
+      session.debugAttachSocketForTest(
+        _RecordingRelaySocket(
+          events,
+          session.debugHandleSocketMessageForTest,
+          onEventAcknowledged: (event) {
+            if (event['kind'] != 9000) return;
+            accepted = true;
+            if ([
+              'equivalent config',
+              'credential change',
+              'relay change',
+            ].contains(mode)) {
+              container
+                  .read(relayConfigProvider.notifier)
+                  .update(
+                    baseUrl: mode == 'relay change'
+                        ? 'https://other.example'
+                        : 'https://relay.example',
+                    nsec: mode == 'credential change'
+                        ? nostr.Keys.generate().nsec
+                        : signer.nsec,
+                  );
+            }
+            if (mode == 'accepted cancellation') {
+              controller.text = 'new draft';
+            }
+          },
+        ),
+      );
+      await _expandComposer(tester);
+      await tester.enterText(
+        find.byType(TextField),
+        savedAgent ? '@hel' : '@ali',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(savedAgent ? 'Helper Bot' : 'Alice'));
+      await tester.pumpAndSettle();
+      controller = tester.widget<TextField>(find.byType(TextField)).controller!;
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      if (find.text('Invite').evaluate().isNotEmpty) {
+        expect(events.where((event) => event['kind'] == 9000), isEmpty);
+        await tester.tap(find.text('Invite'));
+        await tester.pumpAndSettle();
+      }
+      if (mode == 'revision change' || mode == 'policy change') {
+        expect(reads, 2);
+      }
+      if (mode == 'consent change' || mode == 'perwrite change') {
+        expect(reads, 3);
+      }
+      final succeeds = [
+        'equivalent config',
+        'ordinary member',
+        'ordinary invite',
+        'fresh agent',
+      ].contains(mode);
+      expect(sent, succeeds ? [key] : isNull);
+      final writes = events.where((event) => event['kind'] == 9000).toList();
+      expect(
+        writes,
+        hasLength(
+          [
+                    'ordinary invite',
+                    'fresh agent',
+                    'equivalent config',
+                    'credential change',
+                    'relay change',
+                  ].contains(mode) ||
+                  prefix
+              ? 1
+              : 0,
+        ),
+      );
+      if (writes.isNotEmpty) {
+        expect(
+          (writes.single['tags'] as List).where((tag) => tag[0] == 'p').single,
+          ['p', key],
+        );
+        expect(
+          writes.single['tags'],
+          contains(equals(['role', mode == 'fresh agent' ? 'bot' : 'member'])),
+        );
+      }
+      if (!succeeds) {
+        expect(
+          controller.text,
+          ['credential change', 'relay change'].contains(mode)
+              ? '' // The new identity owns a separate empty composer.
+              : mode == 'accepted cancellation'
+              ? 'new draft'
+              : savedAgent
+              ? '@Helper Bot '
+              : '@Alice ',
+        );
+      }
+      if (prefix) {
+        expect(
+          find.textContaining('1 invitation(s) completed and remain'),
+          findsOneWidget,
+        );
+      }
+    });
+  }
+}

--- a/mobile/test/features/channels/compose_bar_test/publication_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/publication_tests.dart
@@ -39,7 +39,7 @@ void _publicationTests() {
                 respondTo: mode == 'deny' || (mode == 'revoke' && reads == 2)
                     ? 'nobody'
                     : 'anyone',
-                channelIds: mode == 'removed' && reads == 2
+                channelIds: mode == 'removed' && reads >= 2
                     ? []
                     : ['channel-1'],
               ),
@@ -59,13 +59,21 @@ void _publicationTests() {
       );
       if (mode != 'allow') {
         expect(
-          find.textContaining('Could not authorize a mentioned agent'),
+          find.textContaining(
+            mode == 'error'
+                ? 'unavailable'
+                : 'Could not authorize a mentioned agent',
+          ),
           findsOneWidget,
         );
       }
       expect(
         reads,
-        const ['allow', 'revoke', 'removed'].contains(mode) ? 2 : 1,
+        mode == 'allow' || mode == 'removed'
+            ? 3
+            : mode == 'revoke'
+            ? 2
+            : 1,
       );
     });
   }
@@ -116,7 +124,16 @@ void _publicationTests() {
             ],
             authorizationReader: (_, _, _, _) {
               reads++;
-              return pending.future;
+              return boundary == 'prompt'
+                  ? Future.value([
+                      AgentDirectoryEntry(
+                        pubkey: key,
+                        ownerPubkey: signer.public,
+                        respondTo: 'anyone',
+                        channelIds: ['channel-1'],
+                      ),
+                    ])
+                  : pending.future;
             },
             onSend: (_, _, {mediaTags = const []}) async {
               sent++;
@@ -148,7 +165,7 @@ void _publicationTests() {
         }
         await tester.tap(find.byIcon(LucideIcons.arrowUp));
         await tester.pump();
-        expect(reads, boundary == 'reader' ? 1 : 0);
+        expect(reads, boundary == 'reader' || boundary == 'prompt' ? 1 : 0);
         if (boundary == 'prompt') {
           await tester.pump(const Duration(milliseconds: 300));
         }


### PR DESCRIPTION
## Summary
Authorize every selected mention using fresh ordinary/agent/unresolved-agent evidence, both for policy selection and membership roles. Saved `isAgent` is denial-only taint, never permission: current agent evidence overrides saved false, and lost saved-true provenance stops effects without silently downgrading roles or shrinking recipients.

Reuse `authorizeAgentMentions` as the sole policy evaluator. Re-read after consent, before individual membership writes and before publication; fence observed profile revision, account/session, draft/visit and upload ownership. Selected evidence reads never populate profile caches. Preserve accepted-ACK receipts before post-write fences and truthful draft/media recovery.

Equivalent relay configuration refreshes preserve scope; actual relay or credential changes still cancel. Includes ordinary member/nonmember, fresh/denied/unknown agent, incomplete evidence, consent/per-write/revision/policy change, accepted-prefix/cancellation and equivalent/changed-config boundary tests.

### Related issue (historical publication context)

The following related-issue and testing text records earlier candidates, including their then-open findings, sizes and private compositions; it is not current-head coverage or status. See the existing final-candidate section below for superseding pins and scope.
Follow-up to #7387 and #7531, serially based on #7527 (`fix/mobile-invitation-commitment-20260909`, exact `97147e9a9f0aae7421067ca121d34701cda7d224`), not main. No existing consumer PR found in head/base queries before creation. Also addresses equivalent-config cancellation reported on #7394. Ancestors are unchanged; this PR's own diff is **460 additions + 55 deletions = 515 lines**.

### Testing (historical candidate receipts)
At substantive consumer HEAD `6513906f9efbc6be9075335e5b5a0a60aa088692`:
- `just mobile-check`: PASS (format/analyzer).
- `cd mobile && flutter test`: **2,147 passed**.
- `just file-size-check`: **FAIL** (1227 logical widget lines exceeds the 1200 limit). The previous PASS label was incorrect; the saved receipt records failure. Correction is in progress.
- `just ci`: attempted, bounded after 65 seconds in workspace Clippy; **no repository-wide green claim**. No native iOS/Android or live-relay workflow exercised; these are automated widget/provider tests, not native restart evidence. No visual-layout changes or new screenshots.

Separately, a local-only composition includes actual persistence/exact-binding/discovery/authority siblings, this consumer and #7530 correction `e9c8be29e2b59080f8e9529a67853d950d8c6a0c`. At private `35b9d518b` the complete mobile suite passes **2,186 tests**, with mobile-check clean. Ten real ComposeDrafts save → disposal → fresh ProviderContainer → restore widget cases pass; replacing fresh policy-key selection with saved-bit trust makes the restarted denied-agent case fail. This cross-sibling restart test patch is a durable **private integration artifact**, not part of this standalone PR or a substitute for its committed boundary regressions. Its governing-event accessor compatibility resolution is explicitly documented in the integration packet; no private composition is published as a release branch.

Fresh independent review requires changes: observed policy/runtime and absent-profile freshness are not completely fenced, and cancellation does not yet cross the transport rate-limit wait. The private composition does not include #7391; its e9 accessor adaptation is not yet public compatibility. These remain open, not covered by the historical green test counts; no merge/approval or all-feedback closure is implied.

### Size correction (historical `85ddfafe` candidate)
At `85ddfafe33b4e4fd2ee2f14c80918af25e0fb294`, extracted newly introduced selected-mention preparation into a sibling part without deleting tests. Current own diff **460 additions +55 deletions =515**. `just file-size-check` PASS, `just mobile-check` PASS, full mobile **2147 passed**, HEAD pinned in each invocation. This closes the standalone size violation only; F1/F2 and public cross-sibling compatibility remain open. The older size FAIL above is deliberately retained as a correction of the previous false claim.

## Published SEND correction — 2026-09-10

Head `9bcf69fd428a988358302ea6af1a0328ecf000e9`; declared base `2943008ec56589140cccd37f507a1393e64a4671`; actual own churn **594 including tests**, strictly below600. Supersedes historical candidate pins and coverage below/above. Normal CI: https://github.com/block/buzz/actions/runs/34431161984 (completion pending).

Cumulative coverage remains conditional on the existing stack: #7527 owns scope/transport and capacity/generation foundation, #7534 classification, #7536 complete observed-evidence binding, and #7539 production-boundary journeys. This is not standalone authorization completeness at an intermediate parent or a backport to #7387. The original reviewed parents' gaps are acknowledged rather than relabeled as already fixed there.

R1/R2: empty latest required audience retires obsolete recipient proof only after successful operation-scope validation; retained recipients remain protected. Genuine community changes use a typed error and invitation StateError revalidates actual scope. Unavailable authority is not falsely described as a community switch. Accepted invitation prefixes remain irreversible and accounted for. A downstream onSend adapter can still encounter generic disconnected-session failure before the typed guard: no enqueue, but the specific community explanation is not exhaustive.

The 41-row matrix includes nine added real-boundary journeys. Production rows use the actual default provider/HTTP reader and real SendMessage → signed-event relay → session. Removing reader currentness or composer aggregation independently leaks kind9; invitation counterparts leak accepted kind9000. Removing only composer guardedDelivery leaks kind9 after real draft editing while SendMessage's wrapper remains. Removing default-provider profile forwarding fails consent/post-ACK continuity (first failing assertion is unwanted kind9, not an independently logged kind9000 failure). Pure capacity and no-capacity profile-revocation rows isolate those causes; the waiting-revocation row does not independently separate coordinates from aged capacity. EMPTY/TYPED mutations fail their observable delivery/UI assertions. Source was restored. These are local mutation receipts on equivalent production, not new published-head mutation executions.

Validation: exact reviewed candidate full-mobile suites passed 2137/2152/2162/2188 for #7527/#7534/#7536/#7539. All mobile production AND test tree objects are byte-identical after mechanical Desktop-only carry; no unnecessary mobile full rerun is claimed. Own-range source-size gates pass after carry; format/analyzer receipts apply to unchanged mobile bytes. Desktop JS package 6450/6450 passed; forum 19+63 and video 7 E2E / 4 buffering unit cases are scoped receipts on identical runtime inputs, not complete Playwright/CI passes.

Private16 is now `79d3a431d08413225dda88f7fea7ca48d2a69e25`: same mobile tree as reviewed `0a28720e89b5319ebc682ea98ef73fae53f5e0d0` (full2231); forum/video test repairs carried once each. Production correspondence to public SEND was independently byte-verified. Earlier same-production restart11 (ten classification plus original exact-draft) and mounted provenance1 receipts are reused, not new final-head executions. Public versus former `668f1ffb` and private versus `cc6c3210` mobile growth is +19/-6 production and +343/-200 tests; allocation is not a net saving. This is 16 constituents, not all20, native/live-relay/VoiceOver or release acceptance. #7391's independent critique is not closed by composition.

Independent delta review e6ec accepted the exact mobile candidates with the qualifications above; old GitHub approvals are not transferred. Normal push-triggered CI is running, not yet green; security skips are not a security verdict. No rerun wave, dispatch, merge or new PR. Evidence: `WORK_LOGS/MOBILE_FEEDBACK_CLASSIFICATION_20260909/GREEN_SEND_DELTA_REVIEW_D231.md`, `GREEN_SEND_IMPLEMENTATION.md`, and `GREEN_STACK_INTEGRATION.md` / `GREEN_6A5/`.


## Mechanical docs-carry note — 2026-09-10

Head mechanically carried to `a3be0741b301a47d5affbc89105b57cfa381d418` (corrected parent #7527 `84f61093b…` + this PR's original own commits, zero conflicts, original messages/authors/DCO preserved). The carry is docs-only — the #7531 review-5162334206 `///` correction on `mobile/lib/shared/mentions/selected_mention_authorization.dart` (comment-stripped file equality; `mobile/test` bytes identical to `9bcf69fd428a988358302ea6af1a0328ecf000e9`); earlier "Head `9bcf69fd428a988358302ea6af1a0328ecf000e9`"/current-HEAD mappings above are dated receipts for their pre-carry heads, including their CI links. Own churn is unchanged at **594 including tests** (inherited docs are not counted as own); no executable delta. Normal CI on the carried head: https://github.com/block/buzz/actions/runs/34436599697.

## Workflows helper test carry — 2026-09-10

Head rebased to `42e830f65596198404f529b57bdb52d0998ce3b0` (single carry commit, author and message preserved, on corrected parent #7527 `f098f9aa877235320dade5a76ae1b2ac02e4fe70`); no conflicts, no merge commits. Own range vs the corrected parent is unchanged at **518 additions + 76 deletions = 594 lines including tests**; the only old-head→new-head content delta is the carried #7531 Desktop E2E test repair in `desktop/tests/e2e/workflows.spec.ts` (+15/−3) and `desktop/tests/e2e/workflow-local-controls.spec.ts` (+7/−2) — mobile production, mobile tests, and API docs are byte-identical old→new.

The carried `workflow-local-controls.spec.ts` repair addresses this head's public Desktop Smoke E2E shard 4 failures (run `34436599697`: "round-trips and reopens structured message-text conditions" failed all three attempts — openTriggerInspector timeout via wrong-target fill, and a mixed-animation-phase geometry retry): the helper now intersects "Message text" with `#wf-step-0-text`, and `waitForAnimations` precedes all three operator geometry samples. Causal wrong-target/bound-target and geometry/settled-geometry controls are documented in `WORK_LOGS/MOBILE_FEEDBACK_CLASSIFICATION_20260909/GREEN_7539_WORKFLOW_REPAIR.md`; the identical subpatch bytes (SHA256 `b8c02397…`) are carried here via #7531. This is a test-only carry and does **not** close the open semantic review blockers from 5162791557 (enqueue-boundary evidence binding and production-seam currentness tests); those remain open on this PR. Current-head review 5162791557 predates this head movement. Normal CI on the new head is running; no green claim is made here.


## Workflow regression test carry — 2026-09-10

Head rebased to `a22b79fa8c6c2db81f37953e9c0f7b168b1043d6` (single carry commit, author and message preserved, on parent #7527 `44d06b378b3c7a95ad2d036fa65d950a5442eb7a`); no conflicts, no merge commits. Own range vs the new parent is unchanged at **518 additions + 76 deletions = 594 lines including tests**; the only old-head→new-head content delta is the carried #7531 test-only +24/−0 regression coverage in `desktop/tests/e2e/workflows.spec.ts` (now also slowing the outgoing trigger pane and asserting the saved payload step id/text and unfiltered `message_posted` trigger in the form-builder scenario) — mobile production, mobile tests, and API docs are byte-identical old→new. This is a test-only carry and does **not** close the open semantic review blockers from 5163166388; those remain open on this PR. Current-head review 5163166388 predates this head movement. Normal CI on the new head: https://github.com/block/buzz/actions/runs/34444699935 (no green claim is made here).
