### PR TITLE
feat(desktop): list workspace agents on the Agents screen

### DIFF
--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -20,6 +20,7 @@ import { TeamDeleteDialog } from "./TeamDeleteDialog";
 import { TeamDialog } from "./TeamDialog";
 import { TeamsSection } from "./TeamsSection";
 import { UnifiedAgentsSection } from "./UnifiedAgentsSection";
+import { WorkspaceAgentsSection } from "./WorkspaceAgentsSection";
 import { useManagedAgentActions } from "./useManagedAgentActions";
 import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
@@ -276,6 +277,20 @@ export function AgentsView() {
                 void personas.handleSetActive(persona, false, "library");
               }}
               onDeletePersona={personas.openDelete}
+            />
+
+            <WorkspaceAgentsSection
+              error={
+                agents.relayAgentsQuery.error instanceof Error
+                  ? agents.relayAgentsQuery.error
+                  : null
+              }
+              isLoading={agents.managedAgentsQuery.isLoading}
+              managedAgents={agents.managedAgents}
+              relayAgents={agents.relayAgentsQuery.data}
+              onOpenAgentProfile={(pubkey) => {
+                openProfilePanel?.(pubkey);
+              }}
             />
 
             <TeamsSection

--- a/desktop/src/features/agents/ui/WorkspaceAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/WorkspaceAgentsSection.tsx
@@ -1,0 +1,158 @@
+import * as React from "react";
+
+import { useAgentAvailabilityLookup } from "@/features/agents/lib/useAgentAvailability";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import type {
+  ManagedAgent,
+  PresenceStatus,
+  RelayAgent,
+} from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { IdentityCardSkeleton } from "@/shared/ui/identity-card-skeleton";
+import { SectionHeader } from "@/shared/ui/PageHeader";
+import { AgentIdentityCard } from "./AgentIdentityCard";
+import { AgentRuntimeAvatarControl } from "./AgentRuntimeAvatarControl";
+import { IDENTITY_CARD_GRID_CLASS } from "./UnifiedAgentsSection";
+import {
+  describeWorkspaceAgent,
+  resolveWorkspaceAgentAvailability,
+  resolveWorkspaceOwnerLabel,
+  selectWorkspaceAgents,
+} from "./workspaceAgents";
+
+type WorkspaceAgentsSectionProps = {
+  error: Error | null;
+  /** Managed agents must be known before dedupe, or own agents flash here. */
+  isLoading: boolean;
+  managedAgents: ManagedAgent[];
+  /** `undefined` until the relay directory has loaded. */
+  relayAgents: RelayAgent[] | undefined;
+  onOpenAgentProfile: (pubkey: string) => void;
+};
+
+/** Read-only view of agents other workspace members run; no lifecycle controls. */
+export function WorkspaceAgentsSection({
+  error,
+  isLoading,
+  managedAgents,
+  relayAgents,
+  onOpenAgentProfile,
+}: WorkspaceAgentsSectionProps) {
+  const agents = React.useMemo(
+    () => selectWorkspaceAgents(relayAgents, managedAgents),
+    [relayAgents, managedAgents],
+  );
+  const agentPubkeys = React.useMemo(
+    () => agents.map((agent) => agent.pubkey),
+    [agents],
+  );
+  // One profile batch covers card avatars and "Managed by" owner names.
+  const profilePubkeys = React.useMemo(
+    () =>
+      agents.flatMap((agent) =>
+        agent.ownerPubkey ? [agent.pubkey, agent.ownerPubkey] : [agent.pubkey],
+      ),
+    [agents],
+  );
+  const profiles = useUsersBatchQuery(profilePubkeys).data?.profiles;
+  const { getAvailability } = useAgentAvailabilityLookup(agentPubkeys);
+  const isPending = isLoading || relayAgents === undefined;
+
+  return (
+    <section
+      className="relative space-y-4"
+      data-testid="agents-library-workspace"
+    >
+      <SectionHeader
+        title="Workspace agents"
+        description="Agents run by other members of this workspace."
+      />
+
+      {isPending ? (
+        <div className={IDENTITY_CARD_GRID_CLASS}>
+          <IdentityCardSkeleton
+            footerSubtitleWidthClass="w-20"
+            footerTitleWidthClass="w-28"
+          />
+          <IdentityCardSkeleton
+            footerSubtitleWidthClass="w-16"
+            footerTitleWidthClass="w-24"
+          />
+        </div>
+      ) : agents.length > 0 ? (
+        <div className={IDENTITY_CARD_GRID_CLASS}>
+          {agents.map((agent) => (
+            <WorkspaceAgentCard
+              agent={agent}
+              availability={resolveWorkspaceAgentAvailability(
+                getAvailability(agent.pubkey),
+                agent.status,
+              )}
+              avatarUrl={
+                profiles?.[normalizePubkey(agent.pubkey)]?.avatarUrl ?? null
+              }
+              key={agent.pubkey}
+              ownerLabel={resolveWorkspaceOwnerLabel(
+                agent.ownerPubkey,
+                agent.ownerPubkey
+                  ? profiles?.[normalizePubkey(agent.ownerPubkey)]
+                  : undefined,
+              )}
+              onOpenAgentProfile={onOpenAgentProfile}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No agents from other workspace members yet.
+        </p>
+      )}
+
+      {error ? (
+        <p className="w-full rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error.message}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function WorkspaceAgentCard({
+  agent,
+  availability,
+  avatarUrl,
+  ownerLabel,
+  onOpenAgentProfile,
+}: {
+  agent: RelayAgent;
+  availability: PresenceStatus | undefined;
+  avatarUrl: string | null;
+  ownerLabel: string | null;
+  onOpenAgentProfile: (pubkey: string) => void;
+}) {
+  return (
+    <AgentIdentityCard
+      ariaLabel={`${agent.name} agent profile`}
+      avatar={
+        // Another member's agent has no Start/Stop here; `isActive` only
+        // selects the presence-dot face over the Start badge (see the control's
+        // prop comment), so `onStart` can never fire.
+        <AgentRuntimeAvatarControl
+          activeTestId={`workspace-agent-presence-${agent.pubkey}`}
+          availability={availability}
+          avatarUrl={avatarUrl}
+          isActive
+          isStarting={false}
+          label={agent.name}
+          startTestId={`workspace-agent-start-${agent.pubkey}`}
+          onStart={() => {}}
+        />
+      }
+      avatarUrl={avatarUrl}
+      dataTestId={`workspace-agent-${agent.pubkey}`}
+      label={agent.name}
+      subtitle={describeWorkspaceAgent(agent, ownerLabel)}
+      onClick={() => onOpenAgentProfile(agent.pubkey)}
+    />
+  );
+}

--- a/desktop/src/features/agents/ui/workspaceAgents.test.mjs
+++ b/desktop/src/features/agents/ui/workspaceAgents.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  describeWorkspaceAgent,
+  resolveWorkspaceAgentAvailability,
+  resolveWorkspaceOwnerLabel,
+  selectWorkspaceAgents,
+} from "./workspaceAgents.ts";
+
+const MINE = "a".repeat(64);
+const THEIRS = "b".repeat(64);
+const OWNER = "c".repeat(64);
+
+function relayAgent(overrides = {}) {
+  return {
+    pubkey: THEIRS,
+    ownerPubkey: OWNER,
+    name: "Scout",
+    agentType: "omp",
+    channels: ["general"],
+    channelIds: ["ch-1"],
+    capabilities: [],
+    status: "unknown",
+    respondTo: null,
+    respondToAllowlist: [],
+    ...overrides,
+  };
+}
+
+test("excludes the viewer's managed agents by pubkey, case-insensitively", () => {
+  const selected = selectWorkspaceAgents(
+    [relayAgent({ pubkey: MINE.toUpperCase() }), relayAgent()],
+    [{ pubkey: ` ${MINE}` }],
+  );
+
+  assert.deepEqual(
+    selected.map((agent) => agent.pubkey),
+    [THEIRS],
+  );
+});
+
+test("collapses duplicate relay entries for one pubkey", () => {
+  const selected = selectWorkspaceAgents(
+    [relayAgent({ name: "First" }), relayAgent({ name: "Second" })],
+    [],
+  );
+
+  assert.deepEqual(
+    selected.map((agent) => agent.name),
+    ["First"],
+  );
+});
+
+test("blank names fall back to the canonical truncated pubkey", () => {
+  const [agent] = selectWorkspaceAgents([relayAgent({ name: "  " })], []);
+
+  assert.equal(agent.name, `${"b".repeat(8)}…${"b".repeat(4)}`);
+});
+
+test("sorts by display name and tolerates undefined inputs", () => {
+  const selected = selectWorkspaceAgents(
+    [
+      relayAgent({ pubkey: "1".repeat(64), name: "Zed" }),
+      relayAgent({ pubkey: "2".repeat(64), name: "Ada" }),
+    ],
+    undefined,
+  );
+
+  assert.deepEqual(
+    selected.map((agent) => agent.name),
+    ["Ada", "Zed"],
+  );
+  assert.deepEqual(selectWorkspaceAgents(undefined, undefined), []);
+});
+
+test("describeWorkspaceAgent joins owner, runtime, and channel count", () => {
+  assert.equal(
+    describeWorkspaceAgent(relayAgent(), "Alice"),
+    "Managed by Alice · omp · in 1 channel",
+  );
+  assert.equal(
+    describeWorkspaceAgent(
+      relayAgent({ agentType: "buzz-acp", channels: ["a", "b", "c"] }),
+      null,
+    ),
+    "buzz-acp · in 3 channels",
+  );
+  assert.equal(
+    describeWorkspaceAgent(relayAgent({ agentType: " ", channels: [] }), null),
+    "in 0 channels",
+  );
+});
+
+test("owner label prefers display name, then name, then truncated pubkey", () => {
+  assert.equal(resolveWorkspaceOwnerLabel(null, { displayName: "Alice" }), null);
+  assert.equal(
+    resolveWorkspaceOwnerLabel(OWNER, { displayName: " Alice ", name: "al" }),
+    "Alice",
+  );
+  assert.equal(
+    resolveWorkspaceOwnerLabel(OWNER, { displayName: "", name: "al" }),
+    "al",
+  );
+  assert.equal(
+    resolveWorkspaceOwnerLabel(OWNER, undefined),
+    `${"c".repeat(8)}…${"c".repeat(4)}`,
+  );
+});
+
+test("availability prefers relay presence over the directory snapshot", () => {
+  assert.equal(resolveWorkspaceAgentAvailability("offline", "online"), "offline");
+  assert.equal(resolveWorkspaceAgentAvailability(undefined, "away"), "away");
+  assert.equal(resolveWorkspaceAgentAvailability(undefined, "unknown"), undefined);
+});

--- a/desktop/src/features/agents/ui/workspaceAgents.ts
+++ b/desktop/src/features/agents/ui/workspaceAgents.ts
@@ -1,0 +1,73 @@
+import type { PresenceStatus, RelayAgent } from "@/shared/api/types";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+
+/**
+ * Relay-discovered agents run by other workspace members, for the read-only
+ * "Workspace agents" section of the Agents screen.
+ *
+ * Excludes every pubkey the viewer already manages (those render as persona /
+ * custom / unknown cards), collapses duplicate relay entries, substitutes the
+ * canonical truncated pubkey for a blank name so every card has a label, and
+ * sorts by that label. The managed side is structurally typed on `{ pubkey }`
+ * so node unit tests don't need full `ManagedAgent` values.
+ */
+export function selectWorkspaceAgents(
+  relayAgents: readonly RelayAgent[] | undefined,
+  managedAgents: readonly { pubkey: string }[] | undefined,
+): RelayAgent[] {
+  const excluded = new Set(
+    (managedAgents ?? []).map((agent) => normalizePubkey(agent.pubkey)),
+  );
+  const workspace: RelayAgent[] = [];
+  for (const agent of relayAgents ?? []) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    if (excluded.has(pubkey)) continue;
+    excluded.add(pubkey);
+    const name = agent.name.trim() || truncatePubkey(agent.pubkey);
+    workspace.push(name === agent.name ? agent : { ...agent, name });
+  }
+  return workspace.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/** Card second line: owner, runtime, and channel count, dot-separated. */
+export function describeWorkspaceAgent(
+  agent: Pick<RelayAgent, "agentType" | "channels">,
+  ownerLabel: string | null,
+): string {
+  const count = agent.channels.length;
+  return [
+    ownerLabel ? `Managed by ${ownerLabel}` : null,
+    agent.agentType.trim() || null,
+    `in ${count} channel${count === 1 ? "" : "s"}`,
+  ]
+    .filter((part) => part !== null)
+    .join(" · ");
+}
+
+/** "Managed by" label: profile display name, kind-0 name, then truncated key. */
+export function resolveWorkspaceOwnerLabel(
+  ownerPubkey: string | null,
+  summary:
+    | { displayName?: string | null; name?: string | null }
+    | null
+    | undefined,
+): string | null {
+  if (!ownerPubkey) return null;
+  return (
+    summary?.displayName?.trim() ||
+    summary?.name?.trim() ||
+    truncatePubkey(ownerPubkey)
+  );
+}
+
+/**
+ * Relay presence is the availability authority (see docs/agent-availability.md);
+ * the directory's own status snapshot only fills in while that read is unknown.
+ */
+export function resolveWorkspaceAgentAvailability(
+  presence: PresenceStatus | undefined,
+  status: RelayAgent["status"],
+): PresenceStatus | undefined {
+  if (presence) return presence;
+  return status === "unknown" ? undefined : status;
+}


### PR DESCRIPTION
## Summary

The Agents screen renders only the viewer's own managed agents and persona library (`AgentsView` → `UnifiedAgentsSection` with `agents.managedAgents` and `personas.libraryPersonas`). Agents that other workspace members run never appear there, even though the desktop already discovers them through `list_relay_agents` for @mention autocomplete, the DM picker, the tray menu and the sidebar working badges.

For a team that runs shared agents on a server (in our case a `buzz-acp` + omp agent deployed through a remote provider, owned by one member), that means everyone else has to find the agent through a channel member list or the mention picker. This adds a read-only **Workspace agents** section to the Agents screen so every member sees the workspace's agents in one place.

What it shows, per agent:

- name (falls back to the truncated pubkey when the directory record has none)
- avatar with the presence dot, using relay presence first and the directory's `status` only while presence is unknown, per `docs/agent-availability.md`
- second line: `Managed by <owner display name> · <runtime> · in N channels`, where the owner label resolves from the NIP-OA-verified `ownerPubkey` via one `useUsersBatchQuery`
- click opens the agent's profile panel (which already renders "Managed by", runtime and status for relay agents)

What it deliberately does not do: no Start / Stop / Delete. The viewer does not own these agents, and `useAgentLifecycleActions` already refuses to act without a local `ManagedAgent`. Agents the viewer manages are excluded by pubkey so nothing is listed twice.

Implementation notes:

- `workspaceAgents.ts` holds the pure selection, labelling and availability rules; `WorkspaceAgentsSection.tsx` is the view; `AgentsView.tsx` mounts it between the unified agents section and Agent teams. `UnifiedAgentsSection` and `useManagedAgentActions` are untouched.
- Rendered as a sibling section rather than a group inside `UnifiedAgentsSection` because that component is mounted by an existing test without `CommunitiesProvider`, which `useUsersBatchQuery` needs.
- One extra presence lookup over the workspace pubkeys (`useAgentAvailabilityLookup`), sharing the existing cache and live subscription.

### Related issue

None found. Closest neighbours are the agent-directory and mention-authorization work in #6224 (relay agent discovery) and the agent availability docs; this is additive UI over the same `list_relay_agents` data.

### Testing

- `desktop/src/features/agents/ui/workspaceAgents.test.mjs`: 7 node tests covering managed-pubkey exclusion (case and whitespace insensitive), duplicate collapse, blank-name fallback, sort order and undefined inputs, subtitle composition (singular/plural, blank runtime), owner-label precedence, and presence-over-snapshot availability. All pass locally.
- `check-pubkey-truncation`, `check-px-text`, `check-file-sizes` pass; both `.tsx` files transpile with no diagnostics; `workspaceAgents.ts` type-checks against the real `RelayAgent` type.
- Full `tsc`, biome and the Playwright e2e suite were not run locally (no `node_modules` on the authoring machine); relying on CI for those.
- UI screenshot: not yet attached. The authoring environment cannot build the desktop bundle; I can add a before/after capture from a CI or dev build on request. One e2e risk worth a reviewer's eye: fixtures that add foreign relay agents whose names match a managed persona could now hit strict-mode locator collisions on the Agents page.
