### PR TITLE
fix(desktop): forum unread state, pagination, and read failures

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
         "**/mention-recipients.spec.ts",
         "**/remote-owned-mentions.spec.ts",
         "**/forum-agent-invitation.spec.ts",
+        "**/forum-pagination.spec.ts",
         "**/team-mentions.spec.ts",
         "**/persistent-agent-audience.spec.ts",
         "**/relay-reconnect.spec.ts",

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -56,6 +56,8 @@ import { useIndependentThreadPanel } from "@/features/messages/useIndependentThr
 import { useThreadReplies } from "@/features/messages/useThreadReplies";
 import { useChannelTyping } from "@/features/messages/useChannelTyping";
 import type { TimelineMessage } from "@/features/messages/types";
+import { useForumPostsQuery } from "@/features/forum/hooks";
+import { latestForumPostAt } from "@/features/forum/lib/latestPostAt";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useRelaySelfQuery } from "@/features/moderation/hooks";
 import type { RelayEvent, RespondToMode } from "@/shared/api/types";
@@ -219,9 +221,22 @@ export function ChannelScreen({
     }
     return null;
   }, [messagesQuery.data]);
-  const activeReadAt = latestActiveMessage
-    ? new Date(latestActiveMessage.created_at * 1_000).toISOString()
-    : null;
+  // Forum channels never populate `messagesQuery` (`useChannelMessagesQuery`
+  // is disabled for them), so their newest top-level event comes from the post
+  // list instead. Without this the open-read marker resolves to null for every
+  // forum and the channel can never become read. Same query key as ForumView,
+  // so this shares that cache rather than issuing a second read.
+  const forumPostsQuery = useForumPostsQuery(
+    activeChannel?.channelType === "forum" ? activeChannel : null,
+  );
+  const latestTopLevelAt =
+    activeChannel?.channelType === "forum"
+      ? latestForumPostAt(forumPostsQuery.data)
+      : (latestActiveMessage?.created_at ?? null);
+  const activeReadAt =
+    latestTopLevelAt === null
+      ? null
+      : new Date(latestTopLevelAt * 1_000).toISOString();
   useChannelOpenReadState(
     activeChannelId,
     activeChannel?.isMember,

--- a/desktop/src/features/forum/hooks.ts
+++ b/desktop/src/features/forum/hooks.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import { getForumPosts, getForumThread } from "@/shared/api/forum";
 import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
@@ -33,6 +38,9 @@ export function forumThreadQueryKey(channelId: string, eventId: string) {
   return ["forum-thread", channelId, eventId] as const;
 }
 
+/** Posts requested per page; also the "is this the last page" test below. */
+export const FORUM_POSTS_PAGE_SIZE = 50;
+
 export function useForumPostsQuery(channel: Channel | null) {
   const refetchInterval = useFocusedRefetchInterval(
     FORUM_POSTS_REFETCH_INTERVAL_MS,
@@ -42,10 +50,35 @@ export function useForumPostsQuery(channel: Channel | null) {
   const enabled = channel !== null && channel.channelType === "forum";
   const relaySelfPubkey = useRelaySelfQuery(enabled).data;
 
-  return useQuery<ForumPostsResponse>({
+  // Paged rather than a single 50-post read: a forum past 50 posts had no way
+  // to reach the rest, because the response cursor was parsed and dropped.
+  // Polling refetches every loaded page, so a forum the user has paged deep
+  // into stays current.
+  return useInfiniteQuery<
+    ForumPostsResponse,
+    Error,
+    ForumPostsResponse[],
+    readonly unknown[],
+    number | undefined
+  >({
     enabled,
     queryKey: [...forumPostsQueryKey(channelId), relaySelfPubkey ?? null],
-    queryFn: () => getForumPosts(channelId, 50, undefined, relaySelfPubkey),
+    queryFn: ({ pageParam }) =>
+      getForumPosts(
+        channelId,
+        FORUM_POSTS_PAGE_SIZE,
+        pageParam,
+        relaySelfPubkey,
+      ),
+    initialPageParam: undefined,
+    // A short page is the end of the forum. The relay hands back a cursor
+    // whenever it served any rows, not only when more remain, so the cursor
+    // alone would offer "load older" on a forum holding a single post.
+    getNextPageParam: (lastPage) =>
+      lastPage.posts.length < FORUM_POSTS_PAGE_SIZE
+        ? undefined
+        : (lastPage.nextCursor ?? undefined),
+    select: (data) => data.pages,
     refetchInterval,
     ...forumFocusRefetchPolicy,
   });

--- a/desktop/src/features/forum/lib/latestPostAt.test.mjs
+++ b/desktop/src/features/forum/lib/latestPostAt.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { latestForumPostAt } from "./latestPostAt.ts";
+
+const page = (...createdAts) => ({
+  posts: createdAts.map((createdAt, index) => ({
+    eventId: `e${index}`,
+    pubkey: "a",
+    content: "c",
+    kind: 45001,
+    createdAt,
+    channelId: "ch",
+    tags: [],
+    threadSummary: null,
+  })),
+  nextCursor: null,
+});
+
+test("returns the newest post across every loaded page", () => {
+  assert.equal(latestForumPostAt([page(30, 20), page(40, 10)]), 40);
+});
+
+test("no pages and empty pages yield null", () => {
+  assert.equal(latestForumPostAt(undefined), null);
+  assert.equal(latestForumPostAt([]), null);
+  assert.equal(latestForumPostAt([page()]), null);
+});
+
+test("a single post is its own latest", () => {
+  assert.equal(latestForumPostAt([page(7)]), 7);
+});

--- a/desktop/src/features/forum/lib/latestPostAt.ts
+++ b/desktop/src/features/forum/lib/latestPostAt.ts
@@ -1,0 +1,23 @@
+import type { ForumPostsResponse } from "@/shared/api/types";
+
+/**
+ * Newest top-level post time across the loaded pages, in unix seconds.
+ *
+ * The channel read marker needs the forum equivalent of "newest top-level
+ * message". Replies are deliberately excluded: opening the post list shows
+ * every new post, not the replies inside each thread, so a thread keeps its
+ * own unread state until it is opened.
+ */
+export function latestForumPostAt(
+  pages: ForumPostsResponse[] | undefined,
+): number | null {
+  let latest: number | null = null;
+  for (const page of pages ?? []) {
+    for (const post of page.posts) {
+      if (latest === null || post.createdAt > latest) {
+        latest = post.createdAt;
+      }
+    }
+  }
+  return latest;
+}

--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, MessageSquare } from "lucide-react";
+import { AlertCircle, ArrowLeft, MessageSquare } from "lucide-react";
 import * as React from "react";
 
 import { handleTimelineMentionCopy } from "@/features/messages/lib/timelineMentionCopy";
@@ -26,6 +26,9 @@ import { ForumComposer } from "./ForumComposer";
 type ForumThreadPanelProps = {
   thread: ForumThreadResponse | undefined;
   isLoading: boolean;
+  /** Set when the thread read failed — shown instead of an endless skeleton. */
+  loadError?: Error | null;
+  onRetry?: () => void;
   isSendingReply: boolean;
   channelId: string;
   postId: string;
@@ -145,6 +148,8 @@ function ReplyRow({
 export function ForumThreadPanel({
   thread,
   isLoading,
+  loadError,
+  onRetry,
   isSendingReply,
   channelId,
   postId,
@@ -184,6 +189,40 @@ export function ForumThreadPanel({
     targetElement.scrollIntoView({ block: "center" });
     onTargetReached?.(targetEventId);
   }, [onTargetReached, targetEventId, thread]);
+
+  if (!thread && loadError) {
+    return (
+      <div className={cn("flex h-full flex-col", channelChrome.contentPadding)}>
+        <div className="border-b border-border/60 px-4 py-3">
+          <Button
+            className="gap-1.5 text-muted-foreground"
+            onClick={onBack}
+            size="sm"
+            variant="ghost"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to posts
+          </Button>
+        </div>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center">
+          <AlertCircle className="h-10 w-10 text-muted-foreground/40" />
+          <div>
+            <p className="text-sm font-medium text-foreground/70">
+              Could not load this post
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {loadError.message}
+            </p>
+          </div>
+          {onRetry ? (
+            <Button onClick={onRetry} size="sm" variant="outline">
+              Try again
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
 
   if (isLoading || !thread) {
     return (

--- a/desktop/src/features/forum/ui/ForumView.tsx
+++ b/desktop/src/features/forum/ui/ForumView.tsx
@@ -1,6 +1,7 @@
 import { MessageSquareText } from "lucide-react";
 import * as React from "react";
 
+import { useAppShell } from "@/app/AppShellContext";
 import { handleTimelineMentionCopy } from "@/features/messages/lib/timelineMentionCopy";
 import { useProfileQuery, useUsersBatchQuery } from "@/features/profile/hooks";
 import { mergeCurrentProfileIntoLookup } from "@/features/profile/lib/identity";
@@ -57,6 +58,7 @@ export function ForumView({
   const [isComposerOpen, setIsComposerOpen] = React.useState(false);
   const postsScrollRef = React.useRef<HTMLDivElement>(null);
 
+  const { markThreadRead } = useAppShell();
   const profileQuery = useProfileQuery();
   const postsQuery = useForumPostsQuery(channel);
   const threadQuery = useForumThreadQuery(
@@ -122,6 +124,19 @@ export function ForumView({
       ),
     [profileQuery.data, profilesQuery.data?.profiles],
   );
+
+  // Reading a thread is the only thing that clears its replies. The channel
+  // marker covers posts, not replies, so without this a thread that has been
+  // replied to keeps its unread dot for good.
+  const openThread = selectedPostId ? threadQuery.data : undefined;
+  React.useEffect(() => {
+    if (!selectedPostId || !openThread) return;
+    const newestSeen = openThread.replies.reduce(
+      (latest, reply) => Math.max(latest, reply.createdAt),
+      openThread.post.createdAt,
+    );
+    markThreadRead(selectedPostId, newestSeen);
+  }, [markThreadRead, openThread, selectedPostId]);
 
   const previousChannelIdRef = React.useRef(channel.id);
   React.useEffect(() => {

--- a/desktop/src/features/forum/ui/ForumView.tsx
+++ b/desktop/src/features/forum/ui/ForumView.tsx
@@ -1,4 +1,4 @@
-import { MessageSquareText } from "lucide-react";
+import { AlertCircle, MessageSquareText } from "lucide-react";
 import * as React from "react";
 
 import { useAppShell } from "@/app/AppShellContext";
@@ -162,6 +162,8 @@ export function ForumView({
         currentPubkey={effectiveCurrentPubkey}
         isDeletingPost={deletePostMutation.isPending}
         isLoading={threadQuery.isLoading}
+        loadError={threadQuery.isError ? threadQuery.error : null}
+        onRetry={() => void threadQuery.refetch()}
         isSendingReply={createReplyMutation.isPending}
         onBack={onClosePost}
         onDeletePost={(eventId) => {
@@ -238,6 +240,28 @@ export function ForumView({
             <Skeleton className="h-24 w-full rounded-xl" />
             <Skeleton className="h-24 w-full rounded-xl" />
             <Skeleton className="h-24 w-full rounded-xl" />
+          </div>
+        ) : postsQuery.isError ? (
+          <div className="flex flex-col items-center justify-center gap-3 px-4 py-16 text-center">
+            <AlertCircle className="h-10 w-10 text-muted-foreground/40" />
+            <div>
+              <p className="text-sm font-medium text-foreground/70">
+                Could not load posts
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {postsQuery.error instanceof Error
+                  ? postsQuery.error.message
+                  : "The forum did not respond."}
+              </p>
+            </div>
+            <Button
+              disabled={postsQuery.isFetching}
+              onClick={() => void postsQuery.refetch()}
+              size="sm"
+              variant="outline"
+            >
+              {postsQuery.isFetching ? "Retrying..." : "Try again"}
+            </Button>
           </div>
         ) : posts.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 px-4 py-16 text-center">

--- a/desktop/src/features/forum/ui/ForumView.tsx
+++ b/desktop/src/features/forum/ui/ForumView.tsx
@@ -8,6 +8,7 @@ import { getMentionTagPubkey } from "@/shared/lib/resolveMentionNames";
 import type { Channel } from "@/shared/api/types";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { VirtualizedList } from "@/shared/ui/VirtualizedList";
 
@@ -70,7 +71,10 @@ export function ForumView({
     selectedPostId,
   );
 
-  const posts = postsQuery.data?.posts ?? [];
+  const posts = React.useMemo(
+    () => (postsQuery.data ?? []).flatMap((page) => page.posts),
+    [postsQuery.data],
+  );
 
   // Collect all pubkeys from posts and thread for profile resolution.
   // Mentioned pubkeys (`p`/`mention` tags) must be included too: mention
@@ -260,6 +264,21 @@ export function ForumView({
             scrollRef={postsScrollRef}
           />
         )}
+
+        {posts.length > 0 && postsQuery.hasNextPage ? (
+          <div className="flex justify-center px-4 pb-6">
+            <Button
+              disabled={postsQuery.isFetchingNextPage}
+              onClick={() => void postsQuery.fetchNextPage()}
+              size="sm"
+              variant="outline"
+            >
+              {postsQuery.isFetchingNextPage
+                ? "Loading older posts..."
+                : "Load older posts"}
+            </Button>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5329,33 +5329,42 @@ async function handleGetForumPosts(args: {
   before?: number | null;
 }): Promise<RawForumPostsResponse> {
   const events = getMockMessageStore(args.channelId);
-  const posts = events
+  const limit = args.limit ?? 50;
+  const matching = events
     .filter((event) => event.kind === 45001)
     .filter((event) => (args.before ? event.created_at < args.before : true))
-    .sort((left, right) => right.created_at - left.created_at)
-    .slice(0, args.limit ?? 50)
-    .map((event) => {
-      const replies = events.filter((candidate) => {
-        if (candidate.kind !== 45003) {
-          return false;
-        }
+    .sort((left, right) => right.created_at - left.created_at);
+  const pageEvents = matching.slice(0, limit);
+  const posts = pageEvents.map((event) => {
+    const replies = events.filter((candidate) => {
+      if (candidate.kind !== 45003) {
+        return false;
+      }
 
-        const thread = getThreadReferenceFromTags(candidate.tags);
-        return (thread.rootEventId ?? thread.parentEventId) === event.id;
-      });
-
-      return toRawForumPost(event, args.channelId, {
-        reply_count: replies.length,
-        descendant_count: replies.length,
-        last_reply_at:
-          replies.length > 0 ? replies[replies.length - 1].created_at : null,
-        participants: [...new Set(replies.map((reply) => reply.pubkey))],
-      });
+      const thread = getThreadReferenceFromTags(candidate.tags);
+      return (thread.rootEventId ?? thread.parentEventId) === event.id;
     });
 
+    return toRawForumPost(event, args.channelId, {
+      reply_count: replies.length,
+      descendant_count: replies.length,
+      last_reply_at:
+        replies.length > 0 ? replies[replies.length - 1].created_at : null,
+      participants: [...new Set(replies.map((reply) => reply.pubkey))],
+    });
+  });
+
+  // Match `get_forum_posts`, which derives the cursor from the last row it
+  // returned and so issues one whenever it returned anything at all — it does
+  // not signal whether more remain. Faithfulness matters here: a mock that
+  // withheld the cursor on a short page would hide whether the client ends the
+  // list on its own.
   return {
     messages: posts,
-    next_cursor: null,
+    next_cursor:
+      pageEvents.length > 0
+        ? pageEvents[pageEvents.length - 1].created_at
+        : null,
   };
 }
 

--- a/desktop/tests/e2e/forum-pagination.spec.ts
+++ b/desktop/tests/e2e/forum-pagination.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+async function waitForMockLiveSubscription(
+  page: import("@playwright/test").Page,
+  channelName: string,
+) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (name) =>
+          window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: name,
+          }) ?? false,
+        channelName,
+      ),
+    )
+    .toBe(true);
+}
+
+// Regression: the forum list read a single page and dropped the `before`
+// cursor the relay returns, so a forum past the page size had no way to reach
+// its older posts.
+test("a forum past one page loads older posts on demand", async ({ page }) => {
+  await installMockBridge(page);
+  await page.goto("/");
+
+  await page.getByTestId("channel-general").click();
+  await waitForMockLiveSubscription(page, "watercooler");
+  // Two mock posts already exist, so 49 more crosses the 50-post page size.
+  await page.evaluate(
+    ({ count, pubkey }) => {
+      for (let index = 1; index <= count; index += 1) {
+        window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+          channelName: "watercooler",
+          content: `Paged post ${index}`,
+          kind: 45001,
+          pubkey,
+        });
+      }
+    },
+    { count: 49, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
+
+  await page.getByTestId("channel-watercooler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("watercooler");
+
+  const loadOlder = page.getByRole("button", { name: "Load older posts" });
+  await expect(loadOlder).toBeVisible();
+
+  await loadOlder.click();
+  // The second page is short, which ends the list — the control must not
+  // offer a page that does not exist.
+  await expect(loadOlder).toHaveCount(0);
+  await expect(
+    page.getByText("Release checklist: async feedback thread."),
+  ).toBeVisible();
+});


### PR DESCRIPTION
Four defects in forum channels, found while running a forum as a bug-ticket queue. Each is independent and in its own commit.

### Posts past the first page are unreachable

`get_forum_posts` returns a `before` cursor and `shared/api/forum.ts` parses it into `nextCursor`, but nothing has ever read it — `ForumView` took `postsQuery.data?.posts` from a single 50-post query. Every post older than the newest 50 in a forum is unreachable in the client, silently, with no control to load more and nothing to indicate the list is truncated.

The posts query is now an infinite query, and the list offers "Load older posts" while pages remain. A page shorter than the page size ends the list, because `get_forum_posts` derives its cursor from the last row it returned (`messages.last().map(|m| m.created_at)`) and so issues one whenever it returned anything at all — it never signals whether more remain. Worth a look separately: the command could use the `has_more` over-fetch that `thread.rs` already does, which would let the client trust the cursor directly.

### A forum channel can never become read

`useChannelOpenReadState` takes the read-marker timestamp from the newest top-level message in `useChannelMessagesQuery`, and that query is disabled for forums (`channelType !== "forum"`). So `activeReadAt` is structurally null for every forum, `resolveChannelReadMarker` returns a null mark, and `markChannelRead` returns before writing anything. No forum has ever advanced its NIP-RS marker, so catch-up keeps comparing new posts against a marker that never moved and the sidebar row stays bold for the life of the profile.

Forum channels now take that timestamp from the newest post, sharing `ForumView`'s query key rather than issuing a second read. Replies are deliberately excluded: opening the post list shows every new post, not the replies inside each thread, so a thread keeps its own unread state until it is opened.

### A thread that has been replied to keeps its dot forever

`markThreadRead` is called from the Home inbox and the channel activity popover, but never from the forum, so no `thread:<rootId>` marker is written for a forum thread. The channel marker deliberately covers posts rather than replies, so nothing could clear it. Opening a thread now marks it read up to its newest reply, which is what the screen already implies: those replies are rendered and have been seen.

### A failed read claims the forum is empty

A failed `get_forum_posts` fell through to the empty state, so a forum that could not be read claimed it had no posts and invited the user to write the first one. A failed `get_forum_thread` left `thread` undefined, which the panel treats as still loading, so the skeleton never resolved. Both now report the failure and offer a retry.

### On test coverage, honestly

The pagination fix has an E2E regression test, and the mock bridge's `get_forum_posts` now pages — faithfully, issuing a cursor whenever it returned rows, so the test exercises the client's own end-of-list decision rather than leaning on the mock to stop.

The two unread fixes have no E2E test and I do not think one is currently writable: the mock bridge never reaches the read-state path, so `markChannelRead` is never called under it and a spec there passes with or without the change. I wrote one, confirmed it passed against unfixed code, and deleted it. The derivation added for the channel marker is unit-tested instead. Both behaviours were verified against a real profile's `observed-unread.db`, where the forum's channel marker had never been written and no `thread:` marker existed at all until the second fix landed. Happy to take direction on a seam that would bind these properly.
