### PR TITLE
buzz-dev-mcp: configure PowerShell UTF-8 pipes

### DIFF
--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -165,7 +165,7 @@ pub async fn run(
     };
     let shell_arg = shell_flag(&bash);
     let mut cmd = Command::new(&bash);
-    cmd.arg(shell_arg).arg(&p.command);
+    cmd.arg(shell_arg).arg(shell_command(&bash, &p.command));
     cmd.current_dir(&workdir);
     cmd.env("PATH", &state.shim.path_env);
     // NOSTR_PRIVATE_KEY is already removed from this process's env (shim.rs).
@@ -344,6 +344,25 @@ fn shell_flag(shell: &Path) -> &'static str {
         Some("cmd") => "/C",
         Some("powershell" | "pwsh") => "-Command",
         _ => "-c",
+    }
+}
+
+fn is_powershell(shell: &Path) -> bool {
+    matches!(
+        shell
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_ascii_lowercase())
+            .as_deref(),
+        Some("powershell" | "pwsh")
+    )
+}
+
+fn shell_command(shell: &Path, command: &str) -> String {
+    if is_powershell(shell) {
+        format!("$OutputEncoding = [System.Text.UTF8Encoding]::new($false); {command}")
+    } else {
+        command.to_string()
     }
 }
 
@@ -1010,6 +1029,20 @@ mod tests {
         assert_eq!(effective_timeout_ms(Some(1_200_000)), 1_200_000);
         assert_eq!(effective_timeout_ms(Some(1_200_001)), 1_200_000);
         assert_eq!(effective_timeout_ms(Some(u64::MAX)), 1_200_000);
+    }
+
+    #[test]
+    fn powershell_commands_configure_utf8_native_pipe_encoding() {
+        let powershell = Path::new("powershell.exe");
+        assert!(is_powershell(powershell));
+        assert_eq!(
+            shell_command(powershell, "Get-Content message.txt | buzz messages send ..."),
+            "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); Get-Content message.txt | buzz messages send ..."
+        );
+        assert_eq!(
+            shell_command(Path::new("bash.exe"), "echo hello"),
+            "echo hello"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Summary
-------
Configure UTF-8 native-pipe output for PowerShell commands launched by the Buzz MCP shell.

Fixes:
------
- https://github.com/block/buzz/issues/5070
- https://github.com/block/buzz/issues/6527

Problem
-------
Windows PowerShell encodes text sent to native processes as US-ASCII.

As result, PowerShell replaces all non-ASCII message characters messages sent by agents when the message is piped from PowerShell to buzz:

```ps1
... | buzz messages send --content -
```

For details, see
- https://github.com/block/buzz/issues/6527

Solution
--------
Prepend a UTF8Encoding OutputEncoding assignment when the resolved shell is powershell.exe or pwsh.exe. Git Bash and other shells retain their existing command text. Add a regression test for both paths.