### PR TITLE
fix(acp): route terminal failures to authors or opt-in sibling handlers

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -25,10 +25,34 @@ not bounce failure notifications back and forth. Fresh ordinary requests in a
 mixed batch can still receive a notification.
 
 This is a best-effort recovery signal, not automatic model substitution or a
-durable task queue. A human-originated request notifies that human; it does not
-invent a reserve coordinator. A recipient must check the original task and any
+durable task queue. By default a human-originated request notifies that human.
+A recipient must check the original task and any
 uncertain side effects before taking over. Publication failure or process exit
 can still prevent notification delivery.
+
+An operator can opt into a reserve with `--failure-handler <hex-pubkey>`
+(`BUZZ_ACP_FAILURE_HANDLER`) for ordinary requests, and
+`--recovery-handler <hex-pubkey>` (`BUZZ_ACP_RECOVERY_HANDLER`) for failed
+recovery notices. Both default to unset. These select existing identities;
+they do not change any model, account, permission, pool or subscription.
+The selected sibling replaces the original authors as the single mention.
+Every source event must have a valid signature and an owner/same-owner sibling
+author; the selected handler must have a valid same-owner NIP-OA attestation
+and a current channel membership snapshot signed by the NIP-11 relay key.
+These checks have one total five-second budget.
+An unavailable or denied preflight retains the default failure notification.
+Other-owner and relay-workflow sources are not automatically promoted to sibling
+authority. The destination's normal inbound gates still apply.
+
+Routed notices include signed `buzz:agent-failure-visited` tags. A chain can
+involve at most eight failing agents and cannot address a visited agent.
+Legacy marker-only notices seed the chain with their author. Mixed batches
+retain the visited set of their recovery events; a fresh request cannot erase
+that loop guard. This is bounded notification routing, not a writer fence or
+an acknowledgement protocol. The reserve must read the task, verify prior run
+status and effects, and arrange any remaining work under its existing mandate.
+An unavailable reserve, failed publication or process exit can still require
+manual resumption; there is no durable retry driver here.
 
 The terminal capacity classifier has live evidence for Claude's
 `You've hit your session limit` ACP error. Its other phrases have synthetic

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -30,6 +30,13 @@ invent a reserve coordinator. A recipient must check the original task and any
 uncertain side effects before taking over. Publication failure or process exit
 can still prevent notification delivery.
 
+The terminal capacity classifier has live evidence for Claude's
+`You've hit your session limit` ACP error. Its other phrases have synthetic
+test coverage only. It does not inspect ordinary assistant text, and provider
+wording changes or authentication failures expressed as assistant text can
+therefore remain outside this path. Do not infer provider availability or
+successful task completion from an Online indicator or a normal turn ending.
+
 ## Prerequisites
 
 - A running Buzz relay (`just relay` starts Docker services automatically, or use a hosted instance)

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -11,6 +11,25 @@ Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
 
 Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
 
+## Failure notifications
+
+When a request exhausts retries or hits a terminal error, the harness posts a
+signed failure notice in the triggering thread and mentions the distinct request
+authors (up to 50, newest first). A delegating agent subscribed to mentions can
+therefore inspect the failure using the existing author and membership gates.
+The notice does not copy the original request's mentions or mention itself.
+
+Native notices carry `buzz:agent-failure=1`. Such events are excluded when
+collecting recipients for another failure notice, so two unavailable agents do
+not bounce failure notifications back and forth. Fresh ordinary requests in a
+mixed batch can still receive a notification.
+
+This is a best-effort recovery signal, not automatic model substitution or a
+durable task queue. A human-originated request notifies that human; it does not
+invent a reserve coordinator. A recipient must check the original task and any
+uncertain side effects before taking over. Publication failure or process exit
+can still prevent notification delivery.
+
 ## Prerequisites
 
 - A running Buzz relay (`just relay` starts Docker services automatically, or use a hosted instance)

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -253,6 +253,14 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_AGENT_OWNER")]
     pub agent_owner: Option<String>,
 
+    /// Sibling pubkey notified when an ordinary request fails (opt-in).
+    #[arg(long, env = "BUZZ_ACP_FAILURE_HANDLER")]
+    pub failure_handler: Option<String>,
+
+    /// Sibling pubkey notified when a recovery notice fails (opt-in).
+    #[arg(long, env = "BUZZ_ACP_RECOVERY_HANDLER")]
+    pub recovery_handler: Option<String>,
+
     #[arg(long, env = "BUZZ_ACP_AGENT_COMMAND", default_value = "goose")]
     pub agent_command: String,
 
@@ -623,6 +631,7 @@ pub struct Config {
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
     /// Replaces the old REST-based owner lookup.
     pub agent_owner: Option<String>,
+    pub(crate) failure_handlers: crate::failure_routing::FailureHandlers,
     /// Disable the `<base>` platform-context section prepended to every prompt.
     pub no_base_prompt: bool,
     /// Resolved content from `--base-prompt-file`, read and validated in
@@ -938,6 +947,13 @@ impl Config {
             .replace_range(.., &"0".repeat(args.private_key.len()));
         args.private_key.clear();
 
+        let failure_handlers = crate::failure_routing::FailureHandlers::parse(
+            args.failure_handler.as_deref(),
+            args.recovery_handler.as_deref(),
+            keys.public_key(),
+        )
+        .map_err(ConfigError::ConfigFile)?;
+
         let system_prompt = if let Some(text) = args.system_prompt {
             Some(text)
         } else if let Some(ref path) = args.system_prompt_file {
@@ -1202,6 +1218,7 @@ impl Config {
             idle_pool_sleep_secs: args.idle_pool_sleep,
             replay_floor_unix: args.replay_floor,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
+            failure_handlers,
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
         };
@@ -1578,6 +1595,7 @@ mod tests {
             idle_pool_sleep_secs: 0,
             replay_floor_unix: None,
             agent_owner: None,
+            failure_handlers: Default::default(),
             no_base_prompt: false,
             base_prompt_content: None,
         }

--- a/crates/buzz-acp/src/failure_notice.rs
+++ b/crates/buzz-acp/src/failure_notice.rs
@@ -12,7 +12,12 @@ const FAILURE_TAG: &str = "buzz:agent-failure";
 const MAX_RECIPIENTS: usize = 50;
 
 /// Build the signed notice sent by the production failure path.
-pub(crate) fn build(keys: &Keys, batch: &FlushBatch, content: &str) -> anyhow::Result<Event> {
+pub(crate) fn build(
+    keys: &Keys,
+    batch: &FlushBatch,
+    content: &str,
+    route: Option<&crate::failure_routing::VerifiedRoute>,
+) -> anyhow::Result<Event> {
     anyhow::ensure!(
         batch.scope.channel_id() == batch.channel_id,
         "failure notice scope/channel mismatch"
@@ -38,7 +43,7 @@ pub(crate) fn build(keys: &Keys, batch: &FlushBatch, content: &str) -> anyhow::R
 
     let own_key = keys.public_key();
     let mut seen = HashSet::new();
-    let recipients: Vec<String> = batch
+    let mut recipients: Vec<String> = batch
         .events
         .iter()
         .rev()
@@ -47,28 +52,37 @@ pub(crate) fn build(keys: &Keys, batch: &FlushBatch, content: &str) -> anyhow::R
             // Never bounce a native failure signal back to its sender. A
             // failed recovery turn may still report a visible, unaddressed
             // notice; a new ordinary request in the batch remains eligible.
-            !item.event.tags.iter().any(|tag| {
-                let parts = tag.as_slice();
-                parts.first().map(String::as_str) == Some(FAILURE_TAG)
-                    && parts.get(1).map(String::as_str) == Some("1")
-            })
+            !crate::failure_routing::is_failure(&item.event)
         })
         .map(|item| item.event.pubkey)
         .filter(|key| *key != own_key && seen.insert(*key))
         .take(MAX_RECIPIENTS)
         .map(|key| key.to_hex())
         .collect();
+    if let Some(route) = route {
+        recipients = vec![route.recipient()];
+    }
+    let content = if route.is_some() {
+        format!("{content}\n\nRecovery notification: read the original task and current run status; inspect prior side effects before resuming. This notice does not prove that a previous writer stopped or authorize replay.")
+    } else {
+        content.to_string()
+    };
     let mentions: Vec<&str> = recipients.iter().map(String::as_str).collect();
     let marker = Tag::parse([FAILURE_TAG, "1"])?;
-    Ok(buzz_sdk::build_message(
+    let mut builder = buzz_sdk::build_message(
         batch.channel_id,
-        content,
+        &content,
         Some(&thread),
         &mentions,
         false,
         &[],
         &[],
     )?
-    .tag(marker)
-    .sign_with_keys(keys)?)
+    .tag(marker);
+    if let Some(route) = route {
+        for visited in route.visited() {
+            builder = builder.tag(Tag::parse([crate::failure_routing::VISITED_TAG, &visited])?);
+        }
+    }
+    Ok(builder.sign_with_keys(keys)?)
 }

--- a/crates/buzz-acp/src/failure_notice.rs
+++ b/crates/buzz-acp/src/failure_notice.rs
@@ -1,0 +1,74 @@
+//! Addressed, thread-bound failure notices. These are recovery signals, not
+//! authority to replay a task or evidence that its prior side effects stopped.
+
+use std::collections::HashSet;
+
+use nostr::{Event, EventId, Keys, Tag};
+
+use crate::queue::{parse_thread_tags, FlushBatch};
+use crate::scope::SessionScope;
+
+const FAILURE_TAG: &str = "buzz:agent-failure";
+const MAX_RECIPIENTS: usize = 50;
+
+/// Build the signed notice sent by the production failure path.
+pub(crate) fn build(keys: &Keys, batch: &FlushBatch, content: &str) -> anyhow::Result<Event> {
+    anyhow::ensure!(
+        batch.scope.channel_id() == batch.channel_id,
+        "failure notice scope/channel mismatch"
+    );
+    let trigger = batch
+        .events
+        .last()
+        .or_else(|| batch.cancelled_events.last())
+        .ok_or_else(|| anyhow::anyhow!("failure notice has no triggering event"))?;
+    let root_id = match &batch.scope {
+        SessionScope::Thread { root_event_id, .. } => EventId::from_hex(root_event_id)?,
+        SessionScope::Conversation { .. } => parse_thread_tags(&trigger.event)
+            .root_event_id
+            .as_deref()
+            .map(EventId::from_hex)
+            .transpose()?
+            .unwrap_or(trigger.event.id),
+    };
+    let thread = buzz_sdk::ThreadRef {
+        root_event_id: root_id,
+        parent_event_id: trigger.event.id,
+    };
+
+    let own_key = keys.public_key();
+    let mut seen = HashSet::new();
+    let recipients: Vec<String> = batch
+        .events
+        .iter()
+        .rev()
+        .chain(batch.cancelled_events.iter().rev())
+        .filter(|item| {
+            // Never bounce a native failure signal back to its sender. A
+            // failed recovery turn may still report a visible, unaddressed
+            // notice; a new ordinary request in the batch remains eligible.
+            !item.event.tags.iter().any(|tag| {
+                let parts = tag.as_slice();
+                parts.first().map(String::as_str) == Some(FAILURE_TAG)
+                    && parts.get(1).map(String::as_str) == Some("1")
+            })
+        })
+        .map(|item| item.event.pubkey)
+        .filter(|key| *key != own_key && seen.insert(*key))
+        .take(MAX_RECIPIENTS)
+        .map(|key| key.to_hex())
+        .collect();
+    let mentions: Vec<&str> = recipients.iter().map(String::as_str).collect();
+    let marker = Tag::parse([FAILURE_TAG, "1"])?;
+    Ok(buzz_sdk::build_message(
+        batch.channel_id,
+        content,
+        Some(&thread),
+        &mentions,
+        false,
+        &[],
+        &[],
+    )?
+    .tag(marker)
+    .sign_with_keys(keys)?)
+}

--- a/crates/buzz-acp/src/failure_notice_tests.rs
+++ b/crates/buzz-acp/src/failure_notice_tests.rs
@@ -93,7 +93,7 @@ fn build_addresses_distinct_authors_and_excludes_processing_agent() {
         vec![],
     );
 
-    let notice = failure_notice::build(&agent, &batch, "limit").expect("notice builds");
+    let notice = failure_notice::build(&agent, &batch, "limit", None).expect("notice builds");
     assert_eq!(
         tag_values(&notice, "p"),
         vec![
@@ -124,7 +124,7 @@ fn build_collects_cancelled_and_current_events_but_skips_marked_failures() {
     let current_id = current.id.to_hex();
     let batch = batch(channel_id, vec![old_failure, current], vec![cancelled]);
 
-    let notice = failure_notice::build(&agent, &batch, "limit").expect("notice builds");
+    let notice = failure_notice::build(&agent, &batch, "limit", None).expect("notice builds");
     assert_eq!(
         tag_values(&notice, "p"),
         vec![
@@ -143,8 +143,13 @@ fn build_top_level_anchors_notice_root_and_parent_to_trigger() {
     let channel_id = uuid::Uuid::new_v4();
     let trigger = event(&author, "trigger", None, false);
     let trigger_id = trigger.id.to_hex();
-    let notice = failure_notice::build(&agent, &batch(channel_id, vec![trigger], vec![]), "limit")
-        .expect("notice builds");
+    let notice = failure_notice::build(
+        &agent,
+        &batch(channel_id, vec![trigger], vec![]),
+        "limit",
+        None,
+    )
+    .expect("notice builds");
     let tags = queue::parse_thread_tags(&notice);
     assert_eq!(tags.root_event_id.as_deref(), Some(trigger_id.as_str()));
     assert_eq!(tags.parent_event_id.as_deref(), Some(trigger_id.as_str()));
@@ -161,7 +166,7 @@ fn build_caps_recipients_at_fifty_without_duplicates_or_self() {
             .iter()
             .map(|keys| event(keys, "request", None, false)),
     );
-    let notice = failure_notice::build(&agent, &batch(channel_id, events, vec![]), "limit")
+    let notice = failure_notice::build(&agent, &batch(channel_id, events, vec![]), "limit", None)
         .expect("notice builds");
     let recipients = tag_values(&notice, "p");
     assert_eq!(recipients.len(), 50);
@@ -240,7 +245,7 @@ async fn post_failure_notice_submits_signed_event_through_local_http() {
         auth_tag_json: None,
     };
 
-    pool::post_failure_notice(&rest, &batch, "limit").await;
+    pool::post_failure_notice(&rest, &batch, "limit", &Default::default(), None).await;
     tokio::time::timeout(std::time::Duration::from_secs(2), server)
         .await
         .expect("fixture completes")
@@ -274,6 +279,7 @@ fn failure_chain_is_not_addressed_again_and_does_not_loop() {
         &worker,
         &batch(channel_id, vec![request], vec![]),
         "worker unavailable",
+        None,
     )
     .expect("worker notice");
     assert_eq!(
@@ -284,6 +290,7 @@ fn failure_chain_is_not_addressed_again_and_does_not_loop() {
         &coordinator,
         &batch(channel_id, vec![worker_notice], vec![]),
         "coordinator also unavailable",
+        None,
     )
     .expect("coordinator notice");
     assert!(
@@ -306,8 +313,13 @@ fn original_mentions_are_not_notification_recipients() {
         .tag(Tag::parse(["p", unrelated.as_str()]).expect("mention tag"))
         .sign_with_keys(&author)
         .expect("sign request");
-    let notice = failure_notice::build(&agent, &batch(channel_id, vec![request], vec![]), "limit")
-        .expect("notice");
+    let notice = failure_notice::build(
+        &agent,
+        &batch(channel_id, vec![request], vec![]),
+        "limit",
+        None,
+    )
+    .expect("notice");
     assert_eq!(tag_values(&notice, "p"), vec![author.public_key().to_hex()]);
     assert!(!tag_values(&notice, "p").contains(&unrelated));
 }
@@ -329,7 +341,7 @@ fn thread_scope_canonical_root_wins_over_raw_event_markers() {
         vec![trigger],
         vec![],
     );
-    let notice = failure_notice::build(&agent, &batch, "limit").expect("notice builds");
+    let notice = failure_notice::build(&agent, &batch, "limit", None).expect("notice builds");
     let e = tag_values(&notice, "e");
     assert_eq!(e[0], canonical_root);
     assert_ne!(e[0], raw_root);
@@ -340,7 +352,9 @@ fn thread_scope_canonical_root_wins_over_raw_event_markers() {
 fn empty_batch_and_scope_channel_mismatch_fail_closed() {
     let agent = Keys::generate();
     let channel_id = uuid::Uuid::new_v4();
-    assert!(failure_notice::build(&agent, &batch(channel_id, vec![], vec![]), "limit").is_err());
+    assert!(
+        failure_notice::build(&agent, &batch(channel_id, vec![], vec![]), "limit", None).is_err()
+    );
     let other_channel = uuid::Uuid::new_v4();
     let author = Keys::generate();
     let mismatch = batch_with_scope(
@@ -351,7 +365,7 @@ fn empty_batch_and_scope_channel_mismatch_fail_closed() {
         vec![event(&author, "request", None, false)],
         vec![],
     );
-    assert!(failure_notice::build(&agent, &mismatch, "limit").is_err());
+    assert!(failure_notice::build(&agent, &mismatch, "limit", None).is_err());
 }
 
 #[test]
@@ -367,6 +381,7 @@ fn owner_originated_failure_has_no_synthetic_reserve_mention() {
             vec![],
         ),
         "limit",
+        None,
     )
     .expect("notice builds");
     assert_eq!(tag_values(&notice, "p"), vec![owner.public_key().to_hex()]);

--- a/crates/buzz-acp/src/failure_notice_tests.rs
+++ b/crates/buzz-acp/src/failure_notice_tests.rs
@@ -1,0 +1,376 @@
+//! Production seam tests for addressed ACP failure notices.
+//!
+//! This module is included from `lib.rs`'s test module.  It deliberately calls
+//! the notice builder and `pool::post_failure_notice`; testing only the tag
+//! collector would allow the submitted event to diverge from the contract.
+
+use std::sync::{Arc, Mutex};
+
+use nostr::{Event, EventBuilder, Keys, Kind, Tag};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::*;
+
+fn event(keys: &Keys, content: &str, thread: Option<(&str, &str)>, failure: bool) -> Event {
+    let mut builder = EventBuilder::new(Kind::Custom(9), content);
+    if let Some((root, parent)) = thread {
+        builder = builder
+            .tag(Tag::parse(vec!["e", root, "", "root"]).expect("root tag"))
+            .tag(Tag::parse(vec!["e", parent, "", "reply"]).expect("parent tag"));
+    }
+    if failure {
+        builder = builder.tag(Tag::parse(vec!["buzz:agent-failure", "1"]).expect("failure tag"));
+    }
+    builder.sign_with_keys(keys).expect("test event signs")
+}
+
+fn batch(
+    channel_id: uuid::Uuid,
+    events: Vec<Event>,
+    cancelled_events: Vec<Event>,
+) -> queue::FlushBatch {
+    queue::FlushBatch {
+        channel_id,
+        scope: scope::SessionScope::Conversation { channel_id },
+        events: events
+            .into_iter()
+            .map(|event| queue::BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: std::time::Instant::now(),
+            })
+            .collect(),
+        cancelled_events: cancelled_events
+            .into_iter()
+            .map(|event| queue::BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: std::time::Instant::now(),
+            })
+            .collect(),
+        cancel_reason: Some(queue::CancelReason::Steer),
+    }
+}
+
+fn batch_with_scope(
+    channel_id: uuid::Uuid,
+    scope: scope::SessionScope,
+    events: Vec<Event>,
+    cancelled_events: Vec<Event>,
+) -> queue::FlushBatch {
+    let mut batch = batch(channel_id, events, cancelled_events);
+    batch.scope = scope;
+    batch
+}
+
+fn tag_values(event: &Event, name: &str) -> Vec<String> {
+    event
+        .tags
+        .iter()
+        .filter_map(|tag| {
+            let fields = tag.as_slice();
+            (fields.first().map(String::as_str) == Some(name))
+                .then(|| fields.get(1).cloned())
+                .flatten()
+        })
+        .collect()
+}
+
+#[test]
+fn build_addresses_distinct_authors_and_excludes_processing_agent() {
+    let agent = Keys::generate();
+    let author_a = Keys::generate();
+    let author_b = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    let batch = batch(
+        channel_id,
+        vec![
+            event(&author_a, "a-1", None, false),
+            event(&agent, "self", None, false),
+            event(&author_a, "a-2", None, false),
+            event(&author_b, "b", None, false),
+        ],
+        vec![],
+    );
+
+    let notice = failure_notice::build(&agent, &batch, "limit").expect("notice builds");
+    assert_eq!(
+        tag_values(&notice, "p"),
+        vec![
+            author_b.public_key().to_hex(),
+            author_a.public_key().to_hex()
+        ]
+    );
+    assert_eq!(tag_values(&notice, "buzz:agent-failure"), vec!["1"]);
+}
+
+#[test]
+fn build_collects_cancelled_and_current_events_but_skips_marked_failures() {
+    let agent = Keys::generate();
+    let author_a = Keys::generate();
+    let author_b = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    let root = event(&author_a, "root", None, false);
+    let root_id = root.id.to_hex();
+    let cancelled = event(&author_a, "cancelled", Some((&root_id, &root_id)), false);
+    let failed_sender = Keys::generate();
+    let old_failure = event(
+        &failed_sender,
+        "old failure",
+        Some((&root_id, &root_id)),
+        true,
+    );
+    let current = event(&author_b, "current", Some((&root_id, &root_id)), false);
+    let current_id = current.id.to_hex();
+    let batch = batch(channel_id, vec![old_failure, current], vec![cancelled]);
+
+    let notice = failure_notice::build(&agent, &batch, "limit").expect("notice builds");
+    assert_eq!(
+        tag_values(&notice, "p"),
+        vec![
+            author_b.public_key().to_hex(),
+            author_a.public_key().to_hex()
+        ]
+    );
+    assert_eq!(tag_values(&notice, "buzz:agent-failure"), vec!["1"]);
+    assert_eq!(tag_values(&notice, "e"), vec![root_id, current_id]);
+}
+
+#[test]
+fn build_top_level_anchors_notice_root_and_parent_to_trigger() {
+    let agent = Keys::generate();
+    let author = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    let trigger = event(&author, "trigger", None, false);
+    let trigger_id = trigger.id.to_hex();
+    let notice = failure_notice::build(&agent, &batch(channel_id, vec![trigger], vec![]), "limit")
+        .expect("notice builds");
+    let tags = queue::parse_thread_tags(&notice);
+    assert_eq!(tags.root_event_id.as_deref(), Some(trigger_id.as_str()));
+    assert_eq!(tags.parent_event_id.as_deref(), Some(trigger_id.as_str()));
+}
+
+#[test]
+fn build_caps_recipients_at_fifty_without_duplicates_or_self() {
+    let agent = Keys::generate();
+    let authors: Vec<Keys> = (0..55).map(|_| Keys::generate()).collect();
+    let channel_id = uuid::Uuid::new_v4();
+    let mut events = vec![event(&agent, "self", None, false)];
+    events.extend(
+        authors
+            .iter()
+            .map(|keys| event(keys, "request", None, false)),
+    );
+    let notice = failure_notice::build(&agent, &batch(channel_id, events, vec![]), "limit")
+        .expect("notice builds");
+    let recipients = tag_values(&notice, "p");
+    assert_eq!(recipients.len(), 50);
+    assert_eq!(
+        recipients,
+        authors[5..]
+            .iter()
+            .rev()
+            .map(|k| k.public_key().to_hex())
+            .collect::<Vec<_>>()
+    );
+    assert!(!recipients.contains(&agent.public_key().to_hex()));
+}
+
+#[tokio::test]
+async fn post_failure_notice_submits_signed_event_through_local_http() {
+    let agent = Keys::generate();
+    let author = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    let trigger = event(&author, "request", None, false);
+    let trigger_id = trigger.id.to_hex();
+    let batch = batch(channel_id, vec![trigger], vec![]);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture");
+    let base_url = format!("http://{}", listener.local_addr().expect("fixture address"));
+    let captured: Arc<Mutex<Option<Event>>> = Arc::new(Mutex::new(None));
+    let captured_server = Arc::clone(&captured);
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept fixture request");
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 4096];
+        let header_end = loop {
+            let size = socket.read(&mut chunk).await.expect("read fixture request");
+            assert!(size > 0, "fixture closed before headers");
+            request.extend_from_slice(&chunk[..size]);
+            if let Some(offset) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break offset + 4;
+            }
+            assert!(request.len() <= 32 * 1024, "fixture headers exceed bound");
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        assert!(
+            headers.starts_with("POST /events "),
+            "notice must POST /events"
+        );
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                line.strip_prefix("Content-Length:")
+                    .or_else(|| line.strip_prefix("content-length:"))
+            })
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .expect("content length header");
+        assert!(content_length <= 64 * 1024, "fixture body exceeds bound");
+        while request.len() - header_end < content_length {
+            let size = socket
+                .read(&mut chunk)
+                .await
+                .expect("read complete fixture body");
+            assert!(size > 0, "fixture closed before complete body");
+            request.extend_from_slice(&chunk[..size]);
+        }
+        let body = &request[header_end..header_end + content_length];
+        let submitted: Event = serde_json::from_slice(body).expect("submitted event JSON");
+        *captured_server.lock().expect("capture lock") = Some(submitted);
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+            .await
+            .expect("write fixture response");
+    });
+    let rest = relay::RestClient {
+        http: reqwest::Client::new(),
+        base_url,
+        keys: agent.clone(),
+        auth_tag_json: None,
+    };
+
+    pool::post_failure_notice(&rest, &batch, "limit").await;
+    tokio::time::timeout(std::time::Duration::from_secs(2), server)
+        .await
+        .expect("fixture completes")
+        .expect("fixture task succeeds");
+    let submitted = captured
+        .lock()
+        .expect("capture lock")
+        .clone()
+        .expect("event captured");
+    assert_eq!(submitted.kind, Kind::Custom(9));
+    assert_eq!(submitted.pubkey, agent.public_key());
+    assert!(submitted.verify().is_ok());
+    assert_eq!(
+        tag_values(&submitted, "p"),
+        vec![author.public_key().to_hex()]
+    );
+    assert_eq!(tag_values(&submitted, "buzz:agent-failure"), vec!["1"]);
+    assert_eq!(tag_values(&submitted, "h"), vec![channel_id.to_string()]);
+    let tags = queue::parse_thread_tags(&submitted);
+    assert_eq!(tags.root_event_id.as_deref(), Some(trigger_id.as_str()));
+    assert_eq!(tags.parent_event_id.as_deref(), Some(trigger_id.as_str()));
+}
+
+#[test]
+fn failure_chain_is_not_addressed_again_and_does_not_loop() {
+    let coordinator = Keys::generate();
+    let worker = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    let request = event(&coordinator, "delegated request", None, false);
+    let worker_notice = failure_notice::build(
+        &worker,
+        &batch(channel_id, vec![request], vec![]),
+        "worker unavailable",
+    )
+    .expect("worker notice");
+    assert_eq!(
+        tag_values(&worker_notice, "p"),
+        vec![coordinator.public_key().to_hex()]
+    );
+    let coordinator_notice = failure_notice::build(
+        &coordinator,
+        &batch(channel_id, vec![worker_notice], vec![]),
+        "coordinator also unavailable",
+    )
+    .expect("coordinator notice");
+    assert!(
+        tag_values(&coordinator_notice, "p").is_empty(),
+        "failure must not wake worker again"
+    );
+    assert_eq!(
+        tag_values(&coordinator_notice, "buzz:agent-failure"),
+        vec!["1"]
+    );
+}
+
+#[test]
+fn original_mentions_are_not_notification_recipients() {
+    let agent = Keys::generate();
+    let author = Keys::generate();
+    let unrelated = Keys::generate().public_key().to_hex();
+    let channel_id = uuid::Uuid::new_v4();
+    let request = EventBuilder::new(Kind::Custom(9), "delegated request")
+        .tag(Tag::parse(["p", unrelated.as_str()]).expect("mention tag"))
+        .sign_with_keys(&author)
+        .expect("sign request");
+    let notice = failure_notice::build(&agent, &batch(channel_id, vec![request], vec![]), "limit")
+        .expect("notice");
+    assert_eq!(tag_values(&notice, "p"), vec![author.public_key().to_hex()]);
+    assert!(!tag_values(&notice, "p").contains(&unrelated));
+}
+
+#[test]
+fn thread_scope_canonical_root_wins_over_raw_event_markers() {
+    let agent = Keys::generate();
+    let author = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    let canonical_root = "ab".repeat(32);
+    let raw_root = "cd".repeat(32);
+    let trigger = event(&author, "reply", Some((&raw_root, &raw_root)), false);
+    let batch = batch_with_scope(
+        channel_id,
+        scope::SessionScope::Thread {
+            channel_id,
+            root_event_id: canonical_root.clone(),
+        },
+        vec![trigger],
+        vec![],
+    );
+    let notice = failure_notice::build(&agent, &batch, "limit").expect("notice builds");
+    let e = tag_values(&notice, "e");
+    assert_eq!(e[0], canonical_root);
+    assert_ne!(e[0], raw_root);
+    assert_eq!(e.len(), 2);
+}
+
+#[test]
+fn empty_batch_and_scope_channel_mismatch_fail_closed() {
+    let agent = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    assert!(failure_notice::build(&agent, &batch(channel_id, vec![], vec![]), "limit").is_err());
+    let other_channel = uuid::Uuid::new_v4();
+    let author = Keys::generate();
+    let mismatch = batch_with_scope(
+        channel_id,
+        scope::SessionScope::Conversation {
+            channel_id: other_channel,
+        },
+        vec![event(&author, "request", None, false)],
+        vec![],
+    );
+    assert!(failure_notice::build(&agent, &mismatch, "limit").is_err());
+}
+
+#[test]
+fn owner_originated_failure_has_no_synthetic_reserve_mention() {
+    let agent = Keys::generate();
+    let owner = Keys::generate();
+    let channel_id = uuid::Uuid::new_v4();
+    let notice = failure_notice::build(
+        &agent,
+        &batch(
+            channel_id,
+            vec![event(&owner, "owner request", None, false)],
+            vec![],
+        ),
+        "limit",
+    )
+    .expect("notice builds");
+    assert_eq!(tag_values(&notice, "p"), vec![owner.public_key().to_hex()]);
+    assert_eq!(tag_values(&notice, "buzz:agent-failure"), vec!["1"]);
+    // No reserve-agent key is invented; a coordinator-originated failure still
+    // needs a separate owner/status recovery path when no distinct sender exists.
+}

--- a/crates/buzz-acp/src/failure_routing.rs
+++ b/crates/buzz-acp/src/failure_routing.rs
@@ -1,0 +1,209 @@
+//! Opt-in recovery notifications. A route selects one sibling, not a model or
+//! execution lease. It must never turn an external request into sibling authority.
+
+use std::{collections::HashSet, time::Duration};
+
+use nostr::{Event, PublicKey};
+
+use crate::{queue::FlushBatch, relay::RestClient, OwnerCache};
+
+pub(crate) const VISITED_TAG: &str = "buzz:agent-failure-visited";
+// At most eight failing agents, including the final recipient. Do not send
+// again once eight agents have already been visited.
+const MAX_HOPS: usize = 8;
+const MAX_AUTHORS: usize = 50;
+const MAX_SOURCE_EVENTS: usize = 256;
+
+/// Explicit operator choices; neither is enabled by default.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct FailureHandlers {
+    pub ordinary: Option<PublicKey>,
+    pub recovery: Option<PublicKey>,
+}
+
+impl FailureHandlers {
+    pub(crate) fn parse(
+        ordinary: Option<&str>,
+        recovery: Option<&str>,
+        own: PublicKey,
+    ) -> Result<Self, String> {
+        let parse = |value: Option<&str>| -> Result<Option<PublicKey>, String> {
+            value
+                .map(|value| {
+                    let key = PublicKey::from_hex(value.trim())
+                        .map_err(|_| "failure handler must be a 64-character hex pubkey")?;
+                    if key == own {
+                        return Err("failure handler cannot be this agent".into());
+                    }
+                    Ok(key)
+                })
+                .transpose()
+        };
+        Ok(Self {
+            ordinary: parse(ordinary)?,
+            recovery: parse(recovery)?,
+        })
+    }
+
+    pub(crate) fn enabled(&self) -> bool {
+        self.ordinary.is_some() || self.recovery.is_some()
+    }
+}
+
+/// Created only after source, sibling and membership checks succeed.
+pub(crate) struct VerifiedRoute {
+    recipient: PublicKey,
+    visited: Vec<PublicKey>,
+}
+
+impl VerifiedRoute {
+    pub(crate) fn recipient(&self) -> String {
+        self.recipient.to_hex()
+    }
+
+    pub(crate) fn visited(&self) -> impl Iterator<Item = String> + '_ {
+        self.visited.iter().map(PublicKey::to_hex)
+    }
+}
+
+pub(crate) fn is_failure(event: &Event) -> bool {
+    event.tags.iter().any(|tag| {
+        let parts = tag.as_slice();
+        parts.first().map(String::as_str) == Some("buzz:agent-failure")
+            && parts.get(1).map(String::as_str) == Some("1")
+    })
+}
+
+fn candidate(
+    own: PublicKey,
+    batch: &FlushBatch,
+    handlers: &FailureHandlers,
+) -> Option<VerifiedRoute> {
+    if batch
+        .events
+        .len()
+        .saturating_add(batch.cancelled_events.len())
+        > MAX_SOURCE_EVENTS
+        || batch.scope.channel_id() != batch.channel_id
+    {
+        return None;
+    }
+    let events: Vec<_> = batch
+        .events
+        .iter()
+        .chain(batch.cancelled_events.iter())
+        .map(|item| &item.event)
+        .collect();
+    if events.is_empty() {
+        return None;
+    }
+    // A fresh request does not erase a recovery branch merged into its batch.
+    // Preserve the union of visited agents even when selecting the ordinary
+    // handler. A separate fresh request can still start a new recovery chain.
+    let recipient = if events.iter().any(|event| !is_failure(event)) {
+        handlers.ordinary?
+    } else {
+        handlers.recovery?
+    };
+    let mut visited = Vec::new();
+    for event in events.iter().filter(|event| is_failure(event)) {
+        for tag in event
+            .tags
+            .iter()
+            .filter(|tag| tag.as_slice().first().map(String::as_str) == Some(VISITED_TAG))
+        {
+            let parts = tag.as_slice();
+            if parts.len() != 2 {
+                return None;
+            }
+            let key = PublicKey::from_hex(&parts[1]).ok()?;
+            if !visited.contains(&key) {
+                visited.push(key);
+            }
+            if visited.len() >= MAX_HOPS {
+                return None;
+            }
+        }
+        if !visited.contains(&event.pubkey) {
+            visited.push(event.pubkey);
+        }
+    }
+    if !visited.contains(&own) {
+        visited.push(own);
+    }
+    if visited.len() >= MAX_HOPS || visited.contains(&recipient) {
+        return None;
+    }
+    Some(VerifiedRoute { recipient, visited })
+}
+
+/// One total preflight deadline. Failure leaves the existing author notification
+/// behavior in place; it never tries another identity or weakens an author gate.
+pub(crate) async fn resolve(
+    rest: &RestClient,
+    batch: &FlushBatch,
+    handlers: &FailureHandlers,
+    owner: Option<String>,
+) -> Option<VerifiedRoute> {
+    let route = candidate(rest.keys.public_key(), batch, handlers)?;
+    let owner = owner?;
+    let checks = async {
+        let cache = OwnerCache::new(Some(owner));
+        let mut authors = HashSet::new();
+        for item in batch.events.iter().chain(batch.cancelled_events.iter()) {
+            if item.event.verify().is_err()
+                || buzz_sdk::extract_channel_id(&item.event) != Some(batch.channel_id)
+            {
+                return None;
+            }
+            authors.insert(item.event.pubkey.to_hex());
+        }
+        if authors.len() > MAX_AUTHORS {
+            return None;
+        }
+        for author in authors {
+            if !crate::is_owner_or_sibling(&author, &cache, rest).await {
+                return None;
+            }
+        }
+        // A handler must be an attested sibling, not the human owner.
+        if !crate::check_sibling_via_profile(&route.recipient(), cache.get()?, rest).await {
+            return None;
+        }
+        let relay_key = PublicKey::from_hex(&rest.relay_self().await.ok()??).ok()?;
+        let membership = rest
+            .query_raw(&[serde_json::json!({
+                "kinds": [39002], "#d": [batch.channel_id.to_string()], "limit": 1
+            })])
+            .await
+            .ok()?;
+        let event: Event = serde_json::from_value(membership.as_array()?.first()?.clone()).ok()?;
+        // NIP-29 snapshots must be signed by the active relay's NIP-11 self key.
+        // A valid signature by an arbitrary channel member is insufficient.
+        let tags = &event.tags;
+        if event.kind.as_u16() != 39002
+            || event.pubkey != relay_key
+            || event.verify().is_err()
+            || !tags.iter().any(|tag| {
+                tag.as_slice().first().map(String::as_str) == Some("d")
+                    && tag.as_slice().get(1).map(String::as_str)
+                        == Some(batch.channel_id.to_string().as_str())
+            })
+        {
+            return None;
+        }
+        let recipient = route.recipient();
+        let member = tags.iter().any(|tag| {
+            tag.as_slice().first().map(String::as_str) == Some("p")
+                && tag.as_slice().get(1).map(String::as_str) == Some(recipient.as_str())
+        });
+        member.then_some(route)
+    };
+    match tokio::time::timeout(Duration::from_secs(5), checks).await {
+        Ok(Some(route)) => Some(route),
+        _ => {
+            tracing::warn!(channel = %batch.channel_id, "failure handler preflight unavailable or denied; retaining default notice");
+            None
+        }
+    }
+}

--- a/crates/buzz-acp/src/failure_routing_config_tests.rs
+++ b/crates/buzz-acp/src/failure_routing_config_tests.rs
@@ -1,0 +1,83 @@
+//! Configuration-only regressions for opt-in failure routing.
+//!
+//! These tests exercise the real clap -> Config::from_args path without
+//! touching process environment or invoking a provider.
+
+use clap::Parser;
+use nostr::{Keys, PublicKey};
+
+use crate::config::{CliArgs, Config};
+
+fn parsed_args(extra: &[&str]) -> CliArgs {
+    let private_key = format!("{}1", "0".repeat(63));
+    let mut argv = vec![
+        "buzz-acp".to_string(),
+        "--private-key".to_string(),
+        private_key,
+    ];
+    argv.extend(extra.iter().map(|value| value.to_string()));
+    CliArgs::try_parse_from(argv).expect("test CLI arguments should parse")
+}
+
+fn config(extra: &[&str]) -> Result<Config, crate::config::ConfigError> {
+    Config::from_args(parsed_args(extra))
+}
+
+fn own_public_key() -> PublicKey {
+    Keys::parse(&format!("{}1", "0".repeat(63)))
+        .expect("test private key should parse")
+        .public_key()
+}
+
+#[test]
+fn failure_routing_defaults_to_no_handlers() {
+    let config = config(&[]).expect("default configuration should be valid");
+
+    assert!(config.failure_handlers.ordinary.is_none());
+    assert!(config.failure_handlers.recovery.is_none());
+    assert!(!config.failure_handlers.enabled());
+}
+
+#[test]
+fn invalid_failure_or_recovery_handler_key_fails_configuration() {
+    for flag in ["--failure-handler", "--recovery-handler"] {
+        let result = config(&[flag, "not-a-pubkey"]);
+        assert!(result.is_err(), "{flag} must reject malformed pubkeys");
+    }
+}
+
+#[test]
+fn handler_cannot_be_this_agents_own_public_key() {
+    let own = own_public_key().to_hex();
+
+    for flag in ["--failure-handler", "--recovery-handler"] {
+        let result = config(&[flag, &own]);
+        assert!(result.is_err(), "{flag} must reject the agent's own pubkey");
+    }
+}
+
+#[test]
+fn valid_handler_keys_are_trimmed_and_normalized() {
+    let ordinary = Keys::generate().public_key().to_hex().to_uppercase();
+    let recovery = Keys::generate().public_key().to_hex().to_uppercase();
+    let ordinary_with_space = format!("  {ordinary}  ");
+    let recovery_with_space = format!("\t{recovery}\n");
+
+    let parsed = config(&[
+        "--failure-handler",
+        &ordinary_with_space,
+        "--recovery-handler",
+        &recovery_with_space,
+    ])
+    .expect("valid handler pubkeys should be accepted");
+
+    assert_eq!(
+        parsed.failure_handlers.ordinary,
+        Some(PublicKey::from_hex(&ordinary.to_lowercase()).unwrap())
+    );
+    assert_eq!(
+        parsed.failure_handlers.recovery,
+        Some(PublicKey::from_hex(&recovery.to_lowercase()).unwrap())
+    );
+    assert!(parsed.failure_handlers.enabled());
+}

--- a/crates/buzz-acp/src/failure_routing_tests.rs
+++ b/crates/buzz-acp/src/failure_routing_tests.rs
@@ -1,0 +1,570 @@
+//! Production and preflight tests for opt-in addressed failure routing.
+//!
+//! The HTTP fixture answers the same `/query` calls used by production: kind:0
+//! sibling profiles carry genuine NIP-OA attestations and kind:39002 carries
+//! the membership snapshot. `/events` captures the signed notice.
+
+use std::sync::{Arc, Mutex};
+
+use nostr::{Event, EventBuilder, Keys, Kind, Tag};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::*;
+
+#[derive(Default)]
+struct Capture {
+    events: Vec<Event>,
+    queries: usize,
+}
+
+#[derive(Clone, Copy)]
+enum MembershipMode {
+    Valid,
+    WrongSigner,
+    SlowProfiles,
+    Tampered,
+}
+
+fn event(
+    keys: &Keys,
+    channel_id: uuid::Uuid,
+    content: &str,
+    failure: bool,
+    visited: &[String],
+) -> Event {
+    let mut builder = EventBuilder::new(Kind::Custom(9), content);
+    builder = builder.tag(Tag::parse(["h".to_string(), channel_id.to_string()]).unwrap());
+    if failure {
+        builder = builder.tag(Tag::parse(["buzz:agent-failure", "1"]).unwrap());
+    }
+    for value in visited {
+        builder = builder.tag(Tag::parse([failure_routing::VISITED_TAG, value.as_str()]).unwrap());
+    }
+    builder.sign_with_keys(keys).unwrap()
+}
+
+fn batch(channel_id: uuid::Uuid, events: Vec<Event>) -> queue::FlushBatch {
+    queue::FlushBatch {
+        channel_id,
+        scope: scope::SessionScope::Conversation { channel_id },
+        events: events
+            .into_iter()
+            .map(|event| queue::BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: std::time::Instant::now(),
+            })
+            .collect(),
+        cancelled_events: vec![],
+        cancel_reason: None,
+    }
+}
+
+fn handlers(ordinary: Option<&Keys>, recovery: Option<&Keys>) -> failure_routing::FailureHandlers {
+    failure_routing::FailureHandlers {
+        ordinary: ordinary.map(Keys::public_key),
+        recovery: recovery.map(Keys::public_key),
+    }
+}
+
+async fn fixture(
+    channel_id: uuid::Uuid,
+    owner: &Keys,
+    valid_agents: &[&Keys],
+    members: &[&Keys],
+    invalid_attestation: bool,
+) -> (
+    relay::RestClient,
+    Arc<Mutex<Capture>>,
+    tokio::task::JoinHandle<()>,
+) {
+    fixture_impl(
+        channel_id,
+        owner,
+        valid_agents,
+        members,
+        invalid_attestation,
+        MembershipMode::Valid,
+    )
+    .await
+}
+
+async fn fixture_mode(
+    channel_id: uuid::Uuid,
+    owner: &Keys,
+    valid_agents: &[&Keys],
+    members: &[&Keys],
+    invalid_attestation: bool,
+    mode: MembershipMode,
+) -> (
+    relay::RestClient,
+    Arc<Mutex<Capture>>,
+    tokio::task::JoinHandle<()>,
+) {
+    fixture_impl(
+        channel_id,
+        owner,
+        valid_agents,
+        members,
+        invalid_attestation,
+        mode,
+    )
+    .await
+}
+
+async fn fixture_impl(
+    channel_id: uuid::Uuid,
+    owner: &Keys,
+    valid_agents: &[&Keys],
+    members: &[&Keys],
+    invalid_attestation: bool,
+    mode: MembershipMode,
+) -> (
+    relay::RestClient,
+    Arc<Mutex<Capture>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let owner = owner.clone();
+    let relay_keys = Keys::generate();
+    let valid: Vec<String> = valid_agents
+        .iter()
+        .map(|k| k.public_key().to_hex())
+        .collect();
+    let members: Vec<String> = members.iter().map(|k| k.public_key().to_hex()).collect();
+    let membership_tags: Vec<Tag> =
+        std::iter::once(Tag::parse(["d".to_string(), channel_id.to_string()]).unwrap())
+            .chain(
+                members
+                    .iter()
+                    .map(|key| Tag::parse(["p".to_string(), key.clone()]).unwrap()),
+            )
+            .collect();
+    let membership_signer = match mode {
+        MembershipMode::WrongSigner => Keys::generate(),
+        MembershipMode::Valid | MembershipMode::Tampered | MembershipMode::SlowProfiles => {
+            relay_keys.clone()
+        }
+    };
+    let mut membership = EventBuilder::new(Kind::Custom(39002), "")
+        .tags(membership_tags)
+        .sign_with_keys(&membership_signer)
+        .unwrap();
+    if matches!(mode, MembershipMode::Tampered) {
+        membership.content.push_str(" tampered");
+    }
+    let relay_self = relay_keys.public_key().to_hex();
+    let captured = Arc::new(Mutex::new(Capture::default()));
+    let captured_server = Arc::clone(&captured);
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            let header_end = loop {
+                let Ok(size) = socket.read(&mut chunk).await else {
+                    return;
+                };
+                if size == 0 || request.len() > 64 * 1024 {
+                    return;
+                }
+                request.extend_from_slice(&chunk[..size]);
+                if let Some(pos) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]).into_owned();
+            let length = headers
+                .lines()
+                .find_map(|line| {
+                    line.to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .map(str::trim)
+                        .and_then(|v| v.parse::<usize>().ok())
+                })
+                .unwrap_or(0);
+            while request.len() - header_end < length {
+                let Ok(size) = socket.read(&mut chunk).await else {
+                    return;
+                };
+                if size == 0 || request.len() + size > 128 * 1024 {
+                    return;
+                }
+                request.extend_from_slice(&chunk[..size]);
+            }
+            let body = &request[header_end..header_end + length];
+            let response = if headers.starts_with("GET /") {
+                serde_json::json!({"self": relay_self})
+            } else if headers.starts_with("POST /events") {
+                if let Ok(submitted) = serde_json::from_slice::<Event>(body) {
+                    captured_server.lock().unwrap().events.push(submitted);
+                }
+                serde_json::json!({})
+            } else if headers.starts_with("POST /query") {
+                captured_server.lock().unwrap().queries += 1;
+                let text = String::from_utf8_lossy(body);
+                if text.contains("39002") {
+                    serde_json::json!([membership.clone()])
+                } else {
+                    if matches!(mode, MembershipMode::SlowProfiles) {
+                        tokio::time::sleep(Duration::from_millis(1500)).await;
+                    }
+                    let author = serde_json::from_slice::<serde_json::Value>(body)
+                        .ok()
+                        .and_then(|v| {
+                            v.get(0)
+                                .and_then(|f| f.get("authors"))
+                                .and_then(|a| a.get(0))
+                                .and_then(|v| v.as_str())
+                                .map(str::to_owned)
+                        });
+                    let profile = author
+                        .filter(|key| valid.contains(key))
+                        .map(|key| {
+                            let agent = nostr::PublicKey::from_hex(&key).unwrap();
+                            let auth = if invalid_attestation {
+                                serde_json::json!([
+                                    "auth",
+                                    owner.public_key().to_hex(),
+                                    "kind=9",
+                                    "0".repeat(128)
+                                ])
+                            } else {
+                                serde_json::from_str::<serde_json::Value>(
+                                    &buzz_sdk::nip_oa::compute_auth_tag(&owner, &agent, "kind=9")
+                                        .unwrap(),
+                                )
+                                .unwrap()
+                            };
+                            serde_json::json!([{"pubkey": key, "tags": [auth]}])
+                        })
+                        .unwrap_or_else(|| serde_json::json!([]));
+                    profile
+                }
+            } else {
+                serde_json::json!({})
+            };
+            let encoded = serde_json::to_vec(&response).unwrap();
+            let reply = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                encoded.len()
+            );
+            socket.write_all(reply.as_bytes()).await.unwrap();
+            socket.write_all(&encoded).await.unwrap();
+            if headers.starts_with("POST /events") {
+                return;
+            }
+        }
+    });
+    (
+        relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        },
+        captured,
+        server,
+    )
+}
+
+#[tokio::test]
+async fn production_post_routes_one_owner_request_to_attested_member() {
+    let owner = Keys::generate();
+    let processing = Keys::generate();
+    let sibling = Keys::generate();
+    let channel = uuid::Uuid::new_v4();
+    let (mut rest, captured, server) =
+        fixture(channel, &owner, &[&sibling], &[&sibling], false).await;
+    rest.keys = processing.clone();
+    let request = event(&owner, channel, "request", false, &[]);
+    pool::post_failure_notice(
+        &rest,
+        &batch(channel, vec![request]),
+        "limit",
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex()),
+    )
+    .await;
+    server.await.unwrap();
+    let guard = captured.lock().unwrap();
+    let events = &guard.events;
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]
+            .tags
+            .iter()
+            .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("p"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events[0]
+            .tags
+            .iter()
+            .find(|tag| tag.as_slice().first().map(String::as_str) == Some("p"))
+            .unwrap()
+            .as_slice()[1],
+        sibling.public_key().to_hex()
+    );
+    assert!(events[0].verify().is_ok());
+}
+
+#[tokio::test]
+async fn nonowner_invalid_attestation_and_missing_membership_are_blocked() {
+    let owner = Keys::generate();
+    let sibling = Keys::generate();
+    let stranger = Keys::generate();
+    let channel = uuid::Uuid::new_v4();
+    let (rest, _, server) = fixture(channel, &owner, &[&sibling], &[&sibling], false).await;
+    let denied = failure_routing::resolve(
+        &rest,
+        &batch(channel, vec![event(&stranger, channel, "x", false, &[])]),
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex()),
+    )
+    .await;
+    assert!(denied.is_none());
+    server.abort();
+
+    let (rest, _, server) = fixture(channel, &owner, &[&owner, &sibling], &[&sibling], false).await;
+    let mut forged = event(&owner, channel, "signed", false, &[]);
+    forged.content.push_str(" mutated");
+    assert!(failure_routing::resolve(
+        &rest,
+        &batch(channel, vec![forged]),
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_none());
+    server.abort();
+
+    let (rest, _, server) = fixture(channel, &owner, &[&sibling], &[&sibling], true).await;
+    let invalid = failure_routing::resolve(
+        &rest,
+        &batch(channel, vec![event(&sibling, channel, "x", false, &[])]),
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex()),
+    )
+    .await;
+    assert!(invalid.is_none());
+    server.abort();
+
+    let (rest, _, server) = fixture(channel, &owner, &[&sibling], &[], false).await;
+    let missing = failure_routing::resolve(
+        &rest,
+        &batch(channel, vec![event(&owner, channel, "x", false, &[])]),
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex()),
+    )
+    .await;
+    assert!(missing.is_none());
+    server.abort();
+
+    let other_channel = uuid::Uuid::new_v4();
+    let (rest, _, server) = fixture(
+        other_channel,
+        &owner,
+        &[&owner, &sibling],
+        &[&sibling],
+        false,
+    )
+    .await;
+    let wrong_channel = failure_routing::resolve(
+        &rest,
+        &batch(
+            channel,
+            vec![event(&owner, other_channel, "wrong-channel", false, &[])],
+        ),
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex()),
+    )
+    .await;
+    assert!(wrong_channel.is_none());
+    server.abort();
+}
+
+#[tokio::test]
+async fn membership_requires_active_relay_signature_and_intact_event() {
+    let owner = Keys::generate();
+    let sibling = Keys::generate();
+    let channel = uuid::Uuid::new_v4();
+    for mode in [MembershipMode::WrongSigner, MembershipMode::Tampered] {
+        let (rest, _, server) =
+            fixture_mode(channel, &owner, &[&sibling], &[&sibling], false, mode).await;
+        assert!(failure_routing::resolve(
+            &rest,
+            &batch(channel, vec![event(&owner, channel, "request", false, &[])]),
+            &handlers(Some(&sibling), None),
+            Some(owner.public_key().to_hex()),
+        )
+        .await
+        .is_none());
+        server.abort();
+    }
+}
+
+#[tokio::test]
+async fn recovery_chain_a_to_b_to_c_stops_before_a_and_mixed_batch_keeps_visited() {
+    let owner = Keys::generate();
+    let a = Keys::generate();
+    let b = Keys::generate();
+    let c = Keys::generate();
+    let channel = uuid::Uuid::new_v4();
+    let mut notice = event(&owner, channel, "request", false, &[]);
+    for (own, next) in [(&a, &b), (&b, &c)] {
+        let (mut rest, _, server) =
+            fixture(channel, &owner, &[&a, &b, &c], &[&a, &b, &c], false).await;
+        rest.keys = (*own).clone();
+        let route = failure_routing::resolve(
+            &rest,
+            &batch(channel, vec![notice.clone()]),
+            &handlers(Some(next), Some(next)),
+            Some(owner.public_key().to_hex()),
+        )
+        .await
+        .expect("route");
+        notice = failure_notice::build(own, &batch(channel, vec![notice]), "failed", Some(&route))
+            .unwrap();
+        server.abort();
+    }
+    let (mut rest, _, server) = fixture(channel, &owner, &[&a, &b, &c], &[&a, &b, &c], false).await;
+    rest.keys = c.clone();
+    assert!(failure_routing::resolve(
+        &rest,
+        &batch(channel, vec![notice.clone()]),
+        &handlers(None, Some(&a)),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_none());
+    server.abort();
+    let fresh = event(&owner, channel, "fresh", false, &[]);
+    let (mut rest, _, server) = fixture(channel, &owner, &[&a, &b, &c], &[&a, &b, &c], false).await;
+    rest.keys = c.clone();
+    assert!(failure_routing::resolve(
+        &rest,
+        &batch(channel, vec![notice, fresh]),
+        &handlers(Some(&a), None),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_none());
+    server.abort();
+}
+
+#[tokio::test]
+async fn defaults_do_not_query_and_invalid_chains_fail_closed() {
+    let owner = Keys::generate();
+    let sibling = Keys::generate();
+    let channel = uuid::Uuid::new_v4();
+    let (rest, captured, server) = fixture(channel, &owner, &[&sibling], &[&sibling], false).await;
+    let input = batch(channel, vec![event(&owner, channel, "request", false, &[])]);
+    assert!(failure_routing::resolve(
+        &rest,
+        &input,
+        &Default::default(),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_none());
+    assert_eq!(captured.lock().unwrap().queries, 0);
+    // Positive control: this exact fixture must accept the configured route.
+    assert!(failure_routing::resolve(
+        &rest,
+        &input,
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_some());
+    let queries = captured.lock().unwrap().queries;
+    let malformed = EventBuilder::new(Kind::Custom(9), "bad")
+        .tag(Tag::parse(["h".to_string(), channel.to_string()]).unwrap())
+        .tag(Tag::parse(["buzz:agent-failure", "1"]).unwrap())
+        .tag(Tag::parse([failure_routing::VISITED_TAG, "bad", "extra"]).unwrap())
+        .sign_with_keys(&owner)
+        .unwrap();
+    assert!(failure_routing::resolve(
+        &rest,
+        &batch(channel, vec![malformed]),
+        &handlers(None, Some(&sibling)),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_none());
+    let visited: Vec<String> = (0..8)
+        .map(|_| Keys::generate().public_key().to_hex())
+        .collect();
+    assert!(failure_routing::resolve(
+        &rest,
+        &batch(
+            channel,
+            vec![event(&owner, channel, "long", true, &visited)]
+        ),
+        &handlers(None, Some(&sibling)),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_none());
+    let sources = (0..257)
+        .map(|index| event(&owner, channel, &format!("source-{index}"), false, &[]))
+        .collect();
+    assert!(failure_routing::resolve(
+        &rest,
+        &batch(channel, sources),
+        &handlers(Some(&sibling), None),
+        Some(owner.public_key().to_hex())
+    )
+    .await
+    .is_none());
+    assert_eq!(
+        captured.lock().unwrap().queries,
+        queries,
+        "invalid chains must stop before querying"
+    );
+    server.abort();
+}
+
+#[tokio::test]
+async fn preflight_deadline_bounds_all_lookups_together() {
+    let owner = Keys::generate();
+    let agents: Vec<Keys> = (0..4).map(|_| Keys::generate()).collect();
+    let channel = uuid::Uuid::new_v4();
+    let refs: Vec<&Keys> = agents.iter().collect();
+    let (rest, captured, server) = fixture_mode(
+        channel,
+        &owner,
+        &refs,
+        &refs,
+        false,
+        MembershipMode::SlowProfiles,
+    )
+    .await;
+    let sources = agents[..3]
+        .iter()
+        .map(|key| event(key, channel, "request", false, &[]))
+        .collect();
+    let input = batch(channel, sources);
+    let choices = handlers(Some(&agents[3]), None);
+    let route = tokio::time::timeout(
+        Duration::from_secs(8),
+        failure_routing::resolve(&rest, &input, &choices, Some(owner.public_key().to_hex())),
+    )
+    .await
+    .unwrap();
+    assert!(
+        route.is_none(),
+        "four individually valid 1.5-second lookups exceed the total five-second budget"
+    );
+    assert_eq!(
+        captured.lock().unwrap().queries,
+        4,
+        "must reach the fourth lookup rather than fail on an unrelated author check"
+    );
+    server.abort();
+}

--- a/crates/buzz-acp/src/failure_routing_tests.rs
+++ b/crates/buzz-acp/src/failure_routing_tests.rs
@@ -221,7 +221,7 @@ async fn fixture_impl(
                                 .and_then(|v| v.as_str())
                                 .map(str::to_owned)
                         });
-                    let profile = author
+                    author
                         .filter(|key| valid.contains(key))
                         .map(|key| {
                             let agent = nostr::PublicKey::from_hex(&key).unwrap();
@@ -241,8 +241,7 @@ async fn fixture_impl(
                             };
                             serde_json::json!([{"pubkey": key, "tags": [auth]}])
                         })
-                        .unwrap_or_else(|| serde_json::json!([]));
-                    profile
+                        .unwrap_or_else(|| serde_json::json!([]))
                 }
             } else {
                 serde_json::json!({})

--- a/crates/buzz-acp/src/failure_routing_tests.rs
+++ b/crates/buzz-acp/src/failure_routing_tests.rs
@@ -85,6 +85,7 @@ async fn fixture(
         members,
         invalid_attestation,
         MembershipMode::Valid,
+        None,
     )
     .await
 }
@@ -108,6 +109,7 @@ async fn fixture_mode(
         members,
         invalid_attestation,
         mode,
+        None,
     )
     .await
 }
@@ -119,6 +121,7 @@ async fn fixture_impl(
     members: &[&Keys],
     invalid_attestation: bool,
     mode: MembershipMode,
+    invalid_profile: Option<String>,
 ) -> (
     relay::RestClient,
     Arc<Mutex<Capture>>,
@@ -225,7 +228,11 @@ async fn fixture_impl(
                         .filter(|key| valid.contains(key))
                         .map(|key| {
                             let agent = nostr::PublicKey::from_hex(&key).unwrap();
-                            let auth = if invalid_attestation {
+                            // Corrupt one profile when isolating source authorization
+                            // from the independently valid handler's attestation.
+                            let auth = if invalid_attestation
+                                || invalid_profile.as_ref() == Some(&key)
+                            {
                                 serde_json::json!([
                                     "auth",
                                     owner.public_key().to_hex(),
@@ -342,16 +349,33 @@ async fn nonowner_invalid_attestation_and_missing_membership_are_blocked() {
     .is_none());
     server.abort();
 
-    let (rest, _, server) = fixture(channel, &owner, &[&sibling], &[&sibling], true).await;
-    let invalid = failure_routing::resolve(
-        &rest,
-        &batch(channel, vec![event(&sibling, channel, "x", false, &[])]),
-        &handlers(Some(&sibling), None),
-        Some(owner.public_key().to_hex()),
-    )
-    .await;
-    assert!(invalid.is_none());
-    server.abort();
+    // The source is the owner, so only the handler attestation changes.
+    for invalid_attestation in [false, true] {
+        let (rest, _, server) = fixture(
+            channel,
+            &owner,
+            &[&sibling],
+            &[&sibling],
+            invalid_attestation,
+        )
+        .await;
+        let route = failure_routing::resolve(
+            &rest,
+            &batch(
+                channel,
+                vec![event(&owner, channel, "handler-control", false, &[])],
+            ),
+            &handlers(Some(&sibling), None),
+            Some(owner.public_key().to_hex()),
+        )
+        .await;
+        assert_eq!(
+            route.is_some(),
+            !invalid_attestation,
+            "owner source isolates the handler attestation guard"
+        );
+        server.abort();
+    }
 
     let (rest, _, server) = fixture(channel, &owner, &[&sibling], &[], false).await;
     let missing = failure_routing::resolve(
@@ -365,14 +389,21 @@ async fn nonowner_invalid_attestation_and_missing_membership_are_blocked() {
     server.abort();
 
     let other_channel = uuid::Uuid::new_v4();
-    let (rest, _, server) = fixture(
-        other_channel,
-        &owner,
-        &[&owner, &sibling],
-        &[&sibling],
-        false,
-    )
-    .await;
+    let (rest, _, server) = fixture(channel, &owner, &[&owner, &sibling], &[&sibling], false).await;
+    assert!(
+        failure_routing::resolve(
+            &rest,
+            &batch(
+                channel,
+                vec![event(&owner, channel, "channel-control", false, &[])]
+            ),
+            &handlers(Some(&sibling), None),
+            Some(owner.public_key().to_hex()),
+        )
+        .await
+        .is_some(),
+        "membership is valid for the batch channel"
+    );
     let wrong_channel = failure_routing::resolve(
         &rest,
         &batch(
@@ -385,6 +416,43 @@ async fn nonowner_invalid_attestation_and_missing_membership_are_blocked() {
     .await;
     assert!(wrong_channel.is_none());
     server.abort();
+}
+
+#[tokio::test]
+async fn source_attestation_is_independent_of_valid_handler_attestation() {
+    let owner = Keys::generate();
+    let source = Keys::generate();
+    let sibling = Keys::generate();
+    let channel = uuid::Uuid::new_v4();
+    for invalid_profile in [None, Some(source.public_key().to_hex())] {
+        let should_accept = invalid_profile.is_none();
+        let (rest, _, server) = fixture_impl(
+            channel,
+            &owner,
+            &[&source, &sibling],
+            &[&sibling],
+            false,
+            MembershipMode::Valid,
+            invalid_profile,
+        )
+        .await;
+        let route = failure_routing::resolve(
+            &rest,
+            &batch(
+                channel,
+                vec![event(&source, channel, "source-control", false, &[])],
+            ),
+            &handlers(Some(&sibling), None),
+            Some(owner.public_key().to_hex()),
+        )
+        .await;
+        assert_eq!(
+            route.is_some(),
+            should_accept,
+            "only the source profile attestation differs between controls"
+        );
+        server.abort();
+    }
 }
 
 #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4641,6 +4641,25 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
     message.contains("Re-authenticate") || message.contains("API Error: 401")
 }
 
+/// Returns `true` when the provider has rejected the turn for a terminal
+/// capacity/usage condition for the current retry window rather than a
+/// transient transport failure.
+fn is_terminal_provider_error(error: &acp::AcpError) -> bool {
+    let acp::AcpError::AgentError { message, .. } = error else {
+        return false;
+    };
+    let message = message.to_ascii_lowercase();
+    message.contains("session limit hit")
+        || message.contains("session limit reached")
+        || message.contains("hit your session limit")
+        || message.contains("usage limit reached")
+        || message.contains("usage limit exceeded")
+        || message.contains("hit your usage limit")
+        || message.contains("usage credits required")
+        || message.contains("quota exceeded")
+        || message.contains("insufficient_quota")
+}
+
 /// Spawn a task that posts a user-visible failure notice to the relay.
 ///
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
@@ -4797,6 +4816,15 @@ fn handle_prompt_result(
                     Please re-authenticate the CLI (e.g. run `claude /login` or `codex login`) \
                     and then re-send."
                     .to_string();
+                spawn_failure_notice(rest_client, &batch, content);
+            } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_terminal_provider_error(e))
+            {
+                tracing::warn!(
+                    channel_id = %batch.channel_id,
+                    events = batch.events.len(),
+                    "dead-lettering batch immediately — terminal provider capacity error"
+                );
+                let content = "⚠️ The provider refused this request because of a session, usage or credit limit. It will not resume automatically. Please re-send once access is available.".to_string();
                 spawn_failure_notice(rest_client, &batch, content);
             } else if let Some(dead) = queue.requeue(batch) {
                 let reason = match &result.outcome {
@@ -10921,6 +10949,35 @@ mod error_outcome_emission_tests {
         );
     }
 
+    #[test]
+    fn terminal_provider_error_requires_a_concrete_rejection_phrase() {
+        let cases = [
+            ("You've hit your session limit · resets 4pm", true),
+            ("Usage limit reached for this provider", true),
+            ("Usage credits required for 1M context", true),
+            ("Quota exceeded", true),
+            ("insufficient_quota", true),
+            ("quota service temporarily unavailable", false),
+            ("This document discusses the session limit", false),
+            ("The session was interrupted", false),
+            ("Internal error while connecting to the provider", false),
+            ("429 Too Many Requests; retry-after: 5", false),
+        ];
+        for (message, expected) in cases {
+            let error = acp::AcpError::AgentError {
+                code: -32603,
+                message: message.to_string(),
+            };
+            assert_eq!(is_terminal_provider_error(&error), expected, "{message}");
+        }
+        assert!(!is_terminal_provider_error(&acp::AcpError::Io(
+            std::io::Error::other("quota service temporarily unavailable")
+        )));
+        assert!(!is_terminal_provider_error(&acp::AcpError::WriteTimeout(
+            std::time::Duration::from_secs(5)
+        )));
+    }
+
     // ── auth error dead-letter behavior ────────────────────────────────────
 
     /// An auth-class `PromptOutcome::Error` must dead-letter immediately
@@ -11012,10 +11069,10 @@ mod error_outcome_emission_tests {
         );
     }
 
-    /// A non-auth application error (e.g. usage credits) must still follow the
-    /// standard requeue path so today's behavior is unchanged.
+    /// A terminal provider capacity error must take the immediate dead-letter
+    /// path; removing that branch must leave the event queued for retry.
     #[tokio::test]
-    async fn non_auth_application_error_is_requeued() {
+    async fn terminal_provider_error_dead_letters_immediately() {
         let keys = nostr::Keys::generate();
         let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "test")
             .sign_with_keys(&keys)
@@ -11033,10 +11090,9 @@ mod error_outcome_emission_tests {
             cancel_reason: None,
         };
 
-        // Usage-credits error — AgentError but NOT an auth error.
         let usage_error = acp::AcpError::AgentError {
-            code: -32000,
-            message: "Usage credits required for 1M context".to_string(),
+            code: -32603,
+            message: "Usage limit reached for this provider".to_string(),
         };
 
         let agent = dummy_agent(0).await;
@@ -11087,16 +11143,102 @@ mod error_outcome_emission_tests {
             None,
         );
 
-        // Non-auth application error: batch IS requeued (first attempt, retry budget > 0).
+        // Terminal provider error: batch is dead-lettered immediately.
+        assert_eq!(
+            queue.pending_channels(),
+            0,
+            "terminal provider error must not requeue the batch"
+        );
+        assert_eq!(
+            queue.queued_event_count(channel_id),
+            0,
+            "terminal provider error must dead-letter the event"
+        );
+    }
+
+    /// A generic provider error remains retryable and preserves the batch.
+    #[tokio::test]
+    async fn non_terminal_application_error_is_requeued() {
+        let keys = nostr::Keys::generate();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "test")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let channel_id = uuid::Uuid::new_v4();
+        let batch = FlushBatch {
+            channel_id,
+            scope: scope::SessionScope::Conversation { channel_id },
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let usage_error = acp::AcpError::AgentError {
+            code: -32603,
+            message: "Internal error while connecting to the provider".to_string(),
+        };
+
+        let agent = dummy_agent(0).await;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: None,
+                scope: None,
+                turn_id: "test-turn-id".to_string(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let removed_channels = std::collections::HashSet::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+        let result = PromptResult {
+            agent,
+            source: PromptSource::Channel(scope::SessionScope::Conversation { channel_id }),
+            turn_id: "test-turn-id".to_string(),
+            outcome: PromptOutcome::Error(usage_error),
+            batch: Some(batch),
+        };
+        handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            result,
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+        );
+
+        // Generic transient provider error: batch remains queued for retry.
         assert_eq!(
             queue.pending_channels(),
             1,
-            "non-auth application error must requeue the batch for retry"
+            "transient provider error must requeue the batch"
         );
         assert_eq!(
             queue.queued_event_count(channel_id),
             1,
-            "non-auth application error must preserve the event for retry"
+            "transient provider error must preserve the event"
         );
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -6,6 +6,11 @@ mod engram_fetch;
 mod failure_notice;
 #[cfg(test)]
 mod failure_notice_tests;
+mod failure_routing;
+#[cfg(test)]
+mod failure_routing_config_tests;
+#[cfg(test)]
+mod failure_routing_tests;
 mod filter;
 mod observer;
 mod pi_launcher;
@@ -4675,6 +4680,7 @@ fn is_terminal_provider_error(error: &acp::AcpError) -> bool {
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
 /// dead-letter path so neither duplicates the tokio::spawn block.
 fn spawn_failure_notice(
+    config: &Config,
     rest_client: Option<&relay::RestClient>,
     batch: &FlushBatch,
     content: String,
@@ -4682,8 +4688,13 @@ fn spawn_failure_notice(
     if let Some(rest) = rest_client {
         let batch = batch.clone();
         let rest = rest.clone();
+        let handlers = config.failure_handlers.clone();
+        let owner = handlers
+            .enabled()
+            .then(|| resolve_agent_owner(config))
+            .flatten();
         tokio::spawn(async move {
-            pool::post_failure_notice(&rest, &batch, &content).await;
+            pool::post_failure_notice(&rest, &batch, &content, &handlers, owner).await;
         });
     }
 }
@@ -4781,10 +4792,10 @@ fn handle_prompt_result(
                     batch.events.len(),
                 );
                 let content = format!(
-                    "⚠️ I couldn't process the last request (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.",
+                    "⚠️ I couldn't process the last request (the turn exceeded the maximum duration ({}s)). This turn will not retry automatically.",
                     config.max_turn_duration_secs
                 );
-                spawn_failure_notice(rest_client, &batch, content);
+                spawn_failure_notice(config, rest_client, &batch, content);
                 hard_timeout_fate_suffix = Some(" — dead-lettered (no recent activity)");
             } else if matches!(
                 result.outcome,
@@ -4799,10 +4810,10 @@ fn handle_prompt_result(
                 );
                 if let Some(dead) = queue.requeue(batch) {
                     let content = format!(
-                        "⚠️ I couldn't process the last request after multiple retries (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.",
+                        "⚠️ I couldn't process the last request after multiple retries (the turn exceeded the maximum duration ({}s)). This turn will not retry automatically.",
                         config.max_turn_duration_secs
                     );
-                    spawn_failure_notice(rest_client, &dead, content);
+                    spawn_failure_notice(config, rest_client, &dead, content);
                     hard_timeout_fate_suffix = Some(" — dead-lettered (retry budget exhausted)");
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
@@ -4819,9 +4830,9 @@ fn handle_prompt_result(
                 );
                 let content = "⚠️ I couldn't process the last request: authentication failed. \
                     Please re-authenticate the CLI (e.g. run `claude /login` or `codex login`) \
-                    and then re-send."
+                    before using this agent again."
                     .to_string();
-                spawn_failure_notice(rest_client, &batch, content);
+                spawn_failure_notice(config, rest_client, &batch, content);
             } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_terminal_provider_error(e))
             {
                 tracing::warn!(
@@ -4829,8 +4840,8 @@ fn handle_prompt_result(
                     events = batch.events.len(),
                     "dead-lettering batch immediately — terminal provider capacity error"
                 );
-                let content = "⚠️ The provider refused this request because of a session, usage or credit limit. It will not resume automatically. Please re-send once access is available.".to_string();
-                spawn_failure_notice(rest_client, &batch, content);
+                let content = "⚠️ The provider refused this request because of a session, usage or credit limit. This turn will not retry automatically.".to_string();
+                spawn_failure_notice(config, rest_client, &batch, content);
             } else if let Some(dead) = queue.requeue(batch) {
                 let reason = match &result.outcome {
                     PromptOutcome::Timeout(TimeoutKind::Idle) => "the turn timed out".to_string(),
@@ -4843,9 +4854,9 @@ fn handle_prompt_result(
                     _ => "repeated failures".to_string(),
                 };
                 let content = format!(
-                    "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
+                    "⚠️ I couldn't process the last request after multiple retries ({reason}). This turn will not retry automatically."
                 );
-                spawn_failure_notice(rest_client, &dead, content);
+                spawn_failure_notice(config, rest_client, &dead, content);
             }
         } else {
             tracing::debug!(
@@ -9213,6 +9224,7 @@ mod build_mcp_servers_tests {
             idle_pool_sleep_secs: 0,
             replay_floor_unix: None,
             agent_owner: None,
+            failure_handlers: Default::default(),
             no_base_prompt: false,
             base_prompt_content: None,
         }
@@ -9439,6 +9451,7 @@ mod error_outcome_emission_tests {
             idle_pool_sleep_secs: 0,
             replay_floor_unix: None,
             agent_owner: None,
+            failure_handlers: Default::default(),
             no_base_prompt: false,
             base_prompt_content: None,
         }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4647,6 +4647,13 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
 /// Returns `true` when the provider has rejected the turn for a terminal
 /// capacity/usage condition for the current retry window rather than a
 /// transient transport failure.
+///
+/// `You've hit your session limit` was observed in a Claude ACP AgentError.
+/// The other phrases are defensive, synthetically tested matches, not live
+/// coverage claims for Codex, Cursor, goose, or any particular subscription.
+/// An ordinary assistant message containing a limit phrase is not an ACP
+/// error and does not enter this classifier. Provider wording can change;
+/// unknown errors retain the existing bounded retry behavior.
 fn is_terminal_provider_error(error: &acp::AcpError) -> bool {
     let acp::AcpError::AgentError { message, .. } = error else {
         return false;

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3,6 +3,9 @@
 mod acp;
 mod config;
 mod engram_fetch;
+mod failure_notice;
+#[cfg(test)]
+mod failure_notice_tests;
 mod filter;
 mod observer;
 mod pi_launcher;
@@ -4670,15 +4673,10 @@ fn spawn_failure_notice(
     content: String,
 ) {
     if let Some(rest) = rest_client {
-        let thread_tags = batch
-            .events
-            .last()
-            .map(|be| queue::parse_thread_tags(&be.event))
-            .unwrap_or_default();
+        let batch = batch.clone();
         let rest = rest.clone();
-        let channel_id = batch.channel_id;
         tokio::spawn(async move {
-            pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
+            pool::post_failure_notice(&rest, &batch, &content).await;
         });
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -5178,9 +5178,12 @@ pub(crate) async fn post_failure_notice(
     rest: &crate::relay::RestClient,
     batch: &FlushBatch,
     content: &str,
+    handlers: &crate::failure_routing::FailureHandlers,
+    owner: Option<String>,
 ) {
     let channel_id = batch.channel_id;
-    let event = match crate::failure_notice::build(&rest.keys, batch, content) {
+    let route = crate::failure_routing::resolve(rest, batch, handlers, owner).await;
+    let event = match crate::failure_notice::build(&rest.keys, batch, content, route.as_ref()) {
         Ok(event) => event,
         Err(e) => {
             tracing::warn!(channel = %channel_id, "failure notice: build failed: {e}");

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -39,7 +39,7 @@ use crate::observer;
 use crate::prompt_project::{pick_authoritative_project_home, PromptProjectInfo};
 use crate::queue::{
     CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
-    PromptProfile, PromptProfileLookup, ThreadTags,
+    PromptProfile, PromptProfileLookup,
 };
 use crate::relay::{ChannelInfo, RestClient};
 use crate::scope::SessionScope;
@@ -5171,47 +5171,19 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     }
 }
 
-/// Best-effort: post a visible failure notice (kind:9) to a channel after a
-/// batch is dead-lettered. Replies into the thread of `thread_tags` when the
-/// triggering event was threaded. Errors are logged and swallowed — the
-/// notice must never take down the main loop.
+/// Best-effort: post a signed, addressed failure notice into the triggering
+/// thread. A requester agent can then inspect the task and arrange recovery;
+/// the notice itself neither replays work nor grants takeover authority.
 pub(crate) async fn post_failure_notice(
     rest: &crate::relay::RestClient,
-    channel_id: Uuid,
-    thread_tags: &ThreadTags,
+    batch: &FlushBatch,
     content: &str,
 ) {
-    let thread_ref = thread_tags.root_event_id.as_deref().and_then(|root| {
-        let root_id = nostr::EventId::from_hex(root).ok()?;
-        let parent_id = thread_tags
-            .parent_event_id
-            .as_deref()
-            .and_then(|p| nostr::EventId::from_hex(p).ok())
-            .unwrap_or(root_id);
-        Some(buzz_sdk::ThreadRef {
-            root_event_id: root_id,
-            parent_event_id: parent_id,
-        })
-    });
-    let builder = match buzz_sdk::build_message(
-        channel_id,
-        content,
-        thread_ref.as_ref(),
-        &[],
-        false,
-        &[],
-        &[],
-    ) {
-        Ok(b) => b,
+    let channel_id = batch.channel_id;
+    let event = match crate::failure_notice::build(&rest.keys, batch, content) {
+        Ok(event) => event,
         Err(e) => {
             tracing::warn!(channel = %channel_id, "failure notice: build failed: {e}");
-            return;
-        }
-    };
-    let event = match builder.sign_with_keys(&rest.keys) {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::warn!(channel = %channel_id, "failure notice: sign failed: {e}");
             return;
         }
     };


### PR DESCRIPTION
When a provider rejects a request because its session or usage allowance is exhausted, Buzz should stop retrying the same unavailable provider and emit a signed, thread-bound failure notice. This R4 candidate keeps that narrow terminal-stop behavior and the opt-in addressed routing to an existing attested sibling, while preserving bounded cycle and preflight guards.

The resulting behavior is:

- narrowly classified terminal provider-limit errors leave the futile retry path immediately;
- the default notice remains available when routing preflight is denied or unavailable;
- an explicitly configured sibling can receive one addressed notice after source signature, same-owner attestation, active relay identity, channel membership and visited-chain checks;
- ordinary assistant text, generic transport errors and uncertain writer state do not become terminal provider errors;
- the change does not implement model substitution, a durable queue, a writer fence, automatic native wake, or authority to replay uncertain side effects.

Validation already available on the R4 source includes a passing baseline and restored baseline for `failure_routing_tests`, plus three guard-removal mutants that fail as expected: source-author attestation, handler attestation and source-channel binding. The mutation receipt records restored production source and the five command outcomes.

The first full R4 CI attempt ended with one mobile failure (`2097` passed): `settings_profile_header_test.dart`, “warms and clears a paused animated-avatar handoff”, expected a cleared handoff but observed one. The named test passed once in isolation; this is currently treated as timing/resource-sensitive evidence, not as a silently ignored pass.

Full `just ci` passed on the unchanged, clean R4 commit `d6a4b53fe6274eaf4fac271cebdc0791c819a5f3` in attempt 2, including 953 ACP tests, 6,488 desktop tests and 2,098 mobile tests. Independent exact-revision review and the offline version-bound gate passed.

Controlled native-app pilots are now complete. One normal read ran through the R4 binary. A separate synthetic terminal-error fixture produced an addressed notice; an already-running, independently authenticated sibling read the original task and published the correct read-only result in the original thread. The first attempt with a stopped sibling did not start it; enabling the existing native Start on launch setting and verifying its process after app restart resolved that prerequisite.

The reserve's normal completion callback produced one unnecessary second notice; the reserve recognized the task as complete and did not repeat it. This is a workflow configuration issue requiring a recovery-specific no-callback rule, not evidence of durable scheduling or exactly-once writes. All synthetic ACP-command overrides were removed. The same hash-bound R4 binary is now running under the official desktop lifecycle on six existing operator-owned instances; both native handler fields were read back from each actual process after restart.

A separate all-unavailable fixture followed the configured five-agent chain and stopped on the visited guard. After removing the fixtures and restarting normal R4, a different included-plan worker resumed the original task from an unchanged checkpoint and published the remaining result in the original root. This demonstrates bounded read-only fallback and explicit resume after restart; it does not implement automatic wake at a later quota reset or prove external-write exactly-once semantics.
