### PR TITLE
feat(identity): add release-selected remote managed identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,14 +1456,19 @@ dependencies = [
 name = "buzz-ws-client"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "futures-util",
  "nostr 0.44.7",
+ "reqwest 0.13.4",
+ "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/buzz-ws-client/Cargo.toml
+++ b/crates/buzz-ws-client/Cargo.toml
@@ -15,3 +15,8 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 tracing = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+zeroize = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/buzz-ws-client/src/enterprise_callback.rs
+++ b/crates/buzz-ws-client/src/enterprise_callback.rs
@@ -1,0 +1,249 @@
+//! Fixed-port native PKCE callback listener. Bind before launching the browser.
+use std::{net::Ipv4Addr, time::Duration};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time::timeout,
+};
+
+use crate::enterprise_oauth::{EnterpriseLoginAttempt, EnterpriseLoginConfig};
+
+/// One bounded callback receiver for the exact release-registered redirect URI.
+/// Dropping it closes the port. It never selects an ephemeral/fallback port.
+pub struct EnterpriseCallback {
+    listener: TcpListener,
+    redirect_uri: String,
+    authority: String,
+}
+
+impl EnterpriseCallback {
+    /// Bind the configured port on 127.0.0.1, failing closed when it is occupied.
+    pub async fn bind(config: &EnterpriseLoginConfig) -> Result<Self, String> {
+        config.validate()?;
+        let port = config.loopback_port()?;
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port))
+            .await
+            .map_err(|_| "Configured corporate login callback port is unavailable")?;
+        Ok(Self {
+            listener,
+            redirect_uri: config.redirect_uri.clone(),
+            authority: format!("127.0.0.1:{port}"),
+        })
+    }
+
+    /// Receive a state-checked callback, with a five-minute overall deadline,
+    /// at most 32 connections, 8 KiB headers, and three-second per-peer IO limits.
+    /// No code/verifier/token is reflected in the browser response.
+    pub async fn receive(self, attempt: &EnterpriseLoginAttempt) -> Result<url::Url, String> {
+        timeout(Duration::from_secs(300), async {
+            for _ in 0..32 {
+                let (mut stream, _) = self.listener.accept().await.map_err(|_| "Login callback failed")?;
+                let request = timeout(Duration::from_secs(3), read_headers(&mut stream)).await;
+                let callback = match request {
+                    Ok(Ok(request)) => self.parse_request(&request, attempt),
+                    _ => Err("Invalid login callback".into()),
+                };
+                let (status, body) = if callback.is_ok() {
+                    ("200 OK", "Return to Buzz to finish signing in.")
+                } else {
+                    ("400 Bad Request", "Invalid login callback.")
+                };
+                let response = format!("HTTP/1.1 {status}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n{body}", body.len());
+                // A disconnected browser must not discard an already valid callback.
+                let _ = timeout(Duration::from_secs(3), async {
+                    stream.write_all(response.as_bytes()).await?;
+                    stream.shutdown().await
+                }).await;
+                if let Ok(callback) = callback { return Ok(callback); }
+            }
+            Err("Too many invalid login callbacks".into())
+        }).await.map_err(|_| "Corporate login timed out")?
+    }
+
+    fn parse_request(
+        &self,
+        request: &str,
+        attempt: &EnterpriseLoginAttempt,
+    ) -> Result<url::Url, String> {
+        let mut lines = request.split("\r\n");
+        let target = lines
+            .next()
+            .and_then(|line| line.strip_prefix("GET "))
+            .and_then(|line| line.strip_suffix(" HTTP/1.1"))
+            .ok_or("Invalid login callback method")?;
+        // Validate BEFORE URL parsing can normalize dot segments or backslashes.
+        if !(target == "/enterprise-callback" || target.starts_with("/enterprise-callback?"))
+            || target.contains(['\\', '#'])
+            || !target.is_ascii()
+        {
+            return Err("Invalid login callback path".into());
+        }
+        let hosts: Vec<_> = lines
+            .take_while(|line| !line.is_empty())
+            .filter_map(|line| line.split_once(':'))
+            .filter(|(name, _)| name.eq_ignore_ascii_case("host"))
+            .map(|(_, value)| value.trim())
+            .collect();
+        if hosts != [self.authority.as_str()] {
+            return Err("Invalid login callback authority".into());
+        }
+        let query = target
+            .strip_prefix("/enterprise-callback")
+            .ok_or("Invalid callback")?;
+        let callback = url::Url::parse(&format!("{}{query}", self.redirect_uri))
+            .map_err(|_| "Invalid callback URL")?;
+        attempt.callback_code(&callback)?;
+        Ok(callback)
+    }
+}
+
+async fn read_headers(stream: &mut TcpStream) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    let mut chunk = [0; 1024];
+    while !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+        let count = stream
+            .read(&mut chunk)
+            .await
+            .map_err(|_| "Callback read failed")?;
+        if count == 0 || bytes.len() + count > 8192 {
+            return Err("Invalid callback size".into());
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+    }
+    String::from_utf8(bytes).map_err(|_| "Invalid callback encoding".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(port: u16) -> EnterpriseLoginConfig {
+        EnterpriseLoginConfig {
+            signer_url: "https://signer.example/cash-app/goose/".into(),
+            issuer: "https://login.example/".into(),
+            client_id: "native".into(),
+            audience: "signer".into(),
+            organization: "org".into(),
+            connection: "corporate".into(),
+            redirect_uri: format!("http://127.0.0.1:{port}/enterprise-callback"),
+        }
+    }
+
+    #[tokio::test]
+    async fn occupied_configured_port_fails_without_fallback() {
+        let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        assert!(
+            EnterpriseCallback::bind(&config(occupied.local_addr().unwrap().port()))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn actual_listener_ignores_bad_callbacks_then_closes_successful_response() {
+        let provisional = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let port = provisional.local_addr().unwrap().port();
+        drop(provisional);
+        let config = config(port);
+        let callback = EnterpriseCallback::bind(&config).await.unwrap();
+        assert_eq!(callback.listener.local_addr().unwrap().port(), port);
+        let attempt = EnterpriseLoginAttempt::new([1; 32], [2; 32], config.redirect_uri.clone());
+        let authorize = attempt.authorization_url(&config).unwrap();
+        let state = authorize
+            .query_pairs()
+            .find(|(k, _)| k == "state")
+            .unwrap()
+            .1
+            .into_owned();
+        let task = tokio::spawn(async move { callback.receive(&attempt).await });
+        for (path, host, expected) in [
+            (
+                "/favicon.ico".to_string(),
+                format!("127.0.0.1:{port}"),
+                "400",
+            ),
+            (
+                format!("/enterprise-callback?state={state}&code=secret"),
+                "attacker.example".into(),
+                "400",
+            ),
+            (
+                "/enterprise-callback?state=wrong&code=secret".into(),
+                format!("127.0.0.1:{port}"),
+                "400",
+            ),
+            (
+                format!("/enterprise-callback?state={state}&code=secret"),
+                format!("127.0.0.1:{port}"),
+                "200",
+            ),
+        ] {
+            let mut peer = TcpStream::connect((Ipv4Addr::LOCALHOST, port))
+                .await
+                .unwrap();
+            peer.write_all(format!("GET {path} HTTP/1.1\r\nHost: {host}\r\n\r\n").as_bytes())
+                .await
+                .unwrap();
+            let mut response = String::new();
+            timeout(Duration::from_secs(2), peer.read_to_string(&mut response))
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(response.starts_with(&format!("HTTP/1.1 {expected}")));
+            assert!(!response.contains("secret"));
+        }
+        assert_eq!(
+            task.await
+                .unwrap()
+                .unwrap()
+                .query_pairs()
+                .find(|(k, _)| k == "code")
+                .unwrap()
+                .1,
+            "secret"
+        );
+        assert!(TcpStream::connect((Ipv4Addr::LOCALHOST, port))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn request_parser_rejects_authority_path_and_normalization_confusion() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let config = config(port);
+        let callback = EnterpriseCallback {
+            listener,
+            redirect_uri: config.redirect_uri.clone(),
+            authority: format!("127.0.0.1:{port}"),
+        };
+        let attempt = EnterpriseLoginAttempt::new([1; 32], [2; 32], config.redirect_uri.clone());
+        let auth = attempt.authorization_url(&config).unwrap();
+        let state = auth
+            .query_pairs()
+            .find(|(k, _)| k == "state")
+            .unwrap()
+            .1
+            .into_owned();
+        let good = format!("GET /enterprise-callback?code=x&state={state} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n");
+        assert!(callback.parse_request(&good, &attempt).is_ok());
+        for bad in [
+            good.replace("GET ", "POST "),
+            good.replace("/enterprise-callback?", "/a/../enterprise-callback?"),
+            good.replace("/enterprise-callback?", "//enterprise-callback?"),
+            good.replace("/enterprise-callback?", "/%65nterprise-callback?"),
+            good.replace("/enterprise-callback?", "/enterprise-callback\\?"),
+            good.replace("Host:", "Not-Host:"),
+            good.replace("Host:", &format!("Host: 127.0.0.1:{port}\r\nHost:")),
+            good.replace("127.0.0.1:", "user@127.0.0.1:"),
+            good.replace(" HTTP/1.1", "#fragment HTTP/1.1"),
+            good.replace("code=x", "code=x&code=y"),
+        ] {
+            assert!(
+                callback.parse_request(&bad, &attempt).is_err(),
+                "accepted {bad}"
+            );
+        }
+    }
+}

--- a/crates/buzz-ws-client/src/enterprise_oauth.rs
+++ b/crates/buzz-ws-client/src/enterprise_oauth.rs
@@ -1,0 +1,431 @@
+//! Public-client authorization-code/PKCE transport. The application owns browser callbacks and secure storage.
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::time::Duration;
+use zeroize::Zeroizing;
+
+/// Non-secret, release-selected corporate login configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EnterpriseLoginConfig {
+    /// Trusted signer base URL, including deployment prefix.
+    pub signer_url: String,
+    /// Auth0 HTTPS issuer origin.
+    pub issuer: String,
+    /// Registered native/public client ID (never a client secret).
+    pub client_id: String,
+    /// Dedicated signer API audience.
+    pub audience: String,
+    /// Exact Auth0 organization.
+    pub organization: String,
+    /// Exact corporate federation connection.
+    pub connection: String,
+    /// Exact registered native loopback redirect, including the owner-selected port.
+    pub redirect_uri: String,
+}
+
+impl EnterpriseLoginConfig {
+    /// Validate the release-owned destinations before opening a browser or transmitting credentials.
+    pub fn validate(&self) -> Result<(), String> {
+        let issuer = crate::remote_identity::trusted_https_url(&self.issuer)?;
+        let authority_and_path = self
+            .issuer
+            .strip_prefix("https://")
+            .ok_or("Invalid issuer")?;
+        let raw_path = authority_and_path
+            .find('/')
+            .map(|i| &authority_and_path[i..])
+            .unwrap_or("");
+        if issuer.path() != "/" || !matches!(raw_path, "" | "/") {
+            return Err("Issuer must be an HTTPS origin".into());
+        }
+        crate::remote_identity::deployment_prefix(&self.signer_url)?;
+        self.loopback_port()?;
+        if [
+            &self.client_id,
+            &self.audience,
+            &self.organization,
+            &self.connection,
+        ]
+        .iter()
+        .any(|s| s.is_empty() || s.len() > 2048 || s.bytes().any(|b| b <= 32 || b >= 127))
+        {
+            return Err("Incomplete enterprise login configuration".into());
+        }
+        if [&self.client_id, &self.organization, &self.connection]
+            .iter()
+            .any(|s| {
+                !s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'))
+            })
+        {
+            return Err("Invalid corporate login identifier".into());
+        }
+        Ok(())
+    }
+
+    /// Return the exact configured port after validating the raw callback spelling.
+    /// No userinfo, query, fragment, alternate IP spelling or port normalization.
+    pub fn loopback_port(&self) -> Result<u16, String> {
+        let port = self
+            .redirect_uri
+            .strip_prefix("http://127.0.0.1:")
+            .and_then(|s| s.strip_suffix("/enterprise-callback"))
+            .ok_or("Invalid registered desktop callback")?;
+        let parsed: u16 = port
+            .parse()
+            .map_err(|_| "Invalid registered desktop port")?;
+        if parsed < 1024 || parsed.to_string() != port {
+            return Err("Invalid registered desktop port".into());
+        }
+        Ok(parsed)
+    }
+}
+
+/// One PKCE attempt. No Debug/Serialize: the verifier is a temporary credential.
+pub struct EnterpriseLoginAttempt {
+    verifier: Zeroizing<String>,
+    state: String,
+    redirect_uri: String,
+}
+impl EnterpriseLoginAttempt {
+    /// Create from OS-random bytes supplied by the native platform (32 bytes each).
+    pub fn new(verifier_entropy: [u8; 32], state_entropy: [u8; 32], redirect_uri: String) -> Self {
+        Self {
+            verifier: Zeroizing::new(URL_SAFE_NO_PAD.encode(verifier_entropy)),
+            state: URL_SAFE_NO_PAD.encode(state_entropy),
+            redirect_uri,
+        }
+    }
+    /// Build authorization URL with PKCE S256 and exact organization/connection.
+    pub fn authorization_url(&self, config: &EnterpriseLoginConfig) -> Result<url::Url, String> {
+        config.validate()?;
+        if self.redirect_uri != config.redirect_uri {
+            return Err("Login attempt must use the configured redirectUri".into());
+        }
+        let mut url = url::Url::parse(&format!(
+            "{}/authorize",
+            config.issuer.trim_end_matches('/')
+        ))
+        .map_err(|_| "Invalid issuer")?;
+        url.query_pairs_mut().extend_pairs([
+            ("response_type", "code"),
+            ("client_id", config.client_id.as_str()),
+            ("redirect_uri", self.redirect_uri.as_str()),
+            ("audience", config.audience.as_str()),
+            ("organization", config.organization.as_str()),
+            ("connection", config.connection.as_str()),
+            // This requests permission; Auth0 RBAC must still emit permissions:["buzz:sign"].
+            ("scope", "openid profile email offline_access buzz:sign"),
+            ("state", self.state.as_str()),
+            ("code_challenge_method", "S256"),
+            (
+                "code_challenge",
+                URL_SAFE_NO_PAD
+                    .encode(Sha256::digest(self.verifier.as_bytes()))
+                    .as_str(),
+            ),
+        ]);
+        Ok(url)
+    }
+    /// Verify callback destination and state before consuming the authorization code.
+    pub fn callback_code(&self, callback: &url::Url) -> Result<String, String> {
+        let mut destination = callback.clone();
+        destination.set_query(None);
+        destination.set_fragment(None);
+        if destination.as_str() != self.redirect_uri || callback.fragment().is_some() {
+            return Err("Invalid login callback destination".into());
+        }
+        let pairs: Vec<_> = callback.query_pairs().collect();
+        let states: Vec<_> = pairs.iter().filter(|(k, _)| k == "state").collect();
+        let codes: Vec<_> = pairs.iter().filter(|(k, _)| k == "code").collect();
+        if states.len() != 1
+            || states[0].1 != self.state
+            || codes.len() != 1
+            || codes[0].1.is_empty()
+            || codes[0].1.len() > 4096
+            || pairs.iter().any(|(k, _)| k == "error")
+        {
+            return Err("Corporate login failed or callback state mismatch".into());
+        }
+        Ok(codes[0].1.to_string())
+    }
+    /// Consume this attempt so the same verifier is not accidentally reused.
+    pub async fn exchange(
+        self,
+        config: &EnterpriseLoginConfig,
+        callback: &url::Url,
+    ) -> Result<EnterpriseOAuthTokens, String> {
+        self.authorization_url(config)?; // Also pins this attempt to the configured redirect.
+        let code = self.callback_code(callback)?;
+        token_request(config, serde_json::json!({"grant_type":"authorization_code", "client_id":config.client_id, "code":code, "redirect_uri":self.redirect_uri, "code_verifier":self.verifier.as_str()})).await
+    }
+}
+
+/// Token response. No Debug; Serialize is only for the application's encrypted credential store.
+#[derive(Serialize, Deserialize)]
+pub struct EnterpriseOAuthTokens {
+    /// Short-lived dedicated API access token.
+    pub access_token: String,
+    /// Rotating refresh credential; never log or place in a URL.
+    pub refresh_token: Option<String>,
+    /// Access token lifetime in seconds.
+    pub expires_in: u64,
+    /// OAuth token type, required to be Bearer.
+    pub token_type: String,
+}
+impl Drop for EnterpriseOAuthTokens {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.access_token.zeroize();
+        if let Some(token) = self.refresh_token.as_mut() {
+            token.zeroize();
+        }
+    }
+}
+/// Refresh once. On an ambiguous failure the owner must require login rather than retry a consumed rotating token.
+pub async fn refresh(
+    config: &EnterpriseLoginConfig,
+    refresh_token: &str,
+) -> Result<EnterpriseOAuthTokens, String> {
+    if refresh_token.is_empty() || refresh_token.len() > 16 * 1024 {
+        return Err("Invalid corporate refresh credential".into());
+    }
+    token_request(config, serde_json::json!({"grant_type":"refresh_token", "client_id":config.client_id, "refresh_token":refresh_token})).await
+}
+async fn token_request(
+    config: &EnterpriseLoginConfig,
+    body: serde_json::Value,
+) -> Result<EnterpriseOAuthTokens, String> {
+    config.validate()?;
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|_| "Cannot initialize corporate login")?;
+    let started = std::time::Instant::now();
+    let mut response = client
+        .post(format!(
+            "{}/oauth/token",
+            config.issuer.trim_end_matches('/')
+        ))
+        .header("Cache-Control", "no-store")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|_| "Corporate token exchange failed; sign in again")?;
+    if !response.status().is_success() {
+        return Err("Corporate token exchange rejected; sign in again".into());
+    }
+    let mut bytes = Zeroizing::new(Vec::new());
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| "Corporate token response failed")?
+    {
+        if bytes.len() + chunk.len() > 64 * 1024 {
+            return Err("Corporate token response too large".into());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    let mut tokens: EnterpriseOAuthTokens =
+        serde_json::from_slice(&bytes).map_err(|_| "Invalid corporate token response")?;
+    tokens.validate()?;
+    // Never extend an authorization lease by the time spent obtaining its reply.
+    let elapsed = started.elapsed();
+    let elapsed_seconds = elapsed.as_secs() + u64::from(elapsed.subsec_nanos() > 0);
+    tokens.expires_in = tokens.expires_in.saturating_sub(elapsed_seconds);
+    tokens.validate()?;
+    Ok(tokens)
+}
+
+impl EnterpriseOAuthTokens {
+    /// Validate fresh AND restored token metadata without extending its deadline.
+    pub fn validate(&self) -> Result<(), String> {
+        let tokens = self;
+        if tokens.access_token.is_empty()
+            || tokens.access_token.len() > 16 * 1024
+            || tokens.access_token.bytes().any(|b| b.is_ascii_whitespace())
+            || tokens.expires_in == 0
+            || tokens.expires_in > 300
+            || !tokens.token_type.eq_ignore_ascii_case("bearer")
+            || tokens
+                .refresh_token
+                .as_ref()
+                .is_some_and(|s| s.is_empty() || s.len() > 16 * 1024)
+        {
+            return Err("Invalid corporate token lifetime or type".into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn config() -> EnterpriseLoginConfig {
+        EnterpriseLoginConfig {
+            signer_url: "https://signer.example/cash-app/goose/".into(),
+            issuer: "https://login.example/".into(),
+            client_id: "native".into(),
+            audience: "signer".into(),
+            organization: "org".into(),
+            connection: "okta".into(),
+            redirect_uri: "http://127.0.0.1:1234/enterprise-callback".into(),
+        }
+    }
+    #[test]
+    fn pkce_login_pins_authority_and_checks_callback_state() {
+        let attempt = EnterpriseLoginAttempt::new(
+            [1; 32],
+            [2; 32],
+            "http://127.0.0.1:1234/enterprise-callback".into(),
+        );
+        let auth = attempt.authorization_url(&config()).unwrap();
+        let params: std::collections::HashMap<_, _> = auth.query_pairs().collect();
+        assert_eq!(auth.origin().ascii_serialization(), "https://login.example");
+        assert_eq!(params["code_challenge_method"], "S256");
+        assert_eq!(params["organization"], "org");
+        assert_eq!(params["connection"], "okta");
+        assert_eq!(
+            params["scope"],
+            "openid profile email offline_access buzz:sign"
+        );
+        assert_eq!(
+            params["code_challenge"],
+            URL_SAFE_NO_PAD.encode(Sha256::digest(URL_SAFE_NO_PAD.encode([1; 32])))
+        );
+        let callback = url::Url::parse(&format!(
+            "http://127.0.0.1:1234/enterprise-callback?code=authorized&state={}",
+            params["state"]
+        ))
+        .unwrap();
+        assert_eq!(attempt.callback_code(&callback).unwrap(), "authorized");
+        for value in [
+            callback.to_string() + "&state=duplicate",
+            callback.to_string() + "&code=duplicate",
+            callback.to_string() + "#fragment",
+            callback.to_string().replace("1234", "4321"),
+            callback
+                .to_string()
+                .replace(params["state"].as_ref(), "wrong"),
+        ] {
+            assert!(attempt
+                .callback_code(&url::Url::parse(&value).unwrap())
+                .is_err());
+        }
+    }
+    #[test]
+    fn config_refuses_insecure_or_credential_bearing_endpoints() {
+        for value in [
+            "http://login.example",
+            "https://user:pass@login.example",
+            "https://login.example?token=x",
+            "https://login.example/path",
+        ] {
+            let mut config = config();
+            config.issuer = value.into();
+            assert!(config.validate().is_err());
+        }
+    }
+    #[test]
+    fn fixed_callback_config_rejects_every_authority_and_port_alias() {
+        for redirect in [
+            "http://127.0.0.1:0/enterprise-callback",
+            "http://127.0.0.1:1023/enterprise-callback",
+            "http://127.0.0.1:65536/enterprise-callback",
+            "http://127.0.0.1:01234/enterprise-callback",
+            "http://127.0.0.1:+1234/enterprise-callback",
+            "http://localhost:1234/enterprise-callback",
+            "http://127.1:1234/enterprise-callback",
+            "http://[::1]:1234/enterprise-callback",
+            "https://127.0.0.1:1234/enterprise-callback",
+            "http://user@127.0.0.1:1234/enterprise-callback",
+            "http://127.0.0.1:1234/enterprise-callback?",
+            "http://127.0.0.1:1234/enterprise-callback#",
+            "http://127.0.0.1:1234/a/../enterprise-callback",
+            "http://127.0.0.1:1234/enterprise-callback/",
+            "buzz://enterprise-login",
+        ] {
+            let mut value = config();
+            value.redirect_uri = redirect.into();
+            assert!(value.validate().is_err(), "accepted {redirect}");
+        }
+        for port in [1024, 65535] {
+            let mut value = config();
+            value.redirect_uri = format!("http://127.0.0.1:{port}/enterprise-callback");
+            assert_eq!(value.loopback_port().unwrap(), port);
+            assert!(value.validate().is_ok());
+        }
+        let attempt = EnterpriseLoginAttempt::new(
+            [1; 32],
+            [2; 32],
+            "http://127.0.0.1:4321/enterprise-callback".into(),
+        );
+        assert!(attempt.authorization_url(&config()).is_err());
+    }
+
+    #[test]
+    fn native_schema_matches_release_subset_and_rejects_secret_or_environment_fields() {
+        let value = serde_json::to_value(config()).unwrap();
+        let mut fields: Vec<_> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        fields.sort();
+        assert_eq!(
+            fields,
+            [
+                "audience",
+                "clientId",
+                "connection",
+                "issuer",
+                "organization",
+                "redirectUri",
+                "signerUrl"
+            ]
+        );
+        for field in ["clientSecret", "environment"] {
+            let mut invalid = value.clone();
+            invalid[field] = serde_json::json!("forbidden");
+            assert!(serde_json::from_value::<EnterpriseLoginConfig>(invalid).is_err());
+        }
+        let mut missing = value.clone();
+        missing.as_object_mut().unwrap().remove("redirectUri");
+        assert!(serde_json::from_value::<EnterpriseLoginConfig>(missing).is_err());
+    }
+
+    #[test]
+    fn token_validation_never_accepts_over_five_minute_authority() {
+        let token = || EnterpriseOAuthTokens {
+            access_token: "test-only-token".into(),
+            refresh_token: Some("test-only-refresh".into()),
+            expires_in: 300,
+            token_type: "Bearer".into(),
+        };
+        assert!(token().validate().is_ok());
+        for lifetime in [0, 301, u64::MAX] {
+            let mut invalid = token();
+            invalid.expires_in = lifetime;
+            assert!(invalid.validate().is_err());
+        }
+        for bearer in ["", "bad token", "bad\r\nheader"] {
+            let mut invalid = token();
+            invalid.access_token = bearer.into();
+            assert!(invalid.validate().is_err());
+        }
+        let mut invalid = token();
+        invalid.token_type = "Basic".into();
+        assert!(invalid.validate().is_err());
+        let mut invalid = token();
+        invalid.refresh_token = Some("".into());
+        assert!(invalid.validate().is_err());
+        let mut valid = token();
+        valid.expires_in = 1;
+        valid.refresh_token = None;
+        assert!(valid.validate().is_ok());
+    }
+}

--- a/crates/buzz-ws-client/src/event_signer.rs
+++ b/crates/buzz-ws-client/src/event_signer.rs
@@ -19,6 +19,19 @@ pub trait EventSigner: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>>;
 }
 
+// Shared capability snapshots remain the same exact-event boundary.
+impl<T: EventSigner + ?Sized> EventSigner for std::sync::Arc<T> {
+    fn public_key(&self) -> PublicKey {
+        (**self).public_key()
+    }
+    fn sign(
+        &self,
+        event: UnsignedEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>> {
+        (**self).sign(event)
+    }
+}
+
 /// An in-process signer backed by local keys. Key management remains outside the signer.
 #[derive(Clone)]
 pub struct LocalEventSigner {

--- a/crates/buzz-ws-client/src/lib.rs
+++ b/crates/buzz-ws-client/src/lib.rs
@@ -1,9 +1,12 @@
 #![deny(unsafe_code)]
 
 pub mod connection;
+pub mod enterprise_callback;
+pub mod enterprise_oauth;
 pub mod error;
 pub mod event_signer;
 pub mod message;
+pub mod remote_identity;
 
 pub use connection::{publish_event, NostrWsConnection};
 pub use error::WsClientError;

--- a/crates/buzz-ws-client/src/remote_identity.rs
+++ b/crates/buzz-ws-client/src/remote_identity.rs
@@ -1,0 +1,376 @@
+//! Managed identity transport. Enrollment is separate from exact-event signing.
+//!
+//! The login owner supplies an authorization snapshot; this module never stores
+//! refresh credentials, generates keys, constructs events, or publishes to a relay.
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use nostr::{Event, PublicKey, UnsignedEvent};
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use crate::event_signer::EventSigner;
+
+/// Server-selected public identity and its community, pinned for a login lifetime.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ManagedIdentity {
+    /// Custodied Nostr public key; never a client-selected request field.
+    pub pubkey: String,
+    /// Community WebSocket origin.
+    pub relay_ws_url: String,
+    /// Community HTTPS origin.
+    pub relay_http_url: String,
+}
+
+impl ManagedIdentity {
+    /// Validate the identity before installing it in a login/session owner.
+    pub fn validate(&self) -> Result<PublicKey, String> {
+        let relay = relay_https_origin(&self.relay_http_url)?;
+        if relay.path() != "/"
+            || self.relay_ws_url
+                != format!(
+                    "wss://{}",
+                    relay[url::Position::BeforeHost..url::Position::AfterPort].to_owned()
+                )
+            || self.pubkey.len() != 64
+            || !self
+                .pubkey
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(failure());
+        }
+        let public_key = PublicKey::from_hex(&self.pubkey).map_err(|_| failure())?;
+        // from_hex only validates length/encoding; ensure must return a curve point.
+        public_key.xonly().map_err(|_| failure())?;
+        Ok(public_key)
+    }
+}
+
+/// An explicit short-lived bearer. Intentionally neither Debug nor Serialize.
+pub struct RemoteCredentials(Zeroizing<String>);
+
+impl RemoteCredentials {
+    /// Own one access token. The login owner must enforce its expiration/refresh.
+    pub fn new(token: String) -> Self {
+        Self(Zeroizing::new(token))
+    }
+
+    fn headers(&self) -> Result<HeaderMap, String> {
+        let token = self.0.as_str();
+        if token.is_empty()
+            || token.len() > 16 * 1024
+            || token.bytes().any(|b| b.is_ascii_whitespace())
+        {
+            return Err(failure());
+        }
+        let mut bearer =
+            HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_| failure())?;
+        bearer.set_sensitive(true);
+        let mut headers = HeaderMap::new();
+        headers.insert(reqwest::header::AUTHORIZATION, bearer);
+        Ok(headers)
+    }
+}
+
+/// Authorization owned by one login generation, not a process-global identity.
+///
+/// Implementations serialize refresh and secure persistence, enforce <=300-second
+/// token lifetimes, and invalidate old snapshots on logout/replacement. They must
+/// never resolve another account or silently fall back to a local key.
+pub trait RemoteAuthorization: Send + Sync {
+    /// Fail if this captured login generation has been invalidated.
+    fn check_active(&self) -> Result<(), String>;
+
+    /// Obtain an unexpired bearer for this same captured login generation.
+    fn credentials(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<RemoteCredentials, String>> + Send + '_>>;
+}
+
+/// HTTPS ensure/sign transport configured with the deployment prefix, not a key.
+#[derive(Clone)]
+pub struct RemoteIdentityClient {
+    client: reqwest::Client,
+    base: url::Url,
+}
+
+impl RemoteIdentityClient {
+    /// Construct from a trusted release-selected HTTPS deployment prefix.
+    /// There is no default host, account selector, route alias or local fallback.
+    pub fn new(base: &str) -> Result<Self, String> {
+        let base = deployment_prefix(base)?;
+        Ok(Self {
+            client: http_client()?,
+            base,
+        })
+    }
+
+    /// Create-or-return custody and initial admission/profile for the authenticated
+    /// account. This is an enrollment operation, NOT a read-only session probe.
+    pub async fn ensure(&self, credentials: &RemoteCredentials) -> Result<ManagedIdentity, String> {
+        let identity: ManagedIdentity = self
+            .post(
+                "v1/buzz/identity/ensure",
+                &serde_json::json!({}),
+                credentials,
+            )
+            .await?;
+        identity.validate()?;
+        Ok(identity)
+    }
+
+    async fn post<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+        credentials: &RemoteCredentials,
+    ) -> Result<T, String> {
+        let body = serde_json::to_vec(body).map_err(|_| failure())?;
+        if body.len() > 128 * 1024 {
+            return Err(failure());
+        }
+        let mut response = self
+            .client
+            .post(self.base.join(path).map_err(|_| failure())?)
+            .headers(credentials.headers()?)
+            .header("Cache-Control", "no-store")
+            .header("Content-Type", "application/json")
+            .body(body)
+            .send()
+            .await
+            .map_err(|_| failure())?;
+        if !response.status().is_success() {
+            return Err(failure());
+        }
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(|_| failure())? {
+            if bytes.len() + chunk.len() > 256 * 1024 {
+                return Err(failure());
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        serde_json::from_slice(&bytes).map_err(|_| failure())
+    }
+}
+
+/// A signer snapshot implementing the neutral exact-event boundary.
+///
+/// It holds the server-selected identity and the SAME authorization owner for its
+/// entire lifetime. Event creation and publication (including retry journals)
+/// remain with callers; sign never enrolls, publishes or retries a failed request.
+#[derive(Clone)]
+pub struct RemoteEventSigner {
+    client: RemoteIdentityClient,
+    public_key: PublicKey,
+    identity: ManagedIdentity,
+    authorization: Arc<dyn RemoteAuthorization>,
+}
+
+impl RemoteEventSigner {
+    /// Bind a validated ensure response to a captured login authorization owner.
+    pub fn new(
+        client: RemoteIdentityClient,
+        identity: &ManagedIdentity,
+        authorization: Arc<dyn RemoteAuthorization>,
+    ) -> Result<Self, String> {
+        let public_key = identity.validate()?;
+        authorization.check_active()?;
+        Ok(Self {
+            client,
+            public_key,
+            identity: identity.clone(),
+            authorization,
+        })
+    }
+
+    // Proof destinations are application-built, but must still belong to this
+    // captured managed community. Never send an off-origin proof for signing.
+    fn validate_proof_scope(&self, kind: u16, tags: &[Vec<String>]) -> Result<(), String> {
+        let value = |name: &str| -> Result<&str, String> {
+            let mut values = tags.iter().filter(|t| t.first().is_some_and(|s| s == name));
+            let tag = values.next().ok_or_else(failure)?;
+            if tag.len() != 2 || values.next().is_some() {
+                return Err(failure());
+            }
+            Ok(tag[1].as_str())
+        };
+        match kind {
+            22242
+                if value("relay")? != self.identity.relay_ws_url
+                    || tags.iter().any(|t| t.first().is_some_and(|s| s == "auth")) =>
+            {
+                return Err(failure());
+            }
+            27235 => {
+                let raw = value("u")?;
+                let target = url::Url::parse(raw).map_err(|_| failure())?;
+                let relay =
+                    url::Url::parse(&self.identity.relay_http_url).map_err(|_| failure())?;
+                if target.scheme() != "https"
+                    || target.origin() != relay.origin()
+                    || !target.username().is_empty()
+                    || target.password().is_some()
+                    || target.fragment().is_some()
+                    || raw.contains('\\')
+                {
+                    return Err(failure());
+                }
+            }
+            24242 => {
+                let relay =
+                    url::Url::parse(&self.identity.relay_http_url).map_err(|_| failure())?;
+                if value("server")? != &relay[url::Position::BeforeHost..url::Position::AfterPort] {
+                    return Err(failure());
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl EventSigner for RemoteEventSigner {
+    fn public_key(&self) -> PublicKey {
+        self.public_key
+    }
+
+    fn sign(
+        &self,
+        unsigned: UnsignedEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<Event, String>> + Send + '_>> {
+        Box::pin(async move {
+            self.authorization.check_active()?;
+            if unsigned.pubkey != self.public_key {
+                return Err(failure());
+            }
+            let tags: Vec<Vec<String>> = unsigned
+                .tags
+                .iter()
+                .map(|t| t.as_slice().to_vec())
+                .collect();
+            self.validate_proof_scope(unsigned.kind.as_u16(), &tags)?;
+            let purpose = match unsigned.kind.as_u16() {
+                22242 => "nip42-auth",
+                27235 => "http-auth",
+                24242
+                    if tags
+                        .iter()
+                        .any(|t| t.len() == 2 && t[0] == "t" && t[1] == "upload") =>
+                {
+                    "media-upload"
+                }
+                24242 => "media-read",
+                _ => "publish",
+            };
+            let template = serde_json::json!({"kind": unsigned.kind.as_u16(), "created_at": unsigned.created_at.as_secs(), "tags": tags, "content": unsigned.content});
+            let credentials = self.authorization.credentials().await?;
+            self.authorization.check_active()?;
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Reply {
+                event: Event,
+            }
+            let reply: Reply = self
+                .client
+                .post(
+                    "v1/buzz/identity/sign",
+                    &serde_json::json!({"purpose": purpose, "event": template}),
+                    &credentials,
+                )
+                .await?;
+            self.authorization.check_active()?;
+            let event = reply.event;
+            if event.pubkey != self.public_key
+                || event.created_at != unsigned.created_at
+                || event.kind != unsigned.kind
+                || event.tags != unsigned.tags
+                || event.content != unsigned.content
+                || event.verify().is_err()
+            {
+                return Err(failure());
+            }
+            Ok(event)
+        })
+    }
+}
+
+fn http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|_| failure())
+}
+
+// Unlike release-owned signer/issuer URLs, the backend community contract
+// (IdentitySigningPolicy) permits an HTTPS origin with a non-default port.
+// Keep raw canonical spelling: no userinfo, query, fragment or normalized path.
+fn relay_https_origin(raw: &str) -> Result<url::Url, String> {
+    let parsed = url::Url::parse(raw).map_err(|_| failure())?;
+    if parsed.scheme() != "https"
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || parsed.path() != "/"
+        || parsed.port() == Some(0)
+        || raw.trim_end_matches('/') != parsed.origin().ascii_serialization()
+        || raw.ends_with("//")
+    {
+        return Err(failure());
+    }
+    Ok(parsed)
+}
+
+// Compare raw authority as well as parsed fields: URL parsers normalize away
+// default ports, empty userinfo and backslashes. Release policy forbids all three.
+pub(crate) fn trusted_https_url(raw: &str) -> Result<url::Url, String> {
+    let url = url::Url::parse(raw).map_err(|_| failure())?;
+    let authority = raw
+        .strip_prefix("https://")
+        .and_then(|s| s.split('/').next())
+        .ok_or_else(failure)?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || raw.contains(['\\', '?', '#'])
+        || raw.bytes().any(|b| b <= 32 || b >= 127)
+        || authority.to_ascii_lowercase() != url.host_str().unwrap_or_default()
+    {
+        return Err(failure());
+    }
+    Ok(url)
+}
+
+pub(crate) fn deployment_prefix(raw: &str) -> Result<url::Url, String> {
+    let url = trusted_https_url(raw)?;
+    let path = raw
+        .strip_prefix("https://")
+        .and_then(|s| s.find('/').map(|i| &s[i..]))
+        .ok_or_else(failure)?;
+    if path == "/"
+        || !path.ends_with('/')
+        || path.contains("//")
+        || path.contains('%')
+        || path.contains("/v1/")
+        || path.split('/').any(|p| p == "." || p == "..")
+    {
+        return Err(failure());
+    }
+    Ok(url)
+}
+
+fn failure() -> String {
+    "Managed identity request failed; corporate login or authorization is required".into()
+}
+
+#[cfg(test)]
+#[path = "remote_identity_tests.rs"]
+mod tests;

--- a/crates/buzz-ws-client/src/remote_identity_tests.rs
+++ b/crates/buzz-ws-client/src/remote_identity_tests.rs
@@ -1,0 +1,418 @@
+use super::*;
+use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+fn identity(keys: &Keys) -> ManagedIdentity {
+    ManagedIdentity {
+        pubkey: keys.public_key().to_hex(),
+        relay_ws_url: "wss://buzz.example".into(),
+        relay_http_url: "https://buzz.example".into(),
+    }
+}
+
+#[derive(Default)]
+struct Authorization {
+    invalid: AtomicBool,
+    calls: AtomicUsize,
+    fail: bool,
+}
+impl RemoteAuthorization for Authorization {
+    fn check_active(&self) -> Result<(), String> {
+        if self.invalid.load(Ordering::Acquire) {
+            Err("login changed".into())
+        } else {
+            Ok(())
+        }
+    }
+    fn credentials(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<RemoteCredentials, String>> + Send + '_>> {
+        Box::pin(async {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            self.check_active()?;
+            if self.fail {
+                Err("refresh failed".into())
+            } else {
+                Ok(RemoteCredentials::new("test-only-bearer".into()))
+            }
+        })
+    }
+}
+
+// Inject only a loopback URL into the production HTTP transport. Its redirect,
+// response bound, request construction and verification paths are unchanged.
+async fn server_reply(
+    body: String,
+    status: &str,
+    extra_headers: &str,
+    invalidate: Option<Arc<Authorization>>,
+) -> (RemoteIdentityClient, tokio::task::JoinHandle<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let status = status.to_owned();
+    let extra_headers = extra_headers.to_owned();
+    let task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        loop {
+            let mut bytes = [0; 4096];
+            let count = stream.read(&mut bytes).await.unwrap();
+            assert!(count > 0);
+            request.extend_from_slice(&bytes[..count]);
+            assert!(request.len() < 256 * 1024);
+            if let Some(end) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&request[..end]).to_lowercase();
+                let length = headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("content-length: "))
+                    .unwrap()
+                    .parse::<usize>()
+                    .unwrap();
+                if request.len() >= end + 4 + length {
+                    break;
+                }
+            }
+        }
+        if let Some(owner) = invalidate {
+            owner.invalid.store(true, Ordering::Release);
+        }
+        let response = format!("HTTP/1.1 {status}\r\n{extra_headers}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len());
+        // Rejection may close a large-response connection before the server finishes.
+        let _ = stream.write_all(response.as_bytes()).await;
+        String::from_utf8(request).unwrap()
+    });
+    (
+        RemoteIdentityClient {
+            client: http_client().unwrap(),
+            base: url::Url::parse(&format!("http://{address}/cash-app/goose/")).unwrap(),
+        },
+        task,
+    )
+}
+
+fn unsigned(keys: &Keys) -> UnsignedEvent {
+    EventBuilder::new(Kind::from(9), "hello 🐝\nexact")
+        .custom_created_at(Timestamp::from(1000))
+        .tags([
+            Tag::parse(["h", "channel"]).unwrap(),
+            Tag::parse(["x", "a", "b"]).unwrap(),
+        ])
+        .build(keys.public_key())
+}
+
+#[test]
+fn release_destination_and_identity_validation_fails_closed() {
+    for base in [
+        "http://signer.example/cash-app/goose/",
+        "https://user:pass@signer.example/api/",
+        "https://@signer.example/api/",
+        "https://signer.example:443/api/",
+        "https://signer.example:444/api/",
+        "https://signer.example/api/?",
+        "https://signer.example/api/#",
+        "https://signer.example/api/\\",
+        "https://signer.example/api",
+        "https://signer.example/",
+        "https://signer.example/api/../goose/",
+        "https://signer.example/api/%2e/goose/",
+        "https://signer.example/api//goose/",
+        "https://signer.example/api/v1/buzz/identity/sign/",
+        "https://signer.example/api/\n",
+    ] {
+        assert!(RemoteIdentityClient::new(base).is_err(), "accepted {base}");
+    }
+    assert!(RemoteIdentityClient::new("https://signer.example/cash-app/goose/").is_ok());
+    let keys = Keys::generate();
+    let mut wrong = identity(&keys);
+    wrong.relay_ws_url = "wss://other.example".into();
+    assert!(wrong.validate().is_err());
+    for pubkey in ["0".repeat(64), "a".repeat(63), "A".repeat(64)] {
+        wrong = identity(&keys);
+        wrong.pubkey = pubkey;
+        assert!(wrong.validate().is_err());
+    }
+    for token in ["", "bad\r\nheader", "bad token"] {
+        assert!(RemoteCredentials::new(token.into()).headers().is_err());
+    }
+    assert!(
+        RemoteCredentials::new("token".into()).headers().unwrap()["authorization"].is_sensitive()
+    );
+}
+
+#[tokio::test]
+async fn ensure_is_separate_enrollment_with_empty_body_and_no_identity_selectors() {
+    let expected = identity(&Keys::generate());
+    let (client, request) = server_reply(
+        serde_json::to_string(&expected).unwrap(),
+        "200 OK",
+        "",
+        None,
+    )
+    .await;
+    assert_eq!(
+        client
+            .ensure(&RemoteCredentials::new("test-only-bearer".into()))
+            .await
+            .unwrap(),
+        expected
+    );
+    let request = request.await.unwrap();
+    assert!(request.starts_with("POST /cash-app/goose/v1/buzz/identity/ensure HTTP/1.1"));
+    assert_eq!(request.split("\r\n\r\n").nth(1).unwrap(), "{}");
+    assert!(request.contains("authorization: Bearer test-only-bearer"));
+    assert!(!request.to_lowercase().contains("cookie:"));
+}
+
+#[tokio::test]
+async fn sign_uses_neutral_exact_event_interface_without_ensure_or_publish() {
+    let keys = Keys::generate();
+    let input = unsigned(&keys);
+    let expected = input.clone().sign_with_keys(&keys).unwrap();
+    let (client, request) = server_reply(
+        serde_json::json!({"event": expected}).to_string(),
+        "200 OK",
+        "",
+        None,
+    )
+    .await;
+    let owner = Arc::new(Authorization::default());
+    let snapshot = RemoteEventSigner::new(client, &identity(&keys), owner.clone()).unwrap();
+    let signer: &dyn EventSigner = &snapshot;
+    let result = signer.sign(input.clone()).await.unwrap();
+    assert_eq!(result.id, expected.id);
+    result.verify().unwrap();
+    assert_eq!(owner.calls.load(Ordering::SeqCst), 1);
+    let request = request.await.unwrap();
+    assert!(request.starts_with("POST /cash-app/goose/v1/buzz/identity/sign HTTP/1.1"));
+    assert!(request.contains("authorization: Bearer test-only-bearer"));
+    let body: serde_json::Value =
+        serde_json::from_str(request.split("\r\n\r\n").nth(1).unwrap()).unwrap();
+    assert_eq!(
+        body,
+        serde_json::json!({"purpose":"publish", "event": {"kind":9, "created_at":1000, "tags":[["h","channel"],["x","a","b"]], "content":"hello 🐝\nexact"}})
+    );
+    assert!(!request.contains("enterprise-signer"));
+}
+
+#[tokio::test]
+async fn rejects_valid_signatures_with_any_template_change_and_invalid_crypto() {
+    let keys = Keys::generate();
+    let input = unsigned(&keys);
+    let mut variants = Vec::new();
+    let mut changed = input.clone();
+    changed.content.push('!');
+    variants.push(changed);
+    let mut changed = input.clone();
+    changed.kind = Kind::from(7);
+    variants.push(changed);
+    let mut changed = input.clone();
+    changed.created_at = Timestamp::from(1001);
+    variants.push(changed);
+    let mut changed = input.clone();
+    changed.tags = nostr::Tags::from_list(vec![Tag::parse(["h", "other"]).unwrap()]);
+    variants.push(changed);
+    let mut replies: Vec<_> = variants
+        .into_iter()
+        .map(|mut e| {
+            e.id = None;
+            serde_json::to_value(e.sign_with_keys(&keys).unwrap()).unwrap()
+        })
+        .collect();
+    let other = Keys::generate();
+    replies.push(serde_json::to_value(unsigned(&other).sign_with_keys(&other).unwrap()).unwrap());
+    let correct = input.clone().sign_with_keys(&keys).unwrap();
+    let mut forged = serde_json::to_value(&correct).unwrap();
+    forged["sig"] = serde_json::json!("0".repeat(128));
+    replies.push(forged);
+    let mut forged = serde_json::to_value(&correct).unwrap();
+    forged["id"] = serde_json::json!("0".repeat(64));
+    replies.push(forged);
+    for event in replies {
+        let (client, request) = server_reply(
+            serde_json::json!({"event": event}).to_string(),
+            "200 OK",
+            "",
+            None,
+        )
+        .await;
+        let signer =
+            RemoteEventSigner::new(client, &identity(&keys), Arc::new(Authorization::default()))
+                .unwrap();
+        assert!(signer.sign(input.clone()).await.is_err());
+        request.await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn refuses_wrong_author_and_failed_credentials_before_network_without_fallback() {
+    let keys = Keys::generate();
+    let owner = Arc::new(Authorization {
+        fail: true,
+        ..Default::default()
+    });
+    let client = RemoteIdentityClient::new("https://signer.invalid/cash-app/goose/").unwrap();
+    let signer = RemoteEventSigner::new(client, &identity(&keys), owner.clone()).unwrap();
+    assert!(signer.sign(unsigned(&Keys::generate())).await.is_err());
+    assert_eq!(owner.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        signer.sign(unsigned(&keys)).await.unwrap_err(),
+        "refresh failed"
+    );
+    owner.invalid.store(true, Ordering::Release);
+    assert_eq!(
+        signer.sign(unsigned(&keys)).await.unwrap_err(),
+        "login changed"
+    );
+    assert_eq!(owner.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(signer.public_key(), keys.public_key());
+}
+
+#[tokio::test]
+async fn invalidated_snapshot_discards_in_flight_signature() {
+    let keys = Keys::generate();
+    let event = unsigned(&keys).sign_with_keys(&keys).unwrap();
+    let owner = Arc::new(Authorization::default());
+    let (client, request) = server_reply(
+        serde_json::json!({"event": event}).to_string(),
+        "200 OK",
+        "",
+        Some(owner.clone()),
+    )
+    .await;
+    let signer = RemoteEventSigner::new(client, &identity(&keys), owner).unwrap();
+    assert_eq!(
+        signer.sign(unsigned(&keys)).await.unwrap_err(),
+        "login changed"
+    );
+    request.await.unwrap();
+}
+
+#[tokio::test]
+async fn denial_malformed_and_oversize_response_propagate_without_local_fallback() {
+    let keys = Keys::generate();
+    for (status, body) in [
+        ("403 Forbidden", "{}".into()),
+        ("200 OK", "not json".into()),
+        ("200 OK", "x".repeat(256 * 1024 + 1)),
+    ] {
+        let (client, request) = server_reply(body, status, "", None).await;
+        let signer =
+            RemoteEventSigner::new(client, &identity(&keys), Arc::new(Authorization::default()))
+                .unwrap();
+        assert!(signer.sign(unsigned(&keys)).await.is_err());
+        request.await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn actual_http_client_refuses_redirect_without_sending_bearer_to_target() {
+    let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let headers = format!("Location: http://{}/leak\r\n", target.local_addr().unwrap());
+    let (client, request) =
+        server_reply("{}".into(), "307 Temporary Redirect", &headers, None).await;
+    assert!(client
+        .ensure(&RemoteCredentials::new("test-only-bearer".into()))
+        .await
+        .is_err());
+    request.await.unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), target.accept())
+            .await
+            .is_err()
+    );
+}
+
+#[test]
+fn managed_community_allows_backend_port_but_never_changes_release_destination_rules() {
+    let keys = Keys::generate();
+    let mut managed = identity(&keys);
+    managed.relay_http_url = "https://buzz.example:8443".into();
+    managed.relay_ws_url = "wss://buzz.example:8443".into();
+    assert!(managed.validate().is_ok());
+    assert!(RemoteIdentityClient::new("https://signer.example:8443/cash-app/goose/").is_err());
+    for invalid in [
+        "http://buzz.example:8443",
+        "https://user@buzz.example:8443",
+        "https://buzz.example:8443/?q",
+        "https://buzz.example:8443/#fragment",
+        "https://buzz.example:8443/a/..",
+        "https://buzz.example:8443//",
+        "https://buzz.example:0",
+    ] {
+        managed.relay_http_url = invalid.into();
+        assert!(managed.validate().is_err(), "{invalid}");
+    }
+}
+
+#[test]
+fn remote_proofs_are_exactly_scoped_before_credentials_or_network() {
+    let keys = Keys::generate();
+    let signer = RemoteEventSigner::new(
+        RemoteIdentityClient::new("https://signer.example/cash-app/goose/").unwrap(),
+        &identity(&keys),
+        Arc::new(Authorization::default()),
+    )
+    .unwrap();
+    for target in [
+        "http://buzz.example/events",
+        "https://other.example/events",
+        "https://buzz.example:8443/events",
+        "https://user@buzz.example/events",
+        "https://buzz.example/events#fragment",
+    ] {
+        assert!(signer
+            .validate_proof_scope(27235, &[vec!["u".into(), target.into()]])
+            .is_err());
+    }
+    assert!(signer
+        .validate_proof_scope(
+            27235,
+            &[vec!["u".into(), "https://buzz.example/events".into()]]
+        )
+        .is_ok());
+    assert!(signer
+        .validate_proof_scope(24242, &[vec!["server".into(), "buzz.example".into()]])
+        .is_ok());
+    assert!(signer
+        .validate_proof_scope(24242, &[vec!["server".into(), "buzz.example:8443".into()]])
+        .is_err());
+    assert!(signer
+        .validate_proof_scope(22242, &[vec!["relay".into(), "wss://other.example".into()]])
+        .is_err());
+    assert!(signer
+        .validate_proof_scope(22242, &[vec!["relay".into(), "wss://buzz.example".into()]])
+        .is_ok());
+}
+
+#[tokio::test]
+async fn production_sign_rejects_wrong_proof_scope_before_authorization_or_network() {
+    let keys = Keys::generate();
+    let auth = Arc::new(Authorization::default());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let client = RemoteIdentityClient {
+        client: http_client().unwrap(),
+        base: url::Url::parse(&format!("http://{}/api/", listener.local_addr().unwrap())).unwrap(),
+    };
+    let signer = RemoteEventSigner::new(client, &identity(&keys), auth.clone()).unwrap();
+    for (kind, tags) in [
+        (27235, vec![vec!["u", "https://other.example/events"]]),
+        (24242, vec![vec!["server", "other.example"]]),
+        (22242, vec![vec!["relay", "wss://other.example"]]),
+    ] {
+        let input = EventBuilder::new(Kind::from(kind), "")
+            .tags(tags.into_iter().map(|tag| Tag::parse(tag).unwrap()))
+            .build(keys.public_key());
+        assert!(signer.sign(input).await.is_err());
+    }
+    assert_eq!(auth.calls.load(Ordering::SeqCst), 0);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), listener.accept())
+            .await
+            .is_err()
+    );
+}

--- a/desktop/MANAGED_IDENTITY.md
+++ b/desktop/MANAGED_IDENTITY.md
@@ -1,0 +1,124 @@
+# Organization-managed desktop identity
+
+This is a release-selected build mode, not a runtime switch or an ordinary service
+publish option. OSS/local-key builds retain their existing behavior. The managed
+build cannot fall back to generating, importing, recovering or exporting a local
+human signing key when corporate login or signing fails.
+
+## Build and service contract
+
+`BUZZ_BUILD_ENTERPRISE` is one JSON object with **exactly seven** fields:
+`signerUrl`, `issuer`, `clientId`, `audience`, `organization`, `connection`,
+`redirectUri`. The release environment selector is not a field in this object.
+The native build consumer validates and canonically embeds it as
+`BUZZ_DESKTOP_BUILD_ENTERPRISE`; corporate builds require `system-keyring`.
+Do not put client secrets, tokens, or user-selected relay/identity values in it.
+Signer and issuer URLs follow the shared release schema (HTTPS, no credentials,
+queries or fragments, and no explicit port). Signer URL is a path prefix ending
+in `/`, not an identity endpoint. Enrollment and signing are respectively:
+
+- `POST <signerUrl>v1/buzz/identity/ensure`, body `{}`;
+- `POST <signerUrl>v1/buzz/identity/sign`, body containing the exact unsigned event.
+
+There are no legacy endpoint aliases. Enrollment pins the returned public key and
+matching HTTPS/WSS relay origin. Backend-supported non-default relay ports are
+allowed; this does not relax signer or issuer validation. Event verification
+rejects any changed public key, kind, content, timestamp, tag, ID or signature.
+The remote signer rejects off-origin HTTP, relay-auth and media proofs before
+asking for credentials or contacting the service.
+
+Browser login uses state and PKCE. The callback binds **exactly** the configured
+`http://127.0.0.1:<fixed-port>/enterprise-callback`; a busy port is a sign-in error,
+not permission to select a new port. The callback wait is bounded. The same
+seven-field validator is consumed by build.rs and native contract tests.
+
+## Ownership and offboarding
+
+`EnterpriseIdentity` owns secure token storage, refresh and session cancellation.
+The signing interface is only `public_key()` plus asynchronous exact-event
+`sign()`; it does not own enrollment, event construction, publication, encryption,
+secret export or login lifecycle. Refresh is singleflight and never re-enrolls.
+Before rotating a refresh credential the owner durably writes a rotation
+pending marker, then atomically stores the replacement. Interrupted/ambiguous
+rotation or any storage/refresh failure requires a fresh sign-in; the old token
+is not replayed. A failed durable cleanup is reported, not silently declared
+successful.
+
+Sign-out/login replacement cancels the old owner, native relay sessions (including
+pending auth/reconnect), and huddle/upload authorization lifetimes. Responses from
+an old signer cannot establish the new identity. A cancelled in-memory owner is
+not restored from old disk credentials. Logout removes the saved session; it does
+not wipe downloaded files, existing local caches/preferences, or revoke already
+issued proofs. Operator offboarding must also remove backend/relay membership and
+corporate authorization. A request accepted before cancellation cannot be undone
+by cancelling the client.
+
+Corporate media read proofs last at most 120 seconds; uploads at most 300 seconds.
+One read-proof entry is owned by each login session and matched by identity and
+exact relay origin (including port). Concurrent misses singleflight, cached proofs
+are not used within ten seconds of expiry, and cancelled signing cannot populate
+or serve the cache. New logins never inherit it. Corporate proof failure (including no session or logout) aborts both media
+proxies and bounded downloads before any upstream transport; only OSS recovery
+retains optional unsigned reads. The avatar card caller also propagates proof
+failure. Authenticated media clients do not follow redirects. Membership checks remain server-side: cached proofs are
+not an offboarding bypass.
+
+## Deliberate exclusions
+
+The service supplies event signatures, **not local private-key/NIP-44 operations**.
+Accordingly:
+
+- No private-key reveal/export/import, NIP-49 key backup, or key-based pairing.
+- No encrypted cross-device read-state, sidebar stars/mutes/sort/sections,
+  project-sidebar membership, or appearance sync. Existing device-local stores
+  and local read-marker persistence remain available; sync managers do not fetch,
+  subscribe, encrypt, publish, or retry in managed mode. No plaintext relay fallback.
+- Encrypted reminders are explicitly unavailable (no background reminder poll).
+- Local managed-agent creation, start, instance-key loading and runtime spawning
+  are denied natively. The Agents surface explains the exclusion. Existing remote
+  relay identities remain public identities, not a promise of local management.
+- Other commands requiring a local human secret, including encrypted agent/team
+  archives and local git credential/agent delegation setup, fail explicitly.
+- Corporate community selection is pinned to the enrolled relay; importing a local
+  identity or applying another community is rejected by the native workspace command.
+
+Settings disclose these differences. These are intentional scope limitations,
+not equivalent replacements for the local-key features or the remote-agent vision.
+
+## Retry semantics and validation limits
+
+Relay submission authenticates the captured relay and signer, and success requires
+an ACK whose ID exactly matches the submitted signed event. Already-signed event
+APIs preserve those bytes for caller-managed retries; media's legacy route retry
+reuses its signed proof. Not every interactive command has a durable signed-event
+outbox. After an ambiguous network failure, a new user action may construct a new
+event: do not promise automatic exactly-once delivery or restart-safe retries.
+There is no broad durable-outbox implementation in this port.
+
+Synthetic tests cover the production scope guard before network/credentials,
+exact-event verification, delayed signer relay capture/ACK matching, token-owner
+faults, native cancellation, media cache fencing, encrypted-feature gating and
+device-local reads. An opt-in compiled corporate-mode test constructs real AppState
+and proves no local key/import persistence; use only synthetic build configuration.
+Loopback OAuth tests exercise the actual fixed callback listener. These do not
+prove live corporate SSO enrollment, signing-service authorization, deployment
+schema integration, or operator offboarding. Live staging remains blocked while
+infrastructure policy is deny-only. Build artifact/source markers alone are not
+runtime proof. No production credentials are needed or used by these tests.
+
+## Known draft limitations and dependent work
+
+Directory/profile-editing operations remain exposed while the managed backend
+excludes ordinary profile mutation: these fail rather than changing directory
+names. The UI/backend mismatch is not solved by remote signing. Mobile additionally
+still invokes ensure during refresh and has weaker direct parser/proof preflight
+than Rust; see `mobile/MANAGED_IDENTITY.md`.
+
+This feature is stacked on extraction draft #7600. Service draft
+`squareup/cash-server#124571` signs but never publishes ordinary events; release
+draft `squareup/buzz-releases#94` provides the seven compiled fields (its
+`environment` selector is release-only). Terraform draft #1385 is unbound and
+deny-only; an approved corporate authority and authorization for the active
+infrastructure repository remain prerequisites. No schema apply, enrollment,
+deployment, live keychain/SSO, native GUI or signed installer was validated here.
+Empty local sidecar placeholders are not packaging evidence.

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       name: "smoke",
       testMatch: [
         "**/smoke.spec.ts",
+        "**/enterprise-login.spec.ts",
         "**/owned-agent-discovery.spec.ts",
         "**/thread-head-stale-edit.spec.ts",
         "**/sidebar-offcanvas-rail.spec.ts",

--- a/desktop/scripts/build-protected-feature-artifacts.mjs
+++ b/desktop/scripts/build-protected-feature-artifacts.mjs
@@ -34,7 +34,15 @@ function buildVariant({ internal, output }) {
 
   const result = spawnSync(
     process.execPath,
-    [viteEntrypoint, "build", "--outDir", output, "--emptyOutDir"],
+    [
+      viteEntrypoint,
+      "build",
+      "--configLoader",
+      "runner",
+      "--outDir",
+      output,
+      "--emptyOutDir",
+    ],
     {
       cwd: desktopRoot,
       env,

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1260,14 +1260,19 @@ dependencies = [
 name = "buzz-ws-client"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "futures-util",
  "nostr 0.44.7",
+ "reqwest 0.13.4",
+ "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ mesh-llm = ["dep:iroh", "dep:mesh-llm-sdk", "dep:mesh-llm-host-runtime", "dep:me
 system-keyring = ["dep:keyring"]
 
 [build-dependencies]
+buzz_ws_client_pkg = { package = "buzz-ws-client", path = "../../crates/buzz-ws-client" }
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,5 @@
+#[path = "src/enterprise_build_config.rs"]
+mod enterprise_build_config;
 // Shared schema, included from the same source the runtime command parses with,
 // so the build-time validation below and the runtime parse cannot drift.
 include!("src/commands/reconnect_hook_config.rs");
@@ -8,6 +10,23 @@ include!("src/managed_agents/reserved_env_keys.rs");
 use base64::Engine as _;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=BUZZ_BUILD_ENTERPRISE");
+    if let Some(raw) = std::env::var_os("BUZZ_BUILD_ENTERPRISE") {
+        let canonical = raw
+            .to_str()
+            .ok_or_else(|| "Invalid corporate build configuration".to_string())
+            .and_then(|raw| {
+                enterprise_build_config::compile_config(
+                    raw,
+                    std::env::var_os("CARGO_FEATURE_SYSTEM_KEYRING").is_some(),
+                )
+            })
+            .unwrap_or_else(|_| {
+                panic!("Invalid corporate build configuration or missing system-keyring")
+            });
+        println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_ENTERPRISE={canonical}");
+    }
+
     println!("cargo:rerun-if-env-changed=BUZZ_RELAY_URL");
     println!("cargo:rerun-if-env-changed=BUZZ_RELAY_HTTP");
     println!("cargo:rerun-if-env-changed=BUZZ_UPDATER_PUBLIC_KEY");

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -17,7 +17,8 @@ use crate::managed_agents::config_bridge::SessionConfigCache;
 use crate::managed_agents::{ManagedAgentPairRuntime, ManagedAgentRuntimeKey};
 
 pub struct AppState {
-    pub keys: Mutex<Keys>,
+    pub(crate) enterprise: crate::enterprise_identity::EnterpriseIdentity,
+    pub keys: Mutex<Option<Keys>>,
     /// Durable backend holding `keys`. Updated after the key write and before
     /// recovery flags are cleared so `get_identity` reports a consistent state.
     pub(crate) identity_storage: AtomicU8,
@@ -147,6 +148,9 @@ pub struct AppState {
 /// fall through to persisted resolution. A malformed value is logged and
 /// treated as absent rather than left on an ephemeral identity.
 fn identity_from_env() -> Option<Keys> {
+    if crate::enterprise_identity::enabled() {
+        return None;
+    }
     match std::env::var("BUZZ_PRIVATE_KEY") {
         Ok(nsec) => match Keys::parse(nsec.trim()) {
             Ok(keys) => Some(keys),
@@ -193,20 +197,25 @@ pub fn build_app_state() -> AppState {
                 "buzz-desktop: configured identity pubkey {}",
                 keys.public_key().to_hex()
             );
-            (keys, IdentityStorage::Environment)
+            (Some(keys), IdentityStorage::Environment)
         }
-        None => (Keys::generate(), IdentityStorage::Ephemeral),
+        None => (
+            (!crate::enterprise_identity::enabled()).then(Keys::generate),
+            IdentityStorage::Ephemeral,
+        ),
     };
 
     AppState {
+        enterprise: crate::enterprise_identity::EnterpriseIdentity::default(),
         keys: Mutex::new(keys),
         identity_storage: AtomicU8::new(identity_storage as u8),
         http_client: reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
             .resolve("localhost", std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
             .pool_idle_timeout(std::time::Duration::from_secs(300))
             .pool_max_idle_per_host(2)
             .build()
-            .unwrap_or_else(|_| reqwest::Client::new()),
+            .unwrap_or_else(|error| panic!("Cannot build no-redirect HTTP client: {error}")),
         media_fetch_client: build_media_fetch_client().expect(
             "media_fetch_client must build with redirect::Policy::none(); a \
              redirect-following fallback would forward the minted media auth \
@@ -264,6 +273,9 @@ mod accessors;
 /// but inaccessible this boot). Both states boot with an ephemeral key; the
 /// frontend shows different recovery screens for each.
 pub fn resolve_persisted_identity(app: &AppHandle, state: &AppState) -> Result<(), String> {
+    if crate::enterprise_identity::enabled() {
+        return Ok(());
+    }
     // Only skip file-based resolution if the env var was present AND parsed
     // successfully. A malformed env var should fall through to the persisted
     // key rather than leaving the app on an ephemeral identity.
@@ -282,7 +294,7 @@ pub fn resolve_persisted_identity(app: &AppHandle, state: &AppState) -> Result<(
     // any thread that reads a flag as false with Acquire sees consistent data.
     {
         let mut active_keys = state.keys.lock().map_err(|e| e.to_string())?;
-        *active_keys = resolved.keys;
+        *active_keys = Some(resolved.keys);
         state.set_identity_storage(resolved.storage);
     }
     state.identity_lost.store(

--- a/desktop/src-tauri/src/app_state_accessors.rs
+++ b/desktop/src-tauri/src/app_state_accessors.rs
@@ -53,6 +53,12 @@ impl AppState {
     /// this instead of locking `state.keys` directly, so that recovery mode
     /// blocks publishing under an invalid or inaccessible identity.
     pub fn signing_keys(&self) -> Result<Keys, String> {
+        if crate::enterprise_identity::enabled() {
+            return Err(
+                "This feature requires a local private key and is unavailable in corporate builds"
+                    .into(),
+            );
+        }
         if self
             .identity_lost
             .load(std::sync::atomic::Ordering::Acquire)
@@ -67,16 +73,34 @@ impl AppState {
         self.keys
             .lock()
             .map_err(|e| e.to_string())
-            .map(|k| k.clone())
+            .and_then(|k| k.clone().ok_or_else(|| "Local identity unavailable".into()))
     }
 
     /// Capture the active event signer after the same recovery checks as local keys.
     /// Secret export, encryption, pairing and provisioning must use `signing_keys`.
     pub fn event_signer(
         &self,
-    ) -> Result<buzz_ws_client_pkg::event_signer::LocalEventSigner, String> {
-        self.signing_keys()
-            .map(buzz_ws_client_pkg::event_signer::LocalEventSigner::new)
+    ) -> Result<std::sync::Arc<dyn buzz_ws_client_pkg::event_signer::EventSigner>, String> {
+        if crate::enterprise_identity::enabled() {
+            return self.enterprise.event_signer();
+        }
+        Ok(std::sync::Arc::new(
+            buzz_ws_client_pkg::event_signer::LocalEventSigner::new(self.signing_keys()?),
+        ))
+    }
+
+    /// Public identity, including recovery-mode local identity display.
+    pub(crate) fn public_key(&self) -> Result<nostr::PublicKey, String> {
+        if crate::enterprise_identity::enabled() {
+            use buzz_ws_client_pkg::event_signer::EventSigner;
+            return Ok(self.enterprise.event_signer()?.public_key());
+        }
+        self.keys
+            .lock()
+            .map_err(|e| e.to_string())?
+            .as_ref()
+            .map(Keys::public_key)
+            .ok_or_else(|| "Local identity unavailable".into())
     }
 
     /// Emit the current huddle state to the frontend via Tauri event.

--- a/desktop/src-tauri/src/app_state_tests.rs
+++ b/desktop/src-tauri/src/app_state_tests.rs
@@ -935,7 +935,7 @@ fn signing_keys_returns_ok_when_normal() {
         "signing_keys() must return Ok when neither flag is set"
     );
     // The returned keys must match the stored keys.
-    let expected = state.keys.lock().unwrap().clone();
+    let expected = state.keys.lock().unwrap().as_ref().unwrap().clone();
     assert_key_eq(&result.unwrap(), &expected);
 }
 

--- a/desktop/src-tauri/src/archive/mod.rs
+++ b/desktop/src-tauri/src/archive/mod.rs
@@ -63,8 +63,7 @@ pub fn spawn_warm_init(app: tauri::AppHandle) {
 }
 
 fn identity_pubkey(state: &AppState) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|e| e.to_string())?;
-    Ok(keys.public_key().to_hex())
+    Ok(state.public_key()?.to_hex())
 }
 
 fn now_secs() -> i64 {
@@ -179,10 +178,10 @@ pub(crate) async fn archive_candidates(
     let bucket_results = query_buckets(plan.buckets, state).await;
 
     // ── Phase 3: persist (blocking SQLite) ──────────────────────────────────
-    let owner_keys = {
-        let keys_guard = state.keys.lock().map_err(|e| e.to_string())?;
-        keys_guard.clone()
-        // guard drops here, before awaiting the blocking commit task.
+    let owner_keys = if crate::enterprise_identity::enabled() {
+        None
+    } else {
+        Some(state.signing_keys()?)
     };
     let commit_identity_pk = identity_pk.clone();
     let commit_relay_url = relay_url.clone();
@@ -195,7 +194,7 @@ pub(crate) async fn archive_candidates(
                 plan.pre_dropped,
                 &commit_identity_pk,
                 &commit_relay_url,
-                &owner_keys,
+                owner_keys.as_ref(),
                 now,
                 conn,
             )

--- a/desktop/src-tauri/src/archive/mod_tests.rs
+++ b/desktop/src-tauri/src/archive/mod_tests.rs
@@ -108,7 +108,7 @@ fn run_batch_sync_with_keys(
         plan.pre_dropped,
         identity_pk,
         relay_url,
-        owner_keys,
+        Some(owner_keys),
         0,
         conn,
     )
@@ -668,7 +668,7 @@ mod real_relay {
     /// is exercised, including NIP-98 signing inside `query_relay`.
     fn make_test_app_state(keys: Keys, relay_url: &str) -> AppState {
         let state = build_app_state();
-        *state.keys.lock().unwrap() = keys;
+        *state.keys.lock().unwrap() = Some(keys);
         *state.relay_url_override.lock().unwrap() = Some(relay_url.to_string());
         state
     }
@@ -749,7 +749,14 @@ mod real_relay {
         state: &AppState,
         db_path: &Path,
     ) -> ArchiveBatchResult {
-        let identity_pk = state.keys.lock().unwrap().public_key().to_hex();
+        let identity_pk = state
+            .keys
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .public_key()
+            .to_hex();
         let relay_url = crate::relay::relay_ws_url_with_override(state);
 
         // Phase 1: plan (sync). Connection dropped before any .await.
@@ -765,14 +772,14 @@ mod real_relay {
 
         // Phase 3: persist (sync). Fresh connection, same file.
         let conn = store::open_archive_db(db_path).expect("open archive db for commit");
-        let owner_keys = state.keys.lock().unwrap().clone();
+        let owner_keys = state.keys.lock().unwrap().as_ref().unwrap().clone();
         commit_archive(
             bucket_results,
             plan.ephemeral,
             plan.pre_dropped,
             &identity_pk,
             &relay_url,
-            &owner_keys,
+            Some(&owner_keys),
             0,
             &conn,
         )

--- a/desktop/src-tauri/src/archive/pipeline.rs
+++ b/desktop/src-tauri/src/archive/pipeline.rs
@@ -263,7 +263,7 @@ pub(super) fn commit_archive(
     pre_dropped: u32,
     identity_pk: &str,
     relay_url: &str,
-    owner_keys: &nostr::Keys,
+    owner_keys: Option<&nostr::Keys>,
     now: i64,
     conn: &Connection,
 ) -> Result<ArchiveBatchResult, String> {
@@ -319,6 +319,10 @@ pub(super) fn commit_archive(
             // ciphertext or partial output.
             let stored_json =
                 if p.event.kind.as_u16() as u64 == super::KIND_AGENT_TURN_METRIC as u64 {
+                    let Some(owner_keys) = owner_keys else {
+                        dropped += 1;
+                        continue;
+                    };
                     match buzz_core_pkg::agent_turn_metric::decrypt_agent_turn_metric(
                         owner_keys, &p.event,
                     ) {
@@ -459,11 +463,13 @@ pub(super) fn commit_archive(
             // Write a status row regardless of outcome so backfill never
             // re-processes this frame (INSERT OR IGNORE on PK is a no-op if
             // the row is already present from a prior run).
-            let channel_id_for_index: Option<String> =
-                buzz_core_pkg::observer::decrypt_observer_payload::<serde_json::Value>(
-                    owner_keys, &p.event,
-                )
-                .ok()
+            let channel_id_for_index: Option<String> = owner_keys
+                .and_then(|keys| {
+                    buzz_core_pkg::observer::decrypt_observer_payload::<serde_json::Value>(
+                        keys, &p.event,
+                    )
+                    .ok()
+                })
                 .and_then(|v| v.get("channelId")?.as_str().map(|s| s.to_owned()));
             store::upsert_observer_channel_index(
                 &tx,

--- a/desktop/src-tauri/src/commands/agent_discovery/relay_directory.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/relay_directory.rs
@@ -78,11 +78,7 @@ fn managed_policy_filters(
 }
 
 fn current_user_pubkey(state: &AppState) -> Result<String, String> {
-    state
-        .keys
-        .lock()
-        .map(|keys| keys.public_key().to_hex())
-        .map_err(|error| error.to_string())
+    Ok(state.public_key()?.to_hex())
 }
 
 pub(super) fn advance_relay_cursor(filter: &mut serde_json::Value, page: &[nostr::Event]) {
@@ -457,7 +453,7 @@ mod real_relay_tests {
 
     fn state_for(keys: Keys) -> AppState {
         let state = build_app_state();
-        *state.keys.lock().unwrap() = keys;
+        *state.keys.lock().unwrap() = Some(keys);
         *state.relay_url_override.lock().unwrap() = Some(relay_ws_url());
         state
     }

--- a/desktop/src-tauri/src/commands/agent_discovery/relay_directory/owned_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/relay_directory/owned_tests.rs
@@ -105,7 +105,7 @@ async fn remote_owned_discovery_and_membership_do_not_require_local_records() {
         axum::serve(listener, router).await.unwrap();
     });
     let state = crate::app_state::build_app_state();
-    *state.keys.lock().unwrap() = owner.clone();
+    *state.keys.lock().unwrap() = Some(owner.clone());
     *state.relay_url_override.lock().unwrap() = Some(format!("ws://{address}"));
 
     let discovered = list_relay_agents_for_state(&state).await.unwrap();

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -23,8 +23,7 @@ use crate::{
 /// Read the workspace owner pubkey without holding the lock. Used to populate `BUZZ_ACP_AGENT_OWNER`
 /// as a fallback for legacy agent records that have no NIP-OA `auth_tag`.
 pub(super) fn workspace_owner_hex(state: &AppState) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|e| e.to_string())?;
-    Ok(keys.public_key().to_hex())
+    Ok(state.public_key()?.to_hex())
 }
 
 #[path = "agents_pending.rs"]
@@ -344,6 +343,10 @@ pub async fn create_managed_agent(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<CreateManagedAgentResponse, String> {
+    if crate::enterprise_identity::enabled() {
+        return Err("Local managed agents are unavailable in enterprise mode".into());
+    }
+
     let name = input.name.trim().to_string();
     let requested_persona_id = input
         .persona_id
@@ -831,6 +834,10 @@ pub async fn start_managed_agent(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<ManagedAgentSummary, String> {
+    if crate::enterprise_identity::enabled() {
+        return Err("Local managed agents are unavailable in enterprise mode".into());
+    }
+
     // Snapshot the workspace owner pubkey for the legacy auth_tag fallback.
     // Read outside the records lock to keep lock ordering simple.
     let owner_hex = workspace_owner_hex(&state)?;

--- a/desktop/src-tauri/src/commands/channels/fetch.rs
+++ b/desktop/src-tauri/src/commands/channels/fetch.rs
@@ -198,10 +198,7 @@ pub(super) async fn fetch_channels(
     #[cfg(debug_assertions)]
     let _profile_start = std::time::Instant::now();
 
-    let my_pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
-    };
+    let my_pubkey = { state.public_key()?.to_hex() };
 
     // Channels this identity created whose kind:39002 membership hasn't yet
     // propagated. Under member-only scope they are the only non-member

--- a/desktop/src-tauri/src/commands/channels/fetch_tests.rs
+++ b/desktop/src-tauri/src/commands/channels/fetch_tests.rs
@@ -108,7 +108,7 @@ impl Relay {
 
     fn state(&self, keys: &Keys) -> AppState {
         let state = crate::app_state::build_app_state();
-        *state.keys.lock().unwrap() = keys.clone();
+        *state.keys.lock().unwrap() = Some(keys.clone());
         *state.relay_url_override.lock().unwrap() = Some(self.url.clone());
         state
     }
@@ -327,7 +327,7 @@ async fn each_fetch_observes_roster_changes_and_the_current_identity_and_relay()
         .await
         .unwrap()
         .is_empty());
-    *state.keys.lock().unwrap() = next_keys.clone();
+    *state.keys.lock().unwrap() = Some(next_keys.clone());
     assert_eq!(
         fetch(&state, DirectoryScope::MemberOnly).await.unwrap()[0].member_pubkeys,
         vec![next.clone()]

--- a/desktop/src-tauri/src/commands/channels_tests.rs
+++ b/desktop/src-tauri/src/commands/channels_tests.rs
@@ -265,14 +265,21 @@ fn pending_owner_mark_uses_signer_captured_before_identity_swap() {
     // Simulate an in-process identity swap landing during the (here,
     // implicit) submit await — e.g. `import_identity` replacing
     // `state.keys` while the create request is in flight.
-    *state.keys.lock().expect("lock keys") = Keys::generate();
+    *state.keys.lock().expect("lock keys") = Some(Keys::generate());
 
     // The mark must use the captured signer, not whatever `state.keys`
     // holds now.
     state.mark_pending_owned_channel(&creator_pubkey, "chan-1");
 
     assert!(state.is_pending_owned_channel(&creator_pubkey, "chan-1"));
-    let post_swap_pubkey = state.keys.lock().expect("lock keys").public_key().to_hex();
+    let post_swap_pubkey = state
+        .keys
+        .lock()
+        .expect("lock keys")
+        .as_ref()
+        .unwrap()
+        .public_key()
+        .to_hex();
     assert!(!state.is_pending_owned_channel(&post_swap_pubkey, "chan-1"));
 }
 

--- a/desktop/src-tauri/src/commands/engrams.rs
+++ b/desktop/src-tauri/src/commands/engrams.rs
@@ -137,10 +137,7 @@ pub async fn get_agent_memory(
     let agent = PublicKey::from_hex(&agent_pubkey)
         .map_err(|e| format!("agent pubkey must be 64-hex: {e}"))?;
 
-    let viewer_pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
-    };
+    let viewer_pubkey = { state.public_key()?.to_hex() };
 
     let managed = load_managed_agents(&app)?;
     let is_managed = managed.iter().any(|m| m.pubkey == agent_pubkey);
@@ -163,7 +160,7 @@ pub async fn get_agent_memory(
     // Owner = viewer. Clone the secret key out of the lock immediately so
     // we don't hold the mutex across the relay round trip.
     let (owner_pubkey, owner_seckey) = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
+        let keys = state.signing_keys()?;
         (keys.public_key(), keys.secret_key().clone())
     };
 

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -54,8 +54,7 @@ mod truncated_display_name_tests {
 
 #[tauri::command]
 pub fn get_identity(state: State<'_, AppState>) -> Result<IdentityInfo, String> {
-    let keys = state.keys.lock().map_err(|error| error.to_string())?;
-    let pubkey = keys.public_key();
+    let pubkey = state.public_key()?;
     let pubkey_hex = pubkey.to_hex();
     let display_name = truncated_display_name(&pubkey)?;
     let lost = state
@@ -71,7 +70,11 @@ pub fn get_identity(state: State<'_, AppState>) -> Result<IdentityInfo, String> 
     Ok(IdentityInfo {
         pubkey: pubkey_hex,
         display_name,
-        storage: state.identity_storage().as_str().to_string(),
+        storage: if crate::enterprise_identity::enabled() {
+            "enterprise".into()
+        } else {
+            state.identity_storage().as_str().to_string()
+        },
         lost,
         locked,
         reset_failed,
@@ -368,6 +371,10 @@ pub async fn import_identity(
     password: Option<String>,
     app_handle: tauri::AppHandle,
 ) -> Result<IdentityInfo, String> {
+    if crate::enterprise_identity::enabled() {
+        return Err("Local identity changes are unavailable in enterprise mode".into());
+    }
+
     tokio::task::spawn_blocking(move || {
         // NIP-49 backups require a passphrase and decrypt entirely in Rust.
         // Raw nsec/hex input follows the existing parser path unchanged.
@@ -439,8 +446,12 @@ pub(crate) fn commit_imported_identity(
     keys: nostr::Keys,
     persist: impl FnOnce(&nostr::Keys) -> Result<crate::app_state::IdentityStorage, String>,
 ) -> Result<(nostr::PublicKey, crate::app_state::IdentityStorage), String> {
+    if crate::enterprise_identity::enabled() {
+        return Err("Local-key import is unavailable in enterprise mode".into());
+    }
+
     // Capture the previous pubkey up front for post-commit cleanup.
-    let previous_pubkey = state.keys.lock().map_err(|e| e.to_string())?.public_key();
+    let previous_pubkey = state.public_key()?;
 
     let storage = persist(&keys)?;
 
@@ -450,7 +461,7 @@ pub(crate) fn commit_imported_identity(
     let pubkey = keys.public_key();
     {
         let mut active_keys = state.keys.lock().map_err(|e| e.to_string())?;
-        *active_keys = keys;
+        *active_keys = Some(keys);
         state.set_identity_storage(storage);
     }
 
@@ -496,6 +507,10 @@ pub(crate) fn commit_imported_identity(
 pub async fn persist_current_identity(
     app_handle: tauri::AppHandle,
 ) -> Result<IdentityInfo, String> {
+    if crate::enterprise_identity::enabled() {
+        return Err("Local identity changes are unavailable in enterprise mode".into());
+    }
+
     tokio::task::spawn_blocking(move || {
         let state = app_handle.state::<AppState>();
 
@@ -513,7 +528,7 @@ pub async fn persist_current_identity(
         }
 
         // Clone current keys without holding the mutex across keyring I/O.
-        let keys = state.keys.lock().map_err(|e| e.to_string())?.clone();
+        let keys = state.signing_keys()?;
 
         let data_dir = app_handle
             .path()
@@ -645,11 +660,7 @@ pub async fn sign_nostr_identity_binding(
         &expires_at,
     )?;
 
-    let keys = state
-        .keys
-        .lock()
-        .map_err(|error| error.to_string())?
-        .clone();
+    let keys = state.signing_keys()?;
 
     tauri::async_runtime::spawn_blocking(move || {
         let event = build_nostr_identity_binding_event(

--- a/desktop/src-tauri/src/commands/identity_archive.rs
+++ b/desktop/src-tauri/src/commands/identity_archive.rs
@@ -137,10 +137,7 @@ pub async fn resolve_oa_owner(
         return Ok(None);
     };
 
-    let my_pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
-    };
+    let my_pubkey = { state.public_key()?.to_hex() };
 
     Ok(Some(OwnerOfAgent {
         is_me: my_pubkey.eq_ignore_ascii_case(&owner_hex),
@@ -294,10 +291,7 @@ async fn maybe_owner_auth_tag(
     state: &AppState,
     target_pubkey: &str,
 ) -> Result<Option<[String; 4]>, String> {
-    let my_pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
-    };
+    let my_pubkey = { state.public_key()?.to_hex() };
 
     // Self path: never attach auth (spec §Self Requests: if actor==target and
     // an `auth` tag is also present, relay MUST treat it as self).
@@ -871,9 +865,9 @@ mod tests {
         let router = Router::new()
             .route(
                 "/events",
-                post(move || async move {
+                post(move |Json(event): Json<serde_json::Value>| async move {
                     Json(serde_json::json!({
-                        "event_id": "e".repeat(64),
+                        "event_id": event["id"],
                         "accepted": accepted,
                         "message": if accepted { "" } else { "rejected by relay" },
                     }))

--- a/desktop/src-tauri/src/commands/identity_key_backup_tests.rs
+++ b/desktop/src-tauri/src/commands/identity_key_backup_tests.rs
@@ -14,7 +14,14 @@ fn verification_returns_only_public_identity_and_match_status() {
     let result = verify_ncryptsec_backup_inner(&state, &backup, PASSWORD).unwrap();
     assert_eq!(
         result.pubkey,
-        state.keys.lock().unwrap().public_key().to_hex()
+        state
+            .keys
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .public_key()
+            .to_hex()
     );
     assert!(result.npub.starts_with("npub1"));
     assert!(result.matches_current_identity);
@@ -112,7 +119,7 @@ fn recovery_mode_blocks_backup_creation() {
 #[test]
 fn concurrent_identity_swap_vs_backup_is_serialized() {
     let state = std::sync::Arc::new(build_app_state());
-    let key_a = state.keys.lock().unwrap().clone();
+    let key_a = state.keys.lock().unwrap().as_ref().unwrap().clone();
     let key_b = Keys::generate();
 
     let swapper = {
@@ -122,7 +129,7 @@ fn concurrent_identity_swap_vs_backup_is_serialized() {
             // Mirrors import_identity's locking: mutation guard held
             // across the key swap.
             let _guard = state.identity_mutation.lock().unwrap();
-            *state.keys.lock().unwrap() = key_b;
+            *state.keys.lock().unwrap() = Some(key_b);
         })
     };
 

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -337,29 +337,31 @@ pub(crate) async fn sign_blossom_get_auth_header(
     ))
 }
 
-/// Mint a `t=get` Authorization header value for a relay media fetch, or
-/// `None` when signing is unavailable (identity in recovery mode).
-///
-/// When signing is unavailable, callers send no header and the relay rejects
-/// the read. This keeps recovery mode from accidentally treating a media URL
-/// as a bearer capability.
+/// Mint a relay media read proof. Corporate identity/proof failures propagate;
+/// only OSS recovery or local signing failure permits an unsigned request.
 ///
 /// Safety contract: callers must only attach the returned header to URLs
 /// constructed from (or validated against) the app's own relay base URL —
 /// never to third-party origins, where the bearer token would leak.
-pub(crate) async fn mint_media_get_auth(state: &AppState, base_url: &str) -> Option<String> {
+pub(crate) async fn mint_media_get_auth(
+    state: &AppState,
+    base_url: &str,
+) -> Result<Option<String>, String> {
+    if crate::enterprise_identity::enabled() {
+        return state.enterprise.media_read_proof(base_url).await.map(Some);
+    }
     let keys = match state.event_signer() {
         Ok(k) => k,
         Err(e) => {
             eprintln!("buzz-desktop: media get auth unavailable (unsigned request): {e}");
-            return None;
+            return Ok(None);
         }
     };
     match sign_blossom_get_auth_header(&keys, base_url, MEDIA_GET_AUTH_EXPIRY_SECS).await {
-        Ok(header) => Some(header),
+        Ok(header) => Ok(Some(header)),
         Err(e) => {
             eprintln!("buzz-desktop: media get auth signing failed (unsigned request): {e}");
-            None
+            Ok(None)
         }
     }
 }
@@ -418,12 +420,33 @@ async fn do_upload(
     progress: Option<(tauri::AppHandle, String)>,
     cancellation: Option<&CancellationToken>,
 ) -> Result<BlobDescriptor, String> {
+    let lifetime = if crate::enterprise_identity::enabled() {
+        state.enterprise.cancellation()?
+    } else {
+        CancellationToken::new()
+    };
+    tokio::select! {
+        biased;
+        _ = lifetime.cancelled() => Err("Corporate login changed; upload cancelled".into()),
+        result = do_upload_scoped(body, mime, state, progress, cancellation) => result,
+    }
+}
+
+async fn do_upload_scoped(
+    body: Vec<u8>,
+    mime: &str,
+    state: &AppState,
+    progress: Option<(tauri::AppHandle, String)>,
+    cancellation: Option<&CancellationToken>,
+) -> Result<BlobDescriptor, String> {
     let sha256 = hex::encode(Sha256::digest(&body));
 
     // Video uploads get a 1-hour auth window to survive slow connections;
     // images use 5 minutes. Must match the server-side max_age_secs values
     // in process_upload (600s) and process_video_upload (3600s).
-    let expiry_secs = if mime.starts_with("video/") {
+    let expiry_secs = if crate::enterprise_identity::enabled() {
+        300
+    } else if mime.starts_with("video/") {
         3600
     } else {
         300

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -253,9 +253,9 @@ fn redirect_refusal_error(status: reqwest::StatusCode) -> Option<String> {
 }
 
 /// Core streaming fetcher with a caller-supplied byte cap.
-pub(super) async fn fetch_blob_bytes_with_cap(
+pub(crate) async fn fetch_blob_bytes_with_cap(
     url: &str,
-    state: &State<'_, AppState>,
+    state: &AppState,
     cap: u64,
     cancellation: Option<&CancellationToken>,
 ) -> Result<Vec<u8>, String> {
@@ -269,7 +269,7 @@ pub(super) async fn fetch_blob_bytes_with_cap(
     // `validate_download_url`, satisfying the mint_media_get_auth safety
     // contract (the token never leaves the relay origin).
     let relay_base = relay_api_base_url_with_override(state);
-    if let Some(auth) = mint_media_get_auth(state, &relay_base).await {
+    if let Some(auth) = mint_media_get_auth(state, &relay_base).await? {
         req = req.header("authorization", auth);
     }
 

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -66,10 +66,7 @@ pub async fn get_feed(
         .map(|t| t.split(',').any(|s| s.trim() == "needs_action"))
         .unwrap_or(true);
 
-    let my_pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
-    };
+    let my_pubkey = { state.public_key()?.to_hex() };
 
     // Mentions: messages that reference me via #p.
     let mut mention_filter = serde_json::json!({
@@ -666,7 +663,7 @@ fn managed_agent_submission_auth_tag(
         return Ok(Some(auth_tag));
     }
 
-    let owner_keys = state.keys.lock().map_err(|error| error.to_string())?;
+    let owner_keys = state.signing_keys()?;
     legacy_managed_agent_auth_tag(&owner_keys, agent_pubkey)
 }
 
@@ -839,10 +836,7 @@ pub async fn remove_reaction(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     // Find our own kind:7 reaction event referencing the target.
-    let my_pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
-    };
+    let my_pubkey = { state.public_key()?.to_hex() };
     let target = event_id.trim();
     let trimmed_emoji = emoji.trim();
 

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -30,7 +30,7 @@ mod link_preview;
 mod managed_agent_definition;
 pub(crate) mod media;
 mod media_animated;
-mod media_download;
+pub(crate) mod media_download;
 mod media_fetch_cancellation;
 mod media_filename;
 mod media_gif;

--- a/desktop/src-tauri/src/commands/personas/card.rs
+++ b/desktop/src-tauri/src/commands/personas/card.rs
@@ -673,7 +673,7 @@ pub async fn mint_agent_card(
             // `media_download.rs`).
             let relay_base = crate::relay::relay_api_base_url_with_override(&state);
             let auth = if is_same_origin(url, &relay_base) {
-                crate::commands::media::mint_media_get_auth(&state, &relay_base).await
+                crate::commands::media::mint_media_get_auth(&state, &relay_base).await?
             } else {
                 None
             };

--- a/desktop/src-tauri/src/commands/personas/inbound/catalog_reconcile_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound/catalog_reconcile_tests.rs
@@ -80,7 +80,7 @@ fn team() -> TeamRecord {
 /// and overrides both so this handle's retention scope lands inside the tempdir.
 fn mock_app(keys: &nostr::Keys) -> tauri::App<tauri::test::MockRuntime> {
     let state = build_app_state();
-    *state.keys.lock().unwrap() = keys.clone();
+    *state.keys.lock().unwrap() = Some(keys.clone());
     *state.relay_url_override.lock().unwrap() = Some(RELAY.to_string());
 
     tauri::test::mock_builder()

--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -393,8 +393,7 @@ pub async fn get_presence(
 }
 
 fn current_pubkey_hex(state: &AppState) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|e| e.to_string())?;
-    Ok(keys.public_key().to_hex())
+    Ok(state.public_key()?.to_hex())
 }
 
 fn current_pubkey_hex_unwrap(state: &AppState) -> String {
@@ -425,11 +424,18 @@ mod tests {
 
         let captured = capture_expected_signer(&state, &original_pubkey)
             .expect("matching identity should be captured");
-        *state.keys.lock().expect("lock keys") = nostr::Keys::generate();
+        *state.keys.lock().expect("lock keys") = Some(nostr::Keys::generate());
 
         assert_eq!(captured.public_key().to_hex(), original_pubkey);
         assert_ne!(
-            state.keys.lock().expect("lock keys").public_key().to_hex(),
+            state
+                .keys
+                .lock()
+                .expect("lock keys")
+                .as_ref()
+                .unwrap()
+                .public_key()
+                .to_hex(),
             original_pubkey
         );
         assert_eq!(

--- a/desktop/src-tauri/src/commands/relay_members.rs
+++ b/desktop/src-tauri/src/commands/relay_members.rs
@@ -64,10 +64,7 @@ pub async fn list_relay_members(state: State<'_, AppState>) -> Result<serde_json
 pub async fn get_my_relay_membership(
     state: State<'_, AppState>,
 ) -> Result<serde_json::Value, String> {
-    let my_pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
-    };
+    let my_pubkey = { state.public_key()?.to_hex() };
 
     let events = query_relay(
         &state,

--- a/desktop/src-tauri/src/commands/teams/pending/tests/gate.rs
+++ b/desktop/src-tauri/src/commands/teams/pending/tests/gate.rs
@@ -149,7 +149,7 @@ fn seed_team_head(db_path: &Path, keys: &nostr::Keys, created_at: i64) {
 
 fn app_state_for(keys: nostr::Keys, relay_http: &str) -> crate::app_state::AppState {
     let state = build_app_state();
-    *state.keys.lock().unwrap() = keys;
+    *state.keys.lock().unwrap() = Some(keys);
     *state.relay_url_override.lock().unwrap() = Some(relay_http.to_string());
     state
 }

--- a/desktop/src-tauri/src/commands/teams/sharing/tests.rs
+++ b/desktop/src-tauri/src/commands/teams/sharing/tests.rs
@@ -301,7 +301,7 @@ async fn delayed_share_after_delete_never_republishes_the_catalog_head() {
     // 3. Flush the tombstone to the relay (Carl's contract: the tombstone
     //    lands BEFORE the delayed publish is released).
     let state = build_app_state();
-    *state.keys.lock().unwrap() = keys.clone();
+    *state.keys.lock().unwrap() = Some(keys.clone());
     *state.relay_url_override.lock().unwrap() = Some(relay_url);
     flush_pending_events_at(
         &db_path,
@@ -449,7 +449,7 @@ async fn concurrent_flushes_never_land_the_head_after_its_tombstone() {
     let _prepared = prepared(&db_path, relay_url.clone(), keys.clone(), true);
 
     let state = Arc::new(build_app_state());
-    *state.keys.lock().unwrap() = keys.clone();
+    *state.keys.lock().unwrap() = Some(keys.clone());
     *state.relay_url_override.lock().unwrap() = Some(relay_url.clone());
 
     // Flush H: publishes the pending head. Its POST blocks in the gated relay,

--- a/desktop/src-tauri/src/commands/workflows.rs
+++ b/desktop/src-tauri/src/commands/workflows.rs
@@ -387,8 +387,7 @@ fn trigger_wire_from_message(
 }
 
 fn current_pubkey_hex(state: &AppState) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|e| e.to_string())?;
-    Ok(keys.public_key().to_hex())
+    Ok(state.public_key()?.to_hex())
 }
 
 fn now_secs() -> i64 {

--- a/desktop/src-tauri/src/commands/workspace.rs
+++ b/desktop/src-tauri/src/commands/workspace.rs
@@ -107,11 +107,11 @@ pub struct ActiveWorkspaceInfo {
 /// Returns the current active workspace info (relay URL + pubkey).
 #[tauri::command]
 pub fn get_active_workspace(state: State<'_, AppState>) -> Result<ActiveWorkspaceInfo, String> {
-    let keys = state.keys.lock().map_err(|e| e.to_string())?;
+    let pubkey = state.public_key()?;
     let relay_url = relay::relay_ws_url_with_override(&state);
     Ok(ActiveWorkspaceInfo {
         relay_url,
-        pubkey: keys.public_key().to_hex(),
+        pubkey: pubkey.to_hex(),
     })
 }
 
@@ -158,6 +158,14 @@ pub async fn apply_workspace(
     app: AppHandle,
 ) -> Result<(), String> {
     let state = app.state::<AppState>();
+    if crate::enterprise_identity::enabled() {
+        let identity = state.enterprise.managed_identity()?;
+        if nsec.is_some() || relay_url != identity.relay_ws_url {
+            return Err("Corporate builds cannot change community or import local keys".into());
+        }
+        return Ok(());
+    }
+
     // Take the generation only after entering the serialized transaction. An
     // apply that is already running remains authoritative until it releases
     // the lock; the next apply then advances the generation. This keeps every
@@ -221,7 +229,7 @@ pub async fn apply_workspace(
 
         if let Some(keys) = parsed_keys {
             let mut keys_guard = state.keys.lock().map_err(|e| e.to_string())?;
-            *keys_guard = keys;
+            *keys_guard = Some(keys);
         }
 
         // Keep the backend-side reconcile guard aligned with the frontend

--- a/desktop/src-tauri/src/egress_guard_tests.rs
+++ b/desktop/src-tauri/src/egress_guard_tests.rs
@@ -277,6 +277,7 @@ const EVENTS_INVENTORY: &[(&str, usize, usize)] = &[
     ("src/native_websocket.rs", 0, 2),                  // boundary 8 (WS frames; no events URL)
     // Test-only fixtures — no production egress, no guard:
     ("src/relay_admission.rs", 1, 0),
+    ("src/relay/submit_signer_tests.rs", 1, 0), // synthetic ACK relay; guarded production funnel
     ("src/native_relay_client_transport_tests.rs", 1, 0),
     ("src/archive/mod_tests.rs", 1, 0),
     ("src/managed_agents/persona_events/tests.rs", 1, 0),

--- a/desktop/src-tauri/src/enterprise_build_config.rs
+++ b/desktop/src-tauri/src/enterprise_build_config.rs
@@ -1,0 +1,44 @@
+//! One build-consumer contract, called by build.rs and tested in the native suite.
+pub(crate) fn compile_config(raw: &str, system_keyring: bool) -> Result<String, String> {
+    if !system_keyring {
+        return Err("Corporate builds require system-keyring".into());
+    }
+    let config: buzz_ws_client_pkg::enterprise_oauth::EnterpriseLoginConfig =
+        serde_json::from_str(raw).map_err(|_| "Invalid corporate build configuration")?;
+    config.validate()?;
+    // Sorted JSON matches the release verifier, unlike declaration-order serialization.
+    let value = serde_json::to_value(config).map_err(|_| "Invalid corporate config")?;
+    serde_json::to_string(&value).map_err(|_| "Invalid corporate config".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const VALID: &str = r#"{"signerUrl":"https://signer.example/cash-app/goose/","issuer":"https://issuer.example/","clientId":"native-client","audience":"https://signer-api.example","organization":"org_corp","connection":"corporate","redirectUri":"http://127.0.0.1:45871/enterprise-callback"}"#;
+    #[test]
+    fn actual_build_consumer_requires_keyring_and_exact_native_schema() {
+        assert!(compile_config(VALID, false).is_err());
+        let canonical = compile_config(VALID, true).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&canonical).unwrap();
+        assert_eq!(parsed.as_object().unwrap().len(), 7);
+        assert_eq!(
+            parsed["redirectUri"],
+            "http://127.0.0.1:45871/enterprise-callback"
+        );
+        assert!(canonical.starts_with("{\"audience\":"));
+        for invalid in [
+            VALID.replace("45871", "0"),
+            VALID.replace("http://127.0.0.1", "http://localhost"),
+            VALID.replace("https://signer.example", "http://signer.example"),
+            VALID.replace("cash-app/goose/", "cash-app/goose/v1/buzz/identity/sign"),
+            VALID.replace("\"issuer\":", "\"environment\":\"staging\",\"issuer\":"),
+            VALID.replace(
+                "\"issuer\":",
+                "\"clientSecret\":\"not-allowed\",\"issuer\":",
+            ),
+            VALID.replace("\"issuer\":", "\"clientId\":\"duplicate\",\"issuer\":"),
+        ] {
+            assert!(compile_config(&invalid, true).is_err());
+        }
+    }
+}

--- a/desktop/src-tauri/src/enterprise_identity.rs
+++ b/desktop/src-tauri/src/enterprise_identity.rs
@@ -1,0 +1,369 @@
+//! Corporate login owns refresh credentials and session lifetime, never event construction.
+use buzz_ws_client_pkg::enterprise_callback::EnterpriseCallback;
+use buzz_ws_client_pkg::enterprise_oauth::{
+    EnterpriseLoginAttempt, EnterpriseLoginConfig, EnterpriseOAuthTokens,
+};
+use buzz_ws_client_pkg::event_signer::EventSigner;
+use buzz_ws_client_pkg::remote_identity::{
+    ManagedIdentity, RemoteAuthorization, RemoteCredentials, RemoteEventSigner,
+    RemoteIdentityClient,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tauri::{Emitter, Manager};
+use tauri_plugin_opener::OpenerExt;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio_util::sync::CancellationToken;
+
+pub(crate) fn build_config() -> Result<Option<EnterpriseLoginConfig>, String> {
+    option_env!("BUZZ_DESKTOP_BUILD_ENTERPRISE")
+        .map(|raw| {
+            let config: EnterpriseLoginConfig =
+                serde_json::from_str(raw).map_err(|_| "Invalid corporate build configuration")?;
+            config.validate()?;
+            Ok(config)
+        })
+        .transpose()
+}
+pub(crate) fn enabled() -> bool {
+    option_env!("BUZZ_DESKTOP_BUILD_ENTERPRISE").is_some()
+}
+
+#[derive(Default)]
+pub(crate) struct EnterpriseIdentity {
+    current: Mutex<Option<Arc<CorporateSession>>>,
+    login: AsyncMutex<()>,
+}
+struct CorporateSession {
+    identity: ManagedIdentity,
+    config: EnterpriseLoginConfig,
+    client: RemoteIdentityClient,
+    tokens: AsyncMutex<StoredTokens>,
+    cancelled: CancellationToken,
+    io: Arc<dyn CorporateSessionIo>,
+    media_reads: crate::enterprise_media_cache::MediaReadProofCache,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredTokens {
+    config: EnterpriseLoginConfig,
+    tokens: EnterpriseOAuthTokens,
+    expires_at: u64,
+    identity: ManagedIdentity,
+    // A durable rotation tombstone prevents replay after an ambiguous exchange/crash.
+    rotation_pending: bool,
+}
+fn now() -> Result<u64, String> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .map_err(|_| "Invalid system clock".into())
+}
+fn secret_store() -> &'static crate::secret_store::SecretStore {
+    static STORE: std::sync::OnceLock<crate::secret_store::SecretStore> =
+        std::sync::OnceLock::new();
+    STORE.get_or_init(|| {
+        crate::secret_store::SecretStore::keyring(format!(
+            "{}-enterprise",
+            crate::build_identity::keyring_service()
+        ))
+    })
+}
+fn persist(stored: &StoredTokens) -> Result<(), String> {
+    let encoded = zeroize::Zeroizing::new(
+        serde_json::to_string(stored).map_err(|_| "Cannot encode corporate credentials")?,
+    );
+    secret_store().store("session", &encoded)
+}
+// Narrow IO seam around the original storage/refresh lifecycle, shared by the
+// production owner and fault-injection tests. No identity lookup or event API.
+trait CorporateSessionIo: Send + Sync {
+    fn persist(&self, stored: &StoredTokens) -> Result<(), String>;
+    fn refresh<'a>(
+        &'a self,
+        config: &'a EnterpriseLoginConfig,
+        refresh: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<EnterpriseOAuthTokens, String>> + Send + 'a>>;
+}
+struct NativeSessionIo;
+impl CorporateSessionIo for NativeSessionIo {
+    fn persist(&self, stored: &StoredTokens) -> Result<(), String> {
+        persist(stored)
+    }
+    fn refresh<'a>(
+        &'a self,
+        config: &'a EnterpriseLoginConfig,
+        refresh: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<EnterpriseOAuthTokens, String>> + Send + 'a>> {
+        Box::pin(buzz_ws_client_pkg::enterprise_oauth::refresh(
+            config, refresh,
+        ))
+    }
+}
+impl RemoteAuthorization for CorporateSession {
+    fn check_active(&self) -> Result<(), String> {
+        if self.cancelled.is_cancelled() {
+            Err("Corporate identity changed; sign in again".into())
+        } else {
+            Ok(())
+        }
+    }
+    fn credentials(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<RemoteCredentials, String>> + Send + '_>> {
+        Box::pin(async move {
+            self.check_active()?;
+            let mut stored = self.tokens.lock().await;
+            self.check_active()?;
+            let result = async {
+                if stored.rotation_pending {
+                    return Err("Corporate rotation interrupted; sign in again".into());
+                }
+                if stored.expires_at <= now()? + 30 {
+                    stored.rotation_pending = true;
+                    self.io.persist(&stored)?;
+                    let refresh = stored
+                        .tokens
+                        .refresh_token
+                        .as_ref()
+                        .ok_or("Corporate session expired; sign in again")?;
+                    let fresh = self.io.refresh(&self.config, refresh).await?;
+                    self.check_active()?;
+                    // Refresh is authorization-only. Do not re-enroll or silently switch identity.
+                    // The sign response must match the pinned public key and exact event.
+                    let next = StoredTokens {
+                        config: self.config.clone(),
+                        expires_at: now()? + fresh.expires_in,
+                        tokens: fresh,
+                        identity: self.identity.clone(),
+                        rotation_pending: false,
+                    };
+                    self.io.persist(&next)?;
+                    *stored = next;
+                }
+                self.check_active()?;
+                Ok(RemoteCredentials::new(stored.tokens.access_token.clone()))
+            }
+            .await;
+            if result.is_err() {
+                self.cancelled.cancel();
+            }
+            result
+        })
+    }
+}
+impl EnterpriseIdentity {
+    fn session(&self) -> Result<Arc<CorporateSession>, String> {
+        let session = self
+            .current
+            .lock()
+            .map_err(|_| "Corporate identity lock failed")?
+            .clone()
+            .ok_or("Corporate login required")?;
+        session.check_active()?;
+        Ok(session)
+    }
+    pub(crate) fn managed_identity(&self) -> Result<ManagedIdentity, String> {
+        Ok(self.session()?.identity.clone())
+    }
+    pub(crate) fn event_signer(&self) -> Result<Arc<dyn EventSigner>, String> {
+        let session = self.session()?;
+        Ok(Arc::new(RemoteEventSigner::new(
+            session.client.clone(),
+            &session.identity,
+            session.clone(),
+        )?))
+    }
+    pub(crate) async fn media_read_proof(&self, base_url: &str) -> Result<String, String> {
+        let session = self.session()?;
+        if session.identity.relay_http_url.trim_end_matches('/') != base_url.trim_end_matches('/') {
+            return Err("Corporate media host does not match login".into());
+        }
+        let signer =
+            RemoteEventSigner::new(session.client.clone(), &session.identity, session.clone())?;
+        session
+            .media_reads
+            .get(
+                &signer,
+                session.identity.relay_http_url.trim_end_matches('/'),
+                &session.cancelled,
+            )
+            .await
+    }
+    pub(crate) fn cancellation(&self) -> Result<CancellationToken, String> {
+        Ok(self.session()?.cancelled.clone())
+    }
+    async fn invalidate(&self) -> Result<(), String> {
+        let old = self
+            .current
+            .lock()
+            .map_err(|_| "Corporate identity lock failed")?
+            .clone();
+        if let Some(old) = old {
+            old.cancelled.cancel();
+            old.media_reads.clear().await;
+            // Wait for an in-flight durable refresh before deleting/replacing its entry.
+            let _tokens = old.tokens.lock().await;
+        }
+        Ok(())
+    }
+    async fn install(
+        &self,
+        config: EnterpriseLoginConfig,
+        stored: StoredTokens,
+    ) -> Result<ManagedIdentity, String> {
+        if serde_json::to_value(&stored.config).map_err(|_| "Invalid saved configuration")?
+            != serde_json::to_value(&config).map_err(|_| "Invalid build configuration")?
+            || stored.rotation_pending
+            || stored.expires_at > now()? + 300
+        {
+            return Err("Corporate build or session changed; sign in again".into());
+        }
+        stored.identity.validate()?;
+        let session = Arc::new(CorporateSession {
+            identity: stored.identity.clone(),
+            client: RemoteIdentityClient::new(&config.signer_url)?,
+            config,
+            tokens: AsyncMutex::new(stored),
+            cancelled: CancellationToken::new(),
+            io: Arc::new(NativeSessionIo),
+            media_reads: Default::default(),
+        });
+        session.credentials().await?;
+        let identity = session.identity.clone();
+        let mut current = self
+            .current
+            .lock()
+            .map_err(|_| "Corporate identity lock failed")?;
+        if let Some(old) = current.replace(session) {
+            old.cancelled.cancel();
+        }
+        Ok(identity)
+    }
+}
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EnterpriseStatus {
+    enabled: bool,
+    identity: Option<ManagedIdentity>,
+}
+#[tauri::command]
+pub(crate) async fn enterprise_status(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, crate::app_state::AppState>,
+) -> Result<EnterpriseStatus, String> {
+    let Some(config) = build_config()? else {
+        return Ok(EnterpriseStatus {
+            enabled: false,
+            identity: None,
+        });
+    };
+    let _login = state.enterprise.login.lock().await;
+    // Never restore a cancelled in-memory login from its old durable credentials.
+    let current = state
+        .enterprise
+        .current
+        .lock()
+        .map_err(|_| "Corporate identity lock failed")?
+        .clone();
+    if let Some(session) = current {
+        let identity = if session.credentials().await.is_ok() {
+            Some(session.identity.clone())
+        } else {
+            None
+        };
+        return Ok(EnterpriseStatus {
+            enabled: true,
+            identity,
+        });
+    }
+    let Some(encoded) = secret_store().load("session")? else {
+        return Ok(EnterpriseStatus {
+            enabled: true,
+            identity: None,
+        });
+    };
+    let encoded = zeroize::Zeroizing::new(encoded);
+    let stored = serde_json::from_str(&encoded).map_err(|_| "Cannot restore corporate login")?;
+    let identity = state.enterprise.install(config, stored).await?;
+    app.state::<crate::native_relay_client::NativeRelayClient>()
+        .bind_identity(state.enterprise.cancellation()?)
+        .await;
+    *state
+        .relay_url_override
+        .lock()
+        .map_err(|_| "Relay lock failed")? = Some(identity.relay_ws_url.clone());
+    Ok(EnterpriseStatus {
+        enabled: true,
+        identity: Some(identity),
+    })
+}
+#[tauri::command]
+pub(crate) async fn enterprise_login(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, crate::app_state::AppState>,
+) -> Result<ManagedIdentity, String> {
+    let config = build_config()?.ok_or("Not a corporate build")?;
+    let _login = state.enterprise.login.lock().await;
+    state.enterprise.invalidate().await?;
+    app.state::<crate::native_relay_client::NativeRelayClient>()
+        .clear_identity()
+        .await;
+    secret_store().delete("session")?;
+    let callback = EnterpriseCallback::bind(&config).await?;
+    let mut verifier = [0; 32];
+    let mut nonce = [0; 32];
+    getrandom::getrandom(&mut verifier).map_err(|_| "Secure random unavailable")?;
+    getrandom::getrandom(&mut nonce).map_err(|_| "Secure random unavailable")?;
+    let attempt = EnterpriseLoginAttempt::new(verifier, nonce, config.redirect_uri.clone());
+    app.opener()
+        .open_url(attempt.authorization_url(&config)?.as_str(), None::<&str>)
+        .map_err(|_| "Cannot open corporate login")?;
+    let callback = callback.receive(&attempt).await?;
+    let tokens = attempt.exchange(&config, &callback).await?;
+    let identity = RemoteIdentityClient::new(&config.signer_url)?
+        .ensure(&RemoteCredentials::new(tokens.access_token.clone()))
+        .await?;
+    let stored = StoredTokens {
+        config: config.clone(),
+        expires_at: now()? + tokens.expires_in,
+        tokens,
+        identity,
+        rotation_pending: false,
+    };
+    persist(&stored)?;
+    let identity = state.enterprise.install(config, stored).await?;
+    app.state::<crate::native_relay_client::NativeRelayClient>()
+        .bind_identity(state.enterprise.cancellation()?)
+        .await;
+    *state
+        .relay_url_override
+        .lock()
+        .map_err(|_| "Relay lock failed")? = Some(identity.relay_ws_url.clone());
+    let _ = app.emit("enterprise-identity-changed", ());
+    Ok(identity)
+}
+#[tauri::command]
+pub(crate) async fn enterprise_logout(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, crate::app_state::AppState>,
+) -> Result<(), String> {
+    if !enabled() {
+        return Err("Not a corporate build".into());
+    }
+    let _login = state.enterprise.login.lock().await;
+    state.enterprise.invalidate().await?;
+    app.state::<crate::native_relay_client::NativeRelayClient>()
+        .clear_identity()
+        .await;
+    secret_store().delete("session")
+}
+
+#[cfg(test)]
+#[path = "enterprise_identity_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/enterprise_identity_tests.rs
+++ b/desktop/src-tauri/src/enterprise_identity_tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn config() -> EnterpriseLoginConfig {
+    serde_json::from_value(serde_json::json!({
+        "signerUrl":"https://signer.example/cash-app/goose/", "issuer":"https://issuer.example/",
+        "clientId":"native-client", "audience":"https://signer-api.example", "organization":"org_corp",
+        "connection":"corporate", "redirectUri":"http://127.0.0.1:45871/enterprise-callback"
+    })).unwrap()
+}
+fn tokens() -> EnterpriseOAuthTokens {
+    serde_json::from_value(serde_json::json!({"access_token":"synthetic-access", "refresh_token":"synthetic-rotation", "expires_in":300, "token_type":"Bearer"})).unwrap()
+}
+fn stored(expires_at: u64) -> StoredTokens {
+    StoredTokens {
+        config: config(),
+        tokens: tokens(),
+        expires_at,
+        identity: ManagedIdentity {
+            pubkey: nostr::Keys::generate().public_key().to_hex(),
+            relay_ws_url: "wss://buzz.example".into(),
+            relay_http_url: "https://buzz.example".into(),
+        },
+        rotation_pending: false,
+    }
+}
+#[derive(Default)]
+struct Io {
+    refreshes: AtomicUsize,
+    saves: Mutex<Vec<bool>>,
+    fail_save: usize,
+    fail_refresh: bool,
+    cancel_during_refresh: Option<CancellationToken>,
+}
+impl CorporateSessionIo for Io {
+    fn persist(&self, stored: &StoredTokens) -> Result<(), String> {
+        let mut saves = self.saves.lock().unwrap();
+        if self.fail_save == saves.len() + 1 {
+            return Err("secure storage unavailable".into());
+        }
+        saves.push(stored.rotation_pending);
+        Ok(())
+    }
+    fn refresh<'a>(
+        &'a self,
+        _: &'a EnterpriseLoginConfig,
+        refresh: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<EnterpriseOAuthTokens, String>> + Send + 'a>> {
+        Box::pin(async move {
+            assert_eq!(refresh, "synthetic-rotation");
+            assert_eq!(*self.saves.lock().unwrap(), vec![true]);
+            self.refreshes.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            if let Some(cancel) = &self.cancel_during_refresh {
+                cancel.cancel();
+            }
+            if self.fail_refresh {
+                return Err("refresh denied".into());
+            }
+            Ok(tokens())
+        })
+    }
+}
+fn session(io: Arc<Io>) -> Arc<CorporateSession> {
+    let stored = stored(0);
+    Arc::new(CorporateSession {
+        config: config(),
+        client: RemoteIdentityClient::new(&config().signer_url).unwrap(),
+        identity: stored.identity.clone(),
+        tokens: AsyncMutex::new(stored),
+        cancelled: CancellationToken::new(),
+        io,
+        media_reads: Default::default(),
+    })
+}
+#[test]
+fn absent_session_has_no_local_fallback() {
+    let owner = EnterpriseIdentity::default();
+    assert!(owner.event_signer().is_err());
+    assert!(owner.managed_identity().is_err());
+}
+#[tokio::test]
+async fn production_authorization_owner_singleflights_and_atomically_persists_rotation() {
+    let io = Arc::new(Io::default());
+    let session = session(io.clone());
+    let original = session.identity.clone();
+    let (a, b, c) = tokio::join!(
+        session.credentials(),
+        session.credentials(),
+        session.credentials()
+    );
+    assert!(a.is_ok() && b.is_ok() && c.is_ok());
+    assert_eq!(io.refreshes.load(Ordering::SeqCst), 1);
+    assert_eq!(*io.saves.lock().unwrap(), vec![true, false]);
+    assert_eq!(session.identity, original);
+    assert!(!session.tokens.lock().await.rotation_pending);
+}
+#[tokio::test]
+async fn every_storage_or_refresh_failure_cancels_owner_and_never_replays_token() {
+    for (fail_save, fail_refresh, refreshes, saved) in [
+        (1, false, 0, vec![]),
+        (2, false, 1, vec![true]),
+        (0, true, 1, vec![true]),
+    ] {
+        let io = Arc::new(Io {
+            fail_save,
+            fail_refresh,
+            ..Io::default()
+        });
+        let session = session(io.clone());
+        assert!(session.credentials().await.is_err());
+        assert!(session.cancelled.is_cancelled());
+        assert!(session.credentials().await.is_err());
+        assert_eq!(io.refreshes.load(Ordering::SeqCst), refreshes);
+        assert_eq!(*io.saves.lock().unwrap(), saved);
+    }
+}
+#[tokio::test]
+async fn logout_during_refresh_discards_response_and_leaves_durable_rotation_tombstone() {
+    let cancel = CancellationToken::new();
+    let io = Arc::new(Io {
+        cancel_during_refresh: Some(cancel.clone()),
+        ..Io::default()
+    });
+    let mut session = session(io.clone());
+    Arc::get_mut(&mut session).unwrap().cancelled = cancel;
+    assert!(session.credentials().await.is_err());
+    assert_eq!(*io.saves.lock().unwrap(), vec![true]);
+    assert!(session.tokens.lock().await.rotation_pending);
+}
+#[tokio::test]
+async fn invalidation_keeps_cancelled_owner_so_status_cannot_restore_old_disk_login() {
+    let owner = EnterpriseIdentity::default();
+    let session = session(Arc::new(Io::default()));
+    *owner.current.lock().unwrap() = Some(session.clone());
+    let signer = owner.event_signer().unwrap();
+    owner.invalidate().await.unwrap();
+    assert!(owner.current.lock().unwrap().is_some());
+    assert!(owner.managed_identity().is_err());
+    assert!(session.credentials().await.is_err());
+    let unsigned =
+        nostr::EventBuilder::new(nostr::Kind::TextNote, "old operation").build(signer.public_key());
+    assert!(signer.sign(unsigned).await.is_err());
+}
+#[tokio::test]
+async fn restore_refuses_interrupted_rotation_or_different_build_without_network() {
+    let owner = EnterpriseIdentity::default();
+    let mut pending = stored(now().unwrap() + 120);
+    pending.rotation_pending = true;
+    assert!(owner.install(config(), pending).await.is_err());
+    let mut changed = stored(now().unwrap() + 120);
+    changed.config.organization = "another-org".into();
+    assert!(owner.install(config(), changed).await.is_err());
+    assert!(owner.event_signer().is_err());
+}
+
+#[test]
+#[ignore = "run with a synthetic BUZZ_BUILD_ENTERPRISE config to test the actual compiled mode"]
+fn compiled_corporate_mode_has_no_key_and_rejects_import_before_persistence() {
+    assert!(enabled());
+    assert!(build_config().unwrap().is_some());
+    let state = crate::app_state::build_app_state();
+    assert!(state.keys.lock().unwrap().is_none());
+    assert!(state.signing_keys().is_err());
+    assert!(state.event_signer().is_err());
+    let mut called = false;
+    let result = crate::commands::commit_imported_identity(
+        &state,
+        std::path::Path::new("/unused"),
+        nostr::Keys::generate(),
+        |_| {
+            called = true;
+            Ok(crate::identity_storage::IdentityStorage::Ephemeral)
+        },
+    );
+    assert!(result.is_err());
+    assert!(!called);
+}
+
+// These invoke the three production transport consumers, not just proof minting.
+#[tokio::test]
+#[ignore = "requires synthetic compiled corporate configuration; never live credentials"]
+async fn compiled_corporate_media_consumers_never_transport_on_denial_or_logout() {
+    assert!(enabled());
+    let requests = Arc::new(AtomicUsize::new(0));
+    let recorded = requests.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            axum::Router::new().route(
+                "/media/blob",
+                axum::routing::get(move || {
+                    let recorded = recorded.clone();
+                    async move {
+                        recorded.fetch_add(1, Ordering::SeqCst);
+                        "must not reach media"
+                    }
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+    });
+    let mut outcomes = Vec::new();
+    for reason in ["missing", "logout", "proof-denial"] {
+        let state = crate::app_state::build_app_state();
+        *state.relay_url_override.lock().unwrap() = Some(base.clone());
+        if reason != "missing" {
+            // A valid HTTPS identity; the stale local relay origin must fail the
+            // real owner's proof check, not become optional auth on a stale URL.
+            let current = session(Arc::new(Io::default()));
+            *state.enterprise.current.lock().unwrap() = Some(current);
+            if reason == "logout" {
+                state.enterprise.invalidate().await.unwrap();
+            }
+        }
+        let response = crate::media_proxy::proxy_handler_with_state(
+            &state,
+            &state.http_client,
+            axum::http::Request::builder()
+                .uri("/media/blob")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await;
+        outcomes.push((reason, "streaming proxy", response.status().as_u16()));
+        let response = crate::media_proxy::handle_buzz_media_with_state(
+            &state,
+            &tauri::http::Request::builder()
+                .uri("buzz-media://localhost/media/blob")
+                .body(Vec::new())
+                .unwrap(),
+        )
+        .await;
+        outcomes.push((reason, "protocol proxy", response.status().as_u16()));
+        let result = crate::commands::media_download::fetch_blob_bytes_with_cap(
+            &format!("{base}/media/blob"),
+            &state,
+            1024,
+            None,
+        )
+        .await;
+        outcomes.push((reason, "download", if result.is_err() { 403 } else { 200 }));
+    }
+    server.abort();
+    assert_eq!(
+        requests.load(Ordering::SeqCst),
+        0,
+        "unsigned transport: {outcomes:?}"
+    );
+    assert!(
+        outcomes.iter().all(|(_, _, status)| *status == 403),
+        "{outcomes:?}"
+    );
+}
+
+#[tokio::test]
+async fn oss_media_consumers_preserve_optional_unsigned_auth() {
+    assert!(!enabled(), "run OSS suite without corporate build config");
+    let requests = Arc::new(AtomicUsize::new(0));
+    let recorded = requests.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            axum::Router::new().route(
+                "/media/blob",
+                axum::routing::get(move |headers: axum::http::HeaderMap| {
+                    let recorded = recorded.clone();
+                    async move {
+                        assert!(!headers.contains_key("authorization"));
+                        recorded.fetch_add(1, Ordering::SeqCst);
+                        "blob"
+                    }
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+    });
+    let state = crate::app_state::build_app_state();
+    *state.keys.lock().unwrap() = None;
+    *state.relay_url_override.lock().unwrap() = Some(base.clone());
+    let streaming = crate::media_proxy::proxy_handler_with_state(
+        &state,
+        &state.http_client,
+        axum::http::Request::builder()
+            .uri("/media/blob")
+            .body(axum::body::Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(streaming.status(), 200);
+    let protocol = crate::media_proxy::handle_buzz_media_with_state(
+        &state,
+        &tauri::http::Request::builder()
+            .uri("buzz-media://localhost/media/blob")
+            .body(Vec::new())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(protocol.status(), 200);
+    assert_eq!(
+        crate::commands::media_download::fetch_blob_bytes_with_cap(
+            &format!("{base}/media/blob"),
+            &state,
+            1024,
+            None,
+        )
+        .await
+        .unwrap(),
+        b"blob"
+    );
+    server.abort();
+    assert_eq!(requests.load(Ordering::SeqCst), 3);
+}

--- a/desktop/src-tauri/src/enterprise_media_cache.rs
+++ b/desktop/src-tauri/src/enterprise_media_cache.rs
@@ -1,0 +1,152 @@
+//! A single bounded read proof per corporate login. A new session gets a new cache.
+use buzz_ws_client_pkg::event_signer::EventSigner;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Default)]
+pub(crate) struct MediaReadProofCache {
+    entry: Mutex<Option<Entry>>,
+}
+struct Entry {
+    pubkey: nostr::PublicKey,
+    origin: String,
+    header: String,
+    expires_at: u64,
+}
+impl MediaReadProofCache {
+    pub(crate) async fn clear(&self) {
+        *self.entry.lock().await = None;
+    }
+
+    pub(crate) async fn get(
+        &self,
+        signer: &dyn EventSigner,
+        origin: &str,
+        cancelled: &CancellationToken,
+    ) -> Result<String, String> {
+        // Serializes avatar-grid bursts without unbounded in-flight work/cache entries.
+        tokio::select! {
+            biased;
+            _ = cancelled.cancelled() => Err("Corporate login changed; media proof cancelled".into()),
+            result = async {
+                let mut entry = self.entry.lock().await;
+                let now = nostr::Timestamp::now().as_secs();
+                if let Some(cached) = entry.as_ref() {
+                    if cached.pubkey == signer.public_key() && cached.origin == origin
+                        && cached.expires_at > now + 10 {
+                        return Ok(cached.header.clone());
+                    }
+                }
+                // Capture expiry before signing: signer latency must not extend cache validity.
+                *entry = None;
+                let header = crate::commands::media::sign_blossom_get_auth_header(
+                    signer, origin, 120,
+                ).await?;
+                if cancelled.is_cancelled() {
+                    return Err("Corporate login changed; media proof cancelled".into());
+                }
+                if now + 120 <= nostr::Timestamp::now().as_secs() + 10 {
+                    return Err("Corporate media proof expired while signing".into());
+                }
+                *entry = Some(Entry {
+                    pubkey: signer.public_key(), origin: origin.into(),
+                    header: header.clone(), expires_at: now + 120,
+                });
+                Ok(header)
+            } => result,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    struct Signer {
+        keys: nostr::Keys,
+        calls: AtomicUsize,
+        cancel: Option<CancellationToken>,
+    }
+    impl EventSigner for Signer {
+        fn public_key(&self) -> nostr::PublicKey {
+            self.keys.public_key()
+        }
+        fn sign(
+            &self,
+            event: nostr::UnsignedEvent,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<nostr::Event, String>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                if let Some(cancel) = &self.cancel {
+                    cancel.cancel();
+                }
+                event.sign_with_keys(&self.keys).map_err(|e| e.to_string())
+            })
+        }
+    }
+    fn signer() -> Signer {
+        Signer {
+            keys: nostr::Keys::generate(),
+            calls: AtomicUsize::new(0),
+            cancel: None,
+        }
+    }
+    #[tokio::test]
+    async fn production_cache_singleflights_and_fences_host_identity_expiry_and_new_session() {
+        let cache = MediaReadProofCache::default();
+        let signer = signer();
+        let cancel = CancellationToken::new();
+        let (a, b, c) = tokio::join!(
+            cache.get(&signer, "https://a.example", &cancel),
+            cache.get(&signer, "https://a.example", &cancel),
+            cache.get(&signer, "https://a.example", &cancel)
+        );
+        assert_eq!(a.unwrap(), b.unwrap());
+        assert!(c.is_ok());
+        assert_eq!(signer.calls.load(Ordering::SeqCst), 1);
+        cache
+            .get(&signer, "https://a.example:8443", &cancel)
+            .await
+            .unwrap();
+        assert_eq!(signer.calls.load(Ordering::SeqCst), 2);
+        cache.entry.lock().await.as_mut().unwrap().expires_at = 0;
+        cache
+            .get(&signer, "https://a.example:8443", &cancel)
+            .await
+            .unwrap();
+        assert_eq!(signer.calls.load(Ordering::SeqCst), 3);
+        let other = super::tests::signer();
+        cache
+            .get(&other, "https://a.example:8443", &cancel)
+            .await
+            .unwrap();
+        assert_eq!(other.calls.load(Ordering::SeqCst), 1);
+        cancel.cancel();
+        assert!(cache
+            .get(&other, "https://a.example:8443", &cancel)
+            .await
+            .is_err());
+        cache.clear().await;
+        assert!(cache.entry.lock().await.is_none());
+        MediaReadProofCache::default()
+            .get(&other, "https://a.example:8443", &CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(other.calls.load(Ordering::SeqCst), 2);
+    }
+    #[tokio::test]
+    async fn cancellation_during_sign_never_populates_cache() {
+        let cache = MediaReadProofCache::default();
+        let cancel = CancellationToken::new();
+        let mut signer = signer();
+        signer.cancel = Some(cancel.clone());
+        assert!(cache
+            .get(&signer, "https://a.example", &cancel)
+            .await
+            .is_err());
+        assert!(cache.entry.lock().await.is_none());
+    }
+}

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -308,11 +308,7 @@ pub async fn start_huddle(
                     *hs.agent_pubkeys.lock().unwrap_or_else(|e| e.into_inner()) =
                         successful_agents.clone();
                     hs.maybe_auto_enable_transcription_for_agents();
-                    let own_pubkey = state
-                        .keys
-                        .lock()
-                        .map(|k| k.public_key().to_hex())
-                        .unwrap_or_default();
+                    let own_pubkey = state.public_key().map(|k| k.to_hex()).unwrap_or_default();
                     let mut participants = successful_agents.clone();
                     if !own_pubkey.is_empty() && !participants.contains(&own_pubkey) {
                         participants.insert(0, own_pubkey);
@@ -428,11 +424,7 @@ pub async fn join_huddle(
     };
 
     // Seed participant list with own pubkey as a fallback until relay responds.
-    let own_pubkey = state
-        .keys
-        .lock()
-        .map(|k| k.public_key().to_hex())
-        .unwrap_or_default();
+    let own_pubkey = state.public_key().map(|k| k.to_hex()).unwrap_or_default();
 
     let committed = {
         let mut hs = state.huddle()?;

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -641,8 +641,8 @@ pub(crate) fn spawn_transcription_task(
     let spawned_gen = session_generation.load(Ordering::Acquire);
 
     let http_client = state.http_client.clone();
-    let keys = match state.keys.lock() {
-        Ok(k) => k.clone(),
+    let keys = match state.event_signer() {
+        Ok(k) => k,
         Err(_) => return,
     };
     let relay_base_url = crate::relay::relay_api_base_url_with_override(state);
@@ -714,6 +714,9 @@ pub(crate) fn spawn_transcription_task(
                 }
             };
 
+            if session_generation.load(Ordering::Acquire) != spawned_gen {
+                break;
+            }
             let response = {
                 http_client
                     .post(&url)

--- a/desktop/src-tauri/src/huddle/relay_api.rs
+++ b/desktop/src-tauri/src/huddle/relay_api.rs
@@ -187,7 +187,12 @@ pub(crate) async fn connect_audio_relay(
     state: &AppState,
 ) -> Result<(CancellationToken, tokio::sync::mpsc::Sender<Vec<u8>>), String> {
     let relay_url = crate::relay::relay_ws_url_with_override(state);
-    let keys = state.keys.lock().map_err(|e| e.to_string())?.clone();
+    let keys = state.event_signer()?;
+    let cancel = if crate::enterprise_identity::enabled() {
+        state.enterprise.cancellation()?.child_token()
+    } else {
+        CancellationToken::new()
+    };
 
     // TTS interrupt flags — recv task cancels TTS when remote humans speak.
     let (
@@ -211,11 +216,11 @@ pub(crate) async fn connect_audio_relay(
 
     let app_handle = state.app_handle.lock().ok().and_then(|g| g.clone());
 
-    let (ws_tx, ws_rx, _peer_index, initial_peers) =
-        connect_authenticated_audio_socket(channel_id, parent_channel_id, &relay_url, &keys, None)
-            .await?;
-
-    let cancel = CancellationToken::new();
+    let (ws_tx, ws_rx, _peer_index, initial_peers) = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return Err("Corporate login changed".into()),
+        result = connect_authenticated_audio_socket(channel_id, parent_channel_id, &relay_url, &keys, None) => result?,
+    };
     let cancel_clone = cancel.clone();
     let (pcm_tx, pcm_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(50);
     let output_device_name = state

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,10 @@ mod channel_head_cache;
 mod commands;
 mod deep_link;
 mod egress_guard;
+#[cfg(test)]
+mod enterprise_build_config;
+mod enterprise_identity;
+mod enterprise_media_cache;
 mod event_signing;
 mod event_sync;
 mod events;
@@ -448,7 +452,7 @@ pub fn run() {
             // has no relay override to the localhost fallback. Preserve the
             // boot-time repos and identity recovery safety gates by only marking
             // restoration pending when both allow it.
-            if restore_agents && !recovery_mode {
+            if restore_agents && !recovery_mode && !enterprise_identity::enabled() {
                 state
                     .managed_agent_restore_pending
                     .store(true, Ordering::Release);
@@ -538,6 +542,9 @@ pub fn run() {
             clear_pending_navigation_deep_links,
             take_pending_entity_deep_link,
             acknowledge_pending_entity_deep_link,
+            enterprise_identity::enterprise_status,
+            enterprise_identity::enterprise_login,
+            enterprise_identity::enterprise_logout,
             start_builderlab_login,
             cancel_builderlab_login,
             get_builderlab_auth,

--- a/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
@@ -966,7 +966,7 @@ mod flush_barrier {
         .sign_with_keys(&keys)
         .unwrap();
         let state = build_app_state();
-        *state.keys.lock().unwrap() = keys;
+        *state.keys.lock().unwrap() = Some(keys);
 
         let fresh = resign_with_fresh_timestamp(&stale, &state).unwrap();
 
@@ -1025,7 +1025,7 @@ mod flush_barrier {
         }
 
         let state = build_app_state();
-        *state.keys.lock().unwrap() = keys;
+        *state.keys.lock().unwrap() = Some(keys);
         *state.relay_url_override.lock().unwrap() = Some(spawn_stub_relay().await);
 
         let flushed = flush_pending_events(&db_path, &state).await.expect("flush");

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -239,12 +239,7 @@ pub async fn restore_managed_agents_on_launch(
     // Snapshot the workspace owner pubkey once for the legacy auth_tag fallback.
     // Read outside the per-agent spawn loop so all parallel spawns see the same
     // value and we don't lock `state.keys` repeatedly.
-    let owner_hex: Option<String> = state
-        .keys
-        .lock()
-        .map_err(|e| e.to_string())
-        .ok()
-        .map(|k| k.public_key().to_hex());
+    let owner_hex: Option<String> = state.public_key().ok().map(|k| k.to_hex());
 
     #[cfg(feature = "mesh-llm")]
     let agents_to_start = {

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -452,6 +452,10 @@ pub fn spawn_agent_child(
     owner_hex: Option<&str>,
     replay_floor_unix: Option<u64>,
 ) -> Result<crate::managed_agents::ManagedAgentProcess, String> {
+    if crate::enterprise_identity::enabled() {
+        return Err("Local managed-agent processes are unavailable in corporate builds".into());
+    }
+
     if let Some(error) = spawn_key_refusal(record) {
         return Err(error);
     }

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -283,11 +283,7 @@ fn start_pair(
     runtimes.remove(&key);
     terminate_untracked_pair_runtime(&app, &key)?;
 
-    let owner = state
-        .keys
-        .lock()
-        .ok()
-        .map(|keys| keys.public_key().to_hex());
+    let owner = state.public_key().ok().map(|k| k.to_hex());
     let mut process =
         spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref(), None)?;
     let now = crate::util::now_iso();

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -266,6 +266,9 @@ fn load_agent_store<R: tauri::Runtime>(
 pub fn load_managed_agents<R: tauri::Runtime>(
     app: &AppHandle<R>,
 ) -> Result<Vec<ManagedAgentRecord>, String> {
+    if crate::enterprise_identity::enabled() {
+        return Err("Local managed-agent keys are unavailable in corporate builds".into());
+    }
     let mut records = load_agent_store(app)?;
     records.retain(|record| !record.pubkey.is_empty());
     hydrate_keys(&mut records);

--- a/desktop/src-tauri/src/media_proxy.rs
+++ b/desktop/src-tauri/src/media_proxy.rs
@@ -27,6 +27,15 @@ struct ProxyState {
 }
 
 async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) -> Response {
+    let app_state = state.app_handle.state::<AppState>();
+    proxy_handler_with_state(&app_state, &state.client, req).await
+}
+
+pub(crate) async fn proxy_handler_with_state(
+    app_state: &AppState,
+    client: &reqwest::Client,
+    req: Request,
+) -> Response {
     // Allow requests with no Origin (e.g. <video> element fetches) or from
     // the Tauri webview origin. Blocks cross-origin JS fetches from other
     // tabs/apps while letting HTML media resource loads through.
@@ -46,21 +55,27 @@ async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) ->
         .unwrap_or("/");
 
     // Resolve relay URL dynamically so workspace switches take effect immediately.
-    let app_state = state.app_handle.state::<AppState>();
-    let base_url = relay::relay_api_base_url_with_override(&app_state);
+    let base_url = relay::relay_api_base_url_with_override(app_state);
     let upstream_url = format!("{base_url}{path_and_query}");
 
     let has_range = req.headers().contains_key("range");
 
-    let mut upstream = state
-        .client
+    let mut upstream = client
         .get(&upstream_url)
         .timeout(std::time::Duration::from_secs(120));
 
     // `upstream_url` is always `{relay base}{path}`, so the token can't reach
     // a third-party origin (mint_media_get_auth safety contract).
-    if let Some(auth) = mint_media_get_auth(&app_state, &base_url).await {
-        upstream = upstream.header("authorization", auth);
+    match mint_media_get_auth(app_state, &base_url).await {
+        Ok(Some(auth)) => upstream = upstream.header("authorization", auth),
+        Ok(None) => {} // OSS optional auth only.
+        Err(_) => {
+            return (
+                StatusCode::FORBIDDEN,
+                "corporate media authorization failed",
+            )
+                .into_response()
+        }
     }
 
     if let Some(range) = req.headers().get("range") {
@@ -162,7 +177,14 @@ pub async fn handle_buzz_media(
     use tauri::Manager;
 
     let state = app.state::<AppState>();
-    let base = relay::relay_api_base_url_with_override(&state);
+    handle_buzz_media_with_state(&state, request).await
+}
+
+pub(crate) async fn handle_buzz_media_with_state(
+    state: &AppState,
+    request: &http::Request<Vec<u8>>,
+) -> http::Response<Vec<u8>> {
+    let base = relay::relay_api_base_url_with_override(state);
 
     // Preserve path + query (thumbnails may have query params).
     // Only proxy /media/ paths — reject anything else.
@@ -187,8 +209,10 @@ pub async fn handle_buzz_media(
 
     // `upstream_url` is always `{relay base}{path}`, so the token can't reach
     // a third-party origin (mint_media_get_auth safety contract).
-    if let Some(auth) = mint_media_get_auth(&state, &base).await {
-        upstream = upstream.header("authorization", auth);
+    match mint_media_get_auth(state, &base).await {
+        Ok(Some(auth)) => upstream = upstream.header("authorization", auth),
+        Ok(None) => {} // OSS optional auth only.
+        Err(_) => return error_response(403, "corporate media authorization failed"),
     }
 
     if let Some(range) = request.headers().get("range") {

--- a/desktop/src-tauri/src/native_relay_client.rs
+++ b/desktop/src-tauri/src/native_relay_client.rs
@@ -87,6 +87,7 @@ pub(crate) struct MatchedEvent {
 #[derive(Default)]
 pub(crate) struct NativeRelayClient {
     current: Mutex<Option<ManagedSession>>,
+    lifetime: std::sync::Mutex<CancellationToken>,
 }
 
 struct ManagedSession {
@@ -135,6 +136,29 @@ impl Drop for SessionLease {
 }
 
 impl NativeRelayClient {
+    pub(crate) async fn clear_identity(&self) {
+        self.bind_identity(CancellationToken::new()).await;
+    }
+
+    pub(crate) async fn bind_identity(&self, lifetime: CancellationToken) {
+        let mut current = self.current.lock().await;
+        if let Some(old) = current.take() {
+            old.session.shutdown();
+        }
+        let mut token = self.lifetime.lock().unwrap_or_else(|e| e.into_inner());
+        token.cancel();
+        *token = lifetime;
+    }
+
+    fn start(&self, relay: String, keys: impl EventSigner + Clone + 'static) -> Arc<RelaySession> {
+        let token = self
+            .lifetime
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .child_token();
+        start_managed(relay, keys, None, token)
+    }
+
     /// Installs the session for `scope`, shutting down whatever scope held the
     /// slot. Destructive on entry, so every caller must already hold proof it
     /// is the current owner — today that is
@@ -152,7 +176,7 @@ impl NativeRelayClient {
         if let Some(previous) = current.take() {
             previous.session.shutdown();
         }
-        let session = start_managed(relay_url, keys, None);
+        let session = self.start(relay_url, keys);
         *current = Some(ManagedSession {
             scope,
             session: Arc::clone(&session),
@@ -198,12 +222,12 @@ impl NativeRelayClient {
                 }
             } else {
                 SessionLease {
-                    session: start_managed(relay_url, keys, None),
+                    session: self.start(relay_url, keys),
                     private: true,
                 }
             };
         }
-        let session = start_managed(relay_url, keys, None);
+        let session = self.start(relay_url, keys);
         *current = Some(ManagedSession {
             scope,
             session: Arc::clone(&session),
@@ -400,7 +424,7 @@ pub(crate) async fn start(
     keys: impl EventSigner + Clone + 'static,
     auth_tag: Option<nostr::Tag>,
 ) -> (Arc<RelaySession>, mpsc::Receiver<MatchedEvent>) {
-    let session = start_managed(relay_url, keys, auth_tag);
+    let session = start_managed(relay_url, keys, auth_tag, CancellationToken::new());
     let events = session.attach_archive().await;
     (session, events)
 }
@@ -409,6 +433,7 @@ fn start_managed(
     relay_url: String,
     keys: impl EventSigner + Clone + 'static,
     auth_tag: Option<nostr::Tag>,
+    cancel: CancellationToken,
 ) -> Arc<RelaySession> {
     let (wake, wake_rx) = mpsc::channel(1);
     let session = Arc::new(RelaySession {
@@ -416,7 +441,7 @@ fn start_managed(
         requests: Arc::new(Mutex::new(HashMap::new())),
         archive_events: Arc::new(Mutex::new(None)),
         wake,
-        cancel: CancellationToken::new(),
+        cancel,
     });
 
     tauri::async_runtime::spawn(run_session(
@@ -443,7 +468,12 @@ async fn run_session(
             return;
         }
 
-        match NostrWsConnection::connect_authenticated(&relay_url, &keys, auth_tag.as_ref()).await {
+        let connection = tokio::select! {
+            biased;
+            _ = session.cancel.cancelled() => return,
+            result = NostrWsConnection::connect_authenticated(&relay_url, &keys, auth_tag.as_ref()) => result,
+        };
+        match connection {
             Ok(conn) => {
                 // A connection that authenticated is healthy regardless of how
                 // long it then lived, so backoff resets here rather than on

--- a/desktop/src-tauri/src/native_relay_client_tests.rs
+++ b/desktop/src-tauri/src/native_relay_client_tests.rs
@@ -894,3 +894,22 @@ async fn the_first_lease_installs_a_session_the_archive_then_reuses() {
 
 #[path = "native_relay_client_transport_tests.rs"]
 mod transport_tests;
+
+#[tokio::test]
+async fn corporate_lifetime_cancels_native_sessions_and_replacement_never_revives_old_session() {
+    let client = NativeRelayClient::default();
+    let lifetime = CancellationToken::new();
+    client.bind_identity(lifetime.clone()).await;
+    let old = client.start("ws://127.0.0.1:1".into(), Keys::generate());
+    assert!(!old.cancel.is_cancelled());
+    lifetime.cancel();
+    assert!(old.cancel.is_cancelled());
+    let replacement = CancellationToken::new();
+    client.bind_identity(replacement.clone()).await;
+    let fresh = client.start("ws://127.0.0.1:1".into(), Keys::generate());
+    assert!(!fresh.cancel.is_cancelled());
+    assert!(old.cancel.is_cancelled());
+    client.clear_identity().await;
+    assert!(fresh.cancel.is_cancelled());
+    assert!(replacement.is_cancelled());
+}

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -125,11 +125,7 @@ pub async fn build_nip98_auth_header(
     body: &[u8],
     state: &AppState,
 ) -> Result<String, String> {
-    let keys = state
-        .keys
-        .lock()
-        .map_err(|error| error.to_string())?
-        .clone();
+    let keys = state.event_signer()?;
     build_nip98_auth_header_for_keys(&keys, method, url, body).await
 }
 
@@ -646,11 +642,12 @@ pub async fn submit_event_with_keys(
     keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&str>,
 ) -> Result<SubmitEventResponse, String> {
+    let base = relay_api_base_url_with_override(state);
     let event = builder
         .sign_with_event_signer(keys)
         .await
         .map_err(|e| format!("failed to sign event: {e}"))?;
-    submit_signed_event_with_keys(&event, state, keys, auth_tag).await
+    submit_signed_event_at_with_auth(&event, state, &base, keys, auth_tag).await
 }
 
 /// POST an already-signed event using the same explicit identity for NIP-98.
@@ -660,11 +657,22 @@ pub async fn submit_signed_event_with_keys(
     keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&str>,
 ) -> Result<SubmitEventResponse, String> {
+    let base = relay_api_base_url_with_override(state);
+    submit_signed_event_at_with_auth(event, state, &base, keys, auth_tag).await
+}
+
+pub(crate) async fn submit_signed_event_at_with_auth(
+    event: &nostr::Event,
+    state: &AppState,
+    base: &str,
+    keys: &(impl EventSigner + ?Sized),
+    auth_tag: Option<&str>,
+) -> Result<SubmitEventResponse, String> {
     if event.pubkey != keys.public_key() {
         return Err("signed event does not match the publishing identity".to_string());
     }
     crate::relay_admission::wait_for_rate_limit().await;
-    let url = format!("{}/events", relay_api_base_url_with_override(state));
+    let url = format!("{}/events", base.trim_end_matches('/'));
     let body_bytes = event.as_json().into_bytes();
     crate::egress_guard::assert_no_key_backup_bytes(&body_bytes, "signed event submit (keys)")?;
     let auth_header =
@@ -693,6 +701,9 @@ pub async fn submit_signed_event_with_keys(
 
     if !result.accepted {
         return Err(format!("relay rejected event: {}", result.message));
+    }
+    if result.event_id != event.id.to_hex() {
+        return Err("Relay acknowledgement ID mismatch".into());
     }
 
     Ok(result)

--- a/desktop/src-tauri/src/relay/submit.rs
+++ b/desktop/src-tauri/src/relay/submit.rs
@@ -49,6 +49,9 @@ pub async fn submit_signed_event_at_with_keys(
     if !result.accepted {
         return Err(format!("relay rejected event: {}", result.message));
     }
+    if result.event_id != event.id.to_hex() {
+        return Err("Relay acknowledgement ID mismatch".into());
+    }
 
     Ok(result)
 }
@@ -121,11 +124,17 @@ pub async fn submit_event_with_keys_created_at(
     keys: &(impl EventSigner + ?Sized),
     auth_tag: Option<&str>,
 ) -> Result<(SubmitEventResponse, i64), String> {
+    let base = relay_api_base_url_with_override(state);
     let event = builder
         .sign_with_event_signer(keys)
         .await
         .map_err(|e| format!("failed to sign event: {e}"))?;
     let created_at = event.created_at.as_secs() as i64;
-    let result = super::submit_signed_event_with_keys(&event, state, keys, auth_tag).await?;
+    let result =
+        super::submit_signed_event_at_with_auth(&event, state, &base, keys, auth_tag).await?;
     Ok((result, created_at))
 }
+
+#[cfg(test)]
+#[path = "submit_signer_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/relay/submit_signer_tests.rs
+++ b/desktop/src-tauri/src/relay/submit_signer_tests.rs
@@ -1,0 +1,106 @@
+//! Synthetic tests drive the actual delayed signer -> HTTP submit -> ACK path.
+use super::*;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use tokio::sync::Notify;
+
+struct DelayedSigner {
+    keys: nostr::Keys,
+    calls: AtomicUsize,
+    entered: Notify,
+    release: Notify,
+}
+impl EventSigner for DelayedSigner {
+    fn public_key(&self) -> nostr::PublicKey {
+        self.keys.public_key()
+    }
+    fn sign(
+        &self,
+        event: nostr::UnsignedEvent,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<nostr::Event, String>> + Send + '_>,
+    > {
+        Box::pin(async move {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.entered.notify_one();
+                self.release.notified().await;
+            }
+            event.sign_with_keys(&self.keys).map_err(|e| e.to_string())
+        })
+    }
+}
+
+#[tokio::test]
+async fn delayed_signer_preserves_captured_relay_and_identity_and_requires_exact_ack_id() {
+    use crate::relay_admission::{reset_rate_limit_gate, TEST_SERIAL};
+    use axum::{routing::post, Json, Router};
+    use nostr::JsonUtil;
+    let _serial = TEST_SERIAL.lock().await;
+    reset_rate_limit_gate();
+    for wrong_ack in [false, true] {
+        let captured = Arc::new(std::sync::Mutex::new(Vec::<nostr::Event>::new()));
+        let received = captured.clone();
+        let router = Router::new().route(
+            "/events",
+            post(move |Json(event): Json<nostr::Event>| {
+                let received = received.clone();
+                async move {
+                    event.verify().unwrap();
+                    let id = if wrong_ack {
+                        "f".repeat(64)
+                    } else {
+                        event.id.to_hex()
+                    };
+                    received.lock().unwrap().push(event);
+                    Json(serde_json::json!({"event_id":id,"accepted":true,"message":""}))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let state = Arc::new(crate::app_state::build_app_state());
+        let signer = Arc::new(DelayedSigner {
+            keys: nostr::Keys::generate(),
+            calls: AtomicUsize::new(0),
+            entered: Notify::new(),
+            release: Notify::new(),
+        });
+        let task_state = state.clone();
+        let task_signer = signer.clone();
+        let task = tokio::spawn(async move {
+            submit_event_at_with_keys(
+                nostr::EventBuilder::new(nostr::Kind::TextNote, "immutable message"),
+                &task_state,
+                &base,
+                &task_signer,
+            )
+            .await
+        });
+        signer.entered.notified().await;
+        *state.relay_url_override.lock().unwrap() = Some("ws://127.0.0.1:1".into());
+        *state.keys.lock().unwrap() = Some(nostr::Keys::generate());
+        signer.release.notify_one();
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .unwrap()
+            .unwrap();
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].pubkey, signer.public_key());
+        assert_eq!(events[0].content, "immutable message");
+        let saved = events[0].as_json();
+        assert_eq!(nostr::Event::from_json(saved).unwrap().id, events[0].id);
+        if wrong_ack {
+            assert!(result.unwrap_err().contains("ID mismatch"));
+        } else {
+            assert_eq!(result.unwrap().event_id, events[0].id.to_hex());
+        }
+        server.abort();
+    }
+    reset_rate_limit_gate();
+}

--- a/desktop/src/features/agents/ui/AgentsScreen.tsx
+++ b/desktop/src/features/agents/ui/AgentsScreen.tsx
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
@@ -123,9 +124,16 @@ export function AgentsScreen() {
     >
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
-          <React.Suspense fallback={<ViewLoadingFallback kind="agents" />}>
-            <AgentsView />
-          </React.Suspense>
+          {!supportsLocalIdentityFeatures() ? (
+            <p className="p-6 text-sm text-muted-foreground">
+              Local managed agents are unavailable in this enterprise build. You
+              can still talk to authorized agents in your community.
+            </p>
+          ) : (
+            <React.Suspense fallback={<ViewLoadingFallback kind="agents" />}>
+              <AgentsView />
+            </React.Suspense>
+          )}
           {profilePanelTarget ? (
             <UserProfilePanel
               canResetWidth={threadPanelWidth.canReset}

--- a/desktop/src/features/channels/readState/readStateManager.test.mjs
+++ b/desktop/src/features/channels/readState/readStateManager.test.mjs
@@ -909,3 +909,40 @@ test("rememberPublishedId_evictsOldestBeyondCap", () => {
 
   mgr.destroy();
 });
+
+test("managed read markers persist locally without encryption, subscription or relay publish", async () => {
+  const { setManagedIdentityMode } = await import(
+    "@/shared/api/identityCapabilities"
+  );
+  const storage = makeLocalStorage();
+  globalThis.window.localStorage = storage;
+  const { timers, restore } = withFakeTimers();
+  let calls = 0;
+  const forbidden = async () => {
+    calls++;
+    throw new Error("no encrypted relay work");
+  };
+  const relay = {
+    fetchEvents: forbidden,
+    subscribeLive: forbidden,
+    publishEvent: forbidden,
+  };
+  setManagedIdentityMode(true);
+  const manager = new ReadStateManager("1".repeat(64), relay);
+  try {
+    await manager.initialize();
+    manager.markContextRead("channel-1", 100);
+    timers.runAll();
+    manager.destroy();
+    const restored = new ReadStateManager("1".repeat(64), relay);
+    await restored.initialize();
+    assert.equal(restored.getEffectiveTimestamp("channel-1"), 100);
+    restored.destroy();
+    assert.equal(calls, 0);
+    assert.equal(timers.size, 0);
+  } finally {
+    manager.destroy();
+    setManagedIdentityMode(false);
+    restore();
+  }
+});

--- a/desktop/src/features/channels/readState/readStateManager.ts
+++ b/desktop/src/features/channels/readState/readStateManager.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { nip44EncryptToSelf, signRelayEvent } from "@/shared/api/tauri";
 import type { RelayClient } from "@/shared/api/relayClientSession";
 import type { RelayEvent } from "@/shared/api/types";
@@ -311,6 +312,11 @@ export class ReadStateManager {
     );
 
     this.hydrateFromLocalStorage();
+    if (!supportsLocalIdentityFeatures()) {
+      this.initialized = true;
+      this.notifyListeners();
+      return;
+    }
 
     await this.fetchAndMerge();
     if (this.destroyed) return;
@@ -632,6 +638,7 @@ export class ReadStateManager {
   }
 
   private schedulePublish(): void {
+    if (!supportsLocalIdentityFeatures()) return;
     if (this.destroyed) return;
     if (this.debounceTimer !== null) {
       window.clearTimeout(this.debounceTimer);
@@ -643,6 +650,7 @@ export class ReadStateManager {
   }
 
   private async publish(): Promise<void> {
+    if (!supportsLocalIdentityFeatures()) return;
     console.debug(`[ReadStateManager] publish starting slotId=${this.slotId}`);
     await this.fetchOwnBlobBeforePublish();
     if (this.destroyed) return;

--- a/desktop/src/features/communities/EnterpriseLoginGate.tsx
+++ b/desktop/src/features/communities/EnterpriseLoginGate.tsx
@@ -1,0 +1,143 @@
+import { setManagedIdentityMode } from "@/shared/api/identityCapabilities";
+import { useEffect, useState, useRef, type ReactNode } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useCommunities } from "./useCommunities";
+import { markCommunityOnboardingComplete } from "@/features/onboarding/communityOnboarding";
+
+type Identity = { pubkey: string; relayWsUrl: string; relayHttpUrl: string };
+type Status = { enabled: boolean; identity: Identity | null };
+
+/** Release-selected login gate; never turns a failed corporate login into local-key onboarding. */
+export function EnterpriseLoginGate({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const { addCommunity, switchCommunity } = useCommunities();
+
+  function accept(identity: Identity) {
+    setManagedIdentityMode(true);
+    const id = addCommunity({
+      id: `enterprise-${identity.pubkey}`,
+      name: "Work",
+      relayUrl: identity.relayWsUrl,
+      pubkey: identity.pubkey,
+      addedAt: new Date().toISOString(),
+    });
+    switchCommunity(id);
+    markCommunityOnboardingComplete(identity.pubkey, identity.relayWsUrl);
+    localStorage.setItem(
+      `buzz-machine-onboarding-complete.v2:${identity.pubkey}`,
+      "true",
+    );
+    setStatus({ enabled: true, identity });
+  }
+
+  const acceptRef = useRef(accept);
+  acceptRef.current = accept;
+
+  useEffect(() => {
+    let active = true;
+    invoke<Status>("enterprise_status")
+      .then((next) => {
+        if (!active) return;
+        setManagedIdentityMode(next.enabled);
+        if (next.identity) acceptRef.current(next.identity);
+        else setStatus(next);
+      })
+      .catch(() => {
+        if (active) {
+          setManagedIdentityMode(true);
+          setStatus({ enabled: true, identity: null });
+          setError("Your work session could not be restored. Sign in again.");
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!status?.enabled || !status.identity) return;
+    let active = true;
+    const timer = window.setInterval(() => {
+      void invoke<Status>("enterprise_status")
+        .then((next) => {
+          if (active && !next.identity) {
+            setStatus(next);
+            setError("Your work session expired. Sign in again.");
+          }
+        })
+        .catch(() => {
+          if (active) {
+            setStatus({ enabled: true, identity: null });
+            setError(
+              "Your work session could not be refreshed. Sign in again.",
+            );
+          }
+        });
+    }, 60_000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [status?.enabled, status?.identity]);
+
+  if (status?.enabled === false) return children;
+  if (status?.identity)
+    return (
+      <>
+        {children}
+        <button
+          type="button"
+          className="fixed bottom-2 right-2 z-50 rounded bg-background px-3 py-1 text-xs text-muted-foreground shadow"
+          onClick={async () => {
+            try {
+              await invoke("enterprise_logout");
+              setStatus({ enabled: true, identity: null });
+            } catch {
+              setError(
+                "Sign-out could not remove saved credentials. Try again.",
+              );
+              setStatus({ enabled: true, identity: null });
+            }
+          }}
+        >
+          Sign out of work account
+        </button>
+      </>
+    );
+
+  return (
+    <main className="flex h-screen flex-col items-center justify-center gap-4 bg-background p-8 text-foreground">
+      <h1 className="text-xl font-semibold">Sign in to Buzz for work</h1>
+      <p className="text-sm">
+        Your organization manages your identity and community.
+      </p>
+      {error ? (
+        <p role="alert" className="text-sm">
+          {error}
+        </p>
+      ) : null}
+      <button
+        type="button"
+        className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+        disabled={!status || busy}
+        onClick={async () => {
+          setBusy(true);
+          setError(null);
+          try {
+            accept(await invoke<Identity>("enterprise_login"));
+          } catch {
+            setError("Sign-in did not complete. Try again.");
+          } finally {
+            setBusy(false);
+          }
+        }}
+      >
+        {busy
+          ? "Waiting for corporate sign-in…"
+          : "Sign in with corporate account"}
+      </button>
+    </main>
+  );
+}

--- a/desktop/src/features/communities/communityMarkRead.ts
+++ b/desktop/src/features/communities/communityMarkRead.ts
@@ -1,3 +1,4 @@
+import { requireLocalIdentityFeature } from "@/shared/api/identityCapabilities";
 import { READ_STATE_MAX_PLAINTEXT_BYTES } from "@/features/channels/readState/readStateFormat";
 import type { Community } from "@/features/communities/types";
 import { fetchObservedChannels } from "@/features/communities/communityUnreadObserver";
@@ -81,6 +82,7 @@ export async function publishCommunityReadState(args: {
   encrypt?: (plaintext: string) => Promise<string>;
   sign?: SignEvent;
 }): Promise<void> {
+  requireLocalIdentityFeature("Cross-community read-state sync");
   const { client, pubkey, relayUrl } = args;
   const encrypt = args.encrypt ?? nip44EncryptToSelf;
   const sign = args.sign ?? signRelayEvent;

--- a/desktop/src/features/communities/useCommunityUnread.ts
+++ b/desktop/src/features/communities/useCommunityUnread.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 
 import { getIdentity } from "@/shared/api/tauriIdentity";
@@ -111,7 +112,10 @@ export function useCommunityUnread(
     };
 
     const pollInactiveCommunities = async () => {
-      if (inactiveCommunities.length === 0) {
+      if (
+        !supportsLocalIdentityFeatures() ||
+        inactiveCommunities.length === 0
+      ) {
         return;
       }
 

--- a/desktop/src/features/projects/lib/projectSidebarMembershipSync.ts
+++ b/desktop/src/features/projects/lib/projectSidebarMembershipSync.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { relayClient } from "@/shared/api/relayClient";
 import {
   nip44DecryptFromSelf,
@@ -60,6 +61,7 @@ export class ProjectSidebarMembershipSyncManager {
   async fetchRemoteMembership(): Promise<
     FetchResult<RemoteProjectSidebarMembership>
   > {
+    if (!supportsLocalIdentityFeatures()) return { status: "failed" };
     try {
       const events = await relayClient.fetchEvents({
         kinds: [KIND_PROJECT_SIDEBAR_MEMBERSHIP],
@@ -106,6 +108,7 @@ export class ProjectSidebarMembershipSyncManager {
   }
 
   publishMembership(store: ProjectSidebarMembershipStore): void {
+    if (!supportsLocalIdentityFeatures()) return;
     this.pendingStore = store;
     if (this.debounceTimer !== null) {
       window.clearTimeout(this.debounceTimer);
@@ -185,6 +188,7 @@ export class ProjectSidebarMembershipSyncManager {
   async subscribe(
     onUpdate: (remote: RemoteProjectSidebarMembership) => void,
   ): Promise<() => Promise<void>> {
+    if (!supportsLocalIdentityFeatures()) return async () => {};
     return relayClient.subscribeLive(
       {
         kinds: [KIND_PROJECT_SIDEBAR_MEMBERSHIP],

--- a/desktop/src/features/projects/lib/useProjectSidebarMembership.ts
+++ b/desktop/src/features/projects/lib/useProjectSidebarMembership.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
@@ -40,6 +41,7 @@ export function useProjectSidebarMembership(
     setStore(readProjectSidebarMembershipStore(relayUrl, pubkey));
     lastAppliedRemoteTs.current = 0;
     lastAppliedEventId.current = "";
+    if (!supportsLocalIdentityFeatures()) return;
     managerRef.current = new ProjectSidebarMembershipSyncManager(
       pubkey,
       relayUrl,

--- a/desktop/src/features/reminders/hooks.ts
+++ b/desktop/src/features/reminders/hooks.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -26,7 +27,7 @@ export const countDueReminders = countDue;
  */
 export function useRemindersQuery(pubkey: string | undefined) {
   return useQuery({
-    enabled: Boolean(pubkey),
+    enabled: Boolean(pubkey) && supportsLocalIdentityFeatures(),
     queryKey: remindersQueryKey(pubkey ?? ""),
     queryFn: () => fetchReminders(pubkey ?? ""),
     staleTime: 30_000,

--- a/desktop/src/features/reminders/lib/reminderService.ts
+++ b/desktop/src/features/reminders/lib/reminderService.ts
@@ -1,3 +1,4 @@
+import { requireLocalIdentityFeature } from "@/shared/api/identityCapabilities";
 import { relayClient } from "@/shared/api/relayClient";
 import {
   nip44DecryptFromSelf,
@@ -142,6 +143,7 @@ async function decryptReminder(event: RelayEvent): Promise<Reminder | null> {
 }
 
 export async function fetchReminders(pubkey: string): Promise<Reminder[]> {
+  requireLocalIdentityFeature("Encrypted reminders");
   const events = await relayClient.fetchEvents({
     kinds: [KIND_EVENT_REMINDER],
     authors: [pubkey],
@@ -157,6 +159,7 @@ export async function createReminder(
   notBefore: number,
   note?: string,
 ): Promise<RelayEvent> {
+  requireLocalIdentityFeature("Encrypted reminders");
   const dTag = randomDTag();
   const content: ReminderContent = {
     target,
@@ -187,6 +190,7 @@ export async function completeReminder(
   _pubkey: string,
   reminder: Reminder,
 ): Promise<RelayEvent> {
+  requireLocalIdentityFeature("Encrypted reminders");
   const content: ReminderContent = {
     ...reminder.content,
     status: "done",
@@ -218,6 +222,7 @@ export async function snoozeReminder(
   reminder: Reminder,
   newNotBefore: number,
 ): Promise<RelayEvent> {
+  requireLocalIdentityFeature("Encrypted reminders");
   const content: ReminderContent = {
     ...reminder.content,
     status: "pending",
@@ -247,6 +252,7 @@ export async function cancelReminder(
   _pubkey: string,
   reminder: Reminder,
 ): Promise<RelayEvent> {
+  requireLocalIdentityFeature("Encrypted reminders");
   const content: ReminderContent = {
     ...reminder.content,
     status: "cancelled",

--- a/desktop/src/features/reminders/ui/RemindMeLaterProvider.tsx
+++ b/desktop/src/features/reminders/ui/RemindMeLaterProvider.tsx
@@ -1,3 +1,5 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
+import { toast } from "sonner";
 import * as React from "react";
 
 import { useRemindersQuery } from "@/features/reminders/hooks";
@@ -30,6 +32,12 @@ export function RemindMeLaterProvider({
   const [target, setTarget] = React.useState<ReminderTarget | null>(null);
 
   const openReminder = React.useCallback((t: ReminderTarget) => {
+    if (!supportsLocalIdentityFeatures()) {
+      toast.error(
+        "Encrypted reminders are unavailable with an organization-managed identity.",
+      );
+      return;
+    }
     setTarget(t);
     setOpen(true);
   }, []);

--- a/desktop/src/features/reminders/ui/RemindersPanel.tsx
+++ b/desktop/src/features/reminders/ui/RemindersPanel.tsx
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { ArrowLeft, Bell, Check, Clock, ExternalLink, X } from "lucide-react";
 import * as React from "react";
 import { toast } from "sonner";
@@ -306,6 +307,15 @@ export function RemindersPanel({
     () => groups.flatMap((group) => group.reminders),
     [groups],
   );
+
+  if (!supportsLocalIdentityFeatures()) {
+    return (
+      <p className="p-4 text-sm text-muted-foreground">
+        Encrypted reminders are unavailable with an organization-managed
+        identity.
+      </p>
+    );
+  }
 
   if (remindersQuery.isLoading) {
     return (

--- a/desktop/src/features/reminders/useReminderNotifications.ts
+++ b/desktop/src/features/reminders/useReminderNotifications.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -116,7 +117,7 @@ export function useReminderNotifications(
   });
 
   React.useEffect(() => {
-    if (!pubkey) return;
+    if (!pubkey || !supportsLocalIdentityFeatures()) return;
 
     const check = () => {
       // Defer until the query has resolved at least once — an empty array from

--- a/desktop/src/features/settings/ui/PrivateKeyBackupRow.tsx
+++ b/desktop/src/features/settings/ui/PrivateKeyBackupRow.tsx
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { Download, Eye, EyeOff, ShieldCheck } from "lucide-react";
 import * as React from "react";
 
@@ -58,6 +59,19 @@ function BackupAvailabilityFill({
  * while expanded; encrypted backup state lives in the app-level provider.
  */
 export function PrivateKeyBackupRow() {
+  if (!supportsLocalIdentityFeatures())
+    return (
+      <p className="text-sm text-muted-foreground">
+        Your organization holds your signing key. Private-key export, backup,
+        and pairing are unavailable. Read markers, sidebar preferences, and
+        appearance stay on this device; encrypted sync, reminders, and local
+        agent management are unavailable.
+      </p>
+    );
+  return <LocalPrivateKeyBackupRow />;
+}
+
+function LocalPrivateKeyBackupRow() {
   const [isOpen, setIsOpen] = React.useState(false);
   const [nsec, setNsec] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);

--- a/desktop/src/features/sidebar/lib/channelMutesSync.ts
+++ b/desktop/src/features/sidebar/lib/channelMutesSync.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { relayClient } from "@/shared/api/relayClient";
 import {
   nip44DecryptFromSelf,
@@ -55,6 +56,7 @@ export class ChannelMuteSyncManager {
   }
 
   async fetchRemoteMutes(): Promise<FetchResult<RemoteMutes>> {
+    if (!supportsLocalIdentityFeatures()) return { status: "failed" };
     try {
       const events = await relayClient.fetchEvents({
         kinds: [KIND_CHANNEL_MUTES],
@@ -101,6 +103,7 @@ export class ChannelMuteSyncManager {
   }
 
   publishMutes(store: ChannelMuteStore): void {
+    if (!supportsLocalIdentityFeatures()) return;
     this.pendingStore = store;
     if (this.debounceTimer !== null) {
       window.clearTimeout(this.debounceTimer);
@@ -197,6 +200,7 @@ export class ChannelMuteSyncManager {
   async subscribeToMutes(
     onUpdate: (remote: RemoteMutes) => void,
   ): Promise<() => Promise<void>> {
+    if (!supportsLocalIdentityFeatures()) return async () => {};
     return relayClient.subscribeLive(
       {
         kinds: [KIND_CHANNEL_MUTES],

--- a/desktop/src/features/sidebar/lib/channelSectionsSync.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsSync.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { relayClient } from "@/shared/api/relayClient";
 import {
   nip44DecryptFromSelf,
@@ -59,6 +60,7 @@ export class ChannelSectionSyncManager {
   }
 
   async fetchRemoteSections(): Promise<FetchResult<RemoteSections>> {
+    if (!supportsLocalIdentityFeatures()) return { status: "failed" };
     try {
       const events = await relayClient.fetchEvents({
         kinds: [KIND_CHANNEL_SECTIONS],
@@ -109,6 +111,7 @@ export class ChannelSectionSyncManager {
   }
 
   publishSections(store: ChannelSectionStore): void {
+    if (!supportsLocalIdentityFeatures()) return;
     this.pendingStore = store;
     if (this.debounceTimer !== null) {
       window.clearTimeout(this.debounceTimer);
@@ -226,6 +229,7 @@ export class ChannelSectionSyncManager {
   async subscribeToSections(
     onUpdate: (remote: RemoteSections) => void,
   ): Promise<() => Promise<void>> {
+    if (!supportsLocalIdentityFeatures()) return async () => {};
     return relayClient.subscribeLive(
       {
         kinds: [KIND_CHANNEL_SECTIONS],

--- a/desktop/src/features/sidebar/lib/channelSortSync.ts
+++ b/desktop/src/features/sidebar/lib/channelSortSync.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { relayClient } from "@/shared/api/relayClient";
 import {
   nip44DecryptFromSelf,
@@ -65,6 +66,7 @@ export class ChannelSortSyncManager {
   }
 
   async fetchRemoteSortPrefs(): Promise<FetchResult<RemoteSortPrefs>> {
+    if (!supportsLocalIdentityFeatures()) return { status: "failed" };
     try {
       const events = await relayClient.fetchEvents({
         kinds: [KIND_CHANNEL_SORT],
@@ -111,6 +113,7 @@ export class ChannelSortSyncManager {
   }
 
   publishSortPrefs(store: ChannelSortStore): void {
+    if (!supportsLocalIdentityFeatures()) return;
     this.pendingStore = store;
     if (this.debounceTimer !== null) {
       window.clearTimeout(this.debounceTimer);
@@ -213,6 +216,7 @@ export class ChannelSortSyncManager {
   async subscribeToSortPrefs(
     onUpdate: (remote: RemoteSortPrefs) => void,
   ): Promise<() => Promise<void>> {
+    if (!supportsLocalIdentityFeatures()) return async () => {};
     return relayClient.subscribeLive(
       {
         kinds: [KIND_CHANNEL_SORT],

--- a/desktop/src/features/sidebar/lib/channelStarsSync.ts
+++ b/desktop/src/features/sidebar/lib/channelStarsSync.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { relayClient } from "@/shared/api/relayClient";
 import {
   nip44DecryptFromSelf,
@@ -55,6 +56,7 @@ export class ChannelStarSyncManager {
   }
 
   async fetchRemoteStars(): Promise<FetchResult<RemoteStars>> {
+    if (!supportsLocalIdentityFeatures()) return { status: "failed" };
     try {
       const events = await relayClient.fetchEvents({
         kinds: [KIND_CHANNEL_STARS],
@@ -101,6 +103,7 @@ export class ChannelStarSyncManager {
   }
 
   publishStars(store: ChannelStarStore): void {
+    if (!supportsLocalIdentityFeatures()) return;
     this.pendingStore = store;
     if (this.debounceTimer !== null) {
       window.clearTimeout(this.debounceTimer);
@@ -197,6 +200,7 @@ export class ChannelStarSyncManager {
   async subscribeToStars(
     onUpdate: (remote: RemoteStars) => void,
   ): Promise<() => Promise<void>> {
+    if (!supportsLocalIdentityFeatures()) return async () => {};
     return relayClient.subscribeLive(
       {
         kinds: [KIND_CHANNEL_STARS],

--- a/desktop/src/features/sidebar/lib/useChannelMutes.ts
+++ b/desktop/src/features/sidebar/lib/useChannelMutes.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
@@ -44,6 +45,7 @@ export function useChannelMutes(
     setStore(readChannelMutesStore(pubkey));
     lastAppliedRemoteTs.current = 0;
     lastAppliedEventId.current = "";
+    if (!supportsLocalIdentityFeatures()) return;
     managerRef.current = new ChannelMuteSyncManager(pubkey, relayUrl);
     return () => {
       managerRef.current?.destroy();

--- a/desktop/src/features/sidebar/lib/useChannelSections.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSections.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
@@ -55,6 +56,7 @@ export function useChannelSections(
     setStore(readChannelSectionsStore(pubkey, relayUrl));
     lastAppliedRemoteTs.current = 0;
     lastAppliedEventId.current = "";
+    if (!supportsLocalIdentityFeatures()) return;
     managerRef.current = new ChannelSectionSyncManager(pubkey, relayUrl);
     return () => {
       managerRef.current?.destroy();

--- a/desktop/src/features/sidebar/lib/useChannelSortPreference.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSortPreference.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
@@ -59,6 +60,7 @@ export function useChannelSortPreference(
     setStore(readChannelSortStore(pubkey, relayUrl));
     lastAppliedRemoteTs.current = 0;
     lastAppliedEventId.current = "";
+    if (!supportsLocalIdentityFeatures()) return;
     managerRef.current = new ChannelSortSyncManager(pubkey, relayUrl);
     return () => {
       managerRef.current?.destroy();

--- a/desktop/src/features/sidebar/lib/useChannelStars.ts
+++ b/desktop/src/features/sidebar/lib/useChannelStars.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
@@ -44,6 +45,7 @@ export function useChannelStars(
     setStore(readChannelStarsStore(pubkey));
     lastAppliedRemoteTs.current = 0;
     lastAppliedEventId.current = "";
+    if (!supportsLocalIdentityFeatures()) return;
     managerRef.current = new ChannelStarSyncManager(pubkey, relayUrl);
     return () => {
       managerRef.current?.destroy();

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -10,6 +10,7 @@ import "@fontsource/jetbrains-mono/700.css";
 import "@/shared/styles/globals.css";
 import { UpdaterProvider } from "@/features/settings/hooks/UpdaterProvider";
 import { migrateLegacyCommunityStorageBeforeRender } from "@/features/communities/legacyCommunityStorage";
+import { EnterpriseLoginGate } from "@/features/communities/EnterpriseLoginGate";
 import { CommunitiesProvider } from "@/features/communities/useCommunities";
 import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
 import { CommunityOnboardingProvider } from "@/features/onboarding/communityOnboarding";
@@ -95,7 +96,9 @@ function renderApp() {
                 <EmojiBurstProvider>
                   <PoofBurstProvider>
                     <UpdaterProvider>
-                      <App />
+                      <EnterpriseLoginGate>
+                        <App />
+                      </EnterpriseLoginGate>
                       <NostrBindConsentDialog />
                     </UpdaterProvider>
                     <Toaster />

--- a/desktop/src/shared/api/identityCapabilities.test.mjs
+++ b/desktop/src/shared/api/identityCapabilities.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+import {
+  setManagedIdentityMode,
+  supportsLocalIdentityFeatures,
+  requireLocalIdentityFeature,
+} from "./identityCapabilities.ts";
+import { relayClient } from "./relayClient.ts";
+import { ChannelStarSyncManager } from "../../features/sidebar/lib/channelStarsSync.ts";
+import { ChannelMuteSyncManager } from "../../features/sidebar/lib/channelMutesSync.ts";
+import { ChannelSortSyncManager } from "../../features/sidebar/lib/channelSortSync.ts";
+import { ChannelSectionSyncManager } from "../../features/sidebar/lib/channelSectionsSync.ts";
+import { ProjectSidebarMembershipSyncManager } from "../../features/projects/lib/projectSidebarMembershipSync.ts";
+import { CommunityThemeSyncManager } from "../theme/communityThemeSync.ts";
+import {
+  createReminder,
+  fetchReminders,
+} from "../../features/reminders/lib/reminderService.ts";
+import { publishCommunityReadState } from "../../features/communities/communityMarkRead.ts";
+import {
+  installFakeWindow,
+  makeFakeWindow,
+} from "../../features/sidebar/lib/sidebarSyncTestHelpers.mjs";
+
+test("managed mode never starts encrypted preference fetches, subscriptions or publish timers", async () => {
+  const fw = makeFakeWindow();
+  const restore = installFakeWindow(fw);
+  let networkCalls = 0;
+  for (const method of ["fetchEvents", "subscribeLive", "publishEvent"]) {
+    mock.method(relayClient, method, () => {
+      networkCalls++;
+      throw new Error("must not use relay");
+    });
+  }
+  setManagedIdentityMode(true);
+  try {
+    assert.equal(supportsLocalIdentityFeatures(), false);
+    for (const [Manager, fetch, publish, subscribe] of [
+      [
+        ChannelStarSyncManager,
+        "fetchRemoteStars",
+        "publishStars",
+        "subscribeToStars",
+      ],
+      [
+        ChannelMuteSyncManager,
+        "fetchRemoteMutes",
+        "publishMutes",
+        "subscribeToMutes",
+      ],
+      [
+        ChannelSortSyncManager,
+        "fetchRemoteSortPrefs",
+        "publishSortPrefs",
+        "subscribeToSortPrefs",
+      ],
+      [
+        ChannelSectionSyncManager,
+        "fetchRemoteSections",
+        "publishSections",
+        "subscribeToSections",
+      ],
+      [
+        ProjectSidebarMembershipSyncManager,
+        "fetchRemoteMembership",
+        "publishMembership",
+        "subscribe",
+      ],
+    ]) {
+      const manager = new Manager("pubkey", "wss://relay.example");
+      assert.equal((await manager[fetch]()).status, "failed");
+      manager[publish]({ version: 1, channels: {}, projects: {} });
+      await (await manager[subscribe](() => assert.fail("remote delivery")))();
+      assert.equal(fw._hasTimer(), false, Manager.name);
+      manager.destroy();
+    }
+    const theme = new CommunityThemeSyncManager("pubkey");
+    theme.publish({
+      version: 1,
+      theme: "macchiato",
+      accent: "blue",
+      followSystem: false,
+    });
+    assert.equal((await theme.fetchRemote()).status, "unavailable");
+    assert.equal(
+      (await theme.subscribeAndFetch(() => {})).result.status,
+      "unavailable",
+    );
+    await (await theme.subscribe(() => {}))();
+    assert.equal(fw._hasTimer(), false);
+    theme.destroy();
+    await assert.rejects(fetchReminders("pubkey"), /unavailable/);
+    await assert.rejects(createReminder({}, 123), /unavailable/);
+    await assert.rejects(
+      publishCommunityReadState({
+        client: relayClient,
+        pubkey: "pubkey",
+        relayUrl: "wss://relay.example",
+      }),
+      /unavailable/,
+    );
+    assert.equal(networkCalls, 0);
+  } finally {
+    setManagedIdentityMode(false);
+    restore();
+    mock.reset();
+  }
+  assert.equal(supportsLocalIdentityFeatures(), true);
+  assert.doesNotThrow(() => requireLocalIdentityFeature("Local features"));
+});

--- a/desktop/src/shared/api/identityCapabilities.ts
+++ b/desktop/src/shared/api/identityCapabilities.ts
@@ -1,0 +1,21 @@
+/** Build capability set by the native login gate before any community UI mounts.
+ * Not identity/community data: remains fixed across login and community remounts.
+ * Native commands independently enforce these exclusions (this is UI policy only).
+ */
+let managedIdentity = false;
+
+export function setManagedIdentityMode(enabled: boolean): void {
+  managedIdentity = enabled;
+}
+
+export function supportsLocalIdentityFeatures(): boolean {
+  return !managedIdentity;
+}
+
+export function requireLocalIdentityFeature(feature: string): void {
+  if (managedIdentity) {
+    throw new Error(
+      `${feature} is unavailable with an organization-managed identity.`,
+    );
+  }
+}

--- a/desktop/src/shared/api/identityTypes.ts
+++ b/desktop/src/shared/api/identityTypes.ts
@@ -2,7 +2,8 @@ export type IdentityStorage =
   | "system-keyring"
   | "local-file"
   | "environment"
-  | "ephemeral";
+  | "ephemeral"
+  | "enterprise";
 
 export type Identity = {
   pubkey: string;

--- a/desktop/src/shared/theme/CommunityThemeController.tsx
+++ b/desktop/src/shared/theme/CommunityThemeController.tsx
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { useCommunities } from "@/features/communities/useCommunities";
 import { relayClient } from "@/shared/api/relayClient";
@@ -95,6 +96,7 @@ export function CommunityThemeController() {
 
   useEffect(() => {
     if (!pubkey || !relayUrl) return;
+    if (!supportsLocalIdentityFeatures()) return;
     const scope = `${pubkey}:${relayUrl}`;
     scopeRef.current = scope;
     lastRemoteRef.current = { createdAt: 0, eventId: "" };
@@ -207,6 +209,7 @@ export function CommunityThemeController() {
     if (stored && sameCommunityThemePreference(stored, preference)) return;
     scopedPreferenceRef.current = preference;
     if (!writeCommunityThemePreference(pubkey, relayUrl, preference)) return;
+    if (!supportsLocalIdentityFeatures()) return;
     if (!writeCommunityThemeOutbox(pubkey, relayUrl, preference)) return;
     managerRef.current?.publish(preference);
   }, [

--- a/desktop/src/shared/theme/communityThemeSync.ts
+++ b/desktop/src/shared/theme/communityThemeSync.ts
@@ -1,3 +1,4 @@
+import { supportsLocalIdentityFeatures } from "@/shared/api/identityCapabilities";
 import { relayClient } from "@/shared/api/relayClient";
 import {
   nip44DecryptFromSelf,
@@ -99,6 +100,7 @@ export class CommunityThemeSyncManager {
   }
 
   async fetchRemote(): Promise<RemoteCommunityThemeResult> {
+    if (!supportsLocalIdentityFeatures()) return { status: "unavailable" };
     try {
       const events = await relayClient.fetchEvents({
         kinds: [KIND_COMMUNITY_THEME],
@@ -129,6 +131,7 @@ export class CommunityThemeSyncManager {
   }
 
   publish(preference: CommunityThemePreference): void {
+    if (!supportsLocalIdentityFeatures()) return;
     if (this.destroyed) return;
     this.pending = preference;
     this.publishRetryAttempt = 0;
@@ -305,6 +308,8 @@ export class CommunityThemeSyncManager {
     result: CommunityThemeHydrationResult;
     unsubscribe: () => Promise<void>;
   }> {
+    if (!supportsLocalIdentityFeatures())
+      return { result: { status: "unavailable" }, unsubscribe: async () => {} };
     // Establish live delivery before querying history. A relay can deliver a
     // replacement while an empty history query is in flight; subscribing
     // second would leave a blind spot where the controller seeds defaults over
@@ -381,6 +386,7 @@ export class CommunityThemeSyncManager {
   async subscribe(
     onUpdate: (remote: RemoteCommunityTheme) => void,
   ): Promise<() => Promise<void>> {
+    if (!supportsLocalIdentityFeatures()) return async () => {};
     return relayClient.subscribeLive(
       {
         kinds: [KIND_COMMUNITY_THEME],

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1237,6 +1237,11 @@ async function writeClipboardFlavors({
 
 declare global {
   interface Window {
+    __BUZZ_E2E_ENTERPRISE__?: {
+      enabled: boolean;
+      loginFails?: boolean;
+      loggedIn?: boolean;
+    };
     __BUZZ_E2E__?: E2eConfig;
     /** Last payload written through the native clipboard command. */
     __BUZZ_E2E_LAST_CLIPBOARD__?: { html: string | null; text: string };
@@ -12581,12 +12586,22 @@ export function maybeInstallE2eTauriMocks() {
           return {
             pubkey: identity.pubkey,
             display_name: identity.username,
+            storage: window.__BUZZ_E2E_ENTERPRISE__?.enabled
+              ? "enterprise"
+              : undefined,
             lost: false,
             locked: false,
           };
         }
 
-        return { ...DEFAULT_MOCK_IDENTITY, lost: isLost, locked: isLocked };
+        return {
+          ...DEFAULT_MOCK_IDENTITY,
+          storage: window.__BUZZ_E2E_ENTERPRISE__?.enabled
+            ? "enterprise"
+            : undefined,
+          lost: isLost,
+          locked: isLocked,
+        };
       }
       case "sign_nostr_identity_binding": {
         const request = payload as {
@@ -13408,6 +13423,38 @@ export function maybeInstallE2eTauriMocks() {
         return getRelayWsUrl(activeConfig);
       case "get_default_relay_url":
         return getRelayWsUrl(activeConfig);
+      case "enterprise_status": {
+        const enterprise = window.__BUZZ_E2E_ENTERPRISE__;
+        return {
+          enabled: enterprise?.enabled ?? false,
+          identity: enterprise?.loggedIn
+            ? {
+                pubkey: identity?.pubkey ?? DEFAULT_MOCK_IDENTITY.pubkey,
+                relayWsUrl: getRelayWsUrl(activeConfig),
+                relayHttpUrl: getRelayWsUrl(activeConfig)
+                  .replace("wss:", "https:")
+                  .replace("ws:", "http:"),
+              }
+            : null,
+        };
+      }
+      case "enterprise_logout":
+        if (window.__BUZZ_E2E_ENTERPRISE__)
+          window.__BUZZ_E2E_ENTERPRISE__.loggedIn = false;
+        return null;
+      case "enterprise_login": {
+        const enterprise = window.__BUZZ_E2E_ENTERPRISE__;
+        if (!enterprise?.enabled || enterprise.loginFails)
+          throw new Error("Corporate login denied");
+        enterprise.loggedIn = true;
+        return {
+          pubkey: identity?.pubkey ?? DEFAULT_MOCK_IDENTITY.pubkey,
+          relayWsUrl: getRelayWsUrl(activeConfig),
+          relayHttpUrl: getRelayWsUrl(activeConfig)
+            .replace("wss:", "https:")
+            .replace("ws:", "http:"),
+        };
+      }
       case "auto_connect_default_relay_enabled":
         return activeConfig?.autoConnectDefaultRelay ?? false;
       case "get_legacy_workspace_storage":

--- a/desktop/tests/e2e/enterprise-login.spec.ts
+++ b/desktop/tests/e2e/enterprise-login.spec.ts
@@ -1,0 +1,90 @@
+import { mkdir } from "node:fs/promises";
+import { waitForAnimations } from "../helpers/animations";
+import { expect, test } from "@playwright/test";
+import { installMockBridge } from "../helpers/bridge";
+import { openSettings } from "../helpers/settings";
+
+test("corporate denial stays at login and never enters local-key onboarding", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.__BUZZ_E2E_ENTERPRISE__ = { enabled: true, loginFails: true };
+  });
+  await installMockBridge(page);
+  await page.goto("/");
+  const login = page.getByRole("button", {
+    name: "Sign in with corporate account",
+  });
+  await expect(login).toBeVisible();
+  await mkdir("test-results/enterprise-login", { recursive: true });
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: "test-results/enterprise-login/01-corporate-login.png",
+  });
+  await login.click();
+  await expect(page.getByRole("alert")).toHaveText(
+    "Sign-in did not complete. Try again.",
+  );
+  await expect(login).toBeEnabled();
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: "test-results/enterprise-login/02-denied-login.png",
+  });
+  const calls = await page.evaluate(() => window.__BUZZ_E2E_COMMANDS__ ?? []);
+  expect(calls).not.toContain("get_nsec");
+  expect(calls).not.toContain("persist_current_identity");
+  expect(calls).not.toContain("sign_event");
+});
+
+test("successful corporate login installs community and bypasses key onboarding", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.__BUZZ_E2E_ENTERPRISE__ = { enabled: true };
+  });
+  await installMockBridge(page);
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Sign in with corporate account" })
+    .click();
+  await expect(
+    page.getByRole("heading", { name: "Sign in to Buzz for work" }),
+  ).not.toBeVisible();
+  await expect(page.getByTestId("open-settings")).toBeVisible();
+  await openSettings(page, "profile");
+  const identity = page.getByTestId("profile-identity-card");
+  if (
+    !(await identity.evaluate(
+      (element) => element instanceof HTMLDetailsElement && element.open,
+    ))
+  ) {
+    await page.getByTestId("profile-identity-toggle").click();
+  }
+  await expect(
+    page.getByText("Your organization holds your signing key.", {
+      exact: false,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("profile-private-key-toggle"),
+  ).not.toBeVisible();
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: "test-results/enterprise-login/03-managed-settings.png",
+  });
+  const calls = await page.evaluate(() => window.__BUZZ_E2E_COMMANDS__ ?? []);
+  for (const command of [
+    "get_nsec",
+    "persist_current_identity",
+    "nip44_encrypt_to_self",
+    "nip44_decrypt_from_self",
+    "create_managed_agent",
+  ]) {
+    expect(calls).not.toContain(command);
+  }
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Sign out of work account" }).click();
+  await expect(
+    page.getByRole("button", { name: "Sign in with corporate account" }),
+  ).toBeVisible();
+});

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/

--- a/mobile/MANAGED_IDENTITY.md
+++ b/mobile/MANAGED_IDENTITY.md
@@ -1,0 +1,105 @@
+# Managed identity on mobile
+
+Managed identity is an opt-in **native build contract**, not an environment
+variable read at runtime. An absent `BUZZ_BUILD_ENTERPRISE` Dart define retains
+OSS self-custody. A present malformed define fails closed at login.
+
+The define is JSON with exactly seven non-secret fields: `signerUrl`, `issuer`,
+`clientId`, `audience`, `organization`, `connection`, and `redirectUri`.
+`redirectUri` must be `buzz://enterprise-login`; `signerUrl` is an HTTPS prefix
+ending in `/`, without the API version. The only identity routes are
+`<prefix>/v1/buzz/identity/ensure` and `<prefix>/v1/buzz/identity/sign`.
+Release selection, credentials, backend enrollment and deployment are separate
+responsibilities; do not put an access token or private key in a build define.
+
+## Authority and lifecycle
+
+`EnterpriseIdentity` owns browser authorization-code/PKCE login, secure-storage
+mutations, rotating refresh, and logout. `RemoteEventSigner` is an immutable
+login-generation/public-key/community capability, not a private-key source.
+Responses must contain a valid Nostr signature and exactly the requested author,
+kind, content, tags and timestamp. Superseded login work cannot publish or
+recreate saved credentials. Refresh is single-flight, verifies the ensured
+identity/community, and fails closed without retrying a potentially consumed
+rotating token. Interactive corporate sign-in is the recovery path.
+
+Callers inject `RelayConfig.signer`; there is no global signing helper which can
+silently select a different account. `SignedEventRelay` captures the session
+lease at construction. `RelaySessionNotifier.publish` and `sendRaw` require a
+lease captured **before** asynchronous signing. A provider rebuild/disposal
+retires that lease; an ordinary reconnect does not. Publication rechecks after
+rate-limit waits, callbacks cannot move a send into a replacement community,
+and acknowledgements must identify the signed event. Direct status updates
+check the lease again after the acknowledgement before updating state/cache.
+HTTP query authentication also retains its originating lease.
+
+## Media
+
+Corporate read proof is limited to `/media/` on the exact HTTPS host and
+effective port of the signer-selected relay. Userinfo is rejected before URL
+normalization. Identity/signing/query/upload/download HTTP requests do not
+follow redirects. Corporate auth failure never becomes an unsigned retry.
+Managed read proofs live for 120 seconds and refresh at 110 seconds (ten-second
+margin), within the backend's 300-second ceiling. OSS reads retain 600-second
+proofs and a 60-second margin. The cache uses the proof construction time, not
+the time the signing request finishes.
+An upload's single signed proof is reused for the bounded legacy-route fallback.
+
+Corporate video uses authenticated Dart download to a temporary file, never a
+native network player; downloads are capped at 256 MiB and two-minute header/body
+waits. The viewer checks scope after awaits and owns cleanup per effect so an
+old effect cannot delete a new community's file. Corporate posterless timeline
+previews do not download videos. Corporate audio uses the bounded Dart file
+path (32 MiB/30-second download limit), not native redirect-following networking.
+Corporate emoji uses the scoped Flutter picker/image path; the OSS native emoji
+loader also rejects redirects. Media image cache identity includes auth scope,
+and scope replacement resets the displayed image rather than preserving an old
+account's pixels while replacement data loads.
+
+## Explicit capability limits
+
+This corporate build intentionally does not provide local-key export/backup,
+device pairing, self-enrollment, arbitrary community selection, or the existing
+local-secret-dependent encrypted read-state/personal-preference/theme/reminder
+synchronization. It does not substitute plaintext publication for encryption.
+Push/NSE authenticated reads needing a local key are unavailable. Local-key OSS
+flows remain separate, including their existing best-effort unsigned media-read
+behavior for invalid local key material; that behavior is not a corporate
+fallback. Settings explains these limits and offers corporate sign-out/sign-in.
+
+This intentionally differs from the default portable self-custodied identity
+vision: the organization holds the key and fixes the community, while preserving
+Nostr event verification and community isolation. It does not redesign the OSS
+identity model.
+
+## Validation boundaries
+
+Tests exercise the production remote signer and publication/lease seam, same-key
+login and community supersession, callback/disposal/rate-limit cancellation,
+ACK identity, exact signed fields, redirect behavior, media limits and upload
+proof reuse. `enterprise_build_config_test.dart` should run both without defines
+and with a synthetic seven-field `--dart-define-from-file` plus
+`EXPECT_MANAGED=true`; the latter calls the real default production parser.
+
+Unit/widget tests and Swift compilation are not proof of live corporate login,
+remote enrollment, device networking, native redirect runtime behavior, signed
+AOT release artifacts or deployment. These require separate authorized runtime
+and release validation. See the integration result manifest for the exact frozen
+source hash, commands, results and remaining gaps.
+
+## Known draft limitations (not rollout-ready)
+
+- Directory/profile-editing operations remain exposed although the managed
+  backend excludes ordinary profile mutation; those requests fail rather than
+  updating directory-owned names. This UI/backend mismatch is not resolved here.
+- Refresh currently calls `ensure` again and verifies the returned pinned
+  identity/community; unlike desktop it is not authorization-only refresh.
+- Mobile's direct config parser and generic signer proof preflight remain less
+  strict than Rust's. The media path has its own exact-origin checks; the backend
+  policy remains required, not replaced by client validation.
+- There is no full operator offboarding/live relay eviction protocol or
+  restart-durable signed-event outbox. Ambiguous retries can construct new events.
+- Release draft 94 and backend draft 124571 are dependencies, not deployed
+  services. Terraform draft 1385 is unbound/deny-only pending an approved
+  corporate authority and active-infrastructure authorization. No live staging
+  readiness, keychain/device login or signed installer is claimed.

--- a/mobile/ios/Runner/NativeEmojiPickerView.swift
+++ b/mobile/ios/Runner/NativeEmojiPickerView.swift
@@ -552,7 +552,7 @@ actor NativeEmojiRemoteImageLoader {
   }
 
   private static func download(_ request: URLRequest) async throws -> UIImage {
-    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    let (bytes, response) = try await URLSession.shared.bytes(for: request, delegate: NoMediaRedirects())
     guard
       let httpResponse = response as? HTTPURLResponse,
       (200..<300).contains(httpResponse.statusCode)
@@ -612,5 +612,16 @@ actor NativeEmojiRemoteImageLoader {
       by: cgImage.height
     )
     return overflow ? Int.max : cost
+  }
+}
+
+/// Never forward a Nostr media proof through an HTTP redirect.
+private final class NoMediaRedirects: NSObject, URLSessionTaskDelegate {
+  func urlSession(
+    _ session: URLSession, task: URLSessionTask,
+    willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest,
+    completionHandler: @escaping (URLRequest?) -> Void
+  ) {
+    completionHandler(nil)
   }
 }

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -28,6 +28,8 @@ import 'features/profile/profile_edit_page.dart';
 import 'features/profile/profile_text_editor.dart';
 import 'features/settings/settings_page.dart';
 import 'shared/auth/auth.dart';
+import 'shared/auth/enterprise_identity.dart';
+import 'shared/auth/enterprise_login_page.dart';
 import 'shared/deeplink/pending_deep_link_provider.dart';
 import 'shared/emoji/emoji_burst.dart';
 import 'shared/push/push_subscription_provider.dart';
@@ -382,7 +384,9 @@ class App extends HookConsumerWidget {
       ),
       home: authState.when(
         loading: () => const _SplashScreen(),
-        error: (_, _) => const PairingPage(),
+        error: (_, _) => enterpriseEnabled
+            ? const EnterpriseLoginPage()
+            : const PairingPage(),
         data: (state) => switch (state.status) {
           AuthStatus.authenticated => DeepLinkDispatcher(
             child: HomePage(
@@ -390,10 +394,13 @@ class App extends HookConsumerWidget {
               hasUnreadInbox: hasUnreadInbox,
             ),
           ),
-          _ => const DeepLinkDispatcher(
-            dispatchMessageLinks: false,
-            child: PairingPage(),
-          ),
+          _ =>
+            enterpriseEnabled
+                ? const EnterpriseLoginPage()
+                : const DeepLinkDispatcher(
+                    dispatchMessageLinks: false,
+                    child: PairingPage(),
+                  ),
         },
       ),
     );

--- a/mobile/lib/features/channels/channel_management_actions.dart
+++ b/mobile/lib/features/channels/channel_management_actions.dart
@@ -390,6 +390,7 @@ final channelActionsProvider = Provider<ChannelActions>((ref) {
     signedEventRelay: SignedEventRelay(
       session: session,
       nsec: relayConfig.nsec,
+      signer: relayConfig.signer,
     ),
     currentPubkey: currentPubkey,
     isCommunityValid: () {

--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -15,8 +15,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
-import 'package:nostr/nostr.dart' as nostr;
-
 import '../../shared/auth/event_signer.dart';
 
 import '../../shared/mentions/agent_identity_provider.dart';

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -379,11 +379,8 @@ void _sendTypingIndicator(
 }) async {
   try {
     final config = ref.read(relayConfigProvider);
-    final nsec = config.nsec;
-    if (nsec == null || nsec.isEmpty) return;
-
-    final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-    if (privkeyHex.isEmpty) return;
+    final signer = config.signer;
+    if (signer == null) return;
 
     final tags = <List<String>>[
       ['h', channelId],
@@ -394,16 +391,18 @@ void _sendTypingIndicator(
         ['e', threadHeadId, '', 'reply'],
     ];
 
+    final session = ref.read(relaySessionProvider.notifier);
+    final lease = session.captureLease();
     final event = await signEvent(
       kind: EventKind.typingIndicator,
       content: '',
       tags: tags,
-      signer: LocalEventSigner(privkeyHex),
+      signer: signer,
     );
 
     // Send directly over WebSocket — fire-and-forget, matching desktop.
-    final session = ref.read(relaySessionProvider.notifier);
-    session.sendRaw(['EVENT', event.toMap()]);
+    config.remoteSigner?.checkCurrent();
+    session.sendRaw(['EVENT', event.toMap()], lease: lease);
   } catch (_) {
     // Fire-and-forget — typing indicator failure is non-fatal.
   }

--- a/mobile/lib/features/channels/emoji_picker.dart
+++ b/mobile/lib/features/channels/emoji_picker.dart
@@ -40,7 +40,13 @@ void showEmojiPicker({
   required void Function(String emoji) onSelect,
   VoidCallback? onDismiss,
 }) {
-  if (defaultTargetPlatform == TargetPlatform.iOS) {
+  final auth = ProviderScope.containerOf(
+    context,
+    listen: false,
+  ).read(mediaGetAuthServiceProvider);
+  // Keep corporate proof in the scoped Dart transport, not a native sheet
+  // whose queued downloads can outlive login/community disposal.
+  if (defaultTargetPlatform == TargetPlatform.iOS && !auth.isRemote) {
     unawaited(
       _presentIosEmojiPicker(
         context: context,

--- a/mobile/lib/features/channels/media_viewer_page/video_viewer.dart
+++ b/mobile/lib/features/channels/media_viewer_page/video_viewer.dart
@@ -1,10 +1,18 @@
 part of '../media_viewer_page.dart';
 
+/// Android supports authenticated range requests; other platforms use a file.
+/// Overridable so widget tests can exercise the actual streaming path.
+final mediaVideoStreamingSupportedProvider = Provider<bool>(
+  (ref) => Platform.isAndroid,
+);
+
 class MediaVideoViewerPage extends HookConsumerWidget {
   final String videoUrl;
   final String? posterUrl;
   final VoidCallback? onReply;
 
+  static const _maxDownloadBytes = 256 * 1024 * 1024;
+  static const _downloadTimeout = Duration(minutes: 2);
   static const _dismissThreshold = 100.0;
   static const _dismissVelocity = 700.0;
   static const _backgroundFadeDivisor = 300.0;
@@ -18,11 +26,8 @@ class MediaVideoViewerPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(mediaGetAuthServiceProvider);
     final controller = useState<VideoPlayerController?>(null);
-    final videoFile = useRef<File?>(null);
-    final downloadRequestAbort = useRef<Completer<void>?>(null);
-    final downloadSubscription = useRef<StreamSubscription<List<int>>?>(null);
-    final downloadSink = useRef<IOSink?>(null);
     final initializeFuture = useState<Future<void>?>(null);
     final error = useState<String?>(null);
     final dragOffset = useState(0.0);
@@ -31,35 +36,49 @@ class MediaVideoViewerPage extends HookConsumerWidget {
       duration: const Duration(milliseconds: 200),
     );
 
-    Future<void> deleteVideoFile() async {
-      final file = videoFile.value;
-      videoFile.value = null;
-      if (file == null) return;
-      try {
-        if (await file.exists()) await file.delete();
-      } on FileSystemException {
-        // Temporary storage cleanup should not make closing the viewer fail.
-      }
-    }
-
     useEffect(() {
+      // Each effect owns its resources: retired cleanup must not touch a new
+      // login/community's download even when the video URL is unchanged.
+      File? videoFile;
+      Completer<void>? downloadRequestAbort;
+      StreamSubscription<List<int>>? downloadSubscription;
+      IOSink? downloadSink;
+      final cancelled = Completer<void>();
       var disposed = false;
+      controller.value = null;
+      error.value = null;
+      Future<void> deleteVideoFile() async {
+        final file = videoFile;
+        videoFile = null;
+        if (file == null) return;
+        try {
+          if (await file.exists()) await file.delete();
+        } on FileSystemException {
+          // Best-effort cleanup of the temporary playback copy.
+        }
+      }
+
       Future<void> initializeVideo() async {
-        final auth = ref.read(mediaGetAuthServiceProvider);
         final uri = Uri.parse(videoUrl);
 
         // ExoPlayer supports the request headers on every range request, so
         // keep Android on its streaming path. iOS uses the authenticated local
         // copy below because AVPlayer can drop those headers after the first
         // request.
-        if (Platform.isAndroid) {
+        if (ref.read(mediaVideoStreamingSupportedProvider) && !auth.isRemote) {
           VideoPlayerController? streamingController;
           try {
+            final headers = await auth.headersFor(videoUrl);
+            if (disposed) return;
             streamingController = VideoPlayerController.networkUrl(
               uri,
-              httpHeaders: await auth.headersFor(videoUrl),
+              httpHeaders: headers,
             );
             await streamingController.initialize();
+            if (disposed) {
+              await streamingController.dispose();
+              return;
+            }
             await streamingController.play();
             if (disposed) {
               await streamingController.dispose();
@@ -71,26 +90,40 @@ class MediaVideoViewerPage extends HookConsumerWidget {
             if (streamingController != null) {
               await streamingController.dispose();
             }
+            if (disposed) return;
             // Fall through to the authenticated local-file path only when the
             // streaming controller cannot initialize.
           }
         }
 
+        VideoPlayerController? localController;
         try {
           final client = ref.read(mediaHttpClientProvider);
+          final headers = await auth.headersFor(videoUrl);
+          if (disposed) return;
           final requestAbort = Completer<void>();
-          downloadRequestAbort.value = requestAbort;
+          downloadRequestAbort = requestAbort;
           final request = http.AbortableStreamedRequest(
             'GET',
             uri,
             abortTrigger: requestAbort.future,
-          )..headers.addAll(await auth.headersFor(videoUrl));
+          )..followRedirects = false;
+          request.headers.addAll(headers);
+          auth.checkCurrent();
           late final http.StreamedResponse response;
           try {
-            response = await client.send(request);
+            response = await client
+                .send(request)
+                .timeout(
+                  _downloadTimeout,
+                  onTimeout: () {
+                    if (!requestAbort.isCompleted) requestAbort.complete();
+                    throw TimeoutException('Video download timed out');
+                  },
+                );
           } finally {
-            if (downloadRequestAbort.value == requestAbort) {
-              downloadRequestAbort.value = null;
+            if (downloadRequestAbort == requestAbort) {
+              downloadRequestAbort = null;
             }
           }
           if (disposed) {
@@ -98,31 +131,53 @@ class MediaVideoViewerPage extends HookConsumerWidget {
             return;
           }
           if (response.statusCode < 200 || response.statusCode >= 300) {
-            await response.stream.drain<void>();
+            await _cancelVideoResponse(response);
             throw HttpException(
               'Video download failed (${response.statusCode})',
               uri: uri,
             );
           }
 
-          final responseSubscription = response.stream.listen(null)..pause();
-          downloadSubscription.value = responseSubscription;
+          try {
+            auth.checkCurrent();
+          } catch (_) {
+            await _cancelVideoResponse(response);
+            rethrow;
+          }
+          if ((response.contentLength ?? 0) > _maxDownloadBytes) {
+            await _cancelVideoResponse(response);
+            throw StateError('Video download is too large');
+          }
+          var downloadedBytes = 0;
+          final responseSubscription =
+              response.stream
+                  .map((chunk) {
+                    downloadedBytes += chunk.length;
+                    if (downloadedBytes > _maxDownloadBytes) {
+                      throw StateError('Video download is too large');
+                    }
+                    return chunk;
+                  })
+                  .listen(null)
+                ..pause();
+          downloadSubscription = responseSubscription;
           final directory = await getTemporaryDirectory();
           if (disposed) {
             await responseSubscription.cancel();
-            if (downloadSubscription.value == responseSubscription) {
-              downloadSubscription.value = null;
+            if (downloadSubscription == responseSubscription) {
+              downloadSubscription = null;
             }
             return;
           }
+          auth.checkCurrent();
           final file = File(
             '${directory.path}${Platform.pathSeparator}'
             'buzz-video-${DateTime.now().microsecondsSinceEpoch}'
             '${_videoFileExtension(uri)}',
           );
-          videoFile.value = file;
+          videoFile = file;
           final sink = file.openWrite();
-          downloadSink.value = sink;
+          downloadSink = sink;
           final completed = Completer<void>();
           responseSubscription
             ..onData(sink.add)
@@ -137,24 +192,39 @@ class MediaVideoViewerPage extends HookConsumerWidget {
               if (!completed.isCompleted) completed.complete();
             })
             ..resume();
-          await completed.future;
-          downloadSubscription.value = null;
-          downloadSink.value = null;
+          await Future.any([
+            completed.future,
+            cancelled.future,
+          ]).timeout(_downloadTimeout);
+          downloadSubscription = null;
+          downloadSink = null;
           if (disposed) {
             await deleteVideoFile();
             return;
           }
 
-          final localController = VideoPlayerController.file(file);
+          auth.checkCurrent();
+          localController = VideoPlayerController.file(file);
           await localController.initialize();
+          if (disposed) {
+            await localController.dispose();
+            await deleteVideoFile();
+            return;
+          }
+          auth.checkCurrent();
           await localController.play();
           if (disposed) {
             await localController.dispose();
             await deleteVideoFile();
             return;
           }
+          auth.checkCurrent();
           controller.value = localController;
         } catch (loadError) {
+          await downloadSubscription?.cancel();
+          await downloadSink?.close();
+          await localController?.dispose();
+          await deleteVideoFile();
           if (!disposed) error.value = loadError.toString();
         }
       }
@@ -162,17 +232,18 @@ class MediaVideoViewerPage extends HookConsumerWidget {
       initializeFuture.value = initializeVideo();
       return () {
         disposed = true;
-        final activeRequestAbort = downloadRequestAbort.value;
+        cancelled.complete();
+        final activeRequestAbort = downloadRequestAbort;
         if (activeRequestAbort != null && !activeRequestAbort.isCompleted) {
           activeRequestAbort.complete();
         }
-        unawaited(downloadSubscription.value?.cancel() ?? Future.value());
-        unawaited(downloadSink.value?.close() ?? Future.value());
+        unawaited(downloadSubscription?.cancel() ?? Future.value());
+        unawaited(downloadSink?.close() ?? Future.value());
         final activeController = controller.value;
         if (activeController != null) unawaited(activeController.dispose());
         unawaited(deleteVideoFile());
       };
-    }, [videoUrl]);
+    }, [videoUrl, auth]);
 
     void animateSnapBack() {
       isDragging.value = false;

--- a/mobile/lib/features/channels/message_actions.dart
+++ b/mobile/lib/features/channels/message_actions.dart
@@ -336,14 +336,9 @@ class _DownloadedImage {
 }
 
 Future<_DownloadedImage> _downloadImage(WidgetRef ref, String imageUrl) async {
-  final response = await ref
-      .read(mediaHttpClientProvider)
-      .get(
-        Uri.parse(imageUrl),
-        headers: await ref
-            .read(mediaGetAuthServiceProvider)
-            .headersFor(imageUrl),
-      );
+  final auth = ref.read(mediaGetAuthServiceProvider);
+  final client = ref.read(mediaHttpClientProvider);
+  final response = await auth.get(client, imageUrl);
   if (response.statusCode < 200 || response.statusCode >= 300) {
     throw HttpException(
       'Image download failed (${response.statusCode})',

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -48,8 +48,15 @@ typedef OpenDownloadedFile =
 
 final openDownloadedFileProvider = Provider<OpenDownloadedFile>((ref) {
   final client = ref.watch(mediaHttpClientProvider);
+  final auth = ref.watch(mediaGetAuthServiceProvider);
   return (url, headers, filename) async {
-    final response = await client.get(Uri.parse(url), headers: headers);
+    auth.checkCurrent();
+    final response = await getMediaWithoutRedirects(
+      client,
+      Uri.parse(url),
+      headers,
+    );
+    auth.checkCurrent();
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw HttpException(
         'Attachment download failed (${response.statusCode})',

--- a/mobile/lib/features/channels/message_content/video_preview.dart
+++ b/mobile/lib/features/channels/message_content/video_preview.dart
@@ -30,8 +30,12 @@ final videoPreviewFrameLoaderProvider = Provider<VideoPreviewFrameLoader>((
   ref,
 ) {
   final auth = ref.watch(mediaGetAuthServiceProvider);
-  return (url) async =>
-      _loadVideoPreviewFrame(url, headers: await auth.headersFor(url));
+  return (url) async {
+    // No full-file download per timeline card and no proof handed to a native
+    // redirect-following player. Corporate videos use their poster or viewer.
+    if (auth.isRemote) return null;
+    return _loadVideoPreviewFrame(url, headers: await auth.headersFor(url));
+  };
 });
 
 class _MessageVideoPreview extends HookConsumerWidget {

--- a/mobile/lib/features/channels/mobile_huddle_controller.dart
+++ b/mobile/lib/features/channels/mobile_huddle_controller.dart
@@ -491,12 +491,13 @@ final class MobileHuddleController extends Notifier<bool> {
   }) {
     final config = ref.read(relayConfigProvider);
     final nsec = config.nsec;
-    if (nsec == null || nsec.isEmpty) {
+    if (config.signer == null) {
       throw StateError('A paired identity is required.');
     }
     return HuddleConnectionParameters(
       relayWebSocketUrl: config.wsUrl,
       nsec: nsec,
+      signer: config.signer,
       parentChannelId: parentChannelId,
       ephemeralChannelId: ephemeralChannelId,
     );

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -231,6 +231,7 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
     signedEventRelay: SignedEventRelay(
       session: ref.read(relaySessionProvider.notifier),
       nsec: config.nsec,
+      signer: config.signer,
     ),
     fetchMembers: (channelId) =>
         ref.read(channelMembersProvider(channelId).future),
@@ -250,7 +251,8 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
     isDeliveryValid: () {
       final currentConfig = ref.read(relayConfigProvider);
       return currentConfig.baseUrl == config.baseUrl &&
-          currentConfig.nsec == config.nsec;
+          currentConfig.nsec == config.nsec &&
+          identical(currentConfig.remoteSigner, config.remoteSigner);
     },
   );
 });

--- a/mobile/lib/features/channels/voice_note_attachment.dart
+++ b/mobile/lib/features/channels/voice_note_attachment.dart
@@ -42,8 +42,10 @@ class VoiceNoteAttachment extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(mediaGetAuthServiceProvider);
     final player = useMemoized(ref.read(voiceNotePlayerFactoryProvider), [
       source,
+      auth,
     ]);
     final playback = useListenable(player);
     final playbackRate = useState(1.0);
@@ -52,8 +54,7 @@ class VoiceNoteAttachment extends HookConsumerWidget {
         unawaited(
           player.loadRemote(
             source,
-            headers: () =>
-                ref.read(mediaGetAuthServiceProvider).headersFor(source),
+            headers: () => auth.headersFor(source),
             fallbackDuration: duration,
           ),
         );

--- a/mobile/lib/features/channels/voice_note_recording.dart
+++ b/mobile/lib/features/channels/voice_note_recording.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import '../../shared/auth/enterprise_identity.dart';
 import 'dart:io';
 import 'dart:math' as math;
 
@@ -468,7 +469,8 @@ class DeviceVoiceNotePlayerController extends VoiceNotePlayerController {
        _client = client,
        _temporaryDirectory = temporaryDirectory ?? getTemporaryDirectory,
        _requiresAuthenticatedLocalFile =
-           requiresAuthenticatedLocalFile ?? Platform.isIOS,
+           requiresAuthenticatedLocalFile ??
+           (Platform.isIOS || enterpriseEnabled),
        _downloadTimeout = downloadTimeout,
        _maxDownloadBytes = maxDownloadBytes,
        _player = player ?? _DeviceVoiceNoteAudioPlayerBackend() {
@@ -608,7 +610,8 @@ class DeviceVoiceNotePlayerController extends VoiceNotePlayerController {
         'GET',
         uri,
         abortTrigger: requestAbort.future,
-      )..headers.addAll(await remote.headers());
+      )..followRedirects = false;
+      request.headers.addAll(await remote.headers());
       if (_disposed ||
           sourceGeneration != _sourceGeneration ||
           playbackOperationGeneration != _playbackOperationGeneration) {

--- a/mobile/lib/features/forum/forum_provider.dart
+++ b/mobile/lib/features/forum/forum_provider.dart
@@ -64,6 +64,7 @@ class ForumEventDelivery {
   final ProviderContainer _container;
   final String _relayUrl;
   final String? _nsec;
+  final Object? _remoteSigner;
   final SignedEventRelay _relay;
   final List<CustomEmoji> _customEmoji;
 
@@ -71,11 +72,13 @@ class ForumEventDelivery {
     required ProviderContainer container,
     required String relayUrl,
     required String? nsec,
+    Object? remoteSigner,
     required SignedEventRelay relay,
     required List<CustomEmoji> customEmoji,
   }) : _container = container,
        _relayUrl = relayUrl,
        _nsec = nsec,
+       _remoteSigner = remoteSigner,
        _relay = relay,
        _customEmoji = customEmoji;
 
@@ -86,9 +89,11 @@ class ForumEventDelivery {
       container: container,
       relayUrl: config.baseUrl,
       nsec: config.nsec,
+      remoteSigner: config.remoteSigner,
       relay: SignedEventRelay(
         session: container.read(relaySessionProvider.notifier),
         nsec: config.nsec,
+        signer: config.signer,
       ),
       customEmoji: List<CustomEmoji>.unmodifiable(
         container.read(customEmojiListProvider),
@@ -144,7 +149,9 @@ class ForumEventDelivery {
     required List<List<String>> mediaTags,
   }) async {
     final currentConfig = _container.read(relayConfigProvider);
-    if (currentConfig.baseUrl != _relayUrl || currentConfig.nsec != _nsec) {
+    if (currentConfig.baseUrl != _relayUrl ||
+        currentConfig.nsec != _nsec ||
+        !identical(currentConfig.remoteSigner, _remoteSigner)) {
       throw StateError(
         'Forum delivery cancelled because the active community changed',
       );

--- a/mobile/lib/features/invites/invite_create_provider.dart
+++ b/mobile/lib/features/invites/invite_create_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import '../../shared/auth/event_signer.dart';
 import 'dart:ui' show Rect;
 
 import 'package:flutter/foundation.dart';
@@ -187,17 +188,20 @@ class RelayCommunityInviteActions implements CommunityInviteActions {
     required http.Client httpClient,
     required String baseUrl,
     required String? nsec,
+    EventSigner? signer,
     required SignedEventRelay signedEventRelay,
     required bool Function() isCommunityActive,
   }) : _httpClient = httpClient,
        _baseUrl = baseUrl,
        _nsec = nsec,
+       _signer = signer,
        _signedEventRelay = signedEventRelay,
        _isCommunityActive = isCommunityActive;
 
   final http.Client _httpClient;
   final String _baseUrl;
   final String? _nsec;
+  final EventSigner? _signer;
   final SignedEventRelay _signedEventRelay;
   final bool Function() _isCommunityActive;
 
@@ -217,20 +221,24 @@ class RelayCommunityInviteActions implements CommunityInviteActions {
     final body = <String, Object>{'ttl_secs': ttlSeconds};
     if (maxUses != null) body['max_uses'] = maxUses;
     final bodyBytes = utf8.encode(jsonEncode(body));
+    final proof = await buildNip98AuthHeader(
+      method: 'POST',
+      url: url,
+      bodyBytes: bodyBytes,
+      nsec: _nsec,
+      signer: _signer,
+    );
+    _ensureCommunityActive();
+    final request = http.Request('POST', Uri.parse(url))
+      ..followRedirects = false;
+    request.headers.addAll({
+      'Authorization': proof,
+      'Content-Type': 'application/json',
+    });
+    request.bodyBytes = bodyBytes;
     final response = await _httpClient
-        .post(
-          Uri.parse(url),
-          headers: {
-            'Authorization': await buildNip98AuthHeader(
-              method: 'POST',
-              url: url,
-              bodyBytes: bodyBytes,
-              nsec: _nsec,
-            ),
-            'Content-Type': 'application/json',
-          },
-          body: bodyBytes,
-        )
+        .send(request)
+        .then(http.Response.fromStream)
         .timeout(const Duration(seconds: 15));
     _ensureCommunityActive();
 
@@ -290,10 +298,17 @@ final communityInviteActionsProvider = Provider<CommunityInviteActions>((ref) {
     httpClient: ref.watch(communityInviteHttpClientProvider),
     baseUrl: config.baseUrl,
     nsec: config.nsec,
-    signedEventRelay: SignedEventRelay(session: session, nsec: config.nsec),
+    signer: config.signer,
+    signedEventRelay: SignedEventRelay(
+      session: session,
+      nsec: config.nsec,
+      signer: config.signer,
+    ),
     isCommunityActive: () {
       final current = ref.read(relayConfigProvider);
-      return current.baseUrl == config.baseUrl && current.nsec == config.nsec;
+      return current.baseUrl == config.baseUrl &&
+          current.nsec == config.nsec &&
+          identical(current.remoteSigner, config.remoteSigner);
     },
   );
 });

--- a/mobile/lib/features/invites/invite_join_provider.dart
+++ b/mobile/lib/features/invites/invite_join_provider.dart
@@ -1,3 +1,4 @@
+import '../../shared/auth/enterprise_identity.dart';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
@@ -119,6 +120,9 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
   InviteJoinState build() => const InviteJoinState();
 
   Future<void> prepare(InviteDeepLink invite) async {
+    if (enterpriseEnabled) {
+      throw StateError('Your organization provisions community access');
+    }
     validateInviteRelayUri(Uri.parse(invite.relayUrl));
     final communities = await ref.read(communityListProvider.future);
     final existing = _existingCommunity(communities, invite.relayUrl);
@@ -157,6 +161,9 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
   }
 
   Future<void> confirmJoin() async {
+    if (enterpriseEnabled) {
+      throw StateError('Your organization provisions community access');
+    }
     final invite = state.invite;
     if (invite == null ||
         state.requiresFreshInvite ||

--- a/mobile/lib/features/pairing/pairing_provider.dart
+++ b/mobile/lib/features/pairing/pairing_provider.dart
@@ -1,3 +1,4 @@
+import '../../shared/auth/enterprise_identity.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
@@ -121,6 +122,9 @@ class PairingNotifier extends Notifier<PairingState> {
   PairingState build() => const PairingState();
 
   Future<void> pair(String rawInput) async {
+    if (enterpriseEnabled) {
+      throw StateError('Pairing requires a local-secret identity');
+    }
     if (state.status == PairingStatus.connecting ||
         state.status == PairingStatus.confirmingSas ||
         state.status == PairingStatus.transferring) {
@@ -136,6 +140,7 @@ class PairingNotifier extends Notifier<PairingState> {
   }
 
   Future<bool> authorizeIdentityExport({required Community community}) async {
+    if (enterpriseEnabled) return false;
     if (state.authorizationInProgress) return false;
 
     final biometricOnly =

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -196,7 +196,11 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
         ..remove('display_name')
         ..remove('name');
     }
-    final relay = SignedEventRelay(session: session, nsec: context.config.nsec);
+    final relay = SignedEventRelay(
+      session: session,
+      nsec: context.config.nsec,
+      signer: context.config.signer,
+    );
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final currentCreatedAt = currentHead?.createdAt ?? 0;
     final previousCreatedAt = currentCreatedAt > _lastCreatedAt
@@ -245,6 +249,7 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
     final currentPubkey = ref.read(myPubkeyProvider);
     if (currentConfig.storedOrigin != context.config.storedOrigin ||
         currentConfig.nsec != context.config.nsec ||
+        !identical(currentConfig.remoteSigner, context.config.remoteSigner) ||
         currentPubkey != context.pubkey ||
         !identical(currentSession, context.session)) {
       throw ProfileCommunityChangedException();
@@ -391,6 +396,7 @@ class PresenceNotifier extends AsyncNotifier<String> {
     final relay = SignedEventRelay(
       session: ref.read(relaySessionProvider.notifier),
       nsec: config.nsec,
+      signer: config.signer,
     );
     try {
       await relay.submit(

--- a/mobile/lib/features/profile/user_status_provider.dart
+++ b/mobile/lib/features/profile/user_status_provider.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:nostr/nostr.dart' as nostr;
 
 import '../../shared/auth/event_signer.dart';
 
@@ -33,17 +32,8 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
 
   Future<UserStatus?> _fetch() async {
     final config = ref.read(relayConfigProvider);
-    final nsec = config.nsec;
-    if (nsec == null || nsec.isEmpty) return null;
-
-    String pubkey;
-    try {
-      final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-      final keyPair = nostr.Keys(privkeyHex);
-      pubkey = keyPair.public.toLowerCase();
-    } catch (_) {
-      return null;
-    }
+    final pubkey = config.publicKey;
+    if (pubkey == null) return null;
 
     final sessionState = ref.read(relaySessionProvider);
     if (sessionState.status != SessionStatus.connected) return null;
@@ -82,8 +72,8 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
   }) async {
     final trimmed = text.trim();
     final config = ref.read(relayConfigProvider);
-    final nsec = config.nsec;
-    if (nsec == null || nsec.isEmpty) return;
+    final signer = config.signer;
+    if (signer == null) return;
 
     final tags = <List<String>>[
       ['d', 'general'],
@@ -95,16 +85,20 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
       tags.add(['expiration', '${expiresAt.millisecondsSinceEpoch ~/ 1000}']);
     }
 
-    final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
+    final session = ref.read(relaySessionProvider.notifier);
+    final lease = session.captureLease();
     final event = await signEvent(
       kind: EventKind.userStatus,
       content: trimmed,
       tags: tags,
-      signer: LocalEventSigner(privkeyHex),
+      signer: signer,
     );
 
-    final session = ref.read(relaySessionProvider.notifier);
-    await session.publish(NostrEvent.fromJson(event.toMap()));
+    config.remoteSigner?.checkCurrent();
+    await session.publish(NostrEvent.fromJson(event.toMap()), lease: lease);
+    lease.ensureCurrent();
+
+    config.remoteSigner?.checkCurrent();
 
     // Optimistic update: update own state immediately.
     final newStatus = (trimmed.isNotEmpty || emoji.isNotEmpty)
@@ -121,8 +115,7 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
     _scheduleExpiration(newStatus);
 
     // Also update the shared cache so other UI reads stay consistent.
-    final keyPair = nostr.Keys(privkeyHex);
-    final pubkey = keyPair.public.toLowerCase();
+    final pubkey = signer.publicKey.toLowerCase();
     ref.read(userStatusCacheProvider.notifier).updateStatus(pubkey, newStatus);
   }
 
@@ -162,14 +155,7 @@ class UserStatusNotifier extends AsyncNotifier<UserStatus?> {
   }
 
   String? _currentPubkey() {
-    final nsec = ref.read(relayConfigProvider).nsec;
-    if (nsec == null || nsec.isEmpty) return null;
-    try {
-      final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-      return nostr.Keys(privkeyHex).public.toLowerCase();
-    } catch (_) {
-      return null;
-    }
+    return ref.read(relayConfigProvider).publicKey?.toLowerCase();
   }
 }
 

--- a/mobile/lib/features/pulse/pulse_actions.dart
+++ b/mobile/lib/features/pulse/pulse_actions.dart
@@ -19,7 +19,11 @@ Future<void> publishNote(
 
   final config = ref.read(relayConfigProvider);
   final session = ref.read(relaySessionProvider.notifier);
-  final relay = SignedEventRelay(session: session, nsec: config.nsec);
+  final relay = SignedEventRelay(
+    session: session,
+    nsec: config.nsec,
+    signer: config.signer,
+  );
   final tags = <List<String>>[];
   final seen = <String>{};
 
@@ -63,7 +67,11 @@ Future<void> setContactList(WidgetRef ref, List<ContactEntry> contacts) async {
   if (currentPubkey == null) return;
   final config = ref.read(relayConfigProvider);
   final session = ref.read(relaySessionProvider.notifier);
-  final relay = SignedEventRelay(session: session, nsec: config.nsec);
+  final relay = SignedEventRelay(
+    session: session,
+    nsec: config.nsec,
+    signer: config.signer,
+  );
 
   await relay.submit(
     kind: EventKind.contactList,

--- a/mobile/lib/features/settings/settings_page.dart
+++ b/mobile/lib/features/settings/settings_page.dart
@@ -1,3 +1,4 @@
+import '../../shared/auth/enterprise_identity.dart';
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -75,6 +76,15 @@ class SettingsPage extends HookConsumerWidget {
     );
 
     Future<void> showEditProfileSheet() async {
+      if (enterpriseEnabled) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Your organization manages your profile.'),
+          ),
+        );
+        return;
+      }
+
       final action = await showBuzzModalBottomSheet<_ProfileEditAction>(
         context: context,
         title: 'Edit profile',

--- a/mobile/lib/features/settings/settings_page/community_section.dart
+++ b/mobile/lib/features/settings/settings_page/community_section.dart
@@ -16,7 +16,7 @@ class _CommunitySection extends ConsumerWidget {
       label: 'Community',
       verticalPadding: Grid.twelve,
       children: [
-        if (canInvite)
+        if (canInvite && !enterpriseEnabled)
           AppListRow(
             icon: LucideIcons.userPlus,
             title: 'Invite to community',
@@ -25,16 +25,17 @@ class _CommunitySection extends ConsumerWidget {
               context,
             ).push(MaterialPageRoute<void>(builder: invitePageBuilder)),
           ),
-        AppListRow(
-          key: const ValueKey('community-theme-row'),
-          icon: LucideIcons.palette,
-          title: 'Theme',
-          value: themeSelectionLabel(preference.theme, preference.mode),
-          trailing: const _RowChevron(),
-          onTap: () => Navigator.of(context).push(
-            MaterialPageRoute<void>(builder: (_) => const ThemePickerPage()),
+        if (!enterpriseEnabled)
+          AppListRow(
+            key: const ValueKey('community-theme-row'),
+            icon: LucideIcons.palette,
+            title: 'Theme',
+            value: themeSelectionLabel(preference.theme, preference.mode),
+            trailing: const _RowChevron(),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(builder: (_) => const ThemePickerPage()),
+            ),
           ),
-        ),
       ],
     );
   }

--- a/mobile/lib/features/settings/settings_page/connection_section.dart
+++ b/mobile/lib/features/settings/settings_page/connection_section.dart
@@ -16,6 +16,14 @@ class _ConnectionSection extends ConsumerWidget {
       label: 'Connection',
       verticalPadding: Grid.twelve,
       children: [
+        if (enterpriseEnabled)
+          const Padding(
+            padding: EdgeInsets.all(Grid.xs),
+            child: Text(
+              'Your organization holds your signing key. Private-key export, backup, pairing, encrypted personal preferences and reminders, and push notifications requiring a local key are unavailable in this build.',
+            ),
+          ),
+
         if (nsec != null && nsec.isNotEmpty && community != null) ...[
           _IdentityRow(nsec: nsec),
           AppListRow(
@@ -104,7 +112,7 @@ class _RemoveCommunitySection extends ConsumerWidget {
       children: [
         AppListRow(
           icon: LucideIcons.logOut,
-          title: 'Remove community',
+          title: enterpriseEnabled ? 'Sign out' : 'Remove community',
           titleColor: context.colors.error,
           onTap: () => _confirmRemoveCommunity(context, ref),
         ),
@@ -153,10 +161,12 @@ void _confirmRemoveCommunity(BuildContext context, WidgetRef ref) {
   showBuzzDialog<void>(
     context: context,
     builder: (ctx) => AlertDialog(
-      title: const Text('Remove Community'),
-      content: const Text(
-        'This will disconnect this community. You will need '
-        'to scan a new pairing code to reconnect.',
+      title: Text(enterpriseEnabled ? 'Sign out' : 'Remove Community'),
+      content: Text(
+        enterpriseEnabled
+            ? 'Sign out of your work account? You can sign in again with your corporate account.'
+            : 'This will disconnect this community. You will need '
+                  'to scan a new pairing code to reconnect.',
       ),
       actions: [
         TextButton(
@@ -181,7 +191,7 @@ void _confirmRemoveCommunity(BuildContext context, WidgetRef ref) {
             Navigator.of(context).popUntil((route) => route.isFirst);
           },
           style: FilledButton.styleFrom(backgroundColor: ctx.colors.error),
-          child: const Text('Remove'),
+          child: Text(enterpriseEnabled ? 'Sign out' : 'Remove'),
         ),
       ],
     ),

--- a/mobile/lib/features/settings/settings_page/notifications_section.dart
+++ b/mobile/lib/features/settings/settings_page/notifications_section.dart
@@ -5,7 +5,7 @@ class _NotificationsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (defaultTargetPlatform != TargetPlatform.iOS) {
+    if (enterpriseEnabled || defaultTargetPlatform != TargetPlatform.iOS) {
       return const SizedBox.shrink();
     }
     final community = ref.watch(activeCommunityProvider).value;

--- a/mobile/lib/shared/auth/auth_provider.dart
+++ b/mobile/lib/shared/auth/auth_provider.dart
@@ -1,6 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
 
+import 'enterprise_identity.dart';
 import '../community/community.dart';
 import '../community/community_provider.dart';
 
@@ -18,6 +19,30 @@ class AuthState {
 class AuthNotifier extends AsyncNotifier<AuthState> {
   @override
   Future<AuthState> build() async {
+    if (enterpriseEnabled) {
+      final revision = EnterpriseIdentity.instance.revision;
+      void changed() {
+        ref.invalidateSelf();
+      }
+
+      revision.addListener(changed);
+      ref.onDispose(() => revision.removeListener(changed));
+      await EnterpriseIdentity.instance.restore();
+      final identity = EnterpriseIdentity.instance;
+      if (!identity.authenticated) {
+        return const AuthState(status: AuthStatus.unauthenticated);
+      }
+      final community = Community(
+        id: 'enterprise-${identity.pubkey}',
+        name: 'Work',
+        relayUrl: identity.relayUrl!,
+        pubkey: identity.pubkey,
+        addedAt: DateTime.now(),
+      );
+      await syncCommunitySnapshot(ref, [community]);
+      return AuthState(status: AuthStatus.authenticated, community: community);
+    }
+
     // Read from storage directly — NOT from community providers.
     // Watching community providers here would create a circular dependency
     // because authenticateWithCommunity() writes to those providers.
@@ -57,6 +82,9 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   /// Writes to storage directly to avoid circular dependency with community
   /// providers.
   Future<void> authenticateWithCommunity(Community community) {
+    if (enterpriseEnabled) {
+      throw StateError('This build requires corporate login');
+    }
     return ref.read(communityTransitionProvider).runExclusive(() async {
       await ref.read(communityTransitionProvider).run();
       final storage = ref.read(communityStorageProvider);
@@ -75,6 +103,14 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   }
 
   Future<void> signOut() {
+    if (enterpriseEnabled) {
+      return () async {
+        await EnterpriseIdentity.instance.logout();
+        await syncCommunitySnapshot(ref, []);
+        state = const AsyncData(AuthState(status: AuthStatus.unauthenticated));
+      }();
+    }
+
     return () async {
       final storage = ref.read(communityStorageProvider);
       await ref

--- a/mobile/lib/shared/auth/enterprise_identity.dart
+++ b/mobile/lib/shared/auth/enterprise_identity.dart
@@ -1,0 +1,526 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:pointycastle/digests/sha256.dart';
+import 'package:pointycastle/ecc/curves/secp256k1.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'event_signer.dart';
+
+/// Non-secret release configuration; absence preserves OSS self-custody.
+const enterpriseBuildConfig = String.fromEnvironment('BUZZ_BUILD_ENTERPRISE');
+bool get enterpriseEnabled => enterpriseBuildConfig.isNotEmpty;
+
+/// One app-owned identity, scoped to the fixed enterprise community. Never contains a Nostr private key.
+class EnterpriseIdentity {
+  EnterpriseIdentity({
+    http.Client? client,
+    FlutterSecureStorage? storage,
+    String config = enterpriseBuildConfig,
+    Stream<Uri>? callbacks,
+    Future<bool> Function(Uri)? openBrowser,
+  }) : _configuration = config,
+       _client = client ?? http.Client(),
+       _storage = storage ?? const FlutterSecureStorage(),
+       _callbacks = callbacks,
+       _openBrowser =
+           openBrowser ??
+           ((uri) => launchUrl(uri, mode: LaunchMode.externalApplication));
+  static final instance = EnterpriseIdentity();
+  final String _configuration;
+  final http.Client _client;
+  final FlutterSecureStorage _storage;
+  final Stream<Uri>? _callbacks;
+  final Future<bool> Function(Uri) _openBrowser;
+  final revision = ValueNotifier<int>(0);
+  Map<String, dynamic>? _tokens;
+  Map<String, dynamic>? _identity;
+  Future<void>? _refreshing;
+  Future<void>? _restoring;
+  bool _loggingIn = false;
+  Completer<void>? _loginCancelled;
+  int _generation = 0;
+  bool get authenticated => _tokens != null && _identity != null;
+  String? get pubkey => _identity?['pubkey'] as String?;
+  String? get relayUrl => _identity?['relayHttpUrl'] as String?;
+  Map<String, dynamic> get _config {
+    final config = jsonDecode(_configuration) as Map<String, dynamic>;
+    for (final key in ['signerUrl', 'issuer']) {
+      final raw = config[key] as String;
+      final url = Uri.parse(raw);
+      if (url.scheme != 'https' ||
+          url.host.isEmpty ||
+          url.userInfo.isNotEmpty ||
+          url.hasPort ||
+          raw != raw.trim() ||
+          !RegExp(r'^https://[^/@:?#]+(?:/[^?#]*)?$').hasMatch(raw) ||
+          url.hasQuery ||
+          url.hasFragment ||
+          (key == 'issuer' && url.path != '' && url.path != '/') ||
+          (key == 'signerUrl' &&
+              (!url.path.endsWith('/') || url.path.contains('/v1/')))) {
+        throw StateError('Invalid enterprise build endpoint');
+      }
+    }
+    for (final key in [
+      'clientId',
+      'audience',
+      'organization',
+      'connection',
+      'redirectUri',
+    ]) {
+      if (config[key] is! String || (config[key] as String).isEmpty) {
+        throw StateError('Incomplete enterprise build configuration');
+      }
+    }
+    if (config.length != 7 ||
+        config['redirectUri'] != 'buzz://enterprise-login') {
+      throw StateError('Invalid enterprise callback');
+    }
+    return config;
+  }
+
+  String _endpoint(String key, String path) =>
+      '${(_config[key] as String).replaceFirst(RegExp(r'/+$'), '')}/$path';
+
+  Future<Map<String, dynamic>> _post(
+    String url,
+    Map<String, dynamic> body, {
+    String? token,
+  }) async {
+    final abort = Completer<void>();
+    final request = http.AbortableRequest(
+      'POST',
+      Uri.parse(url),
+      abortTrigger: abort.future,
+    )..followRedirects = false;
+    request.headers.addAll({
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      if (token != null) 'Authorization': 'Bearer $token',
+    });
+    request.body = jsonEncode(body);
+    return (() async {
+      final response = await _client.send(request);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        await response.stream.listen((_) {}).cancel();
+        throw StateError(
+          'Corporate request rejected (${response.statusCode}); sign in again',
+        );
+      }
+      final bytes = BytesBuilder(copy: false);
+      await for (final chunk in response.stream) {
+        if (bytes.length + chunk.length > 256 * 1024) {
+          throw StateError('Corporate response too large');
+        }
+        bytes.add(chunk);
+      }
+      return jsonDecode(utf8.decode(bytes.takeBytes())) as Map<String, dynamic>;
+    })().timeout(const Duration(seconds: 15)).whenComplete(() {
+      if (!abort.isCompleted) abort.complete();
+    });
+  }
+
+  void _validateTokens(Map<String, dynamic> tokens) {
+    if (tokens['access_token'] is! String ||
+        (tokens['access_token'] as String).isEmpty ||
+        (tokens['access_token'] as String).length > 16384 ||
+        RegExp(r'\s').hasMatch(tokens['access_token'] as String) ||
+        tokens['token_type']?.toString().toLowerCase() != 'bearer' ||
+        tokens['expires_in'] is! int ||
+        tokens['expires_in'] < 1 ||
+        tokens['expires_in'] > 300) {
+      throw StateError('Invalid corporate credentials');
+    }
+    final refresh = tokens['refresh_token'];
+    if (refresh != null &&
+        (refresh is! String || refresh.isEmpty || refresh.length > 16384)) {
+      throw StateError('Invalid corporate refresh credential');
+    }
+    tokens['expiresAt'] =
+        DateTime.now().millisecondsSinceEpoch ~/ 1000 +
+        (tokens['expires_in'] as int);
+  }
+
+  Map<String, dynamic> _validateIdentity(Map<String, dynamic> identity) {
+    if (identity['pubkey'] is! String ||
+        !RegExp(r'^[0-9a-f]{64}$').hasMatch(identity['pubkey'] as String)) {
+      throw StateError('Invalid corporate identity');
+    }
+    // Nostr authors must be actual x-only secp256k1 points, not just hex.
+    final publicKey = identity['pubkey'] as String;
+    final point = ECCurve_secp256k1().curve.decodePoint(
+      Uint8List.fromList([
+        2,
+        for (var i = 0; i < publicKey.length; i += 2)
+          int.parse(publicKey.substring(i, i + 2), radix: 16),
+      ]),
+    );
+    if (point == null || point.isInfinity) {
+      throw StateError('Invalid corporate public key');
+    }
+    final rawRelay = identity['relayHttpUrl'] as String;
+    if (RegExp(r'^https://[^/?#]*@').hasMatch(rawRelay)) {
+      throw StateError('Invalid corporate community');
+    }
+    final relay = Uri.parse(rawRelay);
+    if (relay.scheme != 'https' ||
+        relay.host.isEmpty ||
+        relay.userInfo.isNotEmpty ||
+        relay.hasQuery ||
+        relay.hasFragment ||
+        (relay.path != '' && relay.path != '/') ||
+        identity['relayWsUrl'] != 'wss://${relay.authority}') {
+      throw StateError('Invalid corporate community');
+    }
+    return identity;
+  }
+
+  Future<void> restore() =>
+      _restoring ??= _restore().whenComplete(() => _restoring = null);
+
+  Future<void> _restore() async {
+    if (_configuration.isEmpty || _identity != null || _loggingIn) return;
+    _config; // Validate the real compiled configuration before touching credentials.
+    final generation = _generation;
+    await _storageTail;
+    _checkGeneration(generation);
+    final encoded = await _storage.read(key: 'buzz.enterprise.session');
+    if (encoded == null || generation != _generation) return;
+    final saved = jsonDecode(encoded) as Map<String, dynamic>;
+    // Credentials never cross build-selected issuer/client/signer boundaries.
+    if (saved['config'] != _configuration) {
+      throw StateError('Corporate build changed; sign in again');
+    }
+    _identity = _validateIdentity(
+      Map<String, dynamic>.from(saved['identity'] as Map),
+    );
+    _tokens = Map<String, dynamic>.from(saved['tokens'] as Map);
+    if (_tokens?['access_token'] is! String ||
+        (_tokens!['access_token'] as String).isEmpty ||
+        (_tokens!['access_token'] as String).length > 16384 ||
+        _tokens?['token_type']?.toString().toLowerCase() != 'bearer' ||
+        _tokens?['expiresAt'] is! int) {
+      _tokens = null;
+      _identity = null;
+      throw StateError('Invalid saved corporate credentials');
+    }
+    try {
+      await accessToken();
+      _checkGeneration(generation);
+      revision.value++;
+    } catch (_) {
+      if (generation == _generation) {
+        _identity = null;
+        _tokens = null;
+      }
+      rethrow;
+    }
+  }
+
+  // Serialize secure-storage mutations. A superseded login cannot overwrite a
+  // newer login or recreate credentials after logout.
+  Future<void> _storageTail = Future.value();
+  Future<void> _storageMutation(Future<void> Function() action) {
+    final operation = _storageTail.then((_) => action());
+    _storageTail = operation.then((_) {}, onError: (Object _) {});
+    return operation;
+  }
+
+  Future<void> _deleteSaved() =>
+      _storageMutation(() => _storage.delete(key: 'buzz.enterprise.session'));
+
+  Future<void> _persist(
+    Map<String, dynamic> tokens,
+    Map<String, dynamic> identity,
+    int generation,
+  ) => _storageMutation(() async {
+    _checkGeneration(generation);
+    await _storage.write(
+      key: 'buzz.enterprise.session',
+      value: jsonEncode({
+        'config': _configuration,
+        'tokens': tokens,
+        'identity': identity,
+      }),
+    );
+    if (generation != _generation) {
+      await _storage.delete(key: 'buzz.enterprise.session');
+      _checkGeneration(generation);
+    }
+  });
+
+  Future<String> accessToken() async {
+    final generation = _generation;
+    final tokens = _tokens;
+    if (tokens == null) throw StateError('Corporate login required');
+    if ((tokens['expiresAt'] as int) <=
+        DateTime.now().millisecondsSinceEpoch ~/ 1000 + 30) {
+      _refreshing ??= _refresh().whenComplete(() => _refreshing = null);
+      await _refreshing;
+    }
+    _checkGeneration(generation);
+    return _tokens?['access_token'] as String? ??
+        (throw StateError('Corporate login required'));
+  }
+
+  Future<void> _refresh() async {
+    final generation = _generation;
+    try {
+      final refresh = _tokens?['refresh_token'] as String?;
+      if (refresh == null) {
+        throw StateError('Corporate session expired; sign in again');
+      }
+      await _deleteSaved();
+      _checkGeneration(generation);
+      final next = await _post(_endpoint('issuer', 'oauth/token'), {
+        'grant_type': 'refresh_token',
+        'client_id': _config['clientId'],
+        'refresh_token': refresh,
+      });
+      _checkGeneration(generation);
+      _validateTokens(next);
+      final identity = _validateIdentity(
+        await _post(
+          _endpoint('signerUrl', 'v1/buzz/identity/ensure'),
+          {},
+          token: next['access_token'] as String,
+        ),
+      );
+      if (generation != _generation ||
+          identity['pubkey'] != pubkey ||
+          identity['relayHttpUrl'] != relayUrl) {
+        throw StateError('Corporate account changed');
+      }
+      await _persist(next, identity, generation);
+      if (generation != _generation) {
+        throw StateError('Corporate account changed');
+      }
+      _tokens = next;
+    } catch (_) {
+      if (generation == _generation) {
+        _tokens = null;
+        revision.value++;
+        await _storageMutation(() async {
+          _checkGeneration(generation);
+          await _storage.delete(key: 'buzz.enterprise.session');
+        });
+      }
+      rethrow; // Never retry a potentially consumed rotating refresh token automatically.
+    }
+  }
+
+  Future<void> login() async {
+    if (_loggingIn) throw StateError('Corporate login already in progress');
+    _loggingIn = true;
+    final cancelled = Completer<void>();
+    _loginCancelled = cancelled;
+    final generation = ++_generation;
+    _tokens = null;
+    _identity = null;
+    revision.value++;
+    // Drain any rotating refresh before a new login can replace the same secure-storage record.
+    try {
+      await _refreshing;
+    } catch (_) {
+      /* A new browser login is the recovery path. */
+    }
+    StreamSubscription<Uri>? subscription;
+    try {
+      _checkGeneration(generation);
+      await _deleteSaved();
+      _checkGeneration(generation);
+      final config = _config;
+      final random = Random.secure();
+      String randomToken() => base64Url
+          .encode(List.generate(32, (_) => random.nextInt(256)))
+          .replaceAll('=', '');
+      final verifier = randomToken(), state = randomToken();
+      final challenge = base64Url
+          .encode(
+            SHA256Digest().process(Uint8List.fromList(ascii.encode(verifier))),
+          )
+          .replaceAll('=', '');
+      final redirect = Uri.parse(config['redirectUri'] as String);
+      final callback = Completer<Uri>();
+      subscription = (_callbacks ?? AppLinks().uriLinkStream).listen((uri) {
+        if (uri.scheme != redirect.scheme ||
+            uri.authority != redirect.authority ||
+            uri.path != redirect.path ||
+            uri.hasFragment) {
+          return;
+        }
+        if (uri.queryParametersAll['state']?.length != 1 ||
+            uri.queryParameters['state'] != state ||
+            uri.queryParametersAll['code']?.length != 1 ||
+            uri.queryParameters.containsKey('error')) {
+          return;
+        }
+        if (!callback.isCompleted) callback.complete(uri);
+      });
+      final authorize = Uri.parse(_endpoint('issuer', 'authorize')).replace(
+        queryParameters: {
+          'response_type': 'code',
+          'client_id': config['clientId'],
+          'redirect_uri': redirect.toString(),
+          'audience': config['audience'],
+          'organization': config['organization'],
+          'connection': config['connection'],
+          'scope': 'openid profile email offline_access buzz:sign',
+          'state': state,
+          'code_challenge_method': 'S256',
+          'code_challenge': challenge,
+        },
+      );
+      if (!await _openBrowser(authorize)) {
+        throw StateError('Cannot open corporate login');
+      }
+      _checkGeneration(generation);
+      final uri = await Future.any<Uri>([
+        callback.future,
+        cancelled.future.then(
+          (_) => throw StateError('Corporate login cancelled'),
+        ),
+      ]).timeout(const Duration(minutes: 5));
+      _checkGeneration(generation);
+      final tokens = await _post(_endpoint('issuer', 'oauth/token'), {
+        'grant_type': 'authorization_code',
+        'client_id': config['clientId'],
+        'redirect_uri': redirect.toString(),
+        'code': uri.queryParameters['code'],
+        'code_verifier': verifier,
+      });
+      _checkGeneration(generation);
+      _validateTokens(tokens);
+      final identity = _validateIdentity(
+        await _post(
+          _endpoint('signerUrl', 'v1/buzz/identity/ensure'),
+          {},
+          token: tokens['access_token'] as String,
+        ),
+      );
+      if (generation != _generation) {
+        throw StateError('Corporate login changed');
+      }
+      await _persist(tokens, identity, generation);
+      _checkGeneration(generation);
+      _tokens = tokens;
+      _identity = identity;
+      revision.value++;
+    } catch (_) {
+      if (generation == _generation) {
+        await _storageMutation(() async {
+          _checkGeneration(generation);
+          await _storage.delete(key: 'buzz.enterprise.session');
+        });
+      }
+      rethrow;
+    } finally {
+      await subscription?.cancel();
+      if (identical(_loginCancelled, cancelled)) _loginCancelled = null;
+      _loggingIn = false;
+    }
+  }
+
+  Future<void> logout() async {
+    _generation++;
+    final cancelled = _loginCancelled;
+    if (cancelled != null && !cancelled.isCompleted) cancelled.complete();
+    _tokens = null;
+    _identity = null;
+    revision.value++;
+    await _deleteSaved();
+  }
+
+  /// Capture authority for one login and its server-selected community.
+  RemoteEventSigner captureSigner() {
+    if (!authenticated) throw StateError('Corporate login required');
+    return RemoteEventSigner._(this, _generation, pubkey!, relayUrl!);
+  }
+
+  void _checkGeneration(int generation) {
+    if (generation != _generation) {
+      throw StateError('Corporate account changed');
+    }
+  }
+
+  Future<nostr.Event> _sign(UnsignedEvent unsigned, int generation) async {
+    _checkGeneration(generation);
+    final expected = pubkey;
+    if (!authenticated || expected != unsigned.publicKey) {
+      throw StateError('Corporate signing identity mismatch');
+    }
+    final kind = unsigned.kind;
+    final content = unsigned.content;
+    final tags = unsigned.tags;
+    final template = {
+      'kind': kind,
+      'content': content,
+      'tags': tags.map((t) => List<String>.of(t)).toList(),
+      'created_at': unsigned.createdAt,
+    };
+    final purpose = kind == 22242
+        ? 'nip42-auth'
+        : kind == 27235
+        ? 'http-auth'
+        : kind == 24242
+        ? (tags.any((t) => t.length > 1 && t[0] == 't' && t[1] == 'upload')
+              ? 'media-upload'
+              : 'media-read')
+        : 'publish';
+    final token = await accessToken();
+    _checkGeneration(generation);
+    final response = await _post(
+      _endpoint('signerUrl', 'v1/buzz/identity/sign'),
+      {'purpose': purpose, 'event': template},
+      token: token,
+    );
+    final event = nostr.Event.fromJson(
+      jsonEncode(response['event']),
+    ); // Constructor verifies id and Schnorr signature.
+    if (generation != _generation ||
+        event.pubkey != expected ||
+        event.kind != kind ||
+        event.content != content ||
+        event.createdAt != template['created_at'] ||
+        jsonEncode(event.tags) != jsonEncode(template['tags'])) {
+      throw StateError('Corporate signature or identity mismatch');
+    }
+    return event;
+  }
+}
+
+/// Signing capability captured from an authenticated login, never a key source.
+/// It cannot move to a new login, even if that login returns the same pubkey.
+final class RemoteEventSigner implements EventSigner {
+  RemoteEventSigner._(
+    this._owner,
+    this._generation,
+    this.publicKey,
+    this.relayUrl,
+  );
+  final EnterpriseIdentity _owner;
+  final int _generation;
+  @override
+  final String publicKey;
+  final String relayUrl;
+
+  /// Fail before transport if this capability has been revoked or superseded.
+  void checkCurrent() {
+    _owner._checkGeneration(_generation);
+    if (!_owner.authenticated) throw StateError('Corporate login required');
+  }
+
+  @override
+  Future<nostr.Event> sign(UnsignedEvent event) {
+    checkCurrent();
+    return _owner._sign(event, _generation);
+  }
+}

--- a/mobile/lib/shared/auth/enterprise_login_page.dart
+++ b/mobile/lib/shared/auth/enterprise_login_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../theme/grid.dart';
+import 'auth_provider.dart';
+import 'enterprise_identity.dart';
+
+/// Corporate builds never offer local-key pairing as a fallback.
+class EnterpriseLoginPage extends HookConsumerWidget {
+  const EnterpriseLoginPage({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final busy = useState(false);
+    final error = useState<String?>(null);
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(Grid.sm),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text('Sign in to Buzz for work'),
+                const SizedBox(height: Grid.xs),
+                const Text(
+                  'Your organization manages your identity and community.',
+                ),
+                if (error.value != null)
+                  Semantics(liveRegion: true, child: Text(error.value!)),
+                const SizedBox(height: Grid.sm),
+                FilledButton(
+                  onPressed: busy.value
+                      ? null
+                      : () async {
+                          busy.value = true;
+                          error.value = null;
+                          try {
+                            await EnterpriseIdentity.instance.login();
+                            if (context.mounted) ref.invalidate(authProvider);
+                          } catch (_) {
+                            if (context.mounted) {
+                              error.value =
+                                  'Sign-in did not complete. Try again.';
+                            }
+                          } finally {
+                            if (context.mounted) busy.value = false;
+                          }
+                        },
+                  child: Text(
+                    busy.value
+                        ? 'Waiting for corporate sign-in…'
+                        : 'Sign in with corporate account',
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/shared/community/community_provider.dart
+++ b/mobile/lib/shared/community/community_provider.dart
@@ -1,3 +1,4 @@
+import '../auth/enterprise_identity.dart';
 import 'dart:async';
 import 'dart:developer' as developer;
 import 'dart:math';
@@ -235,6 +236,27 @@ class CommunityListNotifier extends AsyncNotifier<List<Community>> {
 
   @override
   Future<List<Community>> build() async {
+    if (enterpriseEnabled) {
+      final identity = EnterpriseIdentity.instance;
+      void changed() {
+        ref.invalidateSelf();
+      }
+
+      identity.revision.addListener(changed);
+      ref.onDispose(() => identity.revision.removeListener(changed));
+      await identity.restore();
+      if (!identity.authenticated) return [];
+      return [
+        Community(
+          id: 'enterprise-${identity.pubkey}',
+          name: 'Work',
+          relayUrl: identity.relayUrl!,
+          pubkey: identity.pubkey,
+          addedAt: DateTime.fromMillisecondsSinceEpoch(0),
+        ),
+      ];
+    }
+
     final storage = ref.read(communityStorageProvider);
     final communities = await storage.loadAll();
     await syncCommunitySnapshot(ref, communities);
@@ -244,6 +266,9 @@ class CommunityListNotifier extends AsyncNotifier<List<Community>> {
   /// Add a community. If one with the same relay URL already exists, update
   /// its credentials instead. Returns the effective community ID.
   Future<String> addCommunity(Community community) async {
+    if (enterpriseEnabled) {
+      throw StateError('Corporate community is release-managed');
+    }
     final storage = ref.read(communityStorageProvider);
     final current = state.value ?? [];
 
@@ -341,6 +366,9 @@ class CommunityListNotifier extends AsyncNotifier<List<Community>> {
   }
 
   Future<void> switchCommunity(String id) {
+    if (enterpriseEnabled) {
+      throw StateError('Corporate community is release-managed');
+    }
     return ref.read(communityTransitionProvider).runExclusive(() async {
       final storage = ref.read(communityStorageProvider);
       final activeId = await storage.loadActiveId();
@@ -441,6 +469,9 @@ class CommunityListNotifier extends AsyncNotifier<List<Community>> {
   });
 
   Future<void> setPushNotificationsEnabled(String id, bool enabled) async {
+    if (enterpriseEnabled) {
+      throw StateError('Push enrollment requires a local-secret identity');
+    }
     var shouldDeactivate = false;
     await _serializePushMutation(() async {
       final storage = ref.read(communityStorageProvider);
@@ -595,6 +626,7 @@ final communityListProvider =
 /// the community list.
 final activeCommunityProvider = FutureProvider<Community?>((ref) async {
   final communities = await ref.watch(communityListProvider.future);
+  if (enterpriseEnabled) return communities.firstOrNull;
   final storage = ref.read(communityStorageProvider);
   final activeId = await storage.loadActiveId();
 

--- a/mobile/lib/shared/huddle/huddle_auth.dart
+++ b/mobile/lib/shared/huddle/huddle_auth.dart
@@ -10,13 +10,15 @@ import 'huddle_wire.dart';
 @immutable
 final class HuddleConnectionParameters {
   final String relayWebSocketUrl;
-  final String nsec;
+  final String? nsec;
+  final EventSigner? signer;
   final String parentChannelId;
   final String ephemeralChannelId;
 
   HuddleConnectionParameters({
     required this.relayWebSocketUrl,
-    required this.nsec,
+    this.nsec,
+    this.signer,
     required this.parentChannelId,
     required this.ephemeralChannelId,
   }) {
@@ -39,7 +41,7 @@ final class HuddleConnectionParameters {
     }
     _validateUuid(parentChannelId, 'parentChannelId');
     _validateUuid(ephemeralChannelId, 'ephemeralChannelId');
-    if (nsec.trim().isEmpty) {
+    if (signer == null && (nsec == null || nsec!.trim().isEmpty)) {
       throw ArgumentError.value(nsec, 'nsec', 'must not be empty');
     }
   }
@@ -67,7 +69,9 @@ abstract final class HuddleAuthV2 {
       throw const HuddleAuthException('Relay challenge must not be empty.');
     }
 
-    final secretKey = _decodeSecretKey(parameters.nsec);
+    final signer =
+        parameters.signer ??
+        LocalEventSigner(_decodeSecretKey(parameters.nsec!));
     final event = await signEvent(
       kind: EventKind.auth,
       content: '',
@@ -75,7 +79,7 @@ abstract final class HuddleAuthV2 {
         ['relay', parameters.relayWebSocketUrl],
         ['challenge', challenge],
       ],
-      signer: LocalEventSigner(secretKey),
+      signer: signer,
       createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
     );
 

--- a/mobile/lib/shared/relay/media_auth.dart
+++ b/mobile/lib/shared/relay/media_auth.dart
@@ -3,13 +3,18 @@ import 'dart:convert';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:http/http.dart' as http;
 
 import '../auth/event_signer.dart';
+import '../auth/enterprise_identity.dart';
 
 import 'relay_provider.dart';
 
 const _mediaGetAuthKind = 24242;
 const _mediaGetAuthLifetimeSeconds = 600;
+// Managed signer policy caps all bearer media proofs at 300 seconds.
+const _managedMediaGetAuthLifetimeSeconds = 120;
+const _managedMediaGetAuthRefreshMarginSeconds = 10;
 
 /// Re-sign this long before the cached auth event expires, so an in-flight
 /// request signed just before the boundary still lands well within validity.
@@ -21,14 +26,16 @@ const _mediaGetAuthRefreshMarginSeconds = 60;
 /// so callers can safely use this on arbitrary profile/custom-emoji URLs without
 /// leaking Buzz credentials to third-party hosts.
 ///
-/// The signed header is memoized until [_mediaGetAuthRefreshMarginSeconds]
-/// before expiry: repeated calls return the byte-identical map instead of
+/// The signed header is memoized until the refresh margin before expiry
+/// (managed: 120s lifetime/10s margin; OSS: 600s/60s): repeated calls return the byte-identical map instead of
 /// producing a fresh Schnorr signature per widget build. The service itself is
 /// rebuilt (dropping the memo) whenever the relay config — base URL or signing
 /// identity — changes, via [mediaGetAuthServiceProvider].
 class MediaGetAuthService {
   final String _baseUrl;
   final String? _nsec;
+  final EventSigner? _signer;
+  bool _disposed = false;
   final DateTime Function() _now;
 
   Map<String, String>? _cachedHeaders;
@@ -37,12 +44,52 @@ class MediaGetAuthService {
   MediaGetAuthService({
     required String baseUrl,
     required String? nsec,
+    EventSigner? signer,
     DateTime Function()? now,
   }) : _baseUrl = baseUrl,
        _nsec = nsec,
+       _signer = signer,
        _now = now ?? DateTime.now;
 
+  /// Remote credentials must not be handed to redirect-following native players.
+  bool get isRemote => _signer is RemoteEventSigner;
+
+  int get _lifetimeSeconds => isRemote
+      ? _managedMediaGetAuthLifetimeSeconds
+      : _mediaGetAuthLifetimeSeconds;
+  int get _refreshMarginSeconds => isRemote
+      ? _managedMediaGetAuthRefreshMarginSeconds
+      : _mediaGetAuthRefreshMarginSeconds;
+
+  /// Fetch through a transport which cannot forward proof through a redirect.
+  Future<http.Response> get(http.Client client, String url) async {
+    final headers = await headersFor(url);
+    checkCurrent();
+    final response = await getMediaWithoutRedirects(
+      client,
+      Uri.parse(url),
+      headers,
+    );
+    checkCurrent();
+    return response;
+  }
+
+  /// Invalidate cached proof when its provider/community is retired.
+  void dispose() {
+    _disposed = true;
+    _cachedHeaders = null;
+  }
+
+  /// Check immediately before and after a transport await.
+  void checkCurrent() {
+    if (_disposed) throw StateError('Media identity scope changed');
+    if (_signer case final RemoteEventSigner remote) remote.checkCurrent();
+  }
+
   bool isRelayMediaUrl(String url) {
+    // Uri normalizes an empty userinfo marker away; reject it before parsing.
+    final userinfo = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*://[^/?#]*@');
+    if (userinfo.hasMatch(url) || userinfo.hasMatch(_baseUrl)) return false;
     final uri = Uri.tryParse(url);
     final relayUri = Uri.tryParse(_baseUrl);
     if (uri == null || relayUri == null) return false;
@@ -53,7 +100,8 @@ class MediaGetAuthService {
 
   Future<Map<String, String>> headersFor(String url) async {
     final nsec = _nsec;
-    if (nsec == null || nsec.isEmpty) return const {};
+    checkCurrent();
+    if (_signer == null && (nsec == null || nsec.isEmpty)) return const {};
     if (!isRelayMediaUrl(url)) return const {};
 
     final cached = _cachedHeaders;
@@ -70,13 +118,14 @@ class MediaGetAuthService {
       await pending;
       return headersFor(url);
     }
-    return _pendingHeaders = _refreshHeaders(nsec);
+    return _pendingHeaders = _refreshHeaders();
   }
 
-  Future<Map<String, String>> _refreshHeaders(String nsec) async {
+  Future<Map<String, String>> _refreshHeaders() async {
     try {
       final signedAt = _now();
-      final authEvent = await _buildGetAuthEvent(nsec);
+      final authEvent = await _buildGetAuthEvent(signedAt);
+      checkCurrent();
       final encoded = base64Url
           .encode(utf8.encode(authEvent.toJson()))
           .replaceAll('=', '');
@@ -85,13 +134,11 @@ class MediaGetAuthService {
       });
       _cachedHeaders = headers;
       _refreshAt = signedAt.add(
-        const Duration(
-          seconds:
-              _mediaGetAuthLifetimeSeconds - _mediaGetAuthRefreshMarginSeconds,
-        ),
+        Duration(seconds: _lifetimeSeconds - _refreshMarginSeconds),
       );
       return headers;
     } catch (_) {
+      if (_signer is RemoteEventSigner || _disposed) rethrow;
       // Read auth is best-effort: while the relay rollout flag is off, an
       // unsigned fetch still works. Once the flag is on, this request will 403
       // instead of crashing the widget tree because local key material is bad.
@@ -102,6 +149,15 @@ class MediaGetAuthService {
   }
 
   bool _isRelayMediaUrl(Uri uri, Uri relayUri) {
+    if (uri.userInfo.isNotEmpty || relayUri.userInfo.isNotEmpty) return false;
+    if (_signer case final RemoteEventSigner remote) {
+      if (relayUri != Uri.parse(remote.relayUrl)) return false;
+      return uri.scheme == 'https' &&
+          relayUri.scheme == 'https' &&
+          uri.host == relayUri.host &&
+          uri.port == relayUri.port &&
+          uri.path.startsWith('/media/');
+    }
     if (uri.scheme != 'http' && uri.scheme != 'https') return false;
     if (uri.host.isEmpty || relayUri.host.isEmpty) return false;
     // Extract the URL's origin and path. Query strings are ignored for media
@@ -116,14 +172,12 @@ class MediaGetAuthService {
     return uri.path.startsWith('/media/');
   }
 
-  Future<nostr.Event> _buildGetAuthEvent(String nsec) async {
-    final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-    if (privkeyHex.isEmpty) {
-      throw Exception('Invalid nsec');
-    }
+  Future<nostr.Event> _buildGetAuthEvent(DateTime signedAt) async {
+    final signer =
+        _signer ?? LocalEventSigner(nostr.Nip19.decode(payload: _nsec!).data);
 
     final expiration =
-        (_now().millisecondsSinceEpoch ~/ 1000) + _mediaGetAuthLifetimeSeconds;
+        (signedAt.millisecondsSinceEpoch ~/ 1000) + _lifetimeSeconds;
     final tags = <List<String>>[
       ['t', 'get'],
       ['expiration', '$expiration'],
@@ -133,16 +187,23 @@ class MediaGetAuthService {
 
     return signEvent(
       kind: _mediaGetAuthKind,
+      createdAt: signedAt.millisecondsSinceEpoch ~/ 1000,
       content: 'Get buzz-media',
       tags: tags,
-      signer: LocalEventSigner(privkeyHex),
+      signer: signer,
     );
   }
 }
 
 final mediaGetAuthServiceProvider = Provider<MediaGetAuthService>((ref) {
   final config = ref.watch(relayConfigProvider);
-  return MediaGetAuthService(baseUrl: config.baseUrl, nsec: config.nsec);
+  final service = MediaGetAuthService(
+    baseUrl: config.baseUrl,
+    nsec: config.nsec,
+    signer: config.signer,
+  );
+  ref.onDispose(service.dispose);
+  return service;
 });
 
 Future<Map<String, String>> mediaGetHeadersFor(WidgetRef ref, String url) {
@@ -178,4 +239,15 @@ String _normalizeAuthority(String authority) {
     return normalized.substring(0, normalized.length - ':80'.length);
   }
   return normalized;
+}
+
+/// The actual HTTP seam, shared by all credential-bearing media downloads.
+Future<http.Response> getMediaWithoutRedirects(
+  http.Client client,
+  Uri uri,
+  Map<String, String> headers,
+) async {
+  final request = http.Request('GET', uri)..followRedirects = false;
+  request.headers.addAll(headers);
+  return http.Response.fromStream(await client.send(request));
 }

--- a/mobile/lib/shared/relay/media_image.dart
+++ b/mobile/lib/shared/relay/media_image.dart
@@ -97,7 +97,7 @@ class MediaImageProvider extends ImageProvider<MediaImageProvider> {
       final uri = Uri.parse(url);
       final http.Response response;
       try {
-        response = await client.get(uri, headers: await auth.headersFor(url));
+        response = await auth.get(client, url);
       } catch (_) {
         _cooldownUntil[url] = debugNow().add(_defaultCooldown);
         rethrow;
@@ -236,6 +236,7 @@ class MediaImage extends ConsumerWidget {
 
   Widget _image(MediaImageProvider provider, int? cacheWidth) {
     return Image(
+      key: ObjectKey(provider.auth),
       image: ResizeImage.resizeIfNeeded(cacheWidth, null, provider),
       fit: fit,
       width: width,

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -13,6 +13,7 @@ import 'package:nostr/nostr.dart' as nostr;
 import 'package:pointycastle/digests/sha256.dart';
 
 import '../auth/event_signer.dart';
+import '../auth/enterprise_identity.dart';
 
 import 'animated_image_sanitizer.dart';
 import 'media_auth.dart';
@@ -239,6 +240,8 @@ class BlobDescriptor {
 class MediaUploadService {
   final String _baseUrl;
   final String? _nsec;
+  final EventSigner? _signer;
+  bool _disposed = false;
   final PickGalleryImage _pickGalleryImage;
   final PickCameraImage? _pickCameraImage;
   final PickGalleryImages _pickGalleryImages;
@@ -257,6 +260,7 @@ class MediaUploadService {
   MediaUploadService({
     required String baseUrl,
     required String? nsec,
+    EventSigner? signer,
     required PickGalleryImage pickGalleryImage,
     PickCameraImage? pickCameraImage,
     PickGalleryImages? pickGalleryImages,
@@ -272,6 +276,7 @@ class MediaUploadService {
     http.Client? httpClient,
   }) : _baseUrl = baseUrl,
        _nsec = nsec,
+       _signer = signer,
        _pickGalleryImage = pickGalleryImage,
        _pickCameraImage = pickCameraImage,
        _pickGalleryImages =
@@ -295,6 +300,7 @@ class MediaUploadService {
        _ownsHttpClient = httpClient == null;
 
   void dispose() {
+    _disposed = true;
     if (_ownsHttpClient) {
       _http.close();
     }
@@ -590,11 +596,17 @@ class MediaUploadService {
     }
 
     final sha256 = _sha256Hex(bytes);
+    final headers = await _buildUploadHeaders(
+      mimeType: mimeType,
+      sha256: sha256,
+    );
+    _throwIfCancelled(cancellationToken);
     var response = await _sendUploadRequest(
       bytes: bytes,
       mimeType: mimeType,
       sha256: sha256,
       path: _mediaUploadPath,
+      headers: headers,
       onProgress: onProgress,
       cancellationToken: cancellationToken,
     );
@@ -605,6 +617,7 @@ class MediaUploadService {
         mimeType: mimeType,
         sha256: sha256,
         path: _legacyMediaUploadPath,
+        headers: headers,
         onProgress: onProgress,
         cancellationToken: cancellationToken,
       );
@@ -630,6 +643,7 @@ class MediaUploadService {
     required String mimeType,
     required String sha256,
     required String path,
+    required Map<String, String> headers,
     ValueChanged<double>? onProgress,
     UploadCancellationToken? cancellationToken,
   }) async {
@@ -639,21 +653,31 @@ class MediaUploadService {
       Uri.parse(_baseUrl).resolve(path),
       abortTrigger: cancellationToken?.whenCancelled,
     );
+    request.followRedirects = false;
     request.contentLength = bytes.length;
-    request.headers.addAll(
-      await _buildUploadHeaders(mimeType: mimeType, sha256: sha256),
-    );
+    request.headers.addAll(headers);
+    _throwIfCancelled(cancellationToken);
     final writeRequest = request.sink
         .addStream(_uploadByteStream(bytes, onProgress))
         .whenComplete(request.sink.close);
     final response = await _http.send(request);
     await writeRequest;
     _throwIfCancelled(cancellationToken);
-    return http.Response.fromStream(response);
+    final result = await http.Response.fromStream(response);
+    _throwIfCancelled(cancellationToken);
+    return result;
   }
 
   void _throwIfCancelled(UploadCancellationToken? cancellationToken) {
-    if (cancellationToken?.isCancelled ?? false) {
+    if (_signer case final RemoteEventSigner remote) {
+      remote.checkCurrent();
+      if (Uri.parse(_baseUrl) != Uri.parse(remote.relayUrl)) {
+        throw StateError(
+          'Media upload community does not match signing identity',
+        );
+      }
+    }
+    if (_disposed || (cancellationToken?.isCancelled ?? false)) {
       throw const UploadCancelledException();
     }
   }
@@ -678,15 +702,12 @@ class MediaUploadService {
   }
 
   Future<nostr.Event> _buildUploadAuthEvent(String sha256) async {
-    final nsec = _nsec;
-    if (nsec == null || nsec.isEmpty) {
-      throw Exception('Cannot upload media: no signing key available');
-    }
-
-    final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-    if (privkeyHex.isEmpty) {
-      throw Exception('Invalid nsec');
-    }
+    final signer =
+        _signer ??
+        (_nsec == null
+            ? null
+            : LocalEventSigner(nostr.Nip19.decode(payload: _nsec).data));
+    if (signer == null) throw StateError('No media signing identity');
 
     final expiration =
         (_now().millisecondsSinceEpoch ~/ 1000) + _uploadAuthLifetimeSeconds;
@@ -702,7 +723,7 @@ class MediaUploadService {
       kind: _uploadAuthKind,
       content: 'Upload buzz-media',
       tags: tags,
-      signer: LocalEventSigner(privkeyHex),
+      signer: signer,
     );
   }
 

--- a/mobile/lib/shared/relay/media_upload/platform_bindings.dart
+++ b/mobile/lib/shared/relay/media_upload/platform_bindings.dart
@@ -17,6 +17,7 @@ final mediaUploadServiceProvider = Provider<MediaUploadService>((ref) {
   final service = MediaUploadService(
     baseUrl: config.baseUrl,
     nsec: config.nsec,
+    signer: config.signer,
     pickGalleryImage: () => picker.pickImage(
       source: ImageSource.gallery,
       requestFullMetadata: false,

--- a/mobile/lib/shared/relay/relay_http_query_client.dart
+++ b/mobile/lib/shared/relay/relay_http_query_client.dart
@@ -26,8 +26,12 @@ class RelayHttpQueryClient {
         : null;
     generation?.acquire();
     try {
+      final request = http.Request('POST', url)..followRedirects = false;
+      request.headers.addAll(headers);
+      request.bodyBytes = body;
       return await (_injectedClient ?? generation!.client)
-          .post(url, headers: headers, body: body)
+          .send(request)
+          .then(http.Response.fromStream)
           .timeout(timeout);
     } on TimeoutException {
       if (identical(_currentGeneration, generation)) {

--- a/mobile/lib/shared/relay/relay_provider.dart
+++ b/mobile/lib/shared/relay/relay_provider.dart
@@ -3,6 +3,8 @@ import 'package:nostr/nostr.dart' as nostr;
 
 import '../community/community_provider.dart';
 import 'relay_client.dart';
+import '../auth/enterprise_identity.dart';
+import '../auth/event_signer.dart';
 
 /// Relay connection configuration.
 ///
@@ -10,7 +12,21 @@ import 'relay_client.dart';
 ///   - `baseUrl` — where the relay lives (used for WS + media upload)
 ///   - `nsec`    — the user's signing key (drives NIP-42 AUTH and event sigs)
 class RelayConfig {
-  const RelayConfig({required String baseUrl, this.nsec}) : _baseUrl = baseUrl;
+  const RelayConfig({required String baseUrl, this.nsec, this.remoteSigner})
+    : _baseUrl = baseUrl;
+
+  /// Capability captured when the server-selected community becomes active.
+  final RemoteEventSigner? remoteSigner;
+
+  /// Local secrets remain separate; never fall back when remote authority fails.
+  EventSigner? get signer {
+    if (remoteSigner != null) return remoteSigner;
+    final secret = nsec;
+    if (secret == null || secret.isEmpty) return null;
+    return LocalEventSigner(nostr.Nip19.decode(payload: secret).data);
+  }
+
+  String? get publicKey => remoteSigner?.publicKey ?? pubkeyFromNsec(nsec);
 
   /// Relay origin exactly as the active community stored it.
   final String _baseUrl;
@@ -53,6 +69,7 @@ class RelayConfig {
 
   /// Derive the websocket URL from the HTTP base URL.
   String get wsUrl {
+    if (baseUrl.isEmpty) throw StateError('No active community');
     final uri = Uri.parse(baseUrl);
     final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
     return uri.replace(scheme: scheme).toString();
@@ -82,6 +99,16 @@ class RelayConfigNotifier extends Notifier<RelayConfig> {
   RelayConfig build() {
     // Watch the active community so that when it changes (community switch),
     // the config rebuilds, triggering the full provider cascade.
+    if (enterpriseEnabled) {
+      final owner = EnterpriseIdentity.instance;
+      void changed() => ref.invalidateSelf();
+      owner.revision.addListener(changed);
+      ref.onDispose(() => owner.revision.removeListener(changed));
+      // Empty config is inert while logged out: no invented key or destination.
+      if (!owner.authenticated) return const RelayConfig(baseUrl: '');
+      final signer = owner.captureSigner();
+      return RelayConfig(baseUrl: signer.relayUrl, remoteSigner: signer);
+    }
     final activeAsync = ref.watch(activeCommunityProvider);
     final active = activeAsync.value;
     if (active != null) {
@@ -93,6 +120,9 @@ class RelayConfigNotifier extends Notifier<RelayConfig> {
   }
 
   void update({required String baseUrl, String? nsec}) {
+    if (enterpriseEnabled) {
+      throw StateError('Corporate community is release-managed');
+    }
     state = RelayConfig(baseUrl: baseUrl, nsec: nsec);
   }
 }
@@ -116,7 +146,7 @@ String? pubkeyFromNsec(String? nsec) {
 /// The current user's hex pubkey, derived from the active community nsec.
 final myPubkeyProvider = Provider<String?>((ref) {
   final config = ref.watch(relayConfigProvider);
-  return pubkeyFromNsec(config.nsec);
+  return config.publicKey;
 });
 
 /// Provides a [RelayClient] that reacts to config changes.

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -73,6 +73,24 @@ class _BufferedEvent {
   _BufferedEvent(this.subId, this.event);
 }
 
+/// Immutable authority to finish work only in its originating session scope.
+/// Capture before awaiting signing/authentication, never after it completes.
+final class RelaySessionLease {
+  final RelaySessionNotifier _session;
+  final Object _scope;
+
+  RelaySessionLease._(this._session, this._scope);
+
+  /// Throws [RelaySessionSupersededError] if the originating scope retired.
+  void ensureCurrent() => _session._checkLease(this);
+}
+
+/// An operation was cancelled because its originating relay scope retired.
+class RelaySessionSupersededError extends StateError {
+  RelaySessionSupersededError()
+    : super('Relay operation cancelled: originating session scope superseded');
+}
+
 class RelaySessionNotifier extends Notifier<SessionState> {
   RelaySessionNotifier({
     http.Client? httpClient,
@@ -125,6 +143,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   bool _paused = false;
   bool _hasConnectedOnce = false;
   int _connectionGeneration = 0;
+  Object _scope = Object();
   final Map<Object, String> _visibleChannelsByOwner = {};
   final Map<Object, Future<void> Function()> _beforePauseCallbacks = {};
   bool _socketConnected = false;
@@ -143,7 +162,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
     // Auto-connect when authenticated and we have a signing key (NIP-42 AUTH).
     final isAuthenticated = authState.value?.status == AuthStatus.authenticated;
-    if (isAuthenticated && config.nsec != null) {
+    if (isAuthenticated && config.signer != null) {
       // Schedule connection after build completes.
       Future.microtask(() => _connect(config));
     }
@@ -156,6 +175,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     List<NostrFilter> filters, {
     Duration timeout = const Duration(seconds: 8),
   }) async {
+    final lease = captureLease();
     final config = ref.read(relayConfigProvider);
     final url = Uri.parse(config.baseUrl).resolve('/query').toString();
     final bodyBytes = utf8.encode(
@@ -163,20 +183,23 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     );
     // Reuse the session transport on success. A timeout rotates immediately
     // for new queries, then closes the retired client after its peers finish.
+    final proof = await buildNip98AuthHeader(
+      method: 'POST',
+      url: url,
+      bodyBytes: bodyBytes,
+      nsec: config.nsec,
+      signer: config.signer,
+    );
+    lease.ensureCurrent();
+    config.remoteSigner?.checkCurrent();
     final response = await _httpQueryClient.post(
       Uri.parse(url),
-      headers: {
-        'Authorization': await buildNip98AuthHeader(
-          method: 'POST',
-          url: url,
-          bodyBytes: bodyBytes,
-          nsec: config.nsec,
-        ),
-        'Content-Type': 'application/json',
-      },
+      headers: {'Authorization': proof, 'Content-Type': 'application/json'},
       body: bodyBytes,
       timeout: timeout,
     );
+    lease.ensureCurrent();
+    config.remoteSigner?.checkCurrent();
     if (response.statusCode < 200 || response.statusCode >= 300) {
       _activateRateLimitGateFromHttpError(response.body);
       throw RelayException(response.statusCode, response.body);
@@ -310,12 +333,31 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     return () => _unsubscribe(subId);
   }
 
+  /// Capture the scope before starting asynchronous event construction.
+  /// Ordinary reconnects retain it; dependency rebuilds and disposal retire it.
+  RelaySessionLease captureLease() {
+    if (_disposed) throw RelaySessionSupersededError();
+    return RelaySessionLease._(this, _scope);
+  }
+
+  void _checkLease(RelaySessionLease lease) {
+    if (_disposed ||
+        !identical(lease._session, this) ||
+        !identical(lease._scope, _scope)) {
+      throw RelaySessionSupersededError();
+    }
+  }
+
+  /// Publish using the scope captured before signing, including after gate waits.
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
+    _checkLease(lease);
     final generation = _connectionGeneration;
     if (_rateLimitGate.isActive) await _rateLimitGate.wait();
+    _checkLease(lease);
     if (!_isActiveConnection(generation) || !_socketConnected) {
       throw StateError('Relay session is not connected');
     }
@@ -338,11 +380,15 @@ class RelaySessionNotifier extends Notifier<SessionState> {
       timeout: timer,
     );
 
+    // No await or consumer callback between the lease check and the socket's
+    // synchronous sink.add: scope replacement cannot interleave with this write.
     _socket?.send(['EVENT', event.toJson()]);
     return completer.future;
   }
 
-  void sendRaw(List<dynamic> payload) {
+  /// Fire-and-forget send in the scope captured before asynchronous signing.
+  void sendRaw(List<dynamic> payload, {required RelaySessionLease lease}) {
+    _checkLease(lease);
     _socket?.send(payload);
   }
 
@@ -475,7 +521,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   }
 
   Future<void> _connect(RelayConfig config) async {
-    if (_disposed) return;
+    if (_disposed || !identical(config, ref.read(relayConfigProvider))) return;
 
     final generation = ++_connectionGeneration;
     state = SessionState(
@@ -489,6 +535,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     final socket = _socketFactory(
       wsUrl: config.wsUrl,
       nsec: config.nsec,
+      signer: config.signer,
       onMessage: (message) {
         if (generation == _connectionGeneration) _handleMessage(message);
       },
@@ -960,6 +1007,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
   void _dispose() {
     _disposed = true;
+    _scope = Object();
     _beforePauseCallbacks.clear();
     _connectionGeneration++;
     _reconnectTimer?.cancel();

--- a/mobile/lib/shared/relay/relay_session_auth.dart
+++ b/mobile/lib/shared/relay/relay_session_auth.dart
@@ -5,14 +5,12 @@ Future<String> buildNip98AuthHeader({
   required String url,
   required List<int> bodyBytes,
   required String? nsec,
+  EventSigner? signer,
 }) async {
-  if (nsec == null || nsec.isEmpty) {
-    throw Exception('Cannot query relay: no signing key available');
-  }
-  final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-  if (privkeyHex.isEmpty) {
-    throw Exception('Invalid nsec');
-  }
+  signer ??= nsec == null
+      ? null
+      : LocalEventSigner(nostr.Nip19.decode(payload: nsec).data);
+  if (signer == null) throw StateError('No signing identity');
   final payloadHash = SHA256Digest()
       .process(Uint8List.fromList(bodyBytes))
       .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
@@ -26,7 +24,7 @@ Future<String> buildNip98AuthHeader({
       ['payload', payloadHash],
       ['nonce', const Uuid().v4()],
     ],
-    signer: LocalEventSigner(privkeyHex),
+    signer: signer,
   );
   return 'Nostr ${base64.encode(utf8.encode(event.toJson()))}';
 }

--- a/mobile/lib/shared/relay/relay_session_types.dart
+++ b/mobile/lib/shared/relay/relay_session_types.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import 'relay_socket.dart';
+import '../auth/event_signer.dart';
 
 enum SessionStatus { disconnected, connecting, connected, reconnecting }
 
@@ -8,6 +9,7 @@ typedef RelaySocketFactory =
     RelaySocket Function({
       required String wsUrl,
       required String? nsec,
+      EventSigner? signer,
       required void Function(List<dynamic> message) onMessage,
       required void Function() onConnected,
       required void Function(Object? error) onDisconnected,

--- a/mobile/lib/shared/relay/relay_socket.dart
+++ b/mobile/lib/shared/relay/relay_socket.dart
@@ -41,6 +41,7 @@ class RelaySocket {
 
   final String _wsUrl;
   final String? _nsec;
+  final EventSigner? _signer;
   final void Function(List<dynamic> message) _onMessage;
   final void Function() _onConnected;
   final void Function(Object? error) _onDisconnected;
@@ -51,17 +52,20 @@ class RelaySocket {
   Completer<void>? _authCompleter;
   Timer? _authTimeout;
   String? _pendingAuthEventId;
+  int _authChallengeGeneration = 0;
 
   SocketState get state => _state;
 
   RelaySocket({
     required String wsUrl,
     required String? nsec,
+    EventSigner? signer,
     required void Function(List<dynamic> message) onMessage,
     required void Function() onConnected,
     required void Function(Object? error) onDisconnected,
   }) : _wsUrl = wsUrl,
        _nsec = nsec,
+       _signer = signer,
        _onMessage = onMessage,
        _onConnected = onConnected,
        _onDisconnected = onDisconnected;
@@ -198,19 +202,16 @@ class RelaySocket {
     if (data.length < 2) return;
     final challenge = data[1] as String;
     final channel = _channel;
+    final challengeGeneration = ++_authChallengeGeneration;
 
-    if (_nsec == null) {
+    if (_nsec == null && _signer == null) {
       _failAuth(Exception('No nsec available for NIP-42 auth'));
       return;
     }
 
     try {
-      // Decode bech32 nsec to hex private key.
-      final privkeyHex = nostr.Nip19.decode(payload: _nsec).data;
-      if (privkeyHex.isEmpty) {
-        _failAuth(Exception('Invalid nsec'));
-        return;
-      }
+      final signer =
+          _signer ?? LocalEventSigner(nostr.Nip19.decode(payload: _nsec!).data);
 
       // Build the auth tags.
       final tags = <List<String>>[
@@ -223,14 +224,20 @@ class RelaySocket {
         kind: EventKind.auth,
         content: '',
         tags: tags,
-        signer: LocalEventSigner(privkeyHex),
+        signer: signer,
       );
 
-      if (!identical(channel, _channel)) return;
+      if (!identical(channel, _channel) ||
+          challengeGeneration != _authChallengeGeneration) {
+        return;
+      }
       _pendingAuthEventId = event.id;
       send(['AUTH', event.toMap()]);
     } catch (e) {
-      if (!identical(channel, _channel)) return;
+      if (!identical(channel, _channel) ||
+          challengeGeneration != _authChallengeGeneration) {
+        return;
+      }
       _failAuth(e);
     }
   }

--- a/mobile/lib/shared/relay/signed_event_relay.dart
+++ b/mobile/lib/shared/relay/signed_event_relay.dart
@@ -9,23 +9,32 @@ import 'relay_session.dart';
 import 'relay_socket.dart';
 
 /// Signs and submits Nostr events through the relay WebSocket connection.
+///
+/// Bound to the session scope at construction. Recreate after a dependency
+/// rebuild. Signing completions in retired scopes throw
+/// [RelaySessionSupersededError] without invoking [submit]'s callback or
+/// publishing into the replacement scope.
 class SignedEventRelay {
   final RelaySessionNotifier _session;
+  final RelaySessionLease _lease;
   final String? _nsec;
   final EventSigner? _signer;
 
   SignedEventRelay({
     required RelaySessionNotifier session,
     required String? nsec,
+    EventSigner? signer,
   }) : _session = session,
+       _lease = session.captureLease(),
        _nsec = nsec,
-       _signer = null;
+       _signer = signer;
 
   /// Submit with an explicit signer snapshot, without access to a local secret.
   SignedEventRelay.withSigner({
     required RelaySessionNotifier session,
     required EventSigner signer,
   }) : _session = session,
+       _lease = session.captureLease(),
        _signer = signer,
        _nsec = null;
 
@@ -49,6 +58,7 @@ class SignedEventRelay {
     int? createdAt,
     void Function(NostrEvent event)? onSigned,
   }) async {
+    _lease.ensureCurrent();
     final EventSigner signer;
     if (_signer case final supplied?) {
       signer = supplied;
@@ -71,8 +81,14 @@ class SignedEventRelay {
     );
 
     final nostrEvent = NostrEvent.fromJson(event.toMap());
+    _lease.ensureCurrent();
     onSigned?.call(nostrEvent);
-    return _session.publish(nostrEvent);
+    final acknowledgement = await _session.publish(nostrEvent, lease: _lease);
+    _lease.ensureCurrent();
+    if (acknowledgement.id != nostrEvent.id) {
+      throw StateError('Relay acknowledgement does not match the signed event');
+    }
+    return acknowledgement;
   }
 }
 
@@ -111,7 +127,7 @@ Future<NostrEvent> submitSignedEventOnce({
         final bool accepted,
         final String detail,
         ...,
-      ] when eventId == event.id) {
+      ] when eventId == event.id && !result.isCompleted) {
         if (accepted) {
           result.complete(
             NostrEvent(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1654,7 +1654,7 @@ packages:
     source: hosted
     version: "2.9.4"
   video_player_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: video_player_platform_interface
       sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -55,6 +55,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   fake_async: ^1.3.3
   camera_platform_interface: ^2.13.1
+  video_player_platform_interface: ^6.6.0
   crypto: ^3.0.7
   custom_lint: ^0.8.0
   riverpod_lint: ^3.1.0

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -14443,6 +14443,7 @@ class _ReconnectingRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     publishedKinds.add(event.kind);
@@ -14621,6 +14622,7 @@ class _ProfileSubscriptionRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async => event;
 
@@ -14652,6 +14654,7 @@ class _HuddleReactionRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async => event;
 

--- a/mobile/test/features/channels/channel_management_provider_test.dart
+++ b/mobile/test/features/channels/channel_management_provider_test.dart
@@ -760,6 +760,7 @@ class _RecordingPublishRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     publishedEvents.add(event);

--- a/mobile/test/features/channels/message_content_test.dart
+++ b/mobile/test/features/channels/message_content_test.dart
@@ -2228,7 +2228,10 @@ Photos
           expect(preview, findsOneWidget);
 
           await tester.tap(preview);
-          await tester.pumpAndSettle();
+          // Navigation works while the video is loading; do not wait for the
+          // indeterminate player animation/native networking to settle.
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
 
           // Video viewer opens as a modal overlay (no AppBar)
           final viewer = tester.widget<Scaffold>(
@@ -2295,7 +2298,8 @@ Photos
             ),
           ),
         );
-        await tester.pumpAndSettle();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
 
         await tester.drag(
           find.byKey(const ValueKey('message-media-video-viewer-gesture')),

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -272,6 +272,7 @@ class _PendingPublishRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) {
     this.event = event;

--- a/mobile/test/features/channels/video_viewer_cancellation_test.dart
+++ b/mobile/test/features/channels/video_viewer_cancellation_test.dart
@@ -1,0 +1,246 @@
+import 'dart:async';
+
+import 'package:buzz/features/channels/media_viewer_page.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+class _DeferredAuth extends MediaGetAuthService {
+  final ready = Completer<Map<String, String>>();
+  int calls = 0;
+  _DeferredAuth({this.remote = false})
+    : super(baseUrl: 'https://relay.example', nsec: null);
+  final bool remote;
+  @override
+  bool get isRemote => remote;
+  @override
+  Future<Map<String, String>> headersFor(String url) {
+    calls++;
+    return ready.future;
+  }
+}
+
+class _VideoPlatform extends VideoPlayerPlatform {
+  final events = StreamController<VideoEvent>.broadcast();
+  final sources = <DataSource>[];
+  int plays = 0;
+  int disposals = 0;
+  @override
+  Future<void> init() async {}
+  @override
+  Future<int> createWithOptions(VideoCreationOptions options) async {
+    sources.add(options.dataSource);
+    return 1;
+  }
+
+  @override
+  Stream<VideoEvent> videoEventsFor(int playerId) => events.stream;
+  @override
+  Future<void> dispose(int playerId) async => disposals++;
+  @override
+  Future<void> play(int playerId) async => plays++;
+  @override
+  Future<void> pause(int playerId) async {}
+  @override
+  Future<void> setLooping(int playerId, bool looping) async {}
+  @override
+  Future<void> setVolume(int playerId, double volume) async {}
+  @override
+  Future<void> setPlaybackSpeed(int playerId, double speed) async {}
+  @override
+  Widget buildViewWithOptions(VideoViewOptions options) => const SizedBox();
+  void finishInitialization() => events.add(
+    VideoEvent(
+      eventType: VideoEventType.initialized,
+      duration: const Duration(seconds: 10),
+      size: const Size(320, 180),
+    ),
+  );
+}
+
+void main() {
+  late _DeferredAuth auth;
+  late _VideoPlatform platform;
+  late VideoPlayerPlatform previousPlatform;
+  late int httpRequests;
+
+  setUp(() {
+    previousPlatform = VideoPlayerPlatform.instance;
+    httpRequests = 0;
+  });
+  tearDown(() async {
+    VideoPlayerPlatform.instance = previousPlatform;
+    await platform.events.close();
+  });
+
+  Future<void> open(
+    WidgetTester tester, {
+    bool remote = false,
+    http.Client? client,
+  }) {
+    auth = _DeferredAuth(remote: remote);
+    platform = _VideoPlatform();
+    VideoPlayerPlatform.instance = platform;
+    return tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mediaVideoStreamingSupportedProvider.overrideWithValue(
+            defaultTargetPlatform == TargetPlatform.android,
+          ),
+          mediaGetAuthServiceProvider.overrideWithValue(auth),
+          mediaHttpClientProvider.overrideWithValue(
+            client ??
+                MockClient((_) async {
+                  httpRequests++;
+                  return http.Response('', 500);
+                }),
+          ),
+        ],
+        child: const MaterialApp(
+          home: MediaVideoViewerPage(
+            videoUrl: 'https://relay.example/media/video.mp4',
+          ),
+        ),
+      ),
+    );
+  }
+
+  for (final responseKind in ['redirect', 'oversize']) {
+    testWidgets(
+      'corporate Android video rejects $responseKind without native network',
+      (tester) async {
+        final client = MockClient.streaming((request, body) async {
+          httpRequests++;
+          expect(request.followRedirects, false);
+          expect(request.headers['Authorization'], 'captured A auth');
+          return http.StreamedResponse(
+            const Stream.empty(),
+            responseKind == 'redirect' ? 302 : 200,
+            contentLength: responseKind == 'oversize' ? 257 * 1024 * 1024 : 0,
+            headers: {'location': 'https://attacker.example/media/video.mp4'},
+          );
+        });
+        await open(tester, remote: true, client: client);
+        auth.ready.complete({'Authorization': 'captured A auth'});
+        await tester.pump();
+        await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+        await tester.pump();
+        expect(httpRequests, 1);
+        expect(platform.sources, isEmpty);
+        expect(platform.plays, 0);
+        expect(find.text('Failed to load video'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox());
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+  }
+
+  testWidgets(
+    'corporate auth failure never falls back to unsigned video',
+    (tester) async {
+      await open(tester, remote: true);
+      auth.ready.completeError(StateError('Corporate login required'));
+      await tester.pump();
+      expect(httpRequests, 0);
+      expect(platform.sources, isEmpty);
+      expect(find.text('Failed to load video'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+      await tester.pumpWidget(const SizedBox());
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
+  for (final target in [TargetPlatform.android, TargetPlatform.iOS]) {
+    testWidgets(
+      '$target disposal during auth creates no player or request',
+      (tester) async {
+        await open(tester);
+        expect(auth.calls, 1);
+        await tester.pumpWidget(const SizedBox());
+        auth.ready.complete({'Authorization': 'captured A auth'});
+        await tester.pump();
+        expect(platform.sources, isEmpty);
+        expect(platform.plays, 0);
+        expect(httpRequests, 0);
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(target),
+    );
+  }
+
+  testWidgets(
+    'disposal during initialization cleans up without play or fallback',
+    (tester) async {
+      await open(tester);
+      auth.ready.complete({'Authorization': 'captured A auth'});
+      await tester.pump();
+      expect(platform.sources.single.httpHeaders, {
+        'Authorization': 'captured A auth',
+      });
+      await tester.pumpWidget(const SizedBox());
+      platform.finishInitialization();
+      await tester.pump();
+      expect(platform.plays, 0);
+      // Stream cancellation can complete outside the widget fake-async zone.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(platform.disposals, 1);
+      expect(httpRequests, 0);
+      expect(auth.calls, 1);
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
+  testWidgets(
+    'initialization failure after disposal does not enter fallback',
+    (tester) async {
+      await open(tester);
+      auth.ready.complete({});
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox());
+      platform.events.addError(
+        PlatformException(code: 'init', message: 'initialization failed'),
+      );
+      await tester.pump();
+      // Stream cancellation can complete outside the widget fake-async zone.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(platform.disposals, 1);
+      expect(platform.plays, 0);
+      expect(auth.calls, 1);
+      expect(httpRequests, 0);
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
+  testWidgets(
+    'live viewer still initializes, plays, and disposes normally',
+    (tester) async {
+      await open(tester);
+      auth.ready.complete({'Authorization': 'captured A auth'});
+      await tester.pump();
+      platform.finishInitialization();
+      await tester.pump();
+      expect(platform.sources, hasLength(1));
+      expect(platform.plays, 1);
+      expect(platform.disposals, 0);
+      expect(httpRequests, 0);
+      await tester.pumpWidget(const SizedBox());
+      // Stream cancellation can complete outside the widget fake-async zone.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(platform.disposals, 1);
+      expect(tester.takeException(), isNull);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+}

--- a/mobile/test/features/channels/voice_note_recording_test.dart
+++ b/mobile/test/features/channels/voice_note_recording_test.dart
@@ -60,6 +60,7 @@ class _DelayedHttpClient extends http.BaseClient {
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
+    expect(request.followRedirects, false);
     sent.complete(request);
     return response.future;
   }
@@ -71,6 +72,7 @@ class _SequencedHttpClient extends http.BaseClient {
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
+    expect(request.followRedirects, false);
     requests.add(request);
     final response = Completer<http.StreamedResponse>();
     responses.add(response);

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -625,6 +625,7 @@ class _ProfileRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);
@@ -660,6 +661,7 @@ class _ControlledProfileRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);
@@ -686,6 +688,7 @@ class _LosingProfileRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);

--- a/mobile/test/features/profile/user_status_provider_test.dart
+++ b/mobile/test/features/profile/user_status_provider_test.dart
@@ -192,6 +192,7 @@ class _RecordingRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published.add(event);

--- a/mobile/test/shared/auth/enterprise_build_config_test.dart
+++ b/mobile/test/shared/auth/enterprise_build_config_test.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+import 'package:buzz/shared/auth/enterprise_identity.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'compiled Dart define reaches the production native config parser',
+    () async {
+      // Run once normally (OSS), and once with --dart-define-from-file containing
+      // synthetic seven-field JSON. An ordinary shell environment is not enough.
+      const expectedManaged = bool.fromEnvironment('EXPECT_MANAGED');
+      expect(enterpriseEnabled, expectedManaged);
+      FlutterSecureStorage.setMockInitialValues({});
+      final owner =
+          EnterpriseIdentity(); // Actual default compile-time consumer.
+      await owner.restore();
+      expect(owner.authenticated, false);
+      if (expectedManaged) {
+        final config =
+            jsonDecode(enterpriseBuildConfig) as Map<String, dynamic>;
+        expect(config.length, 7);
+        expect(config['redirectUri'], 'buzz://enterprise-login');
+        expect(config.containsKey('environment'), false);
+      } else {
+        expect(enterpriseBuildConfig, isEmpty);
+      }
+    },
+  );
+}

--- a/mobile/test/shared/auth/enterprise_identity_test.dart
+++ b/mobile/test/shared/auth/enterprise_identity_test.dart
@@ -1,0 +1,672 @@
+import 'dart:convert';
+import 'dart:async';
+import 'package:buzz/shared/auth/event_signer.dart';
+import 'package:buzz/shared/relay/media_auth.dart';
+import 'package:buzz/shared/auth/enterprise_identity.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final config = jsonEncode({
+    'signerUrl': 'https://signer.example/cash-app/goose/',
+    'issuer': 'https://login.example/',
+    'clientId': 'native',
+    'audience': 'signer',
+    'organization': 'org',
+    'connection': 'okta',
+    'redirectUri': 'buzz://enterprise-login',
+  });
+  final keys = nostr.Keys.generate();
+  final identity = {
+    'pubkey': keys.public,
+    'relayHttpUrl': 'https://buzz.example',
+    'relayWsUrl': 'wss://buzz.example',
+  };
+  Map<String, dynamic> tokens(int expiresAt) => {
+    'access_token': 'access',
+    'refresh_token': 'refresh',
+    'token_type': 'Bearer',
+    'expires_in': 120,
+    'expiresAt': expiresAt,
+  };
+  void seed({required int expiresAt}) {
+    FlutterSecureStorage.setMockInitialValues({
+      'buzz.enterprise.session': jsonEncode({
+        'config': config,
+        'identity': identity,
+        'tokens': tokens(expiresAt),
+      }),
+    });
+  }
+
+  test(
+    'managed media requests satisfy backend policy and refresh at 110 seconds',
+    () async {
+      var clock = DateTime.now();
+      seed(expiresAt: clock.millisecondsSinceEpoch ~/ 1000 + 300);
+      final requests = <http.Request>[];
+      final expirations = <int>[];
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) async {
+          requests.add(request);
+          expect(request.url.path, '/cash-app/goose/v1/buzz/identity/sign');
+          expect(request.followRedirects, false);
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body['purpose'], 'media-read');
+          final event = body['event'] as Map<String, dynamic>;
+          final tags = (event['tags'] as List)
+              .map((t) => List<String>.from(t as List))
+              .toList();
+          final expiry = int.parse(
+            tags.singleWhere((t) => t.first == 'expiration')[1],
+          );
+          final now = clock.millisecondsSinceEpoch ~/ 1000;
+          // IdentitySigningPolicy.kt (703f0219), media-read: expiry in
+          // (now + 1)..(now + 300), exact server, kind/tags and fresh timestamp.
+          if (expiry < now + 1 || expiry > now + 300) {
+            return http.Response('backend media proof lifetime denied', 403);
+          }
+          expect(event['kind'], 24242);
+          expect(tags.length, 3);
+          expect(tags, contains(equals(['t', 'get'])));
+          expect(tags, contains(equals(['server', 'buzz.example'])));
+          expect(event['created_at'], inInclusiveRange(now - 60, now + 30));
+          expect(expiry, now + 120);
+          expirations.add(expiry);
+          final signed = nostr.Event.from(
+            kind: event['kind'] as int,
+            content: event['content'] as String,
+            tags: tags,
+            createdAt: event['created_at'] as int,
+            secretKey: nostr.Nip19.decode(payload: keys.nsec).data,
+            verify: false,
+          );
+          return http.Response(jsonEncode({'event': signed.toMap()}), 200);
+        }),
+      );
+      await owner.restore();
+      final media = MediaGetAuthService(
+        baseUrl: 'https://buzz.example',
+        nsec: null,
+        signer: owner.captureSigner(),
+        now: () => clock,
+      );
+      var mediaRequests = 0;
+      final transport = MockClient((request) async {
+        mediaRequests++;
+        expect(request.followRedirects, false);
+        expect(request.headers['Authorization'], startsWith('Nostr '));
+        return http.Response('blob', 200);
+      });
+      final first = await media.headersFor('https://buzz.example/media/blob');
+      clock = clock.add(const Duration(seconds: 109));
+      expect(
+        await media.headersFor('https://buzz.example/media/other'),
+        same(first),
+      );
+      expect(requests.length, 1);
+      clock = clock.add(const Duration(seconds: 1));
+      await media.get(transport, 'https://buzz.example/media/blob');
+      expect(requests.length, 2);
+      expect(expirations[1] - expirations[0], 110);
+      expect(mediaRequests, 1);
+      await owner.logout();
+      await expectLater(
+        media.get(transport, 'https://buzz.example/media/blob'),
+        throwsA(isA<StateError>()),
+      );
+      expect(mediaRequests, 1);
+      expect(requests.length, 2);
+    },
+  );
+
+  test(
+    'restored corporate identity sends only bearer and verifies exact signed event',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final requests = <http.Request>[];
+      final service = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) async {
+          requests.add(request);
+          expect(request.followRedirects, false);
+          expect(request.headers['Authorization'], 'Bearer access');
+          expect(request.headers.containsKey('X-BB-Session-Credential'), false);
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          final template = body['event'] as Map<String, dynamic>;
+          expect(template.containsKey('pubkey'), false);
+          final signed = nostr.Event.from(
+            kind: template['kind'] as int,
+            content: template['content'] as String,
+            tags: (template['tags'] as List)
+                .map((t) => List<String>.from(t as List))
+                .toList(),
+            createdAt: template['created_at'] as int,
+            secretKey: nostr.Nip19.decode(payload: keys.nsec).data,
+            verify: false,
+          );
+          return http.Response(jsonEncode({'event': signed.toMap()}), 200);
+        }),
+      );
+      await service.restore();
+      final event = await signEvent(
+        signer: service.captureSigner(),
+        kind: 9,
+        content: 'hello',
+        tags: [
+          ['h', 'channel'],
+        ],
+        createdAt: 1000,
+      );
+      expect(event.pubkey, keys.public);
+      expect(event.createdAt, 1000);
+      expect(
+        requests.single.url.toString(),
+        'https://signer.example/cash-app/goose/v1/buzz/identity/sign',
+      );
+    },
+  );
+  test('forged signatures or changed templates fail closed', () async {
+    for (final forged in [true, false]) {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final service = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) async {
+          final signed = nostr.Event.from(
+            kind: 9,
+            content: forged ? 'hello' : 'changed',
+            tags: [
+              ['h', 'channel'],
+            ],
+            createdAt: 1000,
+            secretKey: nostr.Nip19.decode(payload: keys.nsec).data,
+            verify: false,
+          ).toMap();
+          if (forged) signed['sig'] = '0' * 128;
+          return http.Response(jsonEncode({'event': signed}), 200);
+        }),
+      );
+      await service.restore();
+      await expectLater(
+        signEvent(
+          signer: service.captureSigner(),
+          kind: 9,
+          content: 'hello',
+          tags: [
+            ['h', 'channel'],
+          ],
+          createdAt: 1000,
+        ),
+        throwsA(anything),
+      );
+    }
+  });
+  test(
+    'refresh is single-flight and rotated credential is persisted before use',
+    () async {
+      seed(expiresAt: 0);
+      var refreshes = 0;
+      final service = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) async {
+          if (request.url.path == '/oauth/token') {
+            refreshes++;
+            expect(jsonDecode(request.body)['refresh_token'], 'refresh');
+            return http.Response(
+              jsonEncode({
+                'access_token': 'new-access',
+                'refresh_token': 'rotated',
+                'token_type': 'Bearer',
+                'expires_in': 120,
+              }),
+              200,
+            );
+          }
+          expect(request.headers['Authorization'], 'Bearer new-access');
+          return http.Response(jsonEncode(identity), 200);
+        }),
+      );
+      await service.restore();
+      expect(
+        await Future.wait([service.accessToken(), service.accessToken()]),
+        ['new-access', 'new-access'],
+      );
+      expect(refreshes, 1);
+      final saved = jsonDecode(
+        (await const FlutterSecureStorage().read(
+          key: 'buzz.enterprise.session',
+        ))!,
+      );
+      expect(saved['tokens']['refresh_token'], 'rotated');
+    },
+  );
+  test(
+    'refresh cannot switch account and denial never uses local keys',
+    () async {
+      seed(expiresAt: 0);
+      final service = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) async {
+          if (request.url.path == '/oauth/token') {
+            return http.Response(
+              jsonEncode({
+                'access_token': 'new-access',
+                'refresh_token': 'rotated',
+                'token_type': 'Bearer',
+                'expires_in': 120,
+              }),
+              200,
+            );
+          }
+          return http.Response(
+            jsonEncode({...identity, 'pubkey': nostr.Keys.generate().public}),
+            200,
+          );
+        }),
+      );
+      await expectLater(service.restore(), throwsStateError);
+      expect(service.authenticated, false);
+      await expectLater(service.accessToken(), throwsStateError);
+    },
+  );
+  test(
+    'credentials cannot be restored by a different release-selected issuer',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final service = EnterpriseIdentity(
+        config: config.replaceAll('login.example', 'other.example'),
+        client: MockClient((_) async => throw StateError('must not transmit')),
+      );
+      await expectLater(service.restore(), throwsStateError);
+    },
+  );
+  test(
+    'logout revokes a captured signer even when next login is the same pubkey',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((_) async => throw StateError('must not send')),
+      );
+      await owner.restore();
+      final signer = owner.captureSigner();
+      await owner.logout();
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      await owner.restore();
+      expect(owner.pubkey, signer.publicKey);
+      expect(() => signer.checkCurrent(), throwsStateError);
+      expect(
+        () => signEvent(signer: signer, kind: 9, content: '', tags: []),
+        throwsStateError,
+      );
+    },
+  );
+
+  test(
+    'logout during sign discards a valid response from the old login',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final entered = Completer<void>();
+      final response = Completer<http.Response>();
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((_) {
+          entered.complete();
+          return response.future;
+        }),
+      );
+      await owner.restore();
+      final signing = signEvent(
+        signer: owner.captureSigner(),
+        kind: 9,
+        content: 'hello',
+        tags: [],
+        createdAt: 1000,
+      );
+      final rejected = expectLater(signing, throwsStateError);
+      await entered.future;
+      await owner.logout();
+      final event = nostr.Event.from(
+        kind: 9,
+        content: 'hello',
+        tags: [],
+        createdAt: 1000,
+        secretKey: keys.secret,
+      );
+      response.complete(
+        http.Response(jsonEncode({'event': event.toMap()}), 200),
+      );
+      await rejected;
+    },
+  );
+
+  test(
+    'logout during refresh prevents ensure and does not recreate secure storage',
+    () async {
+      seed(expiresAt: 0);
+      final entered = Completer<void>();
+      final response = Completer<http.Response>();
+      final urls = <String>[];
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) {
+          urls.add(request.url.path);
+          entered.complete();
+          return response.future;
+        }),
+      );
+      final restoring = expectLater(owner.restore(), throwsStateError);
+      await entered.future;
+      await owner.logout();
+      response.complete(http.Response(jsonEncode(tokens(100)), 200));
+      await restoring;
+      expect(urls, ['/oauth/token']);
+      expect(owner.authenticated, false);
+      expect(
+        await const FlutterSecureStorage().read(key: 'buzz.enterprise.session'),
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'corporate media proof is attached only to the exact HTTPS origin',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      var requests = 0;
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) async {
+          requests++;
+          final template = jsonDecode(request.body)['event'];
+          final signed = nostr.Event.from(
+            kind: template['kind'],
+            content: template['content'],
+            tags: (template['tags'] as List)
+                .map((t) => List<String>.from(t))
+                .toList(),
+            createdAt: template['created_at'],
+            secretKey: keys.secret,
+          );
+          return http.Response(jsonEncode({'event': signed.toMap()}), 200);
+        }),
+      );
+      await owner.restore();
+      final auth = MediaGetAuthService(
+        baseUrl: owner.relayUrl!,
+        nsec: null,
+        signer: owner.captureSigner(),
+      );
+      for (final url in [
+        'http://buzz.example/media/a',
+        'http://buzz.example:443/media/a',
+        'https://buzz.example:80/media/a',
+        'https://user@buzz.example/media/a',
+        'https://@buzz.example/media/a',
+        'https://buzz.example:444/media/a',
+        'https://other.example/media/a',
+        'https://buzz.example.evil/media/a',
+        'https://buzz.example/not-media/a',
+      ]) {
+        expect(await auth.headersFor(url), isEmpty, reason: url);
+      }
+      expect(requests, 0);
+      final proof = await auth.headersFor('https://buzz.example/media/a');
+      expect(proof['Authorization'], startsWith('Nostr '));
+      expect(
+        await auth.headersFor('https://buzz.example:443/media/b'),
+        same(proof),
+      );
+      expect(requests, 1);
+      final fetched = await auth.get(
+        MockClient((request) async {
+          expect(request.followRedirects, false);
+          expect(request.headers['Authorization'], proof['Authorization']);
+          return http.Response(
+            '',
+            302,
+            headers: {'location': 'https://evil.example/media/a'},
+          );
+        }),
+        'https://buzz.example/media/a',
+      );
+      expect(fetched.statusCode, 302);
+      auth.dispose();
+      await expectLater(
+        auth.headersFor('https://buzz.example/media/a'),
+        throwsStateError,
+      );
+    },
+  );
+
+  test(
+    'login uses PKCE, exact callback, scope intent and server-selected identity',
+    () async {
+      FlutterSecureStorage.setMockInitialValues({});
+      final callbacks = StreamController<Uri>();
+      final requests = <http.Request>[];
+      final owner = EnterpriseIdentity(
+        config: config,
+        callbacks: callbacks.stream,
+        openBrowser: (uri) async {
+          expect(
+            uri.queryParameters['scope'],
+            'openid profile email offline_access buzz:sign',
+          );
+          expect(uri.queryParameters['code_challenge_method'], 'S256');
+          expect(
+            uri.queryParameters['redirect_uri'],
+            'buzz://enterprise-login',
+          );
+          expect(uri.queryParameters.containsKey('client_secret'), false);
+          final state = uri.queryParameters['state']!;
+          callbacks.add(
+            Uri.parse('buzz://user@enterprise-login?code=wrong&state=$state'),
+          );
+          callbacks.add(
+            Uri.parse('buzz://enterprise-login?code=correct&state=$state'),
+          );
+          return true;
+        },
+        client: MockClient((request) async {
+          requests.add(request);
+          expect(request.followRedirects, false);
+          if (request.url.path == '/oauth/token') {
+            expect(jsonDecode(request.body)['code'], 'correct');
+            expect(jsonDecode(request.body)['code_verifier'], isNotEmpty);
+            return http.Response(jsonEncode(tokens(0)), 200);
+          }
+          expect(request.url.path, '/cash-app/goose/v1/buzz/identity/ensure');
+          expect(jsonDecode(request.body), isEmpty);
+          return http.Response(jsonEncode(identity), 200);
+        }),
+      );
+      await owner.login();
+      expect(owner.authenticated, true);
+      expect(owner.captureSigner().publicKey, keys.public);
+      expect(requests.length, 2);
+      await callbacks.close();
+    },
+  );
+
+  test(
+    'malformed native config fails before browser, storage or transport',
+    () async {
+      final valid = jsonDecode(config) as Map<String, dynamic>;
+      for (final bad in [
+        {...valid, 'redirectUri': 'buzz://enterprise-login/other'},
+        {...valid, 'signerUrl': 'http://signer.example/cash-app/goose/'},
+        {
+          ...valid,
+          'signerUrl': 'https://signer.example/v1/buzz/identity/ensure',
+        },
+        {...valid, 'issuer': 'https://user@login.example/'},
+        {...valid, 'clientSecret': 'forbidden'},
+        {...valid, 'environment': 'staging'},
+        {...valid, 'clientId': ''},
+        {...valid, 'signerUrl': 'https://signer.example:443/cash-app/goose/'},
+        {...valid, 'issuer': 'https://@login.example/'},
+      ]) {
+        final owner = EnterpriseIdentity(
+          config: jsonEncode(bad),
+          openBrowser: (_) async => throw StateError('must not open'),
+          client: MockClient((_) async => throw StateError('must not send')),
+        );
+        await expectLater(owner.restore(), throwsA(anything));
+      }
+    },
+  );
+  test(
+    'simultaneous expired-token consumers join the active refresh',
+    () async {
+      seed(expiresAt: 0);
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      var refreshes = 0;
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((request) async {
+          if (request.url.path == '/oauth/token') {
+            refreshes++;
+            entered.complete();
+            await release.future;
+            return http.Response(jsonEncode(tokens(0)), 200);
+          }
+          return http.Response(jsonEncode(identity), 200);
+        }),
+      );
+      final restoring = owner.restore();
+      await entered.future;
+      final first = owner.accessToken();
+      final second = owner.accessToken();
+      release.complete();
+      await restoring;
+      expect(await Future.wait([first, second]), ['access', 'access']);
+      expect(refreshes, 1);
+    },
+  );
+
+  test(
+    'logout cancels a pending browser callback without waiting five minutes',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final callbacks = StreamController<Uri>();
+      final opened = Completer<void>();
+      final owner = EnterpriseIdentity(
+        config: config,
+        callbacks: callbacks.stream,
+        openBrowser: (_) async {
+          opened.complete();
+          return true;
+        },
+        client: MockClient((_) async => throw StateError('must not send')),
+      );
+      final login = expectLater(owner.login(), throwsStateError);
+      await opened.future;
+      await owner.logout();
+      await login.timeout(const Duration(seconds: 1));
+      expect(
+        await const FlutterSecureStorage().read(key: 'buzz.enterprise.session'),
+        isNull,
+      );
+      await callbacks.close();
+    },
+  );
+
+  test(
+    'failed replacement login cannot restore the previous saved account',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final callbacks = StreamController<Uri>();
+      final owner = EnterpriseIdentity(
+        config: config,
+        callbacks: callbacks.stream,
+        openBrowser: (_) async => false,
+        client: MockClient((_) async => throw StateError('must not send')),
+      );
+      await owner.restore();
+      final old = owner.captureSigner();
+      await expectLater(owner.login(), throwsStateError);
+      expect(() => old.checkCurrent(), throwsStateError);
+      await owner.restore();
+      expect(owner.authenticated, false);
+      expect(
+        await const FlutterSecureStorage().read(key: 'buzz.enterprise.session'),
+        isNull,
+      );
+      await callbacks.close();
+    },
+  );
+
+  test(
+    'valid signatures cannot rewrite any exact event field or author',
+    () async {
+      for (final changed in [
+        'kind',
+        'content',
+        'tags',
+        'created_at',
+        'pubkey',
+      ]) {
+        seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+        final owner = EnterpriseIdentity(
+          config: config,
+          client: MockClient((request) async {
+            final signed = nostr.Event.from(
+              kind: changed == 'kind' ? 10 : 9,
+              content: changed == 'content' ? 'changed' : 'exact',
+              tags: [
+                ['h', changed == 'tags' ? 'other' : 'channel'],
+              ],
+              createdAt: changed == 'created_at' ? 1001 : 1000,
+              secretKey: changed == 'pubkey'
+                  ? nostr.Keys.generate().secret
+                  : keys.secret,
+            );
+            return http.Response(jsonEncode({'event': signed.toMap()}), 200);
+          }),
+        );
+        await owner.restore();
+        await expectLater(
+          signEvent(
+            signer: owner.captureSigner(),
+            kind: 9,
+            content: 'exact',
+            tags: [
+              ['h', 'channel'],
+            ],
+            createdAt: 1000,
+          ),
+          throwsStateError,
+          reason: changed,
+        );
+      }
+    },
+  );
+
+  test(
+    'managed media signing failure propagates, never unsigned fallback',
+    () async {
+      seed(expiresAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120);
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((_) async => http.Response('', 403)),
+      );
+      await owner.restore();
+      final auth = MediaGetAuthService(
+        baseUrl: owner.relayUrl!,
+        nsec: keys.nsec,
+        signer: owner.captureSigner(),
+      );
+      await expectLater(
+        auth.headersFor('https://buzz.example/media/a'),
+        throwsStateError,
+      );
+    },
+  );
+}

--- a/mobile/test/shared/auth/event_signer_test.dart
+++ b/mobile/test/shared/auth/event_signer_test.dart
@@ -24,17 +24,34 @@ final class _DeferredSigner implements EventSigner {
 
 final class _Session extends RelaySessionNotifier {
   NostrEvent? published;
+  bool wrongAck = false;
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published = event;
-    return event;
+    return wrongAck
+        ? NostrEvent.fromJson({...event.toJson(), 'id': '0' * 64})
+        : event;
   }
 }
 
 void main() {
+  test('submission rejects an acknowledgement for a different event', () async {
+    final session = _Session()..wrongAck = true;
+    final relay = SignedEventRelay.withSigner(
+      session: session,
+      signer: LocalEventSigner(nostr.Keys.generate().secret),
+    );
+    await expectLater(
+      relay.submit(kind: 1, content: 'exact', tags: []),
+      throwsStateError,
+    );
+    expect(session.published, isNotNull);
+  });
+
   test('local signer preserves the legacy event id and exact fields', () async {
     final keys = nostr.Keys.generate();
     final signer = LocalEventSigner(keys.secret);
@@ -131,8 +148,9 @@ void main() {
         LocalEventSigner(nostr.Keys.generate().secret),
       );
       final session = _Session();
-      final relay = SignedEventRelay.withSigner(
+      final relay = SignedEventRelay(
         session: session,
+        nsec: nostr.Keys.generate().nsec,
         signer: signer,
       );
       final pending = relay.submit(kind: 1, content: '', tags: []);

--- a/mobile/test/shared/relay/media_image_test.dart
+++ b/mobile/test/shared/relay/media_image_test.dart
@@ -139,6 +139,7 @@ void main() {
     test('resolves one fetch for repeated resolves of the same key', () async {
       var fetches = 0;
       final client = http_testing.MockClient((request) async {
+        expect(request.followRedirects, false);
         fetches += 1;
         return http.Response.bytes(_pngBytes, 200);
       });
@@ -159,6 +160,7 @@ void main() {
     test('sends auth headers with the fetch', () async {
       Map<String, String>? seen;
       final client = http_testing.MockClient((request) async {
+        expect(request.followRedirects, false);
         seen = request.headers;
         return http.Response.bytes(_pngBytes, 200);
       });
@@ -175,6 +177,7 @@ void main() {
     test('failed URL is not refetched until cooldown elapses', () async {
       var fetches = 0;
       final client = http_testing.MockClient((request) async {
+        expect(request.followRedirects, false);
         fetches += 1;
         return http.Response('rate limited', 429);
       });
@@ -207,6 +210,7 @@ void main() {
     test('honors Retry-After on 429 (capped)', () async {
       var fetches = 0;
       final client = http_testing.MockClient((request) async {
+        expect(request.followRedirects, false);
         fetches += 1;
         return http.Response(
           'rate limited',

--- a/mobile/test/shared/relay/media_upload_test.dart
+++ b/mobile/test/shared/relay/media_upload_test.dart
@@ -408,6 +408,7 @@ void main() {
       expect(capturedRequest!.headers['X-SHA-256'], isNotEmpty);
       expect(capturedRequest!.bodyBytes, _pngBytes);
 
+      expect(capturedRequest!.followRedirects, false);
       final authHeader = capturedRequest!.headers['Authorization'];
       expect(authHeader, isNotNull);
       expect(authHeader, startsWith('Nostr '));
@@ -472,7 +473,11 @@ void main() {
         ]);
         expect(requests[1].bodyBytes, requests[0].bodyBytes);
         expect(requests[0].headers['Authorization'], startsWith('Nostr '));
-        expect(requests[1].headers['Authorization'], startsWith('Nostr '));
+        expect(
+          requests[1].headers['Authorization'],
+          requests[0].headers['Authorization'],
+        );
+        expect(requests.every((request) => !request.followRedirects), true);
         expect(
           requests[1].headers['X-SHA-256'],
           requests[0].headers['X-SHA-256'],
@@ -730,6 +735,7 @@ void main() {
       await service.pickAndUploadImage();
 
       expect(capturedRequest, isNotNull);
+      expect(capturedRequest!.followRedirects, false);
       final authHeader = capturedRequest!.headers['Authorization'];
       expect(authHeader, isNotNull);
       final encoded = authHeader!.substring('Nostr '.length);

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -22,6 +22,7 @@ void main() {
     final session = RelaySessionNotifier(httpClient: client);
     final container = ProviderContainer(
       overrides: [
+        authProvider.overrideWith(_FakeAuthNotifier.new),
         relaySessionProvider.overrideWith(() => session),
         relayConfigProvider.overrideWith(
           () => _FakeRelayConfigNotifier(
@@ -32,6 +33,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
+    await container.read(authProvider.future);
 
     const filter = NostrFilter(
       kinds: EventKind.channelTimelineContentKinds,
@@ -54,6 +56,7 @@ void main() {
     expect(capturedRequest!.headers['Content-Type'], 'application/json');
     expect(jsonDecode(capturedRequest!.body), [filter.toJson()]);
 
+    expect(capturedRequest!.followRedirects, false);
     final authHeader = capturedRequest!.headers['Authorization'];
     expect(authHeader, isNotNull);
     expect(authHeader, startsWith('Nostr '));
@@ -88,6 +91,7 @@ void main() {
     );
     final container = ProviderContainer(
       overrides: [
+        authProvider.overrideWith(_FakeAuthNotifier.new),
         relaySessionProvider.overrideWith(() => session),
         relayConfigProvider.overrideWith(
           () => _FakeRelayConfigNotifier(
@@ -98,6 +102,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
+    await container.read(authProvider.future);
 
     await expectLater(
       container.read(relaySessionProvider.notifier).queryRelay(const []),
@@ -116,6 +121,7 @@ void main() {
     );
     final container = ProviderContainer(
       overrides: [
+        authProvider.overrideWith(_FakeAuthNotifier.new),
         relaySessionProvider.overrideWith(() => session),
         relayConfigProvider.overrideWith(
           () => _FakeRelayConfigNotifier(
@@ -126,6 +132,7 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
+    await container.read(authProvider.future);
     container.read(relaySessionProvider);
 
     await expectLater(
@@ -157,6 +164,7 @@ void main() {
       );
       final container = ProviderContainer(
         overrides: [
+          authProvider.overrideWith(_FakeAuthNotifier.new),
           relaySessionProvider.overrideWith(() => session),
           relayConfigProvider.overrideWith(
             () => _FakeRelayConfigNotifier(
@@ -167,6 +175,7 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
+      await container.read(authProvider.future);
       container.read(relaySessionProvider);
       await Future<void>.delayed(Duration.zero);
 
@@ -209,7 +218,7 @@ void main() {
       },
     );
     const body = '{"error":"rate-limited: quota exceeded; retry in 4s"}';
-    final harness = _queryHarness(
+    final harness = await _queryHarness(
       gate: gate,
       client: http_testing.MockClient((_) async => http.Response(body, 429)),
     );
@@ -239,7 +248,7 @@ void main() {
       },
     );
     const body = '{"error":"rate-limited: shared admission unavailable"}';
-    final harness = _queryHarness(
+    final harness = await _queryHarness(
       gate: gate,
       client: http_testing.MockClient((_) async => http.Response(body, 503)),
     );
@@ -269,7 +278,7 @@ void main() {
       },
     );
     const body = '{"error":"not found"}';
-    final harness = _queryHarness(
+    final harness = await _queryHarness(
       gate: gate,
       client: http_testing.MockClient((_) async => http.Response(body, 404)),
     );
@@ -299,7 +308,7 @@ void main() {
       },
     );
     const body = 'upstream unavailable';
-    final harness = _queryHarness(
+    final harness = await _queryHarness(
       gate: gate,
       client: http_testing.MockClient((_) async => http.Response(body, 503)),
     );
@@ -328,7 +337,7 @@ void main() {
         return timer;
       },
     );
-    final harness = _queryHarness(
+    final harness = await _queryHarness(
       gate: gate,
       client: http_testing.MockClient((_) async => http.Response('[]', 200)),
     );
@@ -345,7 +354,7 @@ void main() {
       timerFactory: _ManualTimer.new,
     );
     var requestCount = 0;
-    final harness = _queryHarness(
+    final harness = await _queryHarness(
       gate: gate,
       client: http_testing.MockClient((_) async {
         requestCount++;
@@ -464,6 +473,7 @@ void main() {
           ({
             required wsUrl,
             required nsec,
+            signer,
             required onMessage,
             required onConnected,
             required onDisconnected,
@@ -537,6 +547,7 @@ void main() {
             ({
               required wsUrl,
               required nsec,
+              signer,
               required onMessage,
               required onConnected,
               required onDisconnected,
@@ -594,6 +605,7 @@ void main() {
             ({
               required wsUrl,
               required nsec,
+              signer,
               required onMessage,
               required onConnected,
               required onDisconnected,
@@ -1410,7 +1422,7 @@ void main() {
       final session = RelaySessionNotifier(rateLimitGate: gate);
       session.debugAttachSocketForTest(_RecordingRelaySocket());
 
-      final publish = session.publish(_event());
+      final publish = session.publish(_event(), lease: session.captureLease());
       session.debugHandleMessage([
         'OK',
         'event-1',
@@ -1446,7 +1458,10 @@ void main() {
       final session = RelaySessionNotifier(rateLimitGate: gate);
       session.debugAttachSocketForTest(socket);
 
-      final firstPublish = session.publish(_event(id: 'event-a'));
+      final firstPublish = session.publish(
+        _event(id: 'event-a'),
+        lease: session.captureLease(),
+      );
       session.debugHandleMessage([
         'OK',
         'event-a',
@@ -1457,6 +1472,7 @@ void main() {
 
       var secondSettled = false;
       final secondPublish = session.publish(
+        lease: session.captureLease(),
         _event(id: 'event-b'),
         timeout: Duration.zero,
       );
@@ -1505,7 +1521,10 @@ void main() {
       session.debugAttachSocketForTest(socket);
       gate.activate(4);
 
-      final publish = session.publish(_event(id: 'event-b'));
+      final publish = session.publish(
+        _event(id: 'event-b'),
+        lease: session.captureLease(),
+      );
       session.debugSupersedeConnection();
       gateTimers.single.fire();
 
@@ -1519,7 +1538,7 @@ void main() {
     final session = RelaySessionNotifier(rateLimitGate: gate);
     session.debugAttachSocketForTest(_RecordingRelaySocket());
 
-    final publish = session.publish(_event());
+    final publish = session.publish(_event(), lease: session.captureLease());
     session.debugHandleMessage([
       'OK',
       'event-1',
@@ -1596,13 +1615,14 @@ class _QueryHarness {
   _QueryHarness({required this.container, required this.session});
 }
 
-_QueryHarness _queryHarness({
+Future<_QueryHarness> _queryHarness({
   required RelayRateLimitGate gate,
   required http.Client client,
-}) {
+}) async {
   final session = RelaySessionNotifier(httpClient: client, rateLimitGate: gate);
   final container = ProviderContainer(
     overrides: [
+      authProvider.overrideWith(_FakeAuthNotifier.new),
       relaySessionProvider.overrideWith(() => session),
       relayConfigProvider.overrideWith(
         () => _FakeRelayConfigNotifier(
@@ -1612,6 +1632,7 @@ _QueryHarness _queryHarness({
       ),
     ],
   );
+  await container.read(authProvider.future);
   container.read(relaySessionProvider);
   return _QueryHarness(container: container, session: session);
 }

--- a/mobile/test/shared/relay/signed_event_scope_test.dart
+++ b/mobile/test/shared/relay/signed_event_scope_test.dart
@@ -1,0 +1,476 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:buzz/shared/auth/enterprise_identity.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:buzz/shared/auth/event_signer.dart';
+import 'package:buzz/features/profile/user_status.dart';
+import 'package:buzz/features/profile/user_status_provider.dart';
+import 'package:buzz/features/profile/user_status_cache_provider.dart';
+import 'package:buzz/shared/auth/auth_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+class _Auth extends AuthNotifier {
+  @override
+  Future<AuthState> build() async =>
+      const AuthState(status: AuthStatus.unauthenticated);
+}
+
+class _Config extends RelayConfigNotifier {
+  final String nsec;
+  final RemoteEventSigner? remote;
+  _Config(this.nsec, this.remote);
+  @override
+  RelayConfig build() => RelayConfig(
+    baseUrl: 'https://a.example',
+    nsec: remote == null ? nsec : null,
+    remoteSigner: remote,
+  );
+  void switchCommunity() =>
+      state = RelayConfig(baseUrl: 'https://b.example', nsec: nsec);
+}
+
+class _Signer implements EventSigner {
+  final LocalEventSigner local;
+  final ready = Completer<void>();
+  _Signer(this.local);
+  @override
+  String get publicKey => local.publicKey;
+  @override
+  Future<nostr.Event> sign(UnsignedEvent event) async {
+    await ready.future;
+    return local.sign(event);
+  }
+}
+
+class _Socket extends RelaySocket {
+  final RelaySessionNotifier session;
+  final messages = <List<dynamic>>[];
+  void Function()? afterAck;
+  _Socket(this.session)
+    : super(
+        wsUrl: 'wss://recording.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+  @override
+  void send(List<dynamic> payload) {
+    messages.add(payload);
+    if (payload.first == 'EVENT') {
+      session.debugHandleMessage(['OK', (payload[1] as Map)['id'], true, 'ok']);
+      afterAck?.call();
+    }
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _StatusCache extends UserStatusCacheNotifier {
+  final updates = <UserStatus?>[];
+  @override
+  Map<String, UserStatus?> build() => {};
+  @override
+  void updateStatus(String pubkey, UserStatus? status) => updates.add(status);
+}
+
+class _Harness {
+  _Harness({this.remote, this.httpClient});
+  final RemoteEventSigner? remote;
+  final http.Client? httpClient;
+  final keys = nostr.Keys.generate();
+  late final config = _Config(keys.nsec, remote);
+  final gate = RelayRateLimitGate();
+  final cache = _StatusCache();
+  late final session = RelaySessionNotifier(
+    rateLimitGate: gate,
+    httpClient: httpClient,
+  );
+  late final container = ProviderContainer(
+    overrides: [
+      userStatusCacheProvider.overrideWith(() => cache),
+      authProvider.overrideWith(_Auth.new),
+      relayConfigProvider.overrideWith(() => config),
+      relaySessionProvider.overrideWith(() => session),
+    ],
+  );
+  late final a = _Socket(session);
+
+  Future<void> initialize() async {
+    addTearDown(container.dispose);
+    await container.read(authProvider.future);
+    container.read(relaySessionProvider);
+    session.debugAttachSocketForTest(a);
+  }
+
+  _Socket switchCommunity() {
+    config.switchCommunity();
+    container.read(relaySessionProvider);
+    expect(container.read(relaySessionProvider.notifier), same(session));
+    final b = _Socket(session);
+    session.debugAttachSocketForTest(b);
+    return b;
+  }
+
+  SignedEventRelay relay(EventSigner signer) =>
+      SignedEventRelay.withSigner(session: session, signer: signer);
+}
+
+Future<NostrEvent> _submit(
+  SignedEventRelay relay, {
+  void Function(NostrEvent)? onSigned,
+}) => relay.submit(
+  kind: 40002,
+  content: 'belongs to A',
+  tags: const [
+    ['h', 'channel-a'],
+  ],
+  onSigned: onSigned,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  for (final retirement in ['logout-and-restore', 'community', 'none']) {
+    test('production publication with remote signer: $retirement', () async {
+      final keys = nostr.Keys.generate();
+      final config = jsonEncode({
+        'signerUrl': 'https://signer.example/prefix/',
+        'issuer': 'https://login.example/',
+        'clientId': 'native',
+        'audience': 'signer',
+        'organization': 'org',
+        'connection': 'okta',
+        'redirectUri': 'buzz://enterprise-login',
+      });
+      void seed() => FlutterSecureStorage.setMockInitialValues({
+        'buzz.enterprise.session': jsonEncode({
+          'config': config,
+          'identity': {
+            'pubkey': keys.public,
+            'relayHttpUrl': 'https://a.example',
+            'relayWsUrl': 'wss://a.example',
+          },
+          'tokens': {
+            'access_token': 'access',
+            'token_type': 'Bearer',
+            'expiresAt': DateTime.now().millisecondsSinceEpoch ~/ 1000 + 120,
+          },
+        }),
+      });
+      seed();
+      final started = Completer<http.Request>();
+      final response = Completer<http.Response>();
+      final owner = EnterpriseIdentity(
+        config: config,
+        client: MockClient((r) {
+          started.complete(r);
+          return response.future;
+        }),
+      );
+      await owner.restore();
+      final signer = owner.captureSigner();
+      final h = _Harness(remote: signer);
+      await h.initialize();
+      final callbacks = <NostrEvent>[];
+      final pending = _submit(h.relay(signer), onSigned: callbacks.add);
+      final assertion = retirement == 'none'
+          ? null
+          : expectLater(
+              pending,
+              throwsA(
+                retirement == 'community'
+                    ? isA<RelaySessionSupersededError>()
+                    : isA<StateError>(),
+              ),
+            );
+      final request = await started.future;
+      expect(request.url.path, '/prefix/v1/buzz/identity/sign');
+      expect(request.followRedirects, false);
+      _Socket? b;
+      if (retirement == 'community') b = h.switchCommunity();
+      if (retirement == 'logout-and-restore') {
+        await owner.logout();
+        seed();
+        await owner.restore();
+        expect(owner.pubkey, signer.publicKey);
+      }
+      final template = jsonDecode(request.body)['event'];
+      final signed = nostr.Event.from(
+        kind: template['kind'] as int,
+        content: template['content'] as String,
+        tags: (template['tags'] as List)
+            .map((t) => List<String>.from(t as List))
+            .toList(),
+        createdAt: template['created_at'] as int,
+        secretKey: keys.secret,
+      );
+      response.complete(
+        http.Response(jsonEncode({'event': signed.toMap()}), 200),
+      );
+      if (assertion != null) {
+        await assertion;
+        expect(callbacks, isEmpty);
+        expect(h.a.messages, isEmpty);
+        expect(b?.messages ?? [], isEmpty);
+      } else {
+        final ack = await pending;
+        expect(callbacks.single.id, signed.id);
+        expect(ack.id, signed.id);
+        expect(h.a.messages.single, ['EVENT', signed.toMap()]);
+      }
+    });
+  }
+
+  test(
+    'HTTP query signing cannot cross same-key community replacement',
+    () async {
+      var requests = 0;
+      final h = _Harness(
+        httpClient: MockClient((_) async {
+          requests++;
+          return http.Response('[]', 200);
+        }),
+      );
+      await h.initialize();
+      final pending = h.session.queryRelay([
+        const NostrFilter(kinds: [1]),
+      ]);
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      h.switchCommunity();
+      await assertion;
+      expect(requests, 0);
+    },
+  );
+
+  test(
+    'deferred A signing cannot callback or publish on same-key community B',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      var callbacks = 0;
+      final pending = _submit(h.relay(signer), onSigned: (_) => callbacks++);
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      final b = h.switchCommunity();
+      signer.ready.complete();
+      await assertion;
+      expect(h.a.messages, isEmpty);
+      expect(
+        b.messages,
+        isEmpty,
+        reason: 'A event must never reach B transport',
+      );
+      expect(callbacks, 0);
+    },
+  );
+
+  test(
+    'dependency invalidation cancels even before the next session read',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      var callbacks = 0;
+      final pending = _submit(h.relay(signer), onSigned: (_) => callbacks++);
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      h.config.switchCommunity();
+      signer.ready.complete();
+      await assertion;
+      expect(h.a.messages, isEmpty);
+      expect(callbacks, 0);
+    },
+  );
+
+  test(
+    'normal delayed signing callbacks once then publishes exact event',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      final callbacks = <NostrEvent>[];
+      final pending = _submit(
+        h.relay(signer),
+        onSigned: (event) {
+          expect(h.a.messages, isEmpty);
+          callbacks.add(event);
+        },
+      );
+      expect(callbacks, isEmpty);
+      signer.ready.complete();
+      final result = await pending;
+      expect(callbacks, hasLength(1));
+      expect(h.a.messages.single, ['EVENT', callbacks.single.toJson()]);
+      expect(result.id, callbacks.single.id);
+      expect(result.content, 'ok');
+    },
+  );
+
+  test('retained signed relay cannot start new work after rebuild', () async {
+    final h = _Harness();
+    await h.initialize();
+    final relay = h.relay(LocalEventSigner(h.keys.secret));
+    final b = h.switchCommunity();
+    await expectLater(
+      _submit(relay),
+      throwsA(isA<RelaySessionSupersededError>()),
+    );
+    expect(b.messages, isEmpty);
+  });
+
+  test(
+    'callback switching scope is fenced again at production publish',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      late _Socket b;
+      await expectLater(
+        _submit(
+          h.relay(LocalEventSigner(h.keys.secret)),
+          onSigned: (_) => b = h.switchCommunity(),
+        ),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      expect(h.a.messages, isEmpty);
+      expect(b.messages, isEmpty);
+    },
+  );
+
+  test('direct publication cannot reuse a retired or foreign lease', () async {
+    final h = _Harness();
+    await h.initialize();
+    final lease = h.session.captureLease();
+    final signed = await LocalEventSigner(h.keys.secret).sign(
+      UnsignedEvent(
+        publicKey: h.keys.public,
+        createdAt: 1,
+        kind: 1,
+        content: '',
+        tags: const [],
+      ),
+    );
+    final event = NostrEvent.fromJson(signed.toMap());
+    final b = h.switchCommunity();
+    for (final invalid in [lease, RelaySessionNotifier().captureLease()]) {
+      await expectLater(
+        h.session.publish(event, lease: invalid),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      expect(
+        () => h.session.sendRaw(['EVENT', event.toJson()], lease: invalid),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+    }
+    expect(b.messages, isEmpty);
+  });
+
+  test(
+    'scope retires while production publish waits on rate-limit gate',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final callback = Completer<void>();
+      h.gate.activate(30);
+      final pending = _submit(
+        h.relay(LocalEventSigner(h.keys.secret)),
+        onSigned: (_) => callback.complete(),
+      );
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      await callback.future;
+      expect(h.a.messages, isEmpty);
+      final b = h.switchCommunity();
+      await assertion;
+      expect(b.messages, isEmpty);
+    },
+  );
+
+  test(
+    'ordinary connection supersession does not retire the scope lease',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      final signer = _Signer(LocalEventSigner(h.keys.secret));
+      final pending = _submit(h.relay(signer));
+      h.session.debugSupersedeConnection();
+      signer.ready.complete();
+      await pending;
+      expect(h.a.messages, hasLength(1));
+    },
+  );
+
+  test(
+    'user status direct signer cannot publish across community switch',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      await h.container.read(userStatusProvider.future);
+      final pending = h.container
+          .read(userStatusProvider.notifier)
+          .setStatus('A status', '');
+      final assertion = expectLater(
+        pending,
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      final b = h.switchCommunity();
+      await assertion;
+      expect(h.a.messages, isEmpty);
+      expect(b.messages, isEmpty);
+      expect(h.cache.updates, isEmpty);
+    },
+  );
+
+  test(
+    'user status cannot update B state/cache after an A acknowledgement',
+    () async {
+      final h = _Harness();
+      await h.initialize();
+      await h.container.read(userStatusProvider.future);
+      late _Socket b;
+      h.a.afterAck = () => b = h.switchCommunity();
+      await expectLater(
+        h.container.read(userStatusProvider.notifier).setStatus('A status', ''),
+        throwsA(isA<RelaySessionSupersededError>()),
+      );
+      expect(h.a.messages, hasLength(1));
+      expect(b.messages, isEmpty);
+      expect(h.cache.updates, isEmpty);
+      expect(await h.container.read(userStatusProvider.future), isNull);
+    },
+  );
+
+  test('disposal while signing cancels without callback or send', () async {
+    final h = _Harness();
+    await h.initialize();
+    final signer = _Signer(LocalEventSigner(h.keys.secret));
+    var callbacks = 0;
+    final pending = _submit(h.relay(signer), onSigned: (_) => callbacks++);
+    final assertion = expectLater(
+      pending,
+      throwsA(isA<RelaySessionSupersededError>()),
+    );
+    h.session.debugDispose();
+    signer.ready.complete();
+    await assertion;
+    expect(h.a.messages, isEmpty);
+    expect(callbacks, 0);
+  });
+}

--- a/mobile/test/shared/theme/community_theme_provider_test.dart
+++ b/mobile/test/shared/theme/community_theme_provider_test.dart
@@ -327,6 +327,7 @@ class _ThemeRelaySession extends RelaySessionNotifier {
   @override
   Future<NostrEvent> publish(
     NostrEvent event, {
+    required RelaySessionLease lease,
     Duration timeout = const Duration(seconds: 8),
   }) async {
     published = event;


### PR DESCRIPTION
## Stack and scope

**Draft; not rollout/staging-ready.** Depends on async EventSigner extraction #7600. Target is `baxen/async-event-signer-extraction`, **not main**. Closest existing PR: #7600 (the neutral extraction); no existing remote-managed-identity PR was found before creating this draft.

Adds release-selected organization-held identity to desktop and mobile, with captured `RemoteEventSigner` capabilities separate from login/token ownership. OSS retains local custody and optional local media auth. Managed mode cannot fall back to generating/importing/exporting a local human key. Nostr event construction and publication remain outside the signer; exact returned event fields, author, ID and signature are verified. Relay/session generation and ACK-ID checks fence asynchronous operations.

Local-secret-dependent pairing, key backup/export, encrypted personal sync/reminders, local managed-agent custody and analogous operations are explicitly unavailable rather than silently replaced by plaintext publication. See [desktop/MANAGED_IDENTITY.md](desktop/MANAGED_IDENTITY.md) and [mobile/MANAGED_IDENTITY.md](mobile/MANAGED_IDENTITY.md) for product differences, lifecycle and exclusions.

### Media review fixes

- Corporate desktop read-proof errors now propagate before upstream transport in streaming proxy, custom-protocol proxy and bounded download consumers; avatar-card caller also propagates the Result. OSS recovery alone may omit auth.
- Mobile managed read proofs use **120-second lifetime / 10-second refresh margin**, within the backend's 300-second ceiling; OSS remains **600/60**. Proof timestamp/expiration and cache origin use captured construction time. Exact HTTPS origin/effective port/userinfo checks, generation checks and no-redirect transport remain intact.
- Red-first native recording-server regression reproduced nine unsigned successful requests (three consumers × missing identity/logout/proof denial), then passed with **zero requests**. OSS regression proves its three unsigned requests still succeed. Mobile production media→actual remote signer request test initially receives policy-shaped 403 for 600 seconds, then verifies backend bounds, 120-second proof, cache reuse/refresh at 109/110 seconds and zero further transport after logout. The service mock enforces policy rather than always signing.

## Cross-repository contract

- Only `POST <signerUrl>v1/buzz/identity/ensure` and `POST <signerUrl>v1/buzz/identity/sign`; default deployment prefix `/cash-app/goose/`, no legacy aliases. Sign returns a signature, **never ordinary publication**. Ensure's initial provisioning is separate.
- Exactly seven nonsecret compiled fields: `signerUrl`, `issuer`, `clientId`, `audience`, `organization`, `connection`, `redirectUri`. Release `environment` is not an eighth client field. `signerUrl` includes deployment prefix, not a full endpoint; no client secrets/tokens in build configuration.
- Desktop callback is configured exact `http://127.0.0.1:<fixed-port>/enterprise-callback` (busy bind fails); mobile `buzz://enterprise-login`.
- Aligned with backend draft `squareup/cash-server#124571` at `703f02195041fd53deadbdd95ee885f6f75a4919`, release draft `squareup/buzz-releases#94` at `ed54ec3ba7ceb2c1835bf68450771c0a77432731`. Auth0 Terraform draft #1385 remains unbound/deny-only pending corporate-authority choice and active-infrastructure authorization. These are source contracts, not deployed-service evidence.

## Validation and provenance

Fresh full affected suites on frozen source (HEAD was `59ad3ee6…` with prepared changes), subsequently verified byte-identical to committed tree `b3d50467f5bd3a9ff752a8490bc1a57e690d675c`:

- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml`: **3203 unit + 10 integration passed; 21 ignored**.
- Synthetic compiled corporate `cargo test … compiled_corporate -- --ignored`: **2 passed**, including real AppState no-key/import guard and new zero-transport regression. Native source matches final tree; no live credentials.
- Tauri `cargo clippy --locked … --all-targets -- -D warnings`: passed.
- `flutter test --no-pub --reporter expanded`: **2171 passed**; `flutter analyze --no-pub`: clean; Dart format **563 files, zero changes**; Rust fmt/diff whitespace checks passed.
- File-size policy tests **10 passed** and desktop/web/mobile differential gates passed. Focused mobile auth/media tests **29 passed**. Genuine red logs retained; one subsequent test-only list-matcher defect was corrected without weakening the policy assertions.

**Reused, not rerun**, from matching unchanged source manifests: WS 25 tests/clippy; frontend 6504 JS tests, 2 synthetic Chromium login tests, TypeScript/Biome/text checks and protected internal/OSS build matrix; actual compiled config parser tests, intended missing-system-keyring guard; mobile synthetic define parser (1), actual release source check and three actual Swift emoji sources compiled for iOS 16 arm64 simulator. Native/Flutter suites were rerun because their packages changed. Existing frontend warnings remain as documented in prior evidence.

Full frozen patch SHA256 including all new files: `1596261030009319ddaa0c21f6607cd78d93a2e488ecfb6ac19bfd126c1ab902`. Feature-only patch against `d7a54a876…`: `3242be95c6e29fcc372681453882420e28a384a1e949341d0d498de665913e4b`. Local durable evidence: `/Users/baxen/Development/buzz-remote-managed-identity-artifacts/final-38c81a13/` (logs, before/after manifests, full patches, self-review); inherited evidence attribution is explicit, not a claim all suites ran at the merge SHA. Package/static checks were run directly; wrapper hooks were skipped to avoid installing through shared dependency symlinks or packaging empty sidecar placeholders. A fresh repository-wide `just ci`/packaged-app build was not run.

The extraction's newer mobile content had already been integrated manually. A normal local merge records `d7a54a876…` ancestry, resolving six overlapping files to the reviewed/tested content; merge tree equals feature content tree exactly. No published history rewritten. Size measured honestly: **145 files +5790/−409 feature-only**; combined stack from original baseline **164 files +7262/−567**, versus original enterprise implementation **104 files +3721/−318**. This is not a file-count reduction claim.

## Remaining limitations / blocked runtime gates

- Directory/profile editing remains exposed although the backend excludes ordinary profile mutation; it fails instead of changing directory-owned names.
- Mobile refresh still calls ensure and checks the pinned identity; mobile direct parser/generic proof preflight is weaker than Rust. Backend policy is still required.
- No full operator offboarding/live relay eviction or crash-durable signed-event outbox; ambiguous retries may construct new events.
- No live corporate SSO/enrollment/token rotation, actual keychain, deployed signing/media workflow, full native app link/launch, URLSession runtime redirect test, signed installer/AOT configuration embedding or release/deployment was exercised. Synthetic Chromium is not native GUI; compiled Swift sources/source markers/artifact bytes are not runtime proof. Sidecars are empty placeholders.
- No Auth0 mutation, schema apply, enrollment or deployment. Infrastructure authority and active-repo ownership decisions still block staging readiness.
