### PR TITLE
test(desktop): pin mention undo and status expiry smoke behavior

### DIFF
--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -534,7 +534,7 @@ test("primary+Shift+M favors the most recently mentioned eligible agent", async 
   await expect(input).toHaveText("@Vogue draft text");
 });
 
-test("the mention button opens settings and can undo an address", async ({
+test("the mention button preserves manual rementions after undo until explicitly readdressed", async ({
   page,
 }) => {
   await installAudienceFixtures(page);
@@ -601,25 +601,39 @@ test("the mention button opens settings and can undo an address", async ({
   await expect(
     composer.getByRole("button", { name: "Mention someone" }),
   ).toBeVisible();
+  const avatar = composer.getByTestId(`composer-address-lock-${AGENT_A}`);
+  // Observe the old address exit before testing the manual selection.
+  await expect(avatar).toHaveCount(0);
   await input.fill("");
 
   await menu
     .getByRole("button", { name: "Mention Morgarita", exact: true })
     .click();
   await expect(input).toHaveText("@Morgarita ");
-  await expect(
-    composer.getByTestId(`composer-address-lock-${AGENT_A}`),
-  ).toBeVisible();
+  await expect(avatar).toHaveCount(0);
 
   await input.type("later");
   await input.press("Enter");
   await expect(input).toHaveText("");
   await expect
     .poll(() => readOutgoingMentionPubkeys(page, "@Morgarita later"))
-    .toContain(AGENT_A);
+    .toEqual([AGENT_A]);
   await expect(
     composer.getByTestId(`composer-address-lock-${AGENT_A}`),
   ).toHaveCount(0);
+
+  // Only the explicit automatic action reinstates the excluded address.
+  await automaticallyMention(composer, "Morgarita");
+  await expect(avatar).toBeVisible();
+  await input.type("explicit recovery");
+  await input.press("Enter");
+  await expect
+    .poll(() =>
+      readOutgoingMentionPubkeys(page, "@Morgarita explicit recovery"),
+    )
+    .toEqual([AGENT_A]);
+  await expect(input).toHaveText("@Morgarita ");
+  await expect(avatar).toBeVisible();
 });
 
 test("always-mentioned agents remain selected without replaying their animation while Enter-send resolves", async ({

--- a/desktop/tests/e2e/profile-custom-emoji-status.spec.ts
+++ b/desktop/tests/e2e/profile-custom-emoji-status.spec.ts
@@ -196,17 +196,32 @@ test("set status dialog uses the desktop modal with shared status choices", asyn
 test("keeps an open status draft when the saved status expires", async ({
   page,
 }) => {
+  await page.clock.install();
   await page.goto("/");
-  const nowSeconds = Math.floor(Date.now() / 1_000);
+  const nowSeconds = await page.evaluate(() => Math.floor(Date.now() / 1_000));
   await seedMockStatus(page, {
     text: "Original draft",
     emoji: "📝",
-    expiresAt: nowSeconds + 2,
+    expiresAt: nowSeconds + 5 * 60,
     createdAt: nowSeconds,
   });
   await page.getByTestId("profile-popover-set-status").click();
   const dialog = page.getByTestId("set-status-dialog");
+  await expect(dialog.getByTestId("set-status-input")).toHaveValue(
+    "Original draft",
+  );
+  await expect(page.getByTestId("sidebar-profile-user-status")).toBeVisible();
+  await expect(dialog.getByText("Quick statuses", { exact: true })).toHaveCount(
+    0,
+  );
+  await expect(dialog.getByTestId("set-status-clear")).toBeVisible();
   await dialog.getByTestId("set-status-input").fill("Unsaved draft");
+  await expect(dialog.getByLabel("Save status")).toBeEnabled();
+  await expect(dialog.getByRole("alert")).toHaveCount(0);
+
+  // Expire the saved status only after the open dialog has a live, dirty
+  // baseline. Run the real expiration timer rather than racing dialog setup.
+  await page.clock.fastForward(301_000);
   await expect(page.getByTestId("sidebar-profile-user-status")).toHaveCount(0, {
     timeout: 5_000,
   });


### PR DESCRIPTION
🤖

## Summary

Make two desktop smoke tests reliably check existing behavior: manually mentioning an agent after turning off automatic mentions, and editing a status while the saved status expires. This changes only tests, not production UI behavior, helpers, or configuration.

- **Manual mention recovery:** the old test expected a manual mention to restore the agent's automatic-mention badge. The test now checks that the badge disappears after undo and stays absent when the user manually mentions the agent, while the sent message goes to exactly that agent. Choosing **Automatically mention** explicitly restores the badge and keeps the agent's mention in the composer after sending.
- **Status expiry while editing:** the old test gave the saved status two seconds to expire, racing the dialog setup. The test now controls the page clock, seeds a five-minute status, and establishes an open dialog with unsaved edits before advancing past expiry. The existing checks still require the saved status to disappear from the sidebar without losing the draft, show a future-duration warning, disable Save, and allow recovery by choosing **This week**.

The two-file repair is unchanged from its previous version. This branch includes current main, including the MinIO startup fix in https://github.com/block/buzz/pull/7599; that infrastructure change is not part of this PR's test-only diff.

### Related issue

none found

### Testing

Both specs exercise the UI through the existing test fixtures. Fresh normal CI for `ae6ff228f86f42d5203050c99bcb99cdce3a4626` is pending; historical test results and review of the earlier version do not validate this combined tree. Local dependency installation was blocked by network policy in the authoring environment, so no new local pass is claimed.
