### PR TITLE
fix(relay): allow deleting archived channels

### DIFF
--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -2691,14 +2691,9 @@ async fn ingest_event_inner(
     }
 
     if channel_id.is_some() {
-        // Allow kind:9002 with archived=false (unarchive operation)
-        let is_unarchive = kind_u32 == KIND_NIP29_EDIT_METADATA
-            && event.tags.iter().any(|t| {
-                let parts = t.as_slice();
-                parts.len() >= 2 && parts[0] == "archived" && parts[1] == "false"
-            });
-
-        if !is_unarchive {
+        // Archive is a write-lock, not a tombstone: unarchive (9002 archived=false)
+        // and delete-group (9008) are the only mutations that remain valid.
+        if !crate::handlers::side_effects::allow_event_on_archived_channel(kind_u32, &event) {
             if let Some(channel) = &channel_row {
                 if channel.archived_at.is_some() {
                     return Err(IngestError::Rejected("invalid: channel is archived".into()));

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -28,6 +28,23 @@ pub fn is_admin_kind(kind: u32) -> bool {
     matches!(kind, 9000..=9022)
 }
 
+/// Whether an event may be ingested against an archived channel.
+///
+/// Archive is a write-lock, not a tombstone. The only mutations that remain
+/// valid are restoring the channel (`kind:9002` + `archived=false`) and
+/// deleting it (`kind:9008`). Ephemeral huddle backing channels are archived
+/// on hang-up and by the TTL reaper, so blocking 9008 left them undeletable.
+pub(crate) fn allow_event_on_archived_channel(kind: u32, event: &Event) -> bool {
+    if kind == 9008 {
+        return true;
+    }
+    kind == 9002
+        && event.tags.iter().any(|t| {
+            let parts = t.as_slice();
+            parts.len() >= 2 && parts[0] == "archived" && parts[1] == "false"
+        })
+}
+
 /// Check if a kind triggers side effects after storage.
 ///
 /// NOTE: kind:7 (reaction) is intentionally excluded — dedup and DB writes are
@@ -327,19 +344,15 @@ pub async fn validate_admin_event(
 
     let actor_bytes = event.pubkey.to_bytes().to_vec();
 
-    // Reject mutations on archived channels — except kind:9002 with archived=false
-    // (unarchive), which must be allowed through so the channel can be restored.
+    // Reject mutations on archived channels — except unarchive (kind:9002
+    // archived=false) and delete-group (kind:9008). Archive is a write-lock,
+    // not a tombstone: owners must still be able to restore or remove the channel.
     let channel = state
         .db
         .get_channel_for_event_write(tenant.community(), channel_id)
         .await
         .map_err(|_| anyhow::anyhow!("channel not found"))?;
-    let is_unarchive_request = kind == 9002
-        && event.tags.iter().any(|t| {
-            let parts = t.as_slice();
-            parts.len() >= 2 && parts[0] == "archived" && parts[1] == "false"
-        });
-    if channel.archived_at.is_some() && !is_unarchive_request {
+    if channel.archived_at.is_some() && !allow_event_on_archived_channel(kind, event) {
         return Err(anyhow::anyhow!("channel is archived"));
     }
 
@@ -3768,5 +3781,74 @@ mod tests {
         }];
 
         assert!(actor_is_channel_owner_or_admin(&members, &actor));
+    }
+
+    fn signed_event(kind: u16, tags: Vec<Tag>) -> Event {
+        EventBuilder::new(Kind::Custom(kind), "")
+            .tags(tags)
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign")
+    }
+
+    fn h_tag(channel: &str) -> Tag {
+        Tag::parse(["h", channel]).expect("h tag")
+    }
+
+    #[test]
+    fn archived_channel_allows_unarchive_and_delete_group_only() {
+        let channel = Uuid::new_v4().to_string();
+        let pubkey = "a".repeat(64);
+        let event_id = "b".repeat(64);
+
+        let allowed = [
+            signed_event(9008, vec![h_tag(&channel)]),
+            signed_event(
+                9002,
+                vec![
+                    h_tag(&channel),
+                    Tag::parse(["archived", "false"]).expect("tag"),
+                ],
+            ),
+        ];
+        for event in &allowed {
+            assert!(
+                allow_event_on_archived_channel(event_kind_u32(event), event),
+                "expected kind {} to be allowed on an archived channel",
+                event_kind_u32(event)
+            );
+        }
+
+        let rejected = [
+            signed_event(
+                9002,
+                vec![
+                    h_tag(&channel),
+                    Tag::parse(["archived", "true"]).expect("tag"),
+                ],
+            ),
+            signed_event(
+                9002,
+                vec![
+                    h_tag(&channel),
+                    Tag::parse(["name", "still-locked"]).expect("tag"),
+                ],
+            ),
+            signed_event(
+                9000,
+                vec![h_tag(&channel), Tag::parse(["p", &pubkey]).expect("tag")],
+            ),
+            signed_event(
+                9005,
+                vec![h_tag(&channel), Tag::parse(["e", &event_id]).expect("tag")],
+            ),
+            signed_event(1, vec![h_tag(&channel)]),
+        ];
+        for event in &rejected {
+            assert!(
+                !allow_event_on_archived_channel(event_kind_u32(event), event),
+                "expected kind {} to stay rejected on an archived channel",
+                event_kind_u32(event)
+            );
+        }
     }
 }

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -1324,6 +1324,44 @@ async fn test_unarchive_emits_member_added_notification() {
     ws.disconnect().await.expect("disconnect");
 }
 
+/// Deleting an archived channel must succeed without an unarchive first.
+/// Archive is a write-lock, not a tombstone — kind:9008 is an allowed exception,
+/// matching the huddle/ephemeral-reaper path that archives backing channels.
+#[tokio::test]
+#[ignore]
+async fn test_owner_can_delete_archived_channel() {
+    let url = relay_url();
+    let owner_keys = Keys::generate();
+    let channel_id = create_test_channel(&owner_keys).await;
+
+    let mut ws = BuzzTestClient::connect(&url, &owner_keys)
+        .await
+        .expect("connect as owner");
+
+    let archive = EventBuilder::new(Kind::Custom(9002), "")
+        .tags([
+            Tag::parse(["h", &channel_id]).unwrap(),
+            Tag::parse(["archived", "true"]).unwrap(),
+        ])
+        .sign_with_keys(&owner_keys)
+        .unwrap();
+    let ok = ws.send_event(archive).await.expect("send archive");
+    assert!(ok.accepted, "archive rejected: {}", ok.message);
+
+    let delete = EventBuilder::new(Kind::Custom(9008), "")
+        .tags([Tag::parse(["h", &channel_id]).unwrap()])
+        .sign_with_keys(&owner_keys)
+        .unwrap();
+    let ok = ws.send_event(delete).await.expect("send delete-group");
+    assert!(
+        ok.accepted,
+        "delete of archived channel rejected: {}",
+        ok.message
+    );
+
+    ws.disconnect().await.expect("disconnect");
+}
+
 /// NIP-29 kind 9000 (PUT_USER): "nobody" policy blocks a third party from adding the agent.
 #[tokio::test]
 #[ignore]


### PR DESCRIPTION
## Summary

Archive is a write-lock, not a tombstone. Owners could unarchive a channel (`kind:9002` + `archived=false`) but could not delete it (`kind:9008`), so the relay rejected delete with `invalid: channel is archived`.

That left ephemeral huddle backing channels stuck: hang-up and the TTL reaper archive them, and there was no way to remove them afterward.

This change extracts a shared helper, `allow_event_on_archived_channel`, used by both production gates (`ingest` and `validate_admin_event`). The only mutations that remain valid on an archived channel are:

- unarchive (`kind:9002` + `archived=false`)
- delete-group (`kind:9008`)

Everything else stays rejected (messages, membership, rename, `kind:9005`). Kind `9008` still requires owner (or owner-of-owner-agent) authorization. `soft_delete_channel` already keys on `deleted_at IS NULL`, not `archived_at`, so delete after archive actually lands.

### Related issue

Same bug as [#2954](https://github.com/block/buzz/issues/2954). Open PRs for it: #2988, #4669. Both last moved 2026-08-19. This is not a new diagnosis.

### Compared with #2988 and #4669

All three PRs touch the same three files and the same two archived-channel guards. They are the same fix, restated.

**#2988 (July, Fixes #2954)** is the original. It inlines `is_delete` at both gates instead of sharing a helper, so the two exceptions can drift again. It has no unit test. Its ignored e2e is the strongest of the three: archive/unarchive/re-archive with a nonce so duplicate event ids cannot skip side effects; name-edit still hits `channel is archived`; non-owner 9008 fails with `only owner can delete group` (auth ran, not the archive guard); owner delete then unarchive fails with `channel not found`. It still calls `get_channel`.

**#4669 (August)** is the shared-helper version of that idea (`archived_channel_allows_event`) and uses `KIND_NIP29_DELETE_GROUP` / `KIND_NIP29_EDIT_METADATA`. Unit tests only cover allow-9008, unarchive vs archive, and reject-9000. E2E is owner archive-then-delete `accepted`, like this PR. It also still calls `get_channel`.

**This PR** keeps the shared helper, on current `main` (`get_channel_for_event_write`). The unit table is stricter than #4669: it also rejects name-only `9002`, `9005`, and kind 1. Comments pin 9008 to huddle hang-up and the TTL reaper. The helper uses `9008` / `9002` literals to match nearby `side_effects.rs` match arms; #2988 and #4669 are better on that point. The e2e is weaker than #2988: it does not prove non-owner auth, post-delete disappearance, or that a rename still hits the write-lock.

If maintainers want one of these, #2988 has the issue link and the better live-path test; #4669 and this PR have the better gate structure. This one is the rebase onto today's call sites.

### Testing

- Unit table test `archived_channel_allows_unarchive_and_delete_group_only` binds the production helper: allows 9008 and 9002 `archived=false`; rejects 9002 `archived=true`, name-only 9002, 9000, 9005, and kind 1. Ran locally: pass.
- E2E `test_owner_can_delete_archived_channel` drives archive then 9008 through ingest. `#[ignore]` like the rest of `e2e_relay.rs` (needs a live relay). Weaker than #2988's e2e, as above.
- No UI change, so no screenshots.
