### PR TITLE
fix(ci): pull pinned MinIO images from Quay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -783,7 +783,7 @@ Docker Compose provides the full local development stack. All services include h
 | Postgres | `postgres:17-alpine` | 5432 | Primary event store — events, channels, tokens, workflows, audit; full-text search (`search_tsv` GIN) |
 | Redis | `redis:7-alpine` | 6379 | Pub/sub fan-out, presence (SET EX), typing (sorted sets) |
 | Adminer | `adminer` | 8082 | DB web UI (dev only) |
-| MinIO | `minio/minio` | 9000 (API), 9001 (console) | S3-compatible object storage (media) |
+| MinIO | `quay.io/minio/minio` | 9000 (API), 9001 (console) | S3-compatible object storage (media) |
 | Prometheus | `prom/prometheus` | 9090 | Metrics collection |
 
 ### Postgres Schema (key tables)

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -367,8 +367,8 @@ s3:
 # this disabled and use s3.* (or secrets.existingSecret) against managed S3.
 minio:
   enabled: false                 # quickstart: set true for bundled in-cluster MinIO
-  image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-  mcImage: minio/mc:RELEASE.2025-08-13T08-35-41Z
+  image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+  mcImage: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
   persistence:
     enabled: true
     size: 10Gi

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -85,7 +85,7 @@ services:
       - buzz-net
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
@@ -103,7 +103,7 @@ services:
       - buzz-net
 
   minio-init:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.harness.yml
+++ b/docker-compose.harness.yml
@@ -42,7 +42,7 @@ services:
       start_period: 5s
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: buzz_dev
@@ -60,7 +60,7 @@ services:
       start_period: 10s
 
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     restart: unless-stopped
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     container_name: buzz-minio
     command: server /data --console-address ":9001"
     environment:
@@ -130,7 +130,7 @@ services:
     restart: unless-stopped
 
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     container_name: buzz-minio-init
     depends_on:
       minio:


### PR DESCRIPTION
## Summary

CI is failing in `main` before tests start because Docker Hub denies pulls for `minio/minio` and `minio/mc`. Retrying the failed jobs produced the same errors.

Use MinIO’s Quay images in the development, harness, deployment Compose, and Helm configurations. Pin each image to its multi-platform digest and retain the release tags already used by deployment templates. Update the architecture reference to match.

### Related issue

No duplicate issue or PR found. Addresses the image-pull failures in [main CI attempt 2](https://github.com/block/buzz/actions/runs/34645306855/attempts/2).

### Testing

- Pulled both pinned images for Linux ARM64 and AMD64.
- Started an isolated Compose stack derived from the updated MinIO service definitions, once per architecture (AMD64 under local emulation).
- Verified the existing health check passed and the bucket initializer exited with code 0.
- Uploaded an object with `mc cp`, read it with `mc cat`, compared its content, and deleted it with `mc rm` on both architectures.
- Confirmed the initialized bucket was private and removed the temporary stack and volume.

Generated with Codex
