### PR TITLE
feat(relay): log process id at startup

### DIFF
--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -191,7 +191,7 @@ async fn run_relay_main(boot: BootTracker) -> anyhow::Result<()> {
         }
     }
 
-    info!("Starting buzz-relay");
+    info!(pid = std::process::id(), "Starting buzz-relay");
 
     let (next_boot, config) = boot
         .run_required(StartupPhase::ConfigLoad, Config::from_env, |_error| {


### PR DESCRIPTION
## What

Add the process id as a structured field on the relay's `"Starting buzz-relay"` startup log:

```rust
info!(pid = std::process::id(), "Starting buzz-relay");
```

## Why

Operators can now correlate the running relay process with signals, log lines, and metrics directly from its first startup log line — no `ps`/`pgrep` needed.

## Notes

I targeted `buzz-relay` (the long-running "main entry point" per AGENTS.md) rather than the `buzz` CLI: the CLI emits structured JSON on stdout, so printing a PID there would corrupt machine-readable output. The relay already logs a startup banner via `tracing`, so this rides on the existing structured-logging convention — one-line change, no new output surface.

## Testing

`cargo check -p buzz-relay` passes; pre-push gate (fmt, clippy, rust-tests, desktop-tauri-checks) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)