### PR TITLE
refactor(signing): extract async local event signer boundary

### DIFF
--- a/crates/buzz-ws-client/src/connection.rs
+++ b/crates/buzz-ws-client/src/connection.rs
@@ -1,15 +1,16 @@
 use std::collections::VecDeque;
 use std::time::Duration;
 
+use crate::event_signer::EventSigner;
 use futures_util::{SinkExt, StreamExt};
-use nostr::{Event, Keys, Tag};
+use nostr::{Event, EventBuilder, RelayUrl, Tag};
 use serde_json::{json, Value};
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 use tracing::debug;
 
 use crate::error::WsClientError;
-use crate::message::{build_auth_event, parse_relay_message, OkResponse, RelayMessage};
+use crate::message::{parse_relay_message, OkResponse, RelayMessage};
 
 type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 
@@ -36,7 +37,7 @@ impl NostrWsConnection {
     /// Pass `auth_tag` to include a NIP-OA authorization tag in the AUTH event.
     pub async fn connect_authenticated(
         url: &str,
-        keys: &Keys,
+        keys: &(impl EventSigner + ?Sized),
         auth_tag: Option<&Tag>,
     ) -> Result<Self, WsClientError> {
         let mut conn = Self::connect(url).await?;
@@ -69,14 +70,25 @@ impl NostrWsConnection {
     /// Pass `auth_tag` to include a NIP-OA authorization tag in the AUTH event.
     pub async fn authenticate(
         &mut self,
-        keys: &Keys,
+        keys: &(impl EventSigner + ?Sized),
         auth_tag: Option<&Tag>,
     ) -> Result<(), WsClientError> {
         let challenge = self
             .wait_for_auth_challenge(Duration::from_secs(AUTH_CHALLENGE_TIMEOUT_SECS))
             .await?;
 
-        let auth_event = build_auth_event(&challenge, &self.relay_url, keys, auth_tag)?;
+        let url =
+            RelayUrl::parse(&self.relay_url).map_err(|e| WsClientError::Url(e.to_string()))?;
+        let builder = EventBuilder::auth(&challenge, url);
+        let builder = if let Some(tag) = auth_tag {
+            builder.tags([tag.clone()])
+        } else {
+            builder
+        };
+        let auth_event = keys
+            .sign(builder.build(keys.public_key()))
+            .await
+            .map_err(WsClientError::EventBuilder)?;
         let event_id = auth_event.id.to_hex();
 
         self.send_raw(&json!(["AUTH", auth_event])).await?;
@@ -277,7 +289,7 @@ impl NostrWsConnection {
 pub async fn publish_event(
     relay_url: &str,
     event: Event,
-    keys: &Keys,
+    keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&Tag>,
     timeout_secs: u64,
 ) -> Result<OkResponse, WsClientError> {

--- a/crates/buzz-ws-client/src/event_signer.rs
+++ b/crates/buzz-ws-client/src/event_signer.rs
@@ -1,0 +1,181 @@
+//! Event signing only: construction, credentials, lifecycle and publication belong to callers.
+
+use std::{future::Future, pin::Pin};
+
+use nostr::{Event, Keys, PublicKey, UnsignedEvent};
+
+/// An identity capable of signing an exact, already-constructed Nostr event.
+///
+/// This deliberately exposes no secret export, encryption, login or relay operations.
+/// Callers must capture one signer for the lifetime of an operation.
+pub trait EventSigner: Send + Sync {
+    /// The public key bound to this signer snapshot.
+    fn public_key(&self) -> PublicKey;
+
+    /// Sign without changing the event's public key, timestamp, tags, kind or content.
+    fn sign(
+        &self,
+        event: UnsignedEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>>;
+}
+
+/// An in-process signer backed by local keys. Key management remains outside the signer.
+#[derive(Clone)]
+pub struct LocalEventSigner {
+    keys: Keys,
+}
+
+impl LocalEventSigner {
+    /// Capture the supplied local identity, without generating or looking up keys.
+    pub fn new(keys: Keys) -> Self {
+        Self { keys }
+    }
+}
+
+impl EventSigner for LocalEventSigner {
+    fn public_key(&self) -> PublicKey {
+        self.keys.public_key()
+    }
+
+    fn sign(
+        &self,
+        event: UnsignedEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>> {
+        Box::pin(async move {
+            if event.pubkey != self.public_key() {
+                return Err("unsigned event does not match the signing identity".to_string());
+            }
+            event.sign_with_keys(&self.keys).map_err(|e| e.to_string())
+        })
+    }
+}
+
+// Compatibility for explicit-key callers. Generic consumers see only EventSigner;
+// operations requiring a local secret continue to require Keys explicitly.
+impl EventSigner for Keys {
+    fn public_key(&self) -> PublicKey {
+        Keys::public_key(self)
+    }
+
+    fn sign(
+        &self,
+        event: UnsignedEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>> {
+        Box::pin(async move { LocalEventSigner::new(self.clone()).sign(event).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{EventBuilder, Kind, Tag, Timestamp};
+
+    #[tokio::test]
+    async fn signs_exact_event_like_existing_local_path() {
+        let keys = Keys::generate();
+        let signer = LocalEventSigner::new(keys.clone());
+        let builder = EventBuilder::new(Kind::Custom(40002), "exact 🐝\ncontent")
+            .tags([
+                Tag::parse(["h", "channel"]).unwrap(),
+                Tag::parse(["x", "a", "b"]).unwrap(),
+            ])
+            .custom_created_at(Timestamp::from(1700000000));
+        let legacy = builder.clone().sign_with_keys(&keys).unwrap();
+        let event = signer
+            .sign(builder.build(signer.public_key()))
+            .await
+            .unwrap();
+        assert_eq!(event.id, legacy.id);
+        assert_eq!(event.pubkey, legacy.pubkey);
+        assert_eq!(event.created_at, legacy.created_at);
+        assert_eq!(event.kind, legacy.kind);
+        assert_eq!(event.tags, legacy.tags);
+        assert_eq!(event.content, legacy.content);
+        event.verify().unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_another_author_without_rewriting() {
+        let signer = LocalEventSigner::new(Keys::generate());
+        let event =
+            EventBuilder::new(Kind::TextNote, "unchanged").build(Keys::generate().public_key());
+        assert!(signer.sign(event).await.is_err());
+    }
+}
+
+#[cfg(test)]
+mod transport_tests {
+    use super::*;
+    use crate::NostrWsConnection;
+    use futures_util::{SinkExt, StreamExt};
+    use nostr::Tag;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    struct AsyncSigner(LocalEventSigner);
+    impl EventSigner for AsyncSigner {
+        fn public_key(&self) -> PublicKey {
+            self.0.public_key()
+        }
+        fn sign(
+            &self,
+            event: UnsignedEvent,
+        ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>> {
+            Box::pin(async move {
+                tokio::task::yield_now().await;
+                self.0.sign(event).await
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn nip42_awaits_signer_and_preserves_auth_wire_shape() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let expected_url = url.clone();
+        let signer = AsyncSigner(LocalEventSigner::new(Keys::generate()));
+        let public_key = signer.public_key();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            socket
+                .send(Message::Text(
+                    json!(["AUTH", "challenge"]).to_string().into(),
+                ))
+                .await
+                .unwrap();
+            let frame = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let frame: serde_json::Value = serde_json::from_str(&frame).unwrap();
+            assert_eq!(frame[0], "AUTH"); // Not EVENT: the signer never publishes.
+            let event: Event = serde_json::from_value(frame[1].clone()).unwrap();
+            event.verify().unwrap();
+            assert_eq!(event.pubkey, public_key);
+            assert_eq!(event.kind.as_u16(), 22242);
+            assert_eq!(event.content, "");
+            let tags: Vec<_> = event.tags.iter().map(|t| t.as_slice().to_vec()).collect();
+            assert_eq!(
+                tags,
+                vec![
+                    vec!["challenge".to_string(), "challenge".to_string()],
+                    vec!["relay".to_string(), expected_url],
+                    vec!["auth".to_string(), "test-token".to_string()]
+                ]
+            );
+            socket
+                .send(Message::Text(
+                    json!(["OK", event.id.to_hex(), true, ""])
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+        });
+        let auth = Tag::parse(["auth", "test-token"]).unwrap();
+        let connection = NostrWsConnection::connect_authenticated(&url, &signer, Some(&auth))
+            .await
+            .unwrap();
+        server.await.unwrap();
+        drop(connection);
+    }
+}

--- a/crates/buzz-ws-client/src/lib.rs
+++ b/crates/buzz-ws-client/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod connection;
 pub mod error;
+pub mod event_signer;
 pub mod message;
 
 pub use connection::{publish_event, NostrWsConnection};

--- a/desktop/src-tauri/src/app_state_accessors.rs
+++ b/desktop/src-tauri/src/app_state_accessors.rs
@@ -41,7 +41,10 @@ impl AppState {
         }
     }
 
-    /// Return the active identity keys if they are in a signable state.
+    /// Local-secret capability: return the active identity keys in a signable state.
+    ///
+    /// Backup, pairing, encryption and agent provisioning require this capability;
+    /// generic event consumers should capture `event_signer` instead.
     ///
     /// Returns `Err` when the identity is in a lost state (`identity_lost`
     /// — ephemeral key, user must re-import their nsec) or when the keyring
@@ -65,6 +68,15 @@ impl AppState {
             .lock()
             .map_err(|e| e.to_string())
             .map(|k| k.clone())
+    }
+
+    /// Capture the active event signer after the same recovery checks as local keys.
+    /// Secret export, encryption, pairing and provisioning must use `signing_keys`.
+    pub fn event_signer(
+        &self,
+    ) -> Result<buzz_ws_client_pkg::event_signer::LocalEventSigner, String> {
+        self.signing_keys()
+            .map(buzz_ws_client_pkg::event_signer::LocalEventSigner::new)
     }
 
     /// Emit the current huddle state to the frontend via Tauri event.

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -1,3 +1,4 @@
+use crate::event_signing::EventBuilderSigning;
 use nostr::{
     nips::nip44, Event, EventBuilder, JsonUtil, Keys, Kind, PublicKey, Tag, Timestamp, ToBech32,
 };
@@ -139,9 +140,9 @@ pub async fn sign_event(
     tags: Vec<Vec<String>>,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let keys = state.signing_keys()?;
+    let keys = state.event_signer()?;
 
-    tauri::async_runtime::spawn_blocking(move || {
+    tauri::async_runtime::spawn(async move {
         let nostr_tags = tags
             .into_iter()
             .map(|tag| Tag::parse(tag).map_err(|error| format!("invalid tag: {error}")))
@@ -153,13 +154,14 @@ pub async fn sign_event(
         }
 
         let event = builder
-            .sign_with_keys(&keys)
+            .sign_with_event_signer(&keys)
+            .await
             .map_err(|error| format!("sign failed: {error}"))?;
 
         Ok(event.as_json())
     })
     .await
-    .map_err(|e| format!("spawn_blocking failed: {e}"))?
+    .map_err(|e| format!("spawn failed: {e}"))?
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -1,5 +1,9 @@
+use crate::event_signing::EventBuilderSigning;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag, Timestamp};
+use buzz_ws_client_pkg::event_signer::EventSigner;
+#[cfg(test)]
+use nostr::Keys;
+use nostr::{EventBuilder, JsonUtil, Kind, Tag, Timestamp};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::State;
@@ -308,8 +312,8 @@ pub(crate) const MEDIA_GET_AUTH_EXPIRY_SECS: u64 = 600;
 /// scoping and is safe only because the relay still enforces NIP-43
 /// membership on the verified pubkey — and because callers only attach this
 /// header to requests bound for the relay origin itself.
-pub(crate) fn sign_blossom_get_auth_header(
-    keys: &Keys,
+pub(crate) async fn sign_blossom_get_auth_header(
+    keys: &(impl EventSigner + ?Sized),
     base_url: &str,
     expiry_secs: u64,
 ) -> Result<String, String> {
@@ -324,7 +328,8 @@ pub(crate) fn sign_blossom_get_auth_header(
     ];
     let event = EventBuilder::new(Kind::from(24242), "Get buzz-media")
         .tags(tags)
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| e.to_string())?;
     Ok(format!(
         "Nostr {}",
@@ -342,15 +347,15 @@ pub(crate) fn sign_blossom_get_auth_header(
 /// Safety contract: callers must only attach the returned header to URLs
 /// constructed from (or validated against) the app's own relay base URL —
 /// never to third-party origins, where the bearer token would leak.
-pub(crate) fn mint_media_get_auth(state: &AppState, base_url: &str) -> Option<String> {
-    let keys = match state.signing_keys() {
+pub(crate) async fn mint_media_get_auth(state: &AppState, base_url: &str) -> Option<String> {
+    let keys = match state.event_signer() {
         Ok(k) => k,
         Err(e) => {
             eprintln!("buzz-desktop: media get auth unavailable (unsigned request): {e}");
             return None;
         }
     };
-    match sign_blossom_get_auth_header(&keys, base_url, MEDIA_GET_AUTH_EXPIRY_SECS) {
+    match sign_blossom_get_auth_header(&keys, base_url, MEDIA_GET_AUTH_EXPIRY_SECS).await {
         Ok(header) => Some(header),
         Err(e) => {
             eprintln!("buzz-desktop: media get auth signing failed (unsigned request): {e}");
@@ -359,8 +364,8 @@ pub(crate) fn mint_media_get_auth(state: &AppState, base_url: &str) -> Option<St
     }
 }
 
-fn sign_blossom_upload_auth(
-    keys: &Keys,
+async fn sign_blossom_upload_auth(
+    keys: &(impl EventSigner + ?Sized),
     sha256: &str,
     expiry_secs: u64,
     base_url: &str,
@@ -377,7 +382,8 @@ fn sign_blossom_upload_auth(
     }
     EventBuilder::new(Kind::from(24242), "Upload buzz-media")
         .tags(tags)
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| e.to_string())
 }
 
@@ -424,8 +430,8 @@ async fn do_upload(
     };
     let base_url = relay_api_base_url_with_override(state);
     let auth_event = {
-        let keys = state.signing_keys()?;
-        sign_blossom_upload_auth(&keys, &sha256, expiry_secs, &base_url)?
+        let keys = state.event_signer()?;
+        sign_blossom_upload_auth(&keys, &sha256, expiry_secs, &base_url).await?
     };
 
     let auth_header = format!(
@@ -840,10 +846,12 @@ mod tests {
         assert_eq!(extract_server_authority(""), None);
     }
 
-    #[test]
-    fn test_sign_blossom_get_auth_header_shape() {
+    #[tokio::test]
+    async fn test_sign_blossom_get_auth_header_shape() {
         let keys = Keys::generate();
-        let header = sign_blossom_get_auth_header(&keys, "http://localhost:3000", 600).unwrap();
+        let header = sign_blossom_get_auth_header(&keys, "http://localhost:3000", 600)
+            .await
+            .unwrap();
         let b64 = header.strip_prefix("Nostr ").expect("Nostr scheme prefix");
         let json = URL_SAFE_NO_PAD.decode(b64).unwrap();
         let event = nostr::Event::from_json(std::str::from_utf8(&json).unwrap()).unwrap();
@@ -866,10 +874,12 @@ mod tests {
         assert!(expiration > now && expiration <= now + 600);
     }
 
-    #[test]
-    fn test_sign_blossom_get_auth_header_invalid_base_url() {
+    #[tokio::test]
+    async fn test_sign_blossom_get_auth_header_invalid_base_url() {
         let keys = Keys::generate();
-        assert!(sign_blossom_get_auth_header(&keys, "not-a-url", 600).is_err());
+        assert!(sign_blossom_get_auth_header(&keys, "not-a-url", 600)
+            .await
+            .is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -269,7 +269,7 @@ pub(super) async fn fetch_blob_bytes_with_cap(
     // `validate_download_url`, satisfying the mint_media_get_auth safety
     // contract (the token never leaves the relay origin).
     let relay_base = relay_api_base_url_with_override(state);
-    if let Some(auth) = mint_media_get_auth(state, &relay_base) {
+    if let Some(auth) = mint_media_get_auth(state, &relay_base).await {
         req = req.header("authorization", auth);
     }
 

--- a/desktop/src-tauri/src/commands/personas/card.rs
+++ b/desktop/src-tauri/src/commands/personas/card.rs
@@ -672,9 +672,11 @@ pub async fn mint_agent_card(
             // so the token never leaves the relay (same contract as
             // `media_download.rs`).
             let relay_base = crate::relay::relay_api_base_url_with_override(&state);
-            let auth = is_same_origin(url, &relay_base)
-                .then(|| crate::commands::media::mint_media_get_auth(&state, &relay_base))
-                .flatten();
+            let auth = if is_same_origin(url, &relay_base) {
+                crate::commands::media::mint_media_get_auth(&state, &relay_base).await
+            } else {
+                None
+            };
             fetch_avatar(url, auth.as_deref()).await?
         }
         _ => {

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -827,7 +827,7 @@ pub(crate) async fn submit_engram_event(
     // gate may hold for up to MAX_HINT_SECONDS (300s). Building auth before the
     // wait produces a stale `created_at` that the relay will reject.
     crate::relay_admission::wait_for_rate_limit().await;
-    let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, url, event_json)?;
+    let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, url, event_json).await?;
     let mut request = state
         .http_client
         .post(url)

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -932,7 +932,7 @@ pub(crate) async fn submit_engram_event(
     // gate may hold for up to MAX_HINT_SECONDS (300s). Building auth before the
     // wait produces a stale `created_at` that the relay will reject.
     crate::relay_admission::wait_for_rate_limit().await;
-    let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, url, event_json)?;
+    let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, url, event_json).await?;
     let mut request = state
         .http_client
         .post(url)

--- a/desktop/src-tauri/src/egress_guard_tests.rs
+++ b/desktop/src-tauri/src/egress_guard_tests.rs
@@ -153,8 +153,8 @@ async fn boundary_submit_signed_event_with_keys_blocks_ncryptsec() {
 }
 
 /// Boundary 5: huddle STT publisher (`huddle/pipeline.rs`).
-#[test]
-fn boundary_huddle_stt_blocks_ncryptsec() {
+#[tokio::test]
+async fn boundary_huddle_stt_blocks_ncryptsec() {
     let keys = nostr::Keys::generate();
     let channel = uuid::Uuid::new_v4();
     let builder = crate::events::build_message(
@@ -170,7 +170,9 @@ fn boundary_huddle_stt_blocks_ncryptsec() {
         &crate::relay::relay_api_base_url(),
     )
     .unwrap();
-    let err = crate::huddle::pipeline::sign_and_guard_stt_body(builder, &keys).unwrap_err();
+    let err = crate::huddle::pipeline::sign_and_guard_stt_body(builder, &keys)
+        .await
+        .unwrap_err();
     assert_guard_error(&err);
 
     // Clean transcripts pass through the same seam.
@@ -187,7 +189,11 @@ fn boundary_huddle_stt_blocks_ncryptsec() {
         &crate::relay::relay_api_base_url(),
     )
     .unwrap();
-    assert!(crate::huddle::pipeline::sign_and_guard_stt_body(builder, &keys).is_ok());
+    assert!(
+        crate::huddle::pipeline::sign_and_guard_stt_body(builder, &keys)
+            .await
+            .is_ok()
+    );
 }
 
 /// Boundary 8: native websocket send loop — the single choke point for all

--- a/desktop/src-tauri/src/event_signing.rs
+++ b/desktop/src-tauri/src/event_signing.rs
@@ -1,0 +1,55 @@
+//! Event construction adapter. Signers receive only the completed unsigned event.
+use buzz_ws_client_pkg::event_signer::EventSigner;
+use nostr::{Event, EventBuilder};
+
+pub(crate) trait EventBuilderSigning {
+    async fn sign_with_event_signer(
+        self,
+        signer: &(impl EventSigner + ?Sized),
+    ) -> Result<Event, String>;
+}
+impl EventBuilderSigning for EventBuilder {
+    async fn sign_with_event_signer(
+        self,
+        signer: &(impl EventSigner + ?Sized),
+    ) -> Result<Event, String> {
+        let unsigned = self.build(signer.public_key());
+        signer.sign(unsigned).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{Keys, PublicKey, UnsignedEvent};
+    use std::{future::Future, pin::Pin};
+
+    struct UnavailableSigner(PublicKey);
+    impl EventSigner for UnavailableSigner {
+        fn public_key(&self) -> PublicKey {
+            self.0
+        }
+        fn sign(
+            &self,
+            event: UnsignedEvent,
+        ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>> {
+            Box::pin(async move {
+                tokio::task::yield_now().await;
+                assert_eq!(event.pubkey, self.0);
+                assert_eq!(event.created_at.as_secs(), 1700000000);
+                assert_eq!(event.content, "exact");
+                Err("signer unavailable".to_string())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn construction_adapter_awaits_and_propagates_signer_failure() {
+        let signer = UnavailableSigner(Keys::generate().public_key());
+        let result = EventBuilder::new(nostr::Kind::TextNote, "exact")
+            .custom_created_at(nostr::Timestamp::from(1700000000))
+            .sign_with_event_signer(&signer)
+            .await;
+        assert_eq!(result.unwrap_err(), "signer unavailable");
+    }
+}

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -3,6 +3,8 @@
 //! Handles starting, hot-starting, and spawning transcription tasks for
 //! the voice pipelines. Extracted from mod.rs to keep the command layer thin.
 
+use crate::event_signing::EventBuilderSigning;
+use buzz_ws_client_pkg::event_signer::EventSigner;
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -607,12 +609,13 @@ fn should_reselect_constructed_voice(constructed_voice: &str, latest_voice: &str
 /// Factored out of the transcription loop so egress boundary 5 (huddle STT)
 /// has a directly testable seam: the NIP-49 egress guard runs here, before
 /// any bytes can reach the network.
-pub(crate) fn sign_and_guard_stt_body(
+pub(crate) async fn sign_and_guard_stt_body(
     builder: nostr::EventBuilder,
-    keys: &nostr::Keys,
+    keys: &(impl EventSigner + ?Sized),
 ) -> Result<Vec<u8>, String> {
     let event = builder
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| format!("sign event: {e}"))?;
     let body_bytes = event.as_json().into_bytes();
     crate::egress_guard::assert_no_key_backup_bytes(&body_bytes, "huddle STT publish")?;
@@ -688,7 +691,7 @@ pub(crate) fn spawn_transcription_task(
             // the kind event and build NIP-98 auth after the wait so both
             // timestamps are fresh — single clean order: wait → sign → auth → send.
             crate::relay_admission::wait_for_rate_limit().await;
-            let body_bytes = match sign_and_guard_stt_body(builder, &keys) {
+            let body_bytes = match sign_and_guard_stt_body(builder, &keys).await {
                 Ok(b) => b,
                 Err(e) => {
                     eprintln!("buzz-desktop: STT publish: {e}");
@@ -701,7 +704,9 @@ pub(crate) fn spawn_transcription_task(
                 &reqwest::Method::POST,
                 &url,
                 &body_bytes,
-            ) {
+            )
+            .await
+            {
                 Ok(h) => h,
                 Err(e) => {
                     eprintln!("buzz-desktop: STT NIP-98 auth: {e}");

--- a/desktop/src-tauri/src/huddle/relay_api.rs
+++ b/desktop/src-tauri/src/huddle/relay_api.rs
@@ -10,6 +10,8 @@
 //!   → recv loop: WS binary frame → Opus decode (per-peer) → rodio playback
 //! ```
 
+use crate::event_signing::EventBuilderSigning;
+use buzz_ws_client_pkg::event_signer::EventSigner;
 use futures_util::{SinkExt, StreamExt};
 use std::sync::{atomic::AtomicBool, Arc};
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMsg};
@@ -41,8 +43,8 @@ pub(crate) fn parse_channel_uuid(channel_id: &str) -> Result<Uuid, String> {
 /// Handshake timeout — matches the server's AUTH_TIMEOUT (5 s).
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-fn build_audio_auth_event(
-    keys: &nostr::Keys,
+async fn build_audio_auth_event(
+    keys: &(impl EventSigner + ?Sized),
     relay_url: &str,
     challenge: &str,
     auth_tag_json: Option<&str>,
@@ -65,7 +67,8 @@ fn build_audio_auth_event(
     }
     nostr::EventBuilder::new(nostr::Kind::Custom(22242), "")
         .tags(tags)
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| format!("sign: {e}"))
 }
 
@@ -73,7 +76,7 @@ async fn connect_authenticated_audio_socket(
     channel_id: &str,
     parent_channel_id: Option<&str>,
     relay_url: &str,
-    keys: &nostr::Keys,
+    keys: &(impl EventSigner + ?Sized),
     auth_tag_json: Option<&str>,
 ) -> Result<(WsSink, WsReceiver, u8, Vec<(u8, String, u8)>), String> {
     use nostr::JsonUtil;
@@ -107,7 +110,7 @@ async fn connect_authenticated_audio_socket(
     .await
     .map_err(|_| "timeout waiting for challenge from relay".to_string())??;
 
-    let event = build_audio_auth_event(keys, relay_url, &challenge, auth_tag_json)?;
+    let event = build_audio_auth_event(keys, relay_url, &challenge, auth_tag_json).await?;
     let event_json: serde_json::Value = serde_json::from_str(&event.as_json())
         .map_err(|e| format!("failed to serialize auth event: {e}"))?;
     let auth_msg = serde_json::json!({
@@ -317,7 +320,7 @@ pub(crate) async fn connect_tts_audio_publisher(
     channel_id: &str,
     parent_channel_id: Option<&str>,
     state: &AppState,
-    keys: &nostr::Keys,
+    keys: &(impl EventSigner + ?Sized),
     auth_tag_json: Option<&str>,
     local_tts_publishers: super::tts::LocalTtsPublishers,
 ) -> Result<super::tts::TtsAudioPublisher, String> {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod channel_head_cache;
 mod commands;
 mod deep_link;
 mod egress_guard;
+mod event_signing;
 mod event_sync;
 mod events;
 mod huddle;

--- a/desktop/src-tauri/src/media_proxy.rs
+++ b/desktop/src-tauri/src/media_proxy.rs
@@ -59,7 +59,7 @@ async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) ->
 
     // `upstream_url` is always `{relay base}{path}`, so the token can't reach
     // a third-party origin (mint_media_get_auth safety contract).
-    if let Some(auth) = mint_media_get_auth(&app_state, &base_url) {
+    if let Some(auth) = mint_media_get_auth(&app_state, &base_url).await {
         upstream = upstream.header("authorization", auth);
     }
 
@@ -187,7 +187,7 @@ pub async fn handle_buzz_media(
 
     // `upstream_url` is always `{relay base}{path}`, so the token can't reach
     // a third-party origin (mint_media_get_auth safety contract).
-    if let Some(auth) = mint_media_get_auth(&state, &base) {
+    if let Some(auth) = mint_media_get_auth(&state, &base).await {
         upstream = upstream.header("authorization", auth);
     }
 

--- a/desktop/src-tauri/src/native_relay_client.rs
+++ b/desktop/src-tauri/src/native_relay_client.rs
@@ -24,8 +24,11 @@ use std::{
     time::Duration,
 };
 
+use buzz_ws_client_pkg::event_signer::EventSigner;
 use buzz_ws_client_pkg::{NostrWsConnection, RelayMessage};
-use nostr::{Event, Keys};
+use nostr::Event;
+#[cfg(test)]
+use nostr::Keys;
 use tokio::{
     sync::{mpsc, oneshot, Mutex},
     time::Instant,
@@ -136,7 +139,11 @@ impl NativeRelayClient {
     /// slot. Destructive on entry, so every caller must already hold proof it
     /// is the current owner — today that is
     /// [`crate::archive::sync::ArchiveOwnership`].
-    async fn ensure_session(&self, relay_url: String, keys: Keys) -> Arc<RelaySession> {
+    async fn ensure_session(
+        &self,
+        relay_url: String,
+        keys: impl EventSigner + Clone + 'static,
+    ) -> Arc<RelaySession> {
         let scope = (relay_url.clone(), keys.public_key().to_hex());
         let mut current = self.current.lock().await;
         if let Some(managed) = current.as_ref().filter(|managed| managed.scope == scope) {
@@ -176,7 +183,11 @@ impl NativeRelayClient {
     /// Filling an empty slot is deliberate: at startup the catalog fetch
     /// commonly precedes archive sync, and installing here means the archive
     /// start that follows reuses this socket instead of opening a second one.
-    pub(crate) async fn session(&self, relay_url: String, keys: Keys) -> SessionLease {
+    pub(crate) async fn session(
+        &self,
+        relay_url: String,
+        keys: impl EventSigner + Clone + 'static,
+    ) -> SessionLease {
         let scope = (relay_url.clone(), keys.public_key().to_hex());
         let mut current = self.current.lock().await;
         if let Some(managed) = current.as_ref() {
@@ -216,7 +227,7 @@ impl NativeRelayClient {
     pub(crate) async fn archive_session(
         &self,
         relay_url: String,
-        keys: Keys,
+        keys: impl EventSigner + Clone + 'static,
         _ownership: &crate::archive::sync::ArchiveOwnership<'_>,
     ) -> (Arc<RelaySession>, mpsc::Receiver<MatchedEvent>) {
         let session = self.ensure_session(relay_url, keys).await;
@@ -386,7 +397,7 @@ impl RelaySession {
 #[cfg(test)]
 pub(crate) async fn start(
     relay_url: String,
-    keys: Keys,
+    keys: impl EventSigner + Clone + 'static,
     auth_tag: Option<nostr::Tag>,
 ) -> (Arc<RelaySession>, mpsc::Receiver<MatchedEvent>) {
     let session = start_managed(relay_url, keys, auth_tag);
@@ -394,7 +405,11 @@ pub(crate) async fn start(
     (session, events)
 }
 
-fn start_managed(relay_url: String, keys: Keys, auth_tag: Option<nostr::Tag>) -> Arc<RelaySession> {
+fn start_managed(
+    relay_url: String,
+    keys: impl EventSigner + Clone + 'static,
+    auth_tag: Option<nostr::Tag>,
+) -> Arc<RelaySession> {
     let (wake, wake_rx) = mpsc::channel(1);
     let session = Arc::new(RelaySession {
         state: Arc::new(Mutex::new(SessionState::default())),
@@ -417,7 +432,7 @@ fn start_managed(relay_url: String, keys: Keys, auth_tag: Option<nostr::Tag>) ->
 
 async fn run_session(
     relay_url: String,
-    keys: Keys,
+    keys: impl EventSigner + Clone + 'static,
     auth_tag: Option<nostr::Tag>,
     session: Arc<RelaySession>,
     mut wake_rx: mpsc::Receiver<()>,

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -1,5 +1,7 @@
+use crate::event_signing::EventBuilderSigning;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag};
+use buzz_ws_client_pkg::event_signer::EventSigner;
+use nostr::{EventBuilder, JsonUtil, Kind, Tag};
 use reqwest::Method;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -117,18 +119,23 @@ pub fn relay_api_base_url() -> String {
 
 // ── NIP-98 HTTP auth ────────────────────────────────────────────────────────
 
-pub fn build_nip98_auth_header(
+pub async fn build_nip98_auth_header(
     method: &Method,
     url: &str,
     body: &[u8],
     state: &AppState,
 ) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|error| error.to_string())?;
-    build_nip98_auth_header_for_keys(&keys, method, url, body)
+    let keys = state
+        .keys
+        .lock()
+        .map_err(|error| error.to_string())?
+        .clone();
+    build_nip98_auth_header_for_keys(&keys, method, url, body).await
 }
 
-pub fn build_nip98_auth_header_for_keys(
-    keys: &Keys,
+/// Build NIP-98 outside the signer, retaining the explicit-key API name for callers.
+pub async fn build_nip98_auth_header_for_keys(
+    keys: &(impl EventSigner + ?Sized),
     method: &Method,
     url: &str,
     body: &[u8],
@@ -152,7 +159,8 @@ pub fn build_nip98_auth_header_for_keys(
 
     let event = EventBuilder::new(Kind::HttpAuth, "")
         .tags(tags)
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|error| format!("sign failed: {error}"))?;
 
     Ok(format!(
@@ -374,7 +382,7 @@ pub async fn query_relay_at(
     let url = format!("{}/query", api_base_url);
     let body_bytes =
         serde_json::to_vec(filters).map_err(|e| format!("filter serialization failed: {e}"))?;
-    let auth = build_nip98_auth_header(&Method::POST, &url, &body_bytes, state)?;
+    let auth = build_nip98_auth_header(&Method::POST, &url, &body_bytes, state).await?;
     send_query_request(
         &state.http_client,
         &url,
@@ -390,14 +398,14 @@ pub async fn query_relay_at_with_keys(
     state: &AppState,
     api_base_url: &str,
     filters: &[serde_json::Value],
-    keys: &Keys,
+    keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&str>,
 ) -> Result<Vec<nostr::Event>, String> {
     crate::relay_admission::wait_for_rate_limit().await;
     let url = format!("{}/query", api_base_url);
     let body_bytes =
         serde_json::to_vec(filters).map_err(|e| format!("filter serialization failed: {e}"))?;
-    let auth = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes)?;
+    let auth = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes).await?;
     send_query_request(
         &state.http_client,
         &url,
@@ -531,7 +539,8 @@ pub async fn sync_managed_agent_profile(
     crate::egress_guard::assert_no_key_backup_bytes(&body_bytes, "agent profile sync")?;
 
     let url = format!("{}/events", relay_http_base_url(relay_url));
-    let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, &url, &body_bytes)?;
+    let auth =
+        build_nip98_auth_header_for_keys(agent_keys, &Method::POST, &url, &body_bytes).await?;
 
     let mut request = state
         .http_client
@@ -634,11 +643,12 @@ pub use submit::{
 pub async fn submit_event_with_keys(
     builder: nostr::EventBuilder,
     state: &AppState,
-    keys: &Keys,
+    keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&str>,
 ) -> Result<SubmitEventResponse, String> {
     let event = builder
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| format!("failed to sign event: {e}"))?;
     submit_signed_event_with_keys(&event, state, keys, auth_tag).await
 }
@@ -647,7 +657,7 @@ pub async fn submit_event_with_keys(
 pub async fn submit_signed_event_with_keys(
     event: &nostr::Event,
     state: &AppState,
-    keys: &Keys,
+    keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&str>,
 ) -> Result<SubmitEventResponse, String> {
     if event.pubkey != keys.public_key() {
@@ -657,7 +667,8 @@ pub async fn submit_signed_event_with_keys(
     let url = format!("{}/events", relay_api_base_url_with_override(state));
     let body_bytes = event.as_json().into_bytes();
     crate::egress_guard::assert_no_key_backup_bytes(&body_bytes, "signed event submit (keys)")?;
-    let auth_header = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes)?;
+    let auth_header =
+        build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes).await?;
 
     let mut request = state
         .http_client

--- a/desktop/src-tauri/src/relay/get.rs
+++ b/desktop/src-tauri/src/relay/get.rs
@@ -22,7 +22,7 @@ pub async fn get_relay_json<T: DeserializeOwned>(
         relay_api_base_url_with_override(state),
         path_with_query
     );
-    let auth = build_nip98_auth_header(&Method::GET, &url, &[], state)?;
+    let auth = build_nip98_auth_header(&Method::GET, &url, &[], state).await?;
     let response = state
         .http_client
         .get(&url)

--- a/desktop/src-tauri/src/relay/submit.rs
+++ b/desktop/src-tauri/src/relay/submit.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::event_signing::EventBuilderSigning;
+use buzz_ws_client_pkg::event_signer::EventSigner;
 
 /// Response from `POST /events`.
 #[derive(Debug, Deserialize, serde::Serialize)]
@@ -17,7 +19,7 @@ pub async fn submit_signed_event_at_with_keys(
     event: &nostr::Event,
     state: &AppState,
     api_base_url: &str,
-    keys: &nostr::Keys,
+    keys: &(impl EventSigner + ?Sized),
 ) -> Result<SubmitEventResponse, String> {
     if event.pubkey != keys.public_key() {
         return Err("signed event does not match the publishing identity".to_string());
@@ -26,7 +28,8 @@ pub async fn submit_signed_event_at_with_keys(
     let url = format!("{}/events", api_base_url.trim_end_matches('/'));
     let body_bytes = event.as_json().into_bytes();
     crate::egress_guard::assert_no_key_backup_bytes(&body_bytes, "relay event submit")?;
-    let auth_header = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes)?;
+    let auth_header =
+        build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes).await?;
 
     let response = state
         .http_client
@@ -59,10 +62,11 @@ pub async fn submit_event_at_with_keys(
     builder: nostr::EventBuilder,
     state: &AppState,
     api_base_url: &str,
-    keys: &nostr::Keys,
+    keys: &(impl EventSigner + ?Sized),
 ) -> Result<SubmitEventResponse, String> {
     let event = builder
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| format!("failed to sign event: {e}"))?;
     submit_signed_event_at_with_keys(&event, state, api_base_url, keys).await
 }
@@ -73,7 +77,7 @@ pub async fn submit_event(
     state: &AppState,
 ) -> Result<SubmitEventResponse, String> {
     let api_base_url = relay_api_base_url_with_override(state);
-    let keys = state.signing_keys()?;
+    let keys = state.event_signer()?;
     submit_event_at_with_keys(builder, state, &api_base_url, &keys).await
 }
 
@@ -98,10 +102,11 @@ pub async fn submit_event_at_created_at(
     builder: nostr::EventBuilder,
     state: &AppState,
     api_base_url: &str,
-    keys: &nostr::Keys,
+    keys: &(impl EventSigner + ?Sized),
 ) -> Result<(SubmitEventResponse, i64), String> {
     let event = builder
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| format!("failed to sign event: {e}"))?;
     let created_at = event.created_at.as_secs() as i64;
     let result = submit_signed_event_at_with_keys(&event, state, api_base_url, keys).await?;
@@ -113,11 +118,12 @@ pub async fn submit_event_at_created_at(
 pub async fn submit_event_with_keys_created_at(
     builder: nostr::EventBuilder,
     state: &AppState,
-    keys: &nostr::Keys,
+    keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&str>,
 ) -> Result<(SubmitEventResponse, i64), String> {
     let event = builder
-        .sign_with_keys(keys)
+        .sign_with_event_signer(keys)
+        .await
         .map_err(|e| format!("failed to sign event: {e}"))?;
     let created_at = event.created_at.as_secs() as i64;
     let result = super::submit_signed_event_with_keys(&event, state, keys, auth_tag).await?;

--- a/desktop/src-tauri/src/relay_admission.rs
+++ b/desktop/src-tauri/src/relay_admission.rs
@@ -405,6 +405,7 @@ mod tests {
             "https://relay.example.com/events",
             b"{}",
         )
+        .await
         .expect("header build must succeed");
 
         // Decode the base64-encoded Nostr event from "Nostr <base64>".

--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -17,6 +17,8 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import 'package:nostr/nostr.dart' as nostr;
 
+import '../../shared/auth/event_signer.dart';
+
 import '../../shared/mentions/agent_identity_provider.dart';
 import '../../shared/mentions/mention_bindings.dart';
 import '../../shared/huddle/huddle_session.dart';

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -394,6 +394,8 @@ void _sendTypingIndicator(
         ['e', threadHeadId, '', 'reply'],
     ];
 
+    final session = ref.read(relaySessionProvider.notifier);
+    final lease = session.captureLease();
     final event = await signEvent(
       kind: EventKind.typingIndicator,
       content: '',
@@ -402,8 +404,7 @@ void _sendTypingIndicator(
     );
 
     // Send directly over WebSocket — fire-and-forget, matching desktop.
-    final session = ref.read(relaySessionProvider.notifier);
-    session.sendRaw(['EVENT', event.toMap()]);
+    session.sendRaw(['EVENT', event.toMap()], lease: lease);
   } catch (_) {
     // Fire-and-forget — typing indicator failure is non-fatal.
   }

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -376,7 +376,7 @@ void _sendTypingIndicator(
   required String channelId,
   String? threadHeadId,
   String? rootId,
-}) {
+}) async {
   try {
     final config = ref.read(relayConfigProvider);
     final nsec = config.nsec;
@@ -394,12 +394,11 @@ void _sendTypingIndicator(
         ['e', threadHeadId, '', 'reply'],
     ];
 
-    final event = nostr.Event.from(
+    final event = await signEvent(
       kind: EventKind.typingIndicator,
       content: '',
       tags: tags,
-      secretKey: privkeyHex,
-      verify: false,
+      signer: LocalEventSigner(privkeyHex),
     );
 
     // Send directly over WebSocket — fire-and-forget, matching desktop.

--- a/mobile/lib/features/channels/emoji_picker/ios_native_picker.dart
+++ b/mobile/lib/features/channels/emoji_picker/ios_native_picker.dart
@@ -130,7 +130,7 @@ Future<void> _presentIosEmojiPicker({
       case 'mediaHeaders':
         final url = call.arguments;
         return url is String
-            ? mediaAuth.headersFor(url)
+            ? await mediaAuth.headersFor(url)
             : const <String, String>{};
       case 'selected':
         final emoji = call.arguments;

--- a/mobile/lib/features/channels/media_viewer_page/video_viewer.dart
+++ b/mobile/lib/features/channels/media_viewer_page/video_viewer.dart
@@ -1,5 +1,11 @@
 part of '../media_viewer_page.dart';
 
+/// Android supports authenticated range requests; other platforms use a file.
+/// Overridable so widget tests can exercise the actual streaming path.
+final mediaVideoStreamingSupportedProvider = Provider<bool>(
+  (ref) => Platform.isAndroid,
+);
+
 class MediaVideoViewerPage extends HookConsumerWidget {
   final String videoUrl;
   final String? posterUrl;
@@ -52,14 +58,20 @@ class MediaVideoViewerPage extends HookConsumerWidget {
         // keep Android on its streaming path. iOS uses the authenticated local
         // copy below because AVPlayer can drop those headers after the first
         // request.
-        if (Platform.isAndroid) {
+        if (ref.read(mediaVideoStreamingSupportedProvider)) {
           VideoPlayerController? streamingController;
           try {
+            final headers = await auth.headersFor(videoUrl);
+            if (disposed) return;
             streamingController = VideoPlayerController.networkUrl(
               uri,
-              httpHeaders: await auth.headersFor(videoUrl),
+              httpHeaders: headers,
             );
             await streamingController.initialize();
+            if (disposed) {
+              await streamingController.dispose();
+              return;
+            }
             await streamingController.play();
             if (disposed) {
               await streamingController.dispose();
@@ -71,20 +83,24 @@ class MediaVideoViewerPage extends HookConsumerWidget {
             if (streamingController != null) {
               await streamingController.dispose();
             }
+            if (disposed) return;
             // Fall through to the authenticated local-file path only when the
             // streaming controller cannot initialize.
           }
         }
 
+        VideoPlayerController? localController;
         try {
           final client = ref.read(mediaHttpClientProvider);
+          final headers = await auth.headersFor(videoUrl);
+          if (disposed) return;
           final requestAbort = Completer<void>();
           downloadRequestAbort.value = requestAbort;
           final request = http.AbortableStreamedRequest(
             'GET',
             uri,
             abortTrigger: requestAbort.future,
-          )..headers.addAll(await auth.headersFor(videoUrl));
+          )..headers.addAll(headers);
           late final http.StreamedResponse response;
           try {
             response = await client.send(request);
@@ -145,8 +161,13 @@ class MediaVideoViewerPage extends HookConsumerWidget {
             return;
           }
 
-          final localController = VideoPlayerController.file(file);
+          localController = VideoPlayerController.file(file);
           await localController.initialize();
+          if (disposed) {
+            await localController.dispose();
+            await deleteVideoFile();
+            return;
+          }
           await localController.play();
           if (disposed) {
             await localController.dispose();
@@ -155,6 +176,7 @@ class MediaVideoViewerPage extends HookConsumerWidget {
           }
           controller.value = localController;
         } catch (loadError) {
+          await localController?.dispose();
           if (!disposed) error.value = loadError.toString();
         }
       }

--- a/mobile/lib/features/channels/media_viewer_page/video_viewer.dart
+++ b/mobile/lib/features/channels/media_viewer_page/video_viewer.dart
@@ -57,7 +57,7 @@ class MediaVideoViewerPage extends HookConsumerWidget {
           try {
             streamingController = VideoPlayerController.networkUrl(
               uri,
-              httpHeaders: auth.headersFor(videoUrl),
+              httpHeaders: await auth.headersFor(videoUrl),
             );
             await streamingController.initialize();
             await streamingController.play();
@@ -84,7 +84,7 @@ class MediaVideoViewerPage extends HookConsumerWidget {
             'GET',
             uri,
             abortTrigger: requestAbort.future,
-          )..headers.addAll(auth.headersFor(videoUrl));
+          )..headers.addAll(await auth.headersFor(videoUrl));
           late final http.StreamedResponse response;
           try {
             response = await client.send(request);

--- a/mobile/lib/features/channels/message_actions.dart
+++ b/mobile/lib/features/channels/message_actions.dart
@@ -340,7 +340,9 @@ Future<_DownloadedImage> _downloadImage(WidgetRef ref, String imageUrl) async {
       .read(mediaHttpClientProvider)
       .get(
         Uri.parse(imageUrl),
-        headers: ref.read(mediaGetAuthServiceProvider).headersFor(imageUrl),
+        headers: await ref
+            .read(mediaGetAuthServiceProvider)
+            .headersFor(imageUrl),
       );
   if (response.statusCode < 200 || response.statusCode >= 300) {
     throw HttpException(

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -505,7 +505,7 @@ class MessageContent extends HookConsumerWidget {
         try {
           await ref.read(openDownloadedFileProvider)(
             url,
-            auth.headersFor(url),
+            await auth.headersFor(url),
             text,
           );
         } catch (_) {

--- a/mobile/lib/features/channels/message_content/video_preview.dart
+++ b/mobile/lib/features/channels/message_content/video_preview.dart
@@ -30,7 +30,8 @@ final videoPreviewFrameLoaderProvider = Provider<VideoPreviewFrameLoader>((
   ref,
 ) {
   final auth = ref.watch(mediaGetAuthServiceProvider);
-  return (url) => _loadVideoPreviewFrame(url, headers: auth.headersFor(url));
+  return (url) async =>
+      _loadVideoPreviewFrame(url, headers: await auth.headersFor(url));
 });
 
 class _MessageVideoPreview extends HookConsumerWidget {

--- a/mobile/lib/features/channels/voice_note_recording.dart
+++ b/mobile/lib/features/channels/voice_note_recording.dart
@@ -332,7 +332,7 @@ abstract class VoiceNotePlayerController extends ChangeNotifier {
 
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   });
 
@@ -524,7 +524,7 @@ class DeviceVoiceNotePlayerController extends VoiceNotePlayerController {
   VoiceNotePlaybackState _state = const VoiceNotePlaybackState();
   ({
     String url,
-    Map<String, String> Function() headers,
+    FutureOr<Map<String, String>> Function() headers,
     Duration fallbackDuration,
   })?
   _pendingRemote;
@@ -560,7 +560,7 @@ class DeviceVoiceNotePlayerController extends VoiceNotePlayerController {
   @override
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   }) {
     _replaceSource();
@@ -608,7 +608,12 @@ class DeviceVoiceNotePlayerController extends VoiceNotePlayerController {
         'GET',
         uri,
         abortTrigger: requestAbort.future,
-      )..headers.addAll(remote.headers());
+      )..headers.addAll(await remote.headers());
+      if (_disposed ||
+          sourceGeneration != _sourceGeneration ||
+          playbackOperationGeneration != _playbackOperationGeneration) {
+        return null;
+      }
       final response = await _client
           .send(request)
           .timeout(
@@ -838,7 +843,15 @@ class DeviceVoiceNotePlayerController extends VoiceNotePlayerController {
           }
         } else {
           await _load(
-            () => _player.setUrl(remote.url, headers: remote.headers()),
+            () async {
+              final headers = await remote.headers();
+              if (_disposed ||
+                  sourceGeneration != _sourceGeneration ||
+                  playbackOperationGeneration != _playbackOperationGeneration) {
+                return null;
+              }
+              return _player.setUrl(remote.url, headers: headers);
+            },
             fallbackDuration: remote.fallbackDuration,
             sourceGeneration: sourceGeneration,
             playbackOperationGeneration: playbackOperationGeneration,

--- a/mobile/lib/features/invites/invite_create_provider.dart
+++ b/mobile/lib/features/invites/invite_create_provider.dart
@@ -221,7 +221,7 @@ class RelayCommunityInviteActions implements CommunityInviteActions {
         .post(
           Uri.parse(url),
           headers: {
-            'Authorization': buildNip98AuthHeader(
+            'Authorization': await buildNip98AuthHeader(
               method: 'POST',
               url: url,
               bodyBytes: bodyBytes,

--- a/mobile/lib/features/invites/invite_join_provider.dart
+++ b/mobile/lib/features/invites/invite_join_provider.dart
@@ -211,7 +211,7 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
       final request = http.Request('POST', Uri.parse(url))
         ..followRedirects = false
         ..headers.addAll({
-          'Authorization': buildNip98AuthHeader(
+          'Authorization': await buildNip98AuthHeader(
             method: 'POST',
             url: url,
             bodyBytes: utf8.encode(body),

--- a/mobile/lib/features/profile/user_status_provider.dart
+++ b/mobile/lib/features/profile/user_status_provider.dart
@@ -96,6 +96,8 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
     }
 
     final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
+    final session = ref.read(relaySessionProvider.notifier);
+    final lease = session.captureLease();
     final event = await signEvent(
       kind: EventKind.userStatus,
       content: trimmed,
@@ -103,8 +105,8 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
       signer: LocalEventSigner(privkeyHex),
     );
 
-    final session = ref.read(relaySessionProvider.notifier);
-    await session.publish(NostrEvent.fromJson(event.toMap()));
+    await session.publish(NostrEvent.fromJson(event.toMap()), lease: lease);
+    lease.ensureCurrent();
 
     // Optimistic update: update own state immediately.
     final newStatus = (trimmed.isNotEmpty || emoji.isNotEmpty)

--- a/mobile/lib/features/profile/user_status_provider.dart
+++ b/mobile/lib/features/profile/user_status_provider.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
 
+import '../../shared/auth/event_signer.dart';
+
 import '../../shared/relay/relay.dart';
 import 'user_status.dart';
 import 'user_status_cache_provider.dart';
@@ -94,12 +96,11 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
     }
 
     final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-    final event = nostr.Event.from(
+    final event = await signEvent(
       kind: EventKind.userStatus,
       content: trimmed,
       tags: tags,
-      secretKey: privkeyHex,
-      verify: false,
+      signer: LocalEventSigner(privkeyHex),
     );
 
     final session = ref.read(relaySessionProvider.notifier);

--- a/mobile/lib/shared/auth/event_signer.dart
+++ b/mobile/lib/shared/auth/event_signer.dart
@@ -1,0 +1,74 @@
+import 'package:nostr/nostr.dart' as nostr;
+
+/// A completed Nostr event payload. No clock or tag construction runs in sign().
+final class UnsignedEvent {
+  final String publicKey;
+  final int createdAt;
+  final int kind;
+  final String content;
+  final List<List<String>> tags;
+
+  UnsignedEvent({
+    required this.publicKey,
+    required this.createdAt,
+    required this.kind,
+    required this.content,
+    required List<List<String>> tags,
+  }) : tags = List.unmodifiable(
+         tags.map((tag) => List<String>.unmodifiable(tag)),
+       );
+}
+
+/// Signs an exact event, without login, key export, encryption or publication.
+abstract interface class EventSigner {
+  /// Public key bound to this operation's signer snapshot.
+  String get publicKey;
+
+  /// Sign the supplied fields without rewriting them or selecting another key.
+  Future<nostr.Event> sign(UnsignedEvent event);
+}
+
+/// Local signing only. Secret storage, export and pairing remain separate APIs.
+final class LocalEventSigner implements EventSigner {
+  final String _secretKey;
+
+  /// Capture an explicitly supplied hex secret; never generate or look up keys.
+  LocalEventSigner(String secretKey) : _secretKey = secretKey;
+
+  @override
+  String get publicKey => nostr.Keys(_secretKey).public;
+
+  @override
+  Future<nostr.Event> sign(UnsignedEvent event) async {
+    if (event.publicKey != publicKey) {
+      throw StateError('Unsigned event does not match the signing identity');
+    }
+    return nostr.Event.from(
+      kind: event.kind,
+      content: event.content,
+      tags: event.tags,
+      createdAt: event.createdAt,
+      pubkey: event.publicKey,
+      secretKey: _secretKey,
+      verify: false,
+    );
+  }
+}
+
+/// Construct an event before passing it to the signer. Transport stays with callers.
+Future<nostr.Event> signEvent({
+  required EventSigner signer,
+  required int kind,
+  required String content,
+  required List<List<String>> tags,
+  int? createdAt,
+}) {
+  final event = UnsignedEvent(
+    publicKey: signer.publicKey,
+    createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    kind: kind,
+    content: content,
+    tags: tags,
+  );
+  return signer.sign(event);
+}

--- a/mobile/lib/shared/huddle/huddle_auth.dart
+++ b/mobile/lib/shared/huddle/huddle_auth.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:nostr/nostr.dart' as nostr;
 
+import '../auth/event_signer.dart';
+
 import '../relay/nostr_models.dart';
 import 'huddle_wire.dart';
 
@@ -56,26 +58,25 @@ final class HuddleConnectionParameters {
 
 /// Fixed NIP-42 + Huddle auth envelope used after the audio relay challenge.
 abstract final class HuddleAuthV2 {
-  static Map<String, dynamic> buildMessage({
+  static Future<Map<String, dynamic>> buildMessage({
     required HuddleConnectionParameters parameters,
     required String challenge,
     int? createdAt,
-  }) {
+  }) async {
     if (challenge.isEmpty) {
       throw const HuddleAuthException('Relay challenge must not be empty.');
     }
 
     final secretKey = _decodeSecretKey(parameters.nsec);
-    final event = nostr.Event.from(
+    final event = await signEvent(
       kind: EventKind.auth,
       content: '',
       tags: [
         ['relay', parameters.relayWebSocketUrl],
         ['challenge', challenge],
       ],
-      secretKey: secretKey,
+      signer: LocalEventSigner(secretKey),
       createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
-      verify: false,
     );
 
     return {

--- a/mobile/lib/shared/huddle/huddle_transport.dart
+++ b/mobile/lib/shared/huddle/huddle_transport.dart
@@ -391,7 +391,7 @@ final class HuddleTransport implements HuddleTransportClient {
     }
   }
 
-  void _handleChallenge(Map<String, dynamic> message, int generation) {
+  void _handleChallenge(Map<String, dynamic> message, int generation) async {
     if (_state.phase != HuddleTransportPhase.awaitingChallenge) {
       _handleProtocolProblem('Unexpected Huddle auth challenge.', generation);
       return;
@@ -409,10 +409,11 @@ final class HuddleTransport implements HuddleTransportClient {
     }
 
     try {
-      final auth = HuddleAuthV2.buildMessage(
+      final auth = await HuddleAuthV2.buildMessage(
         parameters: parameters,
         challenge: challenge,
       );
+      if (generation != _generation) return;
       _channel?.sink.add(jsonEncode(auth));
       _emitState(
         HuddleTransportState(

--- a/mobile/lib/shared/relay/media_auth.dart
+++ b/mobile/lib/shared/relay/media_auth.dart
@@ -4,6 +4,8 @@ import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
 
+import '../auth/event_signer.dart';
+
 import 'relay_provider.dart';
 
 const _mediaGetAuthKind = 24242;
@@ -47,7 +49,9 @@ class MediaGetAuthService {
     return _isRelayMediaUrl(uri, relayUri);
   }
 
-  Map<String, String> headersFor(String url) {
+  Future<Map<String, String>>? _pendingHeaders;
+
+  Future<Map<String, String>> headersFor(String url) async {
     final nsec = _nsec;
     if (nsec == null || nsec.isEmpty) return const {};
     if (!isRelayMediaUrl(url)) return const {};
@@ -58,9 +62,21 @@ class MediaGetAuthService {
       return cached;
     }
 
+    final pending = _pendingHeaders;
+    if (pending != null) {
+      // The synchronous path completed each refresh before the next call.
+      // Recheck the cache after waiting: failures must not be shared/cached,
+      // and the existing expiry boundary still applies to every caller.
+      await pending;
+      return headersFor(url);
+    }
+    return _pendingHeaders = _refreshHeaders(nsec);
+  }
+
+  Future<Map<String, String>> _refreshHeaders(String nsec) async {
     try {
       final signedAt = _now();
-      final authEvent = _buildGetAuthEvent(nsec);
+      final authEvent = await _buildGetAuthEvent(nsec);
       final encoded = base64Url
           .encode(utf8.encode(authEvent.toJson()))
           .replaceAll('=', '');
@@ -80,6 +96,8 @@ class MediaGetAuthService {
       // unsigned fetch still works. Once the flag is on, this request will 403
       // instead of crashing the widget tree because local key material is bad.
       return const {};
+    } finally {
+      _pendingHeaders = null;
     }
   }
 
@@ -98,7 +116,7 @@ class MediaGetAuthService {
     return uri.path.startsWith('/media/');
   }
 
-  nostr.Event _buildGetAuthEvent(String nsec) {
+  Future<nostr.Event> _buildGetAuthEvent(String nsec) async {
     final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
     if (privkeyHex.isEmpty) {
       throw Exception('Invalid nsec');
@@ -113,12 +131,11 @@ class MediaGetAuthService {
         ['server', authority],
     ];
 
-    return nostr.Event.from(
+    return signEvent(
       kind: _mediaGetAuthKind,
       content: 'Get buzz-media',
       tags: tags,
-      secretKey: privkeyHex,
-      verify: false,
+      signer: LocalEventSigner(privkeyHex),
     );
   }
 }
@@ -128,11 +145,11 @@ final mediaGetAuthServiceProvider = Provider<MediaGetAuthService>((ref) {
   return MediaGetAuthService(baseUrl: config.baseUrl, nsec: config.nsec);
 });
 
-Map<String, String> mediaGetHeadersFor(WidgetRef ref, String url) {
+Future<Map<String, String>> mediaGetHeadersFor(WidgetRef ref, String url) {
   return ref.read(mediaGetAuthServiceProvider).headersFor(url);
 }
 
-Map<String, String> mediaGetHeadersForContext(
+Future<Map<String, String>> mediaGetHeadersForContext(
   BuildContext context,
   String url,
 ) {

--- a/mobile/lib/shared/relay/media_image.dart
+++ b/mobile/lib/shared/relay/media_image.dart
@@ -97,7 +97,7 @@ class MediaImageProvider extends ImageProvider<MediaImageProvider> {
       final uri = Uri.parse(url);
       final http.Response response;
       try {
-        response = await client.get(uri, headers: auth.headersFor(url));
+        response = await client.get(uri, headers: await auth.headersFor(url));
       } catch (_) {
         _cooldownUntil[url] = debugNow().add(_defaultCooldown);
         rethrow;

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -12,6 +12,8 @@ import 'package:image_picker/image_picker.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:pointycastle/digests/sha256.dart';
 
+import '../auth/event_signer.dart';
+
 import 'animated_image_sanitizer.dart';
 import 'media_auth.dart';
 import 'mp4_fast_start.dart';
@@ -639,7 +641,7 @@ class MediaUploadService {
     );
     request.contentLength = bytes.length;
     request.headers.addAll(
-      _buildUploadHeaders(mimeType: mimeType, sha256: sha256),
+      await _buildUploadHeaders(mimeType: mimeType, sha256: sha256),
     );
     final writeRequest = request.sink
         .addStream(_uploadByteStream(bytes, onProgress))
@@ -656,26 +658,26 @@ class MediaUploadService {
     }
   }
 
-  Map<String, String> _buildUploadHeaders({
+  Future<Map<String, String>> _buildUploadHeaders({
     required String mimeType,
     required String sha256,
-  }) {
+  }) async {
     final headers = <String, String>{
-      'Authorization': _buildUploadAuthHeader(sha256),
+      'Authorization': await _buildUploadAuthHeader(sha256),
       'Content-Type': mimeType,
       'X-SHA-256': sha256,
     };
     return headers;
   }
 
-  String _buildUploadAuthHeader(String sha256) {
-    final authEvent = _buildUploadAuthEvent(sha256);
+  Future<String> _buildUploadAuthHeader(String sha256) async {
+    final authEvent = await _buildUploadAuthEvent(sha256);
     final authJson = authEvent.toJson();
     final encoded = base64Url.encode(utf8.encode(authJson)).replaceAll('=', '');
     return 'Nostr $encoded';
   }
 
-  nostr.Event _buildUploadAuthEvent(String sha256) {
+  Future<nostr.Event> _buildUploadAuthEvent(String sha256) async {
     final nsec = _nsec;
     if (nsec == null || nsec.isEmpty) {
       throw Exception('Cannot upload media: no signing key available');
@@ -696,12 +698,11 @@ class MediaUploadService {
         ['server', authority],
     ];
 
-    return nostr.Event.from(
+    return signEvent(
       kind: _uploadAuthKind,
       content: 'Upload buzz-media',
       tags: tags,
-      secretKey: privkeyHex,
-      verify: false,
+      signer: LocalEventSigner(privkeyHex),
     );
   }
 

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -73,6 +73,24 @@ class _BufferedEvent {
   _BufferedEvent(this.subId, this.event);
 }
 
+/// Immutable authority to finish work only in its originating session scope.
+/// Capture before awaiting signing/authentication, never after it completes.
+final class RelaySessionLease {
+  final RelaySessionNotifier _session;
+  final Object _scope;
+
+  RelaySessionLease._(this._session, this._scope);
+
+  /// Throws [RelaySessionSupersededError] if the originating scope retired.
+  void ensureCurrent() => _session._checkLease(this);
+}
+
+/// An operation was cancelled because its originating relay scope retired.
+class RelaySessionSupersededError extends StateError {
+  RelaySessionSupersededError()
+    : super('Relay operation cancelled: originating session scope superseded');
+}
+
 class RelaySessionNotifier extends Notifier<SessionState> {
   RelaySessionNotifier({
     http.Client? httpClient,
@@ -125,6 +143,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   bool _paused = false;
   bool _hasConnectedOnce = false;
   int _connectionGeneration = 0;
+  Object _scope = Object();
   final Map<Object, String> _visibleChannelsByOwner = {};
   final Map<Object, Future<void> Function()> _beforePauseCallbacks = {};
   bool _socketConnected = false;
@@ -310,12 +329,31 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     return () => _unsubscribe(subId);
   }
 
+  /// Capture the scope before starting asynchronous event construction.
+  /// Ordinary reconnects retain it; dependency rebuilds and disposal retire it.
+  RelaySessionLease captureLease() {
+    if (_disposed) throw RelaySessionSupersededError();
+    return RelaySessionLease._(this, _scope);
+  }
+
+  void _checkLease(RelaySessionLease lease) {
+    if (_disposed ||
+        !identical(lease._session, this) ||
+        !identical(lease._scope, _scope)) {
+      throw RelaySessionSupersededError();
+    }
+  }
+
+  /// Publish using the scope captured before signing, including after gate waits.
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
+    _checkLease(lease);
     final generation = _connectionGeneration;
     if (_rateLimitGate.isActive) await _rateLimitGate.wait();
+    _checkLease(lease);
     if (!_isActiveConnection(generation) || !_socketConnected) {
       throw StateError('Relay session is not connected');
     }
@@ -338,11 +376,15 @@ class RelaySessionNotifier extends Notifier<SessionState> {
       timeout: timer,
     );
 
+    // No await or consumer callback between the lease check and the socket's
+    // synchronous sink.add: scope replacement cannot interleave with this write.
     _socket?.send(['EVENT', event.toJson()]);
     return completer.future;
   }
 
-  void sendRaw(List<dynamic> payload) {
+  /// Fire-and-forget send in the scope captured before asynchronous signing.
+  void sendRaw(List<dynamic> payload, {required RelaySessionLease lease}) {
+    _checkLease(lease);
     _socket?.send(payload);
   }
 
@@ -960,6 +1002,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
   void _dispose() {
     _disposed = true;
+    _scope = Object();
     _beforePauseCallbacks.clear();
     _connectionGeneration++;
     _reconnectTimer?.cancel();

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -10,6 +10,8 @@ import 'package:uuid/uuid.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../auth/event_signer.dart';
+
 import '../auth/auth.dart';
 import 'nostr_models.dart';
 import 'relay_client.dart';
@@ -164,7 +166,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     final response = await _httpQueryClient.post(
       Uri.parse(url),
       headers: {
-        'Authorization': buildNip98AuthHeader(
+        'Authorization': await buildNip98AuthHeader(
           method: 'POST',
           url: url,
           bodyBytes: bodyBytes,

--- a/mobile/lib/shared/relay/relay_session_auth.dart
+++ b/mobile/lib/shared/relay/relay_session_auth.dart
@@ -1,11 +1,11 @@
 part of 'relay_session.dart';
 
-String buildNip98AuthHeader({
+Future<String> buildNip98AuthHeader({
   required String method,
   required String url,
   required List<int> bodyBytes,
   required String? nsec,
-}) {
+}) async {
   if (nsec == null || nsec.isEmpty) {
     throw Exception('Cannot query relay: no signing key available');
   }
@@ -17,7 +17,7 @@ String buildNip98AuthHeader({
       .process(Uint8List.fromList(bodyBytes))
       .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
       .join();
-  final event = nostr.Event.from(
+  final event = await signEvent(
     kind: 27235,
     content: '',
     tags: [
@@ -26,8 +26,7 @@ String buildNip98AuthHeader({
       ['payload', payloadHash],
       ['nonce', const Uuid().v4()],
     ],
-    secretKey: privkeyHex,
-    verify: false,
+    signer: LocalEventSigner(privkeyHex),
   );
   return 'Nostr ${base64.encode(utf8.encode(event.toJson()))}';
 }

--- a/mobile/lib/shared/relay/relay_socket.dart
+++ b/mobile/lib/shared/relay/relay_socket.dart
@@ -6,6 +6,8 @@ import 'package:nostr/nostr.dart' as nostr;
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+import '../auth/event_signer.dart';
+
 import 'nostr_models.dart';
 
 /// Low-level websocket connection with NIP-42 authentication.
@@ -192,9 +194,10 @@ class RelaySocket {
   }
 
   /// Handle the relay's AUTH challenge: sign a kind:22242 event and respond.
-  void _handleAuthChallenge(List<dynamic> data) {
+  void _handleAuthChallenge(List<dynamic> data) async {
     if (data.length < 2) return;
     final challenge = data[1] as String;
+    final channel = _channel;
 
     if (_nsec == null) {
       _failAuth(Exception('No nsec available for NIP-42 auth'));
@@ -216,16 +219,18 @@ class RelaySocket {
       ];
 
       // Create and sign the kind:22242 AUTH event.
-      final event = nostr.Event.from(
+      final event = await signEvent(
         kind: EventKind.auth,
         content: '',
         tags: tags,
-        secretKey: privkeyHex,
+        signer: LocalEventSigner(privkeyHex),
       );
 
+      if (!identical(channel, _channel)) return;
       _pendingAuthEventId = event.id;
       send(['AUTH', event.toMap()]);
     } catch (e) {
+      if (!identical(channel, _channel)) return;
       _failAuth(e);
     }
   }

--- a/mobile/lib/shared/relay/signed_event_relay.dart
+++ b/mobile/lib/shared/relay/signed_event_relay.dart
@@ -9,8 +9,14 @@ import 'relay_session.dart';
 import 'relay_socket.dart';
 
 /// Signs and submits Nostr events through the relay WebSocket connection.
+///
+/// Bound to the session scope at construction. Recreate after a dependency
+/// rebuild. Signing completions in retired scopes throw
+/// [RelaySessionSupersededError] without invoking [submit]'s callback or
+/// publishing into the replacement scope.
 class SignedEventRelay {
   final RelaySessionNotifier _session;
+  final RelaySessionLease _lease;
   final String? _nsec;
   final EventSigner? _signer;
 
@@ -18,6 +24,7 @@ class SignedEventRelay {
     required RelaySessionNotifier session,
     required String? nsec,
   }) : _session = session,
+       _lease = session.captureLease(),
        _nsec = nsec,
        _signer = null;
 
@@ -26,6 +33,7 @@ class SignedEventRelay {
     required RelaySessionNotifier session,
     required EventSigner signer,
   }) : _session = session,
+       _lease = session.captureLease(),
        _signer = signer,
        _nsec = null;
 
@@ -49,6 +57,7 @@ class SignedEventRelay {
     int? createdAt,
     void Function(NostrEvent event)? onSigned,
   }) async {
+    _lease.ensureCurrent();
     final EventSigner signer;
     if (_signer case final supplied?) {
       signer = supplied;
@@ -71,8 +80,9 @@ class SignedEventRelay {
     );
 
     final nostrEvent = NostrEvent.fromJson(event.toMap());
+    _lease.ensureCurrent();
     onSigned?.call(nostrEvent);
-    return _session.publish(nostrEvent);
+    return _session.publish(nostrEvent, lease: _lease);
   }
 }
 

--- a/mobile/lib/shared/relay/signed_event_relay.dart
+++ b/mobile/lib/shared/relay/signed_event_relay.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:nostr/nostr.dart' as nostr;
 
+import '../auth/event_signer.dart';
+
 import 'nostr_models.dart';
 import 'relay_session.dart';
 import 'relay_socket.dart';
@@ -10,15 +12,26 @@ import 'relay_socket.dart';
 class SignedEventRelay {
   final RelaySessionNotifier _session;
   final String? _nsec;
+  final EventSigner? _signer;
 
   SignedEventRelay({
     required RelaySessionNotifier session,
     required String? nsec,
   }) : _session = session,
-       _nsec = nsec;
+       _nsec = nsec,
+       _signer = null;
+
+  /// Submit with an explicit signer snapshot, without access to a local secret.
+  SignedEventRelay.withSigner({
+    required RelaySessionNotifier session,
+    required EventSigner signer,
+  }) : _session = session,
+       _signer = signer,
+       _nsec = null;
 
   /// The hex pubkey derived from the signing key, or null if no key.
   String? get pubkey {
+    if (_signer case final signer?) return signer.publicKey;
     final nsec = _nsec;
     if (nsec == null || nsec.isEmpty) return null;
     final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
@@ -36,23 +49,25 @@ class SignedEventRelay {
     int? createdAt,
     void Function(NostrEvent event)? onSigned,
   }) async {
-    final nsec = _nsec;
-    if (nsec == null || nsec.isEmpty) {
-      throw Exception('Cannot submit event: no signing key available');
+    final EventSigner signer;
+    if (_signer case final supplied?) {
+      signer = supplied;
+    } else {
+      final nsec = _nsec;
+      if (nsec == null || nsec.isEmpty) {
+        throw Exception('Cannot submit event: no signing key available');
+      }
+      final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
+      if (privkeyHex.isEmpty) throw Exception('Invalid nsec');
+      signer = LocalEventSigner(privkeyHex);
     }
 
-    final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-    if (privkeyHex.isEmpty) {
-      throw Exception('Invalid nsec');
-    }
-
-    final event = nostr.Event.from(
+    final event = await signEvent(
       kind: kind,
       content: content,
       tags: tags,
-      secretKey: privkeyHex,
+      signer: signer,
       createdAt: createdAt,
-      verify: false,
     );
 
     final nostrEvent = NostrEvent.fromJson(event.toMap());
@@ -76,13 +91,12 @@ Future<NostrEvent> submitSignedEventOnce({
 }) async {
   final privateKey = nostr.Nip19.decode(payload: nsec).data;
   if (privateKey.isEmpty) throw const FormatException('Invalid nsec');
-  final signed = nostr.Event.from(
+  final signed = await signEvent(
     kind: kind,
     content: content,
     tags: tags,
-    secretKey: privateKey,
+    signer: LocalEventSigner(privateKey),
     createdAt: createdAt,
-    verify: false,
   );
   final event = NostrEvent.fromJson(signed.toMap());
   final result = Completer<NostrEvent>();

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1654,7 +1654,7 @@ packages:
     source: hosted
     version: "2.9.4"
   video_player_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: video_player_platform_interface
       sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -55,6 +55,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   fake_async: ^1.3.3
   camera_platform_interface: ^2.13.1
+  video_player_platform_interface: ^6.6.0
   crypto: ^3.0.7
   custom_lint: ^0.8.0
   riverpod_lint: ^3.1.0

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -14443,6 +14443,7 @@ class _ReconnectingRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     publishedKinds.add(event.kind);
@@ -14621,6 +14622,7 @@ class _ProfileSubscriptionRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async => event;
 
@@ -14652,6 +14654,7 @@ class _HuddleReactionRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async => event;
 

--- a/mobile/test/features/channels/channel_management_provider_test.dart
+++ b/mobile/test/features/channels/channel_management_provider_test.dart
@@ -760,6 +760,7 @@ class _RecordingPublishRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     publishedEvents.add(event);

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -512,7 +512,7 @@ class _FakeVoiceNotePlayer extends VoiceNotePlayerController {
   @override
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   }) => loadLocal(url, fallbackDuration: fallbackDuration);
 

--- a/mobile/test/features/channels/message_content_test.dart
+++ b/mobile/test/features/channels/message_content_test.dart
@@ -78,7 +78,7 @@ class _FakeVoiceNotePlayer extends VoiceNotePlayerController {
   @override
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   }) => loadLocal(url, fallbackDuration: fallbackDuration);
 
@@ -112,7 +112,7 @@ class _LoadingVoiceNotePlayer extends _FakeVoiceNotePlayer {
   @override
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   }) async {}
 }
@@ -140,7 +140,7 @@ class _BufferingVoiceNotePlayer extends _FakeVoiceNotePlayer {
   @override
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   }) async {}
 
@@ -211,7 +211,7 @@ class _RetryableVoiceNotePlayer extends _FakeVoiceNotePlayer {
   @override
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   }) async {}
 

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -272,6 +272,7 @@ class _PendingPublishRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) {
     this.event = event;

--- a/mobile/test/features/channels/video_viewer_cancellation_test.dart
+++ b/mobile/test/features/channels/video_viewer_cancellation_test.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:buzz/features/channels/media_viewer_page.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+class _DeferredAuth extends MediaGetAuthService {
+  final ready = Completer<Map<String, String>>();
+  int calls = 0;
+  _DeferredAuth() : super(baseUrl: 'https://relay.example', nsec: null);
+  @override
+  Future<Map<String, String>> headersFor(String url) {
+    calls++;
+    return ready.future;
+  }
+}
+
+class _VideoPlatform extends VideoPlayerPlatform {
+  final events = StreamController<VideoEvent>.broadcast();
+  final sources = <DataSource>[];
+  int plays = 0;
+  int disposals = 0;
+  @override
+  Future<void> init() async {}
+  @override
+  Future<int> createWithOptions(VideoCreationOptions options) async {
+    sources.add(options.dataSource);
+    return 1;
+  }
+
+  @override
+  Stream<VideoEvent> videoEventsFor(int playerId) => events.stream;
+  @override
+  Future<void> dispose(int playerId) async => disposals++;
+  @override
+  Future<void> play(int playerId) async => plays++;
+  @override
+  Future<void> pause(int playerId) async {}
+  @override
+  Future<void> setLooping(int playerId, bool looping) async {}
+  @override
+  Future<void> setVolume(int playerId, double volume) async {}
+  @override
+  Future<void> setPlaybackSpeed(int playerId, double speed) async {}
+  @override
+  Widget buildViewWithOptions(VideoViewOptions options) => const SizedBox();
+  void finishInitialization() => events.add(
+    VideoEvent(
+      eventType: VideoEventType.initialized,
+      duration: const Duration(seconds: 10),
+      size: const Size(320, 180),
+    ),
+  );
+}
+
+void main() {
+  late _DeferredAuth auth;
+  late _VideoPlatform platform;
+  late VideoPlayerPlatform previousPlatform;
+  late int httpRequests;
+
+  setUp(() {
+    previousPlatform = VideoPlayerPlatform.instance;
+    httpRequests = 0;
+  });
+  tearDown(() async {
+    VideoPlayerPlatform.instance = previousPlatform;
+    await platform.events.close();
+  });
+
+  Future<void> open(WidgetTester tester) {
+    auth = _DeferredAuth();
+    platform = _VideoPlatform();
+    VideoPlayerPlatform.instance = platform;
+    return tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mediaVideoStreamingSupportedProvider.overrideWithValue(
+            defaultTargetPlatform == TargetPlatform.android,
+          ),
+          mediaGetAuthServiceProvider.overrideWithValue(auth),
+          mediaHttpClientProvider.overrideWithValue(
+            MockClient((_) async {
+              httpRequests++;
+              return http.Response('', 500);
+            }),
+          ),
+        ],
+        child: const MaterialApp(
+          home: MediaVideoViewerPage(
+            videoUrl: 'https://relay.example/media/video.mp4',
+          ),
+        ),
+      ),
+    );
+  }
+
+  for (final target in [TargetPlatform.android, TargetPlatform.iOS]) {
+    testWidgets(
+      '$target disposal during auth creates no player or request',
+      (tester) async {
+        await open(tester);
+        expect(auth.calls, 1);
+        await tester.pumpWidget(const SizedBox());
+        auth.ready.complete({'Authorization': 'captured A auth'});
+        await tester.pump();
+        expect(platform.sources, isEmpty);
+        expect(platform.plays, 0);
+        expect(httpRequests, 0);
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(target),
+    );
+  }
+
+  testWidgets(
+    'disposal during initialization cleans up without play or fallback',
+    (tester) async {
+      await open(tester);
+      auth.ready.complete({'Authorization': 'captured A auth'});
+      await tester.pump();
+      expect(platform.sources.single.httpHeaders, {
+        'Authorization': 'captured A auth',
+      });
+      await tester.pumpWidget(const SizedBox());
+      platform.finishInitialization();
+      await tester.pump();
+      expect(platform.plays, 0);
+      // Stream cancellation can complete outside the widget fake-async zone.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(platform.disposals, 1);
+      expect(httpRequests, 0);
+      expect(auth.calls, 1);
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
+  testWidgets(
+    'initialization failure after disposal does not enter fallback',
+    (tester) async {
+      await open(tester);
+      auth.ready.complete({});
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox());
+      platform.events.addError(
+        PlatformException(code: 'init', message: 'initialization failed'),
+      );
+      await tester.pump();
+      // Stream cancellation can complete outside the widget fake-async zone.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(platform.disposals, 1);
+      expect(platform.plays, 0);
+      expect(auth.calls, 1);
+      expect(httpRequests, 0);
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
+  testWidgets(
+    'live viewer still initializes, plays, and disposes normally',
+    (tester) async {
+      await open(tester);
+      auth.ready.complete({'Authorization': 'captured A auth'});
+      await tester.pump();
+      platform.finishInitialization();
+      await tester.pump();
+      expect(platform.sources, hasLength(1));
+      expect(platform.plays, 1);
+      expect(platform.disposals, 0);
+      expect(httpRequests, 0);
+      await tester.pumpWidget(const SizedBox());
+      // Stream cancellation can complete outside the widget fake-async zone.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(platform.disposals, 1);
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+}

--- a/mobile/test/features/channels/voice_note_recording_test.dart
+++ b/mobile/test/features/channels/voice_note_recording_test.dart
@@ -197,7 +197,7 @@ class _CoordinatedPlayer extends VoiceNotePlayerController {
   @override
   Future<void> loadRemote(
     String url, {
-    required Map<String, String> Function() headers,
+    required FutureOr<Map<String, String>> Function() headers,
     required Duration fallbackDuration,
   }) async {}
 
@@ -980,6 +980,41 @@ void main() {
       expect(audioPlayer.playCount, 1);
     },
   );
+
+  for (final localFile in [false, true]) {
+    test(
+      'cancel during async auth prevents source load (local=$localFile)',
+      () async {
+        final audioPlayer = _FakeAudioPlayerBackend();
+        final client = _SequencedHttpClient();
+        final player = DeviceVoiceNotePlayerController(
+          coordinator: VoiceNotePlaybackCoordinator(),
+          client: client,
+          requiresAuthenticatedLocalFile: localFile,
+          player: audioPlayer,
+        );
+        addTearDown(player.dispose);
+        final signingStarted = Completer<void>();
+        final headers = Completer<Map<String, String>>();
+        await player.loadRemote(
+          'https://example.com/voice-note.mp4',
+          headers: () {
+            signingStarted.complete();
+            return headers.future;
+          },
+          fallbackDuration: const Duration(seconds: 7),
+        );
+        final loading = player.toggle();
+        await signingStarted.future;
+        await player.pause();
+        headers.complete({'Authorization': 'Nostr signed-event'});
+        await loading;
+        expect(audioPlayer.loadedUrls, isEmpty);
+        expect(client.requests, isEmpty);
+        expect(audioPlayer.playCount, 0);
+      },
+    );
+  }
 
   test('Android defers remote auth until playback starts', () async {
     final audioPlayer = _FakeAudioPlayerBackend();

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -625,6 +625,7 @@ class _ProfileRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);
@@ -660,6 +661,7 @@ class _ControlledProfileRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);
@@ -686,6 +688,7 @@ class _LosingProfileRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);

--- a/mobile/test/features/profile/user_status_provider_test.dart
+++ b/mobile/test/features/profile/user_status_provider_test.dart
@@ -192,6 +192,7 @@ class _RecordingRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);

--- a/mobile/test/shared/auth/event_signer_test.dart
+++ b/mobile/test/shared/auth/event_signer_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:buzz/shared/auth/event_signer.dart';
+import 'package:buzz/shared/relay/nostr_models.dart';
+import 'package:buzz/shared/relay/relay_session.dart';
+import 'package:buzz/shared/relay/signed_event_relay.dart';
+
+final class _DeferredSigner implements EventSigner {
+  final LocalEventSigner local;
+  final ready = Completer<void>();
+  UnsignedEvent? captured;
+  _DeferredSigner(this.local);
+  @override
+  String get publicKey => local.publicKey;
+  @override
+  Future<nostr.Event> sign(UnsignedEvent event) async {
+    captured = event;
+    await ready.future;
+    return local.sign(event);
+  }
+}
+
+final class _Session extends RelaySessionNotifier {
+  NostrEvent? published;
+  @override
+  Future<NostrEvent> publish(
+    NostrEvent event, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    published = event;
+    return event;
+  }
+}
+
+void main() {
+  test('local signer preserves the legacy event id and exact fields', () async {
+    final keys = nostr.Keys.generate();
+    final signer = LocalEventSigner(keys.secret);
+    final tags = [
+      ['h', 'channel'],
+      ['x', 'one', 'two'],
+    ];
+    final unsigned = UnsignedEvent(
+      publicKey: signer.publicKey,
+      createdAt: 1700000000,
+      kind: 40002,
+      content: 'exact 🐝\ncontent',
+      tags: tags,
+    );
+    final legacy = nostr.Event.from(
+      kind: unsigned.kind,
+      content: unsigned.content,
+      tags: tags,
+      createdAt: unsigned.createdAt,
+      secretKey: keys.secret,
+    );
+    final signed = await signer.sign(unsigned);
+    expect(signed.id, legacy.id);
+    expect(signed.pubkey, legacy.pubkey);
+    expect(signed.tags, legacy.tags);
+    expect(signed.content, legacy.content);
+    expect(signed.createdAt, legacy.createdAt);
+    expect(signed.kind, legacy.kind);
+    expect(signed.isValid(), isTrue);
+    tags.first[1] = 'changed';
+    expect(unsigned.tags.first[1], 'channel');
+    expect(() => unsigned.tags.first.add('mutation'), throwsUnsupportedError);
+  });
+
+  test('wrong author is rejected, never rewritten', () async {
+    final signer = LocalEventSigner(nostr.Keys.generate().secret);
+    await expectLater(
+      signer.sign(
+        UnsignedEvent(
+          publicKey: nostr.Keys.generate().public,
+          createdAt: 1700000000,
+          kind: 1,
+          content: '',
+          tags: [],
+        ),
+      ),
+      throwsStateError,
+    );
+  });
+
+  test(
+    'submission awaits signing and preserves its captured payload',
+    () async {
+      final signer = _DeferredSigner(
+        LocalEventSigner(nostr.Keys.generate().secret),
+      );
+      final session = _Session();
+      final relay = SignedEventRelay.withSigner(
+        session: session,
+        signer: signer,
+      );
+      final tags = [
+        ['h', 'channel'],
+      ];
+      NostrEvent? callback;
+      final pending = relay.submit(
+        kind: 40002,
+        content: 'pending',
+        tags: tags,
+        createdAt: 1700000000,
+        onSigned: (event) => callback = event,
+      );
+      tags.first[1] = 'mutated while signing';
+      expect(session.published, isNull);
+      expect(callback, isNull);
+      expect(signer.captured!.tags, [
+        ['h', 'channel'],
+      ]);
+      signer.ready.complete();
+      final result = await pending;
+      expect(identical(result, session.published), isTrue);
+      expect(identical(result, callback), isTrue);
+      expect(result.tags, [
+        ['h', 'channel'],
+      ]);
+      expect(result.createdAt, 1700000000);
+    },
+  );
+
+  test(
+    'signing failure propagates without publication or a local fallback',
+    () async {
+      final signer = _DeferredSigner(
+        LocalEventSigner(nostr.Keys.generate().secret),
+      );
+      final session = _Session();
+      final relay = SignedEventRelay.withSigner(
+        session: session,
+        signer: signer,
+      );
+      final pending = relay.submit(kind: 1, content: '', tags: []);
+      final assertion = expectLater(pending, throwsStateError);
+      signer.ready.completeError(StateError('sign failed'));
+      await assertion;
+      expect(session.published, isNull);
+    },
+  );
+}

--- a/mobile/test/shared/auth/event_signer_test.dart
+++ b/mobile/test/shared/auth/event_signer_test.dart
@@ -27,6 +27,7 @@ final class _Session extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published = event;

--- a/mobile/test/shared/huddle/huddle_wire_test.dart
+++ b/mobile/test/shared/huddle/huddle_wire_test.dart
@@ -97,7 +97,7 @@ void main() {
   });
 
   group('HuddleAuthV2', () {
-    test('uses the base relay URL and fixed v2 auth envelope', () {
+    test('uses the base relay URL and fixed v2 auth envelope', () async {
       final parameters = HuddleConnectionParameters(
         relayWebSocketUrl: 'wss://buzz.example',
         nsec: _privateKey,
@@ -105,7 +105,7 @@ void main() {
         ephemeralChannelId: _ephemeralChannelId,
       );
 
-      final auth = HuddleAuthV2.buildMessage(
+      final auth = await HuddleAuthV2.buildMessage(
         parameters: parameters,
         challenge: 'relay-challenge',
         createdAt: 1_700_000_000,

--- a/mobile/test/shared/relay/media_image_test.dart
+++ b/mobile/test/shared/relay/media_image_test.dart
@@ -32,36 +32,66 @@ void main() {
   });
 
   group('MediaGetAuthService memoization', () {
-    test('repeated calls return byte-identical headers', () {
+    test('concurrent calls share one header refresh', () async {
+      final auth = _auth(nsec: nostr.Keys.generate().nsec);
+      final headers = await Future.wait([
+        auth.headersFor(_mediaUrl),
+        auth.headersFor(_mediaUrl),
+      ]);
+      expect(headers.first, isNotEmpty);
+      expect(identical(headers.first, headers.last), isTrue);
+    });
+
+    test('concurrent failed refreshes are retried, not cached', () async {
+      var attempts = 0;
+      final auth = _auth(
+        nsec: 'not-an-nsec',
+        now: () {
+          attempts++;
+          return DateTime.utc(2026);
+        },
+      );
+      final headers = await Future.wait([
+        auth.headersFor(_mediaUrl),
+        auth.headersFor(_mediaUrl),
+      ]);
+      expect(headers, everyElement(isEmpty));
+      expect(attempts, 2);
+    });
+
+    test('repeated calls return byte-identical headers', () async {
       final nsec = nostr.Keys.generate().nsec;
       final auth = _auth(nsec: nsec);
-      final first = auth.headersFor(_mediaUrl);
-      final second = auth.headersFor(_mediaUrl);
+      final first = await auth.headersFor(_mediaUrl);
+      final second = await auth.headersFor(_mediaUrl);
       expect(first, isNotEmpty);
       expect(identical(first, second), isTrue);
     });
 
-    test('re-signs only at the refresh margin before expiry', () {
+    test('re-signs only at the refresh margin before expiry', () async {
       final nsec = nostr.Keys.generate().nsec;
       var current = DateTime.utc(2026, 7, 21, 12);
       final auth = _auth(nsec: nsec, now: () => current);
 
-      final first = auth.headersFor(_mediaUrl);
+      final first = await auth.headersFor(_mediaUrl);
       // 600s lifetime - 60s margin = re-sign boundary at +540s.
       current = current.add(const Duration(seconds: 539));
-      expect(identical(auth.headersFor(_mediaUrl), first), isTrue);
+      expect(identical(await auth.headersFor(_mediaUrl), first), isTrue);
 
       current = current.add(const Duration(seconds: 2));
-      final refreshed = auth.headersFor(_mediaUrl);
+      final refreshed = await auth.headersFor(_mediaUrl);
       expect(identical(refreshed, first), isFalse);
       expect(refreshed['Authorization'], isNot(first['Authorization']));
     });
 
-    test('non-relay URLs get no headers even with a key', () {
+    test('non-relay URLs get no headers even with a key', () async {
       final nsec = nostr.Keys.generate().nsec;
       final auth = _auth(nsec: nsec);
-      expect(auth.headersFor('https://elsewhere.com/media/abc.png'), isEmpty);
-      expect(auth.headersFor('$_relayBase/not-media/abc.png'), isEmpty);
+      expect(
+        await auth.headersFor('https://elsewhere.com/media/abc.png'),
+        isEmpty,
+      );
+      expect(await auth.headersFor('$_relayBase/not-media/abc.png'), isEmpty);
     });
   });
 

--- a/mobile/test/shared/relay/media_upload_test.dart
+++ b/mobile/test/shared/relay/media_upload_test.dart
@@ -268,7 +268,7 @@ void main() {
   });
 
   group('MediaGetAuthService', () {
-    test('signs relay media get requests with a server-scoped token', () {
+    test('signs relay media get requests with a server-scoped token', () async {
       final keychain = nostr.Keys.generate();
       final service = MediaGetAuthService(
         baseUrl: 'https://Relay.Example:443',
@@ -276,7 +276,7 @@ void main() {
         now: () => DateTime.fromMillisecondsSinceEpoch(1700000000000),
       );
 
-      final headers = service.headersFor(
+      final headers = await service.headersFor(
         'https://relay.example:443/media/${'a' * 64}.jpg',
       );
 
@@ -295,59 +295,69 @@ void main() {
       expect(authEvent['tags'], contains(equals(['expiration', '1700000600'])));
     });
 
-    test('does not sign non-relay or non-media URLs', () {
+    test('does not sign non-relay or non-media URLs', () async {
       final service = MediaGetAuthService(
         baseUrl: 'https://relay.example',
         nsec: nostr.Keys.generate().nsec,
       );
 
       expect(
-        service.headersFor('https://evil.example/media/${'a' * 64}.jpg'),
-        isEmpty,
-      );
-      expect(service.headersFor('https://relay.example/avatar.png'), isEmpty);
-    });
-
-    test('normalizes default ports and rejects path-prefix lookalikes', () {
-      final service = MediaGetAuthService(
-        baseUrl: 'https://Relay.Example:443',
-        nsec: nostr.Keys.generate().nsec,
-      );
-
-      expect(
-        service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
-        isNotEmpty,
-      );
-      expect(
-        service.headersFor('https://relay.example/media-evil/${'a' * 64}.jpg'),
+        await service.headersFor('https://evil.example/media/${'a' * 64}.jpg'),
         isEmpty,
       );
       expect(
-        service.headersFor('ftp://relay.example/media/${'a' * 64}.jpg'),
+        await service.headersFor('https://relay.example/avatar.png'),
         isEmpty,
       );
     });
 
-    test('does not sign without a key', () {
+    test(
+      'normalizes default ports and rejects path-prefix lookalikes',
+      () async {
+        final service = MediaGetAuthService(
+          baseUrl: 'https://Relay.Example:443',
+          nsec: nostr.Keys.generate().nsec,
+        );
+
+        expect(
+          await service.headersFor(
+            'https://relay.example/media/${'a' * 64}.jpg',
+          ),
+          isNotEmpty,
+        );
+        expect(
+          await service.headersFor(
+            'https://relay.example/media-evil/${'a' * 64}.jpg',
+          ),
+          isEmpty,
+        );
+        expect(
+          await service.headersFor('ftp://relay.example/media/${'a' * 64}.jpg'),
+          isEmpty,
+        );
+      },
+    );
+
+    test('does not sign without a key', () async {
       final service = MediaGetAuthService(
         baseUrl: 'https://relay.example',
         nsec: null,
       );
 
       expect(
-        service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
+        await service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
         isEmpty,
       );
     });
 
-    test('does not throw or sign when the stored key is invalid', () {
+    test('does not throw or sign when the stored key is invalid', () async {
       final service = MediaGetAuthService(
         baseUrl: 'https://relay.example',
         nsec: 'not-an-nsec',
       );
 
       expect(
-        service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
+        await service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
         isEmpty,
       );
     });

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -135,6 +135,8 @@ void main() {
     expect(clients.single.closed, isTrue);
 
     final nextQuery = session.queryRelay(const []);
+    // Signing is asynchronous; wait for the request to reach the transport.
+    await Future<void>.delayed(Duration.zero);
     expect(clients, hasLength(2));
     clients.last.complete(http.Response('[]', 200));
 
@@ -172,13 +174,19 @@ void main() {
         const [],
         timeout: const Duration(milliseconds: 10),
       );
+      final timeoutAssertion = expectLater(
+        timedOutQuery,
+        throwsA(isA<TimeoutException>()),
+      );
       final peerQuery = session.queryRelay(const []);
+      await Future<void>.delayed(Duration.zero);
       expect(clients.single.requestCount, 2);
 
-      await expectLater(timedOutQuery, throwsA(isA<TimeoutException>()));
+      await timeoutAssertion;
       expect(clients.single.closed, isFalse);
 
       final nextQuery = session.queryRelay(const []);
+      await Future<void>.delayed(Duration.zero);
       expect(clients, hasLength(2));
       clients.first.complete(1, http.Response('[]', 200));
       expect(await peerQuery, isEmpty);

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -1410,7 +1410,7 @@ void main() {
       final session = RelaySessionNotifier(rateLimitGate: gate);
       session.debugAttachSocketForTest(_RecordingRelaySocket());
 
-      final publish = session.publish(_event());
+      final publish = session.publish(_event(), lease: session.captureLease());
       session.debugHandleMessage([
         'OK',
         'event-1',
@@ -1446,7 +1446,10 @@ void main() {
       final session = RelaySessionNotifier(rateLimitGate: gate);
       session.debugAttachSocketForTest(socket);
 
-      final firstPublish = session.publish(_event(id: 'event-a'));
+      final firstPublish = session.publish(
+        _event(id: 'event-a'),
+        lease: session.captureLease(),
+      );
       session.debugHandleMessage([
         'OK',
         'event-a',
@@ -1457,6 +1460,7 @@ void main() {
 
       var secondSettled = false;
       final secondPublish = session.publish(
+        lease: session.captureLease(),
         _event(id: 'event-b'),
         timeout: Duration.zero,
       );
@@ -1505,7 +1509,10 @@ void main() {
       session.debugAttachSocketForTest(socket);
       gate.activate(4);
 
-      final publish = session.publish(_event(id: 'event-b'));
+      final publish = session.publish(
+        _event(id: 'event-b'),
+        lease: session.captureLease(),
+      );
       session.debugSupersedeConnection();
       gateTimers.single.fire();
 
@@ -1519,7 +1526,7 @@ void main() {
     final session = RelaySessionNotifier(rateLimitGate: gate);
     session.debugAttachSocketForTest(_RecordingRelaySocket());
 
-    final publish = session.publish(_event());
+    final publish = session.publish(_event(), lease: session.captureLease());
     session.debugHandleMessage([
       'OK',
       'event-1',

--- a/mobile/test/shared/relay/signed_event_scope_test.dart
+++ b/mobile/test/shared/relay/signed_event_scope_test.dart
@@ -1,0 +1,343 @@
+import 'dart:async';
+
+import 'package:buzz/shared/auth/event_signer.dart';
+import 'package:buzz/features/profile/user_status.dart';
+import 'package:buzz/features/profile/user_status_provider.dart';
+import 'package:buzz/features/profile/user_status_cache_provider.dart';
+import 'package:buzz/shared/auth/auth_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+class _Auth extends AuthNotifier {
+  @override
+  Future<AuthState> build() async =>
+      const AuthState(status: AuthStatus.unauthenticated);
+}
+
+class _Config extends RelayConfigNotifier {
+  final String nsec;
+  _Config(this.nsec);
+  @override
+  RelayConfig build() => RelayConfig(baseUrl: 'https://a.example', nsec: nsec);
+  void switchCommunity() =>
+      state = RelayConfig(baseUrl: 'https://b.example', nsec: nsec);
+}
+
+class _Signer implements EventSigner {
+  final LocalEventSigner local;
+  final ready = Completer<void>();
+  _Signer(this.local);
+  @override
+  String get publicKey => local.publicKey;
+  @override
+  Future<nostr.Event> sign(UnsignedEvent event) async {
+    await ready.future;
+    return local.sign(event);
+  }
+}
+
+class _Socket extends RelaySocket {
+  final RelaySessionNotifier session;
+  final messages = <List<dynamic>>[];
+  void Function()? afterAck;
+  _Socket(this.session)
+    : super(
+        wsUrl: 'wss://recording.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+  @override
+  void send(List<dynamic> payload) {
+    messages.add(payload);
+    if (payload.first == 'EVENT') {
+      session.debugHandleMessage(['OK', (payload[1] as Map)['id'], true, 'ok']);
+      afterAck?.call();
+    }
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _StatusCache extends UserStatusCacheNotifier {
+  final updates = <UserStatus?>[];
+  @override
+  Map<String, UserStatus?> build() => {};
+  @override
+  void updateStatus(String pubkey, UserStatus? status) => updates.add(status);
+}
+
+class _Harness {
+  final keys = nostr.Keys.generate();
+  late final config = _Config(keys.nsec);
+  final gate = RelayRateLimitGate();
+  final cache = _StatusCache();
+  late final session = RelaySessionNotifier(rateLimitGate: gate);
+  late final container = ProviderContainer(
+    overrides: [
+      userStatusCacheProvider.overrideWith(() => cache),
+      authProvider.overrideWith(_Auth.new),
+      relayConfigProvider.overrideWith(() => config),
+      relaySessionProvider.overrideWith(() => session),
+    ],
+  );
+  late final a = _Socket(session);
+
+  Future<void> initialize() async {
+    addTearDown(container.dispose);
+    await container.read(authProvider.future);
+    container.read(relaySessionProvider);
+    session.debugAttachSocketForTest(a);
+  }
+
+  _Socket switchCommunity() {
+    config.switchCommunity();
+    container.read(relaySessionProvider);
+    expect(container.read(relaySessionProvider.notifier), same(session));
+    final b = _Socket(session);
+    session.debugAttachSocketForTest(b);
+    return b;
+  }
+
+  SignedEventRelay relay(EventSigner signer) =>
+      SignedEventRelay.withSigner(session: session, signer: signer);
+}
+
+Future<NostrEvent> _submit(
+  SignedEventRelay relay, {
+  void Function(NostrEvent)? onSigned,
+}) => relay.submit(
+  kind: 40002,
+  content: 'belongs to A',
+  tags: const [
+    ['h', 'channel-a'],
+  ],
+  onSigned: onSigned,
+);
+
+void main() {
+  test(
+    'deferred A signing cannot callback or publish on same-key community B',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      var callbacks = 0;
+      final pending = _submit(h.relay(signer), onSigned: (_) => callbacks++);
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      final b = h.switchCommunity();
+      signer.ready.complete();
+      await assertion;
+      expect(h.a.messages, isEmpty);
+      expect(
+        b.messages,
+        isEmpty,
+        reason: 'A event must never reach B transport',
+      );
+      expect(callbacks, 0);
+    },
+  );
+
+  test(
+    'dependency invalidation cancels even before the next session read',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      var callbacks = 0;
+      final pending = _submit(h.relay(signer), onSigned: (_) => callbacks++);
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      h.config.switchCommunity();
+      signer.ready.complete();
+      await assertion;
+      expect(h.a.messages, isEmpty);
+      expect(callbacks, 0);
+    },
+  );
+
+  test(
+    'normal delayed signing callbacks once then publishes exact event',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      final callbacks = <NostrEvent>[];
+      final pending = _submit(
+        h.relay(signer),
+        onSigned: (event) {
+          expect(h.a.messages, isEmpty);
+          callbacks.add(event);
+        },
+      );
+      expect(callbacks, isEmpty);
+      signer.ready.complete();
+      final result = await pending;
+      expect(callbacks, hasLength(1));
+      expect(h.a.messages.single, ['EVENT', callbacks.single.toJson()]);
+      expect(result.id, callbacks.single.id);
+      expect(result.content, 'ok');
+    },
+  );
+
+  test('retained signed relay cannot start new work after rebuild', () async {
+    final h = _Harness();
+    await h.initialize();
+    final relay = h.relay(LocalEventSigner(h.keys.secret));
+    final b = h.switchCommunity();
+    await expectLater(
+      _submit(relay),
+      throwsA(isA<RelaySessionSupersededError>()),
+    );
+    expect(b.messages, isEmpty);
+  });
+
+  test(
+    'callback switching scope is fenced again at production publish',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      late _Socket b;
+      await expectLater(
+        _submit(
+          h.relay(LocalEventSigner(h.keys.secret)),
+          onSigned: (_) => b = h.switchCommunity(),
+        ),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      expect(h.a.messages, isEmpty);
+      expect(b.messages, isEmpty);
+    },
+  );
+
+  test('direct publication cannot reuse a retired or foreign lease', () async {
+    final h = _Harness();
+    await h.initialize();
+    final lease = h.session.captureLease();
+    final signed = await LocalEventSigner(h.keys.secret).sign(
+      UnsignedEvent(
+        publicKey: h.keys.public,
+        createdAt: 1,
+        kind: 1,
+        content: '',
+        tags: const [],
+      ),
+    );
+    final event = NostrEvent.fromJson(signed.toMap());
+    final b = h.switchCommunity();
+    for (final invalid in [lease, RelaySessionNotifier().captureLease()]) {
+      await expectLater(
+        h.session.publish(event, lease: invalid),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      expect(
+        () => h.session.sendRaw(['EVENT', event.toJson()], lease: invalid),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+    }
+    expect(b.messages, isEmpty);
+  });
+
+  test(
+    'scope retires while production publish waits on rate-limit gate',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final callback = Completer<void>();
+      h.gate.activate(30);
+      final pending = _submit(
+        h.relay(LocalEventSigner(h.keys.secret)),
+        onSigned: (_) => callback.complete(),
+      );
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      await callback.future;
+      expect(h.a.messages, isEmpty);
+      final b = h.switchCommunity();
+      await assertion;
+      expect(b.messages, isEmpty);
+    },
+  );
+
+  test(
+    'ordinary connection supersession does not retire the scope lease',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      final pending = _submit(h.relay(signer));
+      h.session.debugSupersedeConnection();
+      signer.ready.complete();
+      await pending;
+      expect(h.a.messages, hasLength(1));
+    },
+  );
+
+  test(
+    'user status direct signer cannot publish across community switch',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      await h.container.read(userStatusProvider.future);
+      final pending = h.container
+          .read(userStatusProvider.notifier)
+          .setStatus('A status', '');
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      final b = h.switchCommunity();
+      await assertion;
+      expect(h.a.messages, isEmpty);
+      expect(b.messages, isEmpty);
+      expect(h.cache.updates, isEmpty);
+    },
+  );
+
+  test(
+    'user status cannot update B state/cache after an A acknowledgement',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      await h.container.read(userStatusProvider.future);
+      late _Socket b;
+      h.a.afterAck = () => b = h.switchCommunity();
+      await expectLater(
+        h.container.read(userStatusProvider.notifier).setStatus('A status', ''),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      expect(h.a.messages, hasLength(1));
+      expect(b.messages, isEmpty);
+      expect(h.cache.updates, isEmpty);
+      expect(await h.container.read(userStatusProvider.future), isNull);
+    },
+  );
+
+  test('disposal while signing cancels without callback or send', () async {
+    final h = _Harness();
+    await h.initialize();
+    final signer = _Signer(LocalEventSigner(h.keys.secret));
+    var callbacks = 0;
+    final pending = _submit(h.relay(signer), onSigned: (_) => callbacks++);
+    final assertion = expectLater(
+      pending,
+      throwsA(isA<RelaySessionSupersededError>()),
+    );
+    h.session.debugDispose();
+    signer.ready.complete();
+    await assertion;
+    expect(h.a.messages, isEmpty);
+    expect(callbacks, 0);
+  });
+}

--- a/mobile/test/shared/theme/community_theme_provider_test.dart
+++ b/mobile/test/shared/theme/community_theme_provider_test.dart
@@ -327,6 +327,7 @@ class _ThemeRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published = event;


### PR DESCRIPTION
## Summary

Extract an async event-signing boundary without adding a remote signer, login flow, or policy changes.

- Add Rust and Dart `EventSigner` / `LocalEventSigner` contracts over completed unsigned events. Construction (timestamps, tags, payload hashes), credentials, lifecycle and publication remain caller-owned.
- Generalize shared NIP-42 WS authentication and desktop event/NIP-98/Blossom/huddle consumers; await signing throughout mobile consumers. Existing explicit-key callers remain compatible.
- Keep local-secret capabilities separate: backup/export, pairing, encryption and agent provisioning still require actual local keys. No dummy keys, new fallback, protocol change or remote transport.
- Preserve async scope/cancellation behavior: bind signed relay submissions to immutable session leases, fence direct status/typing consumers, and cancel video initialization after deferred auth or disposal. These are async-preservation fixes, not a behavioral no-op claim.
- Preserve the existing media auth cache lifetime, refresh margin and best-effort error behavior. Concurrent async callers wait and recheck the cache; a failed refresh is not shared as a cached result. Add cancellation fences before voice-note source loads that now await auth.

## Validation

Initial extraction foundation (`59ad3ee6ce408fa71461475a2430b1b15648c44b`): all listed lanes captured the same patch SHA-256 before and after execution: `64b5200b5be9c306c9ee10c792b6e544b3f530ca2b67919ac8041d61c8d26707`.

| Check | Result |
| --- | --- |
| `cargo test --locked -p buzz-ws-client` | 6 passed |
| Full mobile `flutter test --no-pub --concurrency=2` | 2,129 passed |
| Exact desktop package Node test command | 6,502 passed |
| Tauri desktop package tests | 3,201 passed, 19 existing ignored |
| Tauri `buzz-terminal` workspace member tests | 91 passed, 1 existing ignored on full rerun |
| Rustfmt (root + Tauri), affected Rust/Tauri all-target clippy | Passed |
| Desktop TypeScript `tsc --noEmit` | Passed |
| Dart formatting, `flutter analyze --no-pub` | Passed |
| Repository differential file-size checks and policy tests | Passed |

The supplemental terminal-member run initially hit `cooperative_child_exits_on_term_not_kill` (`Killed` versus `Terminated`) under parallel load. A complete unchanged rerun passed. That member and its dependency graph do not use the signer extraction. No unrelated test or timeout was changed. Mobile's two transport-rotation tests now allow the signing future to complete before inspecting transport effects; their assertions are retained.

The first normal pre-push run additionally passed 13 repository Rust test groups and the full mobile hook, but its second ACP invocation hit the unchanged `keepalive_resets_idle_past_deadline` timing test (~101ms). The earlier full ACP invocation in the same hook passed. The complete normal pre-push retry passed with `RUST_TEST_THREADS=4` (repository Rust unit tests, another full mobile pass, file-size checks and publication guards); no unrelated tests or thresholds were changed. Only the Tauri wrapper hook is excluded because it touches shared sidecar symlink targets; direct Tauri validation is recorded above.

Regression coverage includes exact legacy event IDs/fields and valid signatures, wrong-author rejection, delayed signing and failure propagation with no publication/local fallback, NIP-42 AUTH wire shape, cache success/failure behavior and cancellation during pending media auth.

This is not a claim that repository-wide `just ci`, the optional Tauri `mesh-llm` clippy variant, builds, or live-device workflows were exercised. Direct package commands avoid pnpm reinstalling reused dependencies and Tauri wrapper prerequisites touching read-only reused sidecar binaries. No UI feature or deployment is included.

### Async-preservation follow-up (independent review)

Additive signed-off commit: `d7a54a876d5ef139e6e991cb8435b688190fa23a` (parent `59ad3ee6ce408fa71461475a2430b1b15648c44b`). Only mobile files changed. Final additive diff SHA-256: `fa4fa4a6dbed257b145b1471aa30c1174705c0848136344d736275553b7deb74`, identical before/after every final validation lane and after commit.

- **Red first:** a deferred A signer completed after a same-key community switch, invoked the stale callback, and sent the A EVENT through the production `RelaySessionNotifier.publish` onto the recording B socket. The regression now passes with zero callbacks and zero B sends.
- **Full mobile:** `flutter test --no-pub --concurrency=2` — **2,145 passed** (16 additional regressions). Full Dart format check, `flutter analyze --no-pub`, differential file-size checks and all 10 size-policy tests passed. Normal commit and push passed their mobile/publication hooks; the Tauri wrapper was excluded to avoid shared read-only sidecar mutation. Unchanged Rust/JS packages were not rerun for this mobile-only follow-up; their foundation evidence remains above.
- Production-seam tests cover same-key community rebuild, invalidation before a subsequent provider read, normal deferred signing, retained relay objects, callback-triggered scope switch, retired/foreign direct publish/raw leases, rate-limit wait, ordinary connection supersession, disposal, and status signing/acknowledgement state-cache races.
- Video tests cover deferred auth cancellation on Android/iOS, disposal and failure during Android initialization, and unchanged normal authenticated playback/cleanup. Removing the guards reproduces Android controller creation after disposal and play after disposal. An explicit streaming-capability provider preserves the existing `Platform.isAndroid` production selection while allowing the Android path to be tested on the host. The new test-only platform interface dependency uses the already-locked version; no dependency upgrades.

**Adoption contract:** capture `RelaySessionLease` before signing; `publish` and `sendRaw` require `lease:`. Check `lease.ensureCurrent()` before scope-local post-await mutations. `SignedEventRelay` captures its lease at construction and must be recreated after session dependency rebuilds; ordinary reconnects retain the scope lease. Retired work throws `RelaySessionSupersededError` (a `StateError`). Checks surround signing completion/callback and transport gate waits; `RelaySocket.send` calls `sink.add` synchronously with no intervening await or consumer callback after the final fence. Existing timeout, rate-limit and retry policies are unchanged.

No live-device validation is claimed. Tests record actual production publish calls against a recording socket and actual video-controller calls against a fake platform, not a live relay/player. Typing was audited and migrated but has no standalone deferred-signer widget test. In-progress native initialization is cleaned up when its future settles; this patch adds no new initialization timeout.

## Scope / review

The upstream base was checked as `block/buzz:main` at `78618804ec86a014524ad7d1fb55928e8f5c3edf`; no rebase or merge was needed. This is an extraction draft with bounded async-preservation fixes, intended as the committed foundation for a separate follow-up layer. Authentication/recovery checks stay at their existing call sites; rate-limit, request timeout and retry policies are unchanged.
