### PR TITLE
fix(acp): apply respond-to policy to DMs

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -131,7 +131,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 
 ### Inbound Author Gate
 
-Controls which authors' events the harness forwards to the agent. Events from disallowed authors are silently dropped before reaching subscription rules.
+Controls which authors' events the harness forwards to the agent. Events from disallowed authors are dropped before reaching subscription rules and logged at info (`inbound author gate — dropping event`) with channel, author, mode, `is_dm`, and reason. An authorized event that matches no subscription rule is also logged at info (`authorized event matched no rule — dropping`).
 
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|
@@ -156,7 +156,7 @@ the same author policy as ordinary messages. Legacy workflow messages and
 workflow output without an explicit agent mention remain attributed to the relay
 signer. `nobody` remains absolute.
 
-The gate applies to **all** inbound events — @mentions, DMs, thread replies, and any event delivered by the relay. Owner control commands are checked **before** the gate, so the owner can still manage the harness regardless of mode:
+The gate applies to **all** inbound events — @mentions, DMs, thread replies, and any event delivered by the relay. Direct messages use the same author policy as group channels: `allowlist` admits the listed pubkeys (plus owner and verified same-owner siblings), and `anyone` admits every author. DM clients auto-p-tag participants, so mention-subscription already matches the conversation; the gate is the access policy. Owner control commands are checked **before** the gate, so the owner can still manage the harness regardless of mode:
 
 | Command | Effect |
 |---------|--------|

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -366,7 +366,23 @@ mod inbound_author_gate {
         }
     }
 
+    fn author_gate_drop_reason(respond_to: &RespondTo) -> &'static str {
+        match respond_to {
+            RespondTo::Nobody => "nobody",
+            RespondTo::OwnerOnly => "not-owner-or-sibling",
+            RespondTo::Allowlist => "not-on-allowlist",
+            RespondTo::Anyone => "unexpected-anyone-drop",
+        }
+    }
+
     /// Apply the configured raw-author policy after trusted workflow attribution.
+    ///
+    /// Channel type does not change author policy. DMs auto-p-tag every
+    /// participant, so the mention subscription already matches the
+    /// conversation; `respond-to` is what decides who may query. Owner-only,
+    /// allowlist, anyone, and nobody therefore mean the same thing in a 1:1
+    /// DM as they do in a group. `_is_dm` is accepted so call sites that
+    /// classify the channel can still pass it through for logging.
     ///
     /// This stays private to the gate module so neither listener can bypass
     /// workflow attribution by calling the raw-signer policy directly.
@@ -374,16 +390,10 @@ mod inbound_author_gate {
         respond_to: &RespondTo,
         allowlist: &HashSet<String>,
         author: &str,
-        is_dm: bool,
+        _is_dm: bool,
         owner_cache: &OwnerCache,
         rest_client: &relay::RestClient,
     ) -> bool {
-        if is_dm {
-            return match respond_to {
-                RespondTo::Nobody => false,
-                _ => is_owner_or_sibling(author, owner_cache, rest_client).await,
-            };
-        }
         match respond_to {
             RespondTo::Anyone => true,
             RespondTo::Nobody => false,
@@ -542,12 +552,13 @@ mod inbound_author_gate {
                 )
                 .await;
             if !decision.allowed {
-                tracing::debug!(
+                tracing::info!(
                     channel_id = %buzz_event.channel_id,
                     raw_author = %buzz_event.event.pubkey.to_hex(),
                     effective_author = %decision.effective_author,
                     mode = %respond_to,
                     is_dm = decision.is_dm,
+                    reason = author_gate_drop_reason(respond_to),
                     "inbound author gate — dropping event"
                 );
                 return None;
@@ -598,13 +609,23 @@ impl AuthorizedNormalListenerEvent {
         agent_pubkey_hex: &str,
     ) -> Option<NormalListenerIngress> {
         let (buzz_event, effective_author) = self.0.into_parts();
-        let matched = filter::match_event(
+        let Some(matched) = filter::match_event(
             &buzz_event.event,
             buzz_event.channel_id,
             rules,
             agent_pubkey_hex,
         )
-        .await?;
+        .await
+        else {
+            tracing::info!(
+                channel_id = %buzz_event.channel_id,
+                author = %buzz_event.event.pubkey.to_hex(),
+                effective_author = %effective_author,
+                reason = "no-rule",
+                "authorized event matched no rule — dropping"
+            );
+            return None;
+        };
         Some(NormalListenerIngress {
             buzz_event,
             effective_author,
@@ -3536,7 +3557,6 @@ async fn tokio_main() -> Result<()> {
                                     .match_subscription(&rules, &pubkey_hex)
                                     .await
                             else {
-                                tracing::debug!("authorized event matched no rule — dropping");
                                 continue;
                             };
                             // Derive the session scope once, at admission, from
@@ -7065,10 +7085,10 @@ mod author_gate_tests {
         }
     }
 
-    /// Both production boundaries must retain DM classification when composing
-    /// trusted workflow attribution with configured author policy. External
-    /// allowlist entries and `Anyone` stay denied in a DM; owner and sibling
-    /// principals remain allowed; `Nobody` remains absolute.
+    /// Both production boundaries apply the same author policy in DMs as in
+    /// groups: allowlisted authors and `Anyone` are admitted; strangers are
+    /// still denied under Allowlist; owner and sibling principals remain
+    /// allowed; `Nobody` remains absolute.
     #[tokio::test]
     async fn production_listener_boundaries_enforce_dm_author_policy() {
         for listener in [ListenerBoundary::Normal, ListenerBoundary::Setup] {
@@ -7076,7 +7096,7 @@ mod author_gate_tests {
             let relay_hex = relay_keys.public_key().to_hex();
             let external = nostr::Keys::generate().public_key().to_hex();
             let external_allowlist = HashSet::from([external.clone()]);
-            let denied_external = listener_boundary_scenario(ListenerBoundaryScenario {
+            let admitted_external = listener_boundary_scenario(ListenerBoundaryScenario {
                 listener,
                 relay_keys: &relay_keys,
                 workflow_owner: &external,
@@ -7092,15 +7112,15 @@ mod author_gate_tests {
             })
             .await;
             assert!(
-                !denied_external.1,
-                "{} listener must deny an external allowlist entry in a DM",
+                admitted_external.1,
+                "{} listener must admit an external allowlist entry in a DM",
                 listener.name()
             );
 
             let relay_keys = nostr::Keys::generate();
             let relay_hex = relay_keys.public_key().to_hex();
             let stranger = nostr::Keys::generate().public_key().to_hex();
-            let denied_stranger = listener_boundary_scenario(ListenerBoundaryScenario {
+            let admitted_stranger = listener_boundary_scenario(ListenerBoundaryScenario {
                 listener,
                 relay_keys: &relay_keys,
                 workflow_owner: &stranger,
@@ -7116,8 +7136,32 @@ mod author_gate_tests {
             })
             .await;
             assert!(
-                !denied_stranger.1,
-                "{} listener must deny a stranger in a DM under Anyone",
+                admitted_stranger.1,
+                "{} listener must admit a stranger in a DM under Anyone",
+                listener.name()
+            );
+
+            let relay_keys = nostr::Keys::generate();
+            let relay_hex = relay_keys.public_key().to_hex();
+            let unlisted = nostr::Keys::generate().public_key().to_hex();
+            let denied_unlisted = listener_boundary_scenario(ListenerBoundaryScenario {
+                listener,
+                relay_keys: &relay_keys,
+                workflow_owner: &unlisted,
+                responses: std::collections::VecDeque::from([Ok(
+                    serde_json::json!({ "self": relay_hex }),
+                )]),
+                event_generation: 0,
+                channel_type: "dm",
+                respond_to: RespondTo::Allowlist,
+                allowlist: HashSet::from([external.clone()]),
+                cache_owner: false,
+                cache_sibling: false,
+            })
+            .await;
+            assert!(
+                !denied_unlisted.1,
+                "{} listener must deny a stranger in a DM under Allowlist",
                 listener.name()
             );
 
@@ -7871,19 +7915,20 @@ mod author_gate_tests {
         }
     }
 
-    // ── DM hardening ──────────────────────────────────────────────────────
+    // ── DMs use the same author policy as groups ──────────────────────────
     //
-    // In a DM, clients auto-p-tag every participant, and an agent can be
-    // asked to open a DM with a third party. The gate must therefore ignore
-    // the allowlist and `anyone` mode inside DMs: only owner + verified
-    // siblings fire turns.
+    // Clients auto-p-tag every DM participant, so mention-subscription
+    // already matches the conversation. The inbound author gate is the
+    // access policy: allowlisted users (and `anyone`, when configured)
+    // may query the agent in a 1:1 DM. Owner + verified siblings remain
+    // implicit on every responding mode.
 
     #[tokio::test]
-    async fn test_dm_rejects_allowlisted_external_pubkey() {
+    async fn test_dm_admits_allowlisted_external_pubkey() {
         let cache = cache_with_sibling();
         let allowlist = HashSet::from([EXTERNAL.to_string()]);
         assert!(
-            !inbound_author_gate::test_author_allowed(
+            inbound_author_gate::test_author_allowed(
                 &RespondTo::Allowlist,
                 &allowlist,
                 EXTERNAL,
@@ -7892,15 +7937,33 @@ mod author_gate_tests {
                 &dummy_rest_client()
             )
             .await,
-            "an allowlisted external pubkey must NOT fire a turn inside a DM"
+            "an allowlisted external pubkey must fire a turn inside a DM"
         );
     }
 
     #[tokio::test]
-    async fn test_dm_rejects_stranger_under_anyone() {
+    async fn test_dm_rejects_stranger_under_allowlist() {
         let cache = cache_with_sibling();
+        let allowlist = HashSet::from([EXTERNAL.to_string()]);
         assert!(
             !inbound_author_gate::test_author_allowed(
+                &RespondTo::Allowlist,
+                &allowlist,
+                STRANGER,
+                true,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "a pubkey absent from the allowlist must not fire a turn inside a DM"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dm_admits_stranger_under_anyone() {
+        let cache = cache_with_sibling();
+        assert!(
+            inbound_author_gate::test_author_allowed(
                 &RespondTo::Anyone,
                 &HashSet::new(),
                 STRANGER,
@@ -7909,7 +7972,7 @@ mod author_gate_tests {
                 &dummy_rest_client()
             )
             .await,
-            "respond_to=anyone must still drop non-owner authors inside a DM"
+            "respond_to=anyone must admit non-owner authors inside a DM"
         );
     }
 
@@ -8085,13 +8148,25 @@ mod author_gate_tests {
             !inbound_author_gate::test_author_allowed(
                 &RespondTo::Allowlist,
                 &allowlist,
+                STRANGER,
+                is_dm,
+                &owner_cache,
+                &dummy_rest_client(),
+            )
+            .await,
+            "an unknown author must not pass when startup discovery omitted metadata"
+        );
+        assert!(
+            inbound_author_gate::test_author_allowed(
+                &RespondTo::Allowlist,
+                &allowlist,
                 EXTERNAL,
                 is_dm,
                 &owner_cache,
                 &dummy_rest_client(),
             )
             .await,
-            "an external author must not pass when startup discovery omitted metadata"
+            "an allowlisted author is still admitted when the channel type is unknown"
         );
     }
 

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -430,8 +430,9 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         }
 
         // Apply the same author gate as normal mode so the nudge only goes
-        // to authors the real agent would have answered. Same DM hardening:
-        // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
+        // to authors the real agent would have answered. Unknown channel
+        // types fail closed as DMs for classification; the author policy
+        // itself is the same in DMs and groups.
         let Some(authorized_event) = authorize_setup_listener_event(
             &mut author_gate_ctx,
             buzz_event,

--- a/crates/buzz-cli/src/agent_management.rs
+++ b/crates/buzz-cli/src/agent_management.rs
@@ -6,6 +6,49 @@ use serde::Serialize;
 
 use crate::error::CliError;
 
+pub(crate) fn parse_respond_to_allowlist(raw: &str) -> Result<Vec<String>, CliError> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for entry in raw.split(',') {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(CliError::Usage(format!(
+                "invalid pubkey in --respond-to-allowlist: '{trimmed}' (must be 64 hex characters)"
+            )));
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if seen.insert(lower.clone()) {
+            out.push(lower);
+        }
+    }
+    if out.is_empty() {
+        return Err(CliError::Usage(
+            "--respond-to-allowlist requires at least one pubkey".into(),
+        ));
+    }
+    Ok(out)
+}
+
+fn normalize_respond_to_allowlist(
+    respond_to: Option<&str>,
+    allowlist: Option<Vec<String>>,
+) -> Result<Option<Vec<String>>, CliError> {
+    match (respond_to, allowlist) {
+        (Some("allowlist"), Some(list)) if !list.is_empty() => Ok(Some(list)),
+        (Some("allowlist"), _) => Err(CliError::Usage(
+            "--respond-to allowlist requires --respond-to-allowlist with at least one pubkey"
+                .into(),
+        )),
+        (_, Some(list)) if !list.is_empty() => Err(CliError::Usage(
+            "--respond-to-allowlist is only valid with --respond-to allowlist".into(),
+        )),
+        _ => Ok(None),
+    }
+}
+
 const AGENT_REQUEST_KIND: &str = "agent_management_request";
 const PROJECT_CHANNEL_REQUEST_KIND: &str = "project_channel_request";
 const MAX_NAME_CHARS: usize = 120;
@@ -36,6 +79,8 @@ pub struct UpdateAgentDraft {
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub respond_to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub respond_to_allowlist: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -175,12 +220,14 @@ pub fn build_update(
     let respond_to = optional(draft.respond_to, "respond-to")?;
     if respond_to
         .as_deref()
-        .is_some_and(|value| value != "owner-only" && value != "anyone")
+        .is_some_and(|value| value != "owner-only" && value != "anyone" && value != "allowlist")
     {
         return Err(CliError::Usage(
-            "respond-to must be owner-only or anyone".into(),
+            "respond-to must be owner-only, allowlist, or anyone".into(),
         ));
     }
+    let respond_to_allowlist =
+        normalize_respond_to_allowlist(respond_to.as_deref(), draft.respond_to_allowlist)?;
     let request = UpdateAgentDraft {
         channel_id: channel_id.clone(),
         agent_name: required(draft.agent_name, "agent name", MAX_NAME_CHARS)?,
@@ -193,6 +240,7 @@ pub fn build_update(
         provider: optional(draft.provider, "provider")?,
         model: optional(draft.model, "model")?,
         respond_to,
+        respond_to_allowlist,
     };
     if request.display_name.is_none()
         && request.system_prompt.is_none()
@@ -200,6 +248,7 @@ pub fn build_update(
         && request.provider.is_none()
         && request.model.is_none()
         && request.respond_to.is_none()
+        && request.respond_to_allowlist.is_none()
     {
         return Err(CliError::Usage(
             "include at least one field to update".into(),
@@ -320,10 +369,104 @@ mod tests {
                 provider: None,
                 model: None,
                 respond_to: None,
+                respond_to_allowlist: None,
             },
         )
         .unwrap_err();
         assert!(error.to_string().contains("at least one field"));
+    }
+
+    fn hex64(c: char) -> String {
+        std::iter::repeat_n(c, 64).collect()
+    }
+
+    #[test]
+    fn update_allowlist_roundtrips_into_the_owner_encrypted_payload() {
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let listed = hex64('a');
+        let built = build_update(
+            &agent,
+            &owner.public_key(),
+            UpdateAgentDraft {
+                channel_id: CHANNEL.into(),
+                agent_name: "Scout".into(),
+                display_name: None,
+                system_prompt: None,
+                runtime: None,
+                provider: None,
+                model: None,
+                respond_to: Some("allowlist".into()),
+                respond_to_allowlist: Some(vec![listed.clone()]),
+            },
+        )
+        .unwrap();
+
+        let payload: serde_json::Value = decrypt_observer_payload(&owner, &built.event).unwrap();
+        assert_eq!(payload["payload"]["action"], "update");
+        assert_eq!(payload["payload"]["request"]["respondTo"], "allowlist");
+        assert_eq!(
+            payload["payload"]["request"]["respondToAllowlist"],
+            serde_json::json!([listed])
+        );
+    }
+
+    #[test]
+    fn update_allowlist_requires_pubkeys() {
+        let error = build_update(
+            &Keys::generate(),
+            &Keys::generate().public_key(),
+            UpdateAgentDraft {
+                channel_id: CHANNEL.into(),
+                agent_name: "Scout".into(),
+                display_name: None,
+                system_prompt: None,
+                runtime: None,
+                provider: None,
+                model: None,
+                respond_to: Some("allowlist".into()),
+                respond_to_allowlist: None,
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--respond-to-allowlist"));
+    }
+
+    #[test]
+    fn update_allowlist_flag_requires_allowlist_mode() {
+        let error = build_update(
+            &Keys::generate(),
+            &Keys::generate().public_key(),
+            UpdateAgentDraft {
+                channel_id: CHANNEL.into(),
+                agent_name: "Scout".into(),
+                display_name: None,
+                system_prompt: None,
+                runtime: None,
+                provider: None,
+                model: None,
+                respond_to: Some("anyone".into()),
+                respond_to_allowlist: Some(vec![hex64('a')]),
+            },
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("only valid with --respond-to allowlist"));
+    }
+
+    #[test]
+    fn parse_allowlist_lowercases_and_dedups() {
+        let a = "A".repeat(64);
+        let b = "b".repeat(64);
+        let parsed = parse_respond_to_allowlist(&format!("{a},{b},{a}")).unwrap();
+        assert_eq!(parsed, vec!["a".repeat(64), b]);
+    }
+
+    #[test]
+    fn parse_allowlist_rejects_invalid_hex() {
+        let error = parse_respond_to_allowlist("not-a-pubkey").unwrap_err();
+        assert!(error.to_string().contains("invalid pubkey"));
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -3,7 +3,9 @@ use buzz_sdk::builders::{build_archive_identity_request, build_unarchive_identit
 use nostr::PublicKey;
 use serde_json::json;
 
-use crate::agent_management::{build_create, build_update, CreateAgentDraft, UpdateAgentDraft};
+use crate::agent_management::{
+    build_create, build_update, parse_respond_to_allowlist, CreateAgentDraft, UpdateAgentDraft,
+};
 use crate::client::BuzzClient;
 use crate::error::CliError;
 use crate::validate::{read_or_stdin, validate_hex64};
@@ -52,6 +54,7 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
             provider,
             model,
             respond_to,
+            respond_to_allowlist,
         } => {
             let owner = require_owner(client)?;
             let built = build_update(
@@ -66,6 +69,10 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
                     provider,
                     model,
                     respond_to: respond_to.map(RespondToArg::to_wire),
+                    respond_to_allowlist: match respond_to_allowlist {
+                        Some(raw) => Some(parse_respond_to_allowlist(&raw)?),
+                        None => None,
+                    },
                 },
             )?;
             let response = client.publish_ephemeral_event(built.event).await?;

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -249,6 +249,8 @@ enum Cmd {
 pub enum RespondToArg {
     #[value(name = "owner-only")]
     OwnerOnly,
+    #[value(name = "allowlist")]
+    Allowlist,
     #[value(name = "anyone")]
     Anyone,
 }
@@ -257,6 +259,7 @@ impl RespondToArg {
     fn to_wire(self) -> String {
         match self {
             Self::OwnerOnly => "owner-only",
+            Self::Allowlist => "allowlist",
             Self::Anyone => "anyone",
         }
         .to_string()
@@ -298,6 +301,9 @@ pub enum AgentsCmd {
         model: Option<String>,
         #[arg(long, value_enum)]
         respond_to: Option<RespondToArg>,
+        /// Comma-separated 64-char hex pubkeys. Required when `--respond-to allowlist`.
+        #[arg(long)]
+        respond_to_allowlist: Option<String>,
     },
     /// Submit a NIP-IA archive request for an identity (kind 9035)
     #[command(

--- a/desktop/src/features/agents/agentManagement.test.mjs
+++ b/desktop/src/features/agents/agentManagement.test.mjs
@@ -90,6 +90,65 @@ test("uses an agent's current name, never an internal profile ID", () => {
   assert.deepEqual(parseAgentManagementRequest(payload), payload);
 });
 
+test("parses an allowlist access update into the edit form contract", () => {
+  const listed = "a".repeat(64);
+  const payload = {
+    type: AGENT_MANAGEMENT_REQUEST,
+    action: "update",
+    requestId: "request-4",
+    request: {
+      channelId: CHANNEL_ID,
+      agentName: "Scout",
+      respondTo: "allowlist",
+      respondToAllowlist: [listed.toUpperCase()],
+    },
+  };
+
+  assert.deepEqual(parseAgentManagementRequest(payload), {
+    type: AGENT_MANAGEMENT_REQUEST,
+    action: "update",
+    requestId: "request-4",
+    request: {
+      channelId: CHANNEL_ID,
+      agentName: "Scout",
+      respondTo: "allowlist",
+      respondToAllowlist: [listed],
+    },
+  });
+});
+
+test("rejects allowlist pubkeys on a non-allowlist access update", () => {
+  const payload = {
+    type: AGENT_MANAGEMENT_REQUEST,
+    action: "update",
+    requestId: "request-5",
+    request: {
+      channelId: CHANNEL_ID,
+      agentName: "Scout",
+      respondTo: "anyone",
+      respondToAllowlist: ["a".repeat(64)],
+    },
+  };
+
+  assert.equal(parseAgentManagementRequest(payload), null);
+});
+
+test("rejects a malformed allowlist pubkey", () => {
+  const payload = {
+    type: AGENT_MANAGEMENT_REQUEST,
+    action: "update",
+    requestId: "request-6",
+    request: {
+      channelId: CHANNEL_ID,
+      agentName: "Scout",
+      respondTo: "allowlist",
+      respondToAllowlist: ["not-a-pubkey"],
+    },
+  };
+
+  assert.equal(parseAgentManagementRequest(payload), null);
+});
+
 test("allows agents to update only personal, editable profiles", () => {
   assert.equal(
     requestTargetsEditablePersona({ isBuiltIn: false, sourceTeam: null }),

--- a/desktop/src/features/agents/agentManagement.ts
+++ b/desktop/src/features/agents/agentManagement.ts
@@ -30,6 +30,7 @@ export type AgentManagementUpdateRequest = {
     provider?: string;
     model?: string;
     respondTo?: RespondToMode;
+    respondToAllowlist?: string[];
   };
 };
 
@@ -42,7 +43,29 @@ function isText(value: unknown): value is string {
 }
 
 function isRespondTo(value: unknown): value is RespondToMode | undefined {
-  return value === undefined || value === "owner-only" || value === "anyone";
+  return (
+    value === undefined ||
+    value === "owner-only" ||
+    value === "allowlist" ||
+    value === "anyone"
+  );
+}
+
+function parseRespondToAllowlist(value: unknown): string[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) return null;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") return null;
+    const trimmed = entry.trim().toLowerCase();
+    if (trimmed.length !== 64 || !/^[0-9a-f]+$/.test(trimmed)) return null;
+    if (!seen.has(trimmed)) {
+      seen.add(trimmed);
+      out.push(trimmed);
+    }
+  }
+  return out;
 }
 
 function hasOnlyKeys(
@@ -103,10 +126,19 @@ export function parseAgentManagementRequest(
       "provider",
       "model",
       "respondTo",
+      "respondToAllowlist",
     ]) ||
     !isText(request.channelId) ||
     !isText(request.agentName)
   ) {
+    return null;
+  }
+  let allowlist: string[] | undefined;
+  if (request.respondTo === "allowlist") {
+    const parsed = parseRespondToAllowlist(request.respondToAllowlist);
+    if (parsed === null) return null;
+    allowlist = parsed;
+  } else if (request.respondToAllowlist !== undefined) {
     return null;
   }
   const changes = {
@@ -120,6 +152,7 @@ export function parseAgentManagementRequest(
     ...(isText(request.provider) ? { provider: request.provider } : {}),
     ...(isText(request.model) ? { model: request.model } : {}),
     ...(request.respondTo ? { respondTo: request.respondTo } : {}),
+    ...(allowlist !== undefined ? { respondToAllowlist: allowlist } : {}),
   };
   if (Object.keys(changes).length === 0) return null;
   return {

--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -49,7 +49,10 @@ function updateInputFromRequest(
       ? {
           behavior: {
             respondTo: changes.respondTo,
-            respondToAllowlist: [],
+            respondToAllowlist:
+              changes.respondTo === "allowlist"
+                ? (changes.respondToAllowlist ?? [])
+                : [],
             parallelism: current.behavior?.parallelism,
           },
         }


### PR DESCRIPTION
## Summary

Allowlisted users could `@mention` an agent in a shared group but could not query that same agent in a 1:1 DM. Observed on hosted agents: the owner's DMs woke the process, allowlisted users' DMs did not, and Desktop caches for those DMs were empty. That looked like host-scoped inbound. It was not.

The inbound author gate ignored `allowlist` and `anyone` inside DMs and admitted only the owner plus verified same-owner siblings. Group `@mentions` used the real policy, so they worked. DMs already auto-p-tag every participant, so mention-subscription already matched; the gate was the drop.

## Fix

`respond-to` now means the same thing in a DM as in a group:

- `owner-only` — owner ∪ verified siblings
- `allowlist` — those plus the listed pubkeys
- `anyone` — every author
- `nobody` — still absolute

Gate drops and unmatched subscription rules log at **info** (`channel_id`, author, mode, `is_dm`, reason) instead of debug, so a silent DM is diagnosable.

CLI: `buzz agents draft-update --respond-to allowlist --respond-to-allowlist <hex,hex>`. Desktop's owner-reviewed edit form accepts that list instead of wiping it.

## Out of scope

- Subscription CLOSED already logs `channel access denied by relay` and drops that channel. Not a dead-subscription-looks-live bug for this failure.
- Membership subscribe already replays from the membership timestamp. The 15-minute replay floor for first messages that race a cold start is a separate follow-up.

## Tests

- `cargo test -p buzz-acp -p buzz-cli` — 933 + 468 passed (WSL, rustc 1.95.0)
- `cargo clippy -p buzz-acp -p buzz-cli --all-targets -- -D warnings` passed
- Production listener boundary test now requires allowlisted DM authors to be admitted

Closest existing PR/issue: none found.

Originating conversation: Buzz `#Agent_Coordination` thread `467385cd` / event `61d45889`.