### PR TITLE
fix(mobile): fence selected mentions with session-observed evidence

### DIFF
--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -14,6 +14,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/send_message_provider.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/compose_bar.dart';
 import 'package:buzz/features/channels/channels_provider.dart';

--- a/mobile/test/features/channels/compose_bar_test/classification_tests.dart
+++ b/mobile/test/features/channels/compose_bar_test/classification_tests.dart
@@ -1,7 +1,33 @@
 part of '../compose_bar_test.dart';
 
 void classificationTests() {
-  for (final mode in [
+  for (final scenario in [
+    'production consent profile',
+    'production postack profile',
+    'production invitation revoked',
+    'production invitation draft',
+    'production invitation capacity',
+    'production final revoked',
+    'production final capacity',
+    'production final waiting revocation',
+    'production final draft',
+    'production postack scope',
+    'production reference scope',
+    'production mixed obsolete',
+    'production mixed revoked',
+    'production mixed obsolete media',
+    'production mixed revoked media',
+    'production reference obsolete media',
+    'production postack unavailable media',
+    'production postack scope media',
+    'production postack unavailable',
+    'production reference obsolete',
+    'production accepted roster',
+    'production multiple accepted',
+    'production partial prefix',
+    'production capacity',
+    'production initial capacity',
+    'production replacement',
     'equivalent config',
     'credential change',
     'relay change',
@@ -18,9 +44,60 @@ void classificationTests() {
     'accepted prefix',
     'accepted cancellation',
   ]) {
-    testWidgets('fresh selected classification $mode', (tester) async {
+    testWidgets('fresh selected classification $scenario', (tester) async {
+      final media = scenario.endsWith(' media');
+      final mode = scenario.replaceAll(' media', '');
+      final mixed = mode.startsWith('production mixed');
+      final reference = mode.startsWith('production reference') || mixed;
       final signer = nostr.Keys.generate();
-      final key = 'a' * 64;
+      final target = nostr.Keys.generate();
+      final key = target.public;
+      final production = mode.startsWith('production ');
+      final multiple =
+          mode == 'production multiple accepted' ||
+          mode == 'production partial prefix' ||
+          mixed;
+      final secondSigner = nostr.Keys.generate();
+      final second = secondSigner.public;
+      final relay = nostr.Keys.generate();
+      final acceptedKeys = <String>{};
+      final gate = RelayRateLimitGate();
+      late RelaySessionNotifier productionSession;
+      NostrEvent rosterEvent() => signed(
+        relay,
+        39002,
+        '',
+        time: 100 + acceptedKeys.length,
+        tags: [
+          ['d', 'channel-1'],
+          if (mode == 'production postack unavailable' &&
+              acceptedKeys.isNotEmpty)
+            ['d', 'channel-1'],
+          ['p', signer.public],
+          if (mixed) ['p', second, '', 'member'],
+          for (final member in acceptedKeys) ['p', member, '', 'member'],
+        ],
+      );
+      var profileChanged = false;
+      final client = _selectedRosterClient(
+        relay.public,
+        rosterEvent,
+        extraEvents: () => [
+          if (profileChanged ||
+              mode == 'production postack profile' && acceptedKeys.isNotEmpty)
+            signed(target, 0, {}, time: 200),
+          if (mode == 'production partial prefix' && acceptedKeys.isNotEmpty)
+            signed(
+              target,
+              0,
+              {},
+              time: 200,
+              tags: [
+                ['auth', 'invalid-revoked-authority'],
+              ],
+            ),
+        ],
+      );
       final savedAgent = mode == 'tainted unknown';
       final events = <Map<String, dynamic>>[];
       final prefix = mode.startsWith('accepted');
@@ -28,6 +105,31 @@ void classificationTests() {
       var accepted = false;
       late TextEditingController controller;
       List<String>? sent;
+      List<List<String>>? deliveredTags;
+      var uploaded = false;
+      final service = MediaUploadService(
+        baseUrl: 'https://relay.example',
+        nsec: signer.nsec,
+        pickGalleryVideo: () async => null,
+        pickGalleryImage: () async => null,
+        pickGalleryImages: () async => [
+          XFile.fromData(_pngBytes, name: 'tiny.png'),
+        ],
+        httpClient: http_testing.MockClient((_) async {
+          uploaded = true;
+          return http.Response(
+            jsonEncode({
+              'url': 'https://relay.example/media/test.png',
+              'sha256': '0' * 64,
+              'size': 16,
+              'type': 'image/png',
+              'uploaded': 1,
+            }),
+            200,
+          );
+        }),
+      );
+      late ProviderContainer container;
       final roster = [
         ChannelMember(
           pubkey: key,
@@ -38,73 +140,150 @@ void classificationTests() {
       ];
       await tester.pumpWidget(
         _buildComposeBar(
-          uploadService: _testUploadService(signer.nsec),
+          uploadService: media ? service : _testUploadService(signer.nsec),
           currentPubkey: signer.public,
+          rateLimitGate: production ? gate : null,
+          relayHttpClient: production ? client : null,
+          beforePublish: (event) {
+            if (event.kind != 9000) return;
+            if (mode == 'production invitation revoked') {
+              productionSession.debugHandleSocketMessageForTest([
+                'EVENT',
+                'profile',
+                signed(target, 0, {}, time: 200).toJson(),
+              ]);
+            }
+            if (mode == 'production invitation draft' ||
+                mode == 'production invitation capacity') {
+              gate.activate(300);
+            }
+          },
           relayConfig: () => _SwitchableRelayConfigNotifier(
             RelayConfig(baseUrl: 'https://relay.example', nsec: signer.nsec),
           ),
-          members: savedAgent ? [] : roster,
+          members: savedAgent
+              ? []
+              : [
+                  ...roster,
+                  if (multiple)
+                    ChannelMember(
+                      pubkey: second,
+                      displayName: 'Bob',
+                      role: 'member',
+                      joinedAt: DateTime(2025),
+                    ),
+                ],
           relayAgents: savedAgent ? [_testAgent(key)] : [],
           channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
-          selectedReader:
-              (keys, prior, viewer, channel, current, observed) async {
-                expect(keys, {key});
-                if (reads == 0) expect(prior, savedAgent ? {key} : isEmpty);
-                expect(current(), isTrue);
-                reads++;
-                if (mode == 'revision change') {
-                  observed({
-                    key: NostrEvent(
-                      id: '$reads',
-                      pubkey: key,
-                      createdAt: reads,
-                      kind: 0,
-                      tags: [],
-                      content: '{}',
-                      sig: '',
+          selectedReader: production
+              ? null
+              : (keys, prior, viewer, channel, current, observed) async {
+                  expect(keys, {key});
+                  if (reads == 0) expect(prior, savedAgent ? {key} : isEmpty);
+                  expect(current(), isTrue);
+                  reads++;
+                  if (mode == 'revision change') {
+                    observed({
+                      key: NostrEvent(
+                        id: '$reads',
+                        pubkey: key,
+                        createdAt: reads,
+                        kind: 0,
+                        tags: [],
+                        content: '{}',
+                        sig: '',
+                      ),
+                    });
+                  }
+                  if (mode == 'missing key') return {};
+                  final agent =
+                      mode == 'fresh agent' ||
+                      mode == 'denied agent' ||
+                      mode == 'policy change' ||
+                      (mode == 'consent change' && reads >= 2) ||
+                      (mode == 'perwrite change' && reads >= 3);
+                  return {
+                    key: SelectedMentionAuthorization(
+                      savedAgent || prefix && accepted
+                          ? SelectedMentionKind.unresolvedAgent
+                          : agent
+                          ? SelectedMentionKind.agent
+                          : SelectedMentionKind.ordinary,
+                      mode == 'ordinary member' || accepted,
+                      agent
+                          ? AgentDirectoryEntry(
+                              pubkey: key,
+                              ownerPubkey: viewer,
+                              respondTo:
+                                  (mode == 'denied agent' ||
+                                      mode == 'policy change' && reads >= 2)
+                                  ? 'nobody'
+                                  : 'anyone',
+                              channelIds: accepted ? [channel] : [],
+                            )
+                          : null,
                     ),
-                  });
-                }
-                if (mode == 'missing key') return {};
-                final agent =
-                    mode == 'fresh agent' ||
-                    mode == 'denied agent' ||
-                    mode == 'policy change' ||
-                    (mode == 'consent change' && reads >= 2) ||
-                    (mode == 'perwrite change' && reads >= 3);
-                return {
-                  key: SelectedMentionAuthorization(
-                    savedAgent || prefix && accepted
-                        ? SelectedMentionKind.unresolvedAgent
-                        : agent
-                        ? SelectedMentionKind.agent
-                        : SelectedMentionKind.ordinary,
-                    mode == 'ordinary member' || accepted,
-                    agent
-                        ? AgentDirectoryEntry(
-                            pubkey: key,
-                            ownerPubkey: viewer,
-                            respondTo:
-                                (mode == 'denied agent' ||
-                                    mode == 'policy change' && reads >= 2)
-                                ? 'nobody'
-                                : 'anyone',
-                            channelIds: accepted ? [channel] : [],
-                          )
-                        : null,
-                  ),
-                };
-              },
+                  };
+                },
           onSend: (_, keys, {mediaTags = const []}) async {
-            expect(mediaTags.where((tag) => tag.first == 'mention'), isEmpty);
+            if (reference) {
+              productionSession.debugHandleSocketMessageForTest([
+                'EVENT',
+                'profile',
+                signed(
+                  mode == 'production mixed revoked' ? secondSigner : target,
+                  0,
+                  {},
+                  time: 200,
+                  tags: [
+                    if (mode == 'production mixed revoked')
+                      ['auth', 'invalid-revoked-authority'],
+                  ],
+                ).toJson(),
+              ]);
+            }
             sent = keys;
+            deliveredTags = mediaTags;
+            if (production) {
+              await SendMessage(
+                signedEventRelay: SignedEventRelay(
+                  session: productionSession,
+                  nsec: signer.nsec,
+                ),
+                fetchMembers: (_) async => [],
+                readUserCache: () => {},
+                isDeliveryValid: () => true,
+                completeLocalMessage: (_, _) {},
+                removeLocalMessage: (_, _) {},
+                addLocalMessage: (_, _) {
+                  if (mode == 'production final revoked') {
+                    productionSession.debugHandleSocketMessageForTest([
+                      'EVENT',
+                      'profile',
+                      signed(target, 0, {}, time: 200).toJson(),
+                    ]);
+                  }
+                  if (mode == 'production final waiting revocation' ||
+                      mode == 'production final capacity' ||
+                      mode == 'production final draft') {
+                    gate.activate(300);
+                  }
+                },
+              )(
+                channelId: 'channel-1',
+                content: '',
+                mentionPubkeys: keys,
+                mediaTags: mediaTags,
+              );
+            }
           },
         ),
       );
-      final container = ProviderScope.containerOf(
+      container = ProviderScope.containerOf(
         tester.element(find.byType(ComposeBar)),
       );
       final session = container.read(relaySessionProvider.notifier);
+      productionSession = session;
       session.debugAttachSocketForTest(
         _RecordingRelaySocket(
           events,
@@ -112,7 +291,19 @@ void classificationTests() {
           onEventAcknowledged: (event) {
             if (event['kind'] != 9000) return;
             accepted = true;
+            if (production) {
+              acceptedKeys.add(
+                (event['tags'] as List).firstWhere((t) => t[0] == 'p')[1]
+                    as String,
+              );
+              session.debugHandleSocketMessageForTest([
+                'EVENT',
+                'roster',
+                rosterEvent().toJson(),
+              ]);
+            }
             if ([
+              'production postack scope',
               'equivalent config',
               'credential change',
               'relay change',
@@ -120,7 +311,9 @@ void classificationTests() {
               container
                   .read(relayConfigProvider.notifier)
                   .update(
-                    baseUrl: mode == 'relay change'
+                    baseUrl:
+                        mode == 'relay change' ||
+                            mode == 'production postack scope'
                         ? 'https://other.example'
                         : 'https://relay.example',
                     nsec: mode == 'credential change'
@@ -134,6 +327,10 @@ void classificationTests() {
           },
         ),
       );
+      if (media) {
+        await _openSystemPhotoPicker(tester);
+        await tester.pumpAndSettle();
+      }
       await _expandComposer(tester);
       await tester.enterText(
         find.byType(TextField),
@@ -143,13 +340,140 @@ void classificationTests() {
       await tester.tap(find.text(savedAgent ? 'Helper Bot' : 'Alice'));
       await tester.pumpAndSettle();
       controller = tester.widget<TextField>(find.byType(TextField)).controller!;
+      if (multiple) {
+        await tester.enterText(find.byType(TextField), '${controller.text}@bo');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Bob'));
+        await tester.pumpAndSettle();
+      }
+      final draft = controller.text;
+      if (mode == 'production initial capacity') gate.activate(300);
       await tester.tap(find.byIcon(LucideIcons.arrowUp));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       if (find.text('Invite').evaluate().isNotEmpty) {
         expect(events.where((event) => event['kind'] == 9000), isEmpty);
-        await tester.tap(find.text('Invite'));
-        await tester.pumpAndSettle();
+        if (mode == 'production capacity') gate.activate(300);
+        if (mode == 'production replacement') {
+          session.debugSupersedeConnection();
+        }
+        if (mode == 'production reference scope') {
+          container
+              .read(relayConfigProvider.notifier)
+              .update(baseUrl: 'https://other.example', nsec: signer.nsec);
+        }
+        if (mode == 'production consent profile') profileChanged = true;
+        await tester.tap(
+          find.text(reference ? 'Send without inviting' : 'Invite'),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (mode == 'production invitation draft') {
+        expect(events.where((e) => e['kind'] == 9000), isEmpty);
+        controller.text = 'new draft';
+      }
+      if (mode.startsWith('production final')) {
+        expect(sent, [key]);
+        expect(events.where((e) => e['kind'] == 9), isEmpty);
+        if (mode == 'production final draft') controller.text = 'new draft';
+      }
+      if (mode == 'production final waiting revocation') {
+        productionSession.debugHandleSocketMessageForTest([
+          'EVENT',
+          'profile',
+          signed(target, 0, {}, time: 200).toJson(),
+        ]);
+      }
+      gate.reset();
+      if (media) {
+        await tester.runAsync(() async {
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+        });
+      }
+      await tester.pumpAndSettle();
+      if (production) {
+        final succeeds =
+            mode == 'production reference obsolete' ||
+            mode == 'production mixed obsolete' ||
+            mode == 'production accepted roster' ||
+            mode == 'production multiple accepted';
+        expect(events.where((e) => e['kind'] == 9).length, succeeds ? 1 : 0);
+        expect(
+          acceptedKeys.length,
+          succeeds
+              ? (reference
+                    ? 0
+                    : multiple
+                    ? 2
+                    : 1)
+              : (mode == 'production partial prefix' ||
+                    mode == 'production postack unavailable' ||
+                    mode == 'production postack scope' ||
+                    mode == 'production postack profile' ||
+                    mode.startsWith('production final'))
+              ? 1
+              : 0,
+        );
+        if (media) expect(uploaded, isTrue);
+        if (reference && !mode.endsWith(' scope')) {
+          expect(sent, mixed ? [second] : isEmpty);
+          expect(deliveredTags, contains(equals(['mention', key])));
+        } else if (deliveredTags != null) {
+          expect(
+            deliveredTags!.where((tag) => tag.first == 'mention'),
+            isEmpty,
+          );
+        }
+        if (media && deliveredTags != null) {
+          expect(deliveredTags!.any((tag) => tag.first == 'imeta'), isTrue);
+        }
+        if (mode == 'production mixed revoked') {
+          expect(
+            find.textContaining('Mention evidence changed; retry the draft'),
+            findsOneWidget,
+          );
+        }
+        if (mode == 'production postack unavailable') {
+          expect(
+            find.textContaining('1 invitation(s) completed and remain'),
+            findsOneWidget,
+          );
+          expect(
+            find.text('Message not sent: the community changed'),
+            findsNothing,
+          );
+        }
+        if (mode.endsWith(' scope')) {
+          expect(
+            find.text('Message not sent: the community changed'),
+            findsOneWidget,
+          );
+        }
+        if (reference && succeeds) {
+          expect(controller.text, isEmpty);
+          return;
+        }
+        if (succeeds) {
+          expect(sent, multiple ? [key, second] : [key]);
+        } else {
+          expect(
+            controller.text,
+            mode.endsWith(' scope')
+                ? ''
+                : mode.endsWith(' draft')
+                ? 'new draft'
+                : draft,
+          );
+          if (!mode.endsWith(' draft') &&
+              (!media || mode != 'production mixed revoked')) {
+            expect(find.byType(SnackBar), findsOneWidget);
+          }
+        }
+        return;
+      }
+      if (deliveredTags != null) {
+        expect(deliveredTags!.where((tag) => tag.first == 'mention'), isEmpty);
       }
       if (mode == 'revision change' || mode == 'policy change') {
         expect(reads, 2);


### PR DESCRIPTION
🤖

## Summary (historical allocation; current owner split below)

Keep selected-mention authorization current against signed evidence actually observed by the active relay session, including events arriving while HTTP queries or rate-limited publication are waiting. A stale query must not revive an old policy or miss newly appearing profile evidence.

- One bounded, session-owned coordinate clock for kinds 0/10100, owner-keyed 30177 and relay-authenticated destination 39002. Negative heads and in-flight coordinate retirement fail closed; unrelated coordinates do not invalidate selections. Signed heads follow the same timestamp/event-ID ordering as the existing policy resolver.
- The production reader retains currentness through composer preparation and the #7536 synchronous transport enqueue fence. No second policy evaluator, SEND cache writes, saved-display-bit bypass or blanket ordinary-user block.
- Session rebuild/disposal retires outstanding evidence; delayed HTTP responses from a retired connection cannot contaminate the new session's clock. Remove the consumer's unused profile-order accessor instead of depending on an E9 compatibility map.
- Coherent preparation factoring keeps the composer below its independent 1,200-line source limit.

### Related issue (historical publication context)

The following related-issue and testing text records earlier candidates, including their then-open findings, sizes and private compositions; it is not current-head coverage or status. See the existing final-candidate section below for superseding pins and scope.

Covering follow-up to #7387 and #7534; genuine own delta on #7536 (`156b7ec31b84ac642d4cc52e5d35debb88ea59a4`), not a replacement/backport or duplicated ancestor graph. Existing #7534/#7536 and this branch were checked for duplicate publication; no existing observation PR found. Own range: **510 additions + 83 deletions = 593 lines** including tests.

### Testing (historical candidate receipts)

Exact HEAD `38c768109a29ff66a3c17b71ff46ff9e183ee847`:
- Full mobile suite **2,160 pass**, `just mobile-check` PASS, `just file-size-check` PASS; HEAD pinned before and after (`B6_FINAL_OBSERVATION_{PIN,FULL,CHECK,SIZE}.txt` in `WORK_LOGS/MOBILE_FEEDBACK_CLASSIFICATION_20260909`).
- Production HTTP reader plus real SDK subscription/socket handler: stale policy, runtime, missing-profile and roster completions fail closed; unrelated events proceed. Reader-to-rate-gated kind9000 publication emits no event after policy/profile change.
- Proportional bounded-map regression proves coordinate eviction retires an in-flight capability without globally invalidating a retained unrelated coordinate. Production retired-session HTTP regression fails when the generation admission guard is removed (`B6_ISOLATION_MUTATION.txt`). Earlier socket-observation mutation and old-source failures remain recorded, not claimed as new runs.
- Separate private composition at `a2437984d6fceeb60f90ca1cdce6036b63b8bcb6` includes actual #7391 fixture correction and E9: full **2,203 pass**, mobile-check/file-size PASS, preserving all 10 restart tests. Those restart tests are private composed evidence, not tests contained in this standalone range.

Local observed currentness is not network-atomic authorization: unseen relay changes remain the relay's enforcement responsibility. No rendering change/native screenshot, simulator/VoiceOver/keyboard acceptance, full-repository CI pass, merge or review approval is claimed. Fresh independent review remains pending.

## Published SEND correction — 2026-09-10

Head `722d1aa4e3411b02894aac187a02d40140d8a482`; declared base `2b2a5c68111bacfd7de2486296fbc6a265ab0484`; actual own churn **441 including tests**, strictly below600. Supersedes historical candidate pins and coverage below/above. Normal CI: https://github.com/block/buzz/actions/runs/34431162497 (completion pending).

Cumulative coverage remains conditional on the existing stack: #7527 owns scope/transport and capacity/generation foundation, #7534 classification, #7536 complete observed-evidence binding, and #7539 production-boundary journeys. This is not standalone authorization completeness at an intermediate parent or a backport to #7387. The original reviewed parents' gaps are acknowledged rather than relabeled as already fixed there.

R1/R2: empty latest required audience retires obsolete recipient proof only after successful operation-scope validation; retained recipients remain protected. Genuine community changes use a typed error and invitation StateError revalidates actual scope. Unavailable authority is not falsely described as a community switch. Accepted invitation prefixes remain irreversible and accounted for. A downstream onSend adapter can still encounter generic disconnected-session failure before the typed guard: no enqueue, but the specific community explanation is not exhaustive.

The 41-row matrix includes nine added real-boundary journeys. Production rows use the actual default provider/HTTP reader and real SendMessage → signed-event relay → session. Removing reader currentness or composer aggregation independently leaks kind9; invitation counterparts leak accepted kind9000. Removing only composer guardedDelivery leaks kind9 after real draft editing while SendMessage's wrapper remains. Removing default-provider profile forwarding fails consent/post-ACK continuity (first failing assertion is unwanted kind9, not an independently logged kind9000 failure). Pure capacity and no-capacity profile-revocation rows isolate those causes; the waiting-revocation row does not independently separate coordinates from aged capacity. EMPTY/TYPED mutations fail their observable delivery/UI assertions. Source was restored. These are local mutation receipts on equivalent production, not new published-head mutation executions.

Validation: exact reviewed candidate full-mobile suites passed 2137/2152/2162/2188 for #7527/#7534/#7536/#7539. All mobile production AND test tree objects are byte-identical after mechanical Desktop-only carry; no unnecessary mobile full rerun is claimed. Own-range source-size gates pass after carry; format/analyzer receipts apply to unchanged mobile bytes. Desktop JS package 6450/6450 passed; forum 19+63 and video 7 E2E / 4 buffering unit cases are scoped receipts on identical runtime inputs, not complete Playwright/CI passes.

Private16 is now `79d3a431d08413225dda88f7fea7ca48d2a69e25`: same mobile tree as reviewed `0a28720e89b5319ebc682ea98ef73fae53f5e0d0` (full2231); forum/video test repairs carried once each. Production correspondence to public SEND was independently byte-verified. Earlier same-production restart11 (ten classification plus original exact-draft) and mounted provenance1 receipts are reused, not new final-head executions. Public versus former `668f1ffb` and private versus `cc6c3210` mobile growth is +19/-6 production and +343/-200 tests; allocation is not a net saving. This is 16 constituents, not all20, native/live-relay/VoiceOver or release acceptance. #7391's independent critique is not closed by composition.

Independent delta review e6ec accepted the exact mobile candidates with the qualifications above; old GitHub approvals are not transferred. Normal push-triggered CI is running, not yet green; security skips are not a security verdict. No rerun wave, dispatch, merge or new PR. Evidence: `WORK_LOGS/MOBILE_FEEDBACK_CLASSIFICATION_20260909/GREEN_SEND_DELTA_REVIEW_D231.md`, `GREEN_SEND_IMPLEMENTATION.md`, and `GREEN_STACK_INTEGRATION.md` / `GREEN_6A5/`.


## Docs carry + Desktop workflow test repair — 2026-09-10

Head carried to `11a20c423fe5c458c961ed5dc48cd8703b089ca4`, one commit on the docs-carried parents (corrected #7536 base `4660aae48fc66f2547f835557032df641cad6f45`); the prior "Head `722d1aa4`" section above is a dated receipt for that pre-carry head, and approval 5162354965 was given at `722d1aa4` — old review bindings do not transfer to the carried head. Own churn vs the corrected parent is **450 including tests** (441 mobile test lines + the 9-line Desktop spec delta: +390/−60), still strictly below 600; the inherited #7531 docs are not counted as own (comment-stripped equality; `mobile/test` subtree `31b92bc3b792…` byte-identical to `722d1aa4`).

The Desktop delta is test-only in `desktop/tests/e2e/workflow-local-controls.spec.ts` (+7/−2): the message-step helper now intersects the shared "Message text" label with the existing first-step `#wf-step-0-text` control and asserts the filled value — a controlled wrong-target run shows the old label-only locator filling the outgoing trigger INPUT (`wf-trigger-filter-trigger-text-value`, same label), dropping the send_message step text and timing out the reopened editor at helper line 55; the bound-target control round-trips `text: Workflow notification` through the production YAML. `waitForAnimations` now precedes all three operator geometry samples; a mixed-phase control fails the original x-order assertion (1243.11 vs 1013) and the settled control passes. Full final-candidate spec: 11 passed / 1 failed — the unchanged keyboard-template screenshot differs by the same 438 pixels with byte-identical actual PNGs on the unmodified HEAD, a pre-existing local Darwin snapshot limitation, not updated or claimed green; schedule+message roundtrips pass 2/2 in one worker after instrumentation removal. Desktop `tsc --noEmit`, exact-config Biome, both differential file-size gates, `git diff --check` and hermit `dart format` pass on the exact final tree. Normal CI on the new head: https://github.com/block/buzz/actions/runs/34436598677 (in progress). No product change, snapshot update, or whole-suite rerun is claimed; the incomplete-definition save-path question stays a separate product decision.

## Workflows helper test repair carried; own duplicate deduplicated — 2026-09-10

Head carried to `67b4022c12faa85df8f7f580d16d2942772d265b` on corrected parent #7536 `40573cfac0391974400a9f65a1c9713471f35e9e` (the mobile "preserve SEND scope and authority at owner 7539" commit, author and message preserved). The previously published own repair commit `11a20c423` ("test(desktop): bind workflow message step fill to step control", the 9-line local-controls delta) is now **dropped as a verified duplicate**: `git cherry-pick --no-commit` of that exact commit onto the carried parent produces an empty index — its entire content is the already-carried #7531 subpatch (SHA256 `b8c02397…`), so nothing unrelated was dropped. Own range vs the corrected parent is now **383 additions + 58 deletions = 441 lines including tests** (down from 450 at `11a20c423`; the −9 is exactly the deduplicated own repair), still strictly below 600.

Desktop test files at this new head: `workflow-local-controls.spec.ts` blob `97f70051c995a634c7138417b79e7a00c93a19b6` — byte-identical to the previously published leaf version (all prior local-controls receipts apply unchanged) — plus the newly carried `workflows.spec.ts` repair, blob `38e95034f0076c388c37bda6670f668e203cfc02` (validated in #7531: full spec 29/29, causal red/green under identical animation slowdown; local provenance only, not public CI clearance). The Darwin keyboard-template screenshot golden remains a known unchanged local limitation (438 px; CI runs Linux where it passes). Mobile production, mobile test, and API-doc bytes are unchanged old-head→new-head. The two current-head approvals 5162865273/5162867480 were given at `11a20c423` and are invalidated by this head movement per their own terms; the earlier approval 5162354965 bound `722d1aa4` and never transferred. Normal CI on the new head is running; no green claim is made here. Evidence: `WORK_LOGS/MOBILE_FEEDBACK_CLASSIFICATION_20260909/GREEN_WORKFLOWS_HELPER_REPAIR.md` and `GREEN_DESKTOP_HELPER_PUBLICATION.md`.


## Workflow regression test carry — 2026-09-10

Head rebased to `130d06ae9ab554215a2ddeb7a9a18a0d8812c886` (single carry commit, author and message preserved, on parent #7536 `06a016e1cb69e9fbdcda9826a762c08ea800cba9`); no conflicts, no merge commits. Own range vs the new parent is unchanged at **383 additions + 58 deletions = 441 lines including tests**; the only old-head→new-head content delta is the carried #7531 test-only +24/−0 regression coverage in `desktop/tests/e2e/workflows.spec.ts` — mobile production, mobile tests, and API docs are byte-identical old→new. The approvals 5163189540/5163217119 were given at `67b4022c12faa85df8f7f580d16d2942772d265b` and do **not** transfer to this new head; delta review on the new head is expected per their own terms. Normal CI on the new head: https://github.com/block/buzz/actions/runs/34444699560 (no green claim is made here).
